### PR TITLE
fix(platform): add error boundary to test chat panel and optimize getCustomAgentByVersion

### DIFF
--- a/services/platform/app/features/custom-agents/components/test-chat-panel.tsx
+++ b/services/platform/app/features/custom-agents/components/test-chat-panel.tsx
@@ -2,6 +2,9 @@
 
 import { Trash2, X } from 'lucide-react';
 
+import { isConvexTransientError } from '@/app/components/error-boundaries/boundaries/layout-error-boundary';
+import { ErrorBoundaryBase } from '@/app/components/error-boundaries/core/error-boundary-base';
+import { ErrorDisplayCompact } from '@/app/components/error-boundaries/displays/error-display-compact';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { IconButton } from '@/app/components/ui/primitives/icon-button';
 import { ImagePreviewDialog } from '@/app/features/chat/components/message-bubble';
@@ -126,10 +129,25 @@ function TestChatPanelContent({
   );
 }
 
+const MAX_RETRIES = 3;
+
 export function TestChatPanel(props: TestChatPanelProps) {
   return (
-    <FileUpload.Root>
-      <TestChatPanelContent {...props} />
-    </FileUpload.Root>
+    <ErrorBoundaryBase
+      organizationId={props.organizationId}
+      maxRetries={MAX_RETRIES}
+      isRetryableError={isConvexTransientError}
+      fallback={({ error, reset, organizationId }) => (
+        <ErrorDisplayCompact
+          error={error}
+          organizationId={organizationId}
+          reset={reset}
+        />
+      )}
+    >
+      <FileUpload.Root>
+        <TestChatPanelContent {...props} />
+      </FileUpload.Root>
+    </ErrorBoundaryBase>
   );
 }

--- a/services/platform/convex/custom_agents/queries.ts
+++ b/services/platform/convex/custom_agents/queries.ts
@@ -187,18 +187,31 @@ export const getCustomAgentByVersion = query({
     }
 
     // No versionNumber: prefer draft -> active -> latest archived
-    const allVersions = ctx.db
-      .query('customAgents')
-      .withIndex('by_root', (q) => q.eq('rootVersionId', args.customAgentId))
-      .order('desc');
+    // Concurrent targeted lookups via by_root_status index
+    const rootId = args.customAgentId;
+    const [draft, active, archived] = await Promise.all([
+      ctx.db
+        .query('customAgents')
+        .withIndex('by_root_status', (q) =>
+          q.eq('rootVersionId', rootId).eq('status', 'draft'),
+        )
+        .first(),
+      ctx.db
+        .query('customAgents')
+        .withIndex('by_root_status', (q) =>
+          q.eq('rootVersionId', rootId).eq('status', 'active'),
+        )
+        .first(),
+      ctx.db
+        .query('customAgents')
+        .withIndex('by_root_status', (q) =>
+          q.eq('rootVersionId', rootId).eq('status', 'archived'),
+        )
+        .order('desc')
+        .first(),
+    ]);
 
-    let bestFallback: typeof rootAgent | null = null;
-    for await (const version of allVersions) {
-      if (version.status === 'draft') return version;
-      if (version.status === 'active') return version;
-      if (!bestFallback) bestFallback = version;
-    }
-    return bestFallback;
+    return draft ?? active ?? archived ?? null;
   },
 });
 


### PR DESCRIPTION
## Summary
- Wrap `TestChatPanel` with `ErrorBoundaryBase` to gracefully handle transient Convex errors with automatic retries and a compact error display
- Optimize `getCustomAgentByVersion` query by replacing the full table scan with concurrent targeted lookups via the `by_root_status` index

## Test plan
- [ ] Verify test chat panel renders correctly and handles errors gracefully
- [ ] Confirm `getCustomAgentByVersion` returns the correct version priority (draft → active → archived)
- [ ] Validate the `by_root_status` index is defined in the schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the test chat panel with automatic retry capability and improved error messaging.

* **Performance**
  * Optimized agent version retrieval for faster loading times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->