### PR TITLE
fix(chat): prevent crash when sending attachment without text (#725)

### DIFF
--- a/services/platform/convex/lib/message_deduplication.test.ts
+++ b/services/platform/convex/lib/message_deduplication.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentListMessagesResult } from './message_deduplication';
+
+import { computeDeduplicationState } from './message_deduplication';
+
+function createMessages(
+  messages: Array<{ role: string; content: string | null }>,
+): AgentListMessagesResult {
+  return {
+    page: messages.map((msg, i) => ({
+      _id: `msg_${i}`,
+      message: { role: msg.role, content: msg.content },
+    })),
+    isDone: true,
+    continueCursor: '',
+  };
+}
+
+const emptyResult: AgentListMessagesResult = {
+  page: [],
+  isDone: true,
+  continueCursor: '',
+};
+
+describe('computeDeduplicationState', () => {
+  it('treats a new message as not duplicate when thread is empty', () => {
+    const result = computeDeduplicationState(emptyResult, 'Hello');
+    expect(result.messageAlreadyExists).toBe(false);
+    expect(result.trimmedMessage).toBe('Hello');
+  });
+
+  it('detects duplicate when same user message is latest', () => {
+    const messages = createMessages([{ role: 'user', content: 'Hello' }]);
+    const result = computeDeduplicationState(messages, 'Hello');
+    expect(result.messageAlreadyExists).toBe(true);
+    expect(result.lastUserMessage).toBeDefined();
+  });
+
+  it('skips deduplication when latest is assistant with content', () => {
+    const messages = createMessages([
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'Hello' },
+    ]);
+    const result = computeDeduplicationState(messages, 'Hello');
+    expect(result.messageAlreadyExists).toBe(false);
+  });
+
+  it('does not treat empty incoming message as duplicate when no prior user messages exist', () => {
+    const result = computeDeduplicationState(emptyResult, '');
+    expect(result.messageAlreadyExists).toBe(false);
+  });
+
+  it('does not treat empty incoming message as duplicate when prior messages exist but no user messages', () => {
+    const messages = createMessages([{ role: 'assistant', content: null }]);
+    const result = computeDeduplicationState(messages, '');
+    expect(result.messageAlreadyExists).toBe(false);
+  });
+
+  it('does not treat whitespace-only incoming message as duplicate', () => {
+    const result = computeDeduplicationState(emptyResult, '   ');
+    expect(result.messageAlreadyExists).toBe(false);
+  });
+
+  it('trims incoming message', () => {
+    const result = computeDeduplicationState(emptyResult, '  Hello  ');
+    expect(result.trimmedMessage).toBe('Hello');
+  });
+});

--- a/services/platform/convex/lib/message_deduplication.ts
+++ b/services/platform/convex/lib/message_deduplication.ts
@@ -44,8 +44,13 @@ export function computeDeduplicationState(
   // If the latest message is a non-null assistant message, always treat the
   // user input as a new message (skip deduplication). Otherwise, fall back
   // to the previous "same-as-last-user" deduplication behavior.
+
+  // Empty/whitespace-only messages are never duplicates — this handles the
+  // case where a user sends an attachment with no text.
   const messageAlreadyExists =
-    !latestIsAssistantWithContent && lastUserContent === trimmedMessage;
+    trimmedMessage !== '' &&
+    !latestIsAssistantWithContent &&
+    lastUserContent === trimmedMessage;
 
   return {
     latestMessage,


### PR DESCRIPTION
## Summary
- Empty/whitespace-only messages no longer match as duplicates in computeDeduplicationState
- Fixes crash: Expected lastUserMessage to exist when messageAlreadyExists is true

## Test plan
- [ ] 7 unit tests added covering empty, whitespace, and normal dedup scenarios
- [ ] Send attachment with no text in chat - should work without error

Closes #725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message deduplication to correctly handle empty and whitespace-only messages.

* **Tests**
  * Added comprehensive test coverage for message deduplication behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->