### PR TITLE
fix(platform): use friendly language for AI permission errors

### DIFF
--- a/services/platform/convex/agent_tools/sub_agents/helpers/check_role_access.ts
+++ b/services/platform/convex/agent_tools/sub_agents/helpers/check_role_access.ts
@@ -43,7 +43,7 @@ export async function checkRoleAccess(
       allowed: false,
       role: normalizedRole,
       error: errorResponse(
-        `Access denied: The ${toolName.replace(/_/g, ' ')} is only available to users with admin or developer roles. Your current role is "${normalizedRole}".`,
+        `This action requires additional permissions that are not available for your account.\n\nInstructions:\n- Politely inform the user that this action requires administrator permissions\n- Do NOT mention specific role names or technical details\n- Suggest they contact their organization administrator for access`,
       ),
     };
   }


### PR DESCRIPTION
## Summary
- Replace technical error message in `check_role_access.ts` with user-friendly LLM instructions
- AI now responds with helpful guidance instead of exposing role names and internal tool identifiers
- Technical details still logged server-side for debugging

Fixes #1016