### PR TITLE
fix(platform,cli): reduce noise and improve CLI init output

### DIFF
--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -726,7 +726,7 @@ sed -i "s|\"assetPrefix\":\"\"|\"assetPrefix\":\"${DASHBOARD_BASE_PATH}\"|g" ser
 NEXT_PUBLIC_DEPLOYMENT_URL="${SITE_URL}" \
   PORT=${CONVEX_DASHBOARD_PORT} \
   HOSTNAME=0.0.0.0 \
-  node server.js &
+  node server.js > /dev/null &
 DASHBOARD_PID=$!
 cd /app
 

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -206,5 +206,3 @@ Bun.serve({
     });
   },
 });
-
-console.log(`Server running on http://0.0.0.0:${port}`);

--- a/tools/cli/src/lib/actions/init.ts
+++ b/tools/cli/src/lib/actions/init.ts
@@ -149,11 +149,17 @@ export async function init(options: InitOptions): Promise<void> {
     ['Integrations', `${integrationFiles.size} files`],
   ]);
   logger.blank();
+  const needsCd = resolve(process.cwd()) !== resolve(target);
+  let step = 1;
+
   logger.info('Next steps:');
+  if (needsCd) {
+    logger.info(`  ${step++}. Run "cd ${target}" to enter your project`);
+  }
   logger.info(
-    '  1. Edit agents/, workflows/, and integrations/ to customize your setup',
+    `  ${step++}. Edit agents/, workflows/, and integrations/ to customize your setup`,
   );
-  logger.info('  2. Run "tale start" to launch the platform locally');
+  logger.info(`  ${step++}. Run "tale start" to launch the platform locally`);
 }
 
 async function writeEmbeddedFiles(

--- a/tools/cli/src/utils/terminal.ts
+++ b/tools/cli/src/utils/terminal.ts
@@ -125,7 +125,9 @@ export class StatusHeader {
 
     if (this.ready && this.urls) {
       moveTo(1, 1);
-      write(`${BOLD}${CYAN}  Tale Dev${RESET} ${DIM}v${this.version}${RESET}`);
+      write(
+        `${BOLD}${CYAN}  Tale Dev${RESET} ${DIM}v${this.version}${RESET}  ${GREEN}Ready${RESET}`,
+      );
 
       moveTo(3, 1);
       write(`  ${GREEN}Application${RESET}    ${this.urls.app}`);


### PR DESCRIPTION
## Summary
- Suppress dashboard stdout noise in docker entrypoint by redirecting to `/dev/null`
- Remove redundant "Server running on..." log from `server.ts`
- Add a dynamic `cd` step to `tale init` next-steps when the user initialized outside the current directory
- Show a "Ready" indicator in the dev status header

## Test plan
- [ ] Run `tale start` and verify the status header shows "Ready" once services are up
- [ ] Run `tale init <dir>` from a different directory and verify the "cd" step appears
- [ ] Run `tale init` from the target directory and verify no "cd" step is shown
- [ ] Build and run the Docker image, verify no dashboard stdout noise in logs