### PR TITLE
fix(platform): detect locale vs name in vendor CSV import

### DIFF
--- a/services/platform/app/hooks/__tests__/use-file-import.test.ts
+++ b/services/platform/app/hooks/__tests__/use-file-import.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+
+import { customerMappers, vendorMappers } from '../use-file-import';
+
+describe('vendorMappers.csv', () => {
+  it('parses email only', () => {
+    const result = vendorMappers.csv(['vendor@example.com'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: undefined,
+      locale: 'en',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email with locale (2 fields)', () => {
+    const result = vendorMappers.csv(['vendor@example.com', 'es'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: undefined,
+      locale: 'es',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email with locale containing region (2 fields)', () => {
+    const result = vendorMappers.csv(['vendor@example.com', 'pt-BR'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: undefined,
+      locale: 'pt-BR',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email with locale using underscore separator (2 fields)', () => {
+    const result = vendorMappers.csv(['vendor@example.com', 'zh_Hans'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: undefined,
+      locale: 'zh_Hans',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email with name (2 fields, non-locale value)', () => {
+    const result = vendorMappers.csv(['vendor@example.com', 'Acme Corp'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: 'Acme Corp',
+      locale: 'en',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email, name, and locale (3 fields)', () => {
+    const result = vendorMappers.csv(
+      ['vendor@example.com', 'Acme Corp', 'fr'],
+      0,
+    );
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: 'Acme Corp',
+      locale: 'fr',
+      source: 'manual_import',
+    });
+  });
+
+  it('handles empty name in 3-field format', () => {
+    const result = vendorMappers.csv(['vendor@example.com', '', 'de'], 0);
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: undefined,
+      locale: 'de',
+      source: 'manual_import',
+    });
+  });
+
+  it('returns null for empty email', () => {
+    const result = vendorMappers.csv(['', 'name'], 0);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for missing email', () => {
+    const result = vendorMappers.csv([], 0);
+    expect(result).toBeNull();
+  });
+});
+
+describe('customerMappers.csv', () => {
+  it('parses email with locale (2 fields)', () => {
+    const result = customerMappers.csv(['user@example.com', 'fr'], 0);
+    expect(result).toEqual({
+      email: 'user@example.com',
+      name: undefined,
+      locale: 'fr',
+      status: 'churned',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email with name (2 fields, non-locale value)', () => {
+    const result = customerMappers.csv(['user@example.com', 'John Doe'], 0);
+    expect(result).toEqual({
+      email: 'user@example.com',
+      name: 'John Doe',
+      locale: 'en',
+      status: 'churned',
+      source: 'manual_import',
+    });
+  });
+
+  it('parses email, name, and locale (3 fields)', () => {
+    const result = customerMappers.csv(
+      ['user@example.com', 'John Doe', 'es'],
+      0,
+    );
+    expect(result).toEqual({
+      email: 'user@example.com',
+      name: 'John Doe',
+      locale: 'es',
+      status: 'churned',
+      source: 'manual_import',
+    });
+  });
+});

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -192,10 +192,19 @@ export const vendorMappers = {
     const email = row[0]?.trim();
     if (!email) return null;
 
+    const second = row[1]?.trim();
+    const third = row[2]?.trim();
+    const isLocale = (value?: string) =>
+      !!value && /^[a-z]{2}(?:[-_][A-Za-z]{2,})?$/i.test(value);
+
     return {
       email,
-      name: row[1]?.trim() || undefined,
-      locale: row[2]?.trim() || 'en',
+      name: third
+        ? second || undefined
+        : isLocale(second)
+          ? undefined
+          : second || undefined,
+      locale: third || (isLocale(second) ? second : undefined) || 'en',
       source: 'manual_import' as const,
     };
   },


### PR DESCRIPTION
## Summary
- Apply smart locale detection to vendor CSV mapper (matching customer mapper pattern)
- 2-field input (`email,en`) now correctly detects locale instead of putting it in the name field
- 3-field input (`email,name,locale`) still works as expected
- Added 12 tests covering vendor and customer CSV mapper edge cases

Fixes #1057