### PR TITLE
feat(platform): add inline source citations for RAG and web search

### DIFF
--- a/services/platform/app/features/chat/components/__tests__/citation-link.test.tsx
+++ b/services/platform/app/features/chat/components/__tests__/citation-link.test.tsx
@@ -28,7 +28,9 @@ vi.mock('@/lib/i18n/client', () => ({
 describe('CitationLink', () => {
   describe('accessibility', () => {
     it('passes axe audit with minimal citation', async () => {
-      const { container } = render(<CitationLink citation={{ number: 1 }} />);
+      const { container } = render(
+        <CitationLink citation={{ number: 1, type: 'rag' }} />,
+      );
       await checkAccessibility(container);
     });
 
@@ -41,6 +43,7 @@ describe('CitationLink', () => {
             fileId: 'file-123',
             page: 5,
             relevance: 87.5,
+            type: 'rag',
           }}
           onNavigate={vi.fn()}
         />,

--- a/services/platform/app/features/chat/components/citation-link.tsx
+++ b/services/platform/app/features/chat/components/citation-link.tsx
@@ -12,11 +12,21 @@ interface CitationLinkProps {
   onNavigate?: (fileId: string, page?: number) => void;
 }
 
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 function CitationLinkComponent({ citation, onNavigate }: CitationLinkProps) {
   const { t } = useT('chat');
 
   const handleClick = () => {
-    if (citation.fileId && onNavigate) {
+    if (citation.type === 'web' && citation.url) {
+      window.open(citation.url, '_blank', 'noopener,noreferrer');
+    } else if (citation.fileId && onNavigate) {
       onNavigate(citation.fileId, citation.page);
     }
   };
@@ -43,7 +53,12 @@ function CitationLinkComponent({ citation, onNavigate }: CitationLinkProps) {
         {citation.filename && (
           <div className="font-medium">{citation.filename}</div>
         )}
-        {citation.page != null && (
+        {citation.type === 'web' && citation.url && (
+          <div className="text-muted-foreground truncate text-xs">
+            {getDomain(citation.url)}
+          </div>
+        )}
+        {citation.type === 'rag' && citation.page != null && (
           <div className="text-muted-foreground">
             {t('citations.page', { page: String(citation.page) })}
           </div>
@@ -55,7 +70,17 @@ function CitationLinkComponent({ citation, onNavigate }: CitationLinkProps) {
             })}
           </div>
         )}
-        {citation.fileId && onNavigate && (
+        {citation.type === 'web' && citation.url && (
+          <a
+            href={citation.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {t('citations.visitPage')}
+          </a>
+        )}
+        {citation.type === 'rag' && citation.fileId && onNavigate && (
           <button
             type="button"
             className="text-primary hover:underline"

--- a/services/platform/app/features/chat/components/incremental-markdown.tsx
+++ b/services/platform/app/features/chat/components/incremental-markdown.tsx
@@ -39,10 +39,11 @@ import { remendMarkdown } from '../utils/remend-markdown';
 
 const chatSanitizeSchema = {
   ...defaultSchema,
-  tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary'],
+  tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary', 'cite'],
   attributes: {
     ...defaultSchema.attributes,
     details: [...(defaultSchema.attributes?.details ?? []), 'open'],
+    cite: ['data-n'],
   },
 };
 

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -25,7 +25,10 @@ import { Button } from '@/app/components/ui/primitives/button';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
+import { CitationsContext } from '../context/citations-context';
 import { useMessageMetadata, useFileUrls } from '../hooks/queries';
+import { useCitations } from '../hooks/use-citations';
+import { injectCitationTags } from '../utils/inject-citation-tags';
 import { sanitizeChatError } from '../utils/sanitize-chat-error';
 import {
   FileAttachmentDisplay,
@@ -37,6 +40,7 @@ import {
 } from './message-bubble/image-preview-dialog';
 import type { Message } from './message-bubble/types';
 import { MessageInfoDialog } from './message-info-dialog';
+import { SourceCards } from './source-cards';
 import { StructuredMessage } from './structured-message/structured-message';
 
 export { ImagePreviewDialog } from './message-bubble/image-preview-dialog';
@@ -117,11 +121,6 @@ function MessageBubbleComponent({
     if (onEdit) onEdit(message.id, message.content);
   }, [onEdit, message.id, message.content]);
 
-  const displayContent = message.content ?? '';
-  // Only normalize pipes for assistant messages (markdown table rendering);
-  // user messages must be rendered verbatim to preserve content integrity.
-  const assistantContent = displayContent.replace(/\|\|+/g, '|');
-
   const [isCopied, setIsCopied] = useState(false);
   const [isInfoDialogOpen, setIsInfoDialogOpen] = useState(false);
   const [isGalleryOpen, setIsGalleryOpen] = useState(false);
@@ -132,7 +131,20 @@ function MessageBubbleComponent({
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const { metadata } = useMessageMetadata(message.id);
+  const { citations, hasCitations } = useCitations(metadata?.toolsUsage);
+  const citationNumbers = useMemo(() => new Set(citations.keys()), [citations]);
+  const citationsContextValue = useMemo(() => ({ citations }), [citations]);
   const galleryImages = useMessageGallery(message);
+
+  const displayContent = message.content ?? '';
+  // Only normalize pipes for assistant messages (markdown table rendering);
+  // user messages must be rendered verbatim to preserve content integrity.
+  const normalizedContent = displayContent.replace(/\|\|+/g, '|');
+  // Inject citation tags for known citation numbers so [N] renders as interactive components
+  const assistantContent = useMemo(
+    () => injectCitationTags(normalizedContent, citationNumbers),
+    [normalizedContent, citationNumbers],
+  );
 
   // Map each filePart/attachment to its gallery index (-1 for non-images)
   const { filePartGalleryIndices, attachmentGalleryIndices } = useMemo(() => {
@@ -238,11 +250,13 @@ function MessageBubbleComponent({
                   {displayContent}
                 </p>
               ) : (
-                <StructuredMessage
-                  text={assistantContent}
-                  isStreaming={!!isAssistantStreaming}
-                  onSendFollowUp={onSendFollowUp}
-                />
+                <CitationsContext.Provider value={citationsContextValue}>
+                  <StructuredMessage
+                    text={assistantContent}
+                    isStreaming={!!isAssistantStreaming}
+                    onSendFollowUp={onSendFollowUp}
+                  />
+                </CitationsContext.Provider>
               )}
             </div>
             {isUser && (isOverflowing || isExpanded) && (
@@ -421,6 +435,10 @@ function MessageBubbleComponent({
             activeIndex={galleryIndex}
             onActiveIndexChange={setGalleryIndex}
           />
+        )}
+
+        {!isUser && hasCitations && !isAssistantStreaming && (
+          <SourceCards citations={citations} />
         )}
 
         <MessageInfoDialog

--- a/services/platform/app/features/chat/components/message-bubble/markdown-renderer.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/markdown-renderer.tsx
@@ -21,6 +21,8 @@ import {
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
+import { useCitationsContext } from '../../context/citations-context';
+import { CitationLink } from '../citation-link';
 import { PaginatedMarkdownTable } from '../paginated-markdown-table';
 import { StructuredMessage } from '../structured-message/structured-message';
 import { CodeBlock, HighlightedCode } from './code-block';
@@ -238,6 +240,18 @@ export const markdownComponents = {
       {children}
     </a>
   ),
+  cite: function InlineCitation({
+    'data-n': dataN,
+  }: {
+    node?: unknown;
+    'data-n'?: string;
+  }) {
+    const { citations, onNavigate } = useCitationsContext();
+    const n = dataN ? parseInt(dataN, 10) : NaN;
+    const citation = !isNaN(n) ? citations.get(n) : undefined;
+    if (!citation) return <span>[{dataN}]</span>;
+    return <CitationLink citation={citation} onNavigate={onNavigate} />;
+  },
 };
 
 export function TypewriterTextWrapper({

--- a/services/platform/app/features/chat/components/source-cards.tsx
+++ b/services/platform/app/features/chat/components/source-cards.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { FileText, Globe, ChevronDown, ChevronUp } from 'lucide-react';
+import { memo, useState, useMemo, useCallback } from 'react';
+
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { useOrganizationId } from '@/app/hooks/use-organization-id';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import { DocumentPreviewDialog } from '../../documents/components/document-preview-dialog';
+import type { CitationInfo } from '../hooks/use-citations';
+import { getUniqueCitations } from '../hooks/use-citations';
+
+const COLLAPSED_LIMIT = 3;
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+interface SourceCardProps {
+  citation: CitationInfo;
+  onClick: () => void;
+}
+
+function SourceCard({ citation, onClick }: SourceCardProps) {
+  const isWeb = citation.type === 'web';
+  const Icon = isWeb ? Globe : FileText;
+  const title =
+    citation.filename ??
+    (citation.url ? getDomain(citation.url) : `Source ${citation.number}`);
+  const subtitle = isWeb
+    ? citation.url
+      ? getDomain(citation.url)
+      : undefined
+    : citation.page != null
+      ? `p. ${citation.page}`
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="border-border bg-muted/50 hover:bg-muted flex max-w-[200px] min-w-0 shrink-0 items-center gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors"
+    >
+      <Icon className="text-muted-foreground size-3.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium">{title}</div>
+        {subtitle && (
+          <div className="text-muted-foreground truncate text-[10px]">
+            {subtitle}
+          </div>
+        )}
+      </div>
+      <span className="text-muted-foreground shrink-0 text-[10px]">
+        [{citation.number}]
+      </span>
+    </button>
+  );
+}
+
+interface SourceCardsProps {
+  citations: Map<number, CitationInfo>;
+}
+
+function SourceCardsComponent({ citations }: SourceCardsProps) {
+  const { t } = useT('chat');
+  const organizationId = useOrganizationId();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [previewDocId, setPreviewDocId] = useState<string | undefined>();
+  const [previewFileName, setPreviewFileName] = useState<string | undefined>();
+
+  const citationList = getUniqueCitations(citations);
+
+  // Collect all RAG fileIds to batch-query file metadata
+  const ragFileIds = useMemo(() => {
+    const ids: Id<'_storage'>[] = [];
+    for (const c of citationList) {
+      if (c.type === 'rag' && c.fileId) {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- fileId from RAG metadata is a Convex storage ID string
+        ids.push(c.fileId as Id<'_storage'>);
+      }
+    }
+    return ids;
+  }, [citationList]);
+
+  const { data: fileMetadataList } = useConvexQuery(
+    api.file_metadata.queries.getByStorageIds,
+    ragFileIds.length > 0 ? { storageIds: ragFileIds } : 'skip',
+  );
+
+  // Map storageId → documentId for quick lookup
+  const storageToDocId = useMemo(() => {
+    const map = new Map<string, string>();
+    if (fileMetadataList) {
+      for (const meta of fileMetadataList) {
+        if (meta.documentId) {
+          map.set(meta.storageId, meta.documentId);
+        }
+      }
+    }
+    return map;
+  }, [fileMetadataList]);
+
+  const handleCardClick = useCallback(
+    (citation: CitationInfo) => {
+      if (citation.type === 'web' && citation.url) {
+        window.open(citation.url, '_blank', 'noopener,noreferrer');
+      } else if (citation.type === 'rag' && citation.fileId) {
+        const docId = storageToDocId.get(citation.fileId);
+        if (docId) {
+          setPreviewDocId(docId);
+          setPreviewFileName(citation.filename);
+        }
+      }
+    },
+    [storageToDocId],
+  );
+
+  if (citationList.length === 0) return null;
+
+  const needsCollapse = citationList.length > COLLAPSED_LIMIT;
+  const visibleCitations =
+    needsCollapse && !isExpanded
+      ? citationList.slice(0, COLLAPSED_LIMIT)
+      : citationList;
+
+  return (
+    <div className="mt-1.5">
+      <div className="flex flex-wrap gap-1.5 pb-1">
+        {visibleCitations.map((citation) => (
+          <SourceCard
+            key={citation.number}
+            citation={citation}
+            onClick={() => handleCardClick(citation)}
+          />
+        ))}
+      </div>
+      {needsCollapse && (
+        <button
+          type="button"
+          onClick={() => setIsExpanded((v) => !v)}
+          className="text-muted-foreground hover:text-foreground mt-1 flex items-center gap-0.5 text-xs transition-colors"
+        >
+          {isExpanded ? (
+            <>
+              <ChevronUp className="size-3" />
+              {t('citations.hideSources')}
+            </>
+          ) : (
+            <>
+              <ChevronDown className="size-3" />
+              {t('citations.showAllSources', {
+                count: String(citationList.length),
+              })}
+            </>
+          )}
+        </button>
+      )}
+
+      {organizationId && (
+        <DocumentPreviewDialog
+          open={!!previewDocId}
+          onOpenChange={(open) => {
+            if (!open) setPreviewDocId(undefined);
+          }}
+          organizationId={organizationId}
+          documentId={previewDocId}
+          fileName={previewFileName}
+        />
+      )}
+    </div>
+  );
+}
+
+export const SourceCards = memo(SourceCardsComponent);

--- a/services/platform/app/features/chat/context/citations-context.tsx
+++ b/services/platform/app/features/chat/context/citations-context.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+import type { CitationInfo } from '../hooks/use-citations';
+
+interface CitationsContextValue {
+  citations: Map<number, CitationInfo>;
+  onNavigate?: (fileId: string, page?: number) => void;
+}
+
+export const CitationsContext = createContext<CitationsContextValue>({
+  citations: new Map(),
+});
+
+export function useCitationsContext() {
+  return useContext(CitationsContext);
+}

--- a/services/platform/app/features/chat/hooks/use-citations.ts
+++ b/services/platform/app/features/chat/hooks/use-citations.ts
@@ -6,21 +6,29 @@ export interface CitationInfo {
   fileId?: string;
   page?: number;
   relevance?: number;
+  url?: string;
+  type: 'rag' | 'web';
 }
+
+interface ToolUsageInput {
+  toolName: string;
+  output?: string;
+}
+
+const RAG_CITATION_PATTERN =
+  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[Page:\s*(\d+)\])?(?:\s*\[(?:Modified|Created):\s*[^\]]+\])?(?:\s*\[FileID:\s*([^\]]+)\])?/g;
+
+const WEB_CITATION_PATTERN =
+  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[URL:\s*([^\]]+)\])?/g;
 
 /**
  * Parse citation metadata from RAG search result text.
- *
- * Extracts structured citation data from the format:
- * `[N] (Relevance: X%) [Source: filename] [Page: Y] [FileID: id]`
  */
-export function parseCitations(contextText: string): Map<number, CitationInfo> {
-  const citations = new Map();
-  const pattern =
-    /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[Page:\s*(\d+)\])?(?:\s*\[(?:Modified|Created):\s*[^\]]+\])?(?:\s*\[FileID:\s*([^\]]+)\])?/g;
-
+export function parseRagCitations(text: string): Map<number, CitationInfo> {
+  const citations = new Map<number, CitationInfo>();
   let match;
-  while ((match = pattern.exec(contextText)) !== null) {
+  RAG_CITATION_PATTERN.lastIndex = 0;
+  while ((match = RAG_CITATION_PATTERN.exec(text)) !== null) {
     const num = parseInt(match[1], 10);
     citations.set(num, {
       number: num,
@@ -28,20 +36,161 @@ export function parseCitations(contextText: string): Map<number, CitationInfo> {
       filename: match[3] || undefined,
       page: match[4] ? parseInt(match[4], 10) : undefined,
       fileId: match[5] || undefined,
+      type: 'rag',
     });
   }
-
   return citations;
 }
 
 /**
- * Hook that provides citation lookup from message context.
+ * Parse citation metadata from web search result text.
  */
-export function useCitations(contextText?: string) {
-  const citations = useMemo(
-    () => (contextText ? parseCitations(contextText) : new Map()),
-    [contextText],
-  );
+export function parseWebCitations(text: string): Map<number, CitationInfo> {
+  const citations = new Map<number, CitationInfo>();
+  let match;
+  WEB_CITATION_PATTERN.lastIndex = 0;
+  while ((match = WEB_CITATION_PATTERN.exec(text)) !== null) {
+    const num = parseInt(match[1], 10);
+    citations.set(num, {
+      number: num,
+      relevance: parseFloat(match[2]),
+      filename: match[3] || undefined,
+      url: match[4] || undefined,
+      type: 'web',
+    });
+  }
+  return citations;
+}
+
+/**
+ * Parse citations from tool usage records.
+ *
+ * Processes RAG and web tool outputs in order, offsetting web citation
+ * numbers by the max RAG citation number to avoid collisions.
+ */
+export function parseCitationsFromToolsUsage(
+  toolsUsage: ToolUsageInput[],
+): Map<number, CitationInfo> {
+  const allCitations = new Map<number, CitationInfo>();
+  let maxNumber = 0;
+
+  for (const usage of toolsUsage) {
+    if (!usage.output) continue;
+
+    // toolsUsage.output is safeStringify'd — unwrap if it's a JSON string
+    let output = usage.output;
+    if (output.startsWith('"') && output.endsWith('"')) {
+      try {
+        const parsed: unknown = JSON.parse(output);
+        if (typeof parsed === 'string') {
+          output = parsed;
+        }
+      } catch {
+        // use as-is
+      }
+    }
+
+    if (usage.toolName === 'rag_search') {
+      const ragCitations = parseRagCitations(output);
+      for (const [num, citation] of ragCitations) {
+        allCitations.set(num, citation);
+        if (num > maxNumber) maxNumber = num;
+      }
+    } else if (usage.toolName === 'web') {
+      const webCitations = parseWebCitations(output);
+      for (const [originalNum, citation] of webCitations) {
+        const offsetNum = originalNum + maxNumber;
+        allCitations.set(offsetNum, { ...citation, number: offsetNum });
+      }
+    }
+  }
+
+  return allCitations;
+}
+
+/**
+ * Legacy parser for backward compatibility with contextText.
+ */
+export function parseCitations(contextText: string): Map<number, CitationInfo> {
+  return parseRagCitations(contextText);
+}
+
+/**
+ * Deduplicate citations by source identity (fileId or url).
+ * Keeps the first occurrence of each unique source and builds a
+ * number remapping so inline [N] markers still resolve correctly.
+ */
+function deduplicateCitations(
+  citations: Map<number, CitationInfo>,
+): Map<number, CitationInfo> {
+  const seen = new Map<string, number>(); // sourceKey → kept citation number
+  const deduped = new Map<number, CitationInfo>();
+
+  for (const [num, citation] of citations) {
+    const sourceKey =
+      citation.type === 'rag'
+        ? `rag:${citation.fileId ?? ''}:${citation.page ?? ''}`
+        : `web:${citation.url ?? ''}`;
+
+    const existingNum = seen.get(sourceKey);
+    if (existingNum !== undefined) {
+      // Map this duplicate number to the existing citation
+      const existing = deduped.get(existingNum);
+      if (existing) deduped.set(num, existing);
+    } else {
+      seen.set(sourceKey, num);
+      deduped.set(num, citation);
+    }
+  }
+
+  return deduped;
+}
+
+/**
+ * Get unique citations for display in source cards (no duplicates).
+ */
+export function getUniqueCitations(
+  citations: Map<number, CitationInfo>,
+): CitationInfo[] {
+  const seen = new Set<string>();
+  const unique: CitationInfo[] = [];
+
+  for (const citation of citations.values()) {
+    const sourceKey =
+      citation.type === 'rag'
+        ? `rag:${citation.fileId ?? ''}:${citation.page ?? ''}`
+        : `web:${citation.url ?? ''}`;
+
+    if (!seen.has(sourceKey)) {
+      seen.add(sourceKey);
+      unique.push(citation);
+    }
+  }
+
+  return unique.sort((a, b) => a.number - b.number);
+}
+
+/**
+ * Hook that provides citation lookup from message metadata.
+ *
+ * Prefers structured tool usage data when available, falling back
+ * to raw context text for older messages.
+ */
+export function useCitations(
+  toolsUsage?: ToolUsageInput[],
+  contextText?: string,
+) {
+  const citations = useMemo(() => {
+    let raw: Map<number, CitationInfo>;
+    if (toolsUsage && toolsUsage.length > 0) {
+      raw = parseCitationsFromToolsUsage(toolsUsage);
+    } else if (contextText) {
+      raw = parseCitations(contextText);
+    } else {
+      return new Map<number, CitationInfo>();
+    }
+    return deduplicateCitations(raw);
+  }, [toolsUsage, contextText]);
 
   return { citations, hasCitations: citations.size > 0 };
 }

--- a/services/platform/app/features/chat/utils/inject-citation-tags.ts
+++ b/services/platform/app/features/chat/utils/inject-citation-tags.ts
@@ -1,0 +1,23 @@
+/**
+ * Replace `[N]` patterns in markdown text with `<cite>` HTML tags
+ * for known citation numbers only.
+ *
+ * The allowlist approach prevents false positives — only numbers
+ * that correspond to actual parsed citations are replaced.
+ * Markdown link references like `[1]: url` have a colon after
+ * the bracket, so they won't match the in-text pattern.
+ */
+export function injectCitationTags(
+  text: string,
+  citationNumbers: Set<number>,
+): string {
+  if (citationNumbers.size === 0) return text;
+
+  return text.replace(/\[(\d+)\]/g, (match, num: string) => {
+    const n = parseInt(num, 10);
+    if (citationNumbers.has(n)) {
+      return `<cite data-n="${n}"></cite>`;
+    }
+    return match;
+  });
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -98,6 +98,7 @@ import type * as agent_tools_tool_registry from "../agent_tools/tool_registry.js
 import type * as agent_tools_types from "../agent_tools/types.js";
 import type * as agent_tools_web_helpers_browser_operate from "../agent_tools/web/helpers/browser_operate.js";
 import type * as agent_tools_web_helpers_fetch_and_extract from "../agent_tools/web/helpers/fetch_and_extract.js";
+import type * as agent_tools_web_helpers_format_web_results from "../agent_tools/web/helpers/format_web_results.js";
 import type * as agent_tools_web_helpers_get_crawler_service_url from "../agent_tools/web/helpers/get_crawler_service_url.js";
 import type * as agent_tools_web_helpers_get_operator_service_url from "../agent_tools/web/helpers/get_operator_service_url.js";
 import type * as agent_tools_web_helpers_query_web_context from "../agent_tools/web/helpers/query_web_context.js";
@@ -276,6 +277,7 @@ import type * as file_metadata_helpers from "../file_metadata/helpers.js";
 import type * as file_metadata_internal_mutations from "../file_metadata/internal_mutations.js";
 import type * as file_metadata_internal_queries from "../file_metadata/internal_queries.js";
 import type * as file_metadata_mutations from "../file_metadata/mutations.js";
+import type * as file_metadata_queries from "../file_metadata/queries.js";
 import type * as files_mutations from "../files/mutations.js";
 import type * as files_queries from "../files/queries.js";
 import type * as folders_get_or_create_path from "../folders/get_or_create_path.js";
@@ -1006,6 +1008,7 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/types": typeof agent_tools_types;
   "agent_tools/web/helpers/browser_operate": typeof agent_tools_web_helpers_browser_operate;
   "agent_tools/web/helpers/fetch_and_extract": typeof agent_tools_web_helpers_fetch_and_extract;
+  "agent_tools/web/helpers/format_web_results": typeof agent_tools_web_helpers_format_web_results;
   "agent_tools/web/helpers/get_crawler_service_url": typeof agent_tools_web_helpers_get_crawler_service_url;
   "agent_tools/web/helpers/get_operator_service_url": typeof agent_tools_web_helpers_get_operator_service_url;
   "agent_tools/web/helpers/query_web_context": typeof agent_tools_web_helpers_query_web_context;
@@ -1184,6 +1187,7 @@ declare const fullApi: ApiFromModules<{
   "file_metadata/internal_mutations": typeof file_metadata_internal_mutations;
   "file_metadata/internal_queries": typeof file_metadata_internal_queries;
   "file_metadata/mutations": typeof file_metadata_mutations;
+  "file_metadata/queries": typeof file_metadata_queries;
   "files/mutations": typeof files_mutations;
   "files/queries": typeof files_queries;
   "folders/get_or_create_path": typeof folders_get_or_create_path;

--- a/services/platform/convex/agent_tools/web/helpers/format_web_results.ts
+++ b/services/platform/convex/agent_tools/web/helpers/format_web_results.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared formatting for web search results.
+ *
+ * Used by search_pages (tool mode) and query_web_context (context injection)
+ * to produce a consistent numbered-chunk format matching RAG output style.
+ */
+
+export interface WebSearchPage {
+  title: string;
+  url: string;
+  score: number;
+  content: string;
+}
+
+/**
+ * Format web search pages into a numbered list with relevance scores.
+ *
+ * Example output:
+ * ```
+ * [1] (Relevance: 85.2%) [Source: Page Title] [URL: https://example.com]
+ * <content>
+ *
+ * ---
+ *
+ * [2] (Relevance: 72.1%) [Source: Another Page] [URL: https://example.com/other]
+ * <content>
+ * ```
+ *
+ * Returns `undefined` when there are no pages.
+ */
+export function formatWebResults(pages: WebSearchPage[]): string | undefined {
+  if (pages.length === 0) return undefined;
+
+  return pages
+    .map((page, idx) => {
+      const score = (page.score * 100).toFixed(1);
+      return `[${idx + 1}] (Relevance: ${score}%) [Source: ${page.title}] [URL: ${page.url}]\n${page.content}`;
+    })
+    .join('\n\n---\n\n');
+}

--- a/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
+++ b/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
@@ -10,6 +10,7 @@
 
 import type { ActionCtx } from '../../../_generated/server';
 import { createDebugLog } from '../../../lib/debug_log';
+import { formatWebResults } from './format_web_results';
 import { getCrawlerServiceUrl } from './get_crawler_service_url';
 
 const debugLog = createDebugLog('DEBUG_WEB_CONTEXT', '[WebContext]');
@@ -88,24 +89,20 @@ export async function queryWebContext(
         byUrl.set(result.url, existing);
       }
 
-      const formatted = Array.from(byUrl.entries())
+      const pages = Array.from(byUrl.entries())
         .map(([url, chunks]) => {
           const bestScore = Math.max(...chunks.map((c) => c.score));
           const title = chunks[0].title ?? url;
-          const contentParts = chunks
+          const content = chunks
             .sort((a, b) => a.chunk_index - b.chunk_index)
             .map((c) => c.chunk_content)
             .join('\n\n');
 
-          return {
-            text: `**${title}**\nURL: ${url}\nRelevance: ${(bestScore * 100).toFixed(1)}%\n\n${contentParts}`,
-            score: bestScore,
-          };
+          return { title, url, score: bestScore, content };
         })
-        .sort((a, b) => b.score - a.score)
-        .map((r) => r.text);
+        .sort((a, b) => b.score - a.score);
 
-      const webContext = formatted.join('\n\n---\n\n');
+      const webContext = formatWebResults(pages) ?? '';
 
       debugLog('Web context retrieved', {
         resultCount: results.length,

--- a/services/platform/convex/agent_tools/web/helpers/search_pages.ts
+++ b/services/platform/convex/agent_tools/web/helpers/search_pages.ts
@@ -9,6 +9,7 @@ import type { ToolCtx } from '@convex-dev/agent';
 
 import { internal } from '../../../_generated/api';
 import { createDebugLog } from '../../../lib/debug_log';
+import { formatWebResults } from './format_web_results';
 import { getCrawlerServiceUrl } from './get_crawler_service_url';
 
 const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
@@ -119,24 +120,20 @@ export async function searchPages(
     byUrl.set(result.url, existing);
   }
 
-  const formatted = Array.from(byUrl.entries())
+  const pages = Array.from(byUrl.entries())
     .map(([url, chunks]) => {
       const bestScore = Math.max(...chunks.map((c) => c.score));
       const title = chunks[0].title ?? url;
-      const contentParts = chunks
+      const content = chunks
         .sort((a, b) => a.chunk_index - b.chunk_index)
         .map((c) => c.chunk_content)
         .join('\n\n');
 
-      return {
-        text: `**${title}**\nURL: ${url}\nRelevance: ${(bestScore * 100).toFixed(1)}%\n\n${contentParts}`,
-        score: bestScore,
-      };
+      return { title, url, score: bestScore, content };
     })
-    .sort((a, b) => b.score - a.score)
-    .map((r) => r.text);
+    .sort((a, b) => b.score - a.score);
 
-  const output = formatted.join('\n\n---\n\n');
+  const output = formatWebResults(pages) ?? '';
 
   if (domainFallback) {
     return `No results found on ${validDomain}. Showing results from all indexed websites:\n\n${output}`;

--- a/services/platform/convex/file_metadata/queries.ts
+++ b/services/platform/convex/file_metadata/queries.ts
@@ -1,0 +1,42 @@
+import { v } from 'convex/values';
+
+import { query } from '../_generated/server';
+import { getAuthUserIdentity } from '../lib/rls';
+
+export const getByStorageIds = query({
+  args: {
+    storageIds: v.array(v.id('_storage')),
+  },
+  returns: v.array(
+    v.object({
+      storageId: v.id('_storage'),
+      documentId: v.optional(v.id('documents')),
+      fileName: v.string(),
+      contentType: v.string(),
+      size: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return [];
+
+    const results = await Promise.all(
+      args.storageIds.slice(0, 20).map(async (storageId) => {
+        const meta = await ctx.db
+          .query('fileMetadata')
+          .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
+          .first();
+        if (!meta) return null;
+        return {
+          storageId: meta.storageId,
+          documentId: meta.documentId,
+          fileName: meta.fileName,
+          contentType: meta.contentType,
+          size: meta.size,
+        };
+      }),
+    );
+
+    return results.filter((r) => r !== null);
+  },
+});

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2720,7 +2720,10 @@
       "source": "Source {number}",
       "page": "Page {page}",
       "relevance": "Relevance: {score}%",
-      "viewDocument": "View in document"
+      "viewDocument": "View in document",
+      "visitPage": "Visit page",
+      "showAllSources": "Show all {count} sources",
+      "hideSources": "Hide sources"
     },
     "feedback": {
       "helpful": "Helpful",


### PR DESCRIPTION
## Summary

- Display source citations inline within message text as clickable `[N]` badges with hover popovers
- Show a source card list below the message bubble with document/web source details
- RAG document cards open the document preview dialog; web source cards open URLs in new tabs
- Deduplicate citations by source identity (fileId+page for RAG, URL for web)

Closes #1187

## Changes

**Backend:**
- Add numbered format to web search results (`format_web_results.ts`) consistent with RAG format
- Update `search_pages.ts` and `query_web_context.ts` to use shared formatter
- Add `file_metadata/queries.ts` public query to resolve storageId → documentId

**Frontend:**
- Extend `CitationInfo` type and `useCitations` hook to parse citations from `toolsUsage` records
- Create `CitationsContext` and `<cite>` markdown component for inline citation rendering
- Create `SourceCards` component with collapse/expand for >3 sources
- Update `CitationLink` to support both RAG (document preview) and web (external URL) citations
- Wire everything in `MessageBubble` with citation tag injection and context provider

## Test plan

- [ ] Ask a question that triggers RAG search → verify inline `[1]` badges with popover + source cards below message
- [ ] Click a RAG source card → verify document preview dialog opens
- [ ] Ask a question that triggers web search → verify inline badges + source cards with URL/title
- [ ] Click a web source card → verify URL opens in new tab
- [ ] Verify no errors during streaming; citations + cards appear after completion
- [ ] Verify >3 sources shows "Show all N sources" collapse toggle
- [ ] Verify duplicate sources are deduplicated in source cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat messages now display inline citations linking to web pages and documents
  * Source cards appear below messages displaying all citation sources with an expand/collapse toggle
  * Web citations open directly in new tabs; document citations navigate to relevant pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->