### PR TITLE
feat(platform): UI polish and workflow validation fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -167,7 +167,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -181,7 +181,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -191,7 +191,7 @@
       "version": "6.7.8",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
       "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -205,7 +205,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -215,7 +215,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@azure-rest/core-client": {
@@ -2994,7 +2994,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
       "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3014,7 +3014,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
       "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3038,7 +3038,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
       "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3066,7 +3066,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3089,7 +3089,7 @@
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
       "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3106,7 +3106,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3579,7 +3579,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
       "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -12775,7 +12775,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -14425,7 +14425,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -14445,7 +14445,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -14461,7 +14461,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -14694,7 +14694,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -16771,7 +16771,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -17618,7 +17618,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -17998,7 +17998,7 @@
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
@@ -18038,7 +18038,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -18048,7 +18048,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -19325,7 +19325,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -20888,7 +20888,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -20901,7 +20901,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -21612,7 +21612,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22630,7 +22630,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22956,7 +22956,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -24072,7 +24072,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tabbable": {
@@ -24294,7 +24294,7 @@
       "version": "7.0.22",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
       "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.22"
@@ -24307,7 +24307,7 @@
       "version": "7.0.22",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
       "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -24385,7 +24385,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -24398,7 +24398,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -24827,7 +24827,7 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
       "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -25528,7 +25528,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -25587,7 +25587,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -25612,7 +25612,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -25622,7 +25622,7 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
       "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -26327,7 +26327,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -26346,7 +26346,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -58,13 +58,11 @@ export function UserButton({
   onNavigate,
 }: UserButtonProps) {
   const { t } = useT('auth');
-  const { t: tNav } = useT('navigation');
   const { user, signOut, isLoading: loading } = useAuth();
   const navigate = useNavigate();
   const params = useParams({ strict: false });
   const organizationId = params.id;
   const { theme, setTheme } = useTheme();
-  const { teams, selectedTeamId, setSelectedTeamId } = useTeamFilter();
 
   const { data: memberContext } = useCurrentMemberContext(
     organizationId,
@@ -176,29 +174,7 @@ export function UserButton({
               <span>{t('userButton.settings')}</span>
             </DropdownMenuItem>
 
-            {teams && teams.length > 0 && (
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger className="py-2.5">
-                  <Building2 className="mr-3 size-4" />
-                  <span>{tNav('teamFilter.label')}</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent>
-                  <DropdownMenuRadioGroup
-                    value={selectedTeamId ?? ''}
-                    onValueChange={(val) => setSelectedTeamId(val || null)}
-                  >
-                    <DropdownMenuRadioItem value="">
-                      {tNav('teamFilter.allTeams')}
-                    </DropdownMenuRadioItem>
-                    {teams.map((team) => (
-                      <DropdownMenuRadioItem key={team.id} value={team.id}>
-                        {team.name}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
-            )}
+            <TeamFilterMenu />
 
             <DropdownMenuSeparator />
           </>
@@ -256,5 +232,36 @@ export function UserButton({
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function TeamFilterMenu() {
+  const { t } = useT('navigation');
+  const { teams, selectedTeamId, setSelectedTeamId } = useTeamFilter();
+
+  if (!teams || teams.length === 0) return null;
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="py-2.5">
+        <Building2 className="mr-3 size-4" />
+        <span>{t('teamFilter.label')}</span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>
+        <DropdownMenuRadioGroup
+          value={selectedTeamId ?? ''}
+          onValueChange={(val) => setSelectedTeamId(val || null)}
+        >
+          <DropdownMenuRadioItem value="">
+            {t('teamFilter.allTeams')}
+          </DropdownMenuRadioItem>
+          {teams.map((team) => (
+            <DropdownMenuRadioItem key={team.id} value={team.id}>
+              {team.name}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   );
 }

--- a/services/platform/app/features/automations/components/automation-assistant.tsx
+++ b/services/platform/app/features/automations/components/automation-assistant.tsx
@@ -426,6 +426,17 @@ function AutomationAssistantContent({
     return serverMessages;
   }, [transformedMessages, messages, pendingUserMessage]);
 
+  // Detect when the AI is processing:
+  // - Last message is from user (assistant hasn't started yet), OR
+  // - Last message is assistant but has no content yet (generation just started, streaming empty)
+  const lastDisplayMessage =
+    displayMessages.length > 0
+      ? displayMessages[displayMessages.length - 1]
+      : null;
+  const isWaitingForResponse =
+    lastDisplayMessage !== null &&
+    (lastDisplayMessage.role === 'user' || !lastDisplayMessage.content.trim());
+
   // Scroll to bottom when new messages arrive using throttled scroll
   useEffect(() => {
     if (displayMessages.length === 0) return;
@@ -763,7 +774,7 @@ function AutomationAssistantContent({
                 </div>
               </div>
             ))}
-            {isLoading && (
+            {(isLoading || isWaitingForResponse) && (
               <ThinkingAnimation
                 steps={[
                   t('assistant.thinking.thinking'),

--- a/services/platform/app/features/customers/components/customer-import-form.tsx
+++ b/services/platform/app/features/customers/components/customer-import-form.tsx
@@ -4,9 +4,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { ShopifyIcon } from '@/app/components/icons/shopify-icon';
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
-import { Description } from '@/app/components/ui/forms/description';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
-import { Form } from '@/app/components/ui/forms/form';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Stack, HStack, VStack } from '@/app/components/ui/layout/layout';
 import {
@@ -69,7 +67,7 @@ export function CustomerImportForm({
   const fileValue: File | null = watch('file');
 
   return (
-    <Form>
+    <div className="space-y-5">
       {!hideTabs && !mode && (
         <Tabs
           value={dataSource}
@@ -134,12 +132,12 @@ export function CustomerImportForm({
             }
             {...register('customers')}
           />
-          <Description className="text-xs">
-            <Stack gap={2} className="list-outside list-disc pl-4">
+          <div className="text-muted-foreground text-xs leading-relaxed">
+            <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
               <li className="text-yellow-600">{t('importForm.churnedNote')}</li>
-            </Stack>
-          </Description>
+            </ul>
+          </div>
         </Stack>
       )}
       {dataSource === 'file_upload' && (
@@ -165,12 +163,12 @@ export function CustomerImportForm({
               </p>
             </FileUpload.DropZone>
           </FileUpload.Root>
-          <Description className="text-xs">
-            <Stack gap={2} className="list-outside list-disc pl-4">
+          <div className="text-muted-foreground text-xs leading-relaxed">
+            <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
               <li className="text-yellow-600">{t('importForm.churnedNote')}</li>
-            </Stack>
-          </Description>
+            </ul>
+          </div>
           {typeof errors.file?.message === 'string' && (
             <p className="text-destructive text-sm">{errors.file.message}</p>
           )}
@@ -201,6 +199,6 @@ export function CustomerImportForm({
           )}
         </Stack>
       )}
-    </Form>
+    </div>
   );
 }

--- a/services/platform/app/features/products/components/product-import-form.tsx
+++ b/services/platform/app/features/products/components/product-import-form.tsx
@@ -4,9 +4,7 @@ import { Upload, Trash2 } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
 
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
-import { Description } from '@/app/components/ui/forms/description';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
-import { Form } from '@/app/components/ui/forms/form';
 import { Stack, HStack, VStack } from '@/app/components/ui/layout/layout';
 import { Button } from '@/app/components/ui/primitives/button';
 import { toast } from '@/app/hooks/use-toast';
@@ -54,7 +52,7 @@ export function ProductImportForm({
   const fileValue: File | null = watch('file');
 
   return (
-    <Form>
+    <div className="space-y-5">
       <Stack gap={4}>
         <FileUpload.Root>
           <FileUpload.DropZone
@@ -75,12 +73,12 @@ export function ProductImportForm({
             </p>
           </FileUpload.DropZone>
         </FileUpload.Root>
-        <Description className="text-xs">
+        <div className="text-muted-foreground text-xs leading-relaxed">
           <ul className="list-outside list-disc space-y-2 pl-4">
             <li>{t('import.expectedColumns')}</li>
             <li className="text-blue-600">{t('import.draftStatusNote')}</li>
           </ul>
-        </Description>
+        </div>
         {typeof errors.file?.message === 'string' && (
           <p className="text-destructive text-sm">{errors.file.message}</p>
         )}
@@ -106,6 +104,6 @@ export function ProductImportForm({
           </VStack>
         )}
       </Stack>
-    </Form>
+    </div>
   );
 }

--- a/services/platform/app/features/vendors/components/vendor-import-form.tsx
+++ b/services/platform/app/features/vendors/components/vendor-import-form.tsx
@@ -2,9 +2,7 @@ import { Upload, Trash2 } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
 
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
-import { Description } from '@/app/components/ui/forms/description';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
-import { Form } from '@/app/components/ui/forms/form';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Stack, HStack, VStack } from '@/app/components/ui/layout/layout';
 import {
@@ -67,7 +65,7 @@ export function VendorImportForm({
   const fileValue: File | null = watch('file');
 
   return (
-    <Form>
+    <div className="space-y-5">
       {!hideTabs && !mode && (
         <Tabs
           value={dataSource}
@@ -98,11 +96,11 @@ export function VendorImportForm({
             }
             {...register('vendors')}
           />
-          <Description className="text-xs">
+          <div className="text-muted-foreground text-xs leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
             </ul>
-          </Description>
+          </div>
         </Stack>
       )}
       {dataSource === 'file_upload' && (
@@ -128,11 +126,11 @@ export function VendorImportForm({
               </p>
             </FileUpload.DropZone>
           </FileUpload.Root>
-          <Description className="text-xs">
+          <div className="text-muted-foreground text-xs leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
             </ul>
-          </Description>
+          </div>
           {typeof errors.file?.message === 'string' && (
             <p className="text-destructive text-sm">{errors.file.message}</p>
           )}
@@ -159,6 +157,6 @@ export function VendorImportForm({
           )}
         </Stack>
       )}
-    </Form>
+    </div>
   );
 }

--- a/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
+++ b/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
@@ -16,11 +16,11 @@ export const useVendorsTableConfig = createTableConfigHook<'vendors'>(
       header: () => tTables('headers.name'),
       size: 408,
       cell: ({ row }) => (
-        <Stack gap={1}>
-          <span className="text-foreground text-sm font-medium">
+        <Stack gap={0}>
+          <span className="text-foreground block text-sm font-medium">
             {row.original.name || ''}
           </span>
-          <span className="text-muted-foreground text-xs">
+          <span className="text-muted-foreground block text-xs">
             {row.original.email || tTables('cells.noEmail')}
           </span>
         </Stack>

--- a/services/platform/convex/agent_tools/workflows/update_workflow_step_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/update_workflow_step_tool.ts
@@ -218,15 +218,15 @@ Please try again with a properly structured JSON object. Ensure all field names 
         };
       }
 
-      // Validate step config if it's being updated
-      // Note: When only config is updated without stepType, validation may be incomplete
-      // since we don't fetch the existing step's stepType. The mutation itself will
-      // handle the full validation with the merged step data.
-      if (sanitizedUpdates.config || sanitizedUpdates.stepType) {
+      // Validate step config if both stepType and config are available.
+      // When only config is updated without stepType, we skip client-side validation
+      // since validateStepConfig requires stepType. The mutation itself validates
+      // the merged step data with the existing stepType from the database.
+      if (sanitizedUpdates.stepType && sanitizedUpdates.config) {
         const stepValidation = validateStepConfig({
           stepSlug: 'update', // Placeholder, actual slug comes from existing step
           name: sanitizedUpdates.name ?? 'Step',
-          stepType: sanitizedUpdates.stepType, // May be undefined if only config is being updated
+          stepType: sanitizedUpdates.stepType,
           config: sanitizedUpdates.config,
         });
 

--- a/services/platform/convex/workflow_engine/helpers/validation/steps/action.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/steps/action.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Test: Action Step Validator
+ *
+ * Tests the action step validator (steps/action.ts) which is the layer
+ * between validateStepConfig and validateActionParameters.
+ * Focuses on the nextSteps stripping fix and parameter extraction.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { validateActionStep } from './action';
+
+describe('validateActionStep', () => {
+  describe('valid configurations', () => {
+    it('should pass with parameters wrapper', () => {
+      const result = validateActionStep({
+        type: 'set_variables',
+        parameters: {
+          variables: [{ name: 'counter', value: 0 }],
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass with flat config (legacy format)', () => {
+      const result = validateActionStep({
+        type: 'set_variables',
+        variables: [{ name: 'counter', value: 0 }],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass with conversation create operation', () => {
+      const result = validateActionStep({
+        type: 'conversation',
+        operation: 'create',
+        subject: 'Test conversation',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('nextSteps misplacement (fix verification)', () => {
+    it('should pass when nextSteps is in flat config — stripped before parameter validation', () => {
+      // Before fix: nextSteps leaked into parameters via rest spread, causing
+      // "Unknown field nextSteps" error and infinite retry loops.
+      // After fix: nextSteps is stripped from the rest spread and a warning is emitted.
+      const result = validateActionStep({
+        type: 'set_variables',
+        variables: [{ name: 'counter', value: 0 }],
+        nextSteps: { success: 'next_step' },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings.some((w) => w.includes('nextSteps'))).toBe(true);
+    });
+
+    it('should pass when nextSteps is in flat conversation config', () => {
+      const result = validateActionStep({
+        type: 'conversation',
+        operation: 'create',
+        subject: 'Test',
+        nextSteps: { success: 'send_email', failure: 'log_error' },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some((w) => w.includes('nextSteps'))).toBe(true);
+    });
+
+    it('should not strip nextSteps from parameters wrapper', () => {
+      // When parameters wrapper is used, nextSteps inside it is genuinely wrong
+      // and should be caught by parameter validation
+      const result = validateActionStep({
+        type: 'set_variables',
+        parameters: {
+          variables: [{ name: 'counter', value: 0 }],
+          nextSteps: { success: 'next' },
+        },
+      });
+
+      // nextSteps inside parameters is still invalid
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Unknown field') && e.includes('nextSteps'),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('missing required fields', () => {
+    it('should fail when type is missing', () => {
+      const result = validateActionStep({
+        operation: 'query',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('type'))).toBe(true);
+    });
+
+    it('should fail when type is not a string', () => {
+      const result = validateActionStep({
+        type: 123,
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('type'))).toBe(true);
+    });
+  });
+});

--- a/services/platform/convex/workflow_engine/helpers/validation/steps/action.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/steps/action.ts
@@ -32,13 +32,21 @@ export function validateActionStep(
     return { valid: false, errors, warnings };
   }
 
+  // Warn if nextSteps is misplaced inside config (should be at the step level)
+  if ('nextSteps' in config) {
+    warnings.push(
+      'Found "nextSteps" inside config. FIX: Move nextSteps to the step level (updates.nextSteps), not inside updates.config',
+    );
+  }
+
   // Get parameters - they can be in config.parameters or directly in config
   // Normalize to a single variable with 'type' removed for cleaner validation
   let parameters: unknown;
   if ('parameters' in config) {
     parameters = config.parameters;
   } else {
-    const { type: _type, ...rest } = config;
+    // Strip known non-parameter fields that the AI agent commonly misplaces
+    const { type: _type, nextSteps: _nextSteps, ...rest } = config;
     parameters = rest;
   }
 

--- a/services/platform/convex/workflow_engine/helpers/validation/validate_action_parameters.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/validate_action_parameters.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Test: Action Parameters Validation
+ *
+ * Tests parameter validation against action registry validators.
+ * Focuses on patterns the AI agent commonly generates that cause
+ * validation failures and retry loops.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { validateActionParameters } from './validate_action_parameters';
+
+describe('validateActionParameters', () => {
+  describe('set_variables action', () => {
+    it('should pass with valid parameters', () => {
+      const result = validateActionParameters('set_variables', {
+        variables: [{ name: 'counter', value: 0 }],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail when variables is missing', () => {
+      const result = validateActionParameters('set_variables', {});
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('variables'))).toBe(true);
+    });
+
+    it('should fail when parameters is undefined', () => {
+      const result = validateActionParameters('set_variables', undefined);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('requires parameters'))).toBe(
+        true,
+      );
+    });
+
+    it('should fail with unknown fields alongside variables', () => {
+      // AI agent puts nextSteps or other fields at the parameters level
+      const result = validateActionParameters('set_variables', {
+        variables: [{ name: 'counter', value: 0 }],
+        nextSteps: { success: 'next' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Unknown field') && e.includes('nextSteps'),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('conversation action (discriminated union)', () => {
+    it('should pass with valid create operation', () => {
+      const result = validateActionParameters('conversation', {
+        operation: 'create',
+        subject: 'Test conversation',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail with missing operation', () => {
+      const result = validateActionParameters('conversation', {
+        subject: 'Test conversation',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('operation'))).toBe(true);
+    });
+
+    it('should fail with invalid operation', () => {
+      const result = validateActionParameters('conversation', {
+        operation: 'invalid_op',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Invalid operation') && e.includes('invalid_op'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should fail with nextSteps polluting parameters', () => {
+      // When nextSteps leaks into config without parameters wrapper,
+      // it becomes part of the parameters and fails validation
+      const result = validateActionParameters('conversation', {
+        operation: 'create',
+        subject: 'Test',
+        nextSteps: { success: 'send_email' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Unknown field') && e.includes('nextSteps'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should fail with fields from wrong operation variant', () => {
+      // AI generates create operation but includes fields from update operation
+      const result = validateActionParameters('conversation', {
+        operation: 'create',
+        conversationId: 'some-id',
+        updates: { status: 'closed' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Unknown field'))).toBe(true);
+    });
+  });
+
+  describe('customer action', () => {
+    it('should pass with valid query operation', () => {
+      const result = validateActionParameters('customer', {
+        operation: 'query',
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail when query operation is missing required paginationOpts', () => {
+      // AI agent commonly forgets required fields for an operation
+      const result = validateActionParameters('customer', {
+        operation: 'query',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('paginationOpts'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('unknown action type', () => {
+    it('should fail for non-existent action type', () => {
+      const result = validateActionParameters('nonexistent_action', {
+        foo: 'bar',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Unknown action type'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('nextSteps contamination at parameter level', () => {
+    it('should reject nextSteps as unknown field in raw parameters', () => {
+      // validateActionParameters correctly rejects unknown fields
+      const result = validateActionParameters('set_variables', {
+        variables: [{ name: 'counter', value: 0 }],
+        nextSteps: { success: 'next_step' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Unknown field') && e.includes('nextSteps'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should pass when nextSteps is NOT in the parameters', () => {
+      const result = validateActionParameters('set_variables', {
+        variables: [{ name: 'counter', value: 0 }],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/services/platform/convex/workflow_engine/helpers/validation/validate_step_config.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/validate_step_config.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Test: Step Config Validation
+ *
+ * Tests the step configuration validation, focusing on patterns
+ * that the AI workflow agent commonly generates — particularly
+ * partial updates and misplaced fields.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { validateStepConfig } from './validate_step_config';
+
+describe('validateStepConfig', () => {
+  describe('valid complete step definitions', () => {
+    it('should pass for a valid action step with parameters wrapper', () => {
+      const result = validateStepConfig({
+        stepSlug: 'set_vars',
+        name: 'Set Variables',
+        stepType: 'action',
+        config: {
+          type: 'set_variables',
+          parameters: {
+            variables: [{ name: 'foo', value: 'bar' }],
+          },
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass for a valid action step without parameters wrapper (legacy format)', () => {
+      const result = validateStepConfig({
+        stepSlug: 'set_vars',
+        name: 'Set Variables',
+        stepType: 'action',
+        config: {
+          type: 'set_variables',
+          variables: [{ name: 'foo', value: 'bar' }],
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass for a valid start step', () => {
+      const result = validateStepConfig({
+        stepSlug: 'trigger',
+        name: 'Start',
+        stepType: 'start',
+        config: {},
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass for a valid llm step', () => {
+      const result = validateStepConfig({
+        stepSlug: 'analyze',
+        name: 'Analyze Data',
+        stepType: 'llm',
+        config: {
+          name: 'analyzer',
+          systemPrompt: 'You are a data analyst.',
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('AI agent common mistakes', () => {
+    it('should warn but not fail when nextSteps is placed inside config for action step', () => {
+      // AI agents frequently put nextSteps inside config instead of at the top level.
+      // After fix: nextSteps is stripped from parameters and a warning is emitted,
+      // so validation no longer fails just because of misplaced nextSteps.
+      const result = validateStepConfig({
+        stepSlug: 'find_customers',
+        name: 'Find Customers',
+        stepType: 'action',
+        config: {
+          type: 'customer',
+          operation: 'query',
+          paginationOpts: { numItems: 10, cursor: null },
+          nextSteps: { success: 'next_step' },
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some((w) => w.includes('nextSteps'))).toBe(true);
+    });
+
+    it('should fail when action step has no type field in config', () => {
+      const result = validateStepConfig({
+        stepSlug: 'do_something',
+        name: 'Do Something',
+        stepType: 'action',
+        config: {
+          operation: 'query',
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('type'))).toBe(true);
+    });
+
+    it('should fail when using action type name as stepType', () => {
+      // AI agents sometimes use "customer" or "conversation" as stepType
+      // instead of "action" with config.type = "customer"
+      const result = validateStepConfig({
+        stepSlug: 'find_customers',
+        name: 'Find Customers',
+        stepType: 'customer',
+        config: {
+          operation: 'query',
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.includes('Invalid step type') && e.includes('customer'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should fail when conversation action has unknown fields (flat config)', () => {
+      // AI generates flat config with fields that aren't valid for the operation.
+      // Without parameters wrapper, all config fields (minus type) are treated as parameters.
+      const result = validateStepConfig({
+        stepSlug: 'create_conversation',
+        name: 'Create Conversation',
+        stepType: 'action',
+        config: {
+          type: 'conversation',
+          operation: 'create',
+          customerId: '{{steps.find_customer.result.id}}',
+          subject: 'Follow up',
+          // These are unknown fields for conversation create
+          emailBody: 'Hello',
+          recipientEmail: 'test@test.com',
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Unknown field'))).toBe(true);
+    });
+  });
+
+  describe('partial updates (update_workflow_step scenarios)', () => {
+    it('should fail when stepType is undefined but config is provided', () => {
+      // This is the critical bug: update_workflow_step passes stepType: undefined
+      // when only config is being updated, causing "Step type is required" error.
+      // The AI agent then retries 30 times with the same payload.
+      const result = validateStepConfig({
+        stepSlug: 'update',
+        name: 'Step',
+        stepType: undefined,
+        config: {
+          type: 'set_variables',
+          parameters: {
+            variables: [{ name: 'foo', value: 'bar' }],
+          },
+        },
+      });
+
+      // Current behavior: fails with "Step type is required"
+      // This documents the bug - a partial update with valid config shouldn't fail
+      // just because stepType wasn't re-sent in the update payload
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('Step type is required')),
+      ).toBe(true);
+    });
+
+    it('should fail when stepType is undefined even with valid llm config', () => {
+      const result = validateStepConfig({
+        stepSlug: 'update',
+        name: 'Analyze',
+        stepType: undefined,
+        config: {
+          name: 'analyzer',
+          systemPrompt: 'Analyze the data.',
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('Step type is required')),
+      ).toBe(true);
+    });
+  });
+
+  describe('slug validation', () => {
+    it('should pass for valid snake_case slug', () => {
+      const result = validateStepConfig({
+        stepSlug: 'find_inactive_customers',
+        name: 'Find',
+        stepType: 'start',
+        config: {},
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail for camelCase slug', () => {
+      const result = validateStepConfig({
+        stepSlug: 'findCustomers',
+        name: 'Find',
+        stepType: 'start',
+        config: {},
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('snake_case'))).toBe(true);
+    });
+
+    it('should fail for missing slug', () => {
+      const result = validateStepConfig({
+        stepSlug: undefined,
+        name: 'Find',
+        stepType: 'start',
+        config: {},
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('slug is required'))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/services/platform/convex/workflow_engine/instructions/core_instructions.ts
+++ b/services/platform/convex/workflow_engine/instructions/core_instructions.ts
@@ -41,9 +41,12 @@ For workflows with business logic (NOT data sync), treat LLM as the intelligent 
 - LLM steps = All intelligence, decisions, and content generation
 
 **COMMUNICATION RULES**
-- Be brief and concise
-- Do NOT explain or summarize unless explicitly asked
-- Assume users understand their workflows - they created them
+- Do NOT restate or list workflow steps — the user can see them
+- Issue reported? Use workflow_read to investigate BEFORE responding
+- Execution output shared? Analyze it — extract IDs, statuses, errors. No generic advice
+- Be specific and actionable, not vague suggestions
+- Don't know? Say so — don't pad with restated information
+- One paragraph max unless the user asks for detail
 
 **VERSION STATUS RULES**
 - Draft: editable


### PR DESCRIPTION
## Summary
- Fix assistant thinking indicator to show during empty streaming responses, and extract `TeamFilterMenu` into its own component
- Replace `Form`/`Description` wrappers with native HTML in import forms, fix vendors table cell spacing
- Fix workflow step validation to only run when both `stepType` and `config` are present, preventing infinite retry loops on partial updates
- Strip misplaced `nextSteps` from action config with a warning instead of hard failing
- Improve AI assistant communication rules to be more concise and actionable
- Add tests for action step validation, action parameter validation, and step config validation covering common AI agent mistake patterns

## Test plan
- [ ] Verify assistant thinking animation shows while waiting for AI response
- [ ] Test team filter menu in user dropdown works correctly
- [ ] Verify customer/product/vendor import forms render and submit correctly
- [ ] Test workflow step updates with partial payloads (config-only, no stepType)
- [ ] Verify action steps with misplaced nextSteps emit warning but don't fail
- [ ] Run new validation tests: `npm run test --workspace=@tale/platform`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI assistant to display thinking animation while processing requests
  * Refined workflow step validation logic for partial updates
  * Added warning for incorrectly placed configuration fields

* **Tests**
  * Added comprehensive test coverage for action step validation
  * Added tests for workflow parameter validation
  * Added tests for step configuration validation

* **Refactor**
  * Simplified internal component structure
  * Streamlined markup in import forms

* **Style**
  * Adjusted table cell spacing for better visual alignment

* **Documentation**
  * Enhanced AI assistant communication guidelines with clearer directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->