### PR TITLE
fix: drop privileges at entrypoint to fix data dir permissions

### DIFF
--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -138,7 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --system --gid 1001 app || true \
     && useradd --system --uid 1001 --gid app app || true \
     && mkdir -p /home/app && chmod 777 /home/app \
-    && mkdir -p /app/data/convex /app/data/agents /app/data/workflows /app/data/integrations /dashboard /app/agents-builtin /app/workflows-builtin /app/integrations-builtin /app/providers-builtin \
+    && mkdir -p /app/data/convex /app/data/agents /app/data/workflows /app/data/integrations /app/data/providers /dashboard /app/agents-builtin /app/workflows-builtin /app/integrations-builtin /app/providers-builtin \
     && chown -R app:app /app/data /dashboard /app/agents-builtin /app/workflows-builtin /app/integrations-builtin /app/providers-builtin
 
 # Re-declare VERSION arg (ARGs don't persist after FROM)
@@ -183,7 +183,9 @@ ENV NODE_ENV=production \
     # Workflow template JSON files directory
     WORKFLOWS_DIR=/app/data/workflows \
     # Integration template files directory
-    INTEGRATIONS_DIR=/app/data/integrations
+    INTEGRATIONS_DIR=/app/data/integrations \
+    # Provider config files directory
+    PROVIDERS_DIR=/app/data/providers
 
 COPY --from=convex-dashboard --chown=app:app /app /dashboard
 

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -872,4 +872,4 @@ monitor_convex &
 MONITOR_PID=$!
 
 # Wait for all background processes
-wait "$CONVEX_PID" "$VITE_PID" "$DASHBOARD_PID"
+wait "$CONVEX_PID" "$VITE_PID" "$DASHBOARD_PID" "$MONITOR_PID"


### PR DESCRIPTION
## Summary

- Container now starts as root to fix `/app/data` volume ownership (Docker volumes mount as root by default), then drops to the `app` user via `gosu` before running services. Replaces the static `USER app` directive with runtime privilege dropping — the standard pattern used by postgres, mysql, and redis Docker images.
- Adds missing `/app/data/providers` directory to Dockerfile `mkdir` and `PROVIDERS_DIR` env var to the `ENV` block (was inconsistently absent unlike agents/workflows/integrations).
- Includes `$MONITOR_PID` in the final `wait` so the container properly exits if the Convex process monitor gives up after max restarts.

## Test plan

- [ ] `docker build` completes successfully
- [ ] Fresh `docker run` with new named volume — services start, `/app/data` owned by `app`
- [ ] Restart with existing volume — no permission errors
- [ ] `docker exec <container> id` shows `uid=1001(app)`
- [ ] `docker exec <container> stat -c '%U' /app/data` shows `app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime environment to support provider configuration storage with a dedicated directory structure.
  * Enhanced application startup process with improved directory initialization and permission management.
  * Optimized process lifecycle monitoring during container initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->