### PR TITLE
fix(platform): fix CSV importer column mapping and header detection

### DIFF
--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -91,18 +91,12 @@ export function ProductsImportDialog({
   );
 
   const csvMapper = useCallback(
-    (row: string[], _index: number): ParsedProduct | null => {
-      const name = row[0]?.trim();
-      if (!name) return null;
+    (row: string[], index: number): ParsedProduct | null => {
+      const result = productMappers.csv(row, index);
+      if (!result) return null;
 
       return {
-        name,
-        description: row[1]?.trim() || undefined,
-        imageUrl: row[2]?.trim() || undefined,
-        stock: row[3] ? parseInt(row[3], 10) : 0,
-        price: row[4] ? parseFloat(row[4]) : 0,
-        currency: row[5]?.trim() || 'USD',
-        category: row[6]?.trim() || undefined,
+        ...result,
         status: validateStatus(row[7]),
       };
     },

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -246,9 +246,12 @@ export const productMappers = {
 
     return {
       name,
-      sku: row[1]?.trim() || undefined,
-      description: row[2]?.trim() || undefined,
-      price: row[3] ? parseFloat(row[3]) : undefined,
+      description: row[1]?.trim() || undefined,
+      imageUrl: row[2]?.trim() || undefined,
+      stock: row[3] ? parseInt(row[3], 10) : 0,
+      price: row[4] ? parseFloat(row[4]) : 0,
+      currency: row[5]?.trim() || 'USD',
+      category: row[6]?.trim() || undefined,
       source: 'manual_import' as const,
     };
   },

--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -19,14 +19,60 @@ type CSVParseOptions = {
   skipEmptyLines?: boolean;
 };
 
+const COMMON_HEADER_NAMES = new Set([
+  'name',
+  'email',
+  'description',
+  'price',
+  'sku',
+  'currency',
+  'category',
+  'stock',
+  'status',
+  'locale',
+  'source',
+  'id',
+  'title',
+  'brand',
+  'type',
+  'phone',
+  'address',
+  'country',
+  'city',
+  'image',
+  'imageurl',
+  'image_url',
+  'first name',
+  'last name',
+  'firstname',
+  'lastname',
+  'customer id',
+  'product',
+  'quantity',
+  'amount',
+  'unit',
+  'vendor',
+  'supplier',
+]);
+
+function isHeaderRow(values: string[]): boolean {
+  const nonEmpty = values.filter((v) => v.length > 0);
+  if (nonEmpty.length === 0) return false;
+  const matches = nonEmpty.filter((v) =>
+    COMMON_HEADER_NAMES.has(v.toLowerCase()),
+  );
+  return matches.length >= Math.ceil(nonEmpty.length / 2);
+}
+
 /**
  * Parse CSV text into rows of string arrays.
+ * Automatically detects and skips header rows unless disabled.
  */
 function parseCSVText(
   csvText: string,
   options: CSVParseOptions = {},
 ): string[][] {
-  const { delimiter = ',', skipEmptyLines = true } = options;
+  const { delimiter = ',', skipEmptyLines = true, hasHeaders } = options;
 
   const lines = csvText.trim().split('\n');
   const rows: string[][] = [];
@@ -37,6 +83,10 @@ function parseCSVText(
 
     const values = trimmedLine.split(delimiter).map((item) => item.trim());
     rows.push(values);
+  }
+
+  if (hasHeaders !== false && rows.length >= 2 && isHeaderRow(rows[0])) {
+    rows.shift();
   }
 
   return rows;


### PR DESCRIPTION
## Summary
- Update shared product CSV mapper to correct 8-column format (name, description, imageUrl, stock, price, currency, category)
- Remove conflicting inline mapper from products-import-dialog, delegate to shared mapper
- Add automatic header row detection to `parseCSVText` — standard CSVs with header rows no longer break column alignment

Fixes #1043, fixes #1044, fixes #1031