### PR TITLE
chore: update agent rules to bun and add table skeleton meta

### DIFF
--- a/.agent/rules/general-coding-standards.md
+++ b/.agent/rules/general-coding-standards.md
@@ -31,5 +31,5 @@ activationType: always_on
 - Always ask first before any destructive action
 
 ## Workspace Commands
-- USE npm workspaces for running scripts: `npm run <script> --workspace=@tale/<workspace>`
-- Example: `npm run lint --workspace=@tale/platform`
+- USE Bun workspaces for running scripts: `bun run --filter @tale/<workspace> <script>`
+- Example: `bun run --filter @tale/platform lint`

--- a/.agent/rules/testing-standards.md
+++ b/.agent/rules/testing-standards.md
@@ -19,7 +19,7 @@ modelDecision: Apply this rule when creating new features, fixing bugs, or modif
 
 ## Test Execution
 - Run tests after changes to confirm nothing is broken
-- Use `npm run test` for JavaScript/TypeScript tests
+- Use `bun run test` for JavaScript/TypeScript tests
 - Use appropriate test runners for Python services
 
 ## Test Organization

--- a/services/platform/app/features/automations/hooks/use-automations-table-config.tsx
+++ b/services/platform/app/features/automations/hooks/use-automations-table-config.tsx
@@ -18,6 +18,7 @@ export const useAutomationsTableConfig = createTableConfigHook<'wfDefinitions'>(
       accessorKey: 'name',
       header: tTables('headers.automation'),
       size: 328,
+      meta: { hasAvatar: false },
       cell: ({ row }) => (
         <Text as="span" variant="label" truncate>
           {row.original.name}
@@ -28,6 +29,7 @@ export const useAutomationsTableConfig = createTableConfigHook<'wfDefinitions'>(
       accessorKey: 'status',
       header: tTables('headers.status'),
       size: 140,
+      meta: { skeleton: { type: 'badge' } },
       cell: ({ row }) => {
         const status = row.original.status;
         return (
@@ -45,6 +47,7 @@ export const useAutomationsTableConfig = createTableConfigHook<'wfDefinitions'>(
       id: 'active',
       header: tEntity('columns.active'),
       size: 80,
+      meta: { skeleton: { type: 'switch' } },
       cell: ({ row }) => <AutomationActiveToggle automation={row.original} />,
     },
     {
@@ -55,7 +58,7 @@ export const useAutomationsTableConfig = createTableConfigHook<'wfDefinitions'>(
         </span>
       ),
       size: 100,
-      meta: { headerLabel: tTables('headers.version') },
+      meta: { headerLabel: tTables('headers.version'), align: 'right' },
       cell: ({ row }) => (
         <Text as="span" variant="caption" className="block text-right">
           {row.original.version}

--- a/services/platform/app/features/custom-agents/hooks/use-custom-agents-table-config.tsx
+++ b/services/platform/app/features/custom-agents/hooks/use-custom-agents-table-config.tsx
@@ -40,6 +40,7 @@ export function useCustomAgentsTableConfig({
       {
         id: 'displayName',
         header: t('customAgents.columns.displayName'),
+        meta: { hasAvatar: false },
         cell: ({ row }) => (
           <Text as="span" variant="label">
             {row.original.displayName}
@@ -50,6 +51,7 @@ export function useCustomAgentsTableConfig({
       {
         id: 'status',
         header: tTables('headers.status'),
+        meta: { skeleton: { type: 'badge' } },
         cell: ({ row }) => {
           const { status } = row.original;
           return (
@@ -68,11 +70,13 @@ export function useCustomAgentsTableConfig({
         id: 'active',
         header: t('customAgents.columns.active'),
         size: 80,
+        meta: { skeleton: { type: 'switch' } },
         cell: ({ row }) => <CustomAgentActiveToggle agent={row.original} />,
       },
       {
         id: 'modelPreset',
         header: t('customAgents.columns.modelPreset'),
+        meta: { skeleton: { type: 'badge' } },
         cell: ({ row }) => {
           const preset = row.original.modelPreset;
           const presetLabel = t(`customAgents.form.modelPresets.${preset}`);
@@ -102,7 +106,7 @@ export function useCustomAgentsTableConfig({
           </span>
         ),
         size: 100,
-        meta: { headerLabel: t('customAgents.columns.tools') },
+        meta: { headerLabel: t('customAgents.columns.tools'), align: 'right' },
         cell: ({ row }) => (
           <Text as="span" variant="muted" className="block text-right">
             {row.original.toolNames.length}
@@ -112,6 +116,7 @@ export function useCustomAgentsTableConfig({
       {
         id: 'team',
         header: t('customAgents.columns.team'),
+        meta: { skeleton: { type: 'badge' } },
         cell: ({ row }) => {
           const { teamId: rowTeamId } = row.original;
           if (!rowTeamId) {


### PR DESCRIPTION
## Summary
- Updates agent rules to use Bun workspace commands instead of npm
- Adds skeleton meta (`hasAvatar`, `badge`, `switch`) to automations and custom agents table configs
- Aligns version/tools columns with `align: 'right'` meta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Tables for automations and custom agents now display skeleton loaders while data is loading, providing visual feedback during retrieval. Column alignments have been enhanced for improved layout presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->