### PR TITLE
fix(platform): extract validateAgentName to runtime-agnostic module

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -120,6 +120,7 @@ import type * as agents_queries from "../agents/queries.js";
 import type * as agents_seed_system_defaults from "../agents/seed_system_defaults.js";
 import type * as agents_start_chat from "../agents/start_chat.js";
 import type * as agents_unified_chat from "../agents/unified_chat.js";
+import type * as agents_validators from "../agents/validators.js";
 import type * as agents_webhooks_http_actions from "../agents/webhooks/http_actions.js";
 import type * as agents_webhooks_internal_actions from "../agents/webhooks/internal_actions.js";
 import type * as agents_webhooks_internal_mutations from "../agents/webhooks/internal_mutations.js";
@@ -950,6 +951,7 @@ declare const fullApi: ApiFromModules<{
   "agents/seed_system_defaults": typeof agents_seed_system_defaults;
   "agents/start_chat": typeof agents_start_chat;
   "agents/unified_chat": typeof agents_unified_chat;
+  "agents/validators": typeof agents_validators;
   "agents/webhooks/http_actions": typeof agents_webhooks_http_actions;
   "agents/webhooks/internal_actions": typeof agents_webhooks_internal_actions;
   "agents/webhooks/internal_mutations": typeof agents_webhooks_internal_mutations;

--- a/services/platform/convex/agents/file_utils.ts
+++ b/services/platform/convex/agents/file_utils.ts
@@ -11,10 +11,10 @@ import path from 'node:path';
 
 import { agentJsonSchema } from '../../lib/shared/schemas/agents';
 import { serializeJson, sha256, validateOrgSlug } from '../lib/file_io';
+import { validateAgentName } from './validators';
 
-export { sha256 };
+export { sha256, validateAgentName };
 
-const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
 const MAX_FILE_SIZE_BYTES = 256 * 1024; // 256 KB
 const MAX_HISTORY_ENTRIES = 100;
 
@@ -55,10 +55,6 @@ export type AgentReadResult =
         | 'inaccessible';
       message: string;
     };
-
-export function validateAgentName(name: string): boolean {
-  return AGENT_NAME_REGEX.test(name);
-}
 
 export function agentNameFromFileName(fileName: string): string {
   return path.basename(fileName, '.json');

--- a/services/platform/convex/agents/validators.ts
+++ b/services/platform/convex/agents/validators.ts
@@ -1,0 +1,11 @@
+/**
+ * Agent name validation.
+ *
+ * Runtime-agnostic — safe to import from both Node.js and edge runtimes.
+ */
+
+const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function validateAgentName(name: string): boolean {
+  return AGENT_NAME_REGEX.test(name);
+}

--- a/services/platform/convex/agents/webhooks/mutations.ts
+++ b/services/platform/convex/agents/webhooks/mutations.ts
@@ -1,7 +1,7 @@
 import { v } from 'convex/values';
 
 import { mutation } from '../../_generated/server';
-import { validateAgentName } from '../../agents/file_utils';
+import { validateAgentName } from '../../agents/validators';
 import { authComponent } from '../../auth';
 import { getOrganizationMember } from '../../lib/rls';
 import { generateToken } from '../../workflows/triggers/helpers/crypto';


### PR DESCRIPTION
## Summary
- Extracted `validateAgentName` (pure regex check) from `agents/file_utils.ts` into a new `agents/validators.ts` file with no Node.js imports
- `file_utils.ts` re-exports `validateAgentName` from `validators.ts` so existing consumers are unaffected
- Updated `agents/webhooks/mutations.ts` to import directly from the new module

This fixes the Convex bundler error where `mutations.ts` (edge runtime) transitively pulled in `node:path` and `node:crypto` via `file_utils.ts`.

## Test plan
- [ ] `bun run --filter @tale/platform dev` starts without bundler errors
- [ ] `npx tsc --noEmit` passes from `services/platform/`
- [ ] Webhook creation still validates agent slugs correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal validation logic for improved code maintainability.

---

*No user-facing changes or new features in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->