### PR TITLE
fix: use architecture-aware SOPS downloads and add trustedDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
   "optionalDependencies": {
     "@tailwindcss/oxide-linux-x64-gnu": "^4.2.0"
   },
+  "trustedDependencies": [
+    "core-js-pure",
+    "esbuild"
+  ],
   "patchedDependencies": {
     "convex-helpers@0.1.113": "patches/convex-helpers@0.1.113.patch"
   },

--- a/services/crawler/Dockerfile
+++ b/services/crawler/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y \
     xdg-utils \
     && rm -rf /var/lib/apt/lists/* \
     && fc-cache -fv \
-    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.$(dpkg --print-architecture)" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
 # Install uv for faster package management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -129,7 +129,7 @@ ARG SOPS_VERSION=3.9.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl tini postgresql-client ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.$(dpkg --print-architecture)" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && mkdir -p /usr/local/share/ca-certificates \
     && chmod 755 /usr/local/share/ca-certificates \
     && chmod +x /convex/convex-local-backend /convex/generate_key \

--- a/services/rag/Dockerfile
+++ b/services/rag/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.$(dpkg --print-architecture)" -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
 # Install uv for faster package management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv


### PR DESCRIPTION
## Summary
- Replace hardcoded `linux.amd64` with `dpkg --print-architecture` in all Dockerfiles (crawler, platform, rag) so SOPS installs correctly on arm64 and other architectures
- Add `core-js-pure` and `esbuild` to `trustedDependencies` in package.json

## Test plan
- [ ] Verify Docker builds succeed on amd64
- [ ] Verify Docker builds succeed on arm64
- [ ] Verify `npm install` runs without prompts for trusted dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added trusted dependencies configuration.
  * Updated container build processes across services with automatic CPU architecture detection for enhanced deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->