### PR TITLE
feat(platform): nested workflow schemas and arg normalization

### DIFF
--- a/services/platform/convex/agent_tools/workflows/__tests__/create_bound_workflow_tool.test.ts
+++ b/services/platform/convex/agent_tools/workflows/__tests__/create_bound_workflow_tool.test.ts
@@ -101,7 +101,7 @@ describe('createBoundWorkflowTool', () => {
     expect(description).toContain('daysBack');
   });
 
-  it('omits description suffix when property has no description', () => {
+  it('includes raw JSON schema in description', () => {
     const tool = createBoundWorkflowTool(
       { _id: 'wf-123' as never, name: 'My Workflow' },
       {
@@ -114,8 +114,9 @@ describe('createBoundWorkflowTool', () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
     const description = (tool as unknown as { _description: string })
       ._description;
-    expect(description).toContain('count (number)');
-    expect(description).not.toMatch(/count \(number\):/);
+    expect(description).toContain('Input schema:');
+    expect(description).toContain('"count"');
+    expect(description).toContain('"type": "number"');
   });
 
   it('creates approval on happy path', async () => {
@@ -257,6 +258,233 @@ describe('createBoundWorkflowTool', () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('DB error');
+  });
+
+  it('includes raw JSON schema with nested object properties in description', () => {
+    const tool = createBoundWorkflowTool(
+      { _id: 'wf-123' as never, name: 'My Workflow' },
+      {
+        properties: {
+          baseFile: {
+            type: 'object',
+            description: 'The base file',
+            properties: {
+              fileId: { type: 'string', description: 'Storage ID' },
+              fileName: { type: 'string', description: 'File name' },
+            },
+            required: ['fileId', 'fileName'],
+          },
+        },
+        required: ['baseFile'],
+      },
+    );
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
+    const description = (tool as unknown as { _description: string })
+      ._description;
+    expect(description).toContain('Input schema:');
+    expect(description).toContain('"baseFile"');
+    expect(description).toContain('"fileId"');
+    expect(description).toContain('"Storage ID"');
+  });
+
+  it('normalizes stringified object args before validation', async () => {
+    const fileSchema = {
+      inputSchema: {
+        properties: {
+          baseFile: {
+            type: 'object' as const,
+            properties: {
+              fileId: { type: 'string' as const },
+              fileName: { type: 'string' as const },
+            },
+            required: ['fileId', 'fileName'],
+          },
+          requirements: { type: 'string' as const },
+        },
+        required: ['baseFile', 'requirements'],
+      },
+    };
+
+    const tool = createBoundWorkflowTool(
+      { _id: 'wf-def-123' as never, name: 'Contract Workflow' },
+      fileSchema.inputSchema,
+    );
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
+    const handler = (tool as unknown as { _handler: Function })._handler;
+    const workflow = createMockWorkflow({ name: 'Contract Workflow' });
+    const mockRunMutation = vi.fn().mockResolvedValue('approval-id-5');
+
+    const ctx = createMockCtx({
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(workflow)
+        .mockResolvedValueOnce(fileSchema),
+      runMutation: mockRunMutation,
+    });
+
+    const result = await handler(ctx, {
+      baseFile: '{"fileId":"abc123","fileName":"contract.docx"}',
+      requirements: 'Make it simpler',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRunMutation).toHaveBeenCalledWith(
+      'mock-createWorkflowRunApproval',
+      expect.objectContaining({
+        parameters: {
+          baseFile: { fileId: 'abc123', fileName: 'contract.docx' },
+          requirements: 'Make it simpler',
+        },
+      }),
+    );
+  });
+
+  it('normalizes stringified array items before validation', async () => {
+    const fileSchema = {
+      inputSchema: {
+        properties: {
+          knowledgeFiles: {
+            type: 'array' as const,
+            items: {
+              type: 'object' as const,
+              properties: {
+                fileId: { type: 'string' as const },
+                fileName: { type: 'string' as const },
+              },
+              required: ['fileId', 'fileName'],
+            },
+          },
+        },
+        required: ['knowledgeFiles'],
+      },
+    };
+
+    const tool = createBoundWorkflowTool(
+      { _id: 'wf-def-123' as never, name: 'Test Workflow' },
+      fileSchema.inputSchema,
+    );
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
+    const handler = (tool as unknown as { _handler: Function })._handler;
+    const workflow = createMockWorkflow();
+    const mockRunMutation = vi.fn().mockResolvedValue('approval-id-6');
+
+    const ctx = createMockCtx({
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(workflow)
+        .mockResolvedValueOnce(fileSchema),
+      runMutation: mockRunMutation,
+    });
+
+    const result = await handler(ctx, {
+      knowledgeFiles: [
+        '{"fileId":"id1","fileName":"a.docx"}',
+        '{"fileId":"id2","fileName":"b.docx"}',
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRunMutation).toHaveBeenCalledWith(
+      'mock-createWorkflowRunApproval',
+      expect.objectContaining({
+        parameters: {
+          knowledgeFiles: [
+            { fileId: 'id1', fileName: 'a.docx' },
+            { fileId: 'id2', fileName: 'b.docx' },
+          ],
+        },
+      }),
+    );
+  });
+
+  it('passes native object args without modification', async () => {
+    const fileSchema = {
+      inputSchema: {
+        properties: {
+          baseFile: {
+            type: 'object' as const,
+            properties: {
+              fileId: { type: 'string' as const },
+              fileName: { type: 'string' as const },
+            },
+            required: ['fileId', 'fileName'],
+          },
+        },
+        required: ['baseFile'],
+      },
+    };
+
+    const tool = createBoundWorkflowTool(
+      { _id: 'wf-def-123' as never, name: 'Test Workflow' },
+      fileSchema.inputSchema,
+    );
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
+    const handler = (tool as unknown as { _handler: Function })._handler;
+    const workflow = createMockWorkflow();
+    const mockRunMutation = vi.fn().mockResolvedValue('approval-id-7');
+
+    const ctx = createMockCtx({
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(workflow)
+        .mockResolvedValueOnce(fileSchema),
+      runMutation: mockRunMutation,
+    });
+
+    const nativeObj = { fileId: 'abc123', fileName: 'contract.docx' };
+    const result = await handler(ctx, { baseFile: nativeObj });
+
+    expect(result.success).toBe(true);
+    expect(mockRunMutation).toHaveBeenCalledWith(
+      'mock-createWorkflowRunApproval',
+      expect.objectContaining({
+        parameters: { baseFile: nativeObj },
+      }),
+    );
+  });
+
+  it('does not parse string fields that are legitimately strings', async () => {
+    const schema = {
+      inputSchema: {
+        properties: {
+          requirements: { type: 'string' as const },
+        },
+        required: ['requirements'],
+      },
+    };
+
+    const tool = createBoundWorkflowTool(
+      { _id: 'wf-def-123' as never, name: 'Test Workflow' },
+      schema.inputSchema,
+    );
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only
+    const handler = (tool as unknown as { _handler: Function })._handler;
+    const workflow = createMockWorkflow();
+    const mockRunMutation = vi.fn().mockResolvedValue('approval-id-8');
+
+    const ctx = createMockCtx({
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(workflow)
+        .mockResolvedValueOnce(schema),
+      runMutation: mockRunMutation,
+    });
+
+    const jsonLikeString = '{"key": "value"}';
+    const result = await handler(ctx, { requirements: jsonLikeString });
+
+    expect(result.success).toBe(true);
+    expect(mockRunMutation).toHaveBeenCalledWith(
+      'mock-createWorkflowRunApproval',
+      expect.objectContaining({
+        parameters: { requirements: jsonLikeString },
+      }),
+    );
   });
 });
 

--- a/services/platform/convex/agent_tools/workflows/create_bound_workflow_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/create_bound_workflow_tool.ts
@@ -26,23 +26,83 @@ interface BoundWorkflowDefinition {
   description?: string;
 }
 
-// WORKAROUND: z.unknown() and z.record(z.string(), z.unknown()) produce
-// broken JSON Schema after AI SDK post-processing. z.unknown() → {} (empty
-// schema) and z.record() → { type: "object", additionalProperties: false }
-// because addAdditionalPropertiesToJsonSchema() unconditionally overrides
-// additionalProperties on all object types.
-// Use concrete unions for arrays and z.string() for objects instead.
+// WORKAROUND (partial): z.unknown() and z.record(z.string(), z.unknown())
+// produce broken JSON Schema after AI SDK post-processing because
+// addAdditionalPropertiesToJsonSchema() unconditionally sets
+// additionalProperties: false on all object types.
+// - z.record() → { type: "object", additionalProperties: false } (empty!)
+// - z.object({}) → same problem
+// However, z.object() WITH explicit properties is fine — the AI SDK adds
+// additionalProperties: false which is correct for fixed-shape objects.
+// So we only fall back to z.string() for opaque objects without properties.
 // See: @ai-sdk/provider-utils/src/add-additional-properties-to-json-schema.ts
 const JSON_VALUE = z.union([z.string(), z.number(), z.boolean(), z.null()]);
 
-const ZOD_TYPE_MAP: Record<string, () => z.ZodTypeAny> = {
+const PRIMITIVE_ZOD_MAP: Record<string, () => z.ZodTypeAny> = {
   string: () => z.string(),
   number: () => z.number(),
   integer: () => z.number().int(),
   boolean: () => z.boolean(),
-  array: () => z.array(JSON_VALUE),
-  object: () => z.string().describe('JSON object as string'),
 };
+
+interface NestedProperty {
+  type: string;
+  description?: string;
+}
+
+interface SchemaProperty {
+  type: string;
+  description?: string;
+  properties?: Record<string, NestedProperty>;
+  required?: string[];
+  items?: {
+    type: string;
+    properties?: Record<string, NestedProperty>;
+    required?: string[];
+  };
+}
+
+function buildNestedObjectSchema(
+  properties: Record<string, NestedProperty>,
+  required?: string[],
+): z.ZodTypeAny {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const [name, nested] of Object.entries(properties)) {
+    let field = (PRIMITIVE_ZOD_MAP[nested.type] ?? (() => z.string()))();
+    if (nested.description) field = field.describe(nested.description);
+    if (!required?.includes(name)) field = field.optional();
+    shape[name] = field;
+  }
+  return z.object(shape);
+}
+
+function buildZodType(prop: SchemaProperty): z.ZodTypeAny {
+  if (prop.type === 'object') {
+    if (prop.properties && Object.keys(prop.properties).length > 0) {
+      return buildNestedObjectSchema(prop.properties, prop.required);
+    }
+    return z.string().describe('JSON object as string');
+  }
+
+  if (prop.type === 'array') {
+    if (prop.items) {
+      if (
+        prop.items.type === 'object' &&
+        prop.items.properties &&
+        Object.keys(prop.items.properties).length > 0
+      ) {
+        return z.array(
+          buildNestedObjectSchema(prop.items.properties, prop.items.required),
+        );
+      }
+      const itemFactory = PRIMITIVE_ZOD_MAP[prop.items.type];
+      if (itemFactory) return z.array(itemFactory());
+    }
+    return z.array(JSON_VALUE);
+  }
+
+  return (PRIMITIVE_ZOD_MAP[prop.type] ?? (() => z.unknown()))();
+}
 
 function buildArgsSchema(inputSchema: WorkflowInputSchema | undefined) {
   if (!inputSchema || Object.keys(inputSchema.properties).length === 0) {
@@ -51,12 +111,54 @@ function buildArgsSchema(inputSchema: WorkflowInputSchema | undefined) {
 
   const shape: Record<string, z.ZodTypeAny> = {};
   for (const [name, prop] of Object.entries(inputSchema.properties)) {
-    let field = (ZOD_TYPE_MAP[prop.type] ?? (() => z.unknown()))();
+    let field = buildZodType(prop);
     if (prop.description) field = field.describe(prop.description);
     if (!inputSchema.required?.includes(name)) field = field.optional();
     shape[name] = field;
   }
   return z.object(shape);
+}
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Normalize args for cross-model resilience.
+ *
+ * Some models stringify objects despite receiving a proper z.object() schema.
+ * This function JSON.parses string values where the runtime schema expects
+ * object or array types. Only targets fields where the schema declares
+ * object/array — never touches string fields.
+ */
+function normalizeArgs(
+  args: Record<string, unknown>,
+  inputSchema: WorkflowInputSchema,
+): Record<string, unknown> {
+  const result = { ...args };
+  for (const [field, schema] of Object.entries(inputSchema.properties)) {
+    const value = result[field];
+    if (typeof value === 'string') {
+      if (schema.type === 'object' || schema.type === 'array') {
+        result[field] = tryParseJson(value);
+      }
+      continue;
+    }
+    if (
+      schema.type === 'array' &&
+      Array.isArray(value) &&
+      schema.items?.type === 'object'
+    ) {
+      result[field] = (value as unknown[]).map((item) =>
+        typeof item === 'string' ? tryParseJson(item) : item,
+      );
+    }
+  }
+  return result;
 }
 
 /**
@@ -130,7 +232,13 @@ export function createBoundWorkflowTool(
       );
 
       const runtimeInputSchema = extractInputSchema(startStepConfig);
-      const validation = validateWorkflowInput(args, runtimeInputSchema);
+      const normalizedArgs = runtimeInputSchema
+        ? normalizeArgs(args, runtimeInputSchema)
+        : args;
+      const validation = validateWorkflowInput(
+        normalizedArgs,
+        runtimeInputSchema,
+      );
 
       if (!validation.valid) {
         return {
@@ -150,7 +258,7 @@ export function createBoundWorkflowTool(
             workflowId: resolvedWf._id,
             workflowName: resolvedWf.name,
             workflowDescription: resolvedWf.description,
-            parameters: args,
+            parameters: normalizedArgs,
             threadId,
             messageId,
           },
@@ -184,19 +292,6 @@ export function sanitizeWorkflowName(name: string): string {
     .replace(/^_|_$/g, '');
 }
 
-function formatInputSchema(inputSchema: WorkflowInputSchema): string {
-  const lines: string[] = [];
-  for (const [name, schema] of Object.entries(inputSchema.properties)) {
-    const required = inputSchema.required?.includes(name);
-    let line = `  - ${name} (${schema.type}${required ? ', required' : ''})`;
-    if (schema.description) {
-      line += `: ${schema.description}`;
-    }
-    lines.push(line);
-  }
-  return lines.join('\n');
-}
-
 function buildDescription(
   wfDefinition: BoundWorkflowDefinition,
   inputSchema: WorkflowInputSchema | undefined,
@@ -208,7 +303,7 @@ function buildDescription(
   }
 
   if (inputSchema && Object.keys(inputSchema.properties).length > 0) {
-    lines.push('', 'Input parameters:', formatInputSchema(inputSchema));
+    lines.push('', 'Input schema:', JSON.stringify(inputSchema, null, 2));
   }
 
   lines.push(


### PR DESCRIPTION
## Summary
- Build proper Zod schemas for nested object and array properties in workflow tools instead of falling back to `z.string()`, enabling structured validation for complex inputs like file objects.
- Auto-parse stringified object/array args from models that serialize values despite receiving structured schemas (cross-model resilience).
- Replace human-readable input parameter descriptions with raw JSON schema in tool descriptions for better model comprehension.

## Test plan
- [x] Added test for nested object properties in tool description
- [x] Added test for normalizing stringified object args before validation
- [x] Added test for normalizing stringified array items
- [x] Added test that native object args pass through unchanged
- [x] Added test that legitimate string fields are not parsed
- [x] Existing tests updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON argument normalization in workflow tools: stringified JSON inputs are now properly converted to native objects for validation and execution.
  * Enhanced input schema display formatting with detailed JSON schema information.
  * Better support for nested objects and arrays in workflow input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->