### PR TITLE
feat(platform): add bulk select and delete for products and customers

### DIFF
--- a/services/platform/app/components/ui/data-table/column-builders.tsx
+++ b/services/platform/app/components/ui/data-table/column-builders.tsx
@@ -8,6 +8,7 @@ import {
   TableTimestampCell,
   TableDateCell,
 } from '@/app/components/ui/data-display/table-date-cell';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { HStack } from '@/app/components/ui/layout/layout';
 import { Text } from '@/app/components/ui/typography/text';
 import { startCase } from '@/lib/utils/string';
@@ -268,5 +269,42 @@ export function createTextColumn<TData, K extends keyof TData>(
         </Text>
       );
     },
+  };
+}
+
+/**
+ * Creates a checkbox column for row selection.
+ *
+ * @example
+ * ```tsx
+ * createSelectColumn<Product>()
+ * ```
+ */
+export function createSelectColumn<TData>(): ColumnDef<TData> {
+  return {
+    id: 'select',
+    size: 40,
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected()
+            ? true
+            : table.getIsSomePageRowsSelected()
+              ? 'indeterminate'
+              : false
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        onClick={(e) => e.stopPropagation()}
+        aria-label="Select row"
+      />
+    ),
+    meta: { skeleton: { type: 'action' } },
   };
 }

--- a/services/platform/app/components/ui/data-table/data-table-bulk-actions.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-bulk-actions.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '@/test/utils/render';
+
+import { BulkDeleteBar } from './data-table-bulk-actions';
+
+describe('BulkDeleteBar', () => {
+  const defaultProps = {
+    rowSelection: {},
+    onClearSelection: vi.fn(),
+    onDeleteItem: vi.fn().mockResolvedValue(undefined),
+  };
+
+  it('renders nothing when no rows are selected', () => {
+    const { container } = render(<BulkDeleteBar {...defaultProps} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders selection count and delete button when rows are selected', () => {
+    render(
+      <BulkDeleteBar
+        {...defaultProps}
+        rowSelection={{ id1: true, id2: true }}
+      />,
+    );
+
+    expect(screen.getByText(/2 items selected/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /delete selected/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders singular text for single selection', () => {
+    render(<BulkDeleteBar {...defaultProps} rowSelection={{ id1: true }} />);
+
+    expect(screen.getByText(/1 item selected/)).toBeInTheDocument();
+  });
+
+  it('calls onClearSelection when clear button is clicked', async () => {
+    const onClearSelection = vi.fn();
+    const { user } = render(
+      <BulkDeleteBar
+        {...defaultProps}
+        rowSelection={{ id1: true }}
+        onClearSelection={onClearSelection}
+      />,
+    );
+
+    const clearButton = screen.getByRole('button', { name: /clear all/i });
+    await user.click(clearButton);
+
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens confirmation dialog when delete button is clicked', async () => {
+    const { user } = render(
+      <BulkDeleteBar
+        {...defaultProps}
+        rowSelection={{ id1: true, id2: true }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete selected/i }));
+
+    expect(
+      screen.getByText(/are you sure you want to delete these 2 items/i),
+    ).toBeInTheDocument();
+  });
+
+  it('filters out false-valued selection entries', () => {
+    render(
+      <BulkDeleteBar
+        {...defaultProps}
+        rowSelection={{ id1: true, id2: false, id3: true }}
+      />,
+    );
+
+    expect(screen.getByText(/2 items selected/)).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/components/ui/data-table/data-table-bulk-actions.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-bulk-actions.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { RowSelectionState } from '@tanstack/react-table';
+
+import { Trash2, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
+import { HStack } from '@/app/components/ui/layout/layout';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { toast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+
+interface BulkDeleteBarProps {
+  /** Current row selection state (keyed by row ID) */
+  rowSelection: RowSelectionState;
+  /** Callback to clear selection */
+  onClearSelection: () => void;
+  /** Async function to delete a single item by ID */
+  onDeleteItem: (id: string) => Promise<void>;
+  /** Callback after all deletions complete */
+  onDeleteComplete?: () => void;
+}
+
+export function BulkDeleteBar({
+  rowSelection,
+  onClearSelection,
+  onDeleteItem,
+  onDeleteComplete,
+}: BulkDeleteBarProps) {
+  const { t } = useT('common');
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const selectedIds = Object.keys(rowSelection).filter(
+    (key) => rowSelection[key],
+  );
+  const count = selectedIds.length;
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      const results = await Promise.allSettled(
+        selectedIds.map((id) => onDeleteItem(id)),
+      );
+      const failedCount = results.filter((r) => r.status === 'rejected').length;
+      const successCount = count - failedCount;
+
+      if (failedCount > 0) {
+        toast({
+          title: t('bulkActions.deleteFailed'),
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('bulkActions.deleteSuccess', { count: successCount }),
+        });
+      }
+
+      setIsConfirmOpen(false);
+      onClearSelection();
+      onDeleteComplete?.();
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [selectedIds, count, onDeleteItem, onClearSelection, onDeleteComplete, t]);
+
+  if (count === 0) return null;
+
+  return (
+    <>
+      <div className="bg-muted/80 border-border animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border px-4 py-2 duration-200">
+        <HStack gap={3}>
+          <Text as="span" variant="label" className="text-sm">
+            {t('bulkActions.itemsSelected', { count })}
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearSelection}
+            aria-label={t('actions.clearAll')}
+          >
+            <X className="size-4" />
+          </Button>
+        </HStack>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => setIsConfirmOpen(true)}
+        >
+          <Trash2 className="mr-1.5 size-4" />
+          {t('actions.deleteSelected')}
+        </Button>
+      </div>
+
+      <DeleteDialog
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        title={t('bulkActions.confirmDeleteTitle', { count })}
+        description={t('bulkActions.confirmDeleteDescription', { count })}
+        onDelete={handleDelete}
+        isDeleting={isDeleting}
+        deletingText={t('bulkActions.deleting')}
+      />
+    </>
+  );
+}

--- a/services/platform/app/features/customers/components/customers-table.tsx
+++ b/services/platform/app/features/customers/components/customers-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 
 import { useNavigate } from '@tanstack/react-router';
 import { Users } from 'lucide-react';
@@ -9,9 +9,11 @@ import { useCallback, useMemo, useState } from 'react';
 import type { Doc } from '@/convex/_generated/dataModel';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeleteCustomer } from '../hooks/mutations';
 import {
   useApproxCustomerCount,
   useListCustomersPaginated,
@@ -159,10 +161,25 @@ export function CustomersTable({
   );
 
   const [viewingCustomer, setViewingCustomer] = useState<Customer | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const deleteCustomer = useDeleteCustomer();
 
   const handleRowClick = useCallback((row: Row<Customer>) => {
     setViewingCustomer(row.original);
   }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex Id type from row selection key
+      const customerId = id as Doc<'customers'>['_id'];
+      await deleteCustomer.mutateAsync({ customerId });
+    },
+    [deleteCustomer],
+  );
 
   const list = useListPage<Customer>({
     dataSource: {
@@ -191,12 +208,23 @@ export function CustomersTable({
         columns={columns}
         stickyLayout={stickyLayout}
         onRowClick={handleRowClick}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         actionMenu={<CustomersActionMenu organizationId={organizationId} />}
         emptyState={{
           icon: Users,
           title: tEmpty('customers.title'),
           description: tEmpty('customers.description'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
 

--- a/services/platform/app/features/customers/hooks/use-customers-table-config.tsx
+++ b/services/platform/app/features/customers/hooks/use-customers-table-config.tsx
@@ -12,6 +12,7 @@ export const useCustomersTableConfig = createTableConfigHook<'customers'>(
     defaultSort: '_creationTime',
   },
   ({ tTables, builders }) => [
+    builders.createSelectColumn(),
     {
       accessorKey: 'name',
       header: tTables('headers.name'),

--- a/services/platform/app/features/products/components/products-table.tsx
+++ b/services/platform/app/features/products/components/products-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 
 import { useNavigate } from '@tanstack/react-router';
 import { Package } from 'lucide-react';
@@ -9,9 +9,11 @@ import { useCallback, useMemo, useState } from 'react';
 import type { Doc } from '@/convex/_generated/dataModel';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeleteProduct } from '../hooks/mutations';
 import {
   useApproxProductCount,
   useListProductsPaginated,
@@ -90,10 +92,25 @@ export function ProductsTable({
   );
 
   const [viewingProduct, setViewingProduct] = useState<Product | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const deleteProduct = useDeleteProduct();
 
   const handleRowClick = useCallback((row: Row<Product>) => {
     setViewingProduct(row.original);
   }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex Id type from row selection key
+      const productId = id as Doc<'products'>['_id'];
+      await deleteProduct.mutateAsync({ productId });
+    },
+    [deleteProduct],
+  );
 
   const list = useListPage<Product>({
     dataSource: {
@@ -122,12 +139,23 @@ export function ProductsTable({
         columns={columns}
         stickyLayout={stickyLayout}
         onRowClick={handleRowClick}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         actionMenu={<ProductsActionMenu organizationId={organizationId} />}
         emptyState={{
           icon: Package,
           title: tEmpty('products.title'),
           description: tEmpty('products.description'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
 

--- a/services/platform/app/features/products/hooks/use-products-table-config.tsx
+++ b/services/platform/app/features/products/hooks/use-products-table-config.tsx
@@ -17,6 +17,7 @@ export const useProductsTableConfig = createTableConfigHook<'products'>(
     defaultSort: 'lastUpdated',
   },
   ({ tTables, builders }) => [
+    builders.createSelectColumn(),
     {
       accessorKey: 'name',
       header: tTables('headers.product'),

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -67,7 +67,16 @@
       "logIn": "Log in",
       "saved": "Saved",
       "saveFailed": "Save failed",
-      "remove": "Remove"
+      "remove": "Remove",
+      "deleteSelected": "Delete selected"
+    },
+    "bulkActions": {
+      "itemsSelected": "{count, plural, one {# item selected} other {# items selected}}",
+      "confirmDeleteTitle": "Delete {count, plural, one {# item} other {# items}}",
+      "confirmDeleteDescription": "Are you sure you want to delete {count, plural, one {this item} other {these {count} items}}? This action cannot be undone.",
+      "deleteSuccess": "Successfully deleted {count, plural, one {# item} other {# items}}",
+      "deleteFailed": "Failed to delete some items",
+      "deleting": "Deleting..."
     },
     "upload": {
       "clickToUpload": "Click to upload",


### PR DESCRIPTION
## Summary
- Add reusable `createSelectColumn` builder for checkbox selection in data tables
- Add `BulkDeleteBar` component with count display, clear, and confirmed bulk deletion
- Enable row selection in both products and customers tables
- Wire bulk delete to existing delete mutations with `Promise.allSettled`
- Added 6 tests for the bulk actions component

Fixes #1047