### PR TITLE
fix: surface provider config errors in chat instead of perpetual loading

### DIFF
--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -421,6 +421,22 @@ export const runAgentGeneration = internalAction({
       // Stream cleanup (persistent text stream + agent SDK streams) is handled
       // by generateAgentResponse's catch block. This outer catch only ensures
       // a failed assistant message exists for the frontend.
+
+      // Clear generation status so the UI stops showing "Thinking..."
+      if (streamId) {
+        try {
+          await ctx.runMutation(
+            internal.threads.internal_mutations.clearGenerationStatus,
+            { threadId, streamId },
+          );
+        } catch (clearError) {
+          console.error(
+            '[runAgentGeneration] Failed to clear generation status:',
+            clearError,
+          );
+        }
+      }
+
       try {
         const msgs = await listMessages(ctx, components.agent, {
           threadId,


### PR DESCRIPTION
## Summary
- When a provider's secrets file is missing, sending a chat message would show "Thinking ..." forever with no error feedback
- The root cause: model resolution in `runAgentGeneration` ran outside the try-catch block, so provider loading errors were never caught and no failed message was saved
- Moved the `try` block to wrap all setup code (integration tools, delegation, workflows, model resolution) so errors are caught and surfaced as failed assistant messages with error details and a retry button

## Test plan
- [ ] Remove/rename a provider secrets file (e.g. `openrouter.secrets.json`)
- [ ] Send a message in the chat UI
- [ ] Verify the "Thinking" indicator stops and a failed message appears with error details and retry button
- [ ] Restore the secrets file and verify normal chat works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling and resilience in agent generation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->