### PR TITLE
fix(platform): block disabled users from accessing organization

### DIFF
--- a/services/platform/convex/lib/rls/organization/__tests__/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/__tests__/get_organization_member.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+      },
+    },
+  },
+}));
+
+vi.mock('../../auth/require_authenticated_user', () => ({
+  requireAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock('../../errors', () => {
+  class RLSError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = 'RLSError';
+    }
+  }
+  class UnauthorizedError extends RLSError {
+    constructor(message = 'Not authorized to access this resource') {
+      super(message, 'UNAUTHORIZED');
+    }
+  }
+  return { UnauthorizedError };
+});
+
+const { UnauthorizedError } = await import('../../errors');
+const { getOrganizationMember } = await import('../get_organization_member');
+
+function createMockCtx() {
+  return {
+    runQuery: vi.fn(),
+    db: {},
+    auth: {},
+  };
+}
+
+const authUser = { userId: 'user_1', email: 'test@example.com' };
+
+describe('getOrganizationMember', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns member when role is not disabled', async () => {
+    const ctx = createMockCtx();
+    const member = {
+      _id: 'om_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'admin',
+      createdAt: 1000,
+    };
+    ctx.runQuery.mockResolvedValueOnce({ page: [member] });
+
+    const result = await getOrganizationMember(ctx as never, 'org_1', authUser);
+
+    expect(result).toEqual(member);
+  });
+
+  it('throws UnauthorizedError when member role is disabled', async () => {
+    const ctx = createMockCtx();
+    const member = {
+      _id: 'om_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'disabled',
+      createdAt: 1000,
+    };
+    ctx.runQuery.mockResolvedValueOnce({ page: [member] });
+
+    await expect(
+      getOrganizationMember(ctx as never, 'org_1', authUser),
+    ).rejects.toThrow(UnauthorizedError);
+  });
+
+  it('throws UnauthorizedError when member not found', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+
+    await expect(
+      getOrganizationMember(ctx as never, 'org_1', {
+        userId: 'user_1',
+      }),
+    ).rejects.toThrow(UnauthorizedError);
+  });
+
+  it('throws UnauthorizedError for disabled member found via email fallback', async () => {
+    const ctx = createMockCtx();
+    // First query: no direct match
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    // Email lookup: find user by email
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'user_2', email: 'test@example.com' }],
+    });
+    // Second member lookup by email-resolved userId
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'om_2',
+          organizationId: 'org_1',
+          userId: 'user_2',
+          role: 'disabled',
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    await expect(
+      getOrganizationMember(ctx as never, 'org_1', authUser),
+    ).rejects.toThrow(UnauthorizedError);
+  });
+});

--- a/services/platform/convex/lib/rls/organization/__tests__/get_user_organizations.test.ts
+++ b/services/platform/convex/lib/rls/organization/__tests__/get_user_organizations.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+      },
+    },
+  },
+}));
+
+vi.mock('../../auth/require_authenticated_user', () => ({
+  requireAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock('../../auth/get_trusted_auth_data', () => ({
+  getTrustedAuthData: vi.fn().mockResolvedValue(null),
+}));
+
+const { getUserOrganizations } = await import('../get_user_organizations');
+
+function createMockCtx() {
+  return {
+    runQuery: vi.fn(),
+    db: {},
+    auth: {},
+  };
+}
+
+const authUser = { userId: 'user_1', email: 'test@example.com' };
+
+describe('getUserOrganizations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns non-disabled memberships', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        { organizationId: 'org_1', role: 'admin' },
+        { organizationId: 'org_2', role: 'member' },
+      ],
+    });
+
+    const result = await getUserOrganizations(ctx as never, authUser);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].organizationId).toBe('org_1');
+    expect(result[1].organizationId).toBe('org_2');
+  });
+
+  it('filters out disabled memberships', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        { organizationId: 'org_1', role: 'admin' },
+        { organizationId: 'org_2', role: 'disabled' },
+        { organizationId: 'org_3', role: 'member' },
+      ],
+    });
+
+    const result = await getUserOrganizations(ctx as never, authUser);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.organizationId)).toEqual(['org_1', 'org_3']);
+  });
+
+  it('returns empty array when all memberships are disabled', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ organizationId: 'org_1', role: 'disabled' }],
+    });
+
+    const result = await getUserOrganizations(ctx as never, authUser);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no memberships exist', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+
+    const result = await getUserOrganizations(ctx as never, authUser);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -83,5 +83,11 @@ export async function getOrganizationMember(
     );
   }
 
+  if (member.role === 'disabled') {
+    throw new UnauthorizedError(
+      `Member account is disabled in organization ${organizationId}`,
+    );
+  }
+
   return member;
 }

--- a/services/platform/convex/lib/rls/organization/get_user_organizations.ts
+++ b/services/platform/convex/lib/rls/organization/get_user_organizations.ts
@@ -64,8 +64,8 @@ export async function getUserOrganizations(
     return [];
   }
 
-  return result.page.map(
-    (member: { organizationId: string; role?: string }) => {
+  return result.page
+    .map((member: { organizationId: string; role?: string }) => {
       // Get role from trusted headers if available, otherwise from database
       const rawRole = trustedData?.trustedRole || member.role || 'member';
       const normalizedRole = rawRole.toLowerCase();
@@ -78,6 +78,6 @@ export async function getUserOrganizations(
         role,
         member,
       };
-    },
-  );
+    })
+    .filter((entry) => entry.role !== 'disabled');
 }


### PR DESCRIPTION
## Summary
- Reject disabled members in `getOrganizationMember` — the single chokepoint for all org-scoped operations
- Filter disabled memberships from `getUserOrganizations` so disabled users can't see or select orgs
- Added 8 tests covering normal access, disabled rejection, and edge cases

Fixes #756