### PR TITLE
fix(platform): navigate to active version when clicking automation row

### DIFF
--- a/services/platform/app/features/automations/components/automations-client.tsx
+++ b/services/platform/app/features/automations/components/automations-client.tsx
@@ -3,7 +3,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { type Row } from '@tanstack/react-table';
 import { Workflow } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { Doc } from '@/convex/_generated/dataModel';
 
@@ -30,20 +30,34 @@ export function AutomationsClient({ organizationId }: AutomationsClientProps) {
 
   const { automations, isLoading } = useAutomations(organizationId);
 
+  const activeVersionMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of automations) {
+      if (a.activeVersionId) map.set(a._id, a.activeVersionId);
+    }
+    return map;
+  }, [automations]);
+
+  const tableData = useMemo(
+    () => automations.map(({ activeVersionId: _, ...rest }) => rest),
+    [automations],
+  );
+
   const handleRowClick = useCallback(
     (row: Row<Doc<'wfDefinitions'>>) => {
+      const amId = activeVersionMap.get(row.original._id) ?? row.original._id;
       void navigate({
         to: '/dashboard/$id/automations/$amId',
-        params: { id: organizationId, amId: row.original._id },
+        params: { id: organizationId, amId },
       });
     },
-    [navigate, organizationId],
+    [navigate, organizationId, activeVersionMap],
   );
 
   const list = useListPage({
     dataSource: {
       type: 'query',
-      data: isLoading ? undefined : (automations ?? []),
+      data: isLoading ? undefined : tableData,
     },
     pageSize,
     search: {

--- a/services/platform/convex/workflows/definitions/list_automations.ts
+++ b/services/platform/convex/workflows/definitions/list_automations.ts
@@ -78,6 +78,7 @@ export async function listAutomations(
       status,
       version: activeVersion?.version ?? item.version,
       versionNumber: activeVersion?.versionNumber ?? item.versionNumber,
+      activeVersionId: activeVersion?._id ?? null,
     };
   });
 }


### PR DESCRIPTION
## Summary
- Return `activeVersionId` from the `listAutomations` query so the client knows which version is active
- Use the active version ID for row click navigation, so users land on the active version instead of the definition
- Memoize the version map and filtered table data to avoid unnecessary re-renders

## Test plan
- [ ] Click an automation row that has an active version — verify it navigates to the active version
- [ ] Click an automation row without an active version — verify it falls back to the definition ID
- [ ] Confirm the automations list still loads and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced version tracking for automations to properly identify and navigate to active versions.
  * Optimized automation list rendering for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->