### PR TITLE
fix(platform): inject name into integration templates

### DIFF
--- a/services/platform/app/features/settings/integrations/components/integration-upload/utils/__tests__/fetch-template-files.test.ts
+++ b/services/platform/app/features/settings/integrations/components/integration-upload/utils/__tests__/fetch-template-files.test.ts
@@ -31,6 +31,13 @@ const validConfig = JSON.stringify({
   operations: [{ name: 'list_repos', title: 'List repositories' }],
 });
 
+const validConfigWithoutName = JSON.stringify({
+  title: 'GitHub',
+  authMethod: 'bearer_token',
+  secretBindings: ['accessToken'],
+  operations: [{ name: 'list_repos', title: 'List repositories' }],
+});
+
 const validConnector = `
 const connector = {
   operations: ['list_repos'],
@@ -195,6 +202,46 @@ describe('fetchTemplateFiles', () => {
     const result = await fetchTemplateFiles(restTemplate);
     expect(result.success).toBe(true);
     expect(result.data?.iconFile).toBeUndefined();
+  });
+
+  it('injects template name when config.json omits it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const urlStr = toUrlString(url);
+      if (urlStr.includes('config.json'))
+        return mockResponse(validConfigWithoutName);
+      if (urlStr.includes('connector.ts')) return mockResponse(validConnector);
+      if (urlStr.includes('icon.svg'))
+        return mockResponse(new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+      return mockResponse('', false);
+    });
+
+    const result = await fetchTemplateFiles(restTemplate);
+    expect(result.success).toBe(true);
+    expect(result.data?.config.name).toBe('github');
+  });
+
+  it('preserves existing name in config.json', async () => {
+    const configWithCustomName = JSON.stringify({
+      name: 'custom-github',
+      title: 'GitHub',
+      authMethod: 'bearer_token',
+      secretBindings: ['accessToken'],
+      operations: [{ name: 'list_repos', title: 'List repositories' }],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const urlStr = toUrlString(url);
+      if (urlStr.includes('config.json'))
+        return mockResponse(configWithCustomName);
+      if (urlStr.includes('connector.ts')) return mockResponse(validConnector);
+      if (urlStr.includes('icon.svg'))
+        return mockResponse(new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+      return mockResponse('', false);
+    });
+
+    const result = await fetchTemplateFiles(restTemplate);
+    expect(result.success).toBe(true);
+    expect(result.data?.config.name).toBe('custom-github');
   });
 
   it('handles network errors gracefully', async () => {

--- a/services/platform/app/features/settings/integrations/components/integration-upload/utils/fetch-template-files.ts
+++ b/services/platform/app/features/settings/integrations/components/integration-upload/utils/fetch-template-files.ts
@@ -11,6 +11,23 @@ export function clearTemplateCache() {
   cache.clear();
 }
 
+/**
+ * Ensures the fetched config JSON contains a `name` field.
+ * Remote template configs omit `name` because the directory name serves as the
+ * identifier, but the validation schema requires it.
+ */
+function injectTemplateName(configText: string, name: string): string {
+  try {
+    const parsed: unknown = JSON.parse(configText);
+    if (typeof parsed === 'object' && parsed !== null && !('name' in parsed)) {
+      return JSON.stringify(Object.assign({ name }, parsed));
+    }
+    return configText;
+  } catch {
+    return configText;
+  }
+}
+
 export async function fetchTemplateFiles(
   template: IntegrationTemplate,
 ): Promise<ParseResult> {
@@ -42,8 +59,9 @@ export async function fetchTemplateFiles(
   const files: File[] = [];
 
   const configText = await configResp.text();
+  const configWithName = injectTemplateName(configText, template.name);
   files.push(
-    new File([configText], 'config.json', { type: 'application/json' }),
+    new File([configWithName], 'config.json', { type: 'application/json' }),
   );
 
   if (connectorResp?.ok) {


### PR DESCRIPTION
## Summary
- Template config.json files from GitHub don't include a `name` field, causing validation to fail with "Invalid config.json: name: Invalid input"
- Inject the template slug as the `name` field when fetching template configs, before validation runs
- Preserve existing `name` fields if already present
- Added tests for both scenarios

Fixes #960

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced template configuration handling to ensure integration templates properly include a name field during uploads, preserving custom names when provided or assigning defaults when missing.

* **Tests**
  * Added test coverage for template configuration name handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->