### PR TITLE
fix(proxy): remove redundant HSTS header and default TLS email

### DIFF
--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -220,9 +220,4 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 	}
 
-	# Only set HSTS for HTTPS connections
-	@https {
-		protocol https
-	}
-	header @https Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 }

--- a/services/proxy/docker-entrypoint.sh
+++ b/services/proxy/docker-entrypoint.sh
@@ -66,9 +66,9 @@ case "${TLS_MODE:-selfsigned}" in
         # ACME with email for notifications
         TLS_CONFIG="tls ${TLS_EMAIL}"
       else
-        echo "  Warning: TLS_EMAIL not set, certificate expiry notifications disabled"
-        # ACME without email
-        TLS_CONFIG="tls"
+        TLS_EMAIL_DEFAULT="tls@${HOST:-tale.local}"
+        echo "  Email: ${TLS_EMAIL_DEFAULT} (default, set TLS_EMAIL to override)"
+        TLS_CONFIG="tls ${TLS_EMAIL_DEFAULT}"
       fi
       ;;
     selfsigned|*)


### PR DESCRIPTION
## Summary
- Remove the conditional HSTS header from Caddyfile — Caddy already sets this automatically for HTTPS connections
- Generate a default TLS email from the hostname (`tls@<HOST>`) so ACME certificate expiry notifications are always enabled, instead of running without email

## Test plan
- [ ] Deploy with `TLS_EMAIL` set and verify it's still used
- [ ] Deploy without `TLS_EMAIL` and verify the default email is generated and logged
- [ ] Confirm HSTS header is still present on HTTPS responses (set by Caddy automatically)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated security header configuration for improved protocol handling.
  * Enhanced TLS certificate configuration with automatic default email generation when not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->