### PR TITLE
fix(platform): validate file types on document upload

### DIFF
--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -14,6 +14,8 @@ import { useT } from '@/lib/i18n/client';
 import {
   DOCUMENT_UPLOAD_ACCEPT,
   DOCUMENT_MAX_FILE_SIZE,
+  isAllowedDocumentUpload,
+  resolveFileType,
 } from '@/lib/shared/file-types';
 import { cn } from '@/lib/utils/cn';
 import { formatBytes } from '@/lib/utils/format/number';
@@ -105,9 +107,19 @@ export function DocumentUploadDialog({
       const validFiles: File[] = [];
 
       for (const file of files) {
-        if (file.size <= DOCUMENT_MAX_FILE_SIZE) {
-          validFiles.push(file);
-        } else {
+        const resolved = resolveFileType(file.name, file.type);
+        if (!isAllowedDocumentUpload(resolved, file.name)) {
+          toast({
+            title: tDocuments('upload.unsupportedFileType'),
+            description: tDocuments('upload.unsupportedFileTypeDescription', {
+              name: file.name,
+            }),
+            variant: 'destructive',
+          });
+          continue;
+        }
+
+        if (file.size > DOCUMENT_MAX_FILE_SIZE) {
           const currentSizeMB = (file.size / (1024 * 1024)).toFixed(1);
           toast({
             title: tDocuments('upload.fileTooLarge'),
@@ -118,7 +130,10 @@ export function DocumentUploadDialog({
             }),
             variant: 'destructive',
           });
+          continue;
         }
+
+        validFiles.push(file);
       }
 
       if (validFiles.length > 0) {

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -1,6 +1,10 @@
 import { v } from 'convex/values';
 
 import {
+  isAllowedDocumentUpload,
+  resolveFileType,
+} from '../../lib/shared/file-types';
+import {
   jsonValueValidator,
   jsonRecordValidator,
 } from '../../lib/shared/schemas/utils/json-value';
@@ -114,6 +118,16 @@ export const createDocumentFromUpload = mutation({
       email: authUser.email,
       name: authUser.name,
     });
+
+    const resolvedContentType = resolveFileType(
+      args.fileName,
+      args.contentType ?? '',
+    );
+    if (!isAllowedDocumentUpload(resolvedContentType, args.fileName)) {
+      throw new Error(
+        'Unsupported file type. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images (JPEG, PNG, GIF, WEBP).',
+      );
+    }
 
     let effectiveTeamId = args.teamId;
 

--- a/services/platform/lib/shared/__tests__/file-types.test.ts
+++ b/services/platform/lib/shared/__tests__/file-types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   extractExtension,
+  isAllowedDocumentUpload,
   mimeToExtension,
   resolveFileType,
 } from '../file-types';
@@ -107,6 +108,56 @@ describe('resolveFileType', () => {
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
     expect(resolveFileType('data.csv', '')).toBe('text/csv');
+  });
+});
+
+describe('isAllowedDocumentUpload', () => {
+  it.each([
+    ['application/pdf', 'report.pdf'],
+    ['application/msword', 'file.doc'],
+    [
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'file.docx',
+    ],
+    [
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'slides.pptx',
+    ],
+    [
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'data.xlsx',
+    ],
+    ['text/csv', 'data.csv'],
+    ['text/plain', 'notes.txt'],
+    ['image/jpeg', 'photo.jpg'],
+    ['image/png', 'screenshot.png'],
+    ['image/gif', 'animation.gif'],
+    ['image/webp', 'image.webp'],
+  ])('allows %s (%s)', (mime, fileName) => {
+    expect(isAllowedDocumentUpload(mime, fileName)).toBe(true);
+  });
+
+  it.each([
+    ['audio/mpeg', 'song.mp3'],
+    ['video/mp4', 'video.mp4'],
+    ['application/x-msdownload', 'program.exe'],
+    ['application/zip', 'archive.zip'],
+    ['application/octet-stream', 'unknown.bin'],
+    ['', 'file.mp3'],
+  ])('rejects %s (%s)', (mime, fileName) => {
+    expect(isAllowedDocumentUpload(mime, fileName)).toBe(false);
+  });
+
+  it('allows by extension when MIME is generic', () => {
+    expect(isAllowedDocumentUpload('application/octet-stream', 'doc.pdf')).toBe(
+      true,
+    );
+    expect(isAllowedDocumentUpload('', 'photo.jpg')).toBe(true);
+  });
+
+  it('rejects unknown extensions even with empty MIME', () => {
+    expect(isAllowedDocumentUpload('', 'malware.exe')).toBe(false);
+    expect(isAllowedDocumentUpload('', 'song.mp3')).toBe(false);
   });
 });
 

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -222,6 +222,41 @@ export const CHAT_UPLOAD_ALLOWED_TYPES: readonly string[] = [
   MIME_TYPES.PPTX,
 ];
 
+/** Allowed MIME types for document uploads (used for client + server validation) */
+export const DOCUMENT_UPLOAD_ALLOWED_TYPES: ReadonlySet<string> = new Set([
+  MIME_TYPES.PDF,
+  MIME_TYPES.DOC,
+  MIME_TYPES.DOCX,
+  MIME_TYPES.PPT,
+  MIME_TYPES.PPTX,
+  MIME_TYPES.XLS,
+  MIME_TYPES.XLSX,
+  MIME_TYPES.CSV,
+  MIME_TYPES.PLAIN,
+  MIME_TYPES.JPEG,
+  MIME_TYPES.PNG,
+  MIME_TYPES.GIF,
+  MIME_TYPES.WEBP,
+]);
+
+/** Allowed extensions for document uploads (fallback when MIME is unreliable) */
+export const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
+  'pdf',
+  'doc',
+  'docx',
+  'ppt',
+  'pptx',
+  'xls',
+  'xlsx',
+  'csv',
+  'txt',
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+]);
+
 /** Document upload dialog: all supported document types + images */
 export const DOCUMENT_UPLOAD_ACCEPT = [
   MIME_TYPES.PDF,
@@ -233,8 +268,11 @@ export const DOCUMENT_UPLOAD_ACCEPT = [
   MIME_TYPES.XLSX,
   MIME_TYPES.CSV,
   MIME_TYPES.PLAIN,
-  'image/*',
-  '.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.csv,.txt',
+  MIME_TYPES.JPEG,
+  MIME_TYPES.PNG,
+  MIME_TYPES.GIF,
+  MIME_TYPES.WEBP,
+  '.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.csv,.txt,.jpg,.jpeg,.png,.gif,.webp',
 ].join(',');
 
 /** Data import forms: spreadsheets only */
@@ -427,6 +465,20 @@ export function getFileTypeLabelKey(mimeType: string): string {
     return 'xlsx';
   if (mimeType === MIME_TYPES.CSV) return 'csv';
   return 'file';
+}
+
+/**
+ * Check whether a file is allowed for document upload based on its resolved
+ * MIME type and extension. Returns `true` when either the MIME type or the
+ * file extension matches the allowlist.
+ */
+export function isAllowedDocumentUpload(
+  resolvedMimeType: string,
+  fileName: string,
+): boolean {
+  if (DOCUMENT_UPLOAD_ALLOWED_TYPES.has(resolvedMimeType)) return true;
+  const ext = extractExtension(fileName);
+  return ext ? DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS.has(ext) : false;
 }
 
 /**

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2799,7 +2799,9 @@
       "dropZoneDescription": "PDF, DOCX, XLSX, CSV up to {maxSize} MB",
       "retryUpload": "Retry upload",
       "retry": "Retry",
-      "documentsUploadedSuccessfully": "{count} {count, plural, one {document} other {documents}} uploaded successfully"
+      "documentsUploadedSuccessfully": "{count} {count, plural, one {document} other {documents}} uploaded successfully",
+      "unsupportedFileType": "Unsupported file type",
+      "unsupportedFileTypeDescription": "{name} is not a supported format. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images."
     },
     "import": {
       "noResponseBody": "No response body received"


### PR DESCRIPTION
## Summary
- Replace broad `image/*` wildcard in accept list with explicit MIME types
- Add client-side file type validation before upload begins, with toast error for rejected files
- Add server-side validation in `createDocumentFromUpload` mutation against an allowlist
- Add `isAllowedDocumentUpload` helper with tests covering allowed types, rejected types, and extension fallback

Fixes #1039