### PR TITLE
fix(crawler): recover websites stuck in 'scanning' status on startup

### DIFF
--- a/services/crawler/app/main.py
+++ b/services/crawler/app/main.py
@@ -102,6 +102,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     if stuck:
         logger.info(f"Re-enqueued {len(stuck)} stuck deletion(s)")
 
+    # Reset any scans interrupted by a previous crash
+    stuck_scans = await pg_store_manager.recover_stuck_scans()
+    for domain in stuck_scans:
+        logger.warning(f"Resetting stuck scan for {domain}")
+        await pg_store_manager.update_scan_status(domain, "idle")
+    if stuck_scans:
+        logger.info(f"Reset {len(stuck_scans)} stuck scan(s) to idle")
+
     # Start background scheduler
     scheduler_task = asyncio.create_task(
         run_scheduler(

--- a/services/crawler/app/services/pg_website_store.py
+++ b/services/crawler/app/services/pg_website_store.py
@@ -284,6 +284,18 @@ class PgWebsiteStoreManager:
             rows = await conn.fetch("SELECT domain FROM websites WHERE status = 'deleting'")
         return [r["domain"] for r in rows]
 
+    async def recover_stuck_scans(self) -> list[str]:
+        """Find domains stuck in 'scanning' status for >30 min (e.g. after a crash).
+
+        Uses a 30-minute threshold to avoid resetting websites that are actively
+        being scanned by another container during blue-green deployments.
+        """
+        async with acquire_with_retry(self._pool) as conn:
+            rows = await conn.fetch(
+                "SELECT domain FROM websites WHERE status = 'scanning' AND updated_at < NOW() - INTERVAL '30 minutes'"
+            )
+        return [r["domain"] for r in rows]
+
     async def get_due_websites(self) -> list[dict]:
         async with acquire_with_retry(self._pool) as conn:
             rows = await conn.fetch(

--- a/services/crawler/tests/test_stuck_scan_recovery.py
+++ b/services/crawler/tests/test_stuck_scan_recovery.py
@@ -1,0 +1,126 @@
+"""Tests for recover_stuck_scans: resetting websites stuck in 'scanning' status."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import stamina
+
+from app.services.pg_website_store import PgWebsiteStoreManager
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _fast_stamina_retries():
+    """Keep retries but disable backoff delays for speed."""
+    with stamina.set_testing(True, attempts=1):
+        yield
+
+
+@pytest.fixture
+def mock_conn():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+    conn.executemany = AsyncMock()
+    conn.transaction = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+    return conn
+
+
+@pytest.fixture
+def mock_pool(mock_conn):
+    pool = AsyncMock()
+    pool.acquire = AsyncMock(return_value=mock_conn)
+    pool.release = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def manager(mock_pool):
+    return PgWebsiteStoreManager(mock_pool)
+
+
+class TestRecoverStuckScans:
+    async def test_returns_stuck_scanning_domains(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[{"domain": "stuck.com"}])
+
+        result = await manager.recover_stuck_scans()
+
+        assert result == ["stuck.com"]
+
+    async def test_returns_empty_list_when_no_stuck_websites(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        result = await manager.recover_stuck_scans()
+
+        assert result == []
+
+    async def test_returns_multiple_stuck_domains(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(
+            return_value=[
+                {"domain": "stuck1.com"},
+                {"domain": "stuck2.com"},
+                {"domain": "stuck3.com"},
+            ]
+        )
+
+        result = await manager.recover_stuck_scans()
+
+        assert result == ["stuck1.com", "stuck2.com", "stuck3.com"]
+
+    async def test_query_filters_by_scanning_status(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        await manager.recover_stuck_scans()
+
+        sql = str(mock_conn.fetch.call_args)
+        assert "scanning" in sql
+
+    async def test_query_includes_time_threshold(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        await manager.recover_stuck_scans()
+
+        sql = str(mock_conn.fetch.call_args)
+        assert "30 minutes" in sql
+
+    async def test_idempotent_second_call_returns_empty(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(
+            side_effect=[
+                [{"domain": "stuck.com"}],
+                [],
+            ]
+        )
+
+        first = await manager.recover_stuck_scans()
+        second = await manager.recover_stuck_scans()
+
+        assert first == ["stuck.com"]
+        assert second == []
+
+
+class TestRecoveryStartupFlow:
+    """Test the startup recovery flow: recover_stuck_scans → update_scan_status."""
+
+    async def test_recovered_domain_reset_to_idle(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[{"domain": "stuck.com"}])
+
+        stuck = await manager.recover_stuck_scans()
+        for domain in stuck:
+            await manager.update_scan_status(domain, "idle")
+
+        execute_calls = [str(c) for c in mock_conn.execute.call_args_list]
+        assert any("idle" in c and "stuck.com" in c for c in execute_calls)
+
+    async def test_error_field_is_none_after_recovery(self, manager, mock_conn):
+        mock_conn.fetch = AsyncMock(return_value=[{"domain": "stuck.com"}])
+
+        stuck = await manager.recover_stuck_scans()
+        for domain in stuck:
+            await manager.update_scan_status(domain, "idle")
+
+        call_args = mock_conn.execute.call_args
+        assert call_args[0][3] is None


### PR DESCRIPTION
## Summary
- When the crawler container restarts mid-scan, websites remain stuck in `scanning` status forever because the scheduler excludes them from `get_due_websites()`
- Add `recover_stuck_scans()` to detect and reset stuck websites on startup, mirroring the existing `recover_stuck_deletes()` pattern
- Uses a 30-minute time threshold to avoid interfering with active scans during blue-green deployments

## Changes
- **`pg_website_store.py`**: Add `recover_stuck_scans()` — SELECT-only method that finds websites in `scanning` status with `updated_at > 30 min ago`
- **`main.py`**: Call recovery during startup between `recover_stuck_deletes()` and scheduler start, resetting each stuck website to `idle`
- **`test_stuck_scan_recovery.py`**: 8 test cases covering recovery, idempotency, time threshold, and startup flow

## Test plan
- [x] Unit tests pass (8/8)
- [x] Existing tests unaffected (32/32 pass)
- [x] Docker end-to-end: inserted a stuck website, restarted crawler, confirmed recovery in logs and database status transition (`scanning` → `idle` → scheduler picks up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic recovery mechanism for website scans that become stuck in processing state for extended periods. Stuck scans are now detected at startup and reset to idle status, preventing indefinite scanning states.

* **Tests**
  * Added comprehensive test coverage for the scan recovery workflow, including single/multiple recovery scenarios and idempotent behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->