### PR TITLE
feat(documents): expose fileId in agent document list tool

### DIFF
--- a/services/platform/convex/agent_tools/documents/document_list_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_list_tool.ts
@@ -97,11 +97,14 @@ USE THIS TOOL TO:
 
 DO NOT USE THIS TOOL FOR:
 • Semantic/content search — use rag_search instead
-• Reading indexed document content — use document_retrieve with the document ID instead
-• Extracting data from uploaded files — use pdf, docx, txt, excel, image, or pptx tools instead
+• Reading indexed document content — use document_retrieve with the document ID (id) instead
+• Extracting data from uploaded files — use pdf, docx, txt, excel, image, or pptx tools with the file ID (fileId) instead
 
 RESPONSE FIELDS:
-• documents: Array of {id, title, extension, folderPath, teamId, createdAt (Unix ms UTC), sizeBytes}
+• documents: Array of {id, fileId, title, extension, folderPath, teamId, createdAt (Unix ms UTC), sizeBytes}
+  - id: The document ID (Convex record ID). Use with document_retrieve to read indexed content.
+  - fileId: The storage file ID. Use with file extraction tools (pdf, docx, txt, excel, image, pptx) and any tool that operates on stored files.
+  - IMPORTANT: id and fileId are DIFFERENT identifiers for different purposes. File extraction tools (pdf, docx, excel, image, etc.) require fileId, NOT id. document_retrieve requires id, NOT fileId.
 • totalCount: Total matching documents (number), or null if the scan limit was reached and the true count is unknown — this does NOT mean zero results.
 • hasMore: Whether more results are available
 • cursor: Pass to next call to get the next page

--- a/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
+++ b/services/platform/convex/agent_tools/documents/document_retrieve_tool.ts
@@ -19,7 +19,7 @@ export const documentRetrieveArgs = z
       .string()
       .min(1)
       .describe(
-        'The Convex document ID to retrieve content from. Get IDs from document_list.',
+        'The Convex document ID (the "id" field from document_list, NOT "fileId"). Use fileId with file extraction tools instead.',
       ),
     chunkStart: z
       .number()

--- a/services/platform/convex/documents/__tests__/list_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/__tests__/list_documents_for_agent.test.ts
@@ -24,6 +24,7 @@ interface MockDoc {
   organizationId: string;
   title?: string;
   extension?: string;
+  fileId?: string;
   teamId?: string;
   folderId?: string;
   metadata?: Record<string, unknown>;
@@ -140,6 +141,7 @@ function makeDoc(overrides: Partial<MockDoc> & { _id: string }): MockDoc {
     _creationTime: Date.now(),
     organizationId: 'org1',
     title: 'Untitled',
+    fileId: `file_${overrides._id}`,
     ...overrides,
   };
 }
@@ -164,6 +166,7 @@ describe('listDocumentsForAgent', () => {
       const ctx = createMockCtx({}, [
         makeDoc({
           _id: 'doc1',
+          fileId: 'file1',
           title: 'report.pdf',
           extension: 'pdf',
           _creationTime: 1000,
@@ -179,6 +182,7 @@ describe('listDocumentsForAgent', () => {
       expect(result.documents).toHaveLength(1);
       expect(result.documents[0]).toEqual({
         id: 'doc1',
+        fileId: 'file1',
         title: 'report.pdf',
         extension: 'pdf',
         folderPath: null,
@@ -199,6 +203,38 @@ describe('listDocumentsForAgent', () => {
       );
 
       expect(result.documents[0]?.title).toBe('Untitled');
+    });
+
+    it('returns fileId when document has a file', async () => {
+      const ctx = createMockCtx({}, [
+        makeDoc({
+          _id: 'doc1',
+          fileId: 'storage_abc123',
+          title: 'report.pdf',
+        }),
+      ]);
+
+      const result = await listDocumentsForAgent(
+        ctx as unknown as QueryCtx,
+        baseArgs,
+      );
+
+      expect(result.documents[0]?.fileId).toBe('storage_abc123');
+    });
+
+    it('skips documents without fileId', async () => {
+      const ctx = createMockCtx({}, [
+        makeDoc({ _id: 'doc1', fileId: 'file1', title: 'with-file.pdf' }),
+        makeDoc({ _id: 'doc2', fileId: undefined, title: 'no-file.txt' }),
+      ]);
+
+      const result = await listDocumentsForAgent(
+        ctx as unknown as QueryCtx,
+        baseArgs,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]?.id).toBe('doc1');
     });
 
     it('returns null sizeBytes when metadata is missing', async () => {

--- a/services/platform/convex/documents/list_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.ts
@@ -19,6 +19,7 @@ const MAX_LIMIT = 50;
 
 export interface AgentDocumentItem {
   id: string;
+  fileId: string;
   title: string;
   extension: string | null;
   folderPath: string | null;
@@ -114,6 +115,7 @@ export async function listDocumentsForAgent(
       break;
     }
 
+    if (!doc.fileId) continue;
     if (args.extension && doc.extension !== args.extension) continue;
 
     // Team filter
@@ -173,6 +175,7 @@ export async function listDocumentsForAgent(
   // Build response
   const documents: AgentDocumentItem[] = page.map((doc) => ({
     id: doc._id,
+    fileId: doc.fileId,
     title: getDocumentTitle(doc),
     extension: doc.extension ?? null,
     folderPath: doc.folderId ? (folderPathMap.get(doc.folderId) ?? null) : null,


### PR DESCRIPTION
## Summary
- Add `fileId` to the agent document list tool response so agents can correctly use file extraction tools (pdf, docx, excel, image, pptx) which require `fileId`, not the document `id`
- Clarify tool descriptions to distinguish between `id` (for `document_retrieve`) and `fileId` (for file extraction tools)
- Filter out documents without a `fileId` since they cannot be used with file tools

## Test plan
- [x] Added test: `returns fileId when document has a file`
- [x] Added test: `skips documents without fileId`
- [ ] Verify existing document list tests still pass
- [ ] Confirm agents correctly use `fileId` with file extraction tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents now include a fileId field in list responses for improved document identification.

* **Documentation**
  * Clarified the distinction between id and fileId fields in document-related tools.
  * Updated tool descriptions to specify proper field usage with document retrieval and file extraction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->