### PR TITLE
fix(cli): add safety checks to tale init

### DIFF
--- a/tools/cli/src/lib/actions/init.ts
+++ b/tools/cli/src/lib/actions/init.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 
 import pkg from '../../../package.json';
@@ -72,6 +72,34 @@ export async function init(options: InitOptions): Promise<void> {
     throw new Error(
       `tale.json already exists in ${target}. Use --force to overwrite.`,
     );
+  }
+
+  // Check if directory exists and contains Tale project files
+  if (!force && existsSync(target)) {
+    const hasTaleFiles = await detectTaleProjectFiles(target);
+    if (hasTaleFiles.length > 0) {
+      if (process.stdin.isTTY && process.stdout.isTTY) {
+        const { confirm } = await import('@inquirer/prompts');
+        logger.warn(
+          `Directory "${target}" already contains Tale project files:`,
+        );
+        for (const file of hasTaleFiles) {
+          logger.info(`  - ${file}`);
+        }
+        const shouldOverwrite = await confirm({
+          message: 'Overwrite existing project files?',
+          default: false,
+        });
+        if (!shouldOverwrite) {
+          logger.info('Aborted.');
+          return;
+        }
+      } else {
+        throw new Error(
+          `Directory "${target}" already contains Tale project files (${hasTaleFiles.join(', ')}). Use --force to overwrite.`,
+        );
+      }
+    }
   }
 
   logger.header('Initializing Tale Project');
@@ -213,6 +241,26 @@ export async function init(options: InitOptions): Promise<void> {
     `  ${step++}. Open the project in an AI-powered editor (Claude Code, Cursor, Copilot, or Windsurf) for guided config creation`,
   );
   logger.info(`  ${step++}. Run "tale start" to launch the platform locally`);
+}
+
+const TALE_PROJECT_MARKERS = new Set([
+  '.env',
+  'tale.json',
+  'providers',
+  'agents',
+  'workflows',
+  'integrations',
+  '.tale',
+  'branding',
+]);
+
+async function detectTaleProjectFiles(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir);
+    return entries.filter((entry) => TALE_PROJECT_MARKERS.has(entry));
+  } catch {
+    return [];
+  }
 }
 
 async function writeEmbeddedFiles(

--- a/tools/cli/src/lib/config/ensure-env.ts
+++ b/tools/cli/src/lib/config/ensure-env.ts
@@ -34,6 +34,28 @@ function generatePassword(): string {
   return randomBytes(16).toString('base64url');
 }
 
+const OPENROUTER_KEY_PREFIX = 'sk-or-';
+
+async function warnIfInvalidKeyFormat(key: string): Promise<boolean> {
+  if (key.startsWith(OPENROUTER_KEY_PREFIX)) return true;
+
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    const { confirm } = await import('@inquirer/prompts');
+    logger.warn(
+      `This key does not start with "${OPENROUTER_KEY_PREFIX}", which is the expected format for OpenRouter API keys.`,
+    );
+    return await confirm({
+      message: 'Continue with this key anyway?',
+      default: true,
+    });
+  }
+
+  logger.warn(
+    `API key does not match expected OpenRouter format (prefix "${OPENROUTER_KEY_PREFIX}"). Proceeding anyway.`,
+  );
+  return true;
+}
+
 /** Parse a .env file into a key-value map (ignores comments and blank lines). */
 function parseEnvFile(content: string): Record<string, string> {
   const env: Record<string, string> = {};
@@ -227,6 +249,11 @@ async function runPartialEnvSetup(
         return true;
       },
     });
+    const shouldContinue = await warnIfInvalidKeyFormat(openrouterKey);
+    if (!shouldContinue) {
+      logger.info('Aborted. Please re-run with a valid API key.');
+      return { success: false };
+    }
   }
 
   // Surgically append missing variables to the existing .env (preserves all original content)
@@ -357,6 +384,11 @@ async function runEnvSetup(envPath: string): Promise<EnvSetupResult> {
       return true;
     },
   });
+  const shouldContinue = await warnIfInvalidKeyFormat(openrouterKey);
+  if (!shouldContinue) {
+    logger.info('Aborted. Please re-run with a valid API key.');
+    return { success: false };
+  }
 
   logger.blank();
   logger.step('Generating security secrets...');


### PR DESCRIPTION
## Summary
- Detect existing Tale project files before overwriting and prompt for confirmation (interactive) or error (non-TTY)
- Validate OpenRouter API key format (`sk-or-` prefix) with warning if mismatched
- Non-TTY environments get clear error messages instead of hanging on prompts

Fixes #1050, fixes #1049