### PR TITLE
fix(cli): improve Windows installer download reliability

### DIFF
--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -22,13 +22,17 @@ if ($existing) {
 
 # Fetch latest release tag
 Write-Info "Fetching latest version..."
-$release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ "User-Agent" = "tale-installer/1.0" }
+try {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ "User-Agent" = "tale-installer/1.0" }
+} catch {
+    Write-Err "Failed to fetch latest release. $_"
+}
 $tag = $release.tag_name
 Write-Info "Latest version: $tag"
 
 # Download binary
 $url = "https://github.com/$Repo/releases/download/$tag/tale_windows.exe"
-$tempFile = Join-Path $env:TEMP "tale_download_$([guid]::NewGuid()).exe"
+$tempFile = Join-Path $env:TEMP "tale_download_$([guid]::NewGuid()).tmp"
 
 function Format-FileSize {
     param([long]$bytes)
@@ -76,6 +80,14 @@ try {
         }
     }
 
+    # Validate download integrity
+    if ($totalBytes -and $totalRead -ne $totalBytes) {
+        throw "Download incomplete: received $(Format-FileSize $totalRead) of $(Format-FileSize $totalBytes)"
+    }
+    if ($totalRead -eq 0) {
+        throw "Download failed: received 0 bytes"
+    }
+
     # Final progress line
     $received = Format-FileSize $totalRead
     if ($totalBytes) {
@@ -84,14 +96,18 @@ try {
     }
     Write-Host ""
     Write-Ok "Download complete"
+    $downloadOk = $true
 } catch {
-    if (Test-Path $tempFile) { Remove-Item $tempFile -Force -ErrorAction SilentlyContinue }
-    Write-Err "Failed to download: $_"
+    $errMsg = if ($_.Exception.InnerException) { $_.Exception.InnerException.Message } else { "$_" }
+    Write-Err "Failed to download: $errMsg"
 } finally {
     if ($null -ne $fileStream) { $fileStream.Dispose() }
     if ($null -ne $stream) { $stream.Dispose() }
     if ($null -ne $response) { $response.Dispose() }
     if ($null -ne $httpClient) { $httpClient.Dispose() }
+    if (-not $downloadOk -and (Test-Path $tempFile)) {
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # Ensure install directory exists


### PR DESCRIPTION
## Summary
- Replace `WebClient` with `HttpClient` for streaming downloads with real-time progress (bytes/total/percent), throttled to 250ms updates
- Add download integrity validation (byte count mismatch, zero-byte guard) and proper error unwrapping
- Enforce TLS 1.2, set User-Agent header, use `.tmp` extension during download, and clean up temp files only on failure

## Test plan
- [ ] Run installer on Windows with a stable connection — verify progress output and successful install
- [ ] Simulate network interruption mid-download — verify incomplete download is detected and temp file cleaned up
- [ ] Run on older Windows/PowerShell where TLS 1.2 isn't default — verify the `SecurityProtocol` fix allows the download to succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging for installer retrieval failures.
  * Added validation to ensure complete and correct file downloads.

* **Improvements**
  * Strengthened security protocols for installer connections.
  * Enhanced progress reporting during download operations.
  * Improved temporary file management and cleanup on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->