### PR TITLE
perf(convex): deduplicate auth fetches in RLS helpers

### DIFF
--- a/services/platform/convex/lib/rls/helpers/mutation_with_rls.ts
+++ b/services/platform/convex/lib/rls/helpers/mutation_with_rls.ts
@@ -33,9 +33,12 @@ const rlsConfig: RLSConfig = {
 export const mutationWithRLS = customMutation(
   mutation,
   customCtx(async (ctx: MutationCtx) => {
-    const rules = await rlsRules(ctx);
+    // Fetch auth data ONCE to avoid duplicate queries
     const user = await getAuthenticatedUser(ctx);
     const userOrganizations = user ? await getUserOrganizations(ctx, user) : [];
+
+    // Pass pre-fetched data to rlsRules to avoid duplicate fetches
+    const rules = await rlsRules(ctx, { user, userOrganizations });
 
     return {
       db: wrapDatabaseWriter<

--- a/services/platform/convex/lib/rls/helpers/query_with_rls.ts
+++ b/services/platform/convex/lib/rls/helpers/query_with_rls.ts
@@ -30,9 +30,12 @@ const rlsConfig: RLSConfig = {
 export const queryWithRLS = customQuery(
   query,
   customCtx(async (ctx: QueryCtx) => {
-    const rules = await rlsRules(ctx);
+    // Fetch auth data ONCE to avoid duplicate queries
     const user = await getAuthenticatedUser(ctx);
     const userOrganizations = user ? await getUserOrganizations(ctx, user) : [];
+
+    // Pass pre-fetched data to rlsRules to avoid duplicate fetches
+    const rules = await rlsRules(ctx, { user, userOrganizations });
 
     return {
       db: wrapDatabaseReader<


### PR DESCRIPTION
## Summary
- Fetches `user` and `userOrganizations` once in `mutationWithRLS`/`queryWithRLS` wrappers
- Passes pre-fetched data to `rlsRules()` via optional `prefetchedData` parameter
- Eliminates redundant `getAuthenticatedUser()` and `getUserOrganizations()` calls on every RLS-wrapped query/mutation

## Test plan
- [ ] Verify existing RLS-protected queries/mutations still work correctly
- [ ] Confirm no duplicate auth fetches in Convex function logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication data fetching by pre-fetching user and organization information once and reusing it across related operations, eliminating redundant database calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->