### PR TITLE
ci: debug crawler arm64 build failure

### DIFF
--- a/services/crawler/Dockerfile
+++ b/services/crawler/Dockerfile
@@ -1,5 +1,6 @@
 # Crawler Service Dockerfile
 # Independent service for web crawling using Crawl4AI
+#
 
 # Version argument - injected by CI from git tag, defaults to 'dev' for local builds
 ARG VERSION=dev


### PR DESCRIPTION
## Summary
- Trigger CI to debug crawler arm64 build failure at `playwright install chromium` step
- No code changes — empty commit to run the pipeline

## Test plan
- [ ] Check if crawler arm64 build passes or fails
- [ ] Review build logs for root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor service configuration maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->