### PR TITLE
fix: preserve role cache during auth refresh to prevent admin losing …

### DIFF
--- a/services/platform/app/hooks/__tests__/use-convex-query.test.ts
+++ b/services/platform/app/hooks/__tests__/use-convex-query.test.ts
@@ -83,4 +83,33 @@ describe('useConvexQuery', () => {
     expect(passedOptions).not.toHaveProperty('staleTime');
     expect(passedOptions).not.toHaveProperty('gcTime');
   });
+
+  it('merges enabled option into useQuery call', () => {
+    const args = { organizationId: 'org-123' };
+
+    useConvexQuery(mockQueryRef, args, { enabled: false });
+
+    const passedOptions = mockUseQuery.mock.calls[0]?.[0] as {
+      enabled?: boolean;
+    };
+    expect(passedOptions?.enabled).toBe(false);
+  });
+
+  it('enabled option overrides convexQuery enabled when provided', () => {
+    // Even with normal args (which would produce enabled:true from convexQuery),
+    // passing enabled:false disables the query while keeping the stable query key.
+    useConvexQuery(
+      mockQueryRef,
+      { organizationId: 'org-123' },
+      { enabled: false },
+    );
+
+    expect(mockConvexQuery).toHaveBeenCalledWith(mockQueryRef, {
+      organizationId: 'org-123',
+    });
+    const passedOptions = mockUseQuery.mock.calls[0]?.[0] as {
+      enabled?: boolean;
+    };
+    expect(passedOptions?.enabled).toBe(false);
+  });
 });

--- a/services/platform/app/hooks/__tests__/use-current-member-context.test.ts
+++ b/services/platform/app/hooks/__tests__/use-current-member-context.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@convex-dev/react-query', () => ({
+  convexQuery: vi.fn((func: unknown, args: unknown) => ({
+    queryKey: ['convexQuery', func, args],
+    queryFn: vi.fn(),
+  })),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+  api: {
+    members: {
+      queries: {
+        getCurrentMemberContext: {},
+      },
+    },
+  },
+}));
+
+import { convexQuery } from '@convex-dev/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import { useCurrentMemberContext } from '../use-current-member-context';
+
+const mockConvexQuery = vi.mocked(convexQuery);
+const mockUseQuery = vi.mocked(useQuery);
+
+describe('useCurrentMemberContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses stable { organizationId } query key when skip=false', () => {
+    useCurrentMemberContext('org-123', false);
+
+    expect(mockConvexQuery).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'org-123',
+    });
+    const options = mockUseQuery.mock.calls[0]?.[0] as { enabled?: boolean };
+    expect(options?.enabled).toBe(true);
+  });
+
+  it('uses stable { organizationId } query key when skip=true (not "skip" string)', () => {
+    useCurrentMemberContext('org-123', true);
+
+    // Must use { organizationId } key, NOT 'skip' string, to preserve cached data
+    expect(mockConvexQuery).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'org-123',
+    });
+    const options = mockUseQuery.mock.calls[0]?.[0] as { enabled?: boolean };
+    expect(options?.enabled).toBe(false);
+  });
+
+  it('returns cached data when skip=true (enabled=false)', () => {
+    const cachedData = {
+      role: 'admin' as const,
+      memberId: 'm1',
+      organizationId: 'org-123',
+      userId: 'u1',
+      isAdmin: true,
+      createdAt: 0,
+    };
+    mockUseQuery.mockReturnValueOnce({
+      data: cachedData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+
+    const result = useCurrentMemberContext('org-123', true);
+
+    // Data from cache should be returned even when skip=true
+    expect(result.data).toEqual(cachedData);
+  });
+
+  it('forces isLoading=true when skip=true regardless of query loading state', () => {
+    // Simulates disabled query with cached data: isLoading=false from useQuery
+    mockUseQuery.mockReturnValueOnce({
+      data: { role: 'admin' },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+
+    const result = useCurrentMemberContext('org-123', true);
+
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('forces isLoading=true when skip=true and no cached data', () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+
+    const result = useCurrentMemberContext('org-123', true);
+
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('passes isLoading through from useQuery when skip=false', () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+
+    const result = useCurrentMemberContext('org-123', false);
+
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('falls back to "skip" key when organizationId is undefined', () => {
+    useCurrentMemberContext(undefined, false);
+
+    expect(mockConvexQuery).toHaveBeenCalledWith(expect.anything(), 'skip');
+    const options = mockUseQuery.mock.calls[0]?.[0] as { enabled?: boolean };
+    expect(options?.enabled).toBe(false);
+  });
+
+  it('uses default skip=false when not provided', () => {
+    useCurrentMemberContext('org-123');
+
+    const options = mockUseQuery.mock.calls[0]?.[0] as { enabled?: boolean };
+    expect(options?.enabled).toBe(true);
+  });
+});

--- a/services/platform/app/hooks/use-convex-query.ts
+++ b/services/platform/app/hooks/use-convex-query.ts
@@ -8,6 +8,7 @@ type EmptyObject = Record<string, never>;
 interface ConvexQueryOptions {
   staleTime?: number;
   gcTime?: number;
+  enabled?: boolean;
 }
 
 type QueryArgs<Func extends FunctionReference<'query'>> =

--- a/services/platform/app/hooks/use-current-member-context.ts
+++ b/services/platform/app/hooks/use-current-member-context.ts
@@ -10,6 +10,10 @@ import { api } from '@/convex/_generated/api';
  * When skipped, `isLoading` is forced to `true` because TanStack Query v5's
  * `isLoading` (= isPending && isFetching) is `false` for disabled queries,
  * which would let pages fall through their loading guards and show "Access denied".
+ *
+ * Using `enabled: false` (instead of changing args to 'skip') preserves the stable
+ * `{ organizationId }` query key so TanStack Query returns cached data during auth
+ * token refreshes — preventing a flash of missing permissions on component remount.
  */
 export function useCurrentMemberContext(
   organizationId: string | undefined,
@@ -17,7 +21,8 @@ export function useCurrentMemberContext(
 ) {
   const result = useConvexQuery(
     api.members.queries.getCurrentMemberContext,
-    !organizationId || skip ? 'skip' : { organizationId },
+    organizationId ? { organizationId } : 'skip',
+    { enabled: !!organizationId && !skip },
   );
 
   return {

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -1,4 +1,3 @@
-import { convexQuery } from '@convex-dev/react-query';
 import { Outlet, createFileRoute } from '@tanstack/react-router';
 import { useRef } from 'react';
 
@@ -13,17 +12,9 @@ import { AbilityContext } from '@/app/context/ability-context';
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { TeamFilterProvider } from '@/app/hooks/use-team-filter';
-import { api } from '@/convex/_generated/api';
 import { defineAbilityFor, type AppAbility } from '@/lib/permissions/ability';
 
 export const Route = createFileRoute('/dashboard/$id')({
-  loader: ({ context, params }) => {
-    void context.queryClient.prefetchQuery(
-      convexQuery(api.members.queries.getCurrentMemberContext, {
-        organizationId: params.id,
-      }),
-    );
-  },
   component: DashboardLayout,
 });
 
@@ -37,9 +28,8 @@ function DashboardLayout() {
   );
 
   // Preserve the last known ability across auth token refreshes / WebSocket reconnections.
-  // When convexQuery args change to 'skip', the queryKey changes and data becomes undefined,
-  // which would cause role-gated nav items to briefly disappear.
-  // Only recompute when the role value actually changes to keep abilityRef.current stable.
+  // useCurrentMemberContext returns cached data during auth loading (enabled: false),
+  // so memberContext stays defined. Only recompute when the role actually changes.
   const abilityRef = useRef<AppAbility>(defineAbilityFor(memberContext?.role));
   const lastRoleRef = useRef<string | undefined>(memberContext?.role);
   if (


### PR DESCRIPTION
…permissions

After a period of inactivity the Convex JWT expires. The old loader fired a void prefetchQuery that ran unauthenticated, writing null into the TanStack Query cache for the member context and overwriting the previously cached admin role. At the same time, passing 'skip' as args changed the query key, so cached data was not returned while auth was loading — causing abilityRef to be re-initialised as "disabled" on component remount.

Fix 1: remove the unauthenticated void prefetchQuery from the dashboard loader. Fix 2: use enabled:false (stable { organizationId } query key) instead of changing args to 'skip', so TanStack Query returns cached role data during auth token refreshes and the ability is initialised correctly on remount. Fix 3: add enabled option to ConvexQueryOptions so useConvexQuery supports this pattern without bypassing the shared wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for optional query enablement flag and query behavior validation.
  * Comprehensive test suite for member context retrieval, including query key stability and loading state handling.

* **Refactor**
  * Optimized query caching behavior during authentication events.
  * Enhanced loading state management.
  * Simplified dashboard route configuration by removing route-level data prefetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->