### PR TITLE
fix(documents): exclude folder documents from root list view

### DIFF
--- a/services/platform/convex/documents/list_documents_paginated.test.ts
+++ b/services/platform/convex/documents/list_documents_paginated.test.ts
@@ -35,7 +35,7 @@ function createMockQueryBuilder(
 const DEFAULT_PAGINATION_OPTS = { numItems: 20, cursor: null, id: 0 };
 
 describe('listDocumentsPaginated', () => {
-  it('uses base organizationId index for root view (no folderId)', async () => {
+  it('uses folderId index for root view to exclude documents in folders', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listDocumentsPaginated(ctx as unknown as QueryCtx, {
@@ -46,14 +46,14 @@ describe('listDocumentsPaginated', () => {
 
     expect(ctx.db.query).toHaveBeenCalledWith('documents');
     expect(builder.withIndex).toHaveBeenCalledWith(
-      'by_organizationId',
+      'by_organizationId_and_folderId',
       expect.any(Function),
     );
     expect(builder.order).toHaveBeenCalledWith('desc');
     expect(builder.filter).not.toHaveBeenCalled();
   });
 
-  it('uses sourceProvider as primary index when only sourceProvider is set', async () => {
+  it('applies sourceProvider as secondary filter via .filter()', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listDocumentsPaginated(ctx as unknown as QueryCtx, {
@@ -64,13 +64,13 @@ describe('listDocumentsPaginated', () => {
     });
 
     expect(builder.withIndex).toHaveBeenCalledWith(
-      'by_organizationId_and_sourceProvider',
+      'by_organizationId_and_folderId',
       expect.any(Function),
     );
-    expect(builder.filter).not.toHaveBeenCalled();
+    expect(builder.filter).toHaveBeenCalledTimes(1);
   });
 
-  it('uses extension as primary index when only extension is set', async () => {
+  it('applies extension as secondary filter via .filter()', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listDocumentsPaginated(ctx as unknown as QueryCtx, {
@@ -81,13 +81,13 @@ describe('listDocumentsPaginated', () => {
     });
 
     expect(builder.withIndex).toHaveBeenCalledWith(
-      'by_organizationId_and_extension',
+      'by_organizationId_and_folderId',
       expect.any(Function),
     );
-    expect(builder.filter).not.toHaveBeenCalled();
+    expect(builder.filter).toHaveBeenCalledTimes(1);
   });
 
-  it('uses folderId as primary index and filters sourceProvider and extension', async () => {
+  it('uses folderId index with folder and filters sourceProvider and extension', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listDocumentsPaginated(ctx as unknown as QueryCtx, {

--- a/services/platform/convex/documents/list_documents_paginated.ts
+++ b/services/platform/convex/documents/list_documents_paginated.ts
@@ -22,8 +22,7 @@ interface FilterIndex {
   index: string;
 }
 
-const FILTER_INDEXES: FilterIndex[] = [
-  { field: 'folderId', index: 'by_organizationId_and_folderId' },
+const SECONDARY_FILTER_INDEXES: FilterIndex[] = [
   { field: 'sourceProvider', index: 'by_organizationId_and_sourceProvider' },
   { field: 'extension', index: 'by_organizationId_and_extension' },
 ];
@@ -48,26 +47,12 @@ type FilterArgs = Record<string, string | undefined>;
 function buildBaseQuery(
   ctx: QueryCtx,
   organizationId: string,
-  primary: FilterIndex | undefined,
-  filterArgs: FilterArgs,
+  folderId: Id<'folders'> | undefined,
 ) {
-  if (primary) {
-    const tableQuery = ctx.db.query('documents');
-    const fieldValue = filterArgs[primary.field];
-    const indexFn = (q: {
-      eq: (
-        field: string,
-        value: string | undefined,
-      ) => { eq: (field: string, value: string | undefined) => unknown };
-    }) => q.eq('organizationId', organizationId).eq(primary.field, fieldValue);
-    // @ts-expect-error -- dynamic index name; runtime correct, Convex types require literals
-    return tableQuery.withIndex(primary.index, indexFn);
-  }
-
   return ctx.db
     .query('documents')
-    .withIndex('by_organizationId', (q) =>
-      q.eq('organizationId', organizationId),
+    .withIndex('by_organizationId_and_folderId', (q) =>
+      q.eq('organizationId', organizationId).eq('folderId', folderId),
     );
 }
 
@@ -76,23 +61,16 @@ export async function listDocumentsPaginated(
   args: ListDocumentsPaginatedArgs,
 ): Promise<PaginatedDocumentResult> {
   const filterArgs: FilterArgs = {
-    folderId: args.folderId ? String(args.folderId) : undefined,
     sourceProvider: args.sourceProvider,
     extension: args.extension,
   };
 
-  const primary = FILTER_INDEXES.find(
-    ({ field }) => filterArgs[field] !== undefined,
+  let query = buildBaseQuery(ctx, args.organizationId, args.folderId).order(
+    'desc',
   );
-  let query = buildBaseQuery(
-    ctx,
-    args.organizationId,
-    primary,
-    filterArgs,
-  ).order('desc');
 
-  for (const { field } of FILTER_INDEXES) {
-    if (filterArgs[field] && field !== primary?.field) {
+  for (const { field } of SECONDARY_FILTER_INDEXES) {
+    if (filterArgs[field]) {
       const value = filterArgs[field];
       // @ts-expect-error -- dynamic field name; runtime is correct, Convex types require literal field paths
       query = query.filter((q) => q.eq(q.field(field), value));


### PR DESCRIPTION
## Summary
- Documents uploaded into a folder (e.g., "contracts") were also appearing in the root document list
- Root cause: when no `folderId` was provided, the query fell back to the `by_organizationId` index which returned **all** documents regardless of folder assignment
- Fix: always use the `by_organizationId_and_folderId` compound index — at root level, `.eq('folderId', undefined)` returns only documents not assigned to any folder

## Test plan
- [x] Unit tests updated and passing (9/9)
- [ ] Upload documents into a subfolder → verify they do **not** appear in the root list
- [ ] Navigate into the folder → verify documents appear correctly
- [ ] Verify root-level documents (no folder) still display as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document listing and filtering logic to correctly handle folder-specific queries and secondary filter conditions.

* **Tests**
  * Updated test suite to verify document filtering behavior with new index and filter application patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->