### PR TITLE
fix(chat): resolve getThreadMessagesStreaming query timeout

### DIFF
--- a/services/platform/app/(app)/dashboard/[id]/automations/components/automation-assistant.tsx
+++ b/services/platform/app/(app)/dashboard/[id]/automations/components/automation-assistant.tsx
@@ -187,10 +187,11 @@ export function AutomationAssistant({
   );
 
   // Load thread messages when threadId is available using useUIMessages for file parts support
+  // Reduced initial load to prevent query timeouts - see: https://github.com/tale-project/tale/issues/85
   const { results: uiMessages } = useUIMessages(
     api.threads.getThreadMessagesStreaming,
     threadId ? { threadId } : 'skip',
-    { initialNumItems: 50, stream: true },
+    { initialNumItems: 10, stream: true },
   );
 
   // Load threadId from workflow metadata when workflow is loaded

--- a/services/platform/app/(app)/dashboard/[id]/chat/components/chat-interface.tsx
+++ b/services/platform/app/(app)/dashboard/[id]/chat/components/chat-interface.tsx
@@ -308,7 +308,8 @@ export function ChatInterface({
   const userDraftMessage = optimisticMessage?.content || '';
 
   // Fetch thread messages with streaming support
-  // Use pagination to handle large threads (50+ messages)
+  // Use pagination to handle large threads - reduced initial load to prevent query timeouts
+  // See: https://github.com/tale-project/tale/issues/85
   const {
     results: uiMessages,
     loadMore,
@@ -316,7 +317,7 @@ export function ChatInterface({
   } = useUIMessages(
     api.threads.getThreadMessagesStreaming,
     threadId ? { threadId } : 'skip',
-    { initialNumItems: 50, stream: true },
+    { initialNumItems: 10, stream: true },
   );
 
   // Track pagination state for loading more messages

--- a/services/platform/package-lock.json
+++ b/services/platform/package-lock.json
@@ -11,7 +11,7 @@
         "@ai-sdk/openai": "2.0.74",
         "@ai-sdk/provider-utils": "3.0.17",
         "@convex-dev/action-cache": "^0.3.0",
-        "@convex-dev/agent": "0.3.0",
+        "@convex-dev/agent": "^0.3.2",
         "@convex-dev/better-auth": "0.9.7",
         "@convex-dev/persistent-text-streaming": "^0.3.0",
         "@convex-dev/rate-limiter": "^0.3.2",
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@convex-dev/agent": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@convex-dev/agent/-/agent-0.3.0.tgz",
-      "integrity": "sha512-UA2v9utw8pGmScvfruf9QakPt71eQizQZoyEayjGYV0sVK74fSkJvFDhaT1OuYMvxsjT7SM26orCOjYWfGd75Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/agent/-/agent-0.3.2.tgz",
+      "integrity": "sha512-TMFReXejAIUE22OOn8PYvoOseAqwVOPm4WZU554GFk0lJ9kcNCGRJP/T1NTZfSBXrSaSUjETMFv2vEfXbG+4Qg==",
       "license": "Apache-2.0",
       "optionalDependencies": {
         "@ungap/structured-clone": "^1.3.0"

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/openai": "2.0.74",
     "@ai-sdk/provider-utils": "3.0.17",
     "@convex-dev/action-cache": "^0.3.0",
-    "@convex-dev/agent": "0.3.0",
+    "@convex-dev/agent": "^0.3.2",
     "@convex-dev/better-auth": "0.9.7",
     "@convex-dev/persistent-text-streaming": "^0.3.0",
     "@convex-dev/rate-limiter": "^0.3.2",


### PR DESCRIPTION
## Summary
- Upgrades `@convex-dev/agent` from 0.3.0 to 0.3.2 for performance fixes
- Reduces `initialNumItems` from 50 to 10 in both chat interface and automation assistant to decrease query load
- The `syncStreams` function was causing 3.7s timeouts even with 0 docs

Fixes #85

## Test plan
- [ ] Verify chat interface loads without timeout errors
- [ ] Verify automation assistant loads messages correctly
- [ ] Test pagination (load more) functionality still works
- [ ] Confirm streaming messages display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized initial message loading in chat and automation interfaces to reduce timeouts and improve responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->