### PR TITLE
fix(cli): chown synced files after docker cp to prevent EACCES errors

### DIFF
--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -528,6 +528,15 @@ async function syncProjectFiles(
     ]);
 
     if (result.success) {
+      // docker cp copies files as root — fix ownership so the app user can write
+      await exec('docker', [
+        'exec',
+        containerName,
+        'chown',
+        '-R',
+        'app:app',
+        `/app/data/${dir}/`,
+      ]);
       logger.info(`Synced ${dir}/`);
     } else {
       logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);


### PR DESCRIPTION
## Summary
- `docker cp` creates files as root inside the container, so subdirectories synced after deployment are not writable by the `app` user
- This caused `EACCES: permission denied` errors when Convex tried to write temp files during workflow operations (e.g., installing a workflow)
- Adds `chown -R app:app` after each `docker cp` in the file sync step

## Test plan
- [ ] Revert workflow subdirectory ownership to `root:root` on a running container
- [ ] Deploy with this change and verify subdirectories are owned by `app:app`
- [ ] Confirm workflow install no longer throws EACCES errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a file permission issue in the deployment process where synced files were not properly writable by the application, ensuring proper file access after synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->