### PR TITLE
fix(platform): show specific error for duplicate website

### DIFF
--- a/services/platform/app/features/websites/components/website-add-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-add-dialog.tsx
@@ -105,8 +105,12 @@ export function AddWebsiteDialog({
         },
         onError: (error) => {
           console.error('Failed to add website:', error);
+          const isDuplicate =
+            error instanceof Error && error.message.includes('already exists');
           toast({
-            title: tWebsites('toast.addError'),
+            title: isDuplicate
+              ? tWebsites('toast.addErrorDuplicate')
+              : tWebsites('toast.addError'),
             variant: 'destructive',
           });
         },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3183,6 +3183,7 @@
     "toast": {
       "addSuccess": "Website added successfully",
       "addError": "Failed to add website",
+      "addErrorDuplicate": "This website has already been added",
       "updateSuccess": "Website updated successfully",
       "updateError": "Failed to update website",
       "deleteError": "Failed to delete website",


### PR DESCRIPTION
## Summary
- Check error message for "already exists" in the add website dialog's `onError` handler
- Show "This website has already been added" instead of the generic "Failed to add website"
- Fall back to generic error for non-duplicate failures

Fixes #1007