### PR TITLE
fix(platform): ensure cache invalidation before automation list refresh

### DIFF
--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -17,7 +17,10 @@ import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { slugToUrlParam } from '@/lib/utils/workflow-slug';
 
-import { useSaveWorkflow } from '../hooks/file-mutations';
+import {
+  useInvalidateWorkflows,
+  useSaveWorkflow,
+} from '../hooks/file-mutations';
 import { WorkflowTemplateGrid } from './workflow-template-grid';
 
 type FormData = {
@@ -61,6 +64,7 @@ function BlankTabContent({
   const { t: tCommon } = useT('common');
   const navigate = useNavigate();
   const { mutateAsync: saveWorkflow } = useSaveWorkflow();
+  const invalidateWorkflows = useInvalidateWorkflows();
 
   const formSchema = useMemo(
     () =>
@@ -103,6 +107,7 @@ function BlankTabContent({
           },
         });
 
+        await invalidateWorkflows('default');
         window.dispatchEvent(new Event('workflow-updated'));
         toast({
           title: t('toast.created'),
@@ -127,7 +132,7 @@ function BlankTabContent({
         });
       }
     },
-    [saveWorkflow, organizationId, t, navigate, setError],
+    [saveWorkflow, invalidateWorkflows, organizationId, t, navigate, setError],
   );
 
   return (

--- a/services/platform/app/features/automations/components/workflow-template-grid.tsx
+++ b/services/platform/app/features/automations/components/workflow-template-grid.tsx
@@ -9,7 +9,10 @@ import { Text } from '@/app/components/ui/typography/text';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
-import { useInstallWorkflow } from '../hooks/file-mutations';
+import {
+  useInstallWorkflow,
+  useInvalidateWorkflows,
+} from '../hooks/file-mutations';
 import { useListWorkflows } from '../hooks/file-queries';
 
 interface WorkflowTemplateGridProps {
@@ -27,6 +30,7 @@ export function WorkflowTemplateGrid({
     'templates',
   );
   const { mutateAsync: installWorkflow } = useInstallWorkflow();
+  const invalidateWorkflows = useInvalidateWorkflows();
   const [installingSlug, setInstallingSlug] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,6 +55,7 @@ export function WorkflowTemplateGrid({
 
       try {
         await installWorkflow({ orgSlug: 'default', workflowSlug: slug });
+        await invalidateWorkflows('default');
         window.dispatchEvent(new Event('workflow-updated'));
         onTemplateInstalled(slug);
       } catch (err) {
@@ -61,7 +66,7 @@ export function WorkflowTemplateGrid({
         setInstallingSlug(null);
       }
     },
-    [installWorkflow, onTemplateInstalled, t],
+    [installWorkflow, invalidateWorkflows, onTemplateInstalled, t],
   );
 
   if (isLoadingTemplates) {

--- a/services/platform/app/features/automations/hooks/file-mutations.ts
+++ b/services/platform/app/features/automations/hooks/file-mutations.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { api } from '@/convex/_generated/api';
 
-function useInvalidateWorkflows() {
+export function useInvalidateWorkflows() {
   const queryClient = useQueryClient();
   return (orgSlug: string) =>
     queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- Fixes #1112
- Fixes a race condition where `window.dispatchEvent('workflow-updated')` fired before TanStack Query cache invalidation completed, causing the automations table to refetch stale data
- Exports `useInvalidateWorkflows` and explicitly awaits cache invalidation in both the blank automation creation dialog and the template installation grid before dispatching the refresh event

## Test plan
- [x] Lint and typecheck pass
- [ ] Create a blank automation and verify it appears in the list immediately
- [ ] Install a template automation and verify it appears in the list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows now properly refresh after creation and template installation, ensuring users see up-to-date workflow data immediately without manual refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->