### PR TITLE
fix(platform): fix customer type filter on customers page

### DIFF
--- a/services/platform/app/features/customers/components/customer-import-form.tsx
+++ b/services/platform/app/features/customers/components/customer-import-form.tsx
@@ -135,7 +135,7 @@ export function CustomerImportForm({
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.formatHint')}</li>
               <li>{t('importForm.localeHint')}</li>
-              <li className="text-yellow-600">{t('importForm.churnedNote')}</li>
+              <li>{t('importForm.statusNote')}</li>
             </ul>
           </Text>
         </FormSection>
@@ -170,7 +170,7 @@ export function CustomerImportForm({
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
-              <li className="text-yellow-600">{t('importForm.churnedNote')}</li>
+              <li>{t('importForm.statusNote')}</li>
             </ul>
           </Text>
           {fileValue && (

--- a/services/platform/app/features/customers/components/customers-import-dialog.tsx
+++ b/services/platform/app/features/customers/components/customers-import-dialog.tsx
@@ -18,7 +18,7 @@ export interface ParsedCustomer {
   email: string;
   name?: string;
   locale: string;
-  status: 'churned';
+  status: 'active';
   source: Doc<'customers'>['source'];
 }
 

--- a/services/platform/app/features/customers/components/customers-table.tsx
+++ b/services/platform/app/features/customers/components/customers-table.tsx
@@ -111,7 +111,6 @@ export function CustomersTable({
           { value: 'active', label: tCustomers('filter.status.active') },
           { value: 'potential', label: tCustomers('filter.status.potential') },
           { value: 'churned', label: tCustomers('filter.status.churned') },
-          { value: 'lost', label: tCustomers('filter.status.lost') },
         ],
         selectedValues: status ? [status] : [],
         onChange: handleStatusChange,
@@ -130,7 +129,7 @@ export function CustomersTable({
       {
         key: 'locale',
         title: tTables('headers.locale'),
-        grid: true,
+        columns: 2 as const,
         options: [
           { value: 'en', label: tGlobal('languageCodes.en') },
           { value: 'es', label: tGlobal('languageCodes.es') },

--- a/services/platform/app/hooks/__tests__/use-file-import.test.ts
+++ b/services/platform/app/hooks/__tests__/use-file-import.test.ts
@@ -133,7 +133,7 @@ describe('customerMappers.excel', () => {
       email: 'user@example.com',
       name: 'John Doe',
       locale: 'es',
-      status: 'churned',
+      status: 'active',
       source: 'file_upload',
     });
   });
@@ -144,7 +144,7 @@ describe('customerMappers.excel', () => {
       email: 'user@example.com',
       name: undefined,
       locale: 'en',
-      status: 'churned',
+      status: 'active',
       source: 'file_upload',
     });
   });
@@ -214,7 +214,7 @@ describe('customerMappers.csv', () => {
       email: 'user@example.com',
       name: undefined,
       locale: 'fr',
-      status: 'churned',
+      status: 'active',
       source: 'manual_import',
     });
   });
@@ -225,7 +225,7 @@ describe('customerMappers.csv', () => {
       email: 'user@example.com',
       name: 'John Doe',
       locale: 'en',
-      status: 'churned',
+      status: 'active',
       source: 'manual_import',
     });
   });
@@ -239,7 +239,7 @@ describe('customerMappers.csv', () => {
       email: 'user@example.com',
       name: 'John Doe',
       locale: 'es',
-      status: 'churned',
+      status: 'active',
       source: 'manual_import',
     });
   });

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -155,7 +155,7 @@ export const customerMappers = {
           ? undefined
           : second || undefined,
       locale: third || (isLocale(second) ? second : undefined) || 'en',
-      status: 'churned' as const,
+      status: 'active' as const,
       source: 'manual_import' as const,
     };
   },
@@ -167,7 +167,7 @@ export const customerMappers = {
       email,
       name: getString(record.name) || undefined,
       locale: getString(record.locale) || 'en',
-      status: 'churned' as const,
+      status: 'active' as const,
       source: 'file_upload' as const,
     };
   },

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3079,8 +3079,7 @@
       "status": {
         "active": "Aktiv",
         "potential": "Potenziell",
-        "churned": "Abgewandert",
-        "lost": "Verloren"
+        "churned": "Abgewandert"
       }
     },
     "addButton": "Kunde hinzufügen",
@@ -3094,7 +3093,7 @@
       "syncBusinessData": "Geschäftsdaten synchronisieren",
       "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Kunde pro Zeile.",
       "localeHint": "Unterstützte Sprachen: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH.",
-      "churnedNote": "Importierte Kunden werden als (Abgewandert) markiert"
+      "statusNote": "Importierte Kunden werden als (Aktiv) markiert"
     },
     "editCustomer": "Kunde bearbeiten",
     "deleteCustomer": "Kunde löschen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3132,8 +3132,7 @@
       "status": {
         "active": "Active",
         "potential": "Potential",
-        "churned": "Churned",
-        "lost": "Lost"
+        "churned": "Churned"
       }
     },
     "addButton": "Add customer",
@@ -3147,7 +3146,7 @@
       "syncBusinessData": "Sync business data",
       "formatHint": "Format: email, name (optional), locale (optional). One customer per line.",
       "localeHint": "Supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH.",
-      "churnedNote": "Imported customers are tagged as (Churned)"
+      "statusNote": "Imported customers are tagged as (Active)"
     },
     "editCustomer": "Edit customer",
     "deleteCustomer": "Delete customer",


### PR DESCRIPTION
## Summary
- Remove invalid "Lost" status from filter options (not present in the Convex schema, which only allows `active`, `churned`, `potential`)
- Change default import status from `churned` to `active` so newly added/imported customers appear when filtering by "Active"
- Fix locale filter layout property (`grid: true` -> `columns: 2 as const` to match `FilterConfig` type)
- Update i18n keys (`churnedNote` -> `statusNote`) and test expectations

## Root cause
The customer import pipeline hardcoded `status: 'churned'` for all new customers. When users added customers and then tried to filter by "Active" or "Potential", no results appeared because every customer was "Churned". Additionally, the "Lost" filter option referenced a status value that does not exist in the schema.

Fixes #1133
Fixes #1134
Fixes #1135

## Test plan
- [ ] Import a customer via manual entry and verify it appears with "Active" status
- [ ] Open the filter dropdown and confirm only Active, Potential, Churned options are shown (no "Lost")
- [ ] Select "Active" filter and verify newly imported customers appear
- [ ] Select "Churned" filter and verify previously imported customers (with churned status) still appear
- [ ] Verify the locale filter section renders in a 2-column grid layout
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint --workspace=@tale/platform`)