### PR TITLE
fix(platform): prevent horizontal page overflow on mobile

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -738,7 +738,7 @@ export function DataTable<TData, TValue = unknown>({
         />
       )}
     >
-      <div className={cn('flex flex-col flex-1 min-h-0', className)}>
+      <div className={cn('flex flex-col flex-1 min-h-0 min-w-0', className)}>
         {headerContent && (
           <div className="flex-shrink-0 pb-4">{headerContent}</div>
         )}


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the sticky layout flex container in DataTable
- Allows the table to shrink within its parent instead of expanding the page
- Horizontal scrolling is now contained within the table's own scroll area

Fixes #1032