### PR TITLE
fix(platform): fix customer import column mapping for CSV/Excel files

### DIFF
--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -64,14 +64,19 @@ function isHeaderRow(values: string[]): boolean {
   return matches.length >= Math.ceil(nonEmpty.length / 2);
 }
 
+type CSVParseOutput = {
+  headers: string[] | null;
+  rows: string[][];
+};
+
 /**
  * Parse CSV text into rows of string arrays.
- * Automatically detects and skips header rows unless disabled.
+ * Automatically detects header rows and returns them separately.
  */
 function parseCSVText(
   csvText: string,
   options: CSVParseOptions = {},
-): string[][] {
+): CSVParseOutput {
   const { delimiter = ',', skipEmptyLines = true, hasHeaders } = options;
 
   const lines = csvText.trim().split('\n');
@@ -85,28 +90,43 @@ function parseCSVText(
     rows.push(values);
   }
 
+  let headers: string[] | null = null;
   if (hasHeaders !== false && rows.length >= 2 && isHeaderRow(rows[0])) {
-    rows.shift();
+    headers = rows.shift()!.map((h) => h.toLowerCase());
   }
 
-  return rows;
+  return { headers, rows };
 }
 
 /**
  * Parse CSV text with a mapper function to transform rows into typed objects.
+ * When headers are detected, rows are converted to named records and passed
+ * through the optional recordMapper for accurate column mapping.
  */
 export function parseCSVWithMapper<T>(
   csvText: string,
   mapper: (row: string[], index: number) => T | null,
-  options: CSVParseOptions = {},
+  options: CSVParseOptions & {
+    recordMapper?: (record: Record<string, unknown>) => T | null;
+  } = {},
 ): FileParseResult<T> {
-  const rows = parseCSVText(csvText, options);
+  const { recordMapper, ...csvOptions } = options;
+  const { headers, rows } = parseCSVText(csvText, csvOptions);
   const data: T[] = [];
   const errors: string[] = [];
 
   rows.forEach((row, index) => {
     try {
-      const mapped = mapper(row, index);
+      let mapped: T | null;
+      if (headers && recordMapper) {
+        const record: Record<string, unknown> = {};
+        headers.forEach((header, i) => {
+          record[header] = row[i] ?? '';
+        });
+        mapped = recordMapper(record);
+      } else {
+        mapped = mapper(row, index);
+      }
       if (mapped !== null) {
         data.push(mapped);
       }
@@ -210,7 +230,9 @@ export async function parseImportFile<T>(
   try {
     if (isCSVFile(file)) {
       const text = await readFileAsText(file);
-      const result = parseCSVWithMapper(text, csvMapper);
+      const result = parseCSVWithMapper(text, csvMapper, {
+        recordMapper: excelMapper,
+      });
       return result;
     } else if (isExcelFile(file)) {
       const records = await parseExcelFile(file);


### PR DESCRIPTION
## Summary
- When importing customers (or vendors/products) from a CSV file with headers, columns were mapped by position rather than by header name. This caused data mismatches (e.g. name appearing as email, email appearing as phone) whenever the file's column order didn't match the hardcoded positional expectation.
- Now, when CSV headers are detected during file import, each row is converted to a named record and routed through the same record-based mapper used for Excel files. This ensures columns are matched by name regardless of order.
- Manual CSV text entry (textarea, no headers) continues to use positional mapping unchanged.

## Test plan
- [ ] Import a CSV file with headers in non-default order (e.g. `name,email,locale`) and verify fields map correctly
- [ ] Import an .xlsx file and verify fields still map correctly
- [ ] Import a CSV file without headers and verify positional mapping still works
- [ ] Use manual CSV text entry and verify it still works as before

Closes #1131