### PR TITLE
fix(chat): prevent credit error from permanently blocking conversation

### DIFF
--- a/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { PendingMessage } from '../../context/chat-layout-context';
+
+const mockCreateThread = vi.fn();
+const mockUpdateThread = vi.fn();
+const mockChatWithAgent = vi.fn();
+
+vi.mock('../mutations', () => ({
+  useCreateThread: () => ({ mutateAsync: mockCreateThread }),
+  useUpdateThread: () => ({ mutateAsync: mockUpdateThread }),
+  useUnifiedChatWithAgent: () => ({ mutateAsync: mockChatWithAgent }),
+}));
+
+const mockResetGlobalFreeze = vi.fn();
+vi.mock('../use-stream-buffer', () => ({
+  resetGlobalFreeze: () => mockResetGlobalFreeze(),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+import { useSendMessage } from '../use-send-message';
+
+function createParams(
+  overrides?: Partial<Parameters<typeof useSendMessage>[0]>,
+) {
+  return {
+    organizationId: 'org_1',
+    threadId: 'thread_1',
+    messages: [],
+    setIsPending: vi.fn(),
+    setPendingThreadId: vi.fn(),
+    setPendingMessage: vi.fn<(msg: PendingMessage | null) => void>(),
+    clearChatState: vi.fn(),
+    selectedAgent: { name: 'test-agent', displayName: 'Test Agent' },
+    ...overrides,
+  };
+}
+
+describe('useSendMessage — error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatWithAgent.mockResolvedValue({
+      messageAlreadyExists: false,
+      streamId: 'stream_1',
+    });
+  });
+
+  it('calls clearChatState and resetGlobalFreeze on error', async () => {
+    mockChatWithAgent.mockRejectedValue(new Error('Credit limit exceeded'));
+
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.clearChatState).toHaveBeenCalledOnce();
+    expect(mockResetGlobalFreeze).toHaveBeenCalledOnce();
+  });
+
+  it('shows toast on error', async () => {
+    mockChatWithAgent.mockRejectedValue(new Error('Credit limit exceeded'));
+
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' }),
+    );
+  });
+
+  it('does not call clearChatState or resetGlobalFreeze on success', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.clearChatState).not.toHaveBeenCalled();
+    expect(mockResetGlobalFreeze).not.toHaveBeenCalled();
+  });
+
+  it('resets state even when thread creation fails', async () => {
+    mockCreateThread.mockRejectedValue(new Error('Network error'));
+
+    const params = createParams({ threadId: undefined });
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.clearChatState).toHaveBeenCalledOnce();
+    expect(mockResetGlobalFreeze).toHaveBeenCalledOnce();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' }),
+    );
+  });
+
+  it('does not send when no agent is selected', async () => {
+    const params = createParams({ selectedAgent: null });
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(mockChatWithAgent).not.toHaveBeenCalled();
+    expect(params.setIsPending).not.toHaveBeenCalled();
+  });
+
+  it('allows sending a new message after a previous error', async () => {
+    mockChatWithAgent
+      .mockRejectedValueOnce(new Error('Credit error'))
+      .mockResolvedValueOnce({
+        messageAlreadyExists: false,
+        streamId: 'stream_2',
+      });
+
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('First message');
+    });
+
+    expect(params.clearChatState).toHaveBeenCalledOnce();
+
+    params.clearChatState.mockClear();
+    mockResetGlobalFreeze.mockClear();
+
+    await act(async () => {
+      await result.current.sendMessage('Second message');
+    });
+
+    expect(mockChatWithAgent).toHaveBeenCalledTimes(2);
+    expect(params.clearChatState).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -17,6 +17,7 @@ import {
   useCreateThread,
   useUpdateThread,
 } from './mutations';
+import { resetGlobalFreeze } from './use-stream-buffer';
 
 interface UseSendMessageParams {
   organizationId: string;
@@ -161,7 +162,11 @@ export function useSendMessage({
         });
       } catch (error) {
         console.error('Failed to send message:', error);
+        // Reset all client-side pending/loading state so the chat returns
+        // to an idle, sendable state. Includes the stream freeze flag which
+        // could otherwise block text rendering on the next response.
         clearChatState();
+        resetGlobalFreeze();
         toast({
           title: t('toast.sendFailed'),
           variant: 'destructive',

--- a/services/platform/convex/threads/__tests__/is_thread_generating.test.ts
+++ b/services/platform/convex/threads/__tests__/is_thread_generating.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../_generated/server', () => ({
   query: ({ handler }: { handler: Function }) => handler,
@@ -16,7 +16,12 @@ const isThreadGenerating = isThreadGeneratingQuery as unknown as (
   args: { threadId: string },
 ) => Promise<boolean>;
 
-function createMockCtx(threadMeta?: { generationStatus?: string }) {
+function createMockCtx(
+  threadMeta?: {
+    generationStatus?: string;
+    generationStartTime?: number;
+  } | null,
+) {
   return {
     db: {
       query: () => ({
@@ -31,7 +36,12 @@ function createMockCtx(threadMeta?: { generationStatus?: string }) {
 describe('isThreadGenerating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     mockGetAuthUserIdentity.mockResolvedValue({ userId: 'user_1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('returns false when user is not authenticated', async () => {
@@ -66,9 +76,47 @@ describe('isThreadGenerating', () => {
     expect(result).toBe(false);
   });
 
-  it('returns true when generationStatus is generating', async () => {
+  it('returns true when generationStatus is generating and within time limit', async () => {
+    const now = Date.now();
+    const result = await isThreadGenerating(
+      createMockCtx({
+        generationStatus: 'generating',
+        generationStartTime: now - 5000,
+      }),
+      { threadId: 'thread_1' },
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns true when generationStatus is generating without generationStartTime', async () => {
     const result = await isThreadGenerating(
       createMockCtx({ generationStatus: 'generating' }),
+      { threadId: 'thread_1' },
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false when generationStatus is generating but stale (>10 minutes)', async () => {
+    const now = Date.now();
+    const elevenMinutesAgo = now - 11 * 60 * 1000;
+    const result = await isThreadGenerating(
+      createMockCtx({
+        generationStatus: 'generating',
+        generationStartTime: elevenMinutesAgo,
+      }),
+      { threadId: 'thread_1' },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when generationStatus is generating at exactly 10 minutes', async () => {
+    const now = Date.now();
+    const tenMinutesAgo = now - 10 * 60 * 1000;
+    const result = await isThreadGenerating(
+      createMockCtx({
+        generationStatus: 'generating',
+        generationStartTime: tenMinutesAgo,
+      }),
       { threadId: 'thread_1' },
     );
     expect(result).toBe(true);

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -29,6 +29,13 @@ export const listThreads = query({
   },
 });
 
+/**
+ * Maximum time (ms) a generation is considered active before it's treated as
+ * stale. If the server-side action crashed without resetting generationStatus,
+ * this prevents the client from being permanently blocked.
+ */
+const GENERATION_STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
 export const isThreadGenerating = query({
   args: { threadId: v.string() },
   returns: v.boolean(),
@@ -41,7 +48,17 @@ export const isThreadGenerating = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    return metadata?.generationStatus === 'generating';
+    if (metadata?.generationStatus !== 'generating') return false;
+
+    // Guard against stuck generationStatus: if the action crashed without
+    // cleanup, the generation start time lets us detect staleness and
+    // unblock the client instead of requiring a page refresh.
+    if (metadata.generationStartTime) {
+      const elapsed = Date.now() - metadata.generationStartTime;
+      if (elapsed > GENERATION_STALE_THRESHOLD_MS) return false;
+    }
+
+    return true;
   },
 });
 


### PR DESCRIPTION
## Summary
- Reset stream freeze flag in error handler so subsequent messages can render
- Add 10-minute staleness guard to `isThreadGenerating` query — if generation status is stuck due to a crashed action, the thread auto-recovers
- Added 9 tests covering error cleanup, stale generation recovery, and send-after-error scenarios

Fixes #1037