### PR TITLE
feat(platform): add pagination to product and customer tables

### DIFF
--- a/services/platform/app/features/customers/components/customers-table.tsx
+++ b/services/platform/app/features/customers/components/customers-table.tsx
@@ -173,6 +173,7 @@ export function CustomersTable({
       isLoading: paginatedResult.isLoading,
     },
     pageSize,
+    displayMode: 'pagination',
     search: {
       fields: ['name', 'email', 'externalId'],
       placeholder: searchPlaceholder,

--- a/services/platform/app/features/products/components/products-table.tsx
+++ b/services/platform/app/features/products/components/products-table.tsx
@@ -104,6 +104,7 @@ export function ProductsTable({
       isLoading: paginatedResult.isLoading,
     },
     pageSize,
+    displayMode: 'pagination',
     search: {
       fields: ['name', 'description', 'category'],
       placeholder: searchPlaceholder,

--- a/services/platform/app/hooks/__tests__/use-list-page.test.ts
+++ b/services/platform/app/hooks/__tests__/use-list-page.test.ts
@@ -1,0 +1,159 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { useListPage } from '../use-list-page';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+interface TestItem {
+  _id: string;
+  name: string;
+  category: string;
+}
+
+function makeItems(count: number): TestItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    _id: `id_${i}`,
+    name: `Item ${i}`,
+    category: i % 2 === 0 ? 'even' : 'odd',
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderListPage(
+  overrides: Partial<Parameters<typeof useListPage<TestItem>>[0]> = {},
+) {
+  const items =
+    overrides.dataSource?.type === 'query'
+      ? (overrides.dataSource.data ?? [])
+      : makeItems(50);
+
+  const defaults: Parameters<typeof useListPage<TestItem>>[0] = {
+    dataSource: {
+      type: 'query',
+      data: items,
+    },
+    pageSize: 10,
+    ...overrides,
+  };
+
+  return renderHook(() => useListPage<TestItem>(defaults));
+}
+
+// ---------------------------------------------------------------------------
+// Tests — infinite scroll (default)
+// ---------------------------------------------------------------------------
+
+describe('useListPage — infiniteScroll mode (default)', () => {
+  it('returns sliced data matching pageSize', () => {
+    const { result } = renderListPage();
+
+    expect(result.current.tableProps.data).toHaveLength(10);
+    expect(result.current.totalCount).toBe(50);
+    expect('infiniteScroll' in result.current.tableProps).toBe(true);
+  });
+
+  it('hasMore is true when more data is available', () => {
+    const { result } = renderListPage();
+    const props = result.current.tableProps;
+    if ('infiniteScroll' in props) {
+      expect(props.infiniteScroll.hasMore).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — pagination mode
+// ---------------------------------------------------------------------------
+
+describe('useListPage — pagination mode', () => {
+  it('returns all processed data for client-side pagination', () => {
+    const { result } = renderListPage({ displayMode: 'pagination' });
+
+    expect(result.current.tableProps.data).toHaveLength(50);
+    expect('pagination' in result.current.tableProps).toBe(true);
+  });
+
+  it('includes correct pagination config', () => {
+    const { result } = renderListPage({
+      displayMode: 'pagination',
+      pageSize: 25,
+    });
+
+    const props = result.current.tableProps;
+    if ('pagination' in props) {
+      expect(props.pagination.clientSide).toBe(true);
+      expect(props.pagination.pageSize).toBe(25);
+      expect(props.pagination.total).toBe(50);
+    }
+  });
+
+  it('applies search filter and updates pagination total', () => {
+    const { result } = renderListPage({
+      displayMode: 'pagination',
+      search: {
+        fields: ['name'],
+        placeholder: 'Search...',
+      },
+    });
+
+    // Initially all items
+    expect(result.current.tableProps.data).toHaveLength(50);
+
+    // Trigger search via the search config
+    const props = result.current.tableProps;
+    if (props.search) {
+      act(() => {
+        props.search?.onChange('Item 1');
+      });
+    }
+
+    // Should filter to items matching "Item 1" (Item 1, Item 10-19)
+    const filtered = result.current.tableProps.data;
+    expect(filtered.length).toBeLessThan(50);
+    expect(filtered.length).toBeGreaterThan(0);
+
+    if ('pagination' in result.current.tableProps) {
+      expect(result.current.tableProps.pagination.total).toBe(filtered.length);
+    }
+  });
+
+  it('eagerly loads more from paginated backend source', () => {
+    const loadMore = vi.fn();
+
+    renderListPage({
+      displayMode: 'pagination',
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'CanLoadMore',
+        loadMore,
+        isLoading: false,
+      },
+    });
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('does not eagerly load when backend is exhausted', () => {
+    const loadMore = vi.fn();
+
+    renderListPage({
+      displayMode: 'pagination',
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'Exhausted',
+        loadMore,
+        isLoading: false,
+      },
+    });
+
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/hooks/use-list-page.ts
+++ b/services/platform/app/hooks/use-list-page.ts
@@ -79,13 +79,19 @@ interface UseListPageOptions<TData> {
   approxRowCount?: number;
   /** Lowercase plural entity label (e.g., "websites"). Enables "Showing all X {entity}" footer. */
   entityLabel?: string;
+  /**
+   * Display mode for the table.
+   * - `'infiniteScroll'` (default): renders an infinite-scroll list that loads more as the user scrolls.
+   * - `'pagination'`: renders client-side pagination controls with next/previous navigation.
+   */
+  displayMode?: 'infiniteScroll' | 'pagination';
 }
 
 // ---------------------------------------------------------------------------
 // Hook Return Type
 // ---------------------------------------------------------------------------
 
-interface ListPageTableProps<TData> {
+interface ListPageInfiniteScrollTableProps<TData> {
   data: TData[];
   search?: DataTableSearchConfig;
   filters?: FilterConfig[];
@@ -102,6 +108,26 @@ interface ListPageTableProps<TData> {
   };
   approxRowCount?: number;
 }
+
+interface ListPagePaginationTableProps<TData> {
+  data: TData[];
+  search?: DataTableSearchConfig;
+  filters?: FilterConfig[];
+  onClearFilters?: () => void;
+  getRowId: (row: TData) => string;
+  pagination: {
+    clientSide: true;
+    pageSize: number;
+    total: number;
+    showPageSizeSelector: boolean;
+  };
+  isLoading: boolean;
+  approxRowCount?: number;
+}
+
+type ListPageTableProps<TData> =
+  | ListPageInfiniteScrollTableProps<TData>
+  | ListPagePaginationTableProps<TData>;
 
 interface UseListPageReturn<TData> {
   tableProps: ListPageTableProps<TData>;
@@ -142,6 +168,7 @@ export function useListPage<TData>(
     getRowId,
     approxRowCount,
     entityLabel,
+    displayMode = 'infiniteScroll',
   } = options;
 
   // 1. Normalize data source
@@ -310,13 +337,46 @@ export function useListPage<TData>(
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex documents always have _id; TData generic doesn't enforce it
   const rowIdFn = getRowId ?? ((row: TData) => (row as { _id: string })._id);
 
+  const sharedTableProps = {
+    search: searchConfig,
+    filters: filterConfigs,
+    onClearFilters,
+    getRowId: rowIdFn,
+    approxRowCount,
+  };
+
+  if (displayMode === 'pagination') {
+    // In pagination mode, eagerly load all backend pages and let TanStack Table paginate client-side
+    if (
+      dataSource.type === 'paginated' &&
+      dataSource.status === 'CanLoadMore'
+    ) {
+      dataSource.loadMore(pageSize * 3);
+    }
+
+    return {
+      tableProps: {
+        ...sharedTableProps,
+        data: processed,
+        pagination: {
+          clientSide: true,
+          pageSize,
+          total: processed.length,
+          showPageSizeSelector: false,
+        },
+        isLoading,
+      },
+      processedData: processed,
+      totalCount: rawData.length,
+      filteredCount: processed.length,
+      isLoading,
+    };
+  }
+
   return {
     tableProps: {
+      ...sharedTableProps,
       data: displayed,
-      search: searchConfig,
-      filters: filterConfigs,
-      onClearFilters,
-      getRowId: rowIdFn,
       infiniteScroll: {
         hasMore,
         onLoadMore: handleLoadMore,
@@ -332,7 +392,6 @@ export function useListPage<TData>(
         entityLabel,
         totalCount: entityLabel ? rawData.length : undefined,
       },
-      approxRowCount,
     },
     processedData: processed,
     totalCount: rawData.length,


### PR DESCRIPTION
## Summary
- Add `displayMode: 'pagination'` option to `useListPage` hook, leveraging DataTable's built-in pagination support
- Enable pagination on both products and customers tables (previously infinite scroll only)
- Eagerly loads remaining backend pages for complete client-side pagination
- Added 7 tests covering both display modes

Fixes #1105