### PR TITLE
refactor(platform): clean up route pending states and ability ref

### DIFF
--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -28,25 +28,24 @@ export const Route = createFileRoute('/dashboard/$id')({
 
 function DashboardLayout() {
   const { id: organizationId } = Route.useParams();
-
   const { data: memberContext } = useCurrentMemberContext(organizationId);
 
-  const abilityRef = useRef<AppAbility>(defineAbilityFor(memberContext?.role));
-  const lastRoleRef = useRef<string | undefined>(memberContext?.role);
+  const abilityRef = useRef<{ role: string | null; ability: AppAbility }>(null);
 
-  if (
-    memberContext &&
-    memberContext.role !== undefined &&
-    memberContext.role !== lastRoleRef.current
-  ) {
-    lastRoleRef.current = memberContext.role;
-    abilityRef.current = defineAbilityFor(memberContext.role);
+  const currentRole = memberContext?.role ?? null;
+
+  if (!abilityRef.current || abilityRef.current.role !== currentRole) {
+    abilityRef.current = {
+      role: currentRole,
+      ability: defineAbilityFor(currentRole),
+    };
   }
 
-  const hasRole = !!memberContext?.role;
+  const { role, ability } = abilityRef.current;
+  const hasRole = role !== null;
 
   return (
-    <AbilityContext.Provider value={abilityRef.current}>
+    <AbilityContext.Provider value={ability}>
       <BrandingProvider organizationId={organizationId}>
         <TeamFilterProvider organizationId={organizationId}>
           <AdaptiveHeaderProvider>

--- a/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
@@ -18,8 +18,6 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/customers')({
     meta: seo('customers'),
   }),
   validateSearch: searchSchema,
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.customers.queries.approxCountCustomers, {

--- a/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
@@ -17,8 +17,6 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/products')({
     meta: seo('products'),
   }),
   validateSearch: searchSchema,
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.products.queries.approxCountProducts, {

--- a/services/platform/app/routes/dashboard/$id/_knowledge/tone-of-voice.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/tone-of-voice.tsx
@@ -20,8 +20,6 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/tone-of-voice')(
       meta: seo('toneOfVoice'),
     }),
     validateSearch: searchSchema,
-    pendingComponent: () => null,
-    pendingMs: 0,
     loader: ({ context, params }) => {
       void context.queryClient.prefetchQuery(
         convexQuery(api.tone_of_voice.queries.approxCountExampleMessages, {

--- a/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
@@ -17,8 +17,6 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/vendors')({
     meta: seo('vendors'),
   }),
   validateSearch: searchSchema,
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.vendors.queries.approxCountVendors, {

--- a/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
@@ -16,8 +16,6 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/websites')({
     meta: seo('websites'),
   }),
   validateSearch: searchSchema,
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.websites.queries.approxCountWebsites, {

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -12,8 +12,6 @@ export const Route = createFileRoute('/dashboard/$id/automations/')({
   head: () => ({
     meta: seo('automations'),
   }),
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.wf_definitions.queries.approxCountAutomations, {

--- a/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/custom-agents/index.tsx
@@ -9,8 +9,6 @@ export const Route = createFileRoute('/dashboard/$id/custom-agents/')({
   head: () => ({
     meta: seo('customAgents'),
   }),
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.custom_agents.queries.approxCountCustomAgents, {

--- a/services/platform/app/routes/dashboard/$id/settings/teams.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/teams.tsx
@@ -13,8 +13,6 @@ export const Route = createFileRoute('/dashboard/$id/settings/teams')({
   head: () => ({
     meta: seo('teams'),
   }),
-  pendingComponent: () => null,
-  pendingMs: 0,
   loader: async ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.members.queries.getMyTeams, {

--- a/services/platform/lib/permissions/ability.ts
+++ b/services/platform/lib/permissions/ability.ts
@@ -50,7 +50,7 @@ export type AppAbility = MongoAbility<[AppAction, AppSubject]>;
  * Builds a CASL ability instance for the given platform role.
  * Mirrors the permission matrix defined in convex/auth.ts.
  */
-export function defineAbilityFor(role?: string | null): AppAbility {
+export function defineAbilityFor(role: string | null): AppAbility {
   const { can, cannot, build } = new AbilityBuilder<AppAbility>(
     createMongoAbility,
   );


### PR DESCRIPTION
Remove unnecessary pendingComponent/pendingMs overrides from data table routes now that tables load their parts independently. Simplify the ability ref in dashboard layout to use a single ref object tracking both role and ability, and tighten defineAbilityFor parameter type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized user role and permission computation in the dashboard.
  * Simplified loading behavior across knowledge and automation routes by removing explicit loading placeholders.
  * Updated permission validation logic for role parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->