### PR TITLE
fix(platform): improve file attachment card readability in chat

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -214,7 +214,7 @@ export function ChatInput({
               {fileAttachments.map((attachment) => (
                 <div
                   key={attachment.fileId}
-                  className="bg-muted group relative flex max-w-[216px] items-center gap-2 rounded-lg px-2 py-1"
+                  className="bg-muted group relative flex max-w-[280px] items-center gap-3 rounded-lg px-3 py-2"
                 >
                   <DocumentIcon fileName={attachment.fileName} />
                   <VStack className="min-w-0 flex-1">
@@ -223,6 +223,7 @@ export function ChatInput({
                       variant="label"
                       truncate
                       className="ellipsis"
+                      title={attachment.fileName}
                     >
                       {attachment.fileName}
                     </Text>

--- a/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
@@ -174,13 +174,13 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
 
   if (!displayUrl) {
     return (
-      <div className="bg-muted flex max-w-[216px] items-center gap-2 rounded-lg px-2 py-1.5">
+      <div className="bg-muted flex max-w-[280px] items-center gap-3 rounded-lg px-3 py-2">
         <FileTypeIcon
           fileType={attachment.fileType}
           fileName={attachment.fileName}
         />
         <VStack className="min-w-0 flex-1">
-          <Text as="div" variant="label" truncate>
+          <Text as="div" variant="label" truncate title={attachment.fileName}>
             {attachment.fileName}
           </Text>
           <Text as="div" variant="caption">
@@ -196,14 +196,14 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
       href={displayUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="bg-muted hover:bg-muted/80 flex max-w-[216px] items-center gap-2 rounded-lg px-2 py-1.5 transition-colors"
+      className="bg-muted hover:bg-muted/80 flex max-w-[280px] items-center gap-3 rounded-lg px-3 py-2 transition-colors"
     >
       <FileTypeIcon
         fileType={attachment.fileType}
         fileName={attachment.fileName}
       />
       <VStack className="min-w-0 flex-1">
-        <Text as="div" variant="label" truncate>
+        <Text as="div" variant="label" truncate title={attachment.fileName}>
           {attachment.fileName}
         </Text>
         <Text as="div" variant="caption">
@@ -248,7 +248,10 @@ export const FilePartDisplay = memo(function FilePartDisplay({
     <div className="bg-background border-border flex w-full items-center gap-3 rounded-xl border px-4 py-3 shadow-xs">
       <FileTypeIcon fileType={filePart.mediaType} fileName={fileName} />
       <VStack gap={1} className="min-w-0 flex-1">
-        <p className="text-foreground truncate text-[13px] leading-tight font-medium">
+        <p
+          className="text-foreground truncate text-[13px] leading-tight font-medium"
+          title={fileName}
+        >
           {fileName}
         </p>
         <p className="text-muted-foreground text-[11px] leading-tight">


### PR DESCRIPTION
## Summary
- Widen file attachment cards from `max-w-[216px]` to `max-w-[280px]` in message bubbles and chat input to reduce aggressive filename truncation
- Increase internal padding and icon-text gap for better visual spacing
- Add `title` attribute on filename elements so the full name is visible on hover

Closes #1152