### PR TITLE
fix(platform): apply column widths to data table body cells

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -33,6 +33,15 @@ const columns: ColumnDef<TestRow>[] = [
   },
 ];
 
+const columnsWithSize: ColumnDef<TestRow>[] = [
+  { accessorKey: 'name', header: 'Name', size: 200 },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    meta: { skeleton: { type: 'badge' } },
+  },
+];
+
 const sampleRows: TestRow[] = [
   { _id: '1', name: 'Alice', status: 'active' },
   { _id: '2', name: 'Bob', status: 'inactive' },
@@ -173,6 +182,39 @@ describe('DataTable loading states', () => {
       expect(screen.getByText('Bob')).toBeInTheDocument();
       expect(screen.getByText('Charlie')).toBeInTheDocument();
       expect(getSkeletonRows().length).toBe(0);
+    });
+  });
+
+  describe('column width styling', () => {
+    it('applies explicit column size to data row cells', () => {
+      render(
+        <DataTable
+          columns={columnsWithSize}
+          data={sampleRows}
+          approxRowCount={3}
+        />,
+      );
+
+      const tbody = getTbody();
+      const firstDataRow = within(tbody).getAllByRole('row')[0]!;
+      const cells = within(firstDataRow).getAllByRole('cell');
+      expect(cells[0]).toHaveStyle({ width: '200px' });
+      expect(cells[1]).not.toHaveStyle({ width: '150px' });
+    });
+
+    it('applies explicit column size to skeleton row cells', () => {
+      render(
+        <DataTable
+          columns={columnsWithSize}
+          data={[]}
+          approxRowCount={2}
+          isLoading
+        />,
+      );
+
+      const skeletons = getSkeletonRows();
+      const cells = within(skeletons[0]!).getAllByRole('cell');
+      expect(cells[0]).toHaveStyle({ width: '200px' });
     });
   });
 

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -516,7 +516,19 @@ export function DataTable<TData, TValue = unknown>({
                   );
                 }
 
-                return <TableCell key={colIndex}>{cellContent}</TableCell>;
+                return (
+                  <TableCell
+                    key={colIndex}
+                    style={{
+                      width:
+                        col.size !== undefined && col.size !== 150
+                          ? col.size
+                          : undefined,
+                    }}
+                  >
+                    {cellContent}
+                  </TableCell>
+                );
               })}
             </TableRow>
           ))
@@ -580,7 +592,15 @@ export function DataTable<TData, TValue = unknown>({
                     </TableCell>
                   )}
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      style={{
+                        width:
+                          cell.column.getSize() !== 150
+                            ? cell.column.getSize()
+                            : undefined,
+                      }}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),


### PR DESCRIPTION
## Summary
- Fixes #1111
- Adds inline `width` styles to `<TableCell>` elements in both data rows and skeleton rows of the data-table component, matching the existing pattern on `<TableHead>` header cells
- After the recent split of name+email into separate customer table columns, the missing cell widths caused columns to visually merge

## Test plan
- [x] Added 2 new tests verifying column widths are applied to data and skeleton cells
- [x] All 14 data-table tests pass
- [x] Lint and typecheck pass
- [ ] Verify customer table displays name and email in distinct columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data table column width styling to properly apply explicit width definitions to both skeleton rows (during loading) and actual data rows.

* **Tests**
  * Added test coverage for column width styling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->