### PR TITLE
fix(platform): populate locale field when editing customer

### DIFF
--- a/services/platform/app/features/customers/components/customer-edit-dialog.tsx
+++ b/services/platform/app/features/customers/components/customer-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { useT } from '@/lib/i18n/client';
 import { useUpdateCustomer } from '../hooks/mutations';
 
 const CUSTOMER_STATUSES = ['active', 'churned', 'potential'] as const;
+const LOCALE_PATTERN = /^[a-z]{2}(?:[-_][A-Za-z]{2,})?$/;
 
 type CustomerFormData = {
   name: string;
@@ -49,20 +50,6 @@ export function CustomerEditDialog({
     [tGlobal],
   );
 
-  const localeOptions = useMemo(
-    () => [
-      { value: 'en', label: tGlobal('languages.en') },
-      { value: 'de', label: tGlobal('languages.de') },
-      { value: 'es', label: tGlobal('languages.es') },
-      { value: 'fr', label: tGlobal('languages.fr') },
-      { value: 'it', label: tGlobal('languages.it') },
-      { value: 'nl', label: tGlobal('languages.nl') },
-      { value: 'pt', label: tGlobal('languages.pt') },
-      { value: 'zh', label: tGlobal('languages.zh') },
-    ],
-    [tGlobal],
-  );
-
   const formSchema = useMemo(
     () =>
       z.object({
@@ -72,6 +59,10 @@ export function CustomerEditDialog({
           .string()
           .min(
             1,
+            tCommon('validation.required', { field: tCustomers('locale') }),
+          )
+          .regex(
+            LOCALE_PATTERN,
             tCommon('validation.required', { field: tCustomers('locale') }),
           ),
         status: z.enum(CUSTOMER_STATUSES),
@@ -96,7 +87,6 @@ export function CustomerEditDialog({
     },
   });
 
-  const locale = watch('locale');
   const status = watch('status');
 
   useEffect(() => {
@@ -170,16 +160,14 @@ export function CustomerEditDialog({
         required
       />
 
-      <Select
-        value={locale}
-        onValueChange={(value) =>
-          setValue('locale', value, { shouldDirty: true })
-        }
-        disabled={isSubmitting}
+      <Input
         id="locale"
         label={tCustomers('locale')}
-        error={!!errors.locale}
-        options={localeOptions}
+        placeholder={tCustomers('localePlaceholder')}
+        {...register('locale')}
+        disabled={isSubmitting}
+        errorMessage={errors.locale?.message}
+        required
       />
 
       <Select

--- a/services/platform/app/features/vendors/components/vendor-edit-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendor-edit-dialog.tsx
@@ -7,12 +7,13 @@ import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
-import { Select } from '@/app/components/ui/forms/select';
 import { toast } from '@/app/hooks/use-toast';
 import { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
 import { useUpdateVendor } from '../hooks/mutations';
+
+const LOCALE_PATTERN = /^[a-z]{2}(?:[-_][A-Za-z]{2,})?$/;
 
 type VendorFormData = {
   name: string;
@@ -34,22 +35,7 @@ export function VendorEditDialog({
 }: VendorEditDialogProps) {
   const { t: tVendors } = useT('vendors');
   const { t: tCommon } = useT('common');
-  const { t: tGlobal } = useT('global');
   const { mutateAsync: updateVendor } = useUpdateVendor();
-
-  const localeOptions = useMemo(
-    () => [
-      { value: 'en', label: tGlobal('languages.en') },
-      { value: 'de', label: tGlobal('languages.de') },
-      { value: 'es', label: tGlobal('languages.es') },
-      { value: 'fr', label: tGlobal('languages.fr') },
-      { value: 'it', label: tGlobal('languages.it') },
-      { value: 'nl', label: tGlobal('languages.nl') },
-      { value: 'pt', label: tGlobal('languages.pt') },
-      { value: 'zh', label: tGlobal('languages.zh') },
-    ],
-    [tGlobal],
-  );
 
   const formSchema = useMemo(
     () =>
@@ -61,8 +47,9 @@ export function VendorEditDialog({
         email: z.string().email(tCommon('validation.email')),
         locale: z
           .string()
-          .min(
-            1,
+          .min(1, tCommon('validation.required', { field: tVendors('locale') }))
+          .regex(
+            LOCALE_PATTERN,
             tCommon('validation.required', { field: tVendors('locale') }),
           ),
       }),
@@ -74,8 +61,6 @@ export function VendorEditDialog({
     handleSubmit,
     formState: { errors, isSubmitting, isDirty },
     reset,
-    setValue,
-    watch,
   } = useForm<VendorFormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -84,8 +69,6 @@ export function VendorEditDialog({
       locale: vendor.locale || 'en',
     },
   });
-
-  const locale = watch('locale');
 
   // Reset form when vendor changes
   useEffect(() => {
@@ -157,16 +140,14 @@ export function VendorEditDialog({
         required
       />
 
-      <Select
-        value={locale}
-        onValueChange={(value) =>
-          setValue('locale', value, { shouldDirty: true })
-        }
-        disabled={isSubmitting}
+      <Input
         id="locale"
         label={tVendors('locale')}
-        error={!!errors.locale}
-        options={localeOptions}
+        placeholder={tVendors('localePlaceholder')}
+        {...register('locale')}
+        disabled={isSubmitting}
+        errorMessage={errors.locale?.message}
+        required
       />
     </FormDialog>
   );


### PR DESCRIPTION
## Summary
- Replace the locale `Select` dropdown with a text `Input` in the customer and vendor edit dialogs
- The `Select` only had 8 base language codes (`en`, `de`, etc.) as options, so extended locales like `en-US` stored on the record had no matching option, causing the Radix Select to render the field as empty
- A text `Input` correctly displays any stored locale value and accepts the full range of formats the system supports (e.g. `en`, `en-US`, `de-CH`)
- Added regex validation to ensure the locale matches a valid pattern

## Test plan
- [x] Existing `customer-edit-dialog.test.tsx` tests pass (4/4)
- [ ] Create a customer via manual CSV import with locale `en-US`
- [ ] Open the edit dialog for that customer and verify the locale field shows `en-US`
- [ ] Change the locale to `de-CH`, save, and verify it persists on re-edit
- [ ] Verify vendor edit dialog locale field works the same way

Closes #1132