### PR TITLE
fix(platform): skip live reload for internal file writes

### DIFF
--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -63,8 +63,8 @@ if (liveReloadEnabled) {
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(notifyClients, 100);
       });
-    } catch {
-      // Directory may not exist yet — skip silently
+    } catch (err) {
+      console.warn(`Live reload: failed to watch ${dir}:`, err);
     }
   }
 


### PR DESCRIPTION
## Summary
- Detect `atomicWrite`'s temp-file naming pattern (`.{name}.{ts}.{uuid}.tmp`) in the `fs.watch` callback as a signal that a file change originated from the web UI, suppressing the SSE reload event for 2 seconds
- Skip `.history/` directory writes and file deletions so only genuine external content edits trigger a browser reload
- Log a warning instead of silently catching watch directory errors

## Test plan
- [ ] `tale start` a project, edit an agent in the web UI and save — no "Reload site?" dialog
- [ ] Delete an agent from the web UI — no "Reload site?" dialog
- [ ] Edit a `.json` file in `agents/` with an external editor (vim, VS Code) — should auto-reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live-reload accuracy to prevent unnecessary reloads from internal file operations
  * Enhanced reload filtering to trigger only for relevant content changes
  * Added error logging for file watching setup failures to improve diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->