### PR TITLE
fix(platform): add horizontal padding to chat system messages

### DIFF
--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -217,7 +217,7 @@ export function ChatMessages({
         return (
           <div
             key={message.key}
-            className={`flex items-center gap-1.5 py-1 text-xs ${message.systemMessageDisplay === 'error' ? 'text-destructive' : 'text-warning'}`}
+            className={`flex items-center gap-1.5 px-4 py-1 text-xs ${message.systemMessageDisplay === 'error' ? 'text-destructive' : 'text-warning'}`}
           >
             <AlertTriangle className="size-3.5 shrink-0" aria-hidden="true" />
             <span>{content}</span>


### PR DESCRIPTION
## Summary
- Adds `px-4` horizontal padding to system messages (error/warning) in chat so they align with other message content

## Test plan
- [ ] Verify system messages (error and warning) display with correct horizontal padding
- [ ] Confirm alignment is consistent with other chat message types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual spacing for warning and error system messages in the chat interface by enhancing padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->