### PR TITLE
fix: visibleInChat toggle default should be false for new agents

### DIFF
--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
@@ -105,7 +105,7 @@ function GeneralTab() {
 
       <FormSection>
         <Switch
-          checked={config.visibleInChat !== false}
+          checked={config.visibleInChat === true}
           onCheckedChange={handleVisibilityChange}
           label={t('agents.general.visibleInChat')}
           description={t('agents.general.visibleInChatHelp')}


### PR DESCRIPTION
## Summary
- The "Visible in chat" toggle on agent settings used `!== false`, treating `undefined` as `true`
- New agents are created without `visibleInChat` set, so the toggle appeared enabled despite the agent not actually showing in chat (chat filter requires strict `=== true`)
- Changed to `=== true` so the toggle accurately reflects the agent's actual visibility

## Test plan
- [ ] Create a new agent — verify the "Visible in chat" toggle is off by default
- [ ] Toggle it on, save, and verify the agent appears in the chat agent selector
- [ ] Toggle it off, save, and verify the agent is hidden from the chat agent selector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "visible in chat" toggle switch behavior in the dashboard agent settings. The toggle now correctly renders as unchecked by default unless explicitly enabled, improving the accuracy of the configuration display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->