### PR TITLE
fix(platform): tighten vertical spacing in chat message list

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -353,7 +353,7 @@ export function ChatInterface({
       <div
         ref={contentRef}
         className={cn(
-          'flex flex-col overflow-y-visible p-4 sm:p-8',
+          'flex flex-col overflow-y-visible p-4 sm:p-6',
           showWelcome && 'flex-1 items-center justify-center',
         )}
       >

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -299,7 +299,7 @@ export function ChatMessages({
       aria-live="polite"
       aria-label={t('aria.messageHistory')}
     >
-      <div className="flex flex-col gap-4 pt-10">
+      <div className="flex flex-col gap-3 pt-6">
         {(canLoadMore || isLoadingMore) && (
           <div className="flex justify-center py-2">
             <Button
@@ -323,7 +323,7 @@ export function ChatMessages({
 
         {/* Messages before the last user message — content-visibility skips
             rendering work for messages scrolled offscreen. */}
-        <div className="flex flex-col gap-4 [contain-intrinsic-size:auto_none] [content-visibility:auto]">
+        <div className="flex flex-col gap-3 [contain-intrinsic-size:auto_none] [content-visibility:auto]">
           {beforeItems.map(renderMessage)}
         </div>
 
@@ -335,7 +335,7 @@ export function ChatMessages({
             viewport height, min-height becomes irrelevant. */}
         <div
           ref={responseAreaRef}
-          className="flex shrink-0 flex-col gap-4 [overflow-anchor:none]"
+          className="flex shrink-0 flex-col gap-3 [overflow-anchor:none]"
         >
           {afterItems.map(renderMessage)}
 


### PR DESCRIPTION
## Summary
- Reduced vertical gap between messages from 16px to 12px (`gap-4` to `gap-3`) in the message list, before-items container, and response area
- Reduced top padding of the message list from 40px to 24px (`pt-10` to `pt-6`)
- Reduced desktop content padding from 32px to 24px (`sm:p-8` to `sm:p-6`) for a more compact feel

Closes #1153

## Test plan
- [ ] Verify chat page renders with tighter vertical spacing between messages
- [ ] Confirm no layout regressions on mobile (p-4 unchanged) and desktop (sm:p-6)
- [ ] Check scroll-to-bottom behavior still works correctly with reduced spacing
- [ ] Verify welcome view layout is unaffected