### PR TITLE
feat(platform): filter model selector to only show chat-tagged models

### DIFF
--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -75,6 +75,13 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
     [modelInfoMap, t],
   );
 
+  const filteredModels = useMemo(() => {
+    return supportedModels.filter((modelId) => {
+      const info = modelInfoMap.get(modelId);
+      return info?.tags.includes('chat');
+    });
+  }, [supportedModels, modelInfoMap]);
+
   const getDisplayName = useCallback(
     (modelId: string) =>
       modelInfoMap.get(modelId)?.displayName ?? getModelShortName(modelId),
@@ -83,19 +90,19 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
 
   const currentModelId =
     (effectiveAgent?.name && selectedModelOverrides[effectiveAgent.name]) ||
-    supportedModels[0] ||
+    filteredModels[0] ||
     null;
 
   // Clear stale override when agent changes
   useEffect(() => {
     if (!effectiveAgent?.name) return;
     const override = selectedModelOverrides[effectiveAgent.name];
-    if (override && !supportedModels.includes(override)) {
+    if (override && !filteredModels.includes(override)) {
       setSelectedModelOverride(effectiveAgent.name, null);
     }
   }, [
     effectiveAgent?.name,
-    supportedModels,
+    filteredModels,
     selectedModelOverrides,
     setSelectedModelOverride,
   ]);
@@ -103,13 +110,13 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const handleSelect = useCallback(
     (modelId: string) => {
       if (!effectiveAgent?.name) return;
-      if (modelId === supportedModels[0]) {
+      if (modelId === filteredModels[0]) {
         setSelectedModelOverride(effectiveAgent.name, null);
       } else {
         setSelectedModelOverride(effectiveAgent.name, modelId);
       }
     },
-    [effectiveAgent?.name, supportedModels, setSelectedModelOverride],
+    [effectiveAgent?.name, filteredModels, setSelectedModelOverride],
   );
 
   if (!currentModelId) return null;
@@ -117,7 +124,7 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const currentLabel = getDisplayName(currentModelId);
 
   // Single model — show as read-only text
-  if (supportedModels.length <= 1) {
+  if (filteredModels.length <= 1) {
     return (
       <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
         <Cpu className="size-3.5" aria-hidden="true" />
@@ -126,7 +133,7 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
     );
   }
 
-  const options = supportedModels.map((modelId) => ({
+  const options = filteredModels.map((modelId) => ({
     value: modelId,
     label: getDisplayName(modelId),
     description: modelInfoMap.get(modelId)?.description,


### PR DESCRIPTION
## Summary
- Filter the chat page model selector to only display models with the `chat` tag
- Models without the `chat` tag (e.g., embedding-only models) are now excluded from the dropdown
- Adds a `filteredModels` memo that filters `supportedModels` by checking each model's tags from the provider config

Closes #1258

## Test plan
- [ ] Open the chat page and verify only models with the `chat` tag appear in the model selector dropdown
- [ ] Verify embedding-only models are hidden from the selector
- [ ] Verify model override persistence still works correctly after filtering
- [ ] Verify stale overrides are cleared when the selected model no longer passes the filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selector now displays only chat-compatible models, ensuring users can only select appropriate options for chat functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->