### PR TITLE
fix(platform): handle disabled role in dashboard and use local convex dev

### DIFF
--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -1,5 +1,5 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { BrandingProvider } from '@/app/components/branding/branding-provider';
 import { AccessDenied } from '@/app/components/layout/access-denied';
@@ -14,6 +14,7 @@ import { AbilityContext } from '@/app/context/ability-context';
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { TeamFilterProvider } from '@/app/hooks/use-team-filter';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { defineAbilityFor, type AppAbility } from '@/lib/permissions/ability';
 
@@ -43,8 +44,18 @@ function DashboardLayout() {
   }
 
   const { role, ability } = abilityRef.current;
-  const hasRole = role !== null;
+  const isDisabled = role === 'disabled';
+  const hasRole = role !== null && !isDisabled;
   const isLoading = isAuthLoading || isQueryLoading || isError;
+
+  useEffect(() => {
+    if (isDisabled) {
+      toast({
+        title: t('disabled'),
+        variant: 'destructive',
+      });
+    }
+  }, [isDisabled, t]);
 
   return (
     <AbilityContext.Provider value={ability}>
@@ -69,7 +80,9 @@ function DashboardLayout() {
                     <Spinner size="md" />
                   </div>
                 ) : (
-                  <AccessDenied message={t('noMembership')} />
+                  <AccessDenied
+                    message={t(isDisabled ? 'disabled' : 'noMembership')}
+                  />
                 )}
               </div>
             </div>

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2893,7 +2893,8 @@
     "customAgents": "You need Admin or Developer permissions to manage custom agents.",
     "branding": "You need Admin permissions to access branding settings.",
     "knowledge": "You need Editor, Developer, or Admin permissions to access knowledge.",
-    "noMembership": "You are not a member of this workspace. Please contact an administrator for access."
+    "noMembership": "You are not a member of this workspace. Please contact an administrator for access.",
+    "disabled": "Your account has been disabled. Contact support for assistance."
   },
   "metadata": {
     "suffix": "Tale",

--- a/services/platform/scripts/dev.ts
+++ b/services/platform/scripts/dev.ts
@@ -267,11 +267,15 @@ async function main() {
     }
 
     function spawnConvex() {
-      convexProcess = spawn('bunx', ['convex', 'dev'], {
-        stdio: 'inherit',
-        cwd: platformRoot,
-        env: convexEnv,
-      });
+      convexProcess = spawn(
+        'bunx',
+        ['convex', 'dev', '--local', '--local-force-upgrade'],
+        {
+          stdio: 'inherit',
+          cwd: platformRoot,
+          env: convexEnv,
+        },
+      );
       convexProcess.on('exit', (code) => {
         if (shuttingDown || restarting) return;
         console.log(`[dev] Convex exited with code ${code}`);


### PR DESCRIPTION
## Summary
- Handle `disabled` role in dashboard layout: show access denied page with a destructive toast notification
- Add `disabled` i18n key for the toast message
- Switch convex dev script to use `--local` and `--local-force-upgrade` flags

## Test plan
- [ ] Set a user's role to `disabled` — verify they see the access denied page with a toast
- [ ] Verify non-disabled users still see the dashboard normally
- [ ] Run `bun run --filter @tale/platform dev` — verify convex starts with local flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users now receive immediate notifications when their accounts are disabled, with clear instructions to contact support for assistance
  * Improved access denial messaging to display specific, contextual information based on account status

* **Chores**
  * Refined local development environment configuration for enhanced development workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->