### PR TITLE
refactor(platform): rename delegateAgentIds to delegateSlugs

### DIFF
--- a/services/platform/convex/agent_tools/delegation/create_delegation_tool.ts
+++ b/services/platform/convex/agent_tools/delegation/create_delegation_tool.ts
@@ -9,7 +9,7 @@
  * 1. Validates context (orgId, threadId, userId)
  * 2. Checks time budget
  * 3. Optionally checks role access
- * 4. Gets/creates a sub-thread keyed by delegate rootVersionId
+ * 4. Gets/creates a sub-thread keyed by delegate agentSlug
  * 5. Runs the delegate agent via the generic runAgentGeneration action
  * 6. Returns a structured ToolResponse
  */
@@ -34,7 +34,7 @@ import {
 import { validateToolContext } from '../sub_agents/helpers/validate_context';
 
 export interface DelegateAgentMeta {
-  rootVersionId: string;
+  agentSlug: string;
   name: string;
   displayName: string;
   description: string;
@@ -89,7 +89,7 @@ Pass the user's request in natural language. The agent will handle it and return
             ctx,
             {
               parentThreadId: threadId,
-              subAgentType: delegate.rootVersionId,
+              subAgentType: delegate.agentSlug,
               userId,
             },
           );

--- a/services/platform/convex/agent_tools/delegation/load_delegation_agents.ts
+++ b/services/platform/convex/agent_tools/delegation/load_delegation_agents.ts
@@ -40,7 +40,7 @@ export async function loadDelegateAgents(
       const agentConfig = toSerializableConfig(name, config);
 
       delegates.push({
-        rootVersionId: name,
+        agentSlug: name,
         name,
         displayName: config.displayName,
         description: config.description ?? '',

--- a/services/platform/convex/agents/config.ts
+++ b/services/platform/convex/agents/config.ts
@@ -42,7 +42,7 @@ export function toSerializableConfig(
     knowledgeFileIds: (binding?.knowledgeFiles ?? [])
       .filter((f) => f.ragStatus === 'completed')
       .map((f) => String(f.fileId)),
-    delegateAgentIds: config.delegates,
+    delegateSlugs: config.delegates,
     structuredResponsesEnabled: config.structuredResponsesEnabled ?? true,
     timeoutMs: config.timeoutMs,
     outputReserve: config.outputReserve,

--- a/services/platform/convex/agents/test_chat.test.ts
+++ b/services/platform/convex/agents/test_chat.test.ts
@@ -76,10 +76,7 @@ describe('toSerializableConfig', () => {
       delegates: ['web-assistant', 'file-assistant'],
     });
     const result = toSerializableConfig('a', config);
-    expect(result.delegateAgentIds).toEqual([
-      'web-assistant',
-      'file-assistant',
-    ]);
+    expect(result.delegateSlugs).toEqual(['web-assistant', 'file-assistant']);
   });
 
   it('should default knowledgeMode to off', () => {

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -89,7 +89,7 @@ const serializableAgentConfigValidator = v.object({
   includeOrgKnowledge: v.optional(v.boolean()),
   agentTeamId: v.optional(v.string()),
   knowledgeFileIds: v.optional(v.array(v.string())),
-  delegateAgentIds: v.optional(v.array(v.string())),
+  delegateSlugs: v.optional(v.array(v.string())),
   structuredResponsesEnabled: v.optional(v.boolean()),
   timeoutMs: v.optional(v.number()),
   outputReserve: v.optional(v.number()),
@@ -200,10 +200,10 @@ export const runAgentGeneration = internalAction({
       // Build delegation tools dynamically
       let delegationExtraTools: Record<string, unknown> | undefined;
       let delegationInstructionsAppend = '';
-      if (agentConfig.delegateAgentIds?.length) {
+      if (agentConfig.delegateSlugs?.length) {
         const delegates = await loadDelegateAgents(
           ctx,
-          agentConfig.delegateAgentIds,
+          agentConfig.delegateSlugs,
           organizationId,
           'default',
         );

--- a/services/platform/convex/lib/agent_chat/types.ts
+++ b/services/platform/convex/lib/agent_chat/types.ts
@@ -43,8 +43,8 @@ export interface SerializableAgentConfig {
   agentTeamId?: string;
   /** Pre-resolved completed file IDs from agent-specific knowledge files */
   knowledgeFileIds?: string[];
-  /** Root version IDs of delegate agents */
-  delegateAgentIds?: string[];
+  /** Agent slugs of delegate agents (file-based agent names) */
+  delegateSlugs?: string[];
   /** Whether to inject structured response markers into the system prompt (default true) */
   structuredResponsesEnabled?: boolean;
   /** Per-agent timeout in milliseconds */


### PR DESCRIPTION
## Summary
- Rename `delegateAgentIds` to `delegateSlugs` throughout the delegation pipeline to accurately reflect that these are agent file-name slugs, not Convex document IDs
- Rename `rootVersionId` to `agentSlug` in `DelegateAgentMeta`
- Updated 6 files and test assertions

Fixes #507