### PR TITLE
fix(auth): add navigation links between login and signup pages

### DIFF
--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  Link,
   createFileRoute,
   useNavigate,
   useSearch,
@@ -214,6 +215,13 @@ export function LogInPage() {
           </>
         )}
       </Stack>
+
+      <p className="text-muted-foreground text-center text-sm">
+        {t('login.noAccount')}{' '}
+        <Link to="/sign-up" className="text-foreground hover:underline">
+          {t('login.signUpLink')}
+        </Link>
+      </p>
     </AuthFormLayout>
   );
 }

--- a/services/platform/app/routes/_auth/sign-up.tsx
+++ b/services/platform/app/routes/_auth/sign-up.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo, useCallback, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -214,6 +214,13 @@ function SignUpPage() {
           </>
         )}
       </Stack>
+
+      <p className="text-muted-foreground text-center text-sm">
+        {t('signup.hasAccount')}{' '}
+        <Link to="/log-in" className="text-foreground hover:underline">
+          {t('signup.logInLink')}
+        </Link>
+      </p>
     </AuthFormLayout>
   );
 }

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -458,7 +458,9 @@
         "success": "Signed in successfully",
         "microsoftFailed": "Microsoft sign-in failed. Please try again.",
         "ssoFailed": "SSO login failed. Please try again."
-      }
+      },
+      "noAccount": "Don't have an account?",
+      "signUpLink": "Sign up"
     },
     "signup": {
       "title": "Create account",
@@ -467,6 +469,8 @@
       "creating": "Creating...",
       "createButton": "Create",
       "accountCreated": "Account created successfully!",
+      "hasAccount": "Already have an account?",
+      "logInLink": "Log in",
       "wrongCredentials": "Wrong email or password",
       "microsoftSignInFailed": "Microsoft sign-in failed. Please try again."
     },


### PR DESCRIPTION
## Summary
- Add "Don't have an account? Sign up" link to the login page
- Add "Already have an account? Log in" link to the signup page
- Add translation keys for both navigation prompts

Fixes #953