### PR TITLE
fix(conversations): fix email preview mangling newsletter content

### DIFF
--- a/services/platform/app/components/ui/data-display/email-preview.test.tsx
+++ b/services/platform/app/components/ui/data-display/email-preview.test.tsx
@@ -204,6 +204,20 @@ describe('splitQuotedContent', () => {
     expect(quoted).toBe('');
     expect(main).toBe(html);
   });
+
+  it('splits on HTML-wrapped reply header with <br> after wrote:', () => {
+    const html =
+      '<p>Thanks!</p><div>On Mon, Jan 1, 2024, John wrote:<br></div><p>Original</p>';
+    const { quoted } = splitQuotedContent(html);
+    expect(quoted).toContain('On Mon, Jan 1, 2024, John wrote:');
+  });
+
+  it('splits on reply header wrapped in </p> after wrote:', () => {
+    const html =
+      '<p>Thanks!</p><p>On 2024-01-01, John wrote:</p><p>Original</p>';
+    const { quoted } = splitQuotedContent(html);
+    expect(quoted).toContain('On 2024-01-01, John wrote:');
+  });
 });
 
 describe('EmailPreview', () => {

--- a/services/platform/app/components/ui/data-display/email-preview.tsx
+++ b/services/platform/app/components/ui/data-display/email-preview.tsx
@@ -321,7 +321,8 @@ export function splitQuotedContent(html: string): {
     /Begin forwarded message:/i,
     // "On <date/time>, <name> wrote:" — standard reply header.
     // Requires a colon after "wrote" and a date-like token (digit) between On and wrote.
-    /On\s+(?=.*\d).*\swrote:\s*$/im,
+    // Uses [^<]{0,500} to match text content only (not across HTML tags), keeping it bounded.
+    /On\s[^<]{0,500}\d[^<]{0,500}\swrote:/i,
     // "From: ... Subject: ..." — Outlook-style forwarding header
     /From:\s[\s\S]*?Subject:/i,
     // "-----Original Message-----" — Outlook reply separator


### PR DESCRIPTION
## Summary
- Fixed overly greedy quoted-content detection in `EmailPreview` that was incorrectly splitting newsletter emails (e.g. text containing "wrote about" was triggering the reply-header detector)
- Tightened `splitQuotedContent` regex patterns to require a colon after "wrote", a digit (date) in the "On...wrote:" pattern, and proper line boundaries
- Removed aggressive `>` / `&gt;` stripping from `sanitizePreviewHtml` that was corrupting HTML content

## Test plan
- [x] Added unit tests for `splitQuotedContent` covering false-positives (newsletter prose) and legitimate reply headers
- [ ] Verify newsletter emails render fully in Conversations without "Show quoted text" toggle
- [ ] Verify actual reply emails still correctly detect and collapse quoted content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of quoted and forwarded content detection in email previews by refining pattern matching to reduce false positives.
  * Enhanced handling of various email reply and forward formats (Apple Mail, Outlook, and standard email conventions).

* **Tests**
  * Added comprehensive test coverage for quoted content splitting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->