### PR TITLE
refactor(platform): use options object for audit log helpers

### DIFF
--- a/services/platform/convex/approvals/mutations.ts
+++ b/services/platform/convex/approvals/mutations.ts
@@ -41,9 +41,8 @@ export const updateApprovalStatus = mutation({
     const action =
       args.status === 'executing' ? 'approve_request' : 'reject_request';
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: approval.organizationId,
         actor: {
           id: String(authUser._id),
@@ -52,13 +51,13 @@ export const updateApprovalStatus = mutation({
         },
       },
       action,
-      'workflow',
-      'approval',
-      String(args.approvalId),
-      approval.resourceType,
-      { status: previousStatus },
-      { status: args.status, comments: args.comments },
-    );
+      category: 'workflow',
+      resourceType: 'approval',
+      resourceId: String(args.approvalId),
+      resourceName: approval.resourceType,
+      previousState: { status: previousStatus },
+      newState: { status: args.status, comments: args.comments },
+    });
 
     // Write system message to thread on rejection so the AI knows it was user-initiated
     if (args.status === 'rejected' && approval.threadId) {
@@ -102,9 +101,8 @@ export const removeRecommendedProduct = mutation({
       productId: args.productId,
     });
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: approval.organizationId,
         actor: {
           id: String(authUser._id),
@@ -112,15 +110,13 @@ export const removeRecommendedProduct = mutation({
           type: 'user',
         },
       },
-      'remove_recommended_product',
-      'workflow',
-      'approval',
-      String(args.approvalId),
-      approval.resourceType,
-      undefined,
-      undefined,
-      { productId: args.productId },
-    );
+      action: 'remove_recommended_product',
+      category: 'workflow',
+      resourceType: 'approval',
+      resourceId: String(args.approvalId),
+      resourceName: approval.resourceType,
+      metadata: { productId: args.productId },
+    });
 
     return null;
   },

--- a/services/platform/convex/audit_logs/helpers.ts
+++ b/services/platform/convex/audit_logs/helpers.ts
@@ -167,101 +167,113 @@ export async function createAuditLog(
   return auditLogId;
 }
 
+interface LogSuccessOptions {
+  auditCtx: AuditContext;
+  action: string;
+  category: AuditLogCategory;
+  resourceType: string;
+  resourceId?: string;
+  resourceName?: string;
+  previousState?: Record<string, unknown>;
+  newState?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
 export async function logSuccess(
   ctx: MutationCtx,
-  auditCtx: AuditContext,
-  action: string,
-  category: AuditLogCategory,
-  resourceType: string,
-  resourceId?: string,
-  resourceName?: string,
-  previousState?: Record<string, unknown>,
-  newState?: Record<string, unknown>,
-  metadata?: Record<string, unknown>,
+  options: LogSuccessOptions,
 ): Promise<Id<'auditLogs'>> {
   return createAuditLog(ctx, {
-    organizationId: auditCtx.organizationId,
-    actorId: auditCtx.actor.id,
-    actorEmail: auditCtx.actor.email,
-    actorRole: auditCtx.actor.role,
-    actorType: auditCtx.actor.type,
-    action,
-    category,
-    resourceType,
-    resourceId,
-    resourceName,
-    previousState,
-    newState,
-    sessionId: auditCtx.sessionId,
-    ipAddress: auditCtx.ipAddress,
-    userAgent: auditCtx.userAgent,
-    requestId: auditCtx.requestId,
+    organizationId: options.auditCtx.organizationId,
+    actorId: options.auditCtx.actor.id,
+    actorEmail: options.auditCtx.actor.email,
+    actorRole: options.auditCtx.actor.role,
+    actorType: options.auditCtx.actor.type,
+    action: options.action,
+    category: options.category,
+    resourceType: options.resourceType,
+    resourceId: options.resourceId,
+    resourceName: options.resourceName,
+    previousState: options.previousState,
+    newState: options.newState,
+    sessionId: options.auditCtx.sessionId,
+    ipAddress: options.auditCtx.ipAddress,
+    userAgent: options.auditCtx.userAgent,
+    requestId: options.auditCtx.requestId,
     status: 'success',
-    metadata,
+    metadata: options.metadata,
   });
+}
+
+interface LogFailureOptions {
+  auditCtx: AuditContext;
+  action: string;
+  category: AuditLogCategory;
+  resourceType: string;
+  errorMessage: string;
+  resourceId?: string;
+  resourceName?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export async function logFailure(
   ctx: MutationCtx,
-  auditCtx: AuditContext,
-  action: string,
-  category: AuditLogCategory,
-  resourceType: string,
-  errorMessage: string,
-  resourceId?: string,
-  resourceName?: string,
-  metadata?: Record<string, unknown>,
+  options: LogFailureOptions,
 ): Promise<Id<'auditLogs'>> {
   return createAuditLog(ctx, {
-    organizationId: auditCtx.organizationId,
-    actorId: auditCtx.actor.id,
-    actorEmail: auditCtx.actor.email,
-    actorRole: auditCtx.actor.role,
-    actorType: auditCtx.actor.type,
-    action,
-    category,
-    resourceType,
-    resourceId,
-    resourceName,
-    sessionId: auditCtx.sessionId,
-    ipAddress: auditCtx.ipAddress,
-    userAgent: auditCtx.userAgent,
-    requestId: auditCtx.requestId,
+    organizationId: options.auditCtx.organizationId,
+    actorId: options.auditCtx.actor.id,
+    actorEmail: options.auditCtx.actor.email,
+    actorRole: options.auditCtx.actor.role,
+    actorType: options.auditCtx.actor.type,
+    action: options.action,
+    category: options.category,
+    resourceType: options.resourceType,
+    resourceId: options.resourceId,
+    resourceName: options.resourceName,
+    sessionId: options.auditCtx.sessionId,
+    ipAddress: options.auditCtx.ipAddress,
+    userAgent: options.auditCtx.userAgent,
+    requestId: options.auditCtx.requestId,
     status: 'failure',
-    errorMessage,
-    metadata,
+    errorMessage: options.errorMessage,
+    metadata: options.metadata,
   });
+}
+
+interface LogDeniedOptions {
+  auditCtx: AuditContext;
+  action: string;
+  category: AuditLogCategory;
+  resourceType: string;
+  reason: string;
+  resourceId?: string;
+  resourceName?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export async function logDenied(
   ctx: MutationCtx,
-  auditCtx: AuditContext,
-  action: string,
-  category: AuditLogCategory,
-  resourceType: string,
-  reason: string,
-  resourceId?: string,
-  resourceName?: string,
-  metadata?: Record<string, unknown>,
+  options: LogDeniedOptions,
 ): Promise<Id<'auditLogs'>> {
   return createAuditLog(ctx, {
-    organizationId: auditCtx.organizationId,
-    actorId: auditCtx.actor.id,
-    actorEmail: auditCtx.actor.email,
-    actorRole: auditCtx.actor.role,
-    actorType: auditCtx.actor.type,
-    action,
-    category,
-    resourceType,
-    resourceId,
-    resourceName,
-    sessionId: auditCtx.sessionId,
-    ipAddress: auditCtx.ipAddress,
-    userAgent: auditCtx.userAgent,
-    requestId: auditCtx.requestId,
+    organizationId: options.auditCtx.organizationId,
+    actorId: options.auditCtx.actor.id,
+    actorEmail: options.auditCtx.actor.email,
+    actorRole: options.auditCtx.actor.role,
+    actorType: options.auditCtx.actor.type,
+    action: options.action,
+    category: options.category,
+    resourceType: options.resourceType,
+    resourceId: options.resourceId,
+    resourceName: options.resourceName,
+    sessionId: options.auditCtx.sessionId,
+    ipAddress: options.auditCtx.ipAddress,
+    userAgent: options.auditCtx.userAgent,
+    requestId: options.auditCtx.requestId,
     status: 'denied',
-    errorMessage: reason,
-    metadata,
+    errorMessage: options.reason,
+    metadata: options.metadata,
   });
 }
 

--- a/services/platform/convex/conversations/add_message_to_conversation.ts
+++ b/services/platform/convex/conversations/add_message_to_conversation.ts
@@ -110,22 +110,19 @@ export async function addMessageToConversation(
     },
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, args.organizationId),
-    'add_message_to_conversation',
-    'data',
-    'conversationMessage',
-    String(messageId),
-    undefined,
-    undefined,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, args.organizationId),
+    action: 'add_message_to_conversation',
+    category: 'data',
+    resourceType: 'conversationMessage',
+    resourceId: String(messageId),
+    newState: {
       conversationId: String(args.conversationId),
       direction,
       isCustomer: args.isCustomer,
       sender: args.sender,
     },
-  );
+  });
 
   const message = await ctx.db.get(messageId);
   if (message) {

--- a/services/platform/convex/conversations/bulk_archive_conversations.ts
+++ b/services/platform/convex/conversations/bulk_archive_conversations.ts
@@ -64,23 +64,21 @@ export async function bulkArchiveConversations(
 
   const firstValidConversation = conversations.find((c) => c !== null);
   if (firstValidConversation) {
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      await buildAuditContext(ctx, firstValidConversation.organizationId),
-      'bulk_archive_conversations',
-      'data',
-      'conversation',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: await buildAuditContext(
+        ctx,
+        firstValidConversation.organizationId,
+      ),
+      action: 'bulk_archive_conversations',
+      category: 'data',
+      resourceType: 'conversation',
+      metadata: {
         conversationIds: args.conversationIds.map(String),
         count: args.conversationIds.length,
         successCount,
         failedCount,
       },
-    );
+    });
   }
 
   return { successCount, failedCount, errors };

--- a/services/platform/convex/conversations/bulk_close_conversations.ts
+++ b/services/platform/convex/conversations/bulk_close_conversations.ts
@@ -66,23 +66,21 @@ export async function bulkCloseConversations(
 
   const firstValidConversation = conversations.find((c) => c !== null);
   if (firstValidConversation) {
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      await buildAuditContext(ctx, firstValidConversation.organizationId),
-      'bulk_close_conversations',
-      'data',
-      'conversation',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: await buildAuditContext(
+        ctx,
+        firstValidConversation.organizationId,
+      ),
+      action: 'bulk_close_conversations',
+      category: 'data',
+      resourceType: 'conversation',
+      metadata: {
         conversationIds: args.conversationIds.map(String),
         count: args.conversationIds.length,
         successCount,
         failedCount,
       },
-    );
+    });
   }
 
   return { successCount, failedCount, errors };

--- a/services/platform/convex/conversations/bulk_reopen_conversations.ts
+++ b/services/platform/convex/conversations/bulk_reopen_conversations.ts
@@ -61,23 +61,21 @@ export async function bulkReopenConversations(
 
   const firstValidConversation = conversations.find((c) => c !== null);
   if (firstValidConversation) {
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      await buildAuditContext(ctx, firstValidConversation.organizationId),
-      'bulk_reopen_conversations',
-      'data',
-      'conversation',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: await buildAuditContext(
+        ctx,
+        firstValidConversation.organizationId,
+      ),
+      action: 'bulk_reopen_conversations',
+      category: 'data',
+      resourceType: 'conversation',
+      metadata: {
         conversationIds: args.conversationIds.map(String),
         count: args.conversationIds.length,
         successCount,
         failedCount,
       },
-    );
+    });
   }
 
   return { successCount, failedCount, errors };

--- a/services/platform/convex/conversations/bulk_spam_conversations.ts
+++ b/services/platform/convex/conversations/bulk_spam_conversations.ts
@@ -57,23 +57,21 @@ export async function bulkSpamConversations(
 
   const firstValidConversation = conversations.find((c) => c !== null);
   if (firstValidConversation) {
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      await buildAuditContext(ctx, firstValidConversation.organizationId),
-      'bulk_spam_conversations',
-      'data',
-      'conversation',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: await buildAuditContext(
+        ctx,
+        firstValidConversation.organizationId,
+      ),
+      action: 'bulk_spam_conversations',
+      category: 'data',
+      resourceType: 'conversation',
+      metadata: {
         conversationIds: args.conversationIds.map(String),
         count: args.conversationIds.length,
         successCount,
         failedCount,
       },
-    );
+    });
   }
 
   return { successCount, failedCount, errors };

--- a/services/platform/convex/conversations/bulk_unarchive_conversations.ts
+++ b/services/platform/convex/conversations/bulk_unarchive_conversations.ts
@@ -63,23 +63,21 @@ export async function bulkUnarchiveConversations(
 
   const firstValidConversation = conversations.find((c) => c !== null);
   if (firstValidConversation) {
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      await buildAuditContext(ctx, firstValidConversation.organizationId),
-      'bulk_unarchive_conversations',
-      'data',
-      'conversation',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: await buildAuditContext(
+        ctx,
+        firstValidConversation.organizationId,
+      ),
+      action: 'bulk_unarchive_conversations',
+      category: 'data',
+      resourceType: 'conversation',
+      metadata: {
         conversationIds: args.conversationIds.map(String),
         count: args.conversationIds.length,
         successCount,
         failedCount,
       },
-    );
+    });
   }
 
   return { successCount, failedCount, errors };

--- a/services/platform/convex/conversations/close_conversation.ts
+++ b/services/platform/convex/conversations/close_conversation.ts
@@ -29,17 +29,16 @@ export async function closeConversation(
     },
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, conversation.organizationId),
-    'close_conversation',
-    'data',
-    'conversation',
-    String(args.conversationId),
-    conversation.subject,
-    { status: previousStatus },
-    { status: 'closed', resolvedBy: args.resolvedBy },
-  );
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, conversation.organizationId),
+    action: 'close_conversation',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(args.conversationId),
+    resourceName: conversation.subject,
+    previousState: { status: previousStatus },
+    newState: { status: 'closed', resolvedBy: args.resolvedBy },
+  });
 
   const updatedConversation = await ctx.db.get(args.conversationId);
   if (updatedConversation) {

--- a/services/platform/convex/conversations/create_conversation.ts
+++ b/services/platform/convex/conversations/create_conversation.ts
@@ -27,25 +27,23 @@ export async function createConversation(
     metadata: toConvexJsonRecord(args.metadata),
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: {
       organizationId: args.organizationId,
       actor: { id: 'system', type: 'system' as const },
     },
-    'create_conversation',
-    'data',
-    'conversation',
-    String(conversationId),
-    args.subject,
-    undefined,
-    {
+    action: 'create_conversation',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(conversationId),
+    resourceName: args.subject,
+    newState: {
       channel: args.channel,
       direction: args.direction,
       status: args.status ?? 'open',
       priority: args.priority ?? 'medium',
     },
-  );
+  });
 
   const conversation = await ctx.db.get(conversationId);
   if (conversation) {

--- a/services/platform/convex/conversations/create_conversation_with_message.ts
+++ b/services/platform/convex/conversations/create_conversation_with_message.ts
@@ -130,25 +130,22 @@ export async function createConversationWithMessage(
     },
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: {
       organizationId: args.organizationId,
       actor: { id: 'system', type: 'system' as const },
     },
-    'add_message_to_conversation',
-    'data',
-    'conversationMessage',
-    String(messageId),
-    undefined,
-    undefined,
-    {
+    action: 'add_message_to_conversation',
+    category: 'data',
+    resourceType: 'conversationMessage',
+    resourceId: String(messageId),
+    newState: {
       conversationId: String(conversationId),
       direction,
       isCustomer: args.initialMessage.isCustomer,
       sender: args.initialMessage.sender,
     },
-  );
+  });
 
   return {
     success: true,

--- a/services/platform/convex/conversations/mark_conversation_as_read.ts
+++ b/services/platform/convex/conversations/mark_conversation_as_read.ts
@@ -27,15 +27,14 @@ export async function markConversationAsRead(
     },
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, conversation.organizationId),
-    'mark_conversation_as_read',
-    'data',
-    'conversation',
-    String(args.conversationId),
-    conversation.subject,
-    { unreadCount: previousUnreadCount },
-    { unreadCount: 0 },
-  );
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, conversation.organizationId),
+    action: 'mark_conversation_as_read',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(args.conversationId),
+    resourceName: conversation.subject,
+    previousState: { unreadCount: previousUnreadCount },
+    newState: { unreadCount: 0 },
+  });
 }

--- a/services/platform/convex/conversations/mark_conversation_as_spam.ts
+++ b/services/platform/convex/conversations/mark_conversation_as_spam.ts
@@ -17,15 +17,14 @@ export async function markConversationAsSpam(
 
   await ctx.db.patch(args.conversationId, { status: 'spam' });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, conversation.organizationId),
-    'mark_conversation_as_spam',
-    'data',
-    'conversation',
-    String(args.conversationId),
-    conversation.subject,
-    { status: previousStatus },
-    { status: 'spam' },
-  );
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, conversation.organizationId),
+    action: 'mark_conversation_as_spam',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(args.conversationId),
+    resourceName: conversation.subject,
+    previousState: { status: previousStatus },
+    newState: { status: 'spam' },
+  });
 }

--- a/services/platform/convex/conversations/reopen_conversation.ts
+++ b/services/platform/convex/conversations/reopen_conversation.ts
@@ -23,15 +23,14 @@ export async function reopenConversation(
     metadata: restMetadata,
   });
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, conversation.organizationId),
-    'reopen_conversation',
-    'data',
-    'conversation',
-    String(args.conversationId),
-    conversation.subject,
-    { status: previousStatus },
-    { status: 'open' },
-  );
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, conversation.organizationId),
+    action: 'reopen_conversation',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(args.conversationId),
+    resourceName: conversation.subject,
+    previousState: { status: previousStatus },
+    newState: { status: 'open' },
+  });
 }

--- a/services/platform/convex/conversations/send_message_via_integration.ts
+++ b/services/platform/convex/conversations/send_message_via_integration.ts
@@ -166,22 +166,20 @@ export async function sendMessageViaIntegration(
     });
   }
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, args.organizationId),
-    'send_message_via_integration',
-    'data',
-    'conversationMessage',
-    String(messageId),
-    args.subject,
-    undefined,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, args.organizationId),
+    action: 'send_message_via_integration',
+    category: 'data',
+    resourceType: 'conversationMessage',
+    resourceId: String(messageId),
+    resourceName: args.subject,
+    newState: {
       conversationId: String(args.conversationId),
       integrationName: args.integrationName,
       to: args.to,
       subject: args.subject,
     },
-  );
+  });
 
   return messageId;
 }

--- a/services/platform/convex/conversations/update_conversation.ts
+++ b/services/platform/convex/conversations/update_conversation.ts
@@ -49,15 +49,14 @@ export async function updateConversation(
 
   await ctx.db.patch(args.conversationId, updateData);
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    await buildAuditContext(ctx, conversation.organizationId),
-    'update_conversation',
-    'data',
-    'conversation',
-    String(args.conversationId),
-    conversation.subject,
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: await buildAuditContext(ctx, conversation.organizationId),
+    action: 'update_conversation',
+    category: 'data',
+    resourceType: 'conversation',
+    resourceId: String(args.conversationId),
+    resourceName: conversation.subject,
     previousState,
     newState,
-  );
+  });
 }

--- a/services/platform/convex/conversations/update_conversation_message.ts
+++ b/services/platform/convex/conversations/update_conversation_message.ts
@@ -56,18 +56,16 @@ export async function updateConversationMessage(
   if (args.deliveryState !== undefined)
     newState.deliveryState = args.deliveryState;
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: {
       organizationId: message.organizationId,
       actor: { id: 'system', type: 'system' as const },
     },
-    'update_conversation_message',
-    'data',
-    'conversationMessage',
-    String(args.messageId),
-    undefined,
+    action: 'update_conversation_message',
+    category: 'data',
+    resourceType: 'conversationMessage',
+    resourceId: String(args.messageId),
     previousState,
     newState,
-  );
+  });
 }

--- a/services/platform/convex/conversations/update_conversations.ts
+++ b/services/platform/convex/conversations/update_conversations.ts
@@ -112,25 +112,20 @@ export async function updateConversations(
     const organizationId =
       args.organizationId || conversationsToUpdate[0]?.organizationId;
     if (organizationId) {
-      await AuditLogHelpers.logSuccess(
-        ctx,
-        {
+      await AuditLogHelpers.logSuccess(ctx, {
+        auditCtx: {
           organizationId,
           actor: { id: 'system', type: 'system' as const },
         },
-        'update_conversations',
-        'data',
-        'conversation',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
+        action: 'update_conversations',
+        category: 'data',
+        resourceType: 'conversation',
+        metadata: {
           conversationIds: updatedIds.map(String),
           count: updatedIds.length,
           updates: args.updates,
         },
-      );
+      });
     }
   }
 

--- a/services/platform/convex/integrations/credential_mutations.ts
+++ b/services/platform/convex/integrations/credential_mutations.ts
@@ -97,9 +97,8 @@ export const updateCredentials = mutation({
     );
     await ctx.db.patch(credentialId, cleanUpdates);
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: cred.organizationId,
         actor: {
           id: String(authUser._id),
@@ -108,20 +107,20 @@ export const updateCredentials = mutation({
           type: 'user',
         },
       },
-      'update_credential',
-      'integration',
-      'integrationCredentials',
-      String(credentialId),
-      cred.slug,
-      AuditLogHelpers.redactSensitiveFields({
+      action: 'update_credential',
+      category: 'integration',
+      resourceType: 'integrationCredentials',
+      resourceId: String(credentialId),
+      resourceName: cred.slug,
+      previousState: AuditLogHelpers.redactSensitiveFields({
         status: cred.status,
         authMethod: cred.authMethod,
         isActive: cred.isActive,
       }),
-      AuditLogHelpers.redactSensitiveFields({
+      newState: AuditLogHelpers.redactSensitiveFields({
         ...cleanUpdates,
       }),
-    );
+    });
 
     return null;
   },
@@ -162,9 +161,8 @@ export const deleteCredentials = mutation({
 
     await ctx.db.delete(args.credentialId);
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: cred.organizationId,
         actor: {
           id: String(authUser._id),
@@ -173,18 +171,17 @@ export const deleteCredentials = mutation({
           type: 'user',
         },
       },
-      'delete_credential',
-      'integration',
-      'integrationCredentials',
-      String(args.credentialId),
-      cred.slug,
-      AuditLogHelpers.redactSensitiveFields({
+      action: 'delete_credential',
+      category: 'integration',
+      resourceType: 'integrationCredentials',
+      resourceId: String(args.credentialId),
+      resourceName: cred.slug,
+      previousState: AuditLogHelpers.redactSensitiveFields({
         slug: cred.slug,
         status: cred.status,
         authMethod: cred.authMethod,
       }),
-      undefined,
-    );
+    });
 
     return null;
   },

--- a/services/platform/convex/integrations/mutations.ts
+++ b/services/platform/convex/integrations/mutations.ts
@@ -69,9 +69,8 @@ export const deleteIntegration = mutation({
 
     await deleteIntegrationHelper(ctx, args.integrationId);
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: integration.organizationId,
         actor: {
           id: String(authUser._id),
@@ -80,19 +79,18 @@ export const deleteIntegration = mutation({
           type: 'user',
         },
       },
-      'delete_integration',
-      'integration',
-      'integration',
-      String(args.integrationId),
-      integration.name ?? integration.title,
-      {
+      action: 'delete_integration',
+      category: 'integration',
+      resourceType: 'integration',
+      resourceId: String(args.integrationId),
+      resourceName: integration.name ?? integration.title,
+      previousState: {
         name: integration.name,
         title: integration.title,
         type: integration.type,
         authMethod: integration.authMethod,
       },
-      undefined,
-    );
+    });
 
     return null;
   },

--- a/services/platform/convex/members/mutations.ts
+++ b/services/platform/convex/members/mutations.ts
@@ -91,9 +91,8 @@ export const addMember = mutation({
       isBetterAuthCreateResult(created) ? created._id : created,
     );
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: args.organizationId,
         actor: {
           id: String(authUser._id),
@@ -102,14 +101,13 @@ export const addMember = mutation({
           type: 'user',
         },
       },
-      'add_member',
-      'member',
-      'member',
-      memberId,
-      targetUser?.email ?? targetUser?.name ?? args.userId,
-      undefined,
-      { userId: args.userId, role },
-    );
+      action: 'add_member',
+      category: 'member',
+      resourceType: 'member',
+      resourceId: memberId,
+      resourceName: targetUser?.email ?? targetUser?.name ?? args.userId,
+      newState: { userId: args.userId, role },
+    });
 
     return memberId;
   },
@@ -176,9 +174,8 @@ export const removeMember = mutation({
       },
     });
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: member.organizationId,
         actor: {
           id: String(authUser._id),
@@ -187,14 +184,13 @@ export const removeMember = mutation({
           type: 'user',
         },
       },
-      'remove_member',
-      'member',
-      'member',
-      args.memberId,
-      targetUser?.email ?? member.userId,
-      { userId: member.userId, role: member.role },
-      undefined,
-    );
+      action: 'remove_member',
+      category: 'member',
+      resourceType: 'member',
+      resourceId: args.memberId,
+      resourceName: targetUser?.email ?? member.userId,
+      previousState: { userId: member.userId, role: member.role },
+    });
 
     return null;
   },
@@ -296,9 +292,8 @@ export const updateMemberRole = mutation({
       paginationOpts: { cursor: null, numItems: 1 },
     });
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: member.organizationId,
         actor: {
           id: String(authUser._id),
@@ -307,14 +302,14 @@ export const updateMemberRole = mutation({
           type: 'user',
         },
       },
-      'update_member_role',
-      'member',
-      'member',
-      args.memberId,
-      targetUser?.email ?? member.userId,
-      { role: previousRole },
-      { role: newRole },
-    );
+      action: 'update_member_role',
+      category: 'member',
+      resourceType: 'member',
+      resourceId: args.memberId,
+      resourceName: targetUser?.email ?? member.userId,
+      previousState: { role: previousRole },
+      newState: { role: newRole },
+    });
 
     return null;
   },
@@ -396,9 +391,8 @@ export const transferOwnership = mutation({
         )
       : undefined;
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: targetMember.organizationId,
         actor: {
           id: String(authUser._id),
@@ -407,14 +401,14 @@ export const transferOwnership = mutation({
           type: 'user',
         },
       },
-      'transfer_ownership',
-      'member',
-      'member',
-      args.targetMemberId,
-      targetUser?.email ?? targetMember.userId,
-      { previousOwner: String(authUser._id) },
-      { newOwner: targetMember.userId },
-    );
+      action: 'transfer_ownership',
+      category: 'member',
+      resourceType: 'member',
+      resourceId: args.targetMemberId,
+      resourceName: targetUser?.email ?? targetMember.userId,
+      previousState: { previousOwner: String(authUser._id) },
+      newState: { newOwner: targetMember.userId },
+    });
 
     return null;
   },
@@ -484,9 +478,8 @@ export const updateMemberDisplayName = mutation({
       paginationOpts: { cursor: null, numItems: 1 },
     });
 
-    await AuditLogHelpers.logSuccess(
-      ctx,
-      {
+    await AuditLogHelpers.logSuccess(ctx, {
+      auditCtx: {
         organizationId: member.organizationId,
         actor: {
           id: String(authUser._id),
@@ -495,14 +488,14 @@ export const updateMemberDisplayName = mutation({
           type: 'user',
         },
       },
-      'update_member_name',
-      'member',
-      'member',
-      args.memberId,
-      targetUser?.email ?? member.userId,
-      { name: previousName },
-      { name: args.displayName },
-    );
+      action: 'update_member_name',
+      category: 'member',
+      resourceType: 'member',
+      resourceId: args.memberId,
+      resourceName: targetUser?.email ?? member.userId,
+      previousState: { name: previousName },
+      newState: { name: args.displayName },
+    });
 
     return null;
   },

--- a/services/platform/convex/sso_providers/remove_provider.ts
+++ b/services/platform/convex/sso_providers/remove_provider.ts
@@ -27,9 +27,8 @@ export async function removeProvider(
 
   await ctx.db.delete(existing._id);
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: {
       organizationId: args.organizationId,
       actor: {
         id: args.actorId,
@@ -38,16 +37,15 @@ export async function removeProvider(
         type: 'user',
       },
     },
-    'sso_provider_deleted',
-    'integration',
-    'ssoProvider',
-    existing._id,
-    existing.providerId,
-    {
+    action: 'sso_provider_deleted',
+    category: 'integration',
+    resourceType: 'ssoProvider',
+    resourceId: existing._id,
+    resourceName: existing.providerId,
+    previousState: {
       providerId: existing.providerId,
     },
-    undefined,
-  );
+  });
 
   return null;
 }

--- a/services/platform/convex/sso_providers/upsert_provider.ts
+++ b/services/platform/convex/sso_providers/upsert_provider.ts
@@ -74,9 +74,8 @@ export async function upsertProvider(
 
   const entraFeatures = args.providerFeatures?.entraId;
 
-  await AuditLogHelpers.logSuccess(
-    ctx,
-    {
+  await AuditLogHelpers.logSuccess(ctx, {
+    auditCtx: {
       organizationId: args.organizationId,
       actor: {
         id: args.actorId,
@@ -85,18 +84,17 @@ export async function upsertProvider(
         type: 'user',
       },
     },
-    isNew ? 'sso_provider_created' : 'sso_provider_updated',
-    'integration',
-    'ssoProvider',
-    providerId,
-    args.providerId,
-    undefined,
-    {
+    action: isNew ? 'sso_provider_created' : 'sso_provider_updated',
+    category: 'integration',
+    resourceType: 'ssoProvider',
+    resourceId: providerId,
+    resourceName: args.providerId,
+    newState: {
       providerId: args.providerId,
       autoProvisionTeam: entraFeatures?.autoProvisionTeam,
       autoProvisionRole: args.autoProvisionRole,
     },
-  );
+  });
 
   return providerId;
 }


### PR DESCRIPTION
## Summary
- Refactor `logSuccess`, `logFailure`, and `logDenied` from positional parameters to a single options object
- Add `LogSuccessOptions`, `LogFailureOptions`, `LogDeniedOptions` interfaces
- Updated all 27 call sites across 23 files
- No behavioral changes — purely a signature refactor

Fixes #273