### PR TITLE
fix(db): race condition prevents database creation on fresh deploy

### DIFF
--- a/services/db/docker-entrypoint-wrapper.sh
+++ b/services/db/docker-entrypoint-wrapper.sh
@@ -88,7 +88,7 @@ run_init_scripts() {
     for script in "$INIT_SCRIPTS_DIR"/*.sql; do
         [ -f "$script" ] || continue
         echo "  $(basename "$script")"
-        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$script" 2>&1 | grep -E "^(ERROR|NOTICE)" || true
+        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$script" 2>&1 | grep -E "^(ERROR|FATAL|NOTICE)" || true
     done
     echo "Init scripts complete."
 }
@@ -107,13 +107,21 @@ run_migrations() {
     echo "Migrations complete."
 }
 
-# Run init scripts and migrations in the background after PostgreSQL starts
+# Run init scripts and migrations in the background after PostgreSQL starts.
+# We wait until the target database is actually accessible (not just pg_isready)
+# to avoid racing with docker-entrypoint.sh's first-time init which creates
+# the POSTGRES_USER and POSTGRES_DB after starting a temporary server.
 (
     trap 'exit 0' SIGTERM SIGINT
-    until pg_isready -U "$POSTGRES_USER" -q 2>/dev/null; do
+    until psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\q' 2>/dev/null; do
         sleep 1
     done
     run_init_scripts
+    # dbmate connects via TCP — wait for the server to accept TCP connections
+    # (the temp server during first-time init only listens on Unix socket)
+    until pg_isready -U "$POSTGRES_USER" -h localhost -q 2>/dev/null; do
+        sleep 1
+    done
     run_migrations
     touch /tmp/.db_ready
     echo "Database ready."


### PR DESCRIPTION
## Summary

- On first deploy (empty data volume), the background init subshell's `pg_isready` check passes as soon as docker-entrypoint.sh starts its temporary postgres — before the `tale` user and database exist. Init scripts fail silently (`FATAL` errors not matched by grep, swallowed by `|| true`), so `tale_platform` and `tale_knowledge` are never created.
- Replace `pg_isready` with `psql -c '\q'` which actually connects to the target database, ensuring it only succeeds after docker-entrypoint.sh finishes creating the user and database.
- Add a TCP readiness check (`pg_isready -h localhost`) before dbmate migrations, since the temp server only listens on Unix socket.
- Add `FATAL` to the grep error filter so connection-level errors are surfaced in logs.

## Test plan

- [ ] Fresh deploy (`tale init` + `tale deploy` with no existing DB volume) — verify `tale_platform` and `tale_knowledge` are created and platform starts without errors
- [ ] Re-deploy (`tale deploy` on existing data) — verify no regression, services start normally
- [ ] Verify DB container logs show no silent `FATAL` errors during init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database initialization error reporting to catch additional failure conditions during startup.
  * Strengthened database startup verification by checking actual database connection availability instead of just service readiness.
  * Added TCP connectivity validation to ensure reliable database access before initialization completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->