### PR TITLE
fix(rag): re-initialize Cognee tables after knowledge base reset

### DIFF
--- a/services/rag/app/services/cognee/service.py
+++ b/services/rag/app/services/cognee/service.py
@@ -1519,6 +1519,7 @@ class CogneeService:
             dict with jobs_deleted count
         """
         from ..job_store_db import clear_all_jobs, close_pool, init_job_store
+        from .tenant_manager import ensure_cognee_user_tables
 
         try:
             logger.info("Starting knowledge base reset...")
@@ -1538,7 +1539,11 @@ class CogneeService:
             await init_job_store()
             logger.info("Re-initialized job store")
 
-            # Step 5: Direct cleanup of graph database
+            # Step 5: Re-initialize Cognee user/tenant tables (principals, users, etc.)
+            await ensure_cognee_user_tables()
+            logger.info("Re-initialized Cognee user tables")
+
+            # Step 6: Direct cleanup of graph database
             await self._cleanup_graph_database()
 
             # Reset initialized state so service re-initializes on next use


### PR DESCRIPTION
After dropping and recreating the tale_rag database, only the rag_jobs table was being re-initialized. The Cognee user/tenant tables (principals, users, data, etc.) were not recreated, causing "relation does not exist" errors on subsequent document operations.

Add ensure_cognee_user_tables() call after database reset to recreate all required Cognee schema tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reset process to ensure proper initialization of user and tenant data structures before cleaning up the database, enhancing data consistency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->