### PR TITLE
fix(platform): prevent long email overflow in previews

### DIFF
--- a/services/platform/app/components/ui/data-display/stat-item.tsx
+++ b/services/platform/app/components/ui/data-display/stat-item.tsx
@@ -20,14 +20,18 @@ export function StatItem({
 }: StatItemProps) {
   return (
     <div
-      className={cn('flex flex-col', colSpan === 2 && 'col-span-2', className)}
+      className={cn(
+        'flex min-w-0 flex-col',
+        colSpan === 2 && 'col-span-2',
+        className,
+      )}
     >
       <dt>
         <Text variant="caption" as="span">
           {label}
         </Text>
       </dt>
-      <dd>{children}</dd>
+      <dd className="break-all">{children}</dd>
     </div>
   );
 }

--- a/services/platform/app/features/customers/components/customer-info-popover.tsx
+++ b/services/platform/app/features/customers/components/customer-info-popover.tsx
@@ -68,7 +68,7 @@ export function CustomerInfoCard({ customer }: { customer: CustomerData }) {
             <CustomerStatusBadge status={customer.status} />
           )}
         </div>
-        <Text variant="muted" className="text-xs tracking-tight">
+        <Text variant="muted" className="text-xs tracking-tight break-all">
           {customer.email || t('labels.notAvailable')}
         </Text>
       </div>


### PR DESCRIPTION
## Summary
- Add `min-w-0` to StatItem flex container and `break-all` to value elements so long strings (like emails) wrap instead of overflowing
- Add `break-all` to customer info popover email display

Fixes #1058, fixes #1059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping behavior in stat displays and customer information sections
  * Long text strings now break properly to prevent layout overflow and ensure better content visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->