### PR TITLE
fix(platform): validate system instructions field before saving (#649)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/custom-agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/custom-agents/$agentId/instructions.tsx
@@ -132,7 +132,7 @@ function InstructionsTab() {
   });
 
   const systemInstructionsField = form.register('systemInstructions', {
-    required: true,
+    required: t('customAgents.form.systemInstructionsRequired'),
   });
 
   return (
@@ -150,7 +150,7 @@ function InstructionsTab() {
           {...systemInstructionsField}
           onBlur={(e) => {
             void systemInstructionsField.onBlur(e);
-            void save(form.getValues());
+            void form.handleSubmit((data) => save(data))();
           }}
           required
           rows={8}

--- a/services/platform/convex/custom_agents/mutations.ts
+++ b/services/platform/convex/custom_agents/mutations.ts
@@ -214,6 +214,10 @@ export const createCustomAgent = mutation({
     validateToolNames(args.toolNames);
     validateModelId(args.modelId);
 
+    if (args.systemInstructions.trim().length === 0) {
+      throw new Error('System instructions cannot be empty');
+    }
+
     const { organizationId, toolNames, ...agentFields } = args;
 
     // Sync tool list based on retrieval modes
@@ -287,6 +291,13 @@ export const updateCustomAgent = mutation({
       validateToolNames(args.toolNames);
     }
     validateModelId(args.modelId);
+
+    if (
+      args.systemInstructions !== undefined &&
+      args.systemInstructions.trim().length === 0
+    ) {
+      throw new Error('System instructions cannot be empty');
+    }
 
     const userTeamIds = await getUserTeamIds(ctx, String(authUser._id));
     if (!hasTeamAccess(draft, userTeamIds)) {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -721,6 +721,7 @@
         "descriptionPlaceholder": "What does this agent do?",
         "systemInstructions": "System instructions",
         "systemInstructionsPlaceholder": "You are a helpful assistant that...",
+        "systemInstructionsRequired": "System instructions are required",
         "model": "Model",
         "modelPreset": "Model preset",
         "modelPresets": {


### PR DESCRIPTION
## Summary

- Gates the `onBlur` auto-save through `form.handleSubmit()` so Zod validation runs before any mutation is called
- Adds server-side empty-string rejection in both the `create` and `update` agent mutations
- Surfaces a translated field-level error message when the user clears the instructions field and blurs

## Test plan

- [ ] Clear the system instructions field and click away — error message appears, no save is triggered
- [ ] Enter valid instructions and blur — saves successfully
- [ ] Directly calling the mutation with an empty string returns an error (server-side guard)

Closes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System instructions are now required for custom agents with localized validation messaging
  * Enhanced validation prevents creation and modification of custom agents without valid system instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->