### PR TITLE
fix(platform): resolve chat input appearing cut off at screen bottom

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -166,7 +166,7 @@ export function ChatInput({
           style={{ display: 'none' }}
         />
 
-        <div className="bg-background border-muted-foreground/50 relative flex flex-col gap-2 rounded-t-2xl border border-b-0 px-5 pt-4">
+        <div className="bg-background border-muted-foreground/50 relative mb-3 flex flex-col gap-2 rounded-2xl border px-5 pt-4">
           {(attachments.length > 0 || uploadingFiles.length > 0) && (
             <HStack gap={1} wrap className="mb-2">
               {imageAttachments.map((attachment) => (


### PR DESCRIPTION
## Summary
- Changed the chat input container from `rounded-t-2xl border-b-0` to `rounded-2xl` with full border, so the input looks like a complete card instead of appearing cut off at the bottom edge
- Added `mb-3` for breathing room between the input container and the screen bottom

## Test plan
- [ ] Open any chat conversation and verify the input box has rounded corners on all sides
- [ ] Verify the input has a visible bottom border
- [ ] Verify there is a small gap between the input box and the bottom of the viewport
- [ ] Test with attachments added to ensure layout still looks correct
- [ ] Test on different screen sizes to confirm the input is not cut off

Closes #1147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual presentation of the attachment preview area in chat input with consistent rounded corners and enhanced spacing separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->