### PR TITLE
fix(platform): sort chat history by last activity time

### DIFF
--- a/services/platform/convex/agent_tools/approval_shared.ts
+++ b/services/platform/convex/agent_tools/approval_shared.ts
@@ -70,6 +70,7 @@ export async function triggerCompletionResponseHandler(
     await ctx.db.patch(threadMeta._id, {
       generationStatus: 'generating' as const,
       streamId,
+      updatedAt: Date.now(),
     });
   }
 

--- a/services/platform/convex/agent_tools/human_input/mutations.ts
+++ b/services/platform/convex/agent_tools/human_input/mutations.ts
@@ -176,6 +176,7 @@ async function handleSubmission({
     await ctx.db.patch(threadMeta._id, {
       generationStatus: 'generating' as const,
       streamId,
+      updatedAt: Date.now(),
     });
   }
 

--- a/services/platform/convex/agent_tools/location/mutations.ts
+++ b/services/platform/convex/agent_tools/location/mutations.ts
@@ -142,6 +142,7 @@ async function handleSubmission({
     await ctx.db.patch(threadMeta._id, {
       generationStatus: 'generating' as const,
       streamId,
+      updatedAt: Date.now(),
     });
   }
 

--- a/services/platform/convex/lib/agent_chat/__tests__/start_agent_chat.test.ts
+++ b/services/platform/convex/lib/agent_chat/__tests__/start_agent_chat.test.ts
@@ -139,6 +139,7 @@ describe('startAgentChat — concurrent generation guard', () => {
       cancelledAt: undefined,
       cancelledMessageId: undefined,
       generationStartTime: expect.any(Number),
+      updatedAt: expect.any(Number),
       generationStatus: 'generating',
       streamId: 'new-stream-id',
     });

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -137,6 +137,7 @@ export async function startAgentChat(
       generationStatus: 'generating' as const,
       streamId,
       generationStartTime: Date.now(),
+      updatedAt: Date.now(),
       cancelledAt: undefined,
       cancelledMessageId: undefined,
       ...(args.agentSlug ? { agentSlug: args.agentSlug } : {}),

--- a/services/platform/convex/threads/create_chat_thread.ts
+++ b/services/platform/convex/threads/create_chat_thread.ts
@@ -23,13 +23,15 @@ export async function createChatThread(
     threadId,
   });
 
+  const createdAt = thread?._creationTime ?? Date.now();
   await ctx.db.insert('threadMetadata', {
     threadId,
     userId,
     chatType,
     status: 'active',
     title: resolvedTitle,
-    createdAt: thread?._creationTime ?? Date.now(),
+    createdAt,
+    updatedAt: createdAt,
   });
 
   return threadId;

--- a/services/platform/convex/threads/fork_thread.ts
+++ b/services/platform/convex/threads/fork_thread.ts
@@ -40,13 +40,15 @@ export const forkThread = mutation({
       threadId: newThreadId,
     });
 
+    const createdAt = thread?._creationTime ?? Date.now();
     await ctx.db.insert('threadMetadata', {
       threadId: newThreadId,
       userId,
       chatType: 'general',
       status: 'active',
       title,
-      createdAt: thread?._creationTime ?? Date.now(),
+      createdAt,
+      updatedAt: createdAt,
       forkedFrom: metadata.threadId,
     });
 

--- a/services/platform/convex/threads/list_threads.test.ts
+++ b/services/platform/convex/threads/list_threads.test.ts
@@ -58,6 +58,7 @@ interface ThreadMetadataRow {
   status: 'active' | 'archived';
   title?: string;
   createdAt: number;
+  updatedAt?: number;
 }
 
 let idCounter = 0;
@@ -66,6 +67,7 @@ function makeRow(overrides: {
   threadId: string;
   title?: string;
   createdAt?: number;
+  updatedAt?: number;
 }): ThreadMetadataRow {
   idCounter++;
   const createdAt = overrides.createdAt ?? Date.now() - idCounter * 1000;
@@ -78,6 +80,7 @@ function makeRow(overrides: {
     status: 'active',
     title: overrides.title ?? `Thread ${overrides.threadId}`,
     createdAt,
+    updatedAt: overrides.updatedAt,
   };
 }
 
@@ -128,7 +131,7 @@ describe('listThreads', () => {
     expect(result.isDone).toBe(true);
   });
 
-  it('should map threadId to _id and createdAt to _creationTime', async () => {
+  it('should map threadId to _id and fall back to createdAt for _creationTime', async () => {
     const ctx = makeMockCtx([
       makeRow({ threadId: 't1', title: 'Test Thread', createdAt: 1000 }),
     ]);
@@ -144,6 +147,26 @@ describe('listThreads', () => {
     expect(thread.title).toBe('Test Thread');
     expect(thread.status).toBe('active');
     expect(thread.userId).toBe('user1');
+  });
+
+  it('should use updatedAt as _creationTime when present', async () => {
+    const ctx = makeMockCtx([
+      makeRow({
+        threadId: 't1',
+        title: 'Updated Thread',
+        createdAt: 1000,
+        updatedAt: 5000,
+      }),
+    ]);
+
+    const result = await listThreads(ctx, {
+      userId: 'user1',
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    const thread = result.page[0];
+    expect(thread._id).toBe('t1');
+    expect(thread._creationTime).toBe(5000);
   });
 
   it('should only include _id, _creationTime, title, status, userId, generationStatus in results', async () => {

--- a/services/platform/convex/threads/list_threads.ts
+++ b/services/platform/convex/threads/list_threads.ts
@@ -33,7 +33,7 @@ export async function listThreads(
 ): Promise<ListThreadsPaginatedResult> {
   const result = await ctx.db
     .query('threadMetadata')
-    .withIndex('by_userId_chatType_status', (q) =>
+    .withIndex('by_userId_chatType_status_updated', (q) =>
       q
         .eq('userId', args.userId)
         .eq('chatType', 'general')
@@ -45,7 +45,7 @@ export async function listThreads(
   return {
     page: result.page.map((row) => ({
       _id: row.threadId,
-      _creationTime: row.createdAt,
+      _creationTime: row.updatedAt ?? row.createdAt,
       title: row.title,
       status: row.status,
       userId: row.userId,

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -31,6 +31,7 @@ export const threadMetadataTable = defineTable({
   // Arena mode fields
   arenaGroupId: v.optional(v.string()),
   arenaModelId: v.optional(v.string()),
+  updatedAt: v.optional(v.number()),
 })
   .index('by_threadId', ['threadId'])
   .index('by_userId_chatType_status', [
@@ -38,6 +39,12 @@ export const threadMetadataTable = defineTable({
     'chatType',
     'status',
     'createdAt',
+  ])
+  .index('by_userId_chatType_status_updated', [
+    'userId',
+    'chatType',
+    'status',
+    'updatedAt',
   ])
   .index('by_shareToken', ['shareToken'])
   .index('by_arenaGroupId', ['arenaGroupId']);

--- a/services/platform/convex/threads/update_chat_thread.ts
+++ b/services/platform/convex/threads/update_chat_thread.ts
@@ -17,6 +17,6 @@ export async function updateChatThread(
     .first();
 
   if (existing) {
-    await ctx.db.patch(existing._id, { title });
+    await ctx.db.patch(existing._id, { title, updatedAt: Date.now() });
   }
 }


### PR DESCRIPTION
## Summary
- Add `updatedAt` field to `threadMetadata` schema to track last activity time per thread
- Update the `listThreads` query to use a new `by_userId_chatType_status_updated` index so threads with recent activity appear first
- Set `updatedAt` on thread creation, message send (generation start), title update, fork, and approval-triggered generation resumption
- Existing threads without `updatedAt` gracefully fall back to `createdAt`

## Test plan
- [x] Verify `list_threads.test.ts` passes with new `updatedAt` fallback and preference tests (17 tests)
- [x] Verify `start_agent_chat.test.ts` passes with `updatedAt` in patch expectations (4 tests)
- [x] All 74 thread-related tests pass
- [x] Typecheck passes
- [ ] Manual: send a message in an existing thread and verify it moves to the top of the sidebar

Closes #1149