### PR TITLE
fix(chat): reduce frequencyPenalty to prevent degenerate word-list outputs

### DIFF
--- a/services/platform/convex/lib/create_agent_config.ts
+++ b/services/platform/convex/lib/create_agent_config.ts
@@ -99,7 +99,8 @@ export function createAgentConfig(opts: {
   const callSettings: Record<string, number> = {
     // Add frequency_penalty to discourage repetition loops
     // This penalizes tokens based on their frequency in the generated text so far
-    frequencyPenalty: 0.3,
+    // Reduced from 0.3 to 0.15 to prevent degenerate word-list outputs (issue #88)
+    frequencyPenalty: 0.15,
   };
   if (typeof opts.temperature === 'number') {
     callSettings.temperature = opts.temperature;


### PR DESCRIPTION
## Summary

- Reduced `frequencyPenalty` from `0.3` to `0.15` in agent config to prevent occasional generation of random disconnected word lists instead of coherent content
- The aggressive `0.3` penalty caused models to avoid all token repetition, leading to disconnected word sequences when users requested long-form articles
- The conservative `0.15` value still discourages repetition loops while allowing natural prose

## Test plan

- [ ] Test with prompt: "write an article about environment with 1000 words"
- [ ] Verify normal Q&A responses remain coherent
- [ ] Monitor for any increase in repetition loops

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted agent configuration settings to improve response quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->