### PR TITLE
fix(platform): copy formatted date instead of Unix timestamp

### DIFF
--- a/services/platform/app/components/ui/data-display/copyable-timestamp.stories.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-timestamp.stories.tsx
@@ -15,9 +15,8 @@ const meta: Meta<typeof CopyableTimestamp> = {
     docs: {
       description: {
         component: `
-Displays a formatted date with a copy-to-clipboard button that copies the raw
-Unix millisecond timestamp. Intended for power users who need the exact value
-for debugging or querying.
+Displays a formatted date with a copy-to-clipboard button that copies the
+human-readable formatted date string.
 
 The copy button is hidden by default and appears on hover/focus.
 

--- a/services/platform/app/components/ui/data-display/copyable-timestamp.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-timestamp.tsx
@@ -25,9 +25,8 @@ interface CopyableTimestampProps {
 }
 
 /**
- * Displays a formatted timestamp with a copy button that copies the raw
- * Unix millisecond value to the clipboard — useful for power users who need
- * the exact timestamp for debugging or querying.
+ * Displays a formatted timestamp with a copy button that copies the
+ * human-readable formatted date string to the clipboard.
  *
  * @example
  * ```tsx
@@ -64,7 +63,6 @@ export const CopyableTimestamp = React.memo(function CopyableTimestamp({
       ? new Date(date)
       : date;
 
-  const timestampMs = String(dateObj.valueOf());
   const showTimezone = preset === 'long' || preset === 'time';
   const baseFormatted = customFormat
     ? formatDate(dateObj, preset, { customFormat })
@@ -76,7 +74,6 @@ export const CopyableTimestamp = React.memo(function CopyableTimestamp({
 
   return (
     <CopyableTimestampInner
-      timestampMs={timestampMs}
       formatted={formatted}
       titleText={titleText}
       alignRight={alignRight}
@@ -87,7 +84,6 @@ export const CopyableTimestamp = React.memo(function CopyableTimestamp({
 });
 
 interface CopyableTimestampInnerProps {
-  timestampMs: string;
   formatted: string;
   titleText: string;
   alignRight: boolean;
@@ -96,14 +92,13 @@ interface CopyableTimestampInnerProps {
 }
 
 function CopyableTimestampInner({
-  timestampMs,
   formatted,
   titleText,
   alignRight,
   className,
   tCommon,
 }: CopyableTimestampInnerProps) {
-  const { copied, onClick } = useCopyButton(timestampMs);
+  const { copied, onClick } = useCopyButton(formatted);
 
   return (
     <span


### PR DESCRIPTION
## Summary
- The `CopyableTimestamp` component was passing the raw Unix millisecond value (e.g. `1775551973890`) to the clipboard instead of the formatted date string displayed in the UI.
- Changed `useCopyButton(timestampMs)` to `useCopyButton(formatted)` so the copied value matches what the user sees.
- Removed the now-unused `timestampMs` variable and prop.

Closes #1124

## Test plan
- [ ] Click the copy icon next to any date in a table (e.g. documents, audit logs, websites)
- [ ] Paste the clipboard contents and verify it shows a human-readable date (e.g. "Apr 8, 2026") instead of a Unix timestamp
- [ ] Verify long/time presets include the timezone abbreviation in the copied value