### PR TITLE
feat(platform): custom agents empty state, skeleton, and toggle improvements

### DIFF
--- a/services/platform/app/features/custom-agents/components/custom-agent-active-toggle.test.tsx
+++ b/services/platform/app/features/custom-agents/components/custom-agent-active-toggle.test.tsx
@@ -8,12 +8,17 @@ import { render, screen, waitFor } from '@/test/utils/render';
 import { CustomAgentActiveToggle } from './custom-agent-active-toggle';
 
 const mockActivateVersion = vi.fn();
+const mockPublish = vi.fn();
 const mockUnpublish = vi.fn();
 
 vi.mock('../hooks/mutations', async (importOriginal) => ({
   ...(await importOriginal()),
   useActivateCustomAgentVersion: () => ({
     mutateAsync: mockActivateVersion,
+    isPending: false,
+  }),
+  usePublishCustomAgent: () => ({
+    mutateAsync: mockPublish,
     isPending: false,
   }),
   useUnpublishCustomAgent: () => ({
@@ -52,6 +57,7 @@ describe('CustomAgentActiveToggle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockActivateVersion.mockResolvedValue(null);
+    mockPublish.mockResolvedValue(null);
     mockUnpublish.mockResolvedValue(null);
   });
 
@@ -70,12 +76,24 @@ describe('CustomAgentActiveToggle', () => {
       expect(toggle).toHaveAttribute('data-state', 'unchecked');
     });
 
-    it('renders disabled switch when agent is draft', () => {
+    it('renders disabled switch when agent is an unpublished draft', () => {
       render(
-        <CustomAgentActiveToggle agent={createAgent({ status: 'draft' })} />,
+        <CustomAgentActiveToggle
+          agent={createAgent({ status: 'draft', versionNumber: 1 })}
+        />,
       );
       const toggle = screen.getByRole('switch');
       expect(toggle).toBeDisabled();
+    });
+
+    it('renders enabled switch when agent is a draft with published versions', () => {
+      render(
+        <CustomAgentActiveToggle
+          agent={createAgent({ status: 'draft', versionNumber: 2 })}
+        />,
+      );
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toBeEnabled();
     });
 
     it('renders with label when provided', () => {
@@ -99,6 +117,23 @@ describe('CustomAgentActiveToggle', () => {
           customAgentId: 'agent-root-1',
           targetVersion: 2,
         });
+      });
+    });
+
+    it('calls publishCustomAgent when toggling on a draft with published versions', async () => {
+      const { user } = render(
+        <CustomAgentActiveToggle
+          agent={createAgent({ status: 'draft', versionNumber: 2 })}
+        />,
+      );
+
+      await user.click(screen.getByRole('switch'));
+
+      await waitFor(() => {
+        expect(mockPublish).toHaveBeenCalledWith({
+          customAgentId: 'agent-root-1',
+        });
+        expect(mockActivateVersion).not.toHaveBeenCalled();
       });
     });
 
@@ -136,14 +171,17 @@ describe('CustomAgentActiveToggle', () => {
       });
     });
 
-    it('does not toggle when draft agent is clicked', async () => {
+    it('does not toggle when unpublished draft agent is clicked', async () => {
       const { user } = render(
-        <CustomAgentActiveToggle agent={createAgent({ status: 'draft' })} />,
+        <CustomAgentActiveToggle
+          agent={createAgent({ status: 'draft', versionNumber: 1 })}
+        />,
       );
 
       await user.click(screen.getByRole('switch'));
 
       expect(mockActivateVersion).not.toHaveBeenCalled();
+      expect(mockPublish).not.toHaveBeenCalled();
       expect(mockUnpublish).not.toHaveBeenCalled();
     });
   });

--- a/services/platform/app/features/custom-agents/components/custom-agents-empty-state.tsx
+++ b/services/platform/app/features/custom-agents/components/custom-agents-empty-state.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Bot } from 'lucide-react';
+
+import { DataTableEmptyState } from '@/app/components/ui/data-table/data-table-empty-state';
+import { useT } from '@/lib/i18n/client';
+
+import { CustomAgentsActionMenu } from './custom-agents-action-menu';
+
+interface CustomAgentsEmptyStateProps {
+  organizationId: string;
+}
+
+export function CustomAgentsEmptyState({
+  organizationId,
+}: CustomAgentsEmptyStateProps) {
+  const { t } = useT('emptyStates');
+
+  return (
+    <DataTableEmptyState
+      icon={Bot}
+      title={t('customAgents.title')}
+      description={t('customAgents.description')}
+      actionMenu={<CustomAgentsActionMenu organizationId={organizationId} />}
+    />
+  );
+}

--- a/services/platform/app/features/custom-agents/components/custom-agents-table-skeleton.tsx
+++ b/services/platform/app/features/custom-agents/components/custom-agents-table-skeleton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { DataTableSkeleton } from '@/app/components/ui/data-table/data-table-skeleton';
+import { useT } from '@/lib/i18n/client';
+
+import { CustomAgentsActionMenu } from './custom-agents-action-menu';
+
+interface CustomAgentsTableSkeletonProps {
+  organizationId: string;
+}
+
+export function CustomAgentsTableSkeleton({
+  organizationId,
+}: CustomAgentsTableSkeletonProps) {
+  const { t } = useT('settings');
+
+  return (
+    <DataTableSkeleton
+      className="px-4 py-6"
+      columns={[
+        { size: 250 },
+        { size: 140 },
+        { size: 80 },
+        { size: 200 },
+        { size: 100 },
+        { size: 140 },
+        { size: 80 },
+      ]}
+      noFirstColumnAvatar
+      searchPlaceholder={t('customAgents.searchAgent')}
+      actionMenu={<CustomAgentsActionMenu organizationId={organizationId} />}
+      infiniteScroll
+    />
+  );
+}

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -21,7 +21,7 @@ function AutomationsEmptyState({ organizationId }: { organizationId: string }) {
   const { t: tAutomations } = useT('automations');
 
   return (
-    <ContentWrapper>
+    <ContentWrapper className="p-4">
       <DataTableEmptyState
         icon={Workflow}
         title={tEmpty('automations.title')}

--- a/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { ContentWrapper } from '@/app/components/layout/content-wrapper';
 import { CustomAgentTable } from '@/app/features/custom-agents/components/custom-agent-table';
+import { CustomAgentsEmptyState } from '@/app/features/custom-agents/components/custom-agents-empty-state';
+import { CustomAgentsTableSkeleton } from '@/app/features/custom-agents/components/custom-agents-table-skeleton';
 import { useCustomAgentCollection } from '@/app/features/custom-agents/hooks/collections';
 import { useCustomAgents } from '@/app/features/custom-agents/hooks/queries';
 
@@ -13,6 +15,22 @@ function CustomAgentsIndexPage() {
   const { id: organizationId } = Route.useParams();
   const customAgentCollection = useCustomAgentCollection(organizationId);
   const { agents, isLoading } = useCustomAgents(customAgentCollection);
+
+  if (isLoading) {
+    return (
+      <ContentWrapper>
+        <CustomAgentsTableSkeleton organizationId={organizationId} />
+      </ContentWrapper>
+    );
+  }
+
+  if (agents && agents.length === 0) {
+    return (
+      <ContentWrapper className="p-4">
+        <CustomAgentsEmptyState organizationId={organizationId} />
+      </ContentWrapper>
+    );
+  }
 
   return (
     <ContentWrapper>

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -267,6 +267,10 @@
       "title": "No automations yet",
       "description": "Describe your workflow and let your AI automate it"
     },
+    "customAgents": {
+      "title": "No custom agents yet",
+      "description": "Create your first custom agent to specialize AI behavior for your team"
+    },
     "examples": {
       "title": "No examples yet",
       "description": "Add example messages to train the AI on your tone"
@@ -1532,7 +1536,8 @@
       "namePlaceholder": "e.g., Social media workflow",
       "descriptionPlaceholder": "Describe what this automation does...",
       "creating": "Creating...",
-      "continue": "Continue"
+      "continue": "Continue",
+      "initialPrompt": "I just created a new automation called \"{name}\". Here is what it should do:\n\n{description}\n\nPlease help me build the workflow steps for this automation."
     },
     "editDialog": {
       "title": "Edit automation",
@@ -2543,7 +2548,7 @@
     },
     "editVendor": "Edit vendor",
     "deleteVendor": "Delete vendor",
-    "viewDetails": "View vendor details",
+    "viewDetails": "View details",
     "importMenu": {
       "importVendors": "Import vendors",
       "fromDevice": "From your device",


### PR DESCRIPTION
## Summary
- Add empty state and loading skeleton for the custom agents page
- Improve active toggle to handle draft agents with published versions (re-publish instead of activate)
- Auto-initialize AI assistant thread when creating automations with a description
- Minor UI fixes (automations empty state padding, vendor details label)

## Test plan
- [ ] Verify custom agents page shows skeleton while loading
- [ ] Verify custom agents page shows empty state when no agents exist
- [ ] Verify toggling a draft agent with prior published versions calls publish
- [ ] Verify creating an automation with a description initializes an AI thread
- [ ] Run existing custom agent toggle tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-assisted workflow creation automatically triggered after setting up new automations with thread collaboration
  * Draft custom agents can now be published directly
  * Enhanced custom agents section with loading states and empty-state messaging

* **UI/UX Improvements**
  * Updated UI labels for consistency and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->