### PR TITLE
fix(chat): show new agents in chat selector by default

### DIFF
--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -88,7 +88,7 @@ export function useChatAgents(_organizationId: string) {
         a &&
         'displayName' in a &&
         typeof a.displayName === 'string' &&
-        a.visibleInChat === true
+        a.visibleInChat !== false
       ) {
         chatAgents.push({
           name: a.name,


### PR DESCRIPTION
## Summary
- Change agent filter in `useChatAgents` from `visibleInChat === true` to `visibleInChat !== false`
- New agents with `undefined` visibility are now included in the chat selector
- Agents explicitly set to hidden (`false`) are still excluded

Fixes #948