### PR TITLE
fix(integrations): exclude draft messages from conversation sync

### DIFF
--- a/examples/integrations/outlook/connector.js
+++ b/examples/integrations/outlook/connector.js
@@ -204,12 +204,19 @@ function listMessages(http, headers, params) {
     queryParts.push('$orderby=' + orderby);
   }
 
+  // Exclude draft messages — drafts should never enter the sync pipeline
+  var draftFilter = 'isDraft eq false';
   if (filter) {
-    queryParts.push('$filter=' + filter);
+    queryParts.push('$filter=' + filter + ' and ' + draftFilter);
   } else if (params.folder) {
     queryParts.push(
-      "$filter=parentFolderId eq '" + escapeODataString(params.folder) + "'",
+      "$filter=parentFolderId eq '" +
+        escapeODataString(params.folder) +
+        "' and " +
+        draftFilter,
     );
+  } else {
+    queryParts.push('$filter=' + draftFilter);
   }
   if (params.select) {
     queryParts.push('$select=' + params.select);

--- a/services/platform/convex/node_only/integration_sandbox/__tests__/gmail_draft_filtering.test.ts
+++ b/services/platform/convex/node_only/integration_sandbox/__tests__/gmail_draft_filtering.test.ts
@@ -1,0 +1,242 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { executeIntegrationImpl } from '../execute_integration_impl';
+
+const connectorCode = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../../../../../../examples/integrations/gmail/connector.js',
+  ),
+  'utf-8',
+);
+
+function mockFetchSequence(responses: Array<() => Response>) {
+  let callIndex = 0;
+  return Object.assign(
+    vi.fn().mockImplementation(() => {
+      const factory = responses[callIndex];
+      if (!factory) throw new Error('Unexpected fetch call #' + callIndex);
+      callIndex++;
+      return Promise.resolve(factory());
+    }),
+    { preconnect: vi.fn() },
+  );
+}
+
+function jsonResponse(data: unknown, status = 200) {
+  return () =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+describe('Gmail connector draft filtering', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('listMessages', () => {
+    it('should add -is:draft to the query parameter', async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = Object.assign(
+        vi.fn().mockImplementation((url: string) => {
+          fetchCalls.push(url);
+          return Promise.resolve(
+            jsonResponse({ messages: [], resultSizeEstimate: 0 })(),
+          );
+        }),
+        { preconnect: vi.fn() },
+      );
+
+      await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'list_messages',
+        params: {},
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['gmail.googleapis.com'],
+        timeoutMs: 5000,
+      });
+
+      const listUrl = fetchCalls.find((u) => u.includes('/messages?'));
+      expect(listUrl).toBeDefined();
+      expect(listUrl).toContain(encodeURIComponent('-is:draft'));
+    });
+
+    it('should append -is:draft to existing query', async () => {
+      const fetchCalls: string[] = [];
+      globalThis.fetch = Object.assign(
+        vi.fn().mockImplementation((url: string) => {
+          fetchCalls.push(url);
+          return Promise.resolve(
+            jsonResponse({ messages: [], resultSizeEstimate: 0 })(),
+          );
+        }),
+        { preconnect: vi.fn() },
+      );
+
+      await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'list_messages',
+        params: { q: 'from:user@example.com' },
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['gmail.googleapis.com'],
+        timeoutMs: 5000,
+      });
+
+      const listUrl = fetchCalls.find((u) => u.includes('/messages?'));
+      expect(listUrl).toBeDefined();
+      const qParam = decodeURIComponent(
+        listUrl?.split('q=')[1]?.split('&')[0] ?? '',
+      );
+      expect(qParam).toContain('from:user@example.com');
+      expect(qParam).toContain('-is:draft');
+    });
+  });
+
+  describe('getThread', () => {
+    it('should exclude messages with DRAFT label when format is email', async () => {
+      const profileResponse = jsonResponse({
+        emailAddress: 'me@example.com',
+      });
+      const threadResponse = jsonResponse({
+        id: 'thread-1',
+        messages: [
+          {
+            id: 'msg-1',
+            threadId: 'thread-1',
+            labelIds: ['INBOX'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'customer@example.com' },
+                { name: 'To', value: 'me@example.com' },
+                { name: 'Subject', value: 'Hello' },
+                { name: 'Date', value: '2024-01-01T00:00:00Z' },
+              ],
+            },
+          },
+          {
+            id: 'msg-2',
+            threadId: 'thread-1',
+            labelIds: ['DRAFT'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'me@example.com' },
+                { name: 'To', value: 'customer@example.com' },
+                { name: 'Subject', value: 'Re: Hello' },
+                { name: 'Date', value: '2024-01-01T01:00:00Z' },
+              ],
+            },
+          },
+          {
+            id: 'msg-3',
+            threadId: 'thread-1',
+            labelIds: ['INBOX', 'UNREAD'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'customer@example.com' },
+                { name: 'To', value: 'me@example.com' },
+                { name: 'Subject', value: 'Re: Hello' },
+                { name: 'Date', value: '2024-01-01T02:00:00Z' },
+              ],
+            },
+          },
+        ],
+      });
+
+      globalThis.fetch = mockFetchSequence([
+        // First pass: thread fetch
+        threadResponse,
+        // Second pass: thread fetch (cached), then profile fetch
+        threadResponse,
+        profileResponse,
+      ]);
+
+      const result = await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'get_thread',
+        params: { threadId: 'thread-1', format: 'email' },
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['gmail.googleapis.com'],
+        timeoutMs: 5000,
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.result as {
+        data: Array<{ messageId: string }>;
+        count: number;
+      };
+      expect(data.count).toBe(2);
+      expect(data.data).toHaveLength(2);
+      expect(data.data.map((m) => m.messageId)).toEqual(['msg-1', 'msg-3']);
+    });
+
+    it('should return all messages when none are drafts', async () => {
+      const profileResponse = jsonResponse({
+        emailAddress: 'me@example.com',
+      });
+      const threadResponse = jsonResponse({
+        id: 'thread-1',
+        messages: [
+          {
+            id: 'msg-1',
+            threadId: 'thread-1',
+            labelIds: ['INBOX'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'customer@example.com' },
+                { name: 'To', value: 'me@example.com' },
+                { name: 'Subject', value: 'Hello' },
+                { name: 'Date', value: '2024-01-01T00:00:00Z' },
+              ],
+            },
+          },
+          {
+            id: 'msg-2',
+            threadId: 'thread-1',
+            labelIds: ['SENT'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'me@example.com' },
+                { name: 'To', value: 'customer@example.com' },
+                { name: 'Subject', value: 'Re: Hello' },
+                { name: 'Date', value: '2024-01-01T01:00:00Z' },
+              ],
+            },
+          },
+        ],
+      });
+
+      globalThis.fetch = mockFetchSequence([
+        threadResponse,
+        threadResponse,
+        profileResponse,
+      ]);
+
+      const result = await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'get_thread',
+        params: { threadId: 'thread-1', format: 'email' },
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['gmail.googleapis.com'],
+        timeoutMs: 5000,
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.result as {
+        data: Array<{ messageId: string }>;
+        count: number;
+      };
+      expect(data.count).toBe(2);
+      expect(data.data).toHaveLength(2);
+    });
+  });
+});

--- a/services/platform/convex/node_only/integration_sandbox/__tests__/outlook_draft_filtering.test.ts
+++ b/services/platform/convex/node_only/integration_sandbox/__tests__/outlook_draft_filtering.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { executeIntegrationImpl } from '../execute_integration_impl';
+
+const connectorCode = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../../../../../../examples/integrations/outlook/connector.js',
+  ),
+  'utf-8',
+);
+
+function jsonResponse(data: unknown, status = 200) {
+  return () =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+describe('Outlook connector draft filtering', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('listMessages', () => {
+    it('should include isDraft eq false filter in the request URL', async () => {
+      const fetchCalls: string[] = [];
+      const meResponse = jsonResponse({
+        mail: 'me@example.com',
+        userPrincipalName: 'me@example.com',
+      });
+      const messagesResponse = jsonResponse({ value: [] });
+
+      globalThis.fetch = Object.assign(
+        vi.fn().mockImplementation((url: string) => {
+          fetchCalls.push(url);
+          if (url.includes('/me?') || url.endsWith('/me')) {
+            return Promise.resolve(meResponse());
+          }
+          return Promise.resolve(messagesResponse());
+        }),
+        { preconnect: vi.fn() },
+      );
+
+      await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'list_messages',
+        params: {},
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['graph.microsoft.com'],
+        timeoutMs: 5000,
+      });
+
+      const listUrl = fetchCalls.find((u) => u.includes('/me/messages?'));
+      expect(listUrl).toBeDefined();
+      expect(listUrl).toContain('isDraft eq false');
+    });
+
+    it('should combine isDraft filter with existing filter', async () => {
+      const fetchCalls: string[] = [];
+      const meResponse = jsonResponse({
+        mail: 'me@example.com',
+      });
+      const messagesResponse = jsonResponse({ value: [] });
+
+      globalThis.fetch = Object.assign(
+        vi.fn().mockImplementation((url: string) => {
+          fetchCalls.push(url);
+          if (url.includes('/me?') || url.endsWith('/me')) {
+            return Promise.resolve(meResponse());
+          }
+          return Promise.resolve(messagesResponse());
+        }),
+        { preconnect: vi.fn() },
+      );
+
+      await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'list_messages',
+        params: { filter: 'isRead eq false' },
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['graph.microsoft.com'],
+        timeoutMs: 5000,
+      });
+
+      const listUrl = fetchCalls.find((u) => u.includes('/me/messages?'));
+      expect(listUrl).toBeDefined();
+      expect(listUrl).toContain('isRead eq false');
+      expect(listUrl).toContain('isDraft eq false');
+    });
+
+    it('should combine isDraft filter with folder filter', async () => {
+      const fetchCalls: string[] = [];
+      const meResponse = jsonResponse({
+        mail: 'me@example.com',
+      });
+      const messagesResponse = jsonResponse({ value: [] });
+
+      globalThis.fetch = Object.assign(
+        vi.fn().mockImplementation((url: string) => {
+          fetchCalls.push(url);
+          if (url.includes('/me?') || url.endsWith('/me')) {
+            return Promise.resolve(meResponse());
+          }
+          return Promise.resolve(messagesResponse());
+        }),
+        { preconnect: vi.fn() },
+      );
+
+      await executeIntegrationImpl({
+        code: connectorCode,
+        operation: 'list_messages',
+        params: { folder: 'inbox-id' },
+        variables: {},
+        secrets: { accessToken: 'test-token' },
+        allowedHosts: ['graph.microsoft.com'],
+        timeoutMs: 5000,
+      });
+
+      const listUrl = fetchCalls.find((u) => u.includes('/me/messages?'));
+      expect(listUrl).toBeDefined();
+      expect(listUrl).toContain('inbox-id');
+      expect(listUrl).toContain('isDraft eq false');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Draft emails from Gmail and Outlook were being synced into conversation threads and displayed as normal delivered messages
- **Gmail `listMessages`**: adds `-is:draft` to the query so draft stubs never trigger a sync
- **Gmail `getThread`**: filters out messages with the `DRAFT` label, which is the primary entry point for drafts into the pipeline
- **Outlook `listMessages`**: adds `isDraft eq false` OData filter, combined with any existing filter or folder filter

## Test plan
- [x] Added `gmail_draft_filtering.test.ts` (4 tests) — verifies `-is:draft` query param, query appending, draft exclusion in `getThread`, and non-draft passthrough
- [x] Added `outlook_draft_filtering.test.ts` (3 tests) — verifies `isDraft eq false` filter standalone, combined with custom filter, and combined with folder filter
- [ ] Verify existing integration sandbox tests still pass in CI
- [ ] Manual test: connect a Gmail/Outlook account with draft emails and run conversation sync — drafts should not appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft messages are now properly excluded from Gmail message lists and thread views, ensuring only finalized messages appear in conversations.
  * Draft messages are now consistently excluded from Outlook message list queries across all scenarios.
  * These improvements prevent drafts from cluttering message results in workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->