### PR TITLE
fix: refine chat loading detection, add crash recovery, and fail on partial dataset errors

### DIFF
--- a/services/platform/app/features/chat/hooks/__tests__/use-chat-loading-state.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-chat-loading-state.test.ts
@@ -122,7 +122,7 @@ describe('useChatLoadingState', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    it('returns true when last assistant message is a tool message with terminal status', () => {
+    it('returns true when last part is a tool part (unfinished tool turn)', () => {
       const { result } = renderHook(() =>
         useChatLoadingState({
           isPending: false,
@@ -136,6 +136,74 @@ describe('useChatLoadingState', () => {
               text: 'Let me create that for you.',
               parts: [
                 { type: 'text', text: 'Let me create that for you.' },
+                { type: 'step-start' },
+                {
+                  type: 'tool-excel',
+                  toolCallId: 'call-1',
+                  input: { operation: 'generate' },
+                  state: 'input-available',
+                },
+              ],
+            }),
+          ],
+          threadId: THREAD_A,
+          pendingThreadId: null,
+        }),
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('returns false when tool parts exist but text part follows (completed tool turn)', () => {
+      const { result } = renderHook(() =>
+        useChatLoadingState({
+          isPending: false,
+          setIsPending,
+          uiMessages: [
+            createUIMessage({
+              id: 'msg-1',
+              order: 0,
+              role: 'assistant',
+              status: 'success',
+              text: 'Here are the results...',
+              parts: [
+                { type: 'step-start' },
+                {
+                  type: 'tool-rag_search',
+                  toolCallId: 'call-1',
+                  input: { query: 'test' },
+                  output: { results: [] },
+                  state: 'output-available',
+                },
+                { type: 'text', text: 'Here are the results...' },
+              ],
+            }),
+          ],
+          threadId: THREAD_A,
+          pendingThreadId: null,
+        }),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('returns true when tool message has text preamble before tool call', () => {
+      const { result } = renderHook(() =>
+        useChatLoadingState({
+          isPending: false,
+          setIsPending,
+          uiMessages: [
+            createUIMessage({
+              id: 'msg-1',
+              order: 0,
+              role: 'assistant',
+              status: 'success',
+              text: 'I will create an Excel file for you.',
+              parts: [
+                {
+                  type: 'text',
+                  text: 'I will create an Excel file for you.',
+                },
                 { type: 'step-start' },
                 {
                   type: 'tool-excel',

--- a/services/platform/app/features/chat/hooks/use-chat-loading-state.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-loading-state.ts
@@ -10,10 +10,25 @@ interface UseChatLoadingStateParams {
   pendingThreadId: string | null;
 }
 
-function isToolMessage(message: UIMessage) {
-  return message.parts?.some((part: { type: string }) =>
-    part.type.startsWith('tool-'),
-  );
+/**
+ * Checks whether the assistant message represents an in-progress tool turn
+ * (the final text response has not yet arrived).
+ *
+ * The SDK appends parts in message order: tool-call parts first, then
+ * tool-result merges into existing parts, then final text parts last.
+ * If the last meaningful part is a tool-* part, the final response
+ * hasn't arrived yet.
+ */
+function isUnfinishedToolTurn(message: UIMessage) {
+  const parts = message.parts;
+  if (!parts?.length) return false;
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const type = parts[i].type;
+    if (type === 'step-start' || type.startsWith('source-')) continue;
+    return type.startsWith('tool-');
+  }
+  return false;
 }
 
 /**
@@ -22,7 +37,7 @@ function isToolMessage(message: UIMessage) {
  * The AI turn is considered complete (not loading) only when ALL three
  * conditions are met:
  *   1. The last message is from the assistant
- *   2. The last message is not a tool message (no tool-call parts)
+ *   2. The last meaningful part is not a tool part (final text has arrived)
  *   3. The last message has a terminal status (success/failed)
  *
  * When no messages exist, falls back to `isPending` to bridge the gap
@@ -45,7 +60,7 @@ export function useChatLoadingState({
 
     return !(
       lastMessage.role === 'assistant' &&
-      !isToolMessage(lastMessage) &&
+      !isUnfinishedToolTurn(lastMessage) &&
       (lastMessage.status === 'success' || lastMessage.status === 'failed')
     );
   }, [isPending, uiMessages]);

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -408,6 +408,44 @@ export TMPDIR=/app/convex-data/tmp
 mkdir -p "$TMPDIR"
 cd /app
 
+# Clean up derived data that is safe to rebuild.
+# Search indexes and compiled modules are rebuilt automatically from the database.
+# User uploads (files/) are NEVER touched — they contain permanent user data.
+clean_convex_derived_data() {
+  local data_dir="/app/convex-data"
+
+  # Search indexes: rebuilt from database on startup
+  if [ -d "$data_dir/search" ]; then
+    rm -rf "$data_dir/search"
+    echo "   ✓ Cleaned search indexes (will rebuild from database)"
+  fi
+
+  # Compiled modules: rebuilt on next deploy
+  if [ -d "$data_dir/modules" ]; then
+    rm -rf "$data_dir/modules"
+    echo "   ✓ Cleaned compiled modules (will rebuild on deploy)"
+  fi
+
+  # Stale temp files from interrupted operations
+  rm -rf "$data_dir/tmp/"*
+
+  # Fix permissions on all files we own (non-fatal if some files are owned by root)
+  chmod -R 755 "$data_dir" 2>/dev/null || true
+}
+
+# If a previous crash was recorded, clean derived data before starting.
+# This prevents crash loops where the backend repeatedly hits corrupted search
+# index segments left behind by an unclean shutdown (e.g. VectorCompactor killed
+# mid-compaction, leaving segment metadata pointing to files that don't exist).
+if [ -f "/app/convex-data/crash.log" ]; then
+  echo "⚠️  Previous crash detected, cleaning derived data to prevent crash loop..."
+  clean_convex_derived_data
+  rm -f /app/convex-data/crash.log
+fi
+
+# Clean stale process state from previous container runs
+rm -f /app/convex-data/convex.pid /app/convex-data/convex.lock
+
 # Configure database
 DB_ARGS=$(configure_database)
 
@@ -666,6 +704,11 @@ monitor_convex() {
         kill "$current_pid" 2>/dev/null || true
         wait "$current_pid" 2>/dev/null || true
       fi
+
+      # Clean derived data (search indexes, modules) before restarting to prevent
+      # crash loops from corrupted vector index segments left by the previous crash
+      echo "[$(date -Iseconds)] Cleaning derived data before restart..." | tee -a "$CRASH_LOG"
+      clean_convex_derived_data
 
       # Restart Convex backend
       echo "[$(date -Iseconds)] Restarting Convex backend..." | tee -a "$CRASH_LOG"

--- a/services/rag/app/services/cognee/service.py
+++ b/services/rag/app/services/cognee/service.py
@@ -781,15 +781,28 @@ class CogneeService:
             total_chunks_created = 0
             result = None
             added_datasets: list[str] = []
+            dataset_errors: list[BaseException] = []
             for ds_result_or_err in dataset_results:
                 if isinstance(ds_result_or_err, BaseException):
                     logger.error(f"Dataset processing failed: {ds_result_or_err}")
+                    dataset_errors.append(ds_result_or_err)
                     continue
                 ds_name, ds_result, ds_chunks = ds_result_or_err
                 added_datasets.append(ds_name)
                 total_chunks_created += ds_chunks
                 if result is None:
                     result = ds_result
+
+            # Any dataset failure = job failure.
+            # Don't save content hash so re-upload can retry all datasets.
+            # Don't return success so the job is marked as failed.
+            if dataset_errors:
+                error_summary = "; ".join(str(e) for e in dataset_errors[:3])
+                raise RuntimeError(
+                    f"{len(dataset_errors)}/{len(dataset_results)} dataset(s) failed for document "
+                    f"'{document_id or 'unknown'}': {error_summary}"
+                )
+
             processing_time = (time.time() - start_time) * 1000
             logger.info(
                 f"Document added to {len(added_datasets)} dataset(s) in {processing_time:.2f}ms: {added_datasets}"
@@ -797,7 +810,7 @@ class CogneeService:
 
             doc_id, _ = normalize_add_result(result, document_id)
 
-            # Save original content hash for future deduplication
+            # All datasets succeeded — save content hash for deduplication
             if document_id and new_content_hash:
                 try:
                     await self._save_original_content_hash(document_id, new_content_hash)

--- a/services/rag/tests/test_add_document_dedup.py
+++ b/services/rag/tests/test_add_document_dedup.py
@@ -1,0 +1,154 @@
+"""Tests for add_document dedup and error handling logic.
+
+Verifies the result-processing logic after asyncio.gather in add_document:
+- Content hash is only saved when ALL datasets succeed
+- Any dataset failure (partial or total) raises RuntimeError
+- The job is marked as failed so the caller can retry
+
+These tests replicate the exact logic from CogneeService.add_document()
+(service.py lines ~781-830) without importing heavy dependencies (cognee,
+sqlalchemy, etc.) that are only available in the Docker container.
+"""
+
+import pytest
+
+
+def _process_dataset_results(
+    dataset_results: list,
+    document_id: str | None,
+    new_content_hash: str | None,
+) -> tuple[dict, bool]:
+    """Replicate the post-gather logic from CogneeService.add_document().
+
+    This mirrors the exact code path at service.py lines ~781-830.
+
+    Returns:
+        (result_dict, should_save_hash) or raises RuntimeError on any failure.
+    """
+    total_chunks_created = 0
+    result = None
+    added_datasets: list[str] = []
+    dataset_errors: list[BaseException] = []
+
+    for ds_result_or_err in dataset_results:
+        if isinstance(ds_result_or_err, BaseException):
+            dataset_errors.append(ds_result_or_err)
+            continue
+        ds_name, ds_result, ds_chunks = ds_result_or_err
+        added_datasets.append(ds_name)
+        total_chunks_created += ds_chunks
+        if result is None:
+            result = ds_result
+
+    # Any dataset failure = job failure.
+    # Don't save content hash so re-upload can retry all datasets.
+    if dataset_errors:
+        error_summary = "; ".join(str(e) for e in dataset_errors[:3])
+        raise RuntimeError(
+            f"{len(dataset_errors)}/{len(dataset_results)} dataset(s) failed for document "
+            f"'{document_id or 'unknown'}': {error_summary}"
+        )
+
+    # All datasets succeeded — save content hash for deduplication
+    should_save_hash = bool(document_id and new_content_hash)
+
+    return {
+        "success": True,
+        "document_id": document_id or "unknown",
+        "chunks_created": total_chunks_created,
+        "cleaned_datasets": [],
+    }, should_save_hash
+
+
+class TestHashSaving:
+    """Content hash should only be saved when every dataset succeeds."""
+
+    def test_hash_saved_when_all_datasets_succeed(self):
+        results = [
+            ("tale_team_a", {"id": "doc1", "chunks": 3}, 3),
+        ]
+        response, should_save = _process_dataset_results(results, "doc1", "abc123hash")
+        assert response["success"] is True
+        assert response["chunks_created"] == 3
+        assert should_save is True
+
+    def test_hash_saved_when_multiple_datasets_all_succeed(self):
+        results = [
+            ("tale_team_a", {"id": "doc1", "chunks": 3}, 3),
+            ("tale_team_b", {"id": "doc1", "chunks": 5}, 5),
+        ]
+        response, should_save = _process_dataset_results(results, "doc1", "abc123hash")
+        assert response["success"] is True
+        assert response["chunks_created"] == 8
+        assert should_save is True
+
+    def test_hash_not_saved_when_no_document_id(self):
+        results = [
+            ("tale_team_a", {"id": "doc1", "chunks": 3}, 3),
+        ]
+        response, should_save = _process_dataset_results(results, None, "abc123hash")
+        assert should_save is False
+
+    def test_hash_not_saved_when_no_content_hash(self):
+        results = [
+            ("tale_team_a", {"id": "doc1", "chunks": 3}, 3),
+        ]
+        response, should_save = _process_dataset_results(results, "doc1", None)
+        assert should_save is False
+
+    def test_empty_results_no_errors_saves_hash(self):
+        """Edge case: empty results with no errors should not raise.
+
+        In practice this can't happen (target_datasets is always non-empty),
+        but the code path should not crash.
+        """
+        response, should_save = _process_dataset_results([], "doc1", "abc123hash")
+        assert response["success"] is True
+        assert response["chunks_created"] == 0
+        assert should_save is True
+
+
+class TestDatasetFailure:
+    """Any dataset failure must raise RuntimeError."""
+
+    def test_single_dataset_fails(self):
+        results = [
+            RuntimeError("cognify boom"),
+        ]
+        with pytest.raises(RuntimeError, match=r"1/1 dataset.*failed"):
+            _process_dataset_results(results, "doc1", "abc123hash")
+
+    def test_all_datasets_fail(self):
+        results = [
+            RuntimeError("cognify failed for team_a"),
+            TimeoutError("cognify timed out for team_b"),
+        ]
+        with pytest.raises(RuntimeError, match=r"2/2 dataset.*failed"):
+            _process_dataset_results(results, "doc1", "abc123hash")
+
+    def test_partial_failure_also_raises(self):
+        """Even if some datasets succeed, any failure means the job fails."""
+        results = [
+            ("tale_team_a", {"id": "doc1", "chunks": 3}, 3),
+            RuntimeError("cognify failed for team_b"),
+        ]
+        with pytest.raises(RuntimeError, match=r"1/2 dataset.*failed"):
+            _process_dataset_results(results, "doc1", "abc123hash")
+
+    def test_error_message_includes_document_id(self):
+        results = [
+            RuntimeError("some error"),
+        ]
+        with pytest.raises(RuntimeError, match="doc-xyz"):
+            _process_dataset_results(results, "doc-xyz", "abc123hash")
+
+    def test_error_message_truncates_at_3_errors(self):
+        results = [
+            RuntimeError("err1"),
+            RuntimeError("err2"),
+            RuntimeError("err3"),
+            RuntimeError("err4"),
+        ]
+        with pytest.raises(RuntimeError, match=r"4/4 dataset.*failed") as exc_info:
+            _process_dataset_results(results, "doc1", "abc123hash")
+        assert "err4" not in str(exc_info.value)


### PR DESCRIPTION
## Summary

- **Chat loading state**: Rename `isToolMessage` to `isUnfinishedToolTurn` — checks the last meaningful part (skipping `step-start`/`source-*`) instead of scanning all parts. Completed tool turns where a text part follows tool parts are now correctly detected as done loading.
- **Docker crash recovery**: Add `clean_convex_derived_data()` to docker-entrypoint that removes search indexes and compiled modules (both auto-rebuilt) before restarting after a crash, preventing crash loops from corrupted vector index segments. User uploads (`files/`) are never touched.
- **RAG dedup error handling**: Make `add_document` raise `RuntimeError` when any dataset fails in the `asyncio.gather` results. This prevents the content hash from being saved, so the caller can retry all datasets on the next upload.

## Test plan

- [x] Added tests for completed tool turn (text after tool parts → not loading)
- [x] Added tests for text preamble before tool call → still loading
- [x] Added `test_add_document_dedup.py` covering hash-saving and dataset-failure paths
- [ ] Verify chat loading indicator disappears after tool calls complete in the UI
- [ ] Verify crash recovery cleans search indexes on container restart after crash
- [ ] Verify failed dataset processing does not save content hash (retry works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by preventing crash loops through enhanced recovery cleanup on restart.
  * Enhanced error handling for document processing to prevent partial failures; now properly aggregates and reports all dataset errors.
  * Refined chat loading state detection for improved UI responsiveness during tool interactions.

* **Tests**
  * Expanded test coverage for document processing error handling and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->