### PR TITLE
fix(automations): remove broken AI thread init, fix nav search param, remove rounded-full

### DIFF
--- a/services/platform/app/features/automations/components/automation-assistant/chat-input.tsx
+++ b/services/platform/app/features/automations/components/automation-assistant/chat-input.tsx
@@ -159,7 +159,6 @@ export function ChatInput({
                   (!inputValue.trim() && attachments.length === 0) || isLoading
                 }
                 size="icon"
-                className="rounded-full"
               >
                 <Send className="size-4" />
               </Button>

--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -10,16 +10,10 @@ import { z } from 'zod';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
-import { useCreateThread } from '@/app/features/chat/hooks/mutations';
-import { useAuth } from '@/app/hooks/use-convex-auth';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
-import { useChatWithWorkflowAssistant } from '../hooks/actions';
-import {
-  useCreateAutomation,
-  useUpdateAutomationMetadata,
-} from '../hooks/mutations';
+import { useCreateAutomation } from '../hooks/mutations';
 
 type FormData = {
   name: string;
@@ -39,11 +33,6 @@ export function CreateAutomationDialog({
 }: CreateAutomationDialogProps) {
   const { t } = useT('automations');
   const { t: tCommon } = useT('common');
-  const { user } = useAuth();
-  const { mutateAsync: createChatThread } = useCreateThread();
-  const { mutateAsync: updateWorkflowMetadata } = useUpdateAutomationMetadata();
-  const { mutateAsync: chatWithWorkflowAssistant } =
-    useChatWithWorkflowAssistant();
 
   const formSchema = useMemo(
     () =>
@@ -80,37 +69,6 @@ export function CreateAutomationDialog({
         },
         stepsConfig: [],
       });
-
-      const description = data.description?.trim();
-      if (description && user?.userId) {
-        try {
-          const title =
-            description.length > 50
-              ? `${description.slice(0, 50)}...`
-              : description;
-          const threadId = await createChatThread({
-            organizationId,
-            title,
-            chatType: 'workflow_assistant',
-          });
-          await updateWorkflowMetadata({
-            wfDefinitionId,
-            metadata: { threadId },
-            updatedBy: user.userId,
-          });
-          void chatWithWorkflowAssistant({
-            threadId,
-            organizationId,
-            workflowId: wfDefinitionId,
-            message: t('createDialog.initialPrompt', {
-              name: data.name,
-              description,
-            }),
-          });
-        } catch (error) {
-          console.error('Failed to initialize AI thread:', error);
-        }
-      }
 
       toast({
         title: t('toast.created'),

--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -58,6 +58,7 @@ export function AutomationsTable({ organizationId }: AutomationsTableProps) {
       void navigate({
         to: '/dashboard/$id/automations/$amId',
         params: { id: organizationId, amId },
+        search: { panel: 'ai-chat' },
       });
     },
     [navigate, organizationId, activeVersionMap],


### PR DESCRIPTION
## Summary

Closes #673, closes #674

### Bugs fixed
- **#674 — AI assistant auto-loads a response on create** — the create dialog was firing \`chatWithWorkflowAssistant\` immediately after creation, causing an AI message to appear without any user query.
- **#673 — Assistant chat sidebar not visible on initial load** — navigating to an automation from the table was missing \`panel: 'ai-chat'\` in the search params, so the sidebar wasn't activated on first load.
- **Stray \`rounded-full\` on chat input send button** — inconsistent class removed to match the design system.