### PR TITLE
fix(rag): handle job store lifecycle in reset endpoint

### DIFF
--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -474,12 +474,11 @@ async def reset_knowledge_base():
     knowledge graph data, and job history. Use with caution.
     """
     try:
-        await cognee_service.reset()
-        jobs_deleted = await job_store.clear_all_jobs()
+        result = await cognee_service.reset()
         return {
             "success": True,
             "message": "Knowledge base reset successfully. All data has been deleted.",
-            "jobs_deleted": jobs_deleted,
+            "jobs_deleted": result.get("jobs_deleted", 0),
         }
     except Exception as e:
         logger.error(f"Failed to reset knowledge base: {e}")


### PR DESCRIPTION
The reset endpoint was failing with "relation rag_jobs does not exist" because the database was dropped before clearing jobs, and the table wasn't recreated after.

Fix by reordering operations:
1. Clear jobs BEFORE dropping database
2. Close connection pool (dispose stale connections)
3. Drop and recreate database
4. Re-initialize job store (new pool + table)
5. Cleanup graph database

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed knowledge base reset to accurately track and report the number of deleted background jobs.

* **Improvements**
  * Optimized knowledge base reset process to ensure proper cleanup of background jobs and associated data stores.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->