### PR TITLE
fix(platform): pre-select customer locale in edit dropdown

### DIFF
--- a/services/platform/app/components/ui/forms/select.test.tsx
+++ b/services/platform/app/components/ui/forms/select.test.tsx
@@ -115,6 +115,42 @@ describe('Select', () => {
     });
   });
 
+  describe('controlled value', () => {
+    it('shows controlled value', () => {
+      render(
+        <Select
+          options={options}
+          placeholder="Select fruit"
+          value="cherry"
+          onValueChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('combobox')).toHaveTextContent('Cherry');
+    });
+
+    it('updates displayed value when controlled value changes', () => {
+      const { rerender } = render(
+        <Select
+          options={options}
+          placeholder="Select fruit"
+          value="apple"
+          onValueChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('combobox')).toHaveTextContent('Apple');
+
+      rerender(
+        <Select
+          options={options}
+          placeholder="Select fruit"
+          value="banana"
+          onValueChange={() => {}}
+        />,
+      );
+      expect(screen.getByRole('combobox')).toHaveTextContent('Banana');
+    });
+  });
+
   describe('disabled options', () => {
     it('renders disabled option', async () => {
       const optionsWithDisabled = [

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -91,6 +91,9 @@ export const Select = forwardRef<
       position = 'popper',
       sideOffset,
       disabled,
+      value,
+      defaultValue,
+      onValueChange,
       ...props
     },
     ref,
@@ -100,7 +103,13 @@ export const Select = forwardRef<
     const descriptionId = `${id}-description`;
 
     const trigger = (
-      <SelectPrimitive.Root disabled={disabled} {...props}>
+      <SelectPrimitive.Root
+        disabled={disabled}
+        value={value}
+        defaultValue={defaultValue}
+        onValueChange={onValueChange}
+        {...props}
+      >
         <SelectPrimitive.Trigger
           ref={ref}
           id={id}


### PR DESCRIPTION
## Summary
- Explicitly destructure and forward `value`, `defaultValue`, and `onValueChange` to Radix Select Root instead of relying on spread
- Fixes controlled Select state so saved locale values display correctly in edit forms
- Added 2 tests verifying controlled value display and updates

Fixes #1034