### PR TITLE
Remove unused background decoration field

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,7 +30,6 @@
     "weight": 400
   },
   "background": {
-    "decoration": "windows",
     "color": {
       "light": "#FFFFFF",
       "dark": "#0C1017"


### PR DESCRIPTION
## Summary
This change removes the `decoration` field from the `background` object in `docs.json` as it is no longer used.

## Changes
- Removed `background.decoration` field from `docs.json`

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/tale/tale/editor/feat%2Fmintlify-changes-2?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified background configuration by removing an unused decoration property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->