### PR TITLE
fix: expose raw error messages and flatten tool schemas for OpenAI

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -268,9 +268,21 @@ function MessageBubbleComponent({
                     {tChat('errorGenerating')}
                   </span>
                 </div>
-                <p className="text-muted-foreground text-[13px]">
-                  {tChat(sanitizeChatError(message.error).i18nKey)}
-                </p>
+                {(() => {
+                  const sanitized = sanitizeChatError(message.error);
+                  return (
+                    <>
+                      <p className="text-muted-foreground text-[13px]">
+                        {tChat(sanitized.i18nKey)}
+                      </p>
+                      {sanitized.rawMessage && (
+                        <p className="text-muted-foreground text-xs break-all whitespace-pre-wrap opacity-70">
+                          {sanitized.rawMessage}
+                        </p>
+                      )}
+                    </>
+                  );
+                })()}
                 {onRetry && (
                   <Button
                     variant="secondary"
@@ -299,9 +311,21 @@ function MessageBubbleComponent({
                   {tChat('errorGenerating')}
                 </span>
               </div>
-              <p className="text-muted-foreground text-[13px]">
-                {tChat(sanitizeChatError(message.error).i18nKey)}
-              </p>
+              {(() => {
+                const sanitized = sanitizeChatError(message.error);
+                return (
+                  <>
+                    <p className="text-muted-foreground text-[13px]">
+                      {tChat(sanitized.i18nKey)}
+                    </p>
+                    {sanitized.rawMessage && (
+                      <p className="text-muted-foreground text-xs break-all whitespace-pre-wrap opacity-70">
+                        {sanitized.rawMessage}
+                      </p>
+                    )}
+                  </>
+                );
+              })()}
               {onRetry && (
                 <Button
                   variant="secondary"

--- a/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
+++ b/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
@@ -17,10 +17,11 @@ describe('sanitizeChatError', () => {
     });
   });
 
-  it('returns generic for unknown error messages', () => {
+  it('returns generic with rawMessage for unknown error messages', () => {
     expect(sanitizeChatError('Something unexpected happened')).toEqual({
       category: 'generic',
       i18nKey: 'errorGeneratingDescription',
+      rawMessage: 'Something unexpected happened',
     });
   });
 
@@ -31,6 +32,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError(raw)).toEqual({
         category: 'creditLimit',
         i18nKey: 'errorHintCreditLimit',
+        rawMessage: raw,
       });
     });
 
@@ -38,6 +40,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Exceeded token limit for this model')).toEqual({
         category: 'creditLimit',
         i18nKey: 'errorHintCreditLimit',
+        rawMessage: 'Exceeded token limit for this model',
       });
     });
 
@@ -45,6 +48,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('can only afford 500 tokens')).toEqual({
         category: 'creditLimit',
         i18nKey: 'errorHintCreditLimit',
+        rawMessage: 'can only afford 500 tokens',
       });
     });
   });
@@ -54,6 +58,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Rate limit exceeded')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
+        rawMessage: 'Rate limit exceeded',
       });
     });
 
@@ -61,6 +66,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Too many requests, please slow down')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
+        rawMessage: 'Too many requests, please slow down',
       });
     });
 
@@ -68,6 +74,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Error 429: rate limited')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
+        rawMessage: 'Error 429: rate limited',
       });
     });
   });
@@ -77,6 +84,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Content filter triggered')).toEqual({
         category: 'contentFilter',
         i18nKey: 'errorHintContentFilter',
+        rawMessage: 'Content filter triggered',
       });
     });
 
@@ -84,6 +92,7 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Violated content policy')).toEqual({
         category: 'contentFilter',
         i18nKey: 'errorHintContentFilter',
+        rawMessage: 'Violated content policy',
       });
     });
 
@@ -92,17 +101,18 @@ describe('sanitizeChatError', () => {
         {
           category: 'contentFilter',
           i18nKey: 'errorHintContentFilter',
+          rawMessage: 'Request flagged by moderation system',
         },
       );
     });
   });
 
-  it('strips stack traces by not exposing raw error', () => {
+  it('includes rawMessage alongside i18n key for categorized errors', () => {
     const rawWithStack = `Uncaught Error: This request requires more credits, or fewer max_tokens.
     at <anonymous> (../../node_modules/ai/dist/index.mjs:5758:14)
     at runUpdateMessageJob (../../node_modules/ai/dist/index.mjs:8306:10)`;
     const result = sanitizeChatError(rawWithStack);
     expect(result.i18nKey).toBe('errorHintCreditLimit');
-    expect(result).not.toHaveProperty('rawError');
+    expect(result.rawMessage).toBe(rawWithStack);
   });
 });

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.ts
@@ -7,6 +7,7 @@ type ErrorCategory =
 interface SanitizedError {
   category: ErrorCategory;
   i18nKey: string;
+  rawMessage?: string;
 }
 
 const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
@@ -44,9 +45,17 @@ export function sanitizeChatError(
 
   for (const { pattern, category } of ERROR_PATTERNS) {
     if (pattern.test(rawError)) {
-      return { category, i18nKey: CATEGORY_I18N_KEY[category] };
+      return {
+        category,
+        i18nKey: CATEGORY_I18N_KEY[category],
+        rawMessage: rawError,
+      };
     }
   }
 
-  return { category: 'generic', i18nKey: CATEGORY_I18N_KEY.generic };
+  return {
+    category: 'generic',
+    i18nKey: CATEGORY_I18N_KEY.generic,
+    rawMessage: rawError,
+  };
 }

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -8,7 +8,11 @@
  */
 
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import type { LanguageModelV3 } from '@ai-sdk/provider';
+import type {
+  LanguageModelV3,
+  LanguageModelV3Middleware,
+} from '@ai-sdk/provider';
+import { wrapLanguageModel } from 'ai';
 
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
@@ -27,6 +31,148 @@ interface ResolvedLanguageModel {
   modelData: ResolvedModelData;
 }
 
+/**
+ * Workaround: Flatten tool inputSchemas that use `oneOf`/`anyOf` at the root.
+ *
+ * PROBLEM:
+ * Many of our agent tools use `z.discriminatedUnion()` (zod v4) for their
+ * input schemas. When the AI SDK converts these to JSON Schema, the result
+ * is `{ "oneOf": [...] }` — a valid JSON Schema, but OpenAI's API rejects
+ * schemas that have `oneOf`/`anyOf`/`allOf` at the top level:
+ *
+ *   "Invalid schema for function 'rag_search': schema must have type 'object'
+ *    and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level."
+ *
+ * UPSTREAM BUG:
+ * This is tracked as vercel/ai#7924. Multiple fix PRs exist (#12283, #12942,
+ * #13217) but none have been merged as of 2026-04-10.
+ *
+ * FIX:
+ * We merge all `oneOf`/`anyOf` variant schemas into a single flat object
+ * schema. Properties from all variants are combined (all made optional since
+ * each variant only uses a subset). The `required` array is set to the
+ * intersection of all variants' required fields (typically just the
+ * discriminator like `operation`).
+ *
+ * This preserves the LLM's ability to understand the schema via the tool
+ * description while satisfying OpenAI's strict schema requirements.
+ *
+ * REMOVAL:
+ * Delete this middleware once the upstream fix lands in the `ai` package and
+ * we upgrade past it.
+ *
+ * @see https://github.com/vercel/ai/issues/7924
+ */
+
+type JSONSchema7Object = Record<string, unknown>;
+
+/**
+ * Merge oneOf/anyOf variant schemas into a single flat object schema.
+ * All properties become optional except those required by every variant
+ * (typically just the discriminator field like `operation`).
+ */
+function flattenUnionSchema(schema: JSONSchema7Object): JSONSchema7Object {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON Schema oneOf/anyOf are arrays of schema objects
+  const variants = (schema.oneOf ?? schema.anyOf) as
+    | JSONSchema7Object[]
+    | undefined;
+  if (!variants || variants.length === 0) return schema;
+
+  const mergedProperties: Record<string, unknown> = {};
+  const requiredSets: Set<string>[] = [];
+  // Track `const` values per property so we can merge them into `enum`
+  const constValues: Record<string, unknown[]> = {};
+
+  for (const variant of variants) {
+    if (typeof variant !== 'object' || variant === null) continue;
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON Schema properties is Record<string, unknown>
+    const props = variant.properties as Record<string, unknown> | undefined;
+    if (props) {
+      for (const [key, value] of Object.entries(props)) {
+        const propObj =
+          typeof value === 'object' && value !== null
+            ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by typeof/null check
+              (value as Record<string, unknown>)
+            : null;
+
+        // Collect `const` values across variants for the same property
+        // (e.g., operation: { const: "search" } + operation: { const: "list" }
+        //  → operation: { enum: ["search", "list"] })
+        if (propObj && 'const' in propObj) {
+          if (!constValues[key]) constValues[key] = [];
+          constValues[key].push(propObj.const);
+        }
+
+        if (!(key in mergedProperties)) {
+          mergedProperties[key] = value;
+        }
+      }
+    }
+
+    const req = variant.required;
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON Schema required is string[]
+    requiredSets.push(new Set(Array.isArray(req) ? (req as string[]) : []));
+  }
+
+  // Replace `const` with `enum` for properties that had different const values
+  // across variants (typically the discriminator field like "operation")
+  for (const [key, values] of Object.entries(constValues)) {
+    if (values.length > 1) {
+      const existing =
+        typeof mergedProperties[key] === 'object' &&
+        mergedProperties[key] !== null
+          ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by typeof/null check
+            (mergedProperties[key] as Record<string, unknown>)
+          : {};
+      const { const: _removed, ...rest } = existing;
+      mergedProperties[key] = { ...rest, enum: values };
+    }
+  }
+
+  // Only fields required by ALL variants stay required (usually just the
+  // discriminator like "operation")
+  const commonRequired =
+    requiredSets.length > 0
+      ? [...requiredSets[0]].filter((field) =>
+          requiredSets.every((s) => s.has(field)),
+        )
+      : [];
+
+  return {
+    type: 'object' as const,
+    properties: mergedProperties,
+    ...(commonRequired.length > 0 ? { required: commonRequired } : {}),
+    additionalProperties: false,
+  };
+}
+
+const toolSchemaFixMiddleware: LanguageModelV3Middleware = {
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    if (!params.tools) return params;
+
+    return {
+      ...params,
+      tools: params.tools.map((tool) => {
+        if (tool.type !== 'function') return tool;
+
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSONSchema7 is a Record-like object
+        const schema = tool.inputSchema as JSONSchema7Object | undefined;
+        if (!schema) return tool;
+
+        // Only flatten schemas that have oneOf/anyOf at the root — these come
+        // from z.discriminatedUnion() / z.union() and are rejected by OpenAI.
+        // Schemas that already have type:"object" are left untouched.
+        if (schema.oneOf || schema.anyOf) {
+          return { ...tool, inputSchema: flattenUnionSchema(schema) };
+        }
+        return tool;
+      }),
+    };
+  },
+};
+
 function createLanguageModel(modelData: ResolvedModelData): LanguageModelV3 {
   const provider = createOpenAICompatible({
     name: modelData.providerName,
@@ -34,7 +180,10 @@ function createLanguageModel(modelData: ResolvedModelData): LanguageModelV3 {
     apiKey: modelData.apiKey,
     supportsStructuredOutputs: modelData.supportsStructuredOutputs,
   });
-  return provider.chatModel(modelData.modelId);
+  return wrapLanguageModel({
+    model: provider.chatModel(modelData.modelId),
+    middleware: toolSchemaFixMiddleware,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `rawMessage` field to `SanitizedError` so the chat UI displays the original provider error beneath the translated i18n hint, giving users more debugging context
- Add AI SDK middleware to flatten `oneOf`/`anyOf` tool input schemas into a single object schema, working around OpenAI's strict schema validation (vercel/ai#7924)

Closes #1253
Closes #1254

## Test plan
- [ ] Verify chat error messages show both the i18n hint and the raw provider error
- [ ] Verify agent tools with `z.discriminatedUnion()` schemas work correctly with OpenAI models (ChatGPT 5.2, 5.2 Pro, GPT-5.2 Instant)
- [ ] Run `sanitize-chat-error` unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat error messages now display additional raw error details with improved formatting, including better text wrapping and visual hierarchy for secondary content.
  * Enhanced tool schema handling in language model resolution for improved compatibility and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->