### PR TITLE
fix(platform): make websites interval filter work

### DIFF
--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -53,6 +53,7 @@ export function WebsitesTable({
   const paginatedResult = useListWebsitesPaginated({
     organizationId,
     status,
+    scanInterval: interval,
     initialNumItems: pageSize,
   });
 

--- a/services/platform/app/features/websites/hooks/queries.ts
+++ b/services/platform/app/features/websites/hooks/queries.ts
@@ -26,6 +26,7 @@ export function useWebsites(organizationId: string) {
 interface ListWebsitesPaginatedArgs {
   organizationId: string;
   status?: string;
+  scanInterval?: string;
   initialNumItems: number;
 }
 

--- a/services/platform/convex/websites/list_websites_paginated.ts
+++ b/services/platform/convex/websites/list_websites_paginated.ts
@@ -17,12 +17,14 @@ interface FilterIndex {
 
 const FILTER_INDEXES: FilterIndex[] = [
   { field: 'status', index: 'by_organizationId_and_status' },
+  { field: 'scanInterval', index: 'by_organizationId_and_scanInterval' },
 ];
 
 interface ListWebsitesPaginatedArgs {
   paginationOpts: PaginationOptions;
   organizationId: string;
   status?: string;
+  scanInterval?: string;
 }
 
 type FilterArgs = Record<string, string | undefined>;
@@ -61,6 +63,7 @@ export async function listWebsitesPaginated(
 ): Promise<PaginationResult<Doc<'websites'>>> {
   const filterArgs: FilterArgs = {
     status: args.status,
+    scanInterval: args.scanInterval,
   };
 
   const primary = FILTER_INDEXES.find(({ field }) => filterArgs[field]);

--- a/services/platform/convex/websites/queries.ts
+++ b/services/platform/convex/websites/queries.ts
@@ -39,6 +39,7 @@ export const listWebsitesPaginated = queryWithRLS({
     paginationOpts: paginationOptsValidator,
     organizationId: v.string(),
     status: v.optional(v.string()),
+    scanInterval: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     return await listWebsitesPaginatedHelper(ctx, args);

--- a/services/platform/convex/websites/schema.ts
+++ b/services/platform/convex/websites/schema.ts
@@ -26,4 +26,8 @@ export const websitesTable = defineTable({
   .index('by_organizationId', ['organizationId'])
   .index('by_organizationId_and_status', ['organizationId', 'status'])
   .index('by_organizationId_and_domain', ['organizationId', 'domain'])
+  .index('by_organizationId_and_scanInterval', [
+    'organizationId',
+    'scanInterval',
+  ])
   .index('by_status', ['status']);


### PR DESCRIPTION
## Summary

- The interval filter on the Websites page was not functioning because the selected `scanInterval` value was never forwarded from the component to the backend query.
- Added `scanInterval` support across all layers: Convex schema index (`by_organizationId_and_scanInterval`), paginated query args, filter dispatch in `list_websites_paginated.ts`, frontend query hook, and the `WebsitesTable` component prop passthrough.

## Test plan

- [ ] Navigate to the Websites page
- [ ] Select an interval filter (e.g., "1 hour", "7 days") and verify the table updates to show only websites with that scan interval
- [ ] Clear the filter and verify all websites are shown again
- [ ] Combine status and interval filters and verify the primary filter applies correctly

Closes #1125