### PR TITLE
docs: fix quickstart ready message to match actual output

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,10 +66,10 @@ tale start
 Wait for the ready message:
 
 ```text
-🎉 Tale Platform is running!
+Tale Dev v0.x.x  Ready.
 ```
 
-> **Note:** You will see a stream of health check messages while services are starting. Those are normal. Wait for the ready message before opening your browser.
+> **Note:** The version number will vary. You will see a stream of health check messages while services are starting. Those are normal. Wait for the "Ready" message before opening your browser.
 
 ### Step 4: Open the app
 


### PR DESCRIPTION
## Summary
- Replace incorrect "Tale Platform is running!" with actual "Tale Dev v0.x.x  Ready." format
- Add note that version number will vary

Fixes #1052