### PR TITLE
fix(platform): align table padding across pages

### DIFF
--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -94,6 +94,7 @@ export function AutomationsTable({ organizationId }: AutomationsTableProps) {
 
   return (
     <DataTable
+      className="p-4"
       columns={columns}
       onRowClick={handleRowClick}
       stickyLayout={stickyLayout}

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -451,7 +451,7 @@ export function ExecutionsTable({
 
   return (
     <DataTable<Execution>
-      className="px-4 py-6"
+      className="p-4"
       columns={columns}
       enableExpanding
       renderExpandedRow={renderExpandedRow}

--- a/services/platform/app/features/custom-agents/components/custom-agents-table.tsx
+++ b/services/platform/app/features/custom-agents/components/custom-agents-table.tsx
@@ -100,6 +100,7 @@ export function CustomAgentsTable({ organizationId }: CustomAgentsTableProps) {
 
   return (
     <DataTable
+      className="p-4"
       {...list.tableProps}
       columns={columns}
       stickyLayout={stickyLayout}


### PR DESCRIPTION
Standardize DataTable padding to p-4 to match the knowledge page:
- executions: px-4 py-6 → p-4
- custom agents: add missing p-4
- automations: add missing p-4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table spacing and padding in automations, executions, and custom agents features for improved visual consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->