### PR TITLE
fix(chat): hide empty message bubble on file-only uploads

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -204,11 +204,13 @@ function MessageBubbleComponent({
       {...restProps}
     >
       <div
-        className={`rounded-2xl px-4 py-3 ${
+        className={cn(
+          'rounded-2xl',
           isUser
             ? 'bg-muted text-foreground max-w-xs lg:max-w-md'
-            : 'text-foreground bg-background'
-        }`}
+            : 'text-foreground bg-background',
+          (displayContent || message.isAborted) && 'px-4 py-3',
+        )}
       >
         {displayContent ? (
           <div className="text-sm leading-5">


### PR DESCRIPTION
## Summary
- Make bubble padding (`px-4 py-3`) conditional on having text content or an aborted state
- File-only uploads no longer show an empty bubble above the attachments

Fixes #1000