### PR TITLE
refactor(platform): promote folderPath to top-level documents field

### DIFF
--- a/services/platform/convex/documents/create_document.ts
+++ b/services/platform/convex/documents/create_document.ts
@@ -5,6 +5,7 @@
 import type { MutationCtx } from '../_generated/server';
 import type { CreateDocumentArgs, CreateDocumentResult } from './types';
 
+import { buildFolderPath } from '../folders/queries';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
 import { extractExtension } from './extract_extension';
 import { teamIdToFields } from './team_fields';
@@ -24,6 +25,10 @@ export async function createDocument(
 
   const teamFields = teamIdToFields(args.teamId);
 
+  const folderPath =
+    args.folderPath ??
+    (args.folderId ? await buildFolderPath(ctx, args.folderId) : undefined);
+
   const documentId = await ctx.db.insert('documents', {
     organizationId: args.organizationId,
     title: args.title,
@@ -41,6 +46,7 @@ export async function createDocument(
     sourceModifiedAt: args.sourceModifiedAt,
     createdBy: args.createdBy,
     folderId: args.folderId,
+    folderPath,
   });
 
   return {

--- a/services/platform/convex/documents/list_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_documents_for_agent.ts
@@ -183,7 +183,7 @@ export async function listDocumentsForAgent(
   const page = matches.slice(startIndex, startIndex + limit);
   const hasMore = startIndex + limit < matches.length;
 
-  // Batch-resolve folder paths
+  // Resolve folder paths: prefer top-level folderPath, fall back to breadcrumb
   const folderPathMap = await resolveFolderPaths(ctx, page);
 
   // Build response — type guard narrows fileId (already filtered on line 118)
@@ -196,7 +196,9 @@ export async function listDocumentsForAgent(
     fileId: doc.fileId,
     title: getDocumentTitle(doc),
     extension: doc.extension ?? null,
-    folderPath: doc.folderId ? (folderPathMap.get(doc.folderId) ?? null) : null,
+    folderPath:
+      doc.folderPath ??
+      (doc.folderId ? (folderPathMap.get(doc.folderId) ?? null) : null),
     teamId: doc.teamId ?? null,
     createdAt: doc._creationTime,
     sizeBytes: extractSize(doc.metadata),

--- a/services/platform/convex/documents/schema.ts
+++ b/services/platform/convex/documents/schema.ts
@@ -49,6 +49,7 @@ export const documentsTable = defineTable({
   sourceModifiedAt: v.optional(v.number()),
   createdBy: v.optional(v.string()),
   folderId: v.optional(v.id('folders')),
+  folderPath: v.optional(v.string()),
   metadata: v.optional(jsonRecordValidator),
 })
   .index('by_organizationId', ['organizationId'])
@@ -65,4 +66,5 @@ export const documentsTable = defineTable({
   .index('by_organizationId_and_extension', ['organizationId', 'extension'])
   .index('by_organizationId_and_title', ['organizationId', 'title'])
   .index('by_organizationId_and_fileId', ['organizationId', 'fileId'])
-  .index('by_organizationId_and_indexed', ['organizationId', 'indexed']);
+  .index('by_organizationId_and_indexed', ['organizationId', 'indexed'])
+  .index('by_organizationId_and_folderPath', ['organizationId', 'folderPath']);

--- a/services/platform/convex/documents/types.ts
+++ b/services/platform/convex/documents/types.ts
@@ -73,6 +73,7 @@ export interface CreateDocumentArgs {
   teamId?: string;
   createdBy?: string;
   folderId?: Id<'folders'>;
+  folderPath?: string;
   sourceCreatedAt?: number;
   sourceModifiedAt?: number;
 }

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -6,6 +6,7 @@ import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 
 import { internal } from '../_generated/api';
+import { buildFolderPath } from '../folders/queries';
 
 export type UpdateDocumentInternalArgs = {
   documentId: Id<'documents'>;
@@ -20,6 +21,7 @@ export type UpdateDocumentInternalArgs = {
   contentHash?: string;
   teamId?: string;
   folderId?: Id<'folders'>;
+  folderPath?: string;
 };
 
 export async function updateDocumentInternal(
@@ -48,6 +50,13 @@ export async function updateDocumentInternal(
   let historyFiles = document.historyFiles ?? [];
   if (hashChanged && hasNewFile && document.fileId) {
     historyFiles = [...historyFiles, document.fileId];
+  }
+
+  // Sync folderPath when folderId changes
+  if (updateData.folderId !== undefined) {
+    updateData.folderPath = updateData.folderId
+      ? await buildFolderPath(ctx, updateData.folderId)
+      : undefined;
   }
 
   // Build update data

--- a/services/platform/convex/documents/validators.ts
+++ b/services/platform/convex/documents/validators.ts
@@ -128,6 +128,7 @@ export const documentRecordValidator = v.object({
   mimeType: v.optional(v.string()),
   extension: v.optional(v.string()),
   folderId: v.optional(v.string()),
+  folderPath: v.optional(v.string()),
   metadata: v.optional(jsonRecordValidator),
   sourceProvider: v.optional(sourceProviderValidator),
   externalItemId: v.optional(v.string()),

--- a/services/platform/convex/folders/queries.ts
+++ b/services/platform/convex/folders/queries.ts
@@ -153,3 +153,16 @@ export async function buildBreadcrumb(
   chain.reverse();
   return chain;
 }
+
+/**
+ * Build a slash-separated folder path string from a folder ID.
+ * Returns undefined if the folder cannot be resolved.
+ */
+export async function buildFolderPath(
+  ctx: QueryCtx,
+  folderId: Id<'folders'>,
+): Promise<string | undefined> {
+  const breadcrumb = await buildBreadcrumb(ctx, folderId);
+  if (breadcrumb.length === 0) return undefined;
+  return breadcrumb.map((b) => b.name).join('/');
+}

--- a/services/platform/convex/migrations/backfill_folder_path.ts
+++ b/services/platform/convex/migrations/backfill_folder_path.ts
@@ -1,0 +1,76 @@
+/**
+ * Migration: Backfill folderPath on existing documents.
+ *
+ * For each document with a folderId, compute the folder path from the
+ * folders table hierarchy and write it to the new top-level folderPath field.
+ *
+ * Idempotent: skips documents that already have folderPath set.
+ *
+ * Usage:
+ *   bunx convex run migrations/backfill_folder_path:backfillFolderPath
+ */
+
+import { internalMutation } from '../_generated/server';
+import { buildFolderPath } from '../folders/queries';
+
+const BATCH_SIZE = 200;
+
+export const backfillFolderPath = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    let totalUpdated = 0;
+    let totalSkipped = 0;
+    let cursor: string | null = null;
+    let isDone = false;
+
+    while (!isDone) {
+      let updated = 0;
+      let skipped = 0;
+
+      const result = await ctx.db
+        .query('documents')
+        .paginate({ cursor, numItems: BATCH_SIZE });
+
+      for (const doc of result.page) {
+        if (doc.folderPath) {
+          skipped++;
+          continue;
+        }
+
+        if (!doc.folderId) {
+          skipped++;
+          continue;
+        }
+
+        try {
+          const folderPath = await buildFolderPath(ctx, doc.folderId);
+
+          if (folderPath) {
+            await ctx.db.patch(doc._id, { folderPath });
+            updated++;
+          } else {
+            skipped++;
+          }
+        } catch (err) {
+          console.error(
+            `[backfillFolderPath] Error processing doc ${String(doc._id)} (folderId: ${doc.folderId}):`,
+            err,
+          );
+          skipped++;
+          continue;
+        }
+      }
+
+      console.log(
+        `[backfillFolderPath] Batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
+      );
+
+      totalUpdated += updated;
+      totalSkipped += skipped;
+      cursor = result.continueCursor;
+      isDone = result.isDone;
+    }
+
+    return { updated: totalUpdated, skipped: totalSkipped };
+  },
+});


### PR DESCRIPTION
## Summary
- Add `folderPath` as optional top-level field on documents schema with org+folderPath composite index
- Compute and store folderPath on document create and update (from folder hierarchy)
- Agent listing prefers stored folderPath, falls back to breadcrumb resolution for un-backfilled docs
- Add idempotent backfill migration for existing documents
- Backwards compatible — field is optional, existing documents continue to work

Fixes #703