### PR TITLE
perf(platform): reduce Docker image size by ~1.4GB

### DIFF
--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -115,7 +115,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/convex ./convex
 COPY --from=builder --chown=nextjs:nodejs /app/lib ./lib
 
 
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+# Optimized node_modules: standalone already includes its own minimal node_modules (~75 MB)
+# We only need to add convex CLI dependencies for `npx convex deploy` and `npx convex env set` (~65 MB)
+# This saves ~1.4 GB compared to copying the full node_modules (1.5 GB)
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/convex ./node_modules/convex
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/esbuild ./node_modules/esbuild
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@esbuild ./node_modules/@esbuild
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/prettier ./node_modules/prettier
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
 
 # Copy startup script with correct ownership and set execute permission


### PR DESCRIPTION
## Summary

- Replace full `node_modules` copy (~1.5GB) with minimal dependencies for the runner stage
- Next.js standalone already includes its own node_modules (~75MB)
- Add only convex CLI dependencies needed for deployment: `convex`, `esbuild`, `@esbuild`, `prettier` (~65MB)

## Expected Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| node_modules size | 1.5 GB | ~140 MB | -91% |
| Total image size | 2.77 GB | ~1.4 GB | -49% |

## Test plan

- [ ] Build the optimized Docker image
- [ ] Verify `docker compose up` starts all services correctly
- [ ] Test `npx convex deploy` works at container startup
- [ ] Test `npx convex env set` works for environment variable sync
- [ ] Verify Next.js application serves requests normally
- [ ] Verify Convex functions execute correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image size by selectively including build dependencies in the container, reducing deployment package footprint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->