### PR TITLE
fix(platform): wrap long product names to prevent overflow

### DIFF
--- a/services/platform/app/features/products/components/product-view-dialog.tsx
+++ b/services/platform/app/features/products/components/product-view-dialog.tsx
@@ -119,7 +119,7 @@ export function ProductViewDialog({
             className="size-20 shrink-0 rounded-lg"
           />
           <div className="min-w-0 flex-1">
-            <Heading level={3} truncate>
+            <Heading level={3} className="break-words">
               {product.name}
             </Heading>
             {product.description && (

--- a/services/platform/app/features/products/hooks/use-products-table-config.tsx
+++ b/services/platform/app/features/products/hooks/use-products-table-config.tsx
@@ -28,7 +28,7 @@ export const useProductsTableConfig = createTableConfigHook<'products'>(
             productName={row.original.name}
             className="size-8 shrink-0 rounded"
           />
-          <Text as="span" variant="label">
+          <Text as="span" variant="label" className="break-words">
             {row.original.name}
           </Text>
         </HStack>


### PR DESCRIPTION
## Summary
- Replace `truncate` (single-line ellipsis) with `break-words` on the product name `Heading` in the product view dialog, so long names wrap to multiple lines instead of overflowing the container.
- Add `break-words` to the product name `Text` in the products table for consistency.

Closes #1130

## Test plan
- [ ] Open a product with a very long name (with and without spaces) in the view dialog and confirm the name wraps within the container
- [ ] Verify no horizontal scrollbar appears on the product page
- [ ] Check the products table renders long names without overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Product names in the products table and product view dialog now wrap across multiple lines instead of being truncated, improving full name visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->