### PR TITLE
fix(auth): redirect authenticated users away from login/signup

### DIFF
--- a/services/platform/app/routes/_auth.tsx
+++ b/services/platform/app/routes/_auth.tsx
@@ -1,9 +1,16 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
 
 import { VStack, Spacer } from '@/app/components/ui/layout/layout';
 import { LogoLink } from '@/app/components/ui/logo/logo-link';
+import { authClient } from '@/lib/auth-client';
 
 export const Route = createFileRoute('/_auth')({
+  beforeLoad: async () => {
+    const session = await authClient.getSession();
+    if (session?.data?.user) {
+      throw redirect({ to: '/dashboard' });
+    }
+  },
   component: AuthLayout,
 });
 


### PR DESCRIPTION
## Summary
- Add `beforeLoad` guard to the `_auth` layout route that checks for an active session
- Authenticated users navigating to `/log-in` or `/sign-up` are redirected to `/dashboard`
- Prevents accidental session destruction on page refresh at auth routes

Fixes #1030