### PR TITLE
refactor: add useListPage hook for standardized list management

### DIFF
--- a/services/platform/app/features/customers/components/customers-table.tsx
+++ b/services/platform/app/features/customers/components/customers-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { usePaginatedQuery } from 'convex/react';
 import { Users } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
@@ -8,10 +7,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { CustomersActionMenu } from './customers-action-menu';
 import { useCustomersTableConfig } from '../hooks/use-customers-table-config';
 import { useT } from '@/lib/i18n/client';
-import {
-  filterByTextSearch,
-  filterByFields,
-} from '@/lib/utils/client-utils';
+import { useListPage } from '@/app/hooks/use-list-page';
 
 export interface CustomersTableProps {
   organizationId: string;
@@ -26,153 +22,76 @@ export function CustomersTable({ organizationId }: CustomersTableProps) {
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useCustomersTableConfig();
 
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [sourceFilter, setSourceFilter] = useState<string[]>([]);
-  const [localeFilter, setLocaleFilter] = useState<string[]>([]);
-  const [displayCount, setDisplayCount] = useState(pageSize);
-
-  const { results, status, loadMore, isLoading } = usePaginatedQuery(
+  const paginatedResult = usePaginatedQuery(
     api.customers.queries.listCustomers,
     { organizationId },
     { initialNumItems: pageSize },
   );
 
-  const processed = useMemo(() => {
-    if (!results) return [];
-
-    let data = [...results];
-
-    if (search) {
-      data = filterByTextSearch(data, search, ['name', 'email', 'externalId']);
-    }
-
-    const activeFilters: Array<{ field: keyof (typeof data)[0]; values: Set<string> }> = [];
-    if (statusFilter.length > 0) {
-      activeFilters.push({ field: 'status', values: new Set(statusFilter) });
-    }
-    if (sourceFilter.length > 0) {
-      activeFilters.push({ field: 'source', values: new Set(sourceFilter) });
-    }
-    if (localeFilter.length > 0) {
-      activeFilters.push({ field: 'locale', values: new Set(localeFilter) });
-    }
-
-    if (activeFilters.length > 0) {
-      data = filterByFields(data, activeFilters);
-    }
-
-    return data;
-  }, [results, search, statusFilter, sourceFilter, localeFilter]);
-
-  const displayedCustomers = useMemo(
-    () => processed.slice(0, displayCount),
-    [processed, displayCount],
-  );
-
-  const hasMore =
-    displayCount < processed.length ||
-    status === 'CanLoadMore' ||
-    status === 'LoadingMore';
-
-  const handleLoadMore = () => {
-    if (displayCount >= processed.length && status === 'CanLoadMore') {
-      loadMore(pageSize);
-    }
-    setDisplayCount((prev) => prev + pageSize);
-  };
-
-  const filterConfigs = useMemo(
-    () => [
-      {
-        key: 'status',
-        title: tTables('headers.status'),
-        options: [
-          { value: 'active', label: tCustomers('filter.status.active') },
-          { value: 'potential', label: tCustomers('filter.status.potential') },
-          { value: 'churned', label: tCustomers('filter.status.churned') },
-          { value: 'lost', label: tCustomers('filter.status.lost') },
-        ],
-        selectedValues: statusFilter,
-        onChange: (values: string[]) => {
-          setStatusFilter(values);
-          setDisplayCount(pageSize);
+  const list = useListPage({
+    dataSource: { type: 'paginated', ...paginatedResult },
+    pageSize,
+    search: {
+      fields: ['name', 'email', 'externalId'],
+      placeholder: searchPlaceholder,
+    },
+    filters: {
+      definitions: [
+        {
+          key: 'status',
+          title: tTables('headers.status'),
+          options: [
+            { value: 'active', label: tCustomers('filter.status.active') },
+            {
+              value: 'potential',
+              label: tCustomers('filter.status.potential'),
+            },
+            { value: 'churned', label: tCustomers('filter.status.churned') },
+            { value: 'lost', label: tCustomers('filter.status.lost') },
+          ],
         },
-      },
-      {
-        key: 'source',
-        title: tTables('headers.source'),
-        options: [
-          { value: 'manual_import', label: tCustomers('filter.source.manual') },
-          { value: 'file_upload', label: tCustomers('filter.source.upload') },
-          { value: 'circuly', label: tCustomers('filter.source.circuly') },
-        ],
-        selectedValues: sourceFilter,
-        onChange: (values: string[]) => {
-          setSourceFilter(values);
-          setDisplayCount(pageSize);
+        {
+          key: 'source',
+          title: tTables('headers.source'),
+          options: [
+            {
+              value: 'manual_import',
+              label: tCustomers('filter.source.manual'),
+            },
+            { value: 'file_upload', label: tCustomers('filter.source.upload') },
+            { value: 'circuly', label: tCustomers('filter.source.circuly') },
+          ],
         },
-      },
-      {
-        key: 'locale',
-        title: tTables('headers.locale'),
-        options: [
-          { value: 'en', label: tGlobal('languageCodes.en') },
-          { value: 'es', label: tGlobal('languageCodes.es') },
-          { value: 'fr', label: tGlobal('languageCodes.fr') },
-          { value: 'de', label: tGlobal('languageCodes.de') },
-          { value: 'it', label: tGlobal('languageCodes.it') },
-          { value: 'pt', label: tGlobal('languageCodes.pt') },
-          { value: 'nl', label: tGlobal('languageCodes.nl') },
-          { value: 'zh', label: tGlobal('languageCodes.zh') },
-        ],
-        selectedValues: localeFilter,
-        onChange: (values: string[]) => {
-          setLocaleFilter(values);
-          setDisplayCount(pageSize);
+        {
+          key: 'locale',
+          title: tTables('headers.locale'),
+          options: [
+            { value: 'en', label: tGlobal('languageCodes.en') },
+            { value: 'es', label: tGlobal('languageCodes.es') },
+            { value: 'fr', label: tGlobal('languageCodes.fr') },
+            { value: 'de', label: tGlobal('languageCodes.de') },
+            { value: 'it', label: tGlobal('languageCodes.it') },
+            { value: 'pt', label: tGlobal('languageCodes.pt') },
+            { value: 'nl', label: tGlobal('languageCodes.nl') },
+            { value: 'zh', label: tGlobal('languageCodes.zh') },
+          ],
+          grid: true,
         },
-        grid: true,
-      },
-    ],
-    [statusFilter, sourceFilter, localeFilter, pageSize, tTables, tCustomers, tGlobal],
-  );
-
-  const clearAll = () => {
-    setSearch('');
-    setStatusFilter([]);
-    setSourceFilter([]);
-    setLocaleFilter([]);
-    setDisplayCount(pageSize);
-  };
+      ],
+    },
+  });
 
   return (
     <DataTable
       columns={columns}
-      data={displayedCustomers}
-      getRowId={(row) => row._id}
       stickyLayout={stickyLayout}
-      search={{
-        value: search,
-        onChange: (value) => {
-          setSearch(value);
-          setDisplayCount(pageSize);
-        },
-        placeholder: searchPlaceholder,
-      }}
-      filters={filterConfigs}
-      onClearFilters={clearAll}
       actionMenu={<CustomersActionMenu organizationId={organizationId} />}
       emptyState={{
         icon: Users,
         title: tEmpty('customers.title'),
         description: tEmpty('customers.description'),
       }}
-      infiniteScroll={{
-        hasMore,
-        onLoadMore: handleLoadMore,
-        isLoadingMore: status === 'LoadingMore',
-        isInitialLoading: status === 'LoadingFirstPage',
-      }}
+      {...list.tableProps}
     />
   );
 }

--- a/services/platform/app/features/products/components/product-table.tsx
+++ b/services/platform/app/features/products/components/product-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { usePaginatedQuery } from 'convex/react';
 import { Package } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
@@ -8,10 +7,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { ProductsActionMenu } from './products-action-menu';
 import { useProductsTableConfig } from '../hooks/use-products-table-config';
 import { useT } from '@/lib/i18n/client';
-import {
-  filterByTextSearch,
-  filterByFields,
-} from '@/lib/utils/client-utils';
+import { useListPage } from '@/app/hooks/use-list-page';
 
 export interface ProductTableProps {
   organizationId: string;
@@ -25,106 +21,46 @@ export function ProductTable({ organizationId }: ProductTableProps) {
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useProductsTableConfig();
 
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [displayCount, setDisplayCount] = useState(pageSize);
-
-  const { results, status, loadMore, isLoading } = usePaginatedQuery(
+  const paginatedResult = usePaginatedQuery(
     api.products.queries.listProducts,
     { organizationId },
     { initialNumItems: pageSize },
   );
 
-  const processed = useMemo(() => {
-    if (!results) return [];
-
-    let data = [...results];
-
-    if (search) {
-      data = filterByTextSearch(data, search, ['name', 'description', 'category']);
-    }
-
-    if (statusFilter.length > 0) {
-      data = filterByFields(data, [
-        { field: 'status', values: new Set(statusFilter) },
-      ]);
-    }
-
-    return data;
-  }, [results, search, statusFilter]);
-
-  const displayedProducts = useMemo(
-    () => processed.slice(0, displayCount),
-    [processed, displayCount],
-  );
-
-  const hasMore =
-    displayCount < processed.length ||
-    status === 'CanLoadMore' ||
-    status === 'LoadingMore';
-
-  const handleLoadMore = () => {
-    if (displayCount >= processed.length && status === 'CanLoadMore') {
-      loadMore(pageSize);
-    }
-    setDisplayCount((prev) => prev + pageSize);
-  };
-
-  const filterConfigs = useMemo(
-    () => [
-      {
-        key: 'status',
-        title: tTables('headers.status'),
-        options: [
-          { value: 'active', label: tCommon('status.active') },
-          { value: 'inactive', label: tCommon('status.inactive') },
-          { value: 'draft', label: tCommon('status.draft') },
-          { value: 'archived', label: tCommon('status.archived') },
-        ],
-        selectedValues: statusFilter,
-        onChange: (values: string[]) => {
-          setStatusFilter(values);
-          setDisplayCount(pageSize);
+  const list = useListPage({
+    dataSource: { type: 'paginated', ...paginatedResult },
+    pageSize,
+    search: {
+      fields: ['name', 'description', 'category'],
+      placeholder: searchPlaceholder,
+    },
+    filters: {
+      definitions: [
+        {
+          key: 'status',
+          title: tTables('headers.status'),
+          options: [
+            { value: 'active', label: tCommon('status.active') },
+            { value: 'inactive', label: tCommon('status.inactive') },
+            { value: 'draft', label: tCommon('status.draft') },
+            { value: 'archived', label: tCommon('status.archived') },
+          ],
         },
-      },
-    ],
-    [statusFilter, tTables, tCommon, pageSize],
-  );
-
-  const clearAll = () => {
-    setSearch('');
-    setStatusFilter([]);
-    setDisplayCount(pageSize);
-  };
+      ],
+    },
+  });
 
   return (
     <DataTable
       columns={columns}
-      data={displayedProducts}
-      getRowId={(row) => row._id}
       stickyLayout={stickyLayout}
-      search={{
-        value: search,
-        onChange: (value) => {
-          setSearch(value);
-          setDisplayCount(pageSize);
-        },
-        placeholder: searchPlaceholder,
-      }}
-      filters={filterConfigs}
-      onClearFilters={clearAll}
       actionMenu={<ProductsActionMenu organizationId={organizationId} />}
       emptyState={{
         icon: Package,
         title: tProducts('emptyState.title'),
         description: tProducts('emptyState.description'),
       }}
-      infiniteScroll={{
-        hasMore,
-        onLoadMore: handleLoadMore,
-        isLoadingMore: status === 'LoadingMore',
-        isInitialLoading: status === 'LoadingFirstPage',
-      }}
+      {...list.tableProps}
     />
   );
 }

--- a/services/platform/app/features/vendors/components/vendors-table.tsx
+++ b/services/platform/app/features/vendors/components/vendors-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { usePaginatedQuery } from 'convex/react';
 import { Store } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
@@ -8,10 +7,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { VendorsActionMenu } from './vendors-action-menu';
 import { useVendorsTableConfig } from '../hooks/use-vendors-table-config';
 import { useT } from '@/lib/i18n/client';
-import {
-  filterByTextSearch,
-  filterByFields,
-} from '@/lib/utils/client-utils';
+import { useListPage } from '@/app/hooks/use-list-page';
 
 export interface VendorsTableProps {
   organizationId: string;
@@ -25,133 +21,60 @@ export function VendorsTable({ organizationId }: VendorsTableProps) {
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useVendorsTableConfig();
 
-  const [search, setSearch] = useState('');
-  const [sourceFilter, setSourceFilter] = useState<string[]>([]);
-  const [localeFilter, setLocaleFilter] = useState<string[]>([]);
-  const [displayCount, setDisplayCount] = useState(pageSize);
-
-  const { results, status, loadMore, isLoading } = usePaginatedQuery(
+  const paginatedResult = usePaginatedQuery(
     api.vendors.queries.listVendors,
     { organizationId },
     { initialNumItems: pageSize },
   );
 
-  const processed = useMemo(() => {
-    if (!results) return [];
-
-    let data = [...results];
-
-    if (search) {
-      data = filterByTextSearch(data, search, ['name', 'email', 'externalId']);
-    }
-
-    const activeFilters: Array<{ field: keyof (typeof data)[0]; values: Set<string> }> = [];
-    if (sourceFilter.length > 0) {
-      activeFilters.push({ field: 'source', values: new Set(sourceFilter) });
-    }
-    if (localeFilter.length > 0) {
-      activeFilters.push({ field: 'locale', values: new Set(localeFilter) });
-    }
-
-    if (activeFilters.length > 0) {
-      data = filterByFields(data, activeFilters);
-    }
-
-    return data;
-  }, [results, search, sourceFilter, localeFilter]);
-
-  const displayedVendors = useMemo(
-    () => processed.slice(0, displayCount),
-    [processed, displayCount],
-  );
-
-  const hasMore =
-    displayCount < processed.length ||
-    status === 'CanLoadMore' ||
-    status === 'LoadingMore';
-
-  const handleLoadMore = () => {
-    if (displayCount >= processed.length && status === 'CanLoadMore') {
-      loadMore(pageSize);
-    }
-    setDisplayCount((prev) => prev + pageSize);
-  };
-
-  const filterConfigs = useMemo(
-    () => [
-      {
-        key: 'source',
-        title: tTables('headers.source'),
-        options: [
-          { value: 'manual_import', label: tVendors('filter.source.manual') },
-          { value: 'file_upload', label: tVendors('filter.source.upload') },
-          { value: 'circuly', label: tVendors('filter.source.circuly') },
-        ],
-        selectedValues: sourceFilter,
-        onChange: (values: string[]) => {
-          setSourceFilter(values);
-          setDisplayCount(pageSize);
+  const list = useListPage({
+    dataSource: { type: 'paginated', ...paginatedResult },
+    pageSize,
+    search: {
+      fields: ['name', 'email', 'externalId'],
+      placeholder: searchPlaceholder,
+    },
+    filters: {
+      definitions: [
+        {
+          key: 'source',
+          title: tTables('headers.source'),
+          options: [
+            { value: 'manual_import', label: tVendors('filter.source.manual') },
+            { value: 'file_upload', label: tVendors('filter.source.upload') },
+            { value: 'circuly', label: tVendors('filter.source.circuly') },
+          ],
         },
-      },
-      {
-        key: 'locale',
-        title: tTables('headers.locale'),
-        options: [
-          { value: 'en', label: tGlobal('languageCodes.en') },
-          { value: 'es', label: tGlobal('languageCodes.es') },
-          { value: 'fr', label: tGlobal('languageCodes.fr') },
-          { value: 'de', label: tGlobal('languageCodes.de') },
-          { value: 'it', label: tGlobal('languageCodes.it') },
-          { value: 'pt', label: tGlobal('languageCodes.pt') },
-          { value: 'nl', label: tGlobal('languageCodes.nl') },
-          { value: 'zh', label: tGlobal('languageCodes.zh') },
-        ],
-        selectedValues: localeFilter,
-        onChange: (values: string[]) => {
-          setLocaleFilter(values);
-          setDisplayCount(pageSize);
+        {
+          key: 'locale',
+          title: tTables('headers.locale'),
+          options: [
+            { value: 'en', label: tGlobal('languageCodes.en') },
+            { value: 'es', label: tGlobal('languageCodes.es') },
+            { value: 'fr', label: tGlobal('languageCodes.fr') },
+            { value: 'de', label: tGlobal('languageCodes.de') },
+            { value: 'it', label: tGlobal('languageCodes.it') },
+            { value: 'pt', label: tGlobal('languageCodes.pt') },
+            { value: 'nl', label: tGlobal('languageCodes.nl') },
+            { value: 'zh', label: tGlobal('languageCodes.zh') },
+          ],
+          grid: true,
         },
-        grid: true,
-      },
-    ],
-    [sourceFilter, localeFilter, pageSize, tTables, tVendors, tGlobal],
-  );
-
-  const clearAll = () => {
-    setSearch('');
-    setSourceFilter([]);
-    setLocaleFilter([]);
-    setDisplayCount(pageSize);
-  };
+      ],
+    },
+  });
 
   return (
     <DataTable
       columns={columns}
-      data={displayedVendors}
-      getRowId={(row) => row._id}
       stickyLayout={stickyLayout}
-      search={{
-        value: search,
-        onChange: (value) => {
-          setSearch(value);
-          setDisplayCount(pageSize);
-        },
-        placeholder: searchPlaceholder,
-      }}
-      filters={filterConfigs}
-      onClearFilters={clearAll}
       actionMenu={<VendorsActionMenu organizationId={organizationId} />}
       emptyState={{
         icon: Store,
         title: tVendors('noVendorsYet'),
         description: tVendors('uploadFirstVendor'),
       }}
-      infiniteScroll={{
-        hasMore,
-        onLoadMore: handleLoadMore,
-        isLoadingMore: status === 'LoadingMore',
-        isInitialLoading: status === 'LoadingFirstPage',
-      }}
+      {...list.tableProps}
     />
   );
 }

--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { usePaginatedQuery } from 'convex/react';
 import { Globe } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
@@ -8,10 +7,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { WebsitesActionMenu } from './websites-action-menu';
 import { useWebsitesTableConfig } from '../hooks/use-websites-table-config';
 import { useT } from '@/lib/i18n/client';
-import {
-  filterByTextSearch,
-  filterByFields,
-} from '@/lib/utils/client-utils';
+import { useListPage } from '@/app/hooks/use-list-page';
 
 export interface WebsitesTableProps {
   organizationId: string;
@@ -25,105 +21,45 @@ export function WebsitesTable({ organizationId }: WebsitesTableProps) {
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useWebsitesTableConfig();
 
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [displayCount, setDisplayCount] = useState(pageSize);
-
-  const { results, status, loadMore, isLoading } = usePaginatedQuery(
+  const paginatedResult = usePaginatedQuery(
     api.websites.queries.listWebsites,
     { organizationId },
     { initialNumItems: pageSize },
   );
 
-  const processed = useMemo(() => {
-    if (!results) return [];
-
-    let data = [...results];
-
-    if (search) {
-      data = filterByTextSearch(data, search, ['domain', 'title', 'description']);
-    }
-
-    if (statusFilter.length > 0) {
-      data = filterByFields(data, [
-        { field: 'status', values: new Set(statusFilter) },
-      ]);
-    }
-
-    return data;
-  }, [results, search, statusFilter]);
-
-  const displayedWebsites = useMemo(
-    () => processed.slice(0, displayCount),
-    [processed, displayCount],
-  );
-
-  const hasMore =
-    displayCount < processed.length ||
-    status === 'CanLoadMore' ||
-    status === 'LoadingMore';
-
-  const handleLoadMore = () => {
-    if (displayCount >= processed.length && status === 'CanLoadMore') {
-      loadMore(pageSize);
-    }
-    setDisplayCount((prev) => prev + pageSize);
-  };
-
-  const filterConfigs = useMemo(
-    () => [
-      {
-        key: 'status',
-        title: tTables('headers.status'),
-        options: [
-          { value: 'active', label: tWebsites('filter.status.active') },
-          { value: 'scanning', label: tWebsites('filter.status.scanning') },
-          { value: 'error', label: tWebsites('filter.status.error') },
-        ],
-        selectedValues: statusFilter,
-        onChange: (values: string[]) => {
-          setStatusFilter(values);
-          setDisplayCount(pageSize);
+  const list = useListPage({
+    dataSource: { type: 'paginated', ...paginatedResult },
+    pageSize,
+    search: {
+      fields: ['domain', 'title', 'description'],
+      placeholder: searchPlaceholder,
+    },
+    filters: {
+      definitions: [
+        {
+          key: 'status',
+          title: tTables('headers.status'),
+          options: [
+            { value: 'active', label: tWebsites('filter.status.active') },
+            { value: 'scanning', label: tWebsites('filter.status.scanning') },
+            { value: 'error', label: tWebsites('filter.status.error') },
+          ],
         },
-      },
-    ],
-    [statusFilter, pageSize, tTables, tWebsites],
-  );
-
-  const clearAll = () => {
-    setSearch('');
-    setStatusFilter([]);
-    setDisplayCount(pageSize);
-  };
+      ],
+    },
+  });
 
   return (
     <DataTable
       columns={columns}
-      data={displayedWebsites}
-      getRowId={(row) => row._id}
       stickyLayout={stickyLayout}
-      search={{
-        value: search,
-        onChange: (value) => {
-          setSearch(value);
-          setDisplayCount(pageSize);
-        },
-        placeholder: searchPlaceholder,
-      }}
-      filters={filterConfigs}
-      onClearFilters={clearAll}
       actionMenu={<WebsitesActionMenu organizationId={organizationId} />}
       emptyState={{
         icon: Globe,
         title: tEmpty('websites.title'),
         description: tEmpty('websites.description'),
       }}
-      infiniteScroll={{
-        hasMore,
-        onLoadMore: handleLoadMore,
-        isLoadingMore: status === 'LoadingMore',
-        isInitialLoading: status === 'LoadingFirstPage',
-      }}
+      {...list.tableProps}
     />
   );
 }

--- a/services/platform/app/hooks/use-list-page.ts
+++ b/services/platform/app/hooks/use-list-page.ts
@@ -1,0 +1,327 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import { filterByTextSearch, filterByFields } from '@/lib/utils/client-utils';
+import type { FilterConfig } from '@/app/components/ui/data-table/data-table-filters';
+import type { DataTableSearchConfig } from '@/app/components/ui/data-table/use-data-table';
+
+// ---------------------------------------------------------------------------
+// Data Source Types
+// ---------------------------------------------------------------------------
+
+interface PaginatedDataSource<TData> {
+  type: 'paginated';
+  results: TData[] | undefined;
+  status: 'LoadingFirstPage' | 'CanLoadMore' | 'LoadingMore' | 'Exhausted';
+  loadMore: (numItems: number) => void;
+  isLoading: boolean;
+}
+
+interface QueryDataSource<TData> {
+  type: 'query';
+  data: TData[] | undefined;
+}
+
+type DataSource<TData> = PaginatedDataSource<TData> | QueryDataSource<TData>;
+
+// ---------------------------------------------------------------------------
+// Filter Definition (for managed filters)
+// ---------------------------------------------------------------------------
+
+interface ListFilterDefinition {
+  key: string;
+  title: string;
+  options: Array<{ value: string; label: string }>;
+  grid?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Search Configuration
+// ---------------------------------------------------------------------------
+
+interface ManagedSearch<TData> {
+  fields: (keyof TData & string)[];
+  placeholder?: string;
+}
+
+interface ControlledSearch {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Filter Configuration
+// ---------------------------------------------------------------------------
+
+interface ManagedFilters {
+  definitions: ListFilterDefinition[];
+}
+
+interface ControlledFilters {
+  configs: FilterConfig[];
+  onClear: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook Options
+// ---------------------------------------------------------------------------
+
+interface UseListPageOptions<TData> {
+  dataSource: DataSource<TData>;
+  pageSize: number;
+  search?: ManagedSearch<TData> | ControlledSearch;
+  filters?: ManagedFilters | ControlledFilters;
+  getRowId?: (row: TData) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook Return Type
+// ---------------------------------------------------------------------------
+
+interface ListPageTableProps<TData> {
+  data: TData[];
+  search?: DataTableSearchConfig;
+  filters?: FilterConfig[];
+  onClearFilters?: () => void;
+  getRowId: (row: TData) => string;
+  infiniteScroll: {
+    hasMore: boolean;
+    onLoadMore: () => void;
+    isLoadingMore: boolean;
+    isInitialLoading: boolean;
+  };
+}
+
+interface UseListPageReturn<TData> {
+  tableProps: ListPageTableProps<TData>;
+  processedData: TData[];
+  totalCount: number;
+  filteredCount: number;
+  isLoading: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+function isManagedSearch<TData>(
+  search: ManagedSearch<TData> | ControlledSearch,
+): search is ManagedSearch<TData> {
+  return 'fields' in search;
+}
+
+function isControlledFilters(
+  filters: ManagedFilters | ControlledFilters,
+): filters is ControlledFilters {
+  return 'configs' in filters;
+}
+
+// ---------------------------------------------------------------------------
+// Hook Implementation
+// ---------------------------------------------------------------------------
+
+export function useListPage<TData>(
+  options: UseListPageOptions<TData>,
+): UseListPageReturn<TData> {
+  const { dataSource, pageSize, search, filters, getRowId } = options;
+
+  // 1. Normalize data source
+  const rawData =
+    dataSource.type === 'paginated'
+      ? (dataSource.results ?? [])
+      : (dataSource.data ?? []);
+
+  const isLoading =
+    dataSource.type === 'paginated'
+      ? dataSource.status === 'LoadingFirstPage'
+      : dataSource.data === undefined;
+
+  // 2. Managed search state
+  const [managedSearchValue, setManagedSearchValue] = useState('');
+
+  // 3. Managed filter states (single object for all filters)
+  const [managedFilterStates, setManagedFilterStates] = useState<
+    Record<string, string[]>
+  >({});
+
+  // 4. Display count
+  const [displayCount, setDisplayCount] = useState(pageSize);
+
+  // Determine actual search value
+  const searchValue =
+    search && isManagedSearch(search) ? managedSearchValue : '';
+
+  // Determine actual filter values (only for managed mode)
+  const filterValues =
+    filters && !isControlledFilters(filters) ? managedFilterStates : null;
+
+  // 5. Process data (search + filters)
+  const processed = useMemo(() => {
+    let data = [...rawData];
+
+    // Apply managed text search
+    if (search && isManagedSearch<TData>(search) && searchValue) {
+      data = filterByTextSearch(
+        data,
+        searchValue,
+        search.fields as (keyof TData)[],
+      );
+    }
+
+    // Apply managed field filters
+    if (filterValues) {
+      const activeFilters = Object.entries(filterValues)
+        .filter(([, values]) => values.length > 0)
+        .map(([field, values]) => ({
+          field: field as keyof TData,
+          values: new Set(values),
+        }));
+
+      if (activeFilters.length > 0) {
+        data = filterByFields(data, activeFilters);
+      }
+    }
+
+    return data;
+  }, [rawData, searchValue, filterValues, search]);
+
+  // 6. Slice for display
+  const displayed = useMemo(
+    () => processed.slice(0, displayCount),
+    [processed, displayCount],
+  );
+
+  // 7. Compute hasMore
+  const hasMore =
+    dataSource.type === 'paginated'
+      ? displayCount < processed.length ||
+        dataSource.status === 'CanLoadMore' ||
+        dataSource.status === 'LoadingMore'
+      : displayCount < processed.length;
+
+  // 8. Reset displayCount helper
+  const resetDisplayCount = useCallback(() => {
+    setDisplayCount(pageSize);
+  }, [pageSize]);
+
+  // 9. handleLoadMore
+  const handleLoadMore = useCallback(() => {
+    if (dataSource.type === 'paginated') {
+      if (
+        displayCount >= processed.length &&
+        dataSource.status === 'CanLoadMore'
+      ) {
+        dataSource.loadMore(pageSize);
+      }
+    }
+    setDisplayCount((prev) => prev + pageSize);
+  }, [dataSource, displayCount, processed.length, pageSize]);
+
+  // 10. Build search config
+  const searchConfig = useMemo((): DataTableSearchConfig | undefined => {
+    if (!search) return undefined;
+
+    if (isManagedSearch<TData>(search)) {
+      return {
+        value: managedSearchValue,
+        onChange: (value: string) => {
+          setManagedSearchValue(value);
+          resetDisplayCount();
+        },
+        placeholder: search.placeholder,
+      };
+    }
+
+    return {
+      value: search.value,
+      onChange: (value: string) => {
+        search.onChange(value);
+        resetDisplayCount();
+      },
+      placeholder: search.placeholder,
+    };
+  }, [search, managedSearchValue, resetDisplayCount]);
+
+  // 11. Build filter configs
+  const filterConfigs = useMemo((): FilterConfig[] | undefined => {
+    if (!filters) return undefined;
+
+    if (isControlledFilters(filters)) {
+      return filters.configs;
+    }
+
+    return filters.definitions.map((def) => ({
+      key: def.key,
+      title: def.title,
+      options: def.options,
+      grid: def.grid,
+      selectedValues: managedFilterStates[def.key] ?? [],
+      onChange: (values: string[]) => {
+        setManagedFilterStates((prev) => ({ ...prev, [def.key]: values }));
+        resetDisplayCount();
+      },
+    }));
+  }, [filters, managedFilterStates, resetDisplayCount]);
+
+  // 12. Build clearAll
+  const clearAll = useCallback(() => {
+    if (search && isManagedSearch(search)) {
+      setManagedSearchValue('');
+    }
+    if (filters && !isControlledFilters(filters)) {
+      setManagedFilterStates({});
+    }
+    if (filters && isControlledFilters(filters)) {
+      filters.onClear();
+    }
+    resetDisplayCount();
+  }, [search, filters, resetDisplayCount]);
+
+  // 13. Determine onClearFilters
+  const onClearFilters =
+    filters || (search && isManagedSearch(search)) ? clearAll : undefined;
+
+  // 14. Build getRowId
+  const rowIdFn = getRowId ?? ((row: TData) => (row as { _id: string })._id);
+
+  return {
+    tableProps: {
+      data: displayed,
+      search: searchConfig,
+      filters: filterConfigs,
+      onClearFilters,
+      getRowId: rowIdFn,
+      infiniteScroll: {
+        hasMore,
+        onLoadMore: handleLoadMore,
+        isLoadingMore:
+          dataSource.type === 'paginated'
+            ? dataSource.status === 'LoadingMore'
+            : false,
+        isInitialLoading:
+          dataSource.type === 'paginated'
+            ? dataSource.status === 'LoadingFirstPage'
+            : false,
+      },
+    },
+    processedData: processed,
+    totalCount: rawData.length,
+    filteredCount: processed.length,
+    isLoading,
+  };
+}
+
+export type {
+  UseListPageOptions,
+  UseListPageReturn,
+  ListPageTableProps,
+  PaginatedDataSource,
+  QueryDataSource,
+  DataSource,
+  ListFilterDefinition,
+  ManagedSearch,
+  ControlledSearch,
+  ManagedFilters,
+  ControlledFilters,
+};

--- a/services/platform/types/documents.ts
+++ b/services/platform/types/documents.ts
@@ -1,5 +1,12 @@
 /** RAG ingestion status for a document */
-export type RagStatus = 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'not_indexed' | 'stale';
+export type RagStatus =
+  | 'pending'
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'not_indexed'
+  | 'stale';
 
 export interface DocumentItem {
   id: string;
@@ -7,7 +14,7 @@ export interface DocumentItem {
   type: 'file' | 'folder';
   size?: number;
   storagePath?: string;
-  sourceProvider?: 'onedrive' | 'upload';
+  sourceProvider?: 'onedrive' | 'upload' | 'sharepoint';
   sourceMode?: 'auto' | 'manual';
   lastModified?: number;
   syncConfigId?: string;


### PR DESCRIPTION
## Summary
- Introduces a new `useListPage` hook that centralizes data source handling, client-side search/filtering, pagination, and infinite scroll logic into a single reusable abstraction
- Migrates all list/table components (approvals, automations, executions, customers, documents, products, vendors, websites) to use the new hook, replacing duplicated boilerplate
- Adds `onRowClick` and `rowClassName` props to `DataTable` for row-level interaction support

## Test plan
- [ ] Verify infinite scroll and pagination work across all migrated tables
- [ ] Verify client-side search filtering works on each table
- [ ] Verify managed and controlled filter modes work correctly
- [ ] Test documents table: folder navigation, file preview, and row click behavior
- [ ] Confirm no regressions in approval, automation, and execution list views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SharePoint as a document source provider alongside existing options
  * Enhanced document properties with creator details, RAG indexing status, error tracking, and team tags for improved document management

* **Improvements**
  * Consolidated pagination, search, and filtering across multiple data tables (approvals, automations, executions, customers, documents, products, vendors, websites) for a consistent user experience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->