### PR TITLE
fix(platform): fix drag leave flicker, upload overlay, and minor UI issues

### DIFF
--- a/services/platform/app/components/ui/forms/file-upload.tsx
+++ b/services/platform/app/components/ui/forms/file-upload.tsx
@@ -92,7 +92,13 @@ function DropZone({
     (e: React.DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setIsDragOver(false);
+      const { relatedTarget } = e;
+      if (
+        !(relatedTarget instanceof Node) ||
+        !e.currentTarget.contains(relatedTarget)
+      ) {
+        setIsDragOver(false);
+      }
     },
     [setIsDragOver],
   );

--- a/services/platform/app/components/ui/navigation/navigation.tsx
+++ b/services/platform/app/components/ui/navigation/navigation.tsx
@@ -139,7 +139,7 @@ export function Navigation({ organizationId, role }: NavigationProps) {
           <TaleLogo />
         </Link>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto py-4">
+      <div className="mx-1 min-h-0 flex-1 py-4">
         <NavigationMenuList className="block space-y-2 space-x-0">
           {navigationItems.map((item) => (
             <NavigationItem key={item.href} item={item} role={role} />

--- a/services/platform/app/features/settings/integrations/components/integration-upload/steps/preview-step.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-upload/steps/preview-step.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Code, Database, Key, Globe, Pencil, Puzzle, Zap } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { Image } from '@/app/components/ui/data-display/image';
 import { Badge } from '@/app/components/ui/feedback/badge';
@@ -36,14 +36,6 @@ export function PreviewStep({ parsedPackage, onIconChange }: PreviewStepProps) {
     () => (iconFile ? URL.createObjectURL(iconFile) : null),
     [iconFile],
   );
-
-  useEffect(() => {
-    return () => {
-      if (iconPreviewUrl) {
-        URL.revokeObjectURL(iconPreviewUrl);
-      }
-    };
-  }, [iconPreviewUrl]);
 
   const handleIconUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/services/platform/app/features/settings/integrations/components/integration-upload/steps/upload-step.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-upload/steps/upload-step.tsx
@@ -59,10 +59,14 @@ export function UploadStep({ onPackageParsed }: UploadStepProps) {
           inputId="integration-package-upload"
           aria-label={t('integrations.upload.dropZoneLabel')}
           className={cn(
-            'border-border hover:border-primary/50 flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors',
+            'border-border hover:border-primary/50 relative flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors',
             isParsing && 'pointer-events-none opacity-50',
           )}
         >
+          <FileUpload.Overlay
+            label={t('integrations.upload.dropHere')}
+            className="rounded-lg"
+          />
           <Upload className="text-muted-foreground size-8" />
           <Stack gap={1} className="text-center">
             <p className="text-sm font-medium">
@@ -75,7 +79,6 @@ export function UploadStep({ onPackageParsed }: UploadStepProps) {
             </p>
           </Stack>
         </FileUpload.DropZone>
-        <FileUpload.Overlay label={t('integrations.upload.dropHere')} />
       </FileUpload.Root>
 
       {error && (

--- a/services/platform/app/features/settings/organization/components/organization-settings-client.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings-client.tsx
@@ -117,7 +117,7 @@ export function OrganizationSettingsClient({
             id="org-name"
             label={tSettings('organization.title')}
             {...register('name')}
-            className="max-w-sm flex-1"
+            wrapperClassName="max-w-sm flex-1"
           />
           <Button
             type="submit"


### PR DESCRIPTION
## Summary
- Fix file upload drop zone drag leave firing prematurely when hovering over child elements by using `instanceof Node` type guard with `contains()` check
- Move `FileUpload.Overlay` inside the drop zone for correct overlay positioning
- Remove unnecessary `URL.revokeObjectURL` cleanup `useEffect` in preview step
- Fix navigation sidebar overflow styling (`mx-1`, removed `overflow-y-auto`)
- Fix org settings input using `wrapperClassName` instead of `className`

## Test plan
- [ ] Drag a file over the upload drop zone — overlay should not flicker when hovering over child elements
- [ ] Drop zone overlay should render correctly positioned within the drop zone
- [ ] Navigation sidebar scrolling should work as expected
- [ ] Organization settings name input should have correct width styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior in file upload to prevent unintended state changes when dragging within the drop zone.

* **Style & Layout**
  * Updated navigation layout spacing.
  * Adjusted upload component overlay positioning for improved visual hierarchy.
  * Enhanced input styling flexibility for organization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->