### PR TITLE
fix(platform): prioritize empty state over filtered state in data table

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table-empty-state.stories.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-empty-state.stories.tsx
@@ -1,12 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Package, Users, FileText, Search, Plus } from 'lucide-react';
+import { Package, Users, FileText } from 'lucide-react';
 
-import { DataTableActionMenu } from './data-table-action-menu';
-import {
-  DataTableEmptyState,
-  DataTableFilteredEmptyState,
-} from './data-table-empty-state';
+import { DataTableEmptyState } from './data-table-empty-state';
 
 const meta: Meta<typeof DataTableEmptyState> = {
   title: 'Data Display/DataTable/EmptyState',
@@ -17,35 +13,26 @@ const meta: Meta<typeof DataTableEmptyState> = {
     docs: {
       description: {
         component: `
-Empty state components for DataTable. Two variants:
+Empty state component for DataTable. Used for both initial empty states (no data)
+and filtered empty states (no results matching filters).
 
-- **DataTableEmptyState** — Initial empty state when there's no data at all. Shows icon, title, description, and optional CTA.
-- **DataTableFilteredEmptyState** — Shown when filters are applied but no results match. Includes header content slot for search/filter controls.
+The initial empty state always takes priority — it is shown regardless of active
+filters or search queries.
 
 ## Usage
 \`\`\`tsx
-import { DataTableEmptyState, DataTableFilteredEmptyState } from '@/app/components/ui/data-table/data-table-empty-state';
+import { DataTableEmptyState } from '@/app/components/ui/data-table/data-table-empty-state';
 
-// No data at all
 <DataTableEmptyState
   icon={Users}
   title="No customers yet"
   description="Add your first customer to get started."
-  actionMenu={<DataTableActionMenu label="Add customer" icon={Plus} onClick={handleAdd} />}
-/>
-
-// Filters applied, no results
-<DataTableFilteredEmptyState
-  title="No results found"
-  description="Try adjusting your search or filters."
-  headerContent={<SearchInput />}
 />
 \`\`\`
 
 ## Accessibility
 - Uses semantic heading hierarchy
-- Icon is decorative (inside layout component)
-- Action menu receives keyboard focus
+- Icon is decorative (\`aria-hidden\`)
         `,
       },
     },
@@ -63,62 +50,49 @@ export const Default: Story = {
   },
   decorators: [
     (Story) => (
-      <div className="h-[400px]">
+      <div className="h-[300px]">
         <Story />
       </div>
     ),
   ],
 };
 
-export const WithActionMenu: Story = {
+export const WithoutIcon: Story = {
+  args: {
+    title: 'No results found',
+    description: 'Try adjusting your search or filter criteria.',
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Used for filtered empty states when no results match the current search or filters.',
+      },
+    },
+  },
+};
+
+export const WithIcon: Story = {
   args: {
     icon: Users,
     title: 'No customers yet',
     description:
       'Import customers or add them manually to start managing your relationships.',
-    actionMenu: (
-      <DataTableActionMenu
-        label="Add customer"
-        icon={Plus}
-        onClick={() => {}}
-      />
-    ),
   },
   decorators: [
     (Story) => (
-      <div className="h-[400px]">
+      <div className="h-[300px]">
         <Story />
       </div>
     ),
   ],
-  parameters: {
-    docs: {
-      description: {
-        story: 'Empty state with an action button to add the first item.',
-      },
-    },
-  },
-};
-
-export const WithoutIcon: Story = {
-  args: {
-    title: 'No data available',
-    description: 'There is nothing to display at this time.',
-  },
-  decorators: [
-    (Story) => (
-      <div className="h-[400px]">
-        <Story />
-      </div>
-    ),
-  ],
-  parameters: {
-    docs: {
-      description: {
-        story: 'Empty state without an icon.',
-      },
-    },
-  },
 };
 
 export const TitleOnly: Story = {
@@ -128,7 +102,7 @@ export const TitleOnly: Story = {
   },
   decorators: [
     (Story) => (
-      <div className="h-[400px]">
+      <div className="h-[300px]">
         <Story />
       </div>
     ),
@@ -137,56 +111,6 @@ export const TitleOnly: Story = {
     docs: {
       description: {
         story: 'Minimal empty state with only icon and title.',
-      },
-    },
-  },
-};
-
-export const FilteredEmptyState: StoryObj<typeof DataTableFilteredEmptyState> =
-  {
-    render: () => (
-      <DataTableFilteredEmptyState
-        title="No results found"
-        description="Try adjusting your search or filter criteria."
-      />
-    ),
-    parameters: {
-      docs: {
-        description: {
-          story:
-            'Filtered empty state shown when search/filter produces no matches.',
-        },
-      },
-    },
-  };
-
-export const FilteredWithHeaderContent: StoryObj<
-  typeof DataTableFilteredEmptyState
-> = {
-  render: () => (
-    <div className="flex h-[400px] flex-col">
-      <DataTableFilteredEmptyState
-        title="No matching customers"
-        description="No customers match your current filters."
-        headerContent={
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-[300px] items-center gap-2 rounded-md border px-3">
-              <Search className="text-muted-foreground size-4" />
-              <span className="text-muted-foreground text-sm">
-                Search customers...
-              </span>
-            </div>
-          </div>
-        }
-        stickyLayout
-      />
-    </div>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Filtered empty state with header content (search bar) and sticky layout.',
       },
     },
   },

--- a/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
@@ -1,116 +1,39 @@
-'use client';
-
-import type { ReactNode, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 import { VStack, Center } from '@/app/components/ui/layout/layout';
-import { cn } from '@/lib/utils/cn';
-
-/** Icon component type that accepts className prop */
-export type IconComponent = ComponentType<{ className?: string }>;
 
 export interface DataTableEmptyStateProps {
   /** Icon to display */
-  icon?: IconComponent;
+  icon?: ComponentType<{ className?: string }>;
   /** Title text */
   title: string;
   /** Description text */
   description?: string;
-  /** Action menu element (use DataTableActionMenu component) */
-  actionMenu?: ReactNode;
-  /** Additional class name */
-  className?: string;
 }
 
 /**
- * Initial empty state component for DataTable.
- * Shows when there's no data at all (displays icon, border, and CTA).
+ * Empty state component rendered inside DataTable.
+ * Shows when there's no data at all (highest priority — displayed regardless of active filters).
  */
 export function DataTableEmptyState({
   icon: Icon,
   title,
   description,
-  actionMenu,
-  className,
 }: DataTableEmptyStateProps) {
   return (
-    <Center
-      className={cn(
-        'flex-[1_1_0] ring-1 ring-border rounded-xl p-4',
-        className,
-      )}
-    >
+    <Center className="flex-[1_1_0] py-12">
       <VStack align="center" className="max-w-[24rem] text-center">
-        {Icon && <Icon className="text-secondary mb-4 size-6" />}
-        <div className="mb-1 text-lg leading-tight font-semibold">{title}</div>
-        {description && (
-          <p
-            className={cn(
-              'text-sm text-muted-foreground',
-              actionMenu && 'mb-4',
-            )}
-          >
-            {description}
-          </p>
+        {Icon && (
+          <Icon
+            className="text-muted-foreground/60 mb-3 size-10"
+            aria-hidden="true"
+          />
         )}
-        {actionMenu}
+        <h4 className="text-sm font-medium">{title}</h4>
+        {description && (
+          <p className="text-muted-foreground text-sm">{description}</p>
+        )}
       </VStack>
     </Center>
   );
-}
-
-export interface DataTableFilteredEmptyStateProps {
-  /** Title text */
-  title: string;
-  /** Description text */
-  description?: string;
-  /** Header content (search/filters) to display above the empty state */
-  headerContent?: ReactNode;
-  /** Whether to use sticky layout */
-  stickyLayout?: boolean;
-  /** Additional class name */
-  className?: string;
-}
-
-/**
- * Filtered empty state component for DataTable.
- * Shows when filters are applied but no results match.
- * Includes header content (search/filters) and simpler styling.
- * Note: No action button since it's already in the header.
- */
-export function DataTableFilteredEmptyState({
-  title,
-  description,
-  headerContent,
-  stickyLayout = false,
-  className,
-}: DataTableFilteredEmptyStateProps) {
-  const content = (
-    <VStack align="center" className={cn('text-center', className)}>
-      <h4 className="text-foreground mb-1 text-base font-semibold">{title}</h4>
-      {description && (
-        <p className="text-muted-foreground text-sm">{description}</p>
-      )}
-    </VStack>
-  );
-
-  // If there's header content, wrap in a container with proper layout
-  if (headerContent) {
-    return (
-      <>
-        <div className={cn(stickyLayout && 'flex-shrink-0 pb-4')}>
-          {headerContent}
-        </div>
-        <Center
-          className={cn(
-            'rounded-xl border border-border',
-            stickyLayout ? 'flex-1 min-h-0' : 'py-16',
-          )}
-        >
-          {content}
-        </Center>
-      </>
-    );
-  }
-
-  return <Center className="py-16">{content}</Center>;
 }

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -42,7 +42,7 @@ import {
 } from '@/app/components/ui/data-display/table';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Spinner } from '@/app/components/ui/feedback/spinner';
-import { HStack, Stack, VStack } from '@/app/components/ui/layout/layout';
+import { HStack, Stack } from '@/app/components/ui/layout/layout';
 import { Button } from '@/app/components/ui/primitives/button';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
@@ -80,8 +80,8 @@ export interface DataTableProps<TData, TValue = unknown> {
   data: TData[];
   /** Accessible table caption for screen readers */
   caption?: string;
-  /** Empty state configuration (actionMenu is automatically provided) */
-  emptyState?: Omit<DataTableEmptyStateProps, 'actionMenu'>;
+  /** Empty state configuration */
+  emptyState?: DataTableEmptyStateProps;
   /** Pagination configuration */
   pagination?: Omit<DataTablePaginationProps, 'currentPage'> & {
     /** Whether to use client-side pagination */
@@ -344,9 +344,9 @@ export function DataTable<TData, TValue = unknown>({
   const skeletonRowCount = approxRowCount ?? 0;
   const showSkeleton = isDataLoading && skeletonRowCount > 0;
 
-  // Show the initial empty state when not loading and data is empty with no filters
+  // Show empty state when not loading and data is empty (regardless of filters)
   const showInitialEmptyState =
-    !showSkeleton && data.length === 0 && !!emptyState && !hasActiveFilters;
+    !showSkeleton && data.length === 0 && !!emptyState;
 
   const colSpan = columns.length + (enableExpanding ? 1 : 0);
 
@@ -465,15 +465,11 @@ export function DataTable<TData, TValue = unknown>({
           </TableRow>
         ) : rows.length === 0 && hasActiveFilters ? (
           <TableRow className="hover:bg-transparent">
-            <TableCell colSpan={colSpan} className="py-16 text-center">
-              <VStack align="center" className="text-center">
-                <h4 className="text-foreground mb-1 text-base font-semibold">
-                  {t('search.noResults')}
-                </h4>
-                <p className="text-muted-foreground text-sm">
-                  {t('search.tryAdjusting')}
-                </p>
-              </VStack>
+            <TableCell colSpan={colSpan} className="p-4">
+              <DataTableEmptyState
+                title={t('search.noResults')}
+                description={t('search.tryAdjusting')}
+              />
             </TableCell>
           </TableRow>
         ) : rows.length === 0 ? null : (


### PR DESCRIPTION
Empty state now always displays when data is empty, regardless of active filters or search queries. Previously, filters could override the empty state with a "no results" message even when there was no data at all.

Also simplifies DataTableEmptyState by removing unused props (actionMenu, className) and DataTableFilteredEmptyState (replaced by reusing the same component with different text). Redesigns styling to be lighter and more consistent with the project style guide.