### PR TITLE
refactor(convex): add stronger typing for vendorListResponseValidator items

### DIFF
--- a/services/platform/convex/model/vendors/validators.ts
+++ b/services/platform/convex/model/vendors/validators.ts
@@ -58,7 +58,7 @@ export const vendorInputValidator = v.object({
   name: v.optional(v.string()),
   email: v.string(),
   phone: v.optional(v.string()),
-  externalId: v.optional(v.string()),
+  externalId: v.optional(v.union(v.string(), v.number())),
   source: vendorSourceValidator,
   locale: v.optional(v.string()),
   address: v.optional(vendorAddressValidator),


### PR DESCRIPTION
## Summary
- Add `vendorItemValidator` that matches `Doc<'vendors'>` shape with proper typing
- Replace `v.array(v.any())` with `v.array(vendorItemValidator)` in `vendorListResponseValidator`

## Background
In PR #48, `vendorListResponseValidator` was extracted with `items: v.array(v.any())` which bypassed type validation. This PR addresses the CodeRabbit review feedback to add stronger typing.

## Changes
Created `vendorItemValidator` with all fields from the vendors schema:
- Convex system fields (`_id`, `_creationTime`)
- User-defined fields (`organizationId`, `name`, `email`, `phone`, `externalId`, `source`, `locale`, `address`, `tags`, `metadata`, `notes`)
- Proper typing for `externalId` as `v.union(v.string(), v.number())` to match schema
 
## Test plan
- [x] TypeScript compilation passes
- [x] Validator matches the `Doc<'vendors'>` type from schema
- [ ] Verify `listVendors` query works correctly in dev environment

Closes #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vendor list responses now include enhanced pagination metadata, providing clearer navigation with total page count and indicators for next/previous page availability.

* **Improvements**
  * Strengthened validation framework for vendor items to ensure data consistency and reliability across all vendor records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->