### PR TITLE
perf(platform): add composite index for audit log queries

### DIFF
--- a/services/platform/convex/audit_logs/helpers.ts
+++ b/services/platform/convex/audit_logs/helpers.ts
@@ -433,14 +433,13 @@ export async function getResourceAuditTrail(
 
   for await (const log of ctx.db
     .query('auditLogs')
-    .withIndex('by_resourceType_and_resourceId', (q) =>
-      q.eq('resourceType', args.resourceType).eq('resourceId', args.resourceId),
+    .withIndex('by_org_resourceType_resourceId', (q) =>
+      q
+        .eq('organizationId', args.organizationId)
+        .eq('resourceType', args.resourceType)
+        .eq('resourceId', args.resourceId),
     )
     .order('desc')) {
-    if (log.organizationId !== args.organizationId) {
-      continue;
-    }
-
     logs.push(log as AuditLogItem);
 
     if (logs.length >= limit) {

--- a/services/platform/convex/audit_logs/schema.ts
+++ b/services/platform/convex/audit_logs/schema.ts
@@ -76,4 +76,9 @@ export const auditLogsTable = defineTable({
     'timestamp',
   ])
   .index('by_resourceType_and_resourceId', ['resourceType', 'resourceId'])
+  .index('by_org_resourceType_resourceId', [
+    'organizationId',
+    'resourceType',
+    'resourceId',
+  ])
   .index('by_timestamp', ['timestamp']);


### PR DESCRIPTION
## Summary
- Add `by_org_resourceType_resourceId` composite index to audit_logs schema
- Update `getResourceAuditTrail` to filter by organizationId at the index level instead of in-memory
- Old index preserved for backwards compatibility

Fixes #274