### PR TITLE
fix: resolve DB init race condition on first container start

### DIFF
--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -23,17 +23,13 @@ RUN apt-get update \
         ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /docker-entrypoint-initdb.d \
-                /etc/postgresql/conf.d \
+    && mkdir -p /etc/postgresql/conf.d \
                 /var/lib/postgresql/backup
 
 # Install dbmate for database migrations
 COPY --from=ghcr.io/amacneil/dbmate:2 /usr/local/bin/dbmate /usr/local/bin/dbmate
 
-# Copy initialization scripts
-# - /docker-entrypoint-initdb.d/ : PostgreSQL runs these on first init only
-# - /etc/postgresql/init-scripts/ : Entrypoint wrapper runs these on every startup
-COPY services/db/init-scripts/ /docker-entrypoint-initdb.d/
+# Copy initialization scripts (run on every startup by the entrypoint wrapper)
 COPY services/db/init-scripts/ /etc/postgresql/init-scripts/
 
 # Copy database migrations (tale_knowledge)
@@ -45,8 +41,7 @@ COPY services/db/postgresql.conf /etc/postgresql/postgresql.conf
 # Copy entrypoint wrapper script and set permissions
 COPY services/db/docker-entrypoint-wrapper.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint-wrapper.sh \
-    && chown -R postgres:postgres /docker-entrypoint-initdb.d \
-                                   /etc/postgresql \
+    && chown -R postgres:postgres /etc/postgresql \
                                    /var/lib/postgresql/backup
 
 # Run as root — the standard docker-entrypoint.sh detects root,


### PR DESCRIPTION
## Summary

- Fixes a race condition where `tale start` fails with `duplicate key value violates unique constraint "pg_database_datname_index"` on first container start
- Root cause: init scripts were copied to **both** `/docker-entrypoint-initdb.d/` (PostgreSQL built-in first-init) and `/etc/postgresql/init-scripts/` (custom wrapper every-startup), causing concurrent `CREATE DATABASE` execution via TOCTOU race on `\gexec`
- Fix: removed the `/docker-entrypoint-initdb.d/` path so init scripts only run via the wrapper's `run_init_scripts()`, which already handles idempotent every-startup execution

Fixes #977

## Test plan

- [ ] `docker build` the DB image — confirm it builds cleanly
- [ ] Fresh start (`tale reset --force && tale start`) — databases created without errors
- [ ] Restart (`tale stop && tale start`) — idempotent scripts re-run safely
- [ ] Verify `tale_platform` and `tale_knowledge` databases exist and are accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database service Docker configuration to execute initialization scripts on every container startup rather than only during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->