### PR TITLE
feat(platform): add status field to product and customer edit forms

### DIFF
--- a/services/platform/app/features/customers/components/customer-edit-dialog.tsx
+++ b/services/platform/app/features/customers/components/customer-edit-dialog.tsx
@@ -14,10 +14,13 @@ import { useT } from '@/lib/i18n/client';
 
 import { useUpdateCustomer } from '../hooks/mutations';
 
+const CUSTOMER_STATUSES = ['active', 'churned', 'potential'] as const;
+
 type CustomerFormData = {
   name: string;
   email: string;
   locale: string;
+  status: string;
 };
 
 interface CustomerEditDialogProps {
@@ -36,6 +39,15 @@ export function CustomerEditDialog({
   const { t: tCommon } = useT('common');
   const { t: tGlobal } = useT('global');
   const updateCustomer = useUpdateCustomer();
+
+  const statusOptions = useMemo(
+    () =>
+      CUSTOMER_STATUSES.map((s) => ({
+        value: s,
+        label: tGlobal(`statuses.${s}`),
+      })),
+    [tGlobal],
+  );
 
   const localeOptions = useMemo(
     () => [
@@ -62,6 +74,7 @@ export function CustomerEditDialog({
             1,
             tCommon('validation.required', { field: tCustomers('locale') }),
           ),
+        status: z.enum(CUSTOMER_STATUSES),
       }),
     [tCustomers, tCommon],
   );
@@ -79,16 +92,19 @@ export function CustomerEditDialog({
       name: customer.name || '',
       email: customer.email || '',
       locale: customer.locale || 'en',
+      status: customer.status || 'active',
     },
   });
 
   const locale = watch('locale');
+  const status = watch('status');
 
   useEffect(() => {
     reset({
       name: customer.name || '',
       email: customer.email || '',
       locale: customer.locale || 'en',
+      status: customer.status || 'active',
     });
   }, [customer, reset]);
 
@@ -100,6 +116,7 @@ export function CustomerEditDialog({
         name: trimmedName || undefined,
         email: data.email.trim(),
         locale: data.locale,
+        status: data.status,
       });
 
       toast({
@@ -163,6 +180,18 @@ export function CustomerEditDialog({
         label={tCustomers('locale')}
         error={!!errors.locale}
         options={localeOptions}
+      />
+
+      <Select
+        value={status}
+        onValueChange={(value) =>
+          setValue('status', value, { shouldDirty: true })
+        }
+        disabled={isSubmitting}
+        id="status"
+        label={tCustomers('status')}
+        error={!!errors.status}
+        options={statusOptions}
       />
     </FormDialog>
   );

--- a/services/platform/app/features/products/components/product-edit-dialog.tsx
+++ b/services/platform/app/features/products/components/product-edit-dialog.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Grid } from '@/app/components/ui/layout/layout';
 import { toast } from '@/app/hooks/use-toast';
@@ -32,6 +33,8 @@ interface EditProductDialogProps {
   };
 }
 
+const PRODUCT_STATUSES = ['active', 'inactive', 'draft', 'archived'] as const;
+
 type ProductFormData = {
   name: string;
   description: string;
@@ -40,6 +43,7 @@ type ProductFormData = {
   price: string;
   currency: string;
   category: string;
+  status: string;
 };
 
 export function ProductEditDialog({
@@ -49,6 +53,7 @@ export function ProductEditDialog({
 }: EditProductDialogProps) {
   const { t: tProducts } = useT('products');
   const { t: tCommon } = useT('common');
+  const { t: tGlobal } = useT('global');
   const { mutate: updateProduct, isPending: isSubmitting } = useUpdateProduct();
 
   const formSchema = useMemo(
@@ -69,14 +74,26 @@ export function ProductEditDialog({
         price: z.string(),
         currency: z.string(),
         category: z.string(),
+        status: z.enum(PRODUCT_STATUSES),
       }),
     [tProducts, tCommon],
+  );
+
+  const statusOptions = useMemo(
+    () =>
+      PRODUCT_STATUSES.map((s) => ({
+        value: s,
+        label: tGlobal(`statuses.${s}`),
+      })),
+    [tGlobal],
   );
 
   const {
     register,
     handleSubmit,
     reset,
+    setValue,
+    watch,
     formState: { errors, isDirty },
   } = useForm<ProductFormData>({
     resolver: zodResolver(formSchema),
@@ -88,8 +105,11 @@ export function ProductEditDialog({
       price: product.price?.toString() || '',
       currency: product.currency || 'USD',
       category: product.category || '',
+      status: product.status || 'draft',
     },
   });
+
+  const status = watch('status');
 
   useEffect(() => {
     reset({
@@ -100,6 +120,7 @@ export function ProductEditDialog({
       price: product.price?.toString() || '',
       currency: product.currency || 'USD',
       category: product.category || '',
+      status: product.status || 'draft',
     });
   }, [product, reset]);
 
@@ -114,6 +135,7 @@ export function ProductEditDialog({
         price: data.price ? parseFloat(data.price) : undefined,
         currency: data.currency || undefined,
         category: data.category.trim() || undefined,
+        status: data.status,
       },
       {
         onSuccess: () => {
@@ -212,6 +234,18 @@ export function ProductEditDialog({
           disabled={isSubmitting}
         />
       </Grid>
+
+      <Select
+        value={status}
+        onValueChange={(value) =>
+          setValue('status', value, { shouldDirty: true })
+        }
+        disabled={isSubmitting}
+        id="status"
+        label={tProducts('edit.labels.status')}
+        error={!!errors.status}
+        options={statusOptions}
+      />
     </FormDialog>
   );
 }

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2971,7 +2971,8 @@
         "price": "Price",
         "currency": "Currency",
         "stock": "Stock",
-        "category": "Category"
+        "category": "Category",
+        "status": "Status"
       },
       "validation": {
         "nameRequired": "Product name is required"
@@ -3087,6 +3088,7 @@
     "emailPlaceholder": "Enter email address",
     "locale": "Locale",
     "localePlaceholder": "e.g., en-US",
+    "status": "Status",
     "import": {
       "selectDataSource": "Please select a data source",
       "syncFeature": "Sync feature",

--- a/services/platform/messages/global.json
+++ b/services/platform/messages/global.json
@@ -20,6 +20,14 @@
       "pt": "PT",
       "zh": "ZH"
     },
+    "statuses": {
+      "active": "Active",
+      "inactive": "Inactive",
+      "draft": "Draft",
+      "archived": "Archived",
+      "churned": "Churned",
+      "potential": "Potential"
+    },
     "providers": {
       "gmail": "Gmail",
       "outlook": "Outlook",


### PR DESCRIPTION
## Summary
- Add status Select dropdown to product edit form (active, inactive, draft, archived)
- Add status Select dropdown to customer edit form (active, churned, potential)
- Backend already supported status updates — this exposes the field in the UI
- Added shared status translations in global.json

Fixes #1048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customers now support status assignment in the edit dialog with three options: active, churned, or potential
  * Products now support status assignment in the edit dialog with four options: active, inactive, draft, or archived
  * All status fields include validation and multi-language support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->