### PR TITLE
fix(platform): show page title on mobile for automations list view

### DIFF
--- a/services/platform/app/(app)/dashboard/[id]/automations/layout.tsx
+++ b/services/platform/app/(app)/dashboard/[id]/automations/layout.tsx
@@ -127,35 +127,46 @@ export default function AutomationsLayout({
     <>
       <AdaptiveHeaderRoot standalone={false} showBorder className="gap-2">
         <h1 className="text-base font-semibold truncate">
-          {/* "Automations /" prefix - hidden on mobile */}
+          {/* "Automations" title - always visible, becomes breadcrumb prefix on desktop when automation is selected */}
           <span
             role="button"
             tabIndex={0}
             onClick={handleClickAutomation}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleClickAutomation();
+              }
+            }}
             className={cn(
-              'hidden md:inline text-foreground',
-              automation?.name && 'text-muted-foreground cursor-pointer',
+              'text-foreground',
+              automation?.name &&
+                'hidden md:inline text-muted-foreground cursor-pointer',
             )}
           >
-            {t('title')}&nbsp;&nbsp;
+            {t('title')}
           </span>
           {automation?.name && !editMode && (
-            <span
-              role="button"
-              tabIndex={0}
-              className="text-foreground cursor-pointer"
-              onClick={() => setEditMode(true)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  setEditMode(true);
-                }
-              }}
-            >
+            <>
               {/* "/" separator - hidden on mobile */}
-              <span className="hidden md:inline">/&nbsp;&nbsp;</span>
-              {automation?.name}
-            </span>
+              <span className="hidden md:inline">
+                &nbsp;&nbsp;/&nbsp;&nbsp;
+              </span>
+              <span
+                role="button"
+                tabIndex={0}
+                className="text-foreground cursor-pointer"
+                onClick={() => setEditMode(true)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setEditMode(true);
+                  }
+                }}
+              >
+                {automation?.name}
+              </span>
+            </>
           )}
         </h1>
         {editMode && (


### PR DESCRIPTION
## Summary
- Display "Automations" page title on mobile for the list view
- Title was previously hidden on mobile due to unconditional `hidden md:inline` class
- On desktop with individual automation selected, shows breadcrumb pattern (Automations / [name])

## Test plan
- [ ] Navigate to automations list on mobile - verify "Automations" title appears
- [ ] Navigate to individual automation on mobile - verify automation name appears
- [ ] Verify desktop breadcrumb pattern still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard navigation with full Enter/Space key support on automation title and controls
  * Refined automation name display and breadcrumb presentation
  * Improved header layout organization for better clarity across desktop and mobile devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->