### PR TITLE
fix(agent-tools): add critical URL instruction to image tool

### DIFF
--- a/services/platform/convex/agent_tools/files/image_tool.ts
+++ b/services/platform/convex/agent_tools/files/image_tool.ts
@@ -64,8 +64,9 @@ EXAMPLES:
 • Analyze: { "operation": "analyze", "fileId": "kg2bazp7fbgt9srq63knfagjrd7yfenj", "question": "What is in this image?" }
 
 CRITICAL RULES:
-1. For analyze operation, ALWAYS use the fileId from the image attachment context. NEVER use imageUrl for uploaded images.
-2. The fileId looks like "kg2bazp7fbgt9srq63knfagjrd7yfenj" (alphanumeric string starting with "k").
+1. For generate operation, when presenting download links, copy the EXACT 'url' from the result. Never fabricate or modify URLs.
+2. For analyze operation, ALWAYS use the fileId from the image attachment context. NEVER use imageUrl for uploaded images.
+3. The fileId looks like "kg2bazp7fbgt9srq63knfagjrd7yfenj" (alphanumeric string starting with "k").
 `,
     args: z.object({
       operation: z


### PR DESCRIPTION
## Summary

- Add missing critical instruction to the image tool that prevents the AI model from fabricating URLs when presenting download links
- This matches the pattern used in other document generation tools (PDF, DOCX, PPTX, Excel)

Fixes #142

## Test plan

- [ ] Generate an image using the image tool
- [ ] Verify the AI model's response contains the exact URL from the tool result
- [ ] Confirm the URL uses `/http_api/` path (not `/http_app/` or other variations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download link handling to ensure accurate URLs are used from results, preventing invalid or fabricated links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->