### PR TITLE
feat(platform): add conversation_read agent tool

### DIFF
--- a/services/platform/convex/agent_tools/conversations/__tests__/conversation_read_tool.test.ts
+++ b/services/platform/convex/agent_tools/conversations/__tests__/conversation_read_tool.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { readConversationById } from '../helpers/read_conversation_by_id';
+import { readConversationList } from '../helpers/read_conversation_list';
+import { readConversationMessages } from '../helpers/read_conversation_messages';
+
+vi.mock('../../../_generated/api', () => ({
+  internal: {
+    conversations: {
+      internal_queries: {
+        getConversationById: 'mock-get-conversation-by-id',
+        queryConversations: 'mock-query-conversations',
+        queryConversationMessages: 'mock-query-conversation-messages',
+      },
+    },
+  },
+}));
+
+function createMockCtx(overrides?: Record<string, unknown>) {
+  return {
+    organizationId: 'org1',
+    runQuery: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('readConversationById', () => {
+  it('returns null when conversation is not found', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue(null);
+
+    const result = await readConversationById(ctx as never, {
+      conversationId: 'conv1',
+    });
+
+    expect(result).toEqual({
+      operation: 'get_by_id',
+      conversation: null,
+    });
+  });
+
+  it('returns null when conversation belongs to different org', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      _id: 'conv1',
+      organizationId: 'other-org',
+      subject: 'Test',
+      status: 'open',
+    });
+
+    const result = await readConversationById(ctx as never, {
+      conversationId: 'conv1',
+    });
+
+    expect(result).toEqual({
+      operation: 'get_by_id',
+      conversation: null,
+    });
+  });
+
+  it('returns selected fields when conversation exists', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      _id: 'conv1',
+      organizationId: 'org1',
+      subject: 'Help needed',
+      status: 'open',
+      priority: 'high',
+      channel: 'email',
+      customerId: 'cust1',
+      lastMessageAt: 1700000000000,
+    });
+
+    const result = await readConversationById(ctx as never, {
+      conversationId: 'conv1',
+      fields: ['_id', 'subject', 'status'],
+    });
+
+    expect(result.operation).toBe('get_by_id');
+    expect(result.conversation).toEqual({
+      _id: 'conv1',
+      subject: 'Help needed',
+      status: 'open',
+    });
+  });
+
+  it('always includes _id even if not in fields', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      _id: 'conv1',
+      organizationId: 'org1',
+      subject: 'Test',
+      status: 'open',
+    });
+
+    const result = await readConversationById(ctx as never, {
+      conversationId: 'conv1',
+      fields: ['subject'],
+    });
+
+    expect(result.conversation?._id).toBe('conv1');
+  });
+});
+
+describe('readConversationList', () => {
+  it('throws when organizationId is missing', async () => {
+    const ctx = createMockCtx({ organizationId: undefined });
+
+    await expect(readConversationList(ctx as never, {})).rejects.toThrow(
+      'organizationId is required',
+    );
+  });
+
+  it('returns paginated conversations', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [
+        { _id: 'conv1', subject: 'Test', status: 'open' },
+        { _id: 'conv2', subject: 'Other', status: 'closed' },
+      ],
+      isDone: false,
+      continueCursor: 'cursor-abc',
+    });
+
+    const result = await readConversationList(ctx as never, {});
+
+    expect(result).toEqual({
+      operation: 'list',
+      conversations: [
+        { _id: 'conv1', subject: 'Test', status: 'open' },
+        { _id: 'conv2', subject: 'Other', status: 'closed' },
+      ],
+      pagination: {
+        hasMore: true,
+        totalFetched: 2,
+        cursor: 'cursor-abc',
+      },
+    });
+  });
+
+  it('passes status filter to query', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    await readConversationList(ctx as never, { status: 'open' });
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      'mock-query-conversations',
+      expect.objectContaining({ status: 'open' }),
+    );
+  });
+
+  it('passes customerId filter to query', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    await readConversationList(ctx as never, { customerId: 'cust1' });
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      'mock-query-conversations',
+      expect.objectContaining({ customerId: 'cust1' }),
+    );
+  });
+
+  it('uses default numItems of 50', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    await readConversationList(ctx as never, {});
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      'mock-query-conversations',
+      expect.objectContaining({
+        paginationOpts: { numItems: 50, cursor: null },
+      }),
+    );
+  });
+});
+
+describe('readConversationMessages', () => {
+  it('throws when organizationId is missing', async () => {
+    const ctx = createMockCtx({ organizationId: undefined });
+
+    await expect(
+      readConversationMessages(ctx as never, { conversationId: 'conv1' }),
+    ).rejects.toThrow('organizationId is required');
+  });
+
+  it('returns paginated messages', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [
+        {
+          _id: 'msg1',
+          conversationId: 'conv1',
+          content: 'Hello',
+          direction: 'inbound',
+        },
+        {
+          _id: 'msg2',
+          conversationId: 'conv1',
+          content: 'Hi there',
+          direction: 'outbound',
+        },
+      ],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    const result = await readConversationMessages(ctx as never, {
+      conversationId: 'conv1',
+    });
+
+    expect(result).toEqual({
+      operation: 'get_messages',
+      messages: [
+        {
+          _id: 'msg1',
+          conversationId: 'conv1',
+          content: 'Hello',
+          direction: 'inbound',
+        },
+        {
+          _id: 'msg2',
+          conversationId: 'conv1',
+          content: 'Hi there',
+          direction: 'outbound',
+        },
+      ],
+      pagination: {
+        hasMore: false,
+        totalFetched: 2,
+        cursor: null,
+      },
+    });
+  });
+
+  it('uses default numItems of 100', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    await readConversationMessages(ctx as never, {
+      conversationId: 'conv1',
+    });
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      'mock-query-conversation-messages',
+      expect.objectContaining({
+        paginationOpts: { numItems: 100, cursor: null },
+      }),
+    );
+  });
+
+  it('passes cursor for pagination', async () => {
+    const ctx = createMockCtx();
+    ctx.runQuery.mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: '',
+    });
+
+    await readConversationMessages(ctx as never, {
+      conversationId: 'conv1',
+      cursor: 'cursor-xyz',
+      numItems: 25,
+    });
+
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      'mock-query-conversation-messages',
+      expect.objectContaining({
+        paginationOpts: { numItems: 25, cursor: 'cursor-xyz' },
+      }),
+    );
+  });
+});

--- a/services/platform/convex/agent_tools/conversations/conversation_read_tool.ts
+++ b/services/platform/convex/agent_tools/conversations/conversation_read_tool.ts
@@ -1,0 +1,163 @@
+/**
+ * Convex Tool: Conversation Read
+ *
+ * Unified read-only conversation operations for agents.
+ * Supports:
+ * - operation = 'get_by_id': fetch a single conversation by conversationId
+ * - operation = 'list': list conversations with optional filters (status, customerId)
+ * - operation = 'get_messages': read messages from a specific conversation
+ */
+
+import type { ToolCtx } from '@convex-dev/agent';
+
+import { createTool } from '@convex-dev/agent';
+import { z } from 'zod/v4';
+
+import type { ToolDefinition } from '../types';
+import type {
+  ConversationReadGetByIdResult,
+  ConversationReadListResult,
+  ConversationReadMessagesResult,
+} from './helpers/types';
+
+import { readConversationById } from './helpers/read_conversation_by_id';
+import { readConversationList } from './helpers/read_conversation_list';
+import { readConversationMessages } from './helpers/read_conversation_messages';
+
+const conversationReadArgs = z.discriminatedUnion('operation', [
+  z.object({
+    operation: z.literal('get_by_id'),
+    conversationId: z
+      .string()
+      .describe(
+        'Convex Id<"conversations"> (string format) for the target conversation',
+      ),
+    fields: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Fields to return. Default: ['_id','subject','status','priority','channel','direction','customerId','lastMessageAt']",
+      ),
+  }),
+  z.object({
+    operation: z.literal('list'),
+    status: z
+      .enum(['open', 'closed', 'spam', 'archived'])
+      .optional()
+      .describe('Filter by conversation status'),
+    customerId: z
+      .string()
+      .optional()
+      .describe('Filter by customer ID (Convex Id<"customers"> string format)'),
+    cursor: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Pagination cursor from previous response, or null/omitted for first page',
+      ),
+    numItems: z
+      .number()
+      .optional()
+      .describe('Number of items per page (default: 50)'),
+  }),
+  z.object({
+    operation: z.literal('get_messages'),
+    conversationId: z
+      .string()
+      .describe(
+        'Convex Id<"conversations"> for the conversation to read messages from',
+      ),
+    cursor: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Pagination cursor from previous response, or null/omitted for first page',
+      ),
+    numItems: z
+      .number()
+      .optional()
+      .describe('Number of messages per page (default: 100)'),
+  }),
+]);
+
+export const conversationReadTool: ToolDefinition = {
+  name: 'conversation_read',
+  tool: createTool({
+    description: `Customer conversation read tool for accessing conversation data and message history.
+
+SCOPE LIMITATION:
+This tool accesses the internal conversations database (inbound/outbound customer conversations).
+It does NOT access the agent's own chat thread — use this to look up customer support conversations.
+
+OPERATIONS:
+• 'get_by_id': Fetch a single conversation by its Convex ID. Returns conversation metadata.
+• 'list': Browse conversations for the organization. Supports filters: status (open/closed/spam/archived), customerId.
+  Use pagination (cursor) for large result sets.
+• 'get_messages': Read messages from a specific conversation. Returns message content, sender direction, timestamps, and delivery state.
+  Use pagination (cursor) for conversations with many messages.
+
+AVAILABLE FIELDS FOR get_by_id:
+System fields:
+• _id: Convex document ID (Id<"conversations">)
+• _creationTime: Document creation timestamp (number)
+• organizationId: Organization ID (string)
+
+Core conversation fields:
+• subject: Conversation subject/title (string, optional)
+• status: Conversation status — 'open' | 'closed' | 'spam' | 'archived' (optional)
+• priority: Priority level — 'low' | 'medium' | 'high' | 'urgent' (optional)
+• channel: Communication channel (string, optional)
+• direction: Message direction — 'inbound' | 'outbound' (optional)
+• customerId: Associated customer ID (Id<"customers">, optional)
+• integrationName: Integration source name (string, optional)
+• lastMessageAt: Timestamp of last message (number, optional)
+
+Large/complex fields (use sparingly):
+• metadata: Additional metadata (object, optional) — CAN BE VERY LARGE
+
+MESSAGE FIELDS (returned by get_messages):
+• _id, conversationId, channel, direction, content, deliveryState, sentAt, deliveredAt
+• externalMessageId, integrationName, metadata (HEAVY)
+
+BEST PRACTICES:
+• Use 'list' to find conversations, then 'get_messages' to read their content.
+• Always specify 'fields' in get_by_id to minimize response size.
+• Use status filter in 'list' to narrow results (e.g., only 'open' conversations).
+• Use customerId filter to find conversations for a specific customer.
+• Paginate through messages — some conversations may have hundreds of messages.`,
+    inputSchema: conversationReadArgs,
+    execute: async (
+      ctx: ToolCtx,
+      args,
+    ): Promise<
+      | ConversationReadGetByIdResult
+      | ConversationReadListResult
+      | ConversationReadMessagesResult
+    > => {
+      if (args.operation === 'get_by_id') {
+        return readConversationById(ctx, {
+          conversationId: args.conversationId,
+          fields: args.fields,
+        });
+      }
+
+      if (args.operation === 'get_messages') {
+        return readConversationMessages(ctx, {
+          conversationId: args.conversationId,
+          cursor: args.cursor,
+          numItems: args.numItems,
+        });
+      }
+
+      // operation === 'list'
+      return readConversationList(ctx, {
+        cursor: args.cursor,
+        numItems: args.numItems,
+        status: args.status,
+        customerId: args.customerId,
+      });
+    },
+  }),
+} as const;

--- a/services/platform/convex/agent_tools/conversations/helpers/read_conversation_by_id.ts
+++ b/services/platform/convex/agent_tools/conversations/helpers/read_conversation_by_id.ts
@@ -1,0 +1,66 @@
+import type { ToolCtx } from '@convex-dev/agent';
+
+import { isKeyOf } from '../../../../lib/utils/type-guards';
+import { internal } from '../../../_generated/api';
+import { createDebugLog } from '../../../lib/debug_log';
+import { toId } from '../../../lib/type_cast_helpers';
+import {
+  defaultConversationGetFields,
+  type ConversationReadGetByIdResult,
+} from './types';
+
+const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
+
+export async function readConversationById(
+  ctx: ToolCtx,
+  args: { conversationId: string; fields?: string[] },
+): Promise<ConversationReadGetByIdResult> {
+  const { organizationId } = ctx;
+
+  debugLog('tool:conversation_read get_by_id start', {
+    organizationId,
+    conversationId: args.conversationId,
+  });
+
+  const conversationId = toId<'conversations'>(args.conversationId);
+
+  const conversation = await ctx.runQuery(
+    internal.conversations.internal_queries.getConversationById,
+    { conversationId },
+  );
+
+  if (!conversation || conversation.organizationId !== organizationId) {
+    debugLog('tool:conversation_read get_by_id not found', {
+      organizationId,
+      conversationId: args.conversationId,
+    });
+
+    return {
+      operation: 'get_by_id',
+      conversation: null,
+    };
+  }
+
+  const fields = args.fields ?? defaultConversationGetFields;
+
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (isKeyOf(f, conversation)) {
+      out[f] = conversation[f];
+    }
+  }
+  if (!('_id' in out)) {
+    out._id = conversation._id;
+  }
+
+  const presentKeys = Object.keys(out).filter((k) => out[k] !== undefined);
+  debugLog('tool:conversation_read get_by_id return', {
+    conversationId: args.conversationId,
+    presentKeys,
+  });
+
+  return {
+    operation: 'get_by_id',
+    conversation: out,
+  };
+}

--- a/services/platform/convex/agent_tools/conversations/helpers/read_conversation_list.ts
+++ b/services/platform/convex/agent_tools/conversations/helpers/read_conversation_list.ts
@@ -1,0 +1,52 @@
+import type { ToolCtx } from '@convex-dev/agent';
+
+import type { ConversationReadListResult } from './types';
+
+import { internal } from '../../../_generated/api';
+
+export async function readConversationList(
+  ctx: ToolCtx,
+  args: {
+    cursor?: string | null;
+    numItems?: number;
+    status?: 'open' | 'closed' | 'spam' | 'archived';
+    customerId?: string;
+  },
+): Promise<ConversationReadListResult> {
+  const { organizationId } = ctx;
+
+  if (!organizationId) {
+    throw new Error(
+      'organizationId is required in context for listing conversations',
+    );
+  }
+
+  const numItems = args.numItems ?? 50;
+  const cursor = args.cursor ?? null;
+
+  const result = await ctx.runQuery(
+    internal.conversations.internal_queries.queryConversations,
+    {
+      organizationId,
+      status: args.status,
+      customerId: args.customerId
+        ? // @ts-expect-error -- Convex Id<"customers"> branded type from plain string
+          args.customerId
+        : undefined,
+      paginationOpts: {
+        numItems,
+        cursor,
+      },
+    },
+  );
+
+  return {
+    operation: 'list',
+    conversations: result.page,
+    pagination: {
+      hasMore: !result.isDone,
+      totalFetched: result.page.length,
+      cursor: result.continueCursor || null,
+    },
+  };
+}

--- a/services/platform/convex/agent_tools/conversations/helpers/read_conversation_messages.ts
+++ b/services/platform/convex/agent_tools/conversations/helpers/read_conversation_messages.ts
@@ -1,0 +1,49 @@
+import type { ToolCtx } from '@convex-dev/agent';
+
+import type { ConversationReadMessagesResult } from './types';
+
+import { internal } from '../../../_generated/api';
+import { toId } from '../../../lib/type_cast_helpers';
+
+export async function readConversationMessages(
+  ctx: ToolCtx,
+  args: {
+    conversationId: string;
+    cursor?: string | null;
+    numItems?: number;
+  },
+): Promise<ConversationReadMessagesResult> {
+  const { organizationId } = ctx;
+
+  if (!organizationId) {
+    throw new Error(
+      'organizationId is required in context for reading conversation messages',
+    );
+  }
+
+  const conversationId = toId<'conversations'>(args.conversationId);
+  const numItems = args.numItems ?? 100;
+  const cursor = args.cursor ?? null;
+
+  const result = await ctx.runQuery(
+    internal.conversations.internal_queries.queryConversationMessages,
+    {
+      organizationId,
+      conversationId,
+      paginationOpts: {
+        numItems,
+        cursor,
+      },
+    },
+  );
+
+  return {
+    operation: 'get_messages',
+    messages: result.page,
+    pagination: {
+      hasMore: !result.isDone,
+      totalFetched: result.page.length,
+      cursor: result.continueCursor || null,
+    },
+  };
+}

--- a/services/platform/convex/agent_tools/conversations/helpers/types.ts
+++ b/services/platform/convex/agent_tools/conversations/helpers/types.ts
@@ -1,0 +1,57 @@
+export type ConversationReadGetByIdResult = {
+  operation: 'get_by_id';
+  conversation: Record<string, unknown> | null;
+};
+
+export type ConversationReadListResult = {
+  operation: 'list';
+  conversations: Array<Record<string, unknown>>;
+  pagination: {
+    hasMore: boolean;
+    totalFetched: number;
+    cursor: string | null;
+  };
+};
+
+export type ConversationReadMessagesResult = {
+  operation: 'get_messages';
+  messages: Array<Record<string, unknown>>;
+  pagination: {
+    hasMore: boolean;
+    totalFetched: number;
+    cursor: string | null;
+  };
+};
+
+export const defaultConversationGetFields: string[] = [
+  '_id',
+  'subject',
+  'status',
+  'priority',
+  'channel',
+  'direction',
+  'customerId',
+  'lastMessageAt',
+];
+
+export const defaultConversationListFields: string[] = [
+  '_id',
+  'subject',
+  'status',
+  'priority',
+  'channel',
+  'direction',
+  'customerId',
+  'lastMessageAt',
+];
+
+export const defaultMessageFields: string[] = [
+  '_id',
+  'conversationId',
+  'channel',
+  'direction',
+  'content',
+  'deliveryState',
+  'sentAt',
+  'deliveredAt',
+];

--- a/services/platform/convex/agent_tools/tool_names.ts
+++ b/services/platform/convex/agent_tools/tool_names.ts
@@ -35,6 +35,7 @@ export const TOOL_NAMES = [
   'document_retrieve',
   'document_write',
   'request_user_location',
+  'conversation_read',
 ] as const;
 
 export type ToolName = (typeof TOOL_NAMES)[number];

--- a/services/platform/convex/agent_tools/tool_registry.ts
+++ b/services/platform/convex/agent_tools/tool_registry.ts
@@ -8,6 +8,7 @@
 import type { ToolName } from './tool_names';
 import type { ToolDefinition } from './types';
 
+import { conversationReadTool } from './conversations/conversation_read_tool';
 import { customerReadTool } from './customers/customer_read_tool';
 import { databaseSchemaTool } from './database/database_schema_tool';
 import { documentFindTool } from './documents/document_find_tool';
@@ -66,6 +67,7 @@ export const TOOL_REGISTRY = [
   documentRetrieveTool,
   documentWriteTool,
   requestUserLocationTool,
+  conversationReadTool,
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Add `conversation_read` tool with 3 operations: `get_by_id`, `list`, `get_messages`
- Supports filtering by status and customerId, pagination, and field selection
- Organization scoping enforced on all operations
- Follows existing `customer_read_tool` pattern exactly
- Added 13 tests covering all operations and error cases

Fixes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new conversation read agent tool enabling retrieval of specific conversations by ID, listing conversations with optional status and customer filtering, and accessing paginated conversation message history with cursor navigation support.

* **Tests**
  * Added comprehensive test suite for conversation read operations validating field selection, filtering capabilities, pagination behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->