### PR TITLE
feat(platform): load data table parts independently

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.stories.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.stories.tsx
@@ -451,6 +451,84 @@ export const WithManualLoadMore: Story = {
   },
 };
 
+export const CountLoading: Story = {
+  args: {
+    columns,
+    data: [],
+    caption: 'Loading count',
+    approxRowCount: undefined,
+    isLoading: true,
+    search: {
+      value: '',
+      onChange: () => {},
+      placeholder: 'Search users...',
+    },
+    actionMenu: (
+      <Button size="sm" icon={Plus}>
+        Add User
+      </Button>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Count still loading — header and column headers render instantly, table body shows 3 placeholder skeleton rows.',
+      },
+    },
+  },
+};
+
+export const SkeletonRows: Story = {
+  args: {
+    columns,
+    data: [],
+    caption: 'Skeleton rows',
+    approxRowCount: 8,
+    isLoading: true,
+    search: {
+      value: '',
+      onChange: () => {},
+      placeholder: 'Search users...',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Count known (8), data still loading — shows 8 skeleton rows matching the approximate row count.',
+      },
+    },
+  },
+};
+
+export const EmptyStateImmediate: Story = {
+  args: {
+    columns,
+    data: [],
+    caption: 'Empty state',
+    approxRowCount: 0,
+    emptyState: {
+      title: 'No users yet',
+      description: 'Get started by adding your first user.',
+      icon: Plus,
+    },
+    actionMenu: (
+      <Button size="sm" icon={Plus}>
+        Add User
+      </Button>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Count is 0 — empty state displays immediately without any skeleton flash.',
+      },
+    },
+  },
+};
+
 export const FullFeatured: Story = {
   render: function FullFeaturedStory() {
     const [searchValue, setSearchValue] = useState('');

--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -1,0 +1,259 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen, within } from '@/test/utils/render';
+
+import { DataTable } from './data-table';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/app/hooks/use-organization-id', () => ({
+  useOrganizationId: () => 'org_test',
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+interface TestRow {
+  _id: string;
+  name: string;
+  status: string;
+}
+
+const columns: ColumnDef<TestRow>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    meta: { skeleton: { type: 'badge' } },
+  },
+];
+
+const sampleRows: TestRow[] = [
+  { _id: '1', name: 'Alice', status: 'active' },
+  { _id: '2', name: 'Bob', status: 'inactive' },
+  { _id: '3', name: 'Charlie', status: 'active' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTbody() {
+  // Both <thead> and <tbody> have role="rowgroup"; tbody is the second one
+  const rowgroups = screen.getAllByRole('rowgroup');
+  const tbody = rowgroups[1];
+  if (!tbody) throw new Error('Could not find tbody rowgroup');
+  return tbody;
+}
+
+function getSkeletonRows() {
+  return within(getTbody())
+    .getAllByRole('row')
+    .filter((row) => row.querySelector('[class*="animate-pulse"]'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DataTable loading states', () => {
+  describe('count-loading state (approxRowCount=undefined + loading)', () => {
+    it('renders skeleton placeholder rows when count is still loading', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={undefined}
+          isLoading
+        />,
+      );
+
+      const skeletons = getSkeletonRows();
+      expect(skeletons.length).toBe(3);
+    });
+  });
+
+  describe('skeleton state (approxRowCount > 0 + loading)', () => {
+    it('renders skeleton rows matching approxRowCount', () => {
+      render(
+        <DataTable columns={columns} data={[]} approxRowCount={5} isLoading />,
+      );
+
+      const skeletons = getSkeletonRows();
+      expect(skeletons.length).toBe(5);
+    });
+
+    it('renders skeleton rows with infiniteScroll.isInitialLoading', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={8}
+          infiniteScroll={{
+            hasMore: true,
+            onLoadMore: vi.fn(),
+            isInitialLoading: true,
+          }}
+        />,
+      );
+
+      const skeletons = getSkeletonRows();
+      expect(skeletons.length).toBe(8);
+    });
+  });
+
+  describe('empty state (approxRowCount=0 + emptyState config)', () => {
+    it('shows empty state immediately when count is 0', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={0}
+          emptyState={{
+            title: 'No items found',
+            description: 'Create your first item.',
+          }}
+        />,
+      );
+
+      expect(screen.getByText('No items found')).toBeInTheDocument();
+      expect(screen.getByText('Create your first item.')).toBeInTheDocument();
+      expect(getSkeletonRows().length).toBe(0);
+    });
+
+    it('shows empty state when not loading and data is empty', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          emptyState={{
+            title: 'Nothing here',
+          }}
+        />,
+      );
+
+      expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    });
+  });
+
+  describe('filtered-empty state (active filters + no data)', () => {
+    it('shows filtered empty state when search has a value and data is empty', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          search={{
+            value: 'nonexistent',
+            onChange: vi.fn(),
+            placeholder: 'Search...',
+          }}
+        />,
+      );
+
+      // The filtered empty state uses translation keys; check for the no-results message
+      const rows = within(getTbody()).getAllByRole('row');
+      // Should have a single row with the empty state content, no skeleton rows
+      expect(rows.length).toBe(1);
+      expect(getSkeletonRows().length).toBe(0);
+    });
+  });
+
+  describe('data state', () => {
+    it('renders data rows when items are loaded', () => {
+      render(
+        <DataTable columns={columns} data={sampleRows} approxRowCount={3} />,
+      );
+
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+      expect(getSkeletonRows().length).toBe(0);
+    });
+  });
+
+  describe('structural chrome always renders', () => {
+    it('renders column headers during loading', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={undefined}
+          isLoading
+        />,
+      );
+
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    it('renders column headers with empty state', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={0}
+          emptyState={{ title: 'Empty' }}
+        />,
+      );
+
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    it('renders search input during loading', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={undefined}
+          isLoading
+          search={{
+            value: '',
+            onChange: vi.fn(),
+            placeholder: 'Search items...',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByPlaceholderText('Search items...'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders action menu during loading', () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={undefined}
+          isLoading
+          actionMenu={<button>Add Item</button>}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Add Item' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders table border container during loading', () => {
+      const { container } = render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          approxRowCount={undefined}
+          isLoading
+        />,
+      );
+
+      // The border container has the rounded-xl border class
+      const borderContainer = container.querySelector('.rounded-xl.border');
+      expect(borderContainer).toBeInTheDocument();
+    });
+  });
+});

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -21,6 +21,7 @@ import { ChevronRight } from 'lucide-react';
 import {
   Fragment,
   useState,
+  useMemo,
   useRef,
   useEffect,
   useCallback,
@@ -104,7 +105,12 @@ export interface DataTableProps<TData, TValue = unknown> {
     /** Distance from bottom to trigger load in px (default: 1000) */
     threshold?: number;
   };
-  /** Approximate row count used for skeleton rows during initial loading */
+  /**
+   * Approximate row count for the skeleton display.
+   * - `undefined`: count still loading (shows minimal skeleton placeholder)
+   * - `0`: no data expected (shows empty state immediately)
+   * - `> 0`: shows this many skeleton rows while data loads
+   */
   approxRowCount?: number;
   /** Whether the table data is loading externally (shows skeleton rows) */
   isLoading?: boolean;
@@ -300,6 +306,76 @@ export function DataTable<TData, TValue = unknown>({
     }),
   });
 
+  // Whether any filters are actively applied (memoized for stable dependency)
+  const hasActiveFilters = useMemo(
+    () =>
+      !!(search?.value && search.value.trim().length > 0) ||
+      !!(filters && filters.some((f) => f.selectedValues.length > 0)) ||
+      !!dateRange?.from ||
+      !!dateRange?.to,
+    [search?.value, filters, dateRange?.from, dateRange?.to],
+  );
+
+  // Combined loading signal: data rows are still in flight
+  const isDataLoading = infiniteScroll?.isInitialLoading || isLoading;
+
+  // ---------------------------------------------------------------------------
+  // Table body state machine
+  //
+  // Derives what the table body should render from three independent signals:
+  //   1. approxRowCount — drives skeleton vs empty decision
+  //   2. isDataLoading  — whether the data query is still in flight
+  //   3. data.length    — whether actual rows have arrived
+  //
+  // States:
+  //   'loading'        — count unknown, show minimal skeleton (3 rows)
+  //   'skeleton'       — count known > 0, show N skeleton rows
+  //   'empty'          — no data, emptyState provided, no active filters
+  //   'filtered-empty' — no data, active filters present
+  //   'idle-empty'     — no data, no emptyState, no filters
+  //   'data'           — rows available
+  // ---------------------------------------------------------------------------
+  const tableBodyState = useMemo(() => {
+    const isRowCountLoading = approxRowCount === undefined;
+
+    if (!isDataLoading) {
+      // Has data
+      if (data.length > 0) return 'data';
+      // Has filters
+      if (hasActiveFilters) return 'filtered-empty';
+      // Has empty state
+      if (emptyState) return 'empty';
+      // Has neither data, filters nor empty state
+      return 'idle-empty';
+    }
+
+    if (!isRowCountLoading) {
+      // Can have data
+      if (approxRowCount > 0) return 'skeleton';
+      // Has empty state
+      if (emptyState) return 'empty';
+      // Has neither data nor empty state
+      return 'idle-empty';
+    }
+
+    // Count and data is loading — show minimal skeleton placeholder
+    return 'loading';
+  }, [
+    approxRowCount,
+    isDataLoading,
+    data.length,
+    emptyState,
+    hasActiveFilters,
+  ]);
+
+  // Number of skeleton rows to render based on current state
+  const skeletonRowCount =
+    tableBodyState === 'loading'
+      ? 3
+      : tableBodyState === 'skeleton'
+        ? (approxRowCount ?? 0)
+        : 0;
+
   // If error prop provided, show error display instead of table
   if (error) {
     return (
@@ -328,25 +404,6 @@ export function DataTable<TData, TValue = unknown>({
       {actionMenu}
     </div>
   ) : null;
-
-  // Check if any filters are actively applied
-  const hasActiveFilters =
-    (search?.value && search.value.trim().length > 0) ||
-    (filters && filters.some((f) => f.selectedValues.length > 0)) ||
-    dateRange?.from ||
-    dateRange?.to;
-
-  // Combined loading state: from infiniteScroll or explicit isLoading prop
-  const isDataLoading = infiniteScroll?.isInitialLoading || isLoading;
-
-  // Show skeleton rows only when loading AND approxRowCount > 0.
-  // approxRowCount === 0 or undefined signals "no data expected" — show empty state immediately.
-  const skeletonRowCount = approxRowCount ?? 0;
-  const showSkeleton = isDataLoading && skeletonRowCount > 0;
-
-  // Show empty state when not loading and data is empty (regardless of filters)
-  const showInitialEmptyState =
-    !showSkeleton && data.length === 0 && !!emptyState;
 
   const colSpan = columns.length + (enableExpanding ? 1 : 0);
 
@@ -383,7 +440,9 @@ export function DataTable<TData, TValue = unknown>({
         ))}
       </TableHeader>
       <TableBody>
-        {showSkeleton ? (
+        {tableBodyState === 'loading' || tableBodyState === 'skeleton' ? (
+          // Skeleton rows — count-loading uses 3 placeholder rows,
+          // skeleton uses the actual approxRowCount
           Array.from({ length: skeletonRowCount }).map((_, rowIndex) => (
             <TableRow key={`skeleton-${rowIndex}`}>
               {enableExpanding && <TableCell className="w-[3rem]" />}
@@ -453,17 +512,19 @@ export function DataTable<TData, TValue = unknown>({
               })}
             </TableRow>
           ))
-        ) : showInitialEmptyState ? (
+        ) : tableBodyState === 'empty' ? (
+          // Initial empty state — no data and no filters active
           <TableRow className="hover:bg-transparent">
             <TableCell colSpan={colSpan} className="p-4">
               <DataTableEmptyState
-                icon={emptyState.icon}
-                title={emptyState.title}
-                description={emptyState.description}
+                icon={emptyState?.icon}
+                title={emptyState?.title ?? ''}
+                description={emptyState?.description}
               />
             </TableCell>
           </TableRow>
-        ) : rows.length === 0 && hasActiveFilters ? (
+        ) : tableBodyState === 'filtered-empty' ? (
+          // Filtered empty state — filters applied but no matching rows
           <TableRow className="hover:bg-transparent">
             <TableCell colSpan={colSpan} className="p-4">
               <DataTableEmptyState
@@ -472,7 +533,7 @@ export function DataTable<TData, TValue = unknown>({
               />
             </TableCell>
           </TableRow>
-        ) : rows.length === 0 ? null : (
+        ) : tableBodyState === 'idle-empty' ? null : (
           rows.map((row, index) => {
             const isExpanded = row.getIsExpanded();
             const rowClassNameValue =

--- a/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
@@ -20,14 +20,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/customers')({
   validateSearch: searchSchema,
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
-      convexQuery(api.customers.queries.listCustomers, {
+      convexQuery(api.customers.queries.approxCountCustomers, {
         organizationId: params.id,
       }),
     );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.customers.queries.approxCountCustomers, {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.customers.queries.listCustomers, {
         organizationId: params.id,
       }),
     );

--- a/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
@@ -19,14 +19,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/products')({
   validateSearch: searchSchema,
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
-      convexQuery(api.products.queries.listProducts, {
+      convexQuery(api.products.queries.approxCountProducts, {
         organizationId: params.id,
       }),
     );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.products.queries.approxCountProducts, {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.products.queries.listProducts, {
         organizationId: params.id,
       }),
     );

--- a/services/platform/app/routes/dashboard/$id/_knowledge/tone-of-voice.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/tone-of-voice.tsx
@@ -22,14 +22,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/tone-of-voice')(
     validateSearch: searchSchema,
     pendingComponent: () => null,
     pendingMs: 0,
-    loader: async ({ context, params }) => {
+    loader: ({ context, params }) => {
       void context.queryClient.prefetchQuery(
-        convexQuery(api.tone_of_voice.queries.getToneOfVoiceWithExamples, {
+        convexQuery(api.tone_of_voice.queries.approxCountExampleMessages, {
           organizationId: params.id,
         }),
       );
-      await context.queryClient.ensureQueryData(
-        convexQuery(api.tone_of_voice.queries.approxCountExampleMessages, {
+      void context.queryClient.prefetchQuery(
+        convexQuery(api.tone_of_voice.queries.getToneOfVoiceWithExamples, {
           organizationId: params.id,
         }),
       );

--- a/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
@@ -19,14 +19,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/vendors')({
   validateSearch: searchSchema,
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
-      convexQuery(api.vendors.queries.listVendors, {
+      convexQuery(api.vendors.queries.approxCountVendors, {
         organizationId: params.id,
       }),
     );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.vendors.queries.approxCountVendors, {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.vendors.queries.listVendors, {
         organizationId: params.id,
       }),
     );

--- a/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
@@ -18,14 +18,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/websites')({
   validateSearch: searchSchema,
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
-      convexQuery(api.websites.queries.listWebsites, {
+      convexQuery(api.websites.queries.approxCountWebsites, {
         organizationId: params.id,
       }),
     );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.websites.queries.approxCountWebsites, {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.websites.queries.listWebsites, {
         organizationId: params.id,
       }),
     );

--- a/services/platform/app/routes/dashboard/$id/approvals.tsx
+++ b/services/platform/app/routes/dashboard/$id/approvals.tsx
@@ -25,21 +25,19 @@ export const Route = createFileRoute('/dashboard/$id/approvals')({
       });
     }
   },
-  loader: async ({ context, params }) => {
-    await Promise.all([
-      context.queryClient.ensureQueryData(
-        convexQuery(api.approvals.queries.approxCountApprovalsByStatus, {
-          organizationId: params.id,
-          status: 'pending',
-        }),
-      ),
-      context.queryClient.ensureQueryData(
-        convexQuery(api.approvals.queries.approxCountApprovalsByStatus, {
-          organizationId: params.id,
-          status: 'resolved',
-        }),
-      ),
-    ]);
+  loader: ({ context, params }) => {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.approvals.queries.approxCountApprovalsByStatus, {
+        organizationId: params.id,
+        status: 'resolved',
+      }),
+    );
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.approvals.queries.approxCountApprovalsByStatus, {
+        organizationId: params.id,
+        status: 'pending',
+      }),
+    );
   },
   component: ApprovalsLayout,
 });

--- a/services/platform/app/routes/dashboard/$id/approvals/$status.tsx
+++ b/services/platform/app/routes/dashboard/$id/approvals/$status.tsx
@@ -27,9 +27,23 @@ export const Route = createFileRoute('/dashboard/$id/approvals/$status')({
       throw notFound();
     }
   },
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
     if (isValidStatus(params.status)) {
-      await context.queryClient.ensureQueryData(
+      const isPending = params.status === 'pending';
+
+      void context.queryClient.prefetchQuery(
+        convexQuery(api.approvals.queries.listApprovalsPaginated, {
+          organizationId: params.id,
+          ...(isPending
+            ? { status: 'pending', resourceType: 'product_recommendation' }
+            : {
+                resourceType: 'product_recommendation',
+                excludeStatus: 'pending',
+              }),
+          paginationOpts: { numItems: 30, cursor: null },
+        }),
+      );
+      void context.queryClient.prefetchQuery(
         convexQuery(api.approvals.queries.approxCountApprovalsByStatus, {
           organizationId: params.id,
           status: params.status,

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -14,16 +14,16 @@ export const Route = createFileRoute('/dashboard/$id/automations/')({
   }),
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.wf_definitions.queries.approxCountAutomations, {
+        organizationId: params.id,
+      }),
+    );
     void context.queryClient.prefetchQuery(
       convexQuery(api.wf_definitions.queries.listAutomationsPaginated, {
         organizationId: params.id,
         paginationOpts: { numItems: 10, cursor: null },
-      }),
-    );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.wf_definitions.queries.approxCountAutomations, {
-        organizationId: params.id,
       }),
     );
   },

--- a/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
@@ -11,16 +11,16 @@ export const Route = createFileRoute('/dashboard/$id/custom-agents/')({
   }),
   pendingComponent: () => null,
   pendingMs: 0,
-  loader: async ({ context, params }) => {
+  loader: ({ context, params }) => {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.custom_agents.queries.approxCountCustomAgents, {
+        organizationId: params.id,
+      }),
+    );
     void context.queryClient.prefetchQuery(
       convexQuery(api.custom_agents.queries.listCustomAgentsPaginated, {
         organizationId: params.id,
         paginationOpts: { numItems: 10, cursor: null },
-      }),
-    );
-    await context.queryClient.ensureQueryData(
-      convexQuery(api.custom_agents.queries.approxCountCustomAgents, {
-        organizationId: params.id,
       }),
     );
   },


### PR DESCRIPTION
Replace the monolithic loading logic in DataTable with a state machine that allows each part to load independently. The header (search, filters, action menu), column headers, and table container now render instantly. The table body is driven entirely by approxRowCount:

- undefined: count still loading, show 3 placeholder skeleton rows
- 0: show empty state immediately
- > 0: show N skeleton rows until data arrives

Remove blocking ensureQueryData calls from 9 route loaders, converting them to non-blocking prefetchQuery. This eliminates navigation delays caused by waiting for count queries before rendering.