### PR TITLE
fix: keep lastScannedAt up to date for active and scanning websites

### DIFF
--- a/services/crawler/app/services/scheduler.py
+++ b/services/crawler/app/services/scheduler.py
@@ -219,6 +219,7 @@ async def _scan_website(
     _clear_cancelled(domain)
     site_store = store_manager.get_site_store(domain)
     await store_manager.update_scan_status(domain, "scanning")
+    await store_manager.update_last_scanned(domain)
 
     try:
         if not crawler_service.initialized:

--- a/services/platform/convex/websites/internal_queries.ts
+++ b/services/platform/convex/websites/internal_queries.ts
@@ -55,7 +55,7 @@ export const listStaleWebsites = internalQuery({
   args: {},
   handler: async (ctx) => {
     const results = [];
-    for (const status of ['scanning', 'error'] as const) {
+    for (const status of ['scanning', 'error', 'active'] as const) {
       for await (const website of ctx.db
         .query('websites')
         .withIndex('by_status', (q) => q.eq('status', status))) {


### PR DESCRIPTION
## Summary

- **Convex**: Include `active` websites in `listStaleWebsites` query so the `syncStaleWebsites` cron (every 10 min) also syncs `lastScannedAt` for active websites, not just `scanning`/`error`
- **Crawler**: Update `last_scanned_at` at scan start so large sites (e.g., 243K-page forums that take days to complete) show a current timestamp instead of staying frozen until scan completion

## Test plan

- [ ] Typecheck passes: `npx tsc --noEmit` from `services/platform/`
- [ ] Lint passes: `bun run --filter @tale/platform lint`
- [ ] Crawler syntax valid: `python3 -m py_compile services/crawler/app/services/scheduler.py`
- [ ] Verify an `active` website's `lastScannedAt` updates in the UI within 30 minutes of a crawler re-scan
- [ ] Verify a large scanning website shows a recent `last_scanned_at` timestamp after scan starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced timestamp tracking for domain scans to better monitor scan history
  * Updated stale website detection to now include active websites alongside previously scanned and error-prone sites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->