### PR TITLE
fix(platform): increase V8 isolate heap limits to reduce cold-start latency

### DIFF
--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -155,6 +155,12 @@ ENV NODE_ENV=production \
     # When a browser tab is idle and reconnects, all subscribed queries fire simultaneously,
     # causing burst load that can exceed the default timeout under contention.
     DATABASE_UDF_USER_TIMEOUT_SECONDS=5 \
+    # Increase V8 isolate memory thresholds to reduce cold-start latency spikes.
+    # Default heap (64MB) triggers memory_carry_over recycling when V8 external
+    # memory accumulates to ~48 MiB, causing 3-5s cold-start on the next query.
+    # USER_HEAP 256MB + EXTRA 128MB = 384MB total heap limit per isolate.
+    ISOLATE_MAX_USER_HEAP_SIZE=268435456 \
+    ISOLATE_MAX_HEAP_EXTRA_SIZE=134217728 \
     # CA cert path for self-signed mode - entrypoint script checks if file exists
     # With Let's Encrypt, this file doesn't exist and is safely ignored
     CADDY_CA_CERT_PATH=/caddy-data/caddy/pki/authorities/local/root.crt \


### PR DESCRIPTION
## Summary
- Increases V8 isolate heap limits (`ISOLATE_MAX_USER_HEAP_SIZE` to 256MB, `ISOLATE_MAX_HEAP_EXTRA_SIZE` to 128MB) in the platform Dockerfile
- The default 64MB heap triggers `memory_carry_over` recycling when V8 external memory accumulates to ~48 MiB, causing 3-5s cold-start latency spikes on subsequent queries
- New total heap limit per isolate: 384MB

## Test plan
- [ ] Deploy to staging and monitor cold-start latency metrics
- [ ] Verify no OOM issues under normal load with increased heap limits
- [ ] Confirm `memory_carry_over` recycling events are reduced/eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime memory configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->