### PR TITLE
fix(auth): correct field highlighting on login and signup errors

### DIFF
--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -152,7 +152,6 @@ export function LogInPage() {
               placeholder={t('emailPlaceholder')}
               disabled={isSubmitting}
               autoComplete="email"
-              isInvalid={!!loginError}
               className="shadow-xs"
               {...form.register('email', {
                 onChange: () => setLoginError(null),
@@ -167,7 +166,6 @@ export function LogInPage() {
               placeholder={t('passwordPlaceholder')}
               disabled={isSubmitting}
               autoComplete="current-password"
-              isInvalid={!!loginError}
               className="shadow-xs"
               {...form.register('password', {
                 onChange: () => setLoginError(null),

--- a/services/platform/app/routes/_auth/sign-up.tsx
+++ b/services/platform/app/routes/_auth/sign-up.tsx
@@ -87,8 +87,7 @@ function SignUpPage() {
   const passwordValidationItems = usePasswordValidation(password);
 
   const handleSubmit = async (data: SignUpFormData) => {
-    form.setError('password', { message: '' });
-    form.clearErrors('password');
+    form.clearErrors(['email', 'password']);
     signUpStartedRef.current = true;
 
     try {
@@ -98,15 +97,25 @@ function SignUpPage() {
           onError: (ctx) => {
             const errorMessage =
               ctx.error.message || t('signup.wrongCredentials');
-            form.setError('password', { message: errorMessage });
+            const isUserExists =
+              ctx.error.code === 'USER_ALREADY_EXISTS' ||
+              errorMessage.toLowerCase().includes('already exists');
+            form.setError(isUserExists ? 'email' : 'password', {
+              message: errorMessage,
+            });
           },
         },
       );
 
       if (result.error) {
         signUpStartedRef.current = false;
-        form.setError('password', {
-          message: result.error.message || t('signup.wrongCredentials'),
+        const errorMessage =
+          result.error.message || t('signup.wrongCredentials');
+        const isUserExists =
+          result.error.code === 'USER_ALREADY_EXISTS' ||
+          errorMessage.toLowerCase().includes('already exists');
+        form.setError(isUserExists ? 'email' : 'password', {
+          message: errorMessage,
         });
         return;
       }


### PR DESCRIPTION
## Summary
- **Login (#954):** Remove `isInvalid` from both email and password fields on login failure. The error message still displays below the form, but no field is highlighted — preventing information leakage about which credential is wrong.
- **Signup (#952):** Route "user already exists" errors to the email field instead of the password field, so the correct field is highlighted when a duplicate email is used.

Fixes #952, fixes #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form validation display on the login page.
  * Improved error handling in sign-up form to correctly attribute errors to the appropriate field based on error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->