### PR TITLE
fix(rag): auto-recover from pgvector HNSW index corruption during ingestion

### DIFF
--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -179,9 +179,10 @@ async def _background_ingest(
         )
     except Exception as exc:
         await job_store.mark_failed(job_id=document_id, error=str(exc))
-        logger.error(
-            "Background ingestion failed",
-            extra={"document_id": document_id, "error": str(exc)},
+        logger.opt(exception=True).error(
+            "Background ingestion failed for {}: {}",
+            document_id,
+            exc,
         )
     finally:
         cleanup_memory(context=f"after background ingestion for {document_id}")

--- a/services/rag/app/services/indexing_service.py
+++ b/services/rag/app/services/indexing_service.py
@@ -19,6 +19,8 @@ from tale_shared.db import acquire_with_retry
 from tale_shared.utils.hashing import compute_content_hash
 
 SCHEMA = "private_knowledge"
+_HNSW_INDEX = f"{SCHEMA}.idx_pk_chunks_embedding_hnsw"
+_HNSW_CORRUPTION_MARKER = "should be empty but is not"
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,49 +84,30 @@ async def prepare_document(
     )
 
 
-async def store_prepared_document(
+async def _reindex_chunks_hnsw(pool: asyncpg.Pool) -> None:
+    """Rebuild the HNSW vector index to recover from page corruption."""
+    logger.warning("HNSW index corruption detected — rebuilding {}", _HNSW_INDEX)
+    async with acquire_with_retry(pool) as conn:
+        await conn.execute(f"REINDEX INDEX {_HNSW_INDEX}", timeout=300)
+    logger.info("HNSW index rebuild completed")
+
+
+async def _do_store(
     pool: asyncpg.Pool,
     document_id: str,
     filename: str,
     prepared: PreparedDocument,
+    existing_id: int | None,
     *,
     team_id: str | None = None,
     user_id: str | None = None,
 ) -> dict[str, Any]:
-    """Store a pre-processed document for a single tenant scope.
-
-    Handles dedup check and old-version replacement.
-    """
-    async with acquire_with_retry(pool) as conn:
-        existing = await conn.fetchrow(
-            f"""
-            SELECT id, content_hash FROM {SCHEMA}.documents
-            WHERE document_id = $1
-              AND COALESCE(team_id, '') = COALESCE($2, '')
-              AND COALESCE(user_id, '') = COALESCE($3, '')
-            """,
-            document_id,
-            team_id,
-            user_id,
-        )
-
-    if existing and existing["content_hash"] == prepared.content_hash:
-        logger.info("Document {} content unchanged for team={} user={}, skipping", document_id, team_id, user_id)
-        return {
-            "success": True,
-            "document_id": document_id,
-            "chunks_created": 0,
-            "skipped": True,
-            "skip_reason": "content_unchanged",
-        }
-
-    if existing:
-        logger.info("Document {} content changed, replacing for team={} user={}", document_id, team_id, user_id)
-        async with acquire_with_retry(pool) as conn, conn.transaction():
-            await conn.execute(f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1", existing["id"])
-            await conn.execute(f"DELETE FROM {SCHEMA}.documents WHERE id = $1", existing["id"])
-
+    """Execute the delete-old + insert-new DB operations in a single transaction."""
     async with acquire_with_retry(pool) as conn, conn.transaction():
+        if existing_id is not None:
+            await conn.execute(f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1", existing_id)
+            await conn.execute(f"DELETE FROM {SCHEMA}.documents WHERE id = $1", existing_id)
+
         doc_row = await conn.fetchrow(
             f"""
                 INSERT INTO {SCHEMA}.documents
@@ -163,14 +146,6 @@ async def store_prepared_document(
             chunk_rows,
         )
 
-    logger.info(
-        "Indexed document {}: {} chunks for team={} user={}",
-        document_id,
-        len(prepared.chunks),
-        team_id,
-        user_id,
-    )
-
     return {
         "success": True,
         "document_id": document_id,
@@ -178,6 +153,73 @@ async def store_prepared_document(
         "skipped": False,
         "skip_reason": None,
     }
+
+
+async def store_prepared_document(
+    pool: asyncpg.Pool,
+    document_id: str,
+    filename: str,
+    prepared: PreparedDocument,
+    *,
+    team_id: str | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any]:
+    """Store a pre-processed document for a single tenant scope.
+
+    Handles dedup check, old-version replacement, and HNSW index self-healing.
+    """
+    async with acquire_with_retry(pool) as conn:
+        existing = await conn.fetchrow(
+            f"""
+            SELECT id, content_hash FROM {SCHEMA}.documents
+            WHERE document_id = $1
+              AND COALESCE(team_id, '') = COALESCE($2, '')
+              AND COALESCE(user_id, '') = COALESCE($3, '')
+            """,
+            document_id,
+            team_id,
+            user_id,
+        )
+
+    if existing and existing["content_hash"] == prepared.content_hash:
+        logger.info("Document {} content unchanged for team={} user={}, skipping", document_id, team_id, user_id)
+        return {
+            "success": True,
+            "document_id": document_id,
+            "chunks_created": 0,
+            "skipped": True,
+            "skip_reason": "content_unchanged",
+        }
+
+    if existing:
+        logger.info("Document {} content changed, replacing for team={} user={}", document_id, team_id, user_id)
+
+    existing_id = existing["id"] if existing else None
+
+    for attempt in range(2):
+        try:
+            result = await _do_store(
+                pool,
+                document_id,
+                filename,
+                prepared,
+                existing_id,
+                team_id=team_id,
+                user_id=user_id,
+            )
+            logger.info(
+                "Indexed document {}: {} chunks for team={} user={}",
+                document_id,
+                result["chunks_created"],
+                team_id,
+                user_id,
+            )
+            return result
+        except asyncpg.exceptions.InternalServerError as exc:
+            if _HNSW_CORRUPTION_MARKER in str(exc) and attempt == 0:
+                await _reindex_chunks_hnsw(pool)
+                continue
+            raise
 
 
 async def index_document(

--- a/services/rag/tests/test_indexing_service.py
+++ b/services/rag/tests/test_indexing_service.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import asyncpg.exceptions
 import pytest
 
 pytestmark = pytest.mark.asyncio
@@ -554,3 +555,118 @@ class TestExtractionErrors:
                     "my-file.bin",
                     embedding_service=mock_embed,
                 )
+
+
+class TestHnswIndexSelfHealing:
+    """HNSW index corruption auto-recovery via REINDEX + retry."""
+
+    async def test_reindexes_and_retries_on_hnsw_corruption(self):
+        from app.services.indexing_service import store_prepared_document, PreparedDocument
+
+        pool, mock_conn = _mock_pool(existing_row=None)
+        # fetchrow: SELECT (dedup) → None, INSERT (attempt 1) → id, INSERT (attempt 2) → id
+        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "uuid-1"}, {"id": "uuid-2"}])
+
+        prepared = PreparedDocument(
+            content_hash=SAMPLE_HASH,
+            chunks=SAMPLE_CHUNKS,
+            embeddings=SAMPLE_EMBEDDINGS,
+            vision_used=False,
+        )
+
+        corruption_error = asyncpg.exceptions.InternalServerError(
+            'page 0 of relation "chunks" should be empty but is not'
+        )
+
+        call_count = 0
+        original_executemany = mock_conn.executemany
+
+        async def fail_then_succeed(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise corruption_error
+            return await original_executemany(*args, **kwargs)
+
+        mock_conn.executemany = AsyncMock(side_effect=fail_then_succeed)
+
+        with (
+            _patch_acquire(mock_conn),
+            patch("app.services.indexing_service.compute_content_hash", return_value=SAMPLE_HASH),
+        ):
+            result = await store_prepared_document(
+                pool,
+                SAMPLE_DOC_ID,
+                SAMPLE_FILENAME,
+                prepared,
+                team_id=SAMPLE_TEAM_ID,
+            )
+
+        assert result["success"] is True
+        assert result["chunks_created"] == 2
+        assert call_count == 2
+        reindex_calls = [c for c in mock_conn.execute.call_args_list if "REINDEX" in str(c)]
+        assert len(reindex_calls) == 1
+
+    async def test_raises_on_second_hnsw_corruption(self):
+        from app.services.indexing_service import store_prepared_document, PreparedDocument
+
+        pool, mock_conn = _mock_pool(existing_row=None)
+        # fetchrow: SELECT (dedup) → None, INSERT (attempt 1) → id, INSERT (attempt 2) → id
+        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "uuid-1"}, {"id": "uuid-2"}])
+
+        prepared = PreparedDocument(
+            content_hash=SAMPLE_HASH,
+            chunks=SAMPLE_CHUNKS,
+            embeddings=SAMPLE_EMBEDDINGS,
+            vision_used=False,
+        )
+
+        corruption_error = asyncpg.exceptions.InternalServerError(
+            'page 0 of relation "chunks" should be empty but is not'
+        )
+        mock_conn.executemany = AsyncMock(side_effect=corruption_error)
+
+        with (
+            _patch_acquire(mock_conn),
+            patch("app.services.indexing_service.compute_content_hash", return_value=SAMPLE_HASH),
+        ):
+            with pytest.raises(asyncpg.exceptions.InternalServerError):
+                await store_prepared_document(
+                    pool,
+                    SAMPLE_DOC_ID,
+                    SAMPLE_FILENAME,
+                    prepared,
+                    team_id=SAMPLE_TEAM_ID,
+                )
+
+    async def test_non_hnsw_internal_error_not_retried(self):
+        from app.services.indexing_service import store_prepared_document, PreparedDocument
+
+        pool, mock_conn = _mock_pool(existing_row=None)
+
+        prepared = PreparedDocument(
+            content_hash=SAMPLE_HASH,
+            chunks=SAMPLE_CHUNKS,
+            embeddings=SAMPLE_EMBEDDINGS,
+            vision_used=False,
+        )
+
+        other_error = asyncpg.exceptions.InternalServerError("some other internal error")
+        mock_conn.executemany = AsyncMock(side_effect=other_error)
+
+        with (
+            _patch_acquire(mock_conn),
+            patch("app.services.indexing_service.compute_content_hash", return_value=SAMPLE_HASH),
+        ):
+            with pytest.raises(asyncpg.exceptions.InternalServerError, match="some other internal error"):
+                await store_prepared_document(
+                    pool,
+                    SAMPLE_DOC_ID,
+                    SAMPLE_FILENAME,
+                    prepared,
+                    team_id=SAMPLE_TEAM_ID,
+                )
+
+        reindex_calls = [c for c in mock_conn.execute.call_args_list if "REINDEX" in str(c)]
+        assert len(reindex_calls) == 0


### PR DESCRIPTION
## Summary
- Detects HNSW index corruption (`InternalServerError` with "should be empty but is not") during chunk insertion and automatically runs `REINDEX INDEX` then retries once
- Improved error logging in background ingestion with full tracebacks via `logger.opt(exception=True)`
- Extracted `_do_store()` helper for cleaner retry logic

## Test plan
- [x] 3 new tests: successful recovery, re-raise on second failure, non-HNSW errors not retried
- [ ] Verify existing indexing tests still pass
- [ ] Manual: trigger HNSW corruption scenario and confirm auto-recovery in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document ingestion now automatically detects and recovers from vector index corruption with transparent operation retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->