### PR TITLE
feat(rag): add document content retrieval endpoint

### DIFF
--- a/services/rag/app/models.py
+++ b/services/rag/app/models.py
@@ -158,13 +158,20 @@ class DocumentAddResponse(BaseModel):
     )
 
 
+class ChunkRange(BaseModel):
+    """Range of chunks returned in a content response."""
+
+    start: int = Field(..., description="First chunk returned (1-indexed)")
+    end: int = Field(..., description="Last chunk returned (1-indexed, inclusive)")
+
+
 class DocumentContentResponse(BaseModel):
     """Response containing reassembled document content."""
 
     document_id: str = Field(..., description="Document identifier")
     title: str | None = Field(default=None, description="Original filename")
     content: str = Field(..., description="Reassembled text content")
-    chunk_range: dict[str, int] = Field(..., description="Range of chunks returned (1-indexed, inclusive)")
+    chunk_range: ChunkRange = Field(..., description="Range of chunks returned (1-indexed, inclusive)")
     total_chunks: int = Field(..., description="Total number of chunks in the document")
     total_chars: int = Field(..., description="Total character count of returned content")
 

--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -428,7 +428,7 @@ async def get_document_content(
     if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document '{document_id}' not found",
+            detail="Document not found",
         )
 
     return DocumentContentResponse(**result)

--- a/services/rag/app/services/rag_service.py
+++ b/services/rag/app/services/rag_service.py
@@ -325,6 +325,8 @@ class RagService:
             logger.error("Generation failed: {}", e)
             raise
 
+    MAX_CHUNK_WINDOW = 200
+
     async def get_document_content(
         self,
         document_id: str,
@@ -341,23 +343,28 @@ class RagService:
             team_ids: Team IDs for tenant filtering.
             user_id: User ID for tenant filtering.
             chunk_start: First chunk to return (1-indexed).
-            chunk_end: Last chunk to return (1-indexed, inclusive). None = to end.
+            chunk_end: Last chunk to return (1-indexed, inclusive). None = capped by MAX_CHUNK_WINDOW.
 
         Returns:
             Response dict with content and metadata, or None if not found.
         """
+        if not team_ids and not user_id:
+            raise ValueError("At least one of team_ids or user_id must be provided")
+
         if not self.initialized:
             await self.initialize()
 
         if self._pool is None:
             raise RuntimeError("RagService not initialized: database pool is None")
 
+        if chunk_end is None:
+            chunk_end = chunk_start + self.MAX_CHUNK_WINDOW - 1
+
         # Build tenant WHERE clause
         conditions: list[str] = []
         params: list[Any] = []
         idx = 1
 
-        # $1 = document_id
         conditions.append(f"document_id = ${idx}")
         params.append(document_id)
 
@@ -371,9 +378,7 @@ class RagService:
             tenant_parts.append(f"user_id = ${idx}")
             params.append(user_id)
 
-        if tenant_parts:
-            conditions.append(f"({' OR '.join(tenant_parts)})")
-
+        conditions.append(f"({' OR '.join(tenant_parts)})")
         where = " AND ".join(conditions)
 
         async with acquire_with_retry(self._pool) as conn:
@@ -382,32 +387,19 @@ class RagService:
                 *params,
             )
 
-        if doc is None:
-            return None
+            if doc is None:
+                return None
 
-        doc_uuid = doc["id"]
-        total_chunks = doc["chunks_count"]
+            doc_uuid = doc["id"]
+            total_chunks = doc["chunks_count"]
 
-        # Build chunk query with range filter
-        chunk_conditions = ["document_id = $1"]
-        chunk_params: list[Any] = [doc_uuid]
-        cidx = 1
+            # Convert 1-indexed API params to 0-indexed chunk_index
+            chunk_params: list[Any] = [doc_uuid, chunk_start - 1, chunk_end - 1]
 
-        # Convert 1-indexed API params to 0-indexed chunk_index
-        cidx += 1
-        chunk_conditions.append(f"chunk_index >= ${cidx}")
-        chunk_params.append(chunk_start - 1)
-
-        if chunk_end is not None:
-            cidx += 1
-            chunk_conditions.append(f"chunk_index <= ${cidx}")
-            chunk_params.append(chunk_end - 1)
-
-        chunk_where = " AND ".join(chunk_conditions)
-
-        async with acquire_with_retry(self._pool) as conn:
             rows = await conn.fetch(
-                f"SELECT chunk_index, chunk_content FROM {SCHEMA}.chunks WHERE {chunk_where} ORDER BY chunk_index ASC",
+                f"SELECT chunk_index, chunk_content FROM {SCHEMA}.chunks "
+                f"WHERE document_id = $1 AND chunk_index >= $2 AND chunk_index <= $3 "
+                f"ORDER BY chunk_index ASC",
                 *chunk_params,
             )
 
@@ -416,14 +408,13 @@ class RagService:
                 "document_id": document_id,
                 "title": doc["filename"],
                 "content": "",
-                "chunk_range": {"start": chunk_start, "end": chunk_start},
+                "chunk_range": {"start": 0, "end": 0},
                 "total_chunks": total_chunks,
                 "total_chars": 0,
             }
 
         combined = "\n\n".join(row["chunk_content"] for row in rows)
 
-        # chunk_index is 0-indexed in DB, convert to 1-indexed for response
         actual_start = rows[0]["chunk_index"] + 1
         actual_end = rows[-1]["chunk_index"] + 1
 

--- a/services/rag/tests/test_document_content.py
+++ b/services/rag/tests/test_document_content.py
@@ -175,6 +175,7 @@ class TestGetDocumentContent:
 
         assert result is not None
         assert result["content"] == ""
+        assert result["chunk_range"] == {"start": 0, "end": 0}
 
     async def test_single_chunk_document(self):
         service = _make_service()
@@ -191,17 +192,25 @@ class TestGetDocumentContent:
         assert result["chunk_range"] == {"start": 1, "end": 1}
         assert result["total_chunks"] == 1
 
+    async def test_max_chunk_window_caps_unbounded_request(self):
+        service = _make_service()
+        mock_conn = _mock_conn(fetchrow_return=DOC_ROW, fetch_return=CHUNK_ROWS)
+
+        with patch("app.services.rag_service.acquire_with_retry", return_value=_async_ctx(mock_conn)):
+            await service.get_document_content("doc-1", team_ids=["team-a"], chunk_start=1)
+
+        fetch_call = mock_conn.fetch.call_args
+        sql = fetch_call[0][0]
+        assert "chunk_index <= $3" in sql
+        chunk_end_param = fetch_call[0][3]
+        assert chunk_end_param == service.MAX_CHUNK_WINDOW - 1
+
 
 class TestGetDocumentContentNoTenant:
     """Verify service rejects calls without tenant context."""
 
     async def test_no_tenant_raises_value_error(self):
         service = _make_service()
-        mock_conn = _mock_conn(fetchrow_return=DOC_ROW, fetch_return=CHUNK_ROWS[:1])
 
-        with patch("app.services.rag_service.acquire_with_retry", return_value=_async_ctx(mock_conn)):
-            result = await service.get_document_content("doc-1")
-
-        # Without tenant filtering, the query still runs but SQL won't restrict
-        # The endpoint layer enforces the requirement; service layer is permissive
-        assert result is not None
+        with pytest.raises(ValueError, match="At least one of team_ids or user_id must be provided"):
+            await service.get_document_content("doc-1")


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/documents/{doc_id}/content` endpoint that reassembles stored chunks into full document text
- Chunk-based pagination via `chunk_start`/`chunk_end` query params (1-indexed)
- Multi-tenant isolation enforced via `team_ids`/`user_id` filtering
- Returns `total_chars` metadata for the returned content

## Changed files
- `services/rag/app/models.py` — `DocumentContentResponse` model
- `services/rag/app/services/rag_service.py` — `get_document_content()` service method
- `services/rag/app/routers/documents.py` — GET endpoint with validation
- `services/rag/tests/test_document_content.py` — 10 unit tests

## Test plan
- [x] 10 unit tests pass (happy path, pagination, tenant filtering, 404, empty chunks)
- [x] Manual testing against live RAG service with real documents
- [x] Verified: 404 for nonexistent doc, 400 for missing tenant / invalid range

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve and reassemble document content with chunk-based pagination and tenant/user filtering support, enabling users to fetch document sections efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->