### PR TITLE
fix(platform): prevent duplicate agent names on rename

### DIFF
--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -130,6 +130,7 @@ export const saveAgent = action({
     agentName: v.string(),
     config: v.any(),
     isNew: v.optional(v.boolean()),
+    oldAgentName: v.optional(v.string()),
   },
   returns: v.object({ hash: v.string() }),
   handler: async (ctx, args): Promise<{ hash: string }> => {
@@ -152,6 +153,22 @@ export const saveAgent = action({
           message: `Agent '${args.agentName}' already exists`,
         });
       }
+    }
+
+    if (
+      !args.isNew &&
+      args.oldAgentName &&
+      args.oldAgentName !== args.agentName
+    ) {
+      const existing = await readFileSafe(filePath);
+      if (existing !== null) {
+        throw new ConvexError({
+          code: 'DUPLICATE_NAME',
+          message: `Agent '${args.agentName}' already exists`,
+        });
+      }
+      const oldFilePath = resolveAgentFilePath(args.orgSlug, args.oldAgentName);
+      await unlink(oldFilePath).catch(() => {});
     }
 
     await atomicWrite(filePath, content);


### PR DESCRIPTION
## Summary
- Add `oldAgentName` parameter to `saveAgent` action to detect renames
- When renaming, check target name doesn't already exist before writing
- Clean up old agent file on successful rename
- Existing duplicate check for new agents (`isNew: true`) preserved

Fixes #1046