### PR TITLE
feat(platform): surface website sync errors to users

### DIFF
--- a/services/platform/app/features/websites/components/website-view-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-view-dialog.tsx
@@ -346,7 +346,7 @@ export function ViewWebsiteDialog({
             </Badge>
             {website.status === 'error' && website.metadata?.lastSyncError && (
               <Text variant="caption" className="text-destructive">
-                {website.metadata.lastSyncError as string}
+                {String(website.metadata.lastSyncError)}
               </Text>
             )}
           </div>

--- a/services/platform/app/features/websites/components/website-view-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-view-dialog.tsx
@@ -322,27 +322,34 @@ export function ViewWebsiteDialog({
       {
         label: t('viewDialog.status'),
         value: (
-          <Badge
-            variant={
-              website.status && website.status in statusVariant
-                ? statusVariant[website.status]
-                : 'outline'
-            }
-            dot
-          >
-            {(website.status &&
-              (
-                {
-                  idle: t('filter.status.idle'),
-                  scanning: t('filter.status.scanning'),
-                  active: t('filter.status.active'),
-                  error: t('filter.status.error'),
-                  deleting: t('filter.status.deleting'),
-                } satisfies Record<string, string>
-              )[website.status]) ||
-              website.status ||
-              t('viewDialog.unknown')}
-          </Badge>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant={
+                website.status && website.status in statusVariant
+                  ? statusVariant[website.status]
+                  : 'outline'
+              }
+              dot
+            >
+              {(website.status &&
+                (
+                  {
+                    idle: t('filter.status.idle'),
+                    scanning: t('filter.status.scanning'),
+                    active: t('filter.status.active'),
+                    error: t('filter.status.error'),
+                    deleting: t('filter.status.deleting'),
+                  } satisfies Record<string, string>
+                )[website.status]) ||
+                website.status ||
+                t('viewDialog.unknown')}
+            </Badge>
+            {website.status === 'error' && website.metadata?.lastSyncError && (
+              <Text variant="caption" className="text-destructive">
+                {website.metadata.lastSyncError as string}
+              </Text>
+            )}
+          </div>
         ),
       },
       {

--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -133,10 +133,19 @@ export function WebsitesTable({
     ],
   );
 
-  const [viewingWebsite, setViewingWebsite] = useState<Website | null>(null);
+  const [viewingWebsiteId, setViewingWebsiteId] = useState<string | null>(null);
+
+  const viewingWebsite = useMemo(
+    () =>
+      viewingWebsiteId
+        ? (paginatedResult.results.find((w) => w._id === viewingWebsiteId) ??
+          null)
+        : null,
+    [viewingWebsiteId, paginatedResult.results],
+  );
 
   const handleRowClick = useCallback((row: Row<Website>) => {
-    setViewingWebsite(row.original);
+    setViewingWebsiteId(row.original._id);
   }, []);
 
   const list = useListPage<Website>({
@@ -178,7 +187,7 @@ export function WebsitesTable({
       {viewingWebsite && (
         <ViewWebsiteDialog
           isOpen={!!viewingWebsite}
-          onClose={() => setViewingWebsite(null)}
+          onClose={() => setViewingWebsiteId(null)}
           website={viewingWebsite}
         />
       )}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -73,6 +73,8 @@ import type * as agent_tools_location_actions from "../agent_tools/location/acti
 import type * as agent_tools_location_internal_mutations from "../agent_tools/location/internal_mutations.js";
 import type * as agent_tools_location_mutations from "../agent_tools/location/mutations.js";
 import type * as agent_tools_location_request_user_location_tool from "../agent_tools/location/request_user_location_tool.js";
+import type * as agent_tools_mcp_create_bound_mcp_tool from "../agent_tools/mcp/create_bound_mcp_tool.js";
+import type * as agent_tools_mcp_mcp_call_tool from "../agent_tools/mcp/mcp_call_tool.js";
 import type * as agent_tools_products_helpers_count_products from "../agent_tools/products/helpers/count_products.js";
 import type * as agent_tools_products_helpers_read_product_by_id from "../agent_tools/products/helpers/read_product_by_id.js";
 import type * as agent_tools_products_helpers_read_product_list from "../agent_tools/products/helpers/read_product_list.js";
@@ -117,6 +119,7 @@ import type * as agent_tools_workflows_trigger_completion_action from "../agent_
 import type * as agent_tools_workflows_update_workflow_step_tool from "../agent_tools/workflows/update_workflow_step_tool.js";
 import type * as agent_tools_workflows_workflow_read_tool from "../agent_tools/workflows/workflow_read_tool.js";
 import type * as agent_tools_workflows_workflow_syntax_tool from "../agent_tools/workflows/workflow_syntax_tool.js";
+import type * as agents_arena_chat from "../agents/arena_chat.js";
 import type * as agents_config from "../agents/config.js";
 import type * as agents_file_actions from "../agents/file_actions.js";
 import type * as agents_file_utils from "../agents/file_utils.js";
@@ -290,6 +293,8 @@ import type * as governance_internal_queries from "../governance/internal_querie
 import type * as governance_mutations from "../governance/mutations.js";
 import type * as governance_pii_index from "../governance/pii/index.js";
 import type * as governance_pii_pii_detector from "../governance/pii/pii_detector.js";
+import type * as governance_pii_pii_masker from "../governance/pii/pii_masker.js";
+import type * as governance_pii_pii_patterns from "../governance/pii/pii_patterns.js";
 import type * as governance_queries from "../governance/queries.js";
 import type * as governance_resolve_default_model from "../governance/resolve_default_model.js";
 import type * as governance_retention_cleanup from "../governance/retention_cleanup.js";
@@ -541,6 +546,9 @@ import type * as products_validators from "../products/validators.js";
 import type * as prompts_mutations from "../prompts/mutations.js";
 import type * as prompts_queries from "../prompts/queries.js";
 import type * as prompts_validators from "../prompts/validators.js";
+import type * as providers_circuit_breaker from "../providers/circuit_breaker.js";
+import type * as providers_errors from "../providers/errors.js";
+import type * as providers_failover from "../providers/failover.js";
 import type * as providers_file_actions from "../providers/file_actions.js";
 import type * as providers_file_utils from "../providers/file_utils.js";
 import type * as providers_resolve_model from "../providers/resolve_model.js";
@@ -549,6 +557,7 @@ import type * as sso_providers_actions from "../sso_providers/actions.js";
 import type * as sso_providers_create_user_session from "../sso_providers/create_user_session.js";
 import type * as sso_providers_entra_id_adapter from "../sso_providers/entra_id/adapter.js";
 import type * as sso_providers_entra_id_constants from "../sso_providers/entra_id/constants.js";
+import type * as sso_providers_entra_id_error_codes from "../sso_providers/entra_id/error_codes.js";
 import type * as sso_providers_entra_id_role_mapping from "../sso_providers/entra_id/role_mapping.js";
 import type * as sso_providers_entra_id_team_sync from "../sso_providers/entra_id/team_sync.js";
 import type * as sso_providers_find_or_create_sso_user from "../sso_providers/find_or_create_sso_user.js";
@@ -950,6 +959,8 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/location/internal_mutations": typeof agent_tools_location_internal_mutations;
   "agent_tools/location/mutations": typeof agent_tools_location_mutations;
   "agent_tools/location/request_user_location_tool": typeof agent_tools_location_request_user_location_tool;
+  "agent_tools/mcp/create_bound_mcp_tool": typeof agent_tools_mcp_create_bound_mcp_tool;
+  "agent_tools/mcp/mcp_call_tool": typeof agent_tools_mcp_mcp_call_tool;
   "agent_tools/products/helpers/count_products": typeof agent_tools_products_helpers_count_products;
   "agent_tools/products/helpers/read_product_by_id": typeof agent_tools_products_helpers_read_product_by_id;
   "agent_tools/products/helpers/read_product_list": typeof agent_tools_products_helpers_read_product_list;
@@ -994,6 +1005,7 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/workflows/update_workflow_step_tool": typeof agent_tools_workflows_update_workflow_step_tool;
   "agent_tools/workflows/workflow_read_tool": typeof agent_tools_workflows_workflow_read_tool;
   "agent_tools/workflows/workflow_syntax_tool": typeof agent_tools_workflows_workflow_syntax_tool;
+  "agents/arena_chat": typeof agents_arena_chat;
   "agents/config": typeof agents_config;
   "agents/file_actions": typeof agents_file_actions;
   "agents/file_utils": typeof agents_file_utils;
@@ -1167,6 +1179,8 @@ declare const fullApi: ApiFromModules<{
   "governance/mutations": typeof governance_mutations;
   "governance/pii/index": typeof governance_pii_index;
   "governance/pii/pii_detector": typeof governance_pii_pii_detector;
+  "governance/pii/pii_masker": typeof governance_pii_pii_masker;
+  "governance/pii/pii_patterns": typeof governance_pii_pii_patterns;
   "governance/queries": typeof governance_queries;
   "governance/resolve_default_model": typeof governance_resolve_default_model;
   "governance/retention_cleanup": typeof governance_retention_cleanup;
@@ -1418,6 +1432,9 @@ declare const fullApi: ApiFromModules<{
   "prompts/mutations": typeof prompts_mutations;
   "prompts/queries": typeof prompts_queries;
   "prompts/validators": typeof prompts_validators;
+  "providers/circuit_breaker": typeof providers_circuit_breaker;
+  "providers/errors": typeof providers_errors;
+  "providers/failover": typeof providers_failover;
   "providers/file_actions": typeof providers_file_actions;
   "providers/file_utils": typeof providers_file_utils;
   "providers/resolve_model": typeof providers_resolve_model;
@@ -1426,6 +1443,7 @@ declare const fullApi: ApiFromModules<{
   "sso_providers/create_user_session": typeof sso_providers_create_user_session;
   "sso_providers/entra_id/adapter": typeof sso_providers_entra_id_adapter;
   "sso_providers/entra_id/constants": typeof sso_providers_entra_id_constants;
+  "sso_providers/entra_id/error_codes": typeof sso_providers_entra_id_error_codes;
   "sso_providers/entra_id/role_mapping": typeof sso_providers_entra_id_role_mapping;
   "sso_providers/entra_id/team_sync": typeof sso_providers_entra_id_team_sync;
   "sso_providers/find_or_create_sso_user": typeof sso_providers_find_or_create_sso_user;

--- a/services/platform/convex/websites/actions.ts
+++ b/services/platform/convex/websites/actions.ts
@@ -139,7 +139,15 @@ export const updateWebsite = action({
         ) {
           await ctx.runMutation(
             internal.websites.internal_mutations.patchWebsite,
-            { websiteId: args.websiteId, status: 'error' as const },
+            {
+              websiteId: args.websiteId,
+              status: 'error' as const,
+              metadata: {
+                ...website.metadata,
+                lastSyncError:
+                  'Website not found in crawler. Please delete and re-add it.',
+              },
+            },
           );
           throw new Error(
             'Website not found in crawler. Please delete and re-add it.',

--- a/services/platform/convex/websites/internal_actions.ts
+++ b/services/platform/convex/websites/internal_actions.ts
@@ -116,20 +116,16 @@ export async function fetchWebsiteInfo(
   domain: string,
 ): Promise<CrawlerWebsiteInfo | null> {
   const crawlerUrl = getCrawlerUrl();
-  try {
-    const res = await fetchWithTimeout(
-      `${crawlerUrl}/api/v1/websites/${encodeURIComponent(domain)}`,
-    );
-    if (res.ok) {
-      return await res.json();
-    }
-  } catch (error) {
-    console.warn(
-      `[fetchWebsiteInfo] Failed to fetch info for ${domain}:`,
-      error,
-    );
+  const res = await fetchWithTimeout(
+    `${crawlerUrl}/api/v1/websites/${encodeURIComponent(domain)}`,
+  );
+  if (res.ok) {
+    return await res.json();
   }
-  return null;
+  if (res.status === 404) {
+    return null;
+  }
+  throw new Error(`Crawler API returned ${res.status} ${res.statusText}`);
 }
 
 interface WebsiteForSync {
@@ -273,6 +269,7 @@ export const registerAndSync = internalAction({
     try {
       await registerDomainWithCrawler(args.domain, args.scanInterval);
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       console.error(
         `[registerAndSync] Failed to register domain ${args.domain}:`,
         error,
@@ -280,6 +277,7 @@ export const registerAndSync = internalAction({
       await ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
         websiteId: args.websiteId,
         status: 'error',
+        metadata: { lastSyncError: message },
       });
       return;
     }
@@ -306,20 +304,62 @@ export const syncSingleWebsite = internalAction({
     domain: v.string(),
   },
   handler: async (ctx, args): Promise<void> => {
-    const info = await fetchWebsiteInfo(args.domain);
-    if (!info) return;
+    const website = await ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: args.websiteId },
+    );
+    if (!website) return;
 
-    await ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
-      websiteId: args.websiteId,
-      status: info.status,
-      pageCount: info.page_count,
-      crawledPageCount: info.crawled_count,
-      title: info.title ?? undefined,
-      description: info.description ?? undefined,
-      lastScannedAt: info.last_scanned_at
-        ? new Date(info.last_scanned_at).getTime()
-        : undefined,
-    });
+    try {
+      const info = await fetchWebsiteInfo(args.domain);
+
+      if (info) {
+        await ctx.runMutation(
+          internal.websites.internal_mutations.patchWebsite,
+          {
+            websiteId: args.websiteId,
+            status: info.status,
+            pageCount: info.page_count,
+            crawledPageCount: info.crawled_count,
+            title: info.title ?? undefined,
+            description: info.description ?? undefined,
+            lastScannedAt: info.last_scanned_at
+              ? new Date(info.last_scanned_at).getTime()
+              : undefined,
+            metadata: {
+              ...website.metadata,
+              lastSyncError: undefined,
+            },
+          },
+        );
+      } else {
+        await ctx.runMutation(
+          internal.websites.internal_mutations.patchWebsite,
+          {
+            websiteId: args.websiteId,
+            status: 'error',
+            metadata: {
+              ...website.metadata,
+              lastSyncError:
+                'Website not found in crawler. Please delete and re-add it.',
+            },
+          },
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `[syncSingleWebsite] Failed to sync ${args.domain}: ${message}`,
+      );
+      await ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
+        websiteId: args.websiteId,
+        status: 'error',
+        metadata: {
+          ...website.metadata,
+          lastSyncError: message,
+        },
+      });
+    }
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3260,7 +3260,8 @@
       "titleField": "Titel",
       "description": "Beschreibung",
       "created": "Erstellt",
-      "unknown": "Unbekannt"
+      "unknown": "Unbekannt",
+      "errorReason": "Fehlergrund"
     },
     "viewPages": "Seiten anzeigen",
     "indexed": "Indexiert",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3313,7 +3313,8 @@
       "titleField": "Title",
       "description": "Description",
       "created": "Created",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "errorReason": "Error reason"
     },
     "viewPages": "View pages",
     "indexed": "Indexed",


### PR DESCRIPTION
## Summary
- Store `lastSyncError` in website metadata when crawler registration, sync, or fetch fails, and display the error message in the website view dialog
- Fix `fetchWebsiteInfo` to properly propagate non-404 errors instead of silently returning null
- Derive viewed website from paginated results by ID so status updates appear in real time

## Test plan
- [ ] Trigger a website sync error (e.g. crawler unavailable) and verify the error message appears in the view dialog
- [ ] Verify successful syncs clear any previous `lastSyncError`
- [ ] Confirm the view dialog updates status in real time without needing to close/reopen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Website view dialog now displays sync error reasons when synchronization encounters issues.

* **Bug Fixes**
  * Improved error handling and tracking throughout website synchronization, including enhanced messaging for crawler communication failures and missing websites. Better error visibility aids troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->