### PR TITLE
feat(platform): add REST API with OpenAPI spec and API key auth

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 import { VStack, Center } from '@/app/components/ui/layout/layout';
 import { Text } from '@/app/components/ui/typography/text';
@@ -8,8 +8,8 @@ export interface DataTableEmptyStateProps {
   icon?: ComponentType<{ className?: string }>;
   /** Title text */
   title: string;
-  /** Description text */
-  description?: string;
+  /** Description text or rich content */
+  description?: ReactNode;
 }
 
 /**

--- a/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { Key } from 'lucide-react';
+import { BookOpen, Key } from 'lucide-react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Stack } from '@/app/components/ui/layout/layout';
+import { buttonVariants } from '@/app/components/ui/primitives/button';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
@@ -13,6 +15,24 @@ import { ApiKeysActionMenu } from './api-keys-action-menu';
 interface ApiKeysTableProps {
   apiKeys: ApiKey[] | undefined;
   organizationId: string;
+}
+
+function ApiDocsLink() {
+  const { t: tSettings } = useT('settings');
+
+  return (
+    <div className="flex justify-center py-4">
+      <a
+        href="/docs"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={buttonVariants({ variant: 'outline', size: 'sm' })}
+      >
+        <BookOpen className="mr-2 size-4" />
+        {tSettings('apiDocs.openDocs')}
+      </a>
+    </div>
+  );
 }
 
 export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
@@ -30,17 +50,27 @@ export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
     entityLabel: tSettings('apiKeys.entityLabel'),
   });
 
+  const hasKeys = apiKeys && apiKeys.length > 0;
+
   return (
-    <DataTable
-      columns={columns}
-      stickyLayout={stickyLayout}
-      actionMenu={<ApiKeysActionMenu organizationId={organizationId} />}
-      emptyState={{
-        icon: Key,
-        title: tEmpty('apiKeys.title'),
-        description: tEmpty('apiKeys.description'),
-      }}
-      {...list.tableProps}
-    />
+    <Stack gap={0}>
+      <DataTable
+        columns={columns}
+        stickyLayout={stickyLayout}
+        actionMenu={<ApiKeysActionMenu organizationId={organizationId} />}
+        emptyState={{
+          icon: Key,
+          title: tEmpty('apiKeys.title'),
+          description: (
+            <>
+              {tEmpty('apiKeys.description')}
+              <ApiDocsLink />
+            </>
+          ),
+        }}
+        {...list.tableProps}
+      />
+      {hasKeys && <ApiDocsLink />}
+    </Stack>
   );
 }

--- a/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
@@ -26,7 +26,7 @@ function ApiDocsLink() {
         href="/docs"
         target="_blank"
         rel="noopener noreferrer"
-        className={buttonVariants({ variant: 'outline', size: 'sm' })}
+        className={buttonVariants({ variant: 'secondary', size: 'sm' })}
       >
         <BookOpen className="mr-2 size-4" />
         {tSettings('apiDocs.openDocs')}

--- a/services/platform/app/routes/docs.tsx
+++ b/services/platform/app/routes/docs.tsx
@@ -45,6 +45,9 @@ function ApiDocsPage() {
       showCommonExtensions: true,
       tryItOutEnabled: true,
       persistAuthorization: true,
+      deepLinking: true,
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
       requestInterceptor: (req: Record<string, unknown>) => {
         if (typeof req.url === 'string' && req.url.includes('/api/')) {
           req.credentials = 'include';

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -130,6 +130,7 @@ import type * as agents_internal_queries from "../agents/internal_queries.js";
 import type * as agents_legacy_schema from "../agents/legacy_schema.js";
 import type * as agents_mutations from "../agents/mutations.js";
 import type * as agents_queries from "../agents/queries.js";
+import type * as agents_rest_api from "../agents/rest_api.js";
 import type * as agents_seed_system_defaults from "../agents/seed_system_defaults.js";
 import type * as agents_start_chat from "../agents/start_chat.js";
 import type * as agents_translate_fields from "../agents/translate_fields.js";
@@ -219,6 +220,7 @@ import type * as customers_list_customers_paginated from "../customers/list_cust
 import type * as customers_mutations from "../customers/mutations.js";
 import type * as customers_queries from "../customers/queries.js";
 import type * as customers_query_customers from "../customers/query_customers.js";
+import type * as customers_rest_api from "../customers/rest_api.js";
 import type * as customers_search_customers from "../customers/search_customers.js";
 import type * as customers_types from "../customers/types.js";
 import type * as customers_update_customer from "../customers/update_customer.js";
@@ -263,6 +265,7 @@ import type * as documents_mutations from "../documents/mutations.js";
 import type * as documents_queries from "../documents/queries.js";
 import type * as documents_query_documents from "../documents/query_documents.js";
 import type * as documents_read_file_base64_from_storage from "../documents/read_file_base64_from_storage.js";
+import type * as documents_rest_api from "../documents/rest_api.js";
 import type * as documents_team_fields from "../documents/team_fields.js";
 import type * as documents_transform_to_document_item from "../documents/transform_to_document_item.js";
 import type * as documents_types from "../documents/types.js";
@@ -408,6 +411,7 @@ import type * as lib_response_cache_internal_queries from "../lib/response_cache
 import type * as lib_response_cache_normalize from "../lib/response_cache/normalize.js";
 import type * as lib_response_cache_semantic_cache from "../lib/response_cache/semantic_cache.js";
 import type * as lib_response_cache_tool_cacheability from "../lib/response_cache/tool_cacheability.js";
+import type * as lib_rest_helpers from "../lib/rest/helpers.js";
 import type * as lib_rls_auth_get_auth_user_identity from "../lib/rls/auth/get_auth_user_identity.js";
 import type * as lib_rls_auth_get_authenticated_user from "../lib/rls/auth/get_authenticated_user.js";
 import type * as lib_rls_auth_get_trusted_auth_data from "../lib/rls/auth/get_trusted_auth_data.js";
@@ -553,6 +557,7 @@ import type * as products_list_products_paginated from "../products/list_product
 import type * as products_mutations from "../products/mutations.js";
 import type * as products_queries from "../products/queries.js";
 import type * as products_query_products from "../products/query_products.js";
+import type * as products_rest_api from "../products/rest_api.js";
 import type * as products_search_products_by_metadata from "../products/search_products_by_metadata.js";
 import type * as products_types from "../products/types.js";
 import type * as products_update_product from "../products/update_product.js";
@@ -636,6 +641,7 @@ import type * as threads_list_archived_threads from "../threads/list_archived_th
 import type * as threads_list_threads from "../threads/list_threads.js";
 import type * as threads_mutations from "../threads/mutations.js";
 import type * as threads_queries from "../threads/queries.js";
+import type * as threads_rest_api from "../threads/rest_api.js";
 import type * as threads_share_thread from "../threads/share_thread.js";
 import type * as threads_types from "../threads/types.js";
 import type * as threads_update_chat_thread from "../threads/update_chat_thread.js";
@@ -657,9 +663,12 @@ import type * as users_update_user_name from "../users/update_user_name.js";
 import type * as users_update_user_password from "../users/update_user_password.js";
 import type * as users_validators from "../users/validators.js";
 import type * as vendors_helpers from "../vendors/helpers.js";
+import type * as vendors_internal_mutations from "../vendors/internal_mutations.js";
+import type * as vendors_internal_queries from "../vendors/internal_queries.js";
 import type * as vendors_list_vendors_paginated from "../vendors/list_vendors_paginated.js";
 import type * as vendors_mutations from "../vendors/mutations.js";
 import type * as vendors_queries from "../vendors/queries.js";
+import type * as vendors_rest_api from "../vendors/rest_api.js";
 import type * as vendors_validators from "../vendors/validators.js";
 import type * as websites_actions from "../websites/actions.js";
 import type * as websites_bulk_create_websites from "../websites/bulk_create_websites.js";
@@ -675,6 +684,7 @@ import type * as websites_internal_queries from "../websites/internal_queries.js
 import type * as websites_list_websites_paginated from "../websites/list_websites_paginated.js";
 import type * as websites_mutations from "../websites/mutations.js";
 import type * as websites_queries from "../websites/queries.js";
+import type * as websites_rest_api from "../websites/rest_api.js";
 import type * as websites_search_websites from "../websites/search_websites.js";
 import type * as websites_types from "../websites/types.js";
 import type * as websites_update_website from "../websites/update_website.js";
@@ -899,6 +909,7 @@ import type * as workflows_processing_records_record_claimed from "../workflows/
 import type * as workflows_processing_records_record_processed from "../workflows/processing_records/record_processed.js";
 import type * as workflows_processing_records_run_query from "../workflows/processing_records/run_query.js";
 import type * as workflows_processing_records_types from "../workflows/processing_records/types.js";
+import type * as workflows_rest_api from "../workflows/rest_api.js";
 import type * as workflows_triggers_actions from "../workflows/triggers/actions.js";
 import type * as workflows_triggers_api_http from "../workflows/triggers/api_http.js";
 import type * as workflows_triggers_emit_event from "../workflows/triggers/emit_event.js";
@@ -1042,6 +1053,7 @@ declare const fullApi: ApiFromModules<{
   "agents/legacy_schema": typeof agents_legacy_schema;
   "agents/mutations": typeof agents_mutations;
   "agents/queries": typeof agents_queries;
+  "agents/rest_api": typeof agents_rest_api;
   "agents/seed_system_defaults": typeof agents_seed_system_defaults;
   "agents/start_chat": typeof agents_start_chat;
   "agents/translate_fields": typeof agents_translate_fields;
@@ -1131,6 +1143,7 @@ declare const fullApi: ApiFromModules<{
   "customers/mutations": typeof customers_mutations;
   "customers/queries": typeof customers_queries;
   "customers/query_customers": typeof customers_query_customers;
+  "customers/rest_api": typeof customers_rest_api;
   "customers/search_customers": typeof customers_search_customers;
   "customers/types": typeof customers_types;
   "customers/update_customer": typeof customers_update_customer;
@@ -1175,6 +1188,7 @@ declare const fullApi: ApiFromModules<{
   "documents/queries": typeof documents_queries;
   "documents/query_documents": typeof documents_query_documents;
   "documents/read_file_base64_from_storage": typeof documents_read_file_base64_from_storage;
+  "documents/rest_api": typeof documents_rest_api;
   "documents/team_fields": typeof documents_team_fields;
   "documents/transform_to_document_item": typeof documents_transform_to_document_item;
   "documents/types": typeof documents_types;
@@ -1320,6 +1334,7 @@ declare const fullApi: ApiFromModules<{
   "lib/response_cache/normalize": typeof lib_response_cache_normalize;
   "lib/response_cache/semantic_cache": typeof lib_response_cache_semantic_cache;
   "lib/response_cache/tool_cacheability": typeof lib_response_cache_tool_cacheability;
+  "lib/rest/helpers": typeof lib_rest_helpers;
   "lib/rls/auth/get_auth_user_identity": typeof lib_rls_auth_get_auth_user_identity;
   "lib/rls/auth/get_authenticated_user": typeof lib_rls_auth_get_authenticated_user;
   "lib/rls/auth/get_trusted_auth_data": typeof lib_rls_auth_get_trusted_auth_data;
@@ -1465,6 +1480,7 @@ declare const fullApi: ApiFromModules<{
   "products/mutations": typeof products_mutations;
   "products/queries": typeof products_queries;
   "products/query_products": typeof products_query_products;
+  "products/rest_api": typeof products_rest_api;
   "products/search_products_by_metadata": typeof products_search_products_by_metadata;
   "products/types": typeof products_types;
   "products/update_product": typeof products_update_product;
@@ -1548,6 +1564,7 @@ declare const fullApi: ApiFromModules<{
   "threads/list_threads": typeof threads_list_threads;
   "threads/mutations": typeof threads_mutations;
   "threads/queries": typeof threads_queries;
+  "threads/rest_api": typeof threads_rest_api;
   "threads/share_thread": typeof threads_share_thread;
   "threads/types": typeof threads_types;
   "threads/update_chat_thread": typeof threads_update_chat_thread;
@@ -1569,9 +1586,12 @@ declare const fullApi: ApiFromModules<{
   "users/update_user_password": typeof users_update_user_password;
   "users/validators": typeof users_validators;
   "vendors/helpers": typeof vendors_helpers;
+  "vendors/internal_mutations": typeof vendors_internal_mutations;
+  "vendors/internal_queries": typeof vendors_internal_queries;
   "vendors/list_vendors_paginated": typeof vendors_list_vendors_paginated;
   "vendors/mutations": typeof vendors_mutations;
   "vendors/queries": typeof vendors_queries;
+  "vendors/rest_api": typeof vendors_rest_api;
   "vendors/validators": typeof vendors_validators;
   "websites/actions": typeof websites_actions;
   "websites/bulk_create_websites": typeof websites_bulk_create_websites;
@@ -1587,6 +1607,7 @@ declare const fullApi: ApiFromModules<{
   "websites/list_websites_paginated": typeof websites_list_websites_paginated;
   "websites/mutations": typeof websites_mutations;
   "websites/queries": typeof websites_queries;
+  "websites/rest_api": typeof websites_rest_api;
   "websites/search_websites": typeof websites_search_websites;
   "websites/types": typeof websites_types;
   "websites/update_website": typeof websites_update_website;
@@ -1811,6 +1832,7 @@ declare const fullApi: ApiFromModules<{
   "workflows/processing_records/record_processed": typeof workflows_processing_records_record_processed;
   "workflows/processing_records/run_query": typeof workflows_processing_records_run_query;
   "workflows/processing_records/types": typeof workflows_processing_records_types;
+  "workflows/rest_api": typeof workflows_rest_api;
   "workflows/triggers/actions": typeof workflows_triggers_actions;
   "workflows/triggers/api_http": typeof workflows_triggers_api_http;
   "workflows/triggers/emit_event": typeof workflows_triggers_emit_event;

--- a/services/platform/convex/agents/internal_actions.ts
+++ b/services/platform/convex/agents/internal_actions.ts
@@ -1,14 +1,26 @@
 'use node';
 
+import { readdir } from 'node:fs/promises';
+
 import { v } from 'convex/values';
 
 import { isRecord, getString } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
 import { getPollingInterval } from '../documents/internal_actions';
+import { readJsonFile } from '../lib/file_io';
 import { getRagConfig } from '../lib/helpers/rag_config';
 import { deleteDocumentById } from '../workflow_engine/action_defs/rag/helpers/delete_document';
 import { uploadDocument } from '../workflow_engine/action_defs/rag/helpers/upload_document';
+import type { AgentJsonConfig, AgentReadResult } from './file_utils';
+import {
+  MAX_FILE_SIZE_BYTES,
+  agentNameFromFileName,
+  parseAgentJson,
+  resolveAgentFilePath,
+  resolveAgentsDir,
+  validateAgentName,
+} from './file_utils';
 
 const INITIAL_POLLING_DELAY_MS = 10_000;
 const MAX_POLLING_ATTEMPTS = 50;
@@ -242,5 +254,84 @@ export const deleteKnowledgeFileFromRag = internalAction({
     }
 
     return null;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// REST API helpers — internal actions for listing/reading agent configs
+// ---------------------------------------------------------------------------
+
+async function readAgentFileInternal(
+  orgSlug: string,
+  agentName: string,
+): Promise<AgentReadResult> {
+  const filePath = resolveAgentFilePath(orgSlug, agentName);
+  const result = await readJsonFile<AgentJsonConfig>(
+    filePath,
+    MAX_FILE_SIZE_BYTES,
+    parseAgentJson,
+  );
+  if (result.ok) {
+    return { ok: true, config: result.data, hash: result.hash };
+  }
+  return result;
+}
+
+export const listAgentsInternal = internalAction({
+  args: {
+    orgSlug: v.string(),
+  },
+  returns: v.any(),
+  handler: async (_ctx, args) => {
+    const dir = resolveAgentsDir(args.orgSlug);
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return [];
+    }
+
+    const jsonFiles = entries.filter(
+      (e) => e.endsWith('.json') && !e.startsWith('.'),
+    );
+
+    const results = await Promise.all(
+      jsonFiles.map(async (fileName) => {
+        const agentName = agentNameFromFileName(fileName);
+        if (!validateAgentName(agentName)) return null;
+        const result = await readAgentFileInternal(args.orgSlug, agentName);
+        if (result.ok) {
+          return {
+            name: agentName,
+            displayName: result.config.displayName,
+            description: result.config.description,
+            visibleInChat: result.config.visibleInChat,
+            supportedModels: result.config.supportedModels,
+            toolNames: result.config.toolNames,
+            roleRestriction: result.config.roleRestriction,
+            conversationStarters: result.config.conversationStarters,
+            i18n: result.config.i18n,
+          };
+        }
+        return {
+          name: agentName,
+          status: result.error,
+          message: result.message,
+        };
+      }),
+    );
+
+    return results.filter(Boolean);
+  },
+});
+
+export const readAgentInternal = internalAction({
+  args: {
+    orgSlug: v.string(),
+    agentName: v.string(),
+  },
+  returns: v.any(),
+  handler: async (_ctx, args) => {
+    return readAgentFileInternal(args.orgSlug, args.agentName);
   },
 });

--- a/services/platform/convex/agents/internal_queries.ts
+++ b/services/platform/convex/agents/internal_queries.ts
@@ -25,3 +25,32 @@ export const getBindingByAgent = internalQuery({
       .first();
   },
 });
+
+export const getAvailableIntegrations = internalQuery({
+  args: {
+    organizationId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<Array<{ name: string; title: string; type: string }>> => {
+    const integrations: Array<{ name: string; title: string; type: string }> =
+      [];
+    const credentialQuery = ctx.db
+      .query('integrationCredentials')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', args.organizationId),
+      );
+
+    for await (const cred of credentialQuery) {
+      if (cred.status !== 'active') continue;
+      integrations.push({
+        name: cred.slug,
+        title: cred.slug,
+        type: cred.sqlConnectionConfig ? 'sql' : 'rest_api',
+      });
+    }
+
+    return integrations;
+  },
+});

--- a/services/platform/convex/agents/rest_api.ts
+++ b/services/platform/convex/agents/rest_api.ts
@@ -1,0 +1,88 @@
+/**
+ * Agents REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/agents              — List agents
+ *   GET    /api/v1/agents/tools        — List available tools
+ *   GET    /api/v1/agents/integrations — List available integrations
+ *   GET    /api/v1/agents/:slug        — Get agent config + binding
+ *   PATCH  /api/v1/agents/:slug        — Update agent binding (team assignment)
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  withRestAuth,
+} from '../lib/rest/helpers';
+
+const PREFIX = '/api/v1/agents/';
+
+export const listAgents = withRestAuth('rest:api', async (rc) => {
+  const agents = await rc.ctx.runAction(
+    internal.agents.internal_actions.listAgentsInternal,
+    { orgSlug: rc.org.orgSlug },
+  );
+
+  return jsonOk(agents);
+});
+
+export const getAgent = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: slug, subPath } = extractPathParts(url, PREFIX);
+
+  if (!slug) {
+    return jsonError('Missing agent slug', 400);
+  }
+
+  // Handle special sub-paths at the collection level
+  if (slug === 'tools' && !subPath) {
+    const { TOOL_NAMES } = await import('../agent_tools/tool_names');
+    return jsonOk(
+      TOOL_NAMES.map((name: string) => ({ name, available: true })),
+    );
+  }
+
+  if (slug === 'integrations' && !subPath) {
+    const integrations = await rc.ctx.runQuery(
+      internal.agents.internal_queries.getAvailableIntegrations,
+      { organizationId: rc.org.organizationId },
+    );
+    return jsonOk(integrations);
+  }
+
+  // Get agent config from filesystem
+  const agentConfig = await rc.ctx.runAction(
+    internal.agents.internal_actions.readAgentInternal,
+    { orgSlug: rc.org.orgSlug, agentName: slug },
+  );
+
+  // Get binding from DB
+  const binding = await rc.ctx.runQuery(
+    internal.agents.internal_queries.getBindingByAgent,
+    { organizationId: rc.org.organizationId, agentSlug: slug },
+  );
+
+  return jsonOk({ config: agentConfig, binding });
+});
+
+export const patchAgent = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: slug } = extractPathParts(url, PREFIX);
+
+  if (!slug) {
+    return jsonError('Missing agent slug', 400);
+  }
+
+  const body = await request.json();
+
+  await rc.ctx.runMutation(internal.agents.mutations.upsertBinding, {
+    organizationId: rc.org.organizationId,
+    agentSlug: slug,
+    teamId: body.teamId,
+  });
+
+  return jsonNoContent();
+});

--- a/services/platform/convex/customers/internal_mutations.ts
+++ b/services/platform/convex/customers/internal_mutations.ts
@@ -2,11 +2,15 @@ import { v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
+import { bulkCreateCustomers as bulkCreateCustomersHelper } from './bulk_create_customers';
+import { deleteCustomer as deleteCustomerHelper } from './delete_customer';
 import * as CustomersHelpers from './helpers';
+import { updateCustomer as updateCustomerHelper } from './update_customer';
 import {
   customerAddressValidator,
   customerSourceValidator,
   customerStatusValidator,
+  customerValidator,
 } from './validators';
 
 export const createCustomer = internalMutation({
@@ -45,6 +49,71 @@ export const findOrCreateCustomer = internalMutation({
   }),
   handler: async (ctx, args) => {
     return await CustomersHelpers.findOrCreateCustomer(ctx, args);
+  },
+});
+
+export const updateCustomer = internalMutation({
+  args: {
+    customerId: v.id('customers'),
+    name: v.optional(v.string()),
+    email: v.optional(v.string()),
+    externalId: v.optional(v.string()),
+    status: v.optional(customerStatusValidator),
+    source: v.optional(customerSourceValidator),
+    locale: v.optional(v.string()),
+    address: v.optional(customerAddressValidator),
+    metadata: v.optional(jsonRecordValidator),
+  },
+  returns: v.union(customerValidator, v.null()),
+  handler: async (ctx, args) => {
+    return await updateCustomerHelper(ctx, args);
+  },
+});
+
+export const deleteCustomer = internalMutation({
+  args: {
+    customerId: v.id('customers'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    return await deleteCustomerHelper(ctx, args.customerId);
+  },
+});
+
+export const bulkCreateCustomers = internalMutation({
+  args: {
+    organizationId: v.string(),
+    customers: v.array(
+      v.object({
+        name: v.optional(v.string()),
+        email: v.string(),
+        externalId: v.optional(v.string()),
+        status: customerStatusValidator,
+        source: customerSourceValidator,
+        locale: v.optional(v.string()),
+        address: v.optional(customerAddressValidator),
+        metadata: v.optional(jsonRecordValidator),
+      }),
+    ),
+  },
+  returns: v.object({
+    success: v.number(),
+    failed: v.number(),
+    errors: v.array(
+      v.object({
+        index: v.number(),
+        error: v.string(),
+        errorCode: v.string(),
+        customer: v.any(),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    return await bulkCreateCustomersHelper(
+      ctx,
+      args.organizationId,
+      args.customers,
+    );
   },
 });
 

--- a/services/platform/convex/customers/rest_api.ts
+++ b/services/platform/convex/customers/rest_api.ts
@@ -25,133 +25,118 @@ import { toId } from '../lib/type_cast_helpers';
 
 const PREFIX = '/api/v1/customers/';
 
-export const listCustomers = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const cursor = url.searchParams.get('cursor') ?? null;
-    const limit = parseIntParam(url, 'limit', 25);
-    const status = url.searchParams.get('status') ?? undefined;
-    const source = url.searchParams.get('source') ?? undefined;
-    const locale = url.searchParams.get('locale') ?? undefined;
+export const listCustomers = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const status = url.searchParams.get('status') ?? undefined;
+  const source = url.searchParams.get('source') ?? undefined;
+  const locale = url.searchParams.get('locale') ?? undefined;
 
-    const result = await rc.ctx.runQuery(
-      internal.customers.internal_queries.queryCustomers,
-      {
-        organizationId: rc.org.organizationId,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
-        status: status as 'active' | 'churned' | 'potential' | undefined,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
-        source: source as DataSource | undefined,
-        locale: locale ? [locale] : undefined,
-        paginationOpts: { numItems: limit, cursor },
-      },
-    );
+  const result = await rc.ctx.runQuery(
+    internal.customers.internal_queries.queryCustomers,
+    {
+      organizationId: rc.org.organizationId,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+      status: status as 'active' | 'churned' | 'potential' | undefined,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+      source: source as DataSource | undefined,
+      locale: locale ? [locale] : undefined,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
 
-    return jsonOk(result);
-  },
-);
+  return jsonOk(result);
+});
 
-export const createCustomer = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const body = await request.json();
+export const createCustomer = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
 
-    const result = await rc.ctx.runMutation(
-      internal.customers.internal_mutations.createCustomer,
-      {
-        organizationId: rc.org.organizationId,
-        name: body.name,
-        email: body.email,
-        status: body.status,
-        source: body.source,
-        locale: body.locale,
-        address: body.address,
-        externalId: body.externalId,
-        metadata: body.metadata,
-      },
-    );
+  const result = await rc.ctx.runMutation(
+    internal.customers.internal_mutations.createCustomer,
+    {
+      organizationId: rc.org.organizationId,
+      name: body.name,
+      email: body.email,
+      status: body.status,
+      source: body.source,
+      locale: body.locale,
+      address: body.address,
+      externalId: body.externalId,
+      metadata: body.metadata,
+    },
+  );
 
-    return jsonCreated({ id: result.customerId });
-  },
-);
+  return jsonCreated({ id: result.customerId });
+});
 
-export const getCustomer = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const getCustomer = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing customer ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing customer ID', 400);
+  }
 
-    const customer = await rc.ctx.runQuery(
-      internal.customers.internal_queries.getCustomerById,
-      { customerId: toId<'customers'>(id) },
-    );
+  const customer = await rc.ctx.runQuery(
+    internal.customers.internal_queries.getCustomerById,
+    { customerId: toId<'customers'>(id) },
+  );
 
-    if (!customer) {
-      return jsonError('Customer not found', 404);
-    }
+  if (!customer) {
+    return jsonError('Customer not found', 404);
+  }
 
-    return jsonOk(customer);
-  },
-);
+  return jsonOk(customer);
+});
 
-export const patchCustomer = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const patchCustomer = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing customer ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing customer ID', 400);
+  }
 
-    const body = await request.json();
+  const body = await request.json();
 
-    const updated = await rc.ctx.runMutation(
-      internal.customers.internal_mutations.updateCustomer,
-      {
-        customerId: toId<'customers'>(id),
-        name: body.name,
-        email: body.email,
-        externalId: body.externalId,
-        status: body.status,
-        source: body.source,
-        locale: body.locale,
-        address: body.address,
-        metadata: body.metadata,
-      },
-    );
+  const updated = await rc.ctx.runMutation(
+    internal.customers.internal_mutations.updateCustomer,
+    {
+      customerId: toId<'customers'>(id),
+      name: body.name,
+      email: body.email,
+      externalId: body.externalId,
+      status: body.status,
+      source: body.source,
+      locale: body.locale,
+      address: body.address,
+      metadata: body.metadata,
+    },
+  );
 
-    if (!updated) {
-      return jsonError('Customer not found', 404);
-    }
+  if (!updated) {
+    return jsonError('Customer not found', 404);
+  }
 
-    return jsonOk(updated);
-  },
-);
+  return jsonOk(updated);
+});
 
-export const deleteCustomer = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const deleteCustomer = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing customer ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing customer ID', 400);
+  }
 
-    await rc.ctx.runMutation(
-      internal.customers.internal_mutations.deleteCustomer,
-      { customerId: toId<'customers'>(id) },
-    );
+  await rc.ctx.runMutation(
+    internal.customers.internal_mutations.deleteCustomer,
+    { customerId: toId<'customers'>(id) },
+  );
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
 export const customerPostActions = withRestAuth(
   'rest:api',

--- a/services/platform/convex/customers/rest_api.ts
+++ b/services/platform/convex/customers/rest_api.ts
@@ -1,0 +1,182 @@
+/**
+ * Customers REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/customers          — List customers (paginated)
+ *   POST   /api/v1/customers          — Create customer
+ *   POST   /api/v1/customers/bulk     — Bulk create customers
+ *   GET    /api/v1/customers/:id      — Get customer by ID
+ *   PATCH  /api/v1/customers/:id      — Update customer
+ *   DELETE /api/v1/customers/:id      — Delete customer
+ */
+
+import type { DataSource } from '../../lib/shared/schemas/common';
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+
+const PREFIX = '/api/v1/customers/';
+
+export const listCustomers = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor') ?? null;
+    const limit = parseIntParam(url, 'limit', 25);
+    const status = url.searchParams.get('status') ?? undefined;
+    const source = url.searchParams.get('source') ?? undefined;
+    const locale = url.searchParams.get('locale') ?? undefined;
+
+    const result = await rc.ctx.runQuery(
+      internal.customers.internal_queries.queryCustomers,
+      {
+        organizationId: rc.org.organizationId,
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+        status: status as 'active' | 'churned' | 'potential' | undefined,
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+        source: source as DataSource | undefined,
+        locale: locale ? [locale] : undefined,
+        paginationOpts: { numItems: limit, cursor },
+      },
+    );
+
+    return jsonOk(result);
+  },
+);
+
+export const createCustomer = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    const result = await rc.ctx.runMutation(
+      internal.customers.internal_mutations.createCustomer,
+      {
+        organizationId: rc.org.organizationId,
+        name: body.name,
+        email: body.email,
+        status: body.status,
+        source: body.source,
+        locale: body.locale,
+        address: body.address,
+        externalId: body.externalId,
+        metadata: body.metadata,
+      },
+    );
+
+    return jsonCreated({ id: result.customerId });
+  },
+);
+
+export const getCustomer = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing customer ID', 400);
+    }
+
+    const customer = await rc.ctx.runQuery(
+      internal.customers.internal_queries.getCustomerById,
+      { customerId: toId<'customers'>(id) },
+    );
+
+    if (!customer) {
+      return jsonError('Customer not found', 404);
+    }
+
+    return jsonOk(customer);
+  },
+);
+
+export const patchCustomer = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing customer ID', 400);
+    }
+
+    const body = await request.json();
+
+    const updated = await rc.ctx.runMutation(
+      internal.customers.internal_mutations.updateCustomer,
+      {
+        customerId: toId<'customers'>(id),
+        name: body.name,
+        email: body.email,
+        externalId: body.externalId,
+        status: body.status,
+        source: body.source,
+        locale: body.locale,
+        address: body.address,
+        metadata: body.metadata,
+      },
+    );
+
+    if (!updated) {
+      return jsonError('Customer not found', 404);
+    }
+
+    return jsonOk(updated);
+  },
+);
+
+export const deleteCustomer = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing customer ID', 400);
+    }
+
+    await rc.ctx.runMutation(
+      internal.customers.internal_mutations.deleteCustomer,
+      { customerId: toId<'customers'>(id) },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const customerPostActions = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id: subPath } = extractPathParts(url, PREFIX);
+
+    if (subPath === 'bulk') {
+      const body = await request.json();
+
+      if (!Array.isArray(body.customers)) {
+        return jsonError('Missing or invalid "customers" array', 400);
+      }
+
+      const result = await rc.ctx.runMutation(
+        internal.customers.internal_mutations.bulkCreateCustomers,
+        {
+          organizationId: rc.org.organizationId,
+          customers: body.customers,
+        },
+      );
+
+      return jsonCreated(result);
+    }
+
+    return jsonError(`Unknown action: ${subPath}`, 404);
+  },
+);

--- a/services/platform/convex/documents/rest_api.ts
+++ b/services/platform/convex/documents/rest_api.ts
@@ -1,0 +1,173 @@
+/**
+ * Documents REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/documents          — List documents (paginated)
+ *   POST   /api/v1/documents          — Create document
+ *   GET    /api/v1/documents/:id      — Get document by ID
+ *   PATCH  /api/v1/documents/:id      — Update document
+ *   DELETE /api/v1/documents/:id      — Delete document
+ *   POST   /api/v1/documents/:id/retry-indexing — Retry RAG indexing
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+
+const PREFIX = '/api/v1/documents/';
+
+export const listDocuments = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor') ?? null;
+    const limit = parseIntParam(url, 'limit', 25);
+    const sourceProvider = url.searchParams.get('sourceProvider') ?? undefined;
+
+    const result = await rc.ctx.runQuery(
+      internal.documents.internal_queries.queryDocuments,
+      {
+        organizationId: rc.org.organizationId,
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+        sourceProvider: sourceProvider as
+          | 'upload'
+          | 'onedrive'
+          | 'sharepoint'
+          | 'agent'
+          | undefined,
+        paginationOpts: { numItems: limit, cursor },
+      },
+    );
+
+    return jsonOk(result);
+  },
+);
+
+export const createDocument = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    const documentId = await rc.ctx.runMutation(
+      internal.documents.internal_mutations.createDocument,
+      {
+        organizationId: rc.org.organizationId,
+        title: body.title,
+        content: body.content,
+        fileId: body.fileId,
+        mimeType: body.mimeType,
+        extension: body.extension,
+        sourceProvider: body.sourceProvider,
+        metadata: body.metadata,
+        teamId: body.teamId,
+        folderId: body.folderId,
+        createdBy: rc.user.userId,
+      },
+    );
+
+    return jsonCreated({ id: documentId });
+  },
+);
+
+export const getDocument = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing document ID', 400);
+    }
+
+    const document = await rc.ctx.runQuery(
+      internal.documents.internal_queries.getDocumentByIdRaw,
+      { documentId: toId<'documents'>(id) },
+    );
+
+    if (!document) {
+      return jsonError('Document not found', 404);
+    }
+
+    return jsonOk(document);
+  },
+);
+
+export const patchDocument = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing document ID', 400);
+    }
+
+    const body = await request.json();
+
+    await rc.ctx.runMutation(
+      internal.documents.internal_mutations.updateDocument,
+      {
+        documentId: toId<'documents'>(id),
+        title: body.title,
+        content: body.content,
+        metadata: body.metadata,
+        mimeType: body.mimeType,
+        extension: body.extension,
+        sourceProvider: body.sourceProvider,
+        teamId: body.teamId,
+        folderId: body.folderId,
+      },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const deleteDocument = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing document ID', 400);
+    }
+
+    await rc.ctx.runMutation(
+      internal.documents.internal_mutations.deleteDocumentById,
+      { documentId: toId<'documents'>(id) },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const documentSubActions = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id, subPath } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing document ID', 400);
+    }
+
+    if (subPath === 'retry-indexing') {
+      await rc.ctx.runAction(
+        internal.documents.internal_actions.uploadDocumentToRag,
+        { documentId: toId<'documents'>(id) },
+      );
+      return jsonOk({ status: 'indexing' });
+    }
+
+    return jsonError(`Unknown action: ${subPath}`, 404);
+  },
+);

--- a/services/platform/convex/documents/rest_api.ts
+++ b/services/platform/convex/documents/rest_api.ts
@@ -24,131 +24,116 @@ import { toId } from '../lib/type_cast_helpers';
 
 const PREFIX = '/api/v1/documents/';
 
-export const listDocuments = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const cursor = url.searchParams.get('cursor') ?? null;
-    const limit = parseIntParam(url, 'limit', 25);
-    const sourceProvider = url.searchParams.get('sourceProvider') ?? undefined;
+export const listDocuments = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const sourceProvider = url.searchParams.get('sourceProvider') ?? undefined;
 
-    const result = await rc.ctx.runQuery(
-      internal.documents.internal_queries.queryDocuments,
-      {
-        organizationId: rc.org.organizationId,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
-        sourceProvider: sourceProvider as
-          | 'upload'
-          | 'onedrive'
-          | 'sharepoint'
-          | 'agent'
-          | undefined,
-        paginationOpts: { numItems: limit, cursor },
-      },
-    );
+  const result = await rc.ctx.runQuery(
+    internal.documents.internal_queries.queryDocuments,
+    {
+      organizationId: rc.org.organizationId,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+      sourceProvider: sourceProvider as
+        | 'upload'
+        | 'onedrive'
+        | 'sharepoint'
+        | 'agent'
+        | undefined,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
 
-    return jsonOk(result);
-  },
-);
+  return jsonOk(result);
+});
 
-export const createDocument = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const body = await request.json();
+export const createDocument = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
 
-    const documentId = await rc.ctx.runMutation(
-      internal.documents.internal_mutations.createDocument,
-      {
-        organizationId: rc.org.organizationId,
-        title: body.title,
-        content: body.content,
-        fileId: body.fileId,
-        mimeType: body.mimeType,
-        extension: body.extension,
-        sourceProvider: body.sourceProvider,
-        metadata: body.metadata,
-        teamId: body.teamId,
-        folderId: body.folderId,
-        createdBy: rc.user.userId,
-      },
-    );
+  const documentId = await rc.ctx.runMutation(
+    internal.documents.internal_mutations.createDocument,
+    {
+      organizationId: rc.org.organizationId,
+      title: body.title,
+      content: body.content,
+      fileId: body.fileId,
+      mimeType: body.mimeType,
+      extension: body.extension,
+      sourceProvider: body.sourceProvider,
+      metadata: body.metadata,
+      teamId: body.teamId,
+      folderId: body.folderId,
+      createdBy: rc.user.userId,
+    },
+  );
 
-    return jsonCreated({ id: documentId });
-  },
-);
+  return jsonCreated({ id: documentId });
+});
 
-export const getDocument = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const getDocument = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing document ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing document ID', 400);
+  }
 
-    const document = await rc.ctx.runQuery(
-      internal.documents.internal_queries.getDocumentByIdRaw,
-      { documentId: toId<'documents'>(id) },
-    );
+  const document = await rc.ctx.runQuery(
+    internal.documents.internal_queries.getDocumentByIdRaw,
+    { documentId: toId<'documents'>(id) },
+  );
 
-    if (!document) {
-      return jsonError('Document not found', 404);
-    }
+  if (!document) {
+    return jsonError('Document not found', 404);
+  }
 
-    return jsonOk(document);
-  },
-);
+  return jsonOk(document);
+});
 
-export const patchDocument = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const patchDocument = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing document ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing document ID', 400);
+  }
 
-    const body = await request.json();
+  const body = await request.json();
 
-    await rc.ctx.runMutation(
-      internal.documents.internal_mutations.updateDocument,
-      {
-        documentId: toId<'documents'>(id),
-        title: body.title,
-        content: body.content,
-        metadata: body.metadata,
-        mimeType: body.mimeType,
-        extension: body.extension,
-        sourceProvider: body.sourceProvider,
-        teamId: body.teamId,
-        folderId: body.folderId,
-      },
-    );
+  await rc.ctx.runMutation(
+    internal.documents.internal_mutations.updateDocument,
+    {
+      documentId: toId<'documents'>(id),
+      title: body.title,
+      content: body.content,
+      metadata: body.metadata,
+      mimeType: body.mimeType,
+      extension: body.extension,
+      sourceProvider: body.sourceProvider,
+      teamId: body.teamId,
+      folderId: body.folderId,
+    },
+  );
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
-export const deleteDocument = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const deleteDocument = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing document ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing document ID', 400);
+  }
 
-    await rc.ctx.runMutation(
-      internal.documents.internal_mutations.deleteDocumentById,
-      { documentId: toId<'documents'>(id) },
-    );
+  await rc.ctx.runMutation(
+    internal.documents.internal_mutations.deleteDocumentById,
+    { documentId: toId<'documents'>(id) },
+  );
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
 export const documentSubActions = withRestAuth(
   'rest:api',

--- a/services/platform/convex/http.ts
+++ b/services/platform/convex/http.ts
@@ -2,17 +2,39 @@ import { httpRouter } from 'convex/server';
 
 import { httpAction } from './_generated/server';
 import {
+  listAgents as listAgentsRest,
+  getAgent,
+  patchAgent,
+} from './agents/rest_api';
+import {
   agentWebhookHandler,
   agentWebhookOptionsHandler,
 } from './agents/webhooks/http_actions';
 import { apiGatewayOptions, apiGatewayRun } from './api_gateway';
 import { authComponent, createAuth } from './auth';
+import {
+  listCustomers,
+  createCustomer,
+  getCustomer,
+  patchCustomer,
+  deleteCustomer,
+  customerPostActions,
+} from './customers/rest_api';
+import {
+  listDocuments,
+  createDocument,
+  getDocument,
+  patchDocument,
+  deleteDocument,
+  documentSubActions,
+} from './documents/rest_api';
 import { imageProxyHandler } from './images/http_actions';
 import { integrationOAuth2CallbackHandler } from './integrations/oauth2_callback';
 import {
   checkIpRateLimit,
   RateLimitExceededError,
 } from './lib/rate_limiter/helpers';
+import { restOptionsHandler } from './lib/rest/helpers';
 import { toId } from './lib/type_cast_helpers';
 import {
   chatCompletionsHandler,
@@ -20,6 +42,13 @@ import {
   modelsListHandler,
   modelsOptionsHandler,
 } from './openai_compat/http_actions';
+import {
+  listProducts,
+  createProduct,
+  getProduct,
+  patchProduct,
+  deleteProduct,
+} from './products/rest_api';
 import {
   ssoDiscoverHandler,
   ssoAuthorizeHandler,
@@ -30,7 +59,37 @@ import {
   streamChatHttp,
   streamChatHttpOptions,
 } from './streaming/http_actions';
+import {
+  listThreads,
+  createThread,
+  getThread,
+  patchThread,
+  deleteThread,
+  threadPostActions,
+} from './threads/rest_api';
 import { trustedHeadersAuthHandler } from './trusted_headers_auth/http_handlers';
+import {
+  listVendors,
+  createVendor,
+  bulkCreateVendors,
+  getVendor,
+  patchVendor,
+  deleteVendor,
+} from './vendors/rest_api';
+import {
+  listWebsites,
+  createWebsite,
+  getWebsite,
+  patchWebsite,
+  deleteWebsite,
+  websitePostActions,
+} from './websites/rest_api';
+import {
+  getWorkflow,
+  postWorkflow,
+  patchWorkflow,
+  deleteWorkflow,
+} from './workflows/rest_api';
 import {
   apiTriggerHandler,
   apiTriggerOptionsHandler,
@@ -229,7 +288,282 @@ http.route({
   handler: modelsOptionsHandler,
 });
 
+// ---------------------------------------------------------------------------
+// REST API v1 Routes
+// ---------------------------------------------------------------------------
+
+// Documents
+http.route({
+  path: '/api/v1/documents',
+  method: 'GET',
+  handler: listDocuments,
+});
+http.route({
+  path: '/api/v1/documents',
+  method: 'POST',
+  handler: createDocument,
+});
+http.route({
+  path: '/api/v1/documents',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/documents/',
+  method: 'GET',
+  handler: getDocument,
+});
+http.route({
+  pathPrefix: '/api/v1/documents/',
+  method: 'PATCH',
+  handler: patchDocument,
+});
+http.route({
+  pathPrefix: '/api/v1/documents/',
+  method: 'DELETE',
+  handler: deleteDocument,
+});
+http.route({
+  pathPrefix: '/api/v1/documents/',
+  method: 'POST',
+  handler: documentSubActions,
+});
+http.route({
+  pathPrefix: '/api/v1/documents/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Websites
+http.route({ path: '/api/v1/websites', method: 'GET', handler: listWebsites });
+http.route({
+  path: '/api/v1/websites',
+  method: 'POST',
+  handler: createWebsite,
+});
+http.route({
+  path: '/api/v1/websites',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/websites/',
+  method: 'GET',
+  handler: getWebsite,
+});
+http.route({
+  pathPrefix: '/api/v1/websites/',
+  method: 'PATCH',
+  handler: patchWebsite,
+});
+http.route({
+  pathPrefix: '/api/v1/websites/',
+  method: 'DELETE',
+  handler: deleteWebsite,
+});
+http.route({
+  pathPrefix: '/api/v1/websites/',
+  method: 'POST',
+  handler: websitePostActions,
+});
+http.route({
+  pathPrefix: '/api/v1/websites/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Products
+http.route({ path: '/api/v1/products', method: 'GET', handler: listProducts });
+http.route({
+  path: '/api/v1/products',
+  method: 'POST',
+  handler: createProduct,
+});
+http.route({
+  path: '/api/v1/products',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/products/',
+  method: 'GET',
+  handler: getProduct,
+});
+http.route({
+  pathPrefix: '/api/v1/products/',
+  method: 'PATCH',
+  handler: patchProduct,
+});
+http.route({
+  pathPrefix: '/api/v1/products/',
+  method: 'DELETE',
+  handler: deleteProduct,
+});
+http.route({
+  pathPrefix: '/api/v1/products/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Customers
+http.route({
+  path: '/api/v1/customers',
+  method: 'GET',
+  handler: listCustomers,
+});
+http.route({
+  path: '/api/v1/customers',
+  method: 'POST',
+  handler: createCustomer,
+});
+http.route({
+  path: '/api/v1/customers',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/customers/',
+  method: 'GET',
+  handler: getCustomer,
+});
+http.route({
+  pathPrefix: '/api/v1/customers/',
+  method: 'PATCH',
+  handler: patchCustomer,
+});
+http.route({
+  pathPrefix: '/api/v1/customers/',
+  method: 'DELETE',
+  handler: deleteCustomer,
+});
+http.route({
+  pathPrefix: '/api/v1/customers/',
+  method: 'POST',
+  handler: customerPostActions,
+});
+http.route({
+  pathPrefix: '/api/v1/customers/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Vendors
+http.route({ path: '/api/v1/vendors', method: 'GET', handler: listVendors });
+http.route({ path: '/api/v1/vendors', method: 'POST', handler: createVendor });
+http.route({
+  path: '/api/v1/vendors',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/vendors/',
+  method: 'GET',
+  handler: getVendor,
+});
+http.route({
+  pathPrefix: '/api/v1/vendors/',
+  method: 'PATCH',
+  handler: patchVendor,
+});
+http.route({
+  pathPrefix: '/api/v1/vendors/',
+  method: 'DELETE',
+  handler: deleteVendor,
+});
+http.route({
+  pathPrefix: '/api/v1/vendors/',
+  method: 'POST',
+  handler: bulkCreateVendors,
+});
+http.route({
+  pathPrefix: '/api/v1/vendors/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Threads
+http.route({ path: '/api/v1/threads', method: 'GET', handler: listThreads });
+http.route({ path: '/api/v1/threads', method: 'POST', handler: createThread });
+http.route({
+  path: '/api/v1/threads',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({
+  pathPrefix: '/api/v1/threads/',
+  method: 'GET',
+  handler: getThread,
+});
+http.route({
+  pathPrefix: '/api/v1/threads/',
+  method: 'PATCH',
+  handler: patchThread,
+});
+http.route({
+  pathPrefix: '/api/v1/threads/',
+  method: 'DELETE',
+  handler: deleteThread,
+});
+http.route({
+  pathPrefix: '/api/v1/threads/',
+  method: 'POST',
+  handler: threadPostActions,
+});
+http.route({
+  pathPrefix: '/api/v1/threads/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Agents
+http.route({ path: '/api/v1/agents', method: 'GET', handler: listAgentsRest });
+http.route({
+  path: '/api/v1/agents',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+http.route({ pathPrefix: '/api/v1/agents/', method: 'GET', handler: getAgent });
+http.route({
+  pathPrefix: '/api/v1/agents/',
+  method: 'PATCH',
+  handler: patchAgent,
+});
+http.route({
+  pathPrefix: '/api/v1/agents/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// Workflows (triggers + executions)
+http.route({
+  pathPrefix: '/api/v1/workflows/',
+  method: 'GET',
+  handler: getWorkflow,
+});
+http.route({
+  pathPrefix: '/api/v1/workflows/',
+  method: 'POST',
+  handler: postWorkflow,
+});
+http.route({
+  pathPrefix: '/api/v1/workflows/',
+  method: 'PATCH',
+  handler: patchWorkflow,
+});
+http.route({
+  pathPrefix: '/api/v1/workflows/',
+  method: 'DELETE',
+  handler: deleteWorkflow,
+});
+http.route({
+  pathPrefix: '/api/v1/workflows/',
+  method: 'OPTIONS',
+  handler: restOptionsHandler,
+});
+
+// ---------------------------------------------------------------------------
 // API Gateway Routes - Handle /api/run/* paths with session cookie or API key authentication
+// ---------------------------------------------------------------------------
 http.route({
   pathPrefix: '/api/run/',
   method: 'POST',

--- a/services/platform/convex/lib/rate_limiter/index.ts
+++ b/services/platform/convex/lib/rate_limiter/index.ts
@@ -177,6 +177,12 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
     period: MINUTE,
     capacity: 50,
   },
+  'rest:api': {
+    kind: 'token bucket',
+    rate: 120,
+    period: MINUTE,
+    capacity: 200,
+  },
   'agent:document-list': {
     kind: 'fixed window',
     rate: 30,

--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -1,0 +1,294 @@
+/**
+ * Shared REST API helpers for manual HTTP endpoints.
+ *
+ * Provides authentication, organization resolution, response builders,
+ * URL parsing, and CORS handling used across all /api/v1/* REST routes.
+ */
+
+import { internal } from '../../_generated/api';
+import { httpAction } from '../../_generated/server';
+import { createAuth } from '../../auth';
+import {
+  checkIpRateLimit,
+  RateLimitExceededError,
+} from '../rate_limiter/helpers';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Context type for httpAction handlers. */
+export type HttpCtx = Parameters<Parameters<typeof httpAction>[0]>[0];
+
+export interface AuthUser {
+  userId: string;
+  email: string;
+  name: string;
+}
+
+export interface OrgInfo {
+  organizationId: string;
+  orgSlug: string;
+}
+
+export interface RestContext {
+  ctx: HttpCtx;
+  user: AuthUser;
+  org: OrgInfo;
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
+
+export const REST_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Max-Age': '86400',
+};
+
+export const restOptionsHandler = httpAction(async () => {
+  return new Response(null, { status: 204, headers: REST_CORS_HEADERS });
+});
+
+// ---------------------------------------------------------------------------
+// Response builders
+// ---------------------------------------------------------------------------
+
+export function jsonOk(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...REST_CORS_HEADERS },
+  });
+}
+
+export function jsonCreated(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json', ...REST_CORS_HEADERS },
+  });
+}
+
+export function jsonNoContent(): Response {
+  return new Response(null, { status: 204, headers: REST_CORS_HEADERS });
+}
+
+export function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...REST_CORS_HEADERS },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/**
+ * Authenticate a REST request via Bearer token.
+ * Extracts the API key from the Authorization header and validates it
+ * through BetterAuth, returning the authenticated user info.
+ */
+export async function authenticateRequest(
+  ctx: HttpCtx,
+  request: Request,
+): Promise<AuthUser> {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new AuthError('Missing or invalid Authorization header');
+  }
+
+  const apiKey = authHeader.slice('Bearer '.length).trim();
+  if (!apiKey) {
+    throw new AuthError('Empty API key');
+  }
+
+  const syntheticHeaders = new Headers();
+  syntheticHeaders.set('x-api-key', apiKey);
+
+  const auth = createAuth(ctx);
+  try {
+    const session = await auth.api.getSession({
+      headers: syntheticHeaders,
+    });
+
+    if (!session?.user) {
+      throw new AuthError('Invalid API key or session');
+    }
+
+    return {
+      userId: session.user.id,
+      email: session.user.email ?? '',
+      name: session.user.name ?? '',
+    };
+  } catch (error) {
+    if (error instanceof AuthError) throw error;
+    throw new AuthError('Invalid API key or session');
+  }
+}
+
+/**
+ * Resolve the user's organization automatically.
+ * For single-org deployments, this finds the user's sole membership.
+ */
+export async function resolveOrganization(
+  ctx: HttpCtx,
+  userId: string,
+): Promise<OrgInfo> {
+  return await ctx.runQuery(
+    internal.openai_compat.internal_queries.resolveUserOrganization,
+    { userId },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply IP-based rate limiting. Returns an error response if exceeded,
+ * or null if the request is allowed.
+ */
+export async function applyRateLimit(
+  ctx: HttpCtx,
+  key: string,
+  request: Request,
+): Promise<Response | null> {
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+  try {
+    await checkIpRateLimit(ctx, key, ip);
+    return null;
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return jsonError('Rate limit exceeded', 429);
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract path segments after a prefix.
+ *
+ * Example: extractPathParts('/api/v1/documents/abc123/retry-indexing', '/api/v1/documents/')
+ *   → { id: 'abc123', subPath: 'retry-indexing' }
+ *
+ * Example: extractPathParts('/api/v1/documents/abc123', '/api/v1/documents/')
+ *   → { id: 'abc123', subPath: null }
+ */
+export function extractPathParts(
+  url: URL,
+  prefix: string,
+): { id: string; subPath: string | null } {
+  const rest = url.pathname.slice(prefix.length);
+  const parts = rest.split('/').filter(Boolean);
+  return {
+    id: parts[0] ?? '',
+    subPath: parts.length > 1 ? parts.slice(1).join('/') : null,
+  };
+}
+
+/**
+ * Parse query string parameters from a URL.
+ * Returns string values for specified keys, or undefined if not present.
+ */
+export function parseQueryParams(
+  url: URL,
+  keys: string[],
+): Record<string, string | undefined> {
+  const result: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    result[key] = url.searchParams.get(key) ?? undefined;
+  }
+  return result;
+}
+
+/**
+ * Parse numeric query parameter with a default value.
+ */
+export function parseIntParam(
+  url: URL,
+  key: string,
+  defaultValue: number,
+): number {
+  const val = url.searchParams.get(key);
+  if (!val) return defaultValue;
+  const parsed = parseInt(val, 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+// ---------------------------------------------------------------------------
+// High-level handler wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap an httpAction handler with authentication, org resolution,
+ * rate limiting, and error handling.
+ *
+ * Usage:
+ * ```ts
+ * export const listDocuments = withRestAuth('rest:documents', async (rc, request) => {
+ *   const docs = await rc.ctx.runQuery(internal.documents.internal_queries.queryDocuments, {
+ *     organizationId: rc.org.organizationId,
+ *   });
+ *   return jsonOk(docs);
+ * });
+ * ```
+ */
+export function withRestAuth(
+  rateLimitKey: string,
+  handler: (rc: RestContext, request: Request) => Promise<Response>,
+) {
+  return httpAction(async (ctx, request) => {
+    // Rate limit
+    const rateLimited = await applyRateLimit(ctx, rateLimitKey, request);
+    if (rateLimited) return rateLimited;
+
+    // Auth
+    let user: AuthUser;
+    try {
+      user = await authenticateRequest(ctx, request);
+    } catch (error) {
+      if (error instanceof AuthError) {
+        return jsonError(error.message, 401);
+      }
+      throw error;
+    }
+
+    // Org resolution
+    let org: OrgInfo;
+    try {
+      org = await resolveOrganization(ctx, user.userId);
+    } catch (error) {
+      const msg =
+        error instanceof Error
+          ? error.message
+          : 'Failed to resolve organization';
+      return jsonError(msg, 400);
+    }
+
+    // Delegate to handler
+    try {
+      return await handler({ ctx, user, org }, request);
+    } catch (error) {
+      console.error(`[REST ${rateLimitKey}]`, error);
+      const msg =
+        error instanceof Error ? error.message : 'Internal server error';
+      return jsonError(msg, 500);
+    }
+  });
+}

--- a/services/platform/convex/products/internal_mutations.ts
+++ b/services/platform/convex/products/internal_mutations.ts
@@ -1,7 +1,9 @@
 import { v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
+import type { Id } from '../_generated/dataModel';
 import { internalMutation } from '../_generated/server';
+import { deleteProduct as deleteProductHandler } from './delete_product';
 import * as ProductsHelpers from './helpers';
 import type { CreateProductResult, UpdateProductsResult } from './types';
 import { productStatusValidator } from './validators';
@@ -61,5 +63,15 @@ export const updateProducts = internalMutation({
   }),
   handler: async (ctx, args): Promise<UpdateProductsResult> => {
     return await ProductsHelpers.updateProducts(ctx, args);
+  },
+});
+
+export const deleteProduct = internalMutation({
+  args: {
+    productId: v.id('products'),
+  },
+  returns: v.id('products'),
+  handler: async (ctx, args): Promise<Id<'products'>> => {
+    return await deleteProductHandler(ctx, args.productId);
   },
 });

--- a/services/platform/convex/products/rest_api.ts
+++ b/services/platform/convex/products/rest_api.ts
@@ -23,56 +23,50 @@ import { toId } from '../lib/type_cast_helpers';
 
 const PREFIX = '/api/v1/products/';
 
-export const listProducts = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const cursor = url.searchParams.get('cursor') ?? null;
-    const limit = parseIntParam(url, 'limit', 25);
-    const status = url.searchParams.get('status') ?? undefined;
-    const category = url.searchParams.get('category') ?? undefined;
+export const listProducts = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const status = url.searchParams.get('status') ?? undefined;
+  const category = url.searchParams.get('category') ?? undefined;
 
-    const result = await rc.ctx.runQuery(
-      internal.products.internal_queries.queryProducts,
-      {
-        organizationId: rc.org.organizationId,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
-        status: status as 'active' | 'draft' | 'archived' | undefined,
-        category,
-        paginationOpts: { numItems: limit, cursor },
-      },
-    );
+  const result = await rc.ctx.runQuery(
+    internal.products.internal_queries.queryProducts,
+    {
+      organizationId: rc.org.organizationId,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+      status: status as 'active' | 'draft' | 'archived' | undefined,
+      category,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
 
-    return jsonOk(result);
-  },
-);
+  return jsonOk(result);
+});
 
-export const createProduct = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const body = await request.json();
+export const createProduct = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
 
-    const result = await rc.ctx.runMutation(
-      internal.products.internal_mutations.ingestProduct,
-      {
-        organizationId: rc.org.organizationId,
-        name: body.name,
-        description: body.description,
-        imageUrl: body.imageUrl,
-        stock: body.stock,
-        price: body.price,
-        currency: body.currency,
-        category: body.category,
-        tags: body.tags,
-        status: body.status,
-        externalId: body.externalId,
-        metadata: body.metadata,
-      },
-    );
+  const result = await rc.ctx.runMutation(
+    internal.products.internal_mutations.ingestProduct,
+    {
+      organizationId: rc.org.organizationId,
+      name: body.name,
+      description: body.description,
+      imageUrl: body.imageUrl,
+      stock: body.stock,
+      price: body.price,
+      currency: body.currency,
+      category: body.category,
+      tags: body.tags,
+      status: body.status,
+      externalId: body.externalId,
+      metadata: body.metadata,
+    },
+  );
 
-    return jsonCreated(result);
-  },
-);
+  return jsonCreated(result);
+});
 
 export const getProduct = withRestAuth('rest:api', async (rc, request) => {
   const url = new URL(request.url);
@@ -94,57 +88,50 @@ export const getProduct = withRestAuth('rest:api', async (rc, request) => {
   return jsonOk(product);
 });
 
-export const patchProduct = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const patchProduct = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing product ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing product ID', 400);
+  }
 
-    const body = await request.json();
+  const body = await request.json();
 
-    await rc.ctx.runMutation(
-      internal.products.internal_mutations.updateProducts,
-      {
-        productId: toId<'products'>(id),
-        updates: {
-          name: body.name,
-          description: body.description,
-          imageUrl: body.imageUrl,
-          stock: body.stock,
-          price: body.price,
-          currency: body.currency,
-          category: body.category,
-          tags: body.tags,
-          status: body.status,
-          externalId: body.externalId,
-          metadata: body.metadata,
-        },
+  await rc.ctx.runMutation(
+    internal.products.internal_mutations.updateProducts,
+    {
+      productId: toId<'products'>(id),
+      updates: {
+        name: body.name,
+        description: body.description,
+        imageUrl: body.imageUrl,
+        stock: body.stock,
+        price: body.price,
+        currency: body.currency,
+        category: body.category,
+        tags: body.tags,
+        status: body.status,
+        externalId: body.externalId,
+        metadata: body.metadata,
       },
-    );
+    },
+  );
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
-export const deleteProduct = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const deleteProduct = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing product ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing product ID', 400);
+  }
 
-    await rc.ctx.runMutation(
-      internal.products.internal_mutations.deleteProduct,
-      { productId: toId<'products'>(id) },
-    );
+  await rc.ctx.runMutation(internal.products.internal_mutations.deleteProduct, {
+    productId: toId<'products'>(id),
+  });
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});

--- a/services/platform/convex/products/rest_api.ts
+++ b/services/platform/convex/products/rest_api.ts
@@ -1,0 +1,150 @@
+/**
+ * Products REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/products          — List products (paginated)
+ *   POST   /api/v1/products          — Create product
+ *   GET    /api/v1/products/:id      — Get product by ID
+ *   PATCH  /api/v1/products/:id      — Update product
+ *   DELETE /api/v1/products/:id      — Delete product
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+
+const PREFIX = '/api/v1/products/';
+
+export const listProducts = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor') ?? null;
+    const limit = parseIntParam(url, 'limit', 25);
+    const status = url.searchParams.get('status') ?? undefined;
+    const category = url.searchParams.get('category') ?? undefined;
+
+    const result = await rc.ctx.runQuery(
+      internal.products.internal_queries.queryProducts,
+      {
+        organizationId: rc.org.organizationId,
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+        status: status as 'active' | 'draft' | 'archived' | undefined,
+        category,
+        paginationOpts: { numItems: limit, cursor },
+      },
+    );
+
+    return jsonOk(result);
+  },
+);
+
+export const createProduct = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    const result = await rc.ctx.runMutation(
+      internal.products.internal_mutations.ingestProduct,
+      {
+        organizationId: rc.org.organizationId,
+        name: body.name,
+        description: body.description,
+        imageUrl: body.imageUrl,
+        stock: body.stock,
+        price: body.price,
+        currency: body.currency,
+        category: body.category,
+        tags: body.tags,
+        status: body.status,
+        externalId: body.externalId,
+        metadata: body.metadata,
+      },
+    );
+
+    return jsonCreated(result);
+  },
+);
+
+export const getProduct = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing product ID', 400);
+  }
+
+  const product = await rc.ctx.runQuery(
+    internal.products.internal_queries.getProductById,
+    { productId: toId<'products'>(id) },
+  );
+
+  if (!product) {
+    return jsonError('Product not found', 404);
+  }
+
+  return jsonOk(product);
+});
+
+export const patchProduct = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing product ID', 400);
+    }
+
+    const body = await request.json();
+
+    await rc.ctx.runMutation(
+      internal.products.internal_mutations.updateProducts,
+      {
+        productId: toId<'products'>(id),
+        updates: {
+          name: body.name,
+          description: body.description,
+          imageUrl: body.imageUrl,
+          stock: body.stock,
+          price: body.price,
+          currency: body.currency,
+          category: body.category,
+          tags: body.tags,
+          status: body.status,
+          externalId: body.externalId,
+          metadata: body.metadata,
+        },
+      },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const deleteProduct = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing product ID', 400);
+    }
+
+    await rc.ctx.runMutation(
+      internal.products.internal_mutations.deleteProduct,
+      { productId: toId<'products'>(id) },
+    );
+
+    return jsonNoContent();
+  },
+);

--- a/services/platform/convex/threads/internal_mutations.ts
+++ b/services/platform/convex/threads/internal_mutations.ts
@@ -1,8 +1,15 @@
 import { v } from 'convex/values';
 
 import { internalMutation } from '../_generated/server';
+import {
+  archiveChatThread as archiveHelper,
+  unarchiveChatThread as unarchiveHelper,
+} from './archive_chat_thread';
 import { cleanupOrphanedSubThreads as cleanupOrphanedSubThreadsHandler } from './cleanup_orphaned_sub_threads';
+import { createChatThread as createHelper } from './create_chat_thread';
+import { deleteChatThread as deleteHelper } from './delete_chat_thread';
 import { getOrCreateSubThread } from './get_or_create_sub_thread';
+import { updateChatThread as updateHelper } from './update_chat_thread';
 
 export const getOrCreateSubThreadAtomic = internalMutation({
   args: {
@@ -54,5 +61,59 @@ export const cleanupOrphanedSubThreads = internalMutation({
       args.parentThreadId,
       args.subThreadIds,
     );
+  },
+});
+
+// ---------------------------------------------------------------------------
+// REST API helpers
+// ---------------------------------------------------------------------------
+
+export const createChatThreadInternal = internalMutation({
+  args: {
+    userId: v.string(),
+    title: v.optional(v.string()),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    return await createHelper(ctx, args.userId, args.title, 'general');
+  },
+});
+
+export const updateChatThreadInternal = internalMutation({
+  args: {
+    threadId: v.string(),
+    title: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await updateHelper(ctx, args.threadId, args.title);
+    return null;
+  },
+});
+
+export const deleteChatThreadInternal = internalMutation({
+  args: { threadId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await deleteHelper(ctx, args.threadId);
+    return null;
+  },
+});
+
+export const archiveChatThreadInternal = internalMutation({
+  args: { threadId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await archiveHelper(ctx, args.threadId);
+    return null;
+  },
+});
+
+export const unarchiveChatThreadInternal = internalMutation({
+  args: { threadId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await unarchiveHelper(ctx, args.threadId);
+    return null;
   },
 });

--- a/services/platform/convex/threads/internal_queries.ts
+++ b/services/platform/convex/threads/internal_queries.ts
@@ -1,6 +1,9 @@
+import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
 import { internalQuery } from '../_generated/server';
+import { getThreadMessages as getThreadMessagesHelper } from './get_thread_messages';
+import { listThreads as listThreadsHelper } from './list_threads';
 
 export const getThreadMetadata = internalQuery({
   args: { threadId: v.string() },
@@ -9,5 +12,64 @@ export const getThreadMetadata = internalQuery({
       .query('threadMetadata')
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
+  },
+});
+
+// ---------------------------------------------------------------------------
+// REST API helpers
+// ---------------------------------------------------------------------------
+
+export const listThreadsInternal = internalQuery({
+  args: {
+    userId: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return await listThreadsHelper(ctx, {
+      userId: args.userId,
+      paginationOpts: args.paginationOpts,
+    });
+  },
+});
+
+export const listArchivedThreadsInternal = internalQuery({
+  args: {
+    userId: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_userId_chatType_status_updated', (q) =>
+        q
+          .eq('userId', args.userId)
+          .eq('chatType', 'general')
+          .eq('status', 'archived'),
+      )
+      .order('desc')
+      .paginate(args.paginationOpts);
+
+    return {
+      page: result.page
+        .filter((row) => !row.isBranch)
+        .map((row) => ({
+          _id: row.threadId,
+          _creationTime: row.updatedAt ?? row.createdAt,
+          title: row.title,
+          status: row.status,
+          userId: row.userId,
+        })),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+export const getThreadMessagesInternal = internalQuery({
+  args: {
+    threadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await getThreadMessagesHelper(ctx, args.threadId);
   },
 });

--- a/services/platform/convex/threads/rest_api.ts
+++ b/services/platform/convex/threads/rest_api.ts
@@ -1,0 +1,169 @@
+/**
+ * Threads REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/threads              — List threads (paginated)
+ *   POST   /api/v1/threads              — Create thread
+ *   GET    /api/v1/threads/:id          — Get thread status
+ *   GET    /api/v1/threads/:id/messages — Get thread messages
+ *   PATCH  /api/v1/threads/:id          — Update thread title
+ *   DELETE /api/v1/threads/:id          — Delete thread
+ *   POST   /api/v1/threads/:id/archive  — Archive thread
+ *   POST   /api/v1/threads/:id/unarchive — Unarchive thread
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+
+const PREFIX = '/api/v1/threads/';
+
+export const listThreads = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const archived = url.searchParams.get('archived') === 'true';
+
+  if (archived) {
+    const result = await rc.ctx.runQuery(
+      internal.threads.internal_queries.listArchivedThreadsInternal,
+      {
+        userId: rc.user.userId,
+        paginationOpts: { numItems: limit, cursor },
+      },
+    );
+    return jsonOk(result);
+  }
+
+  const result = await rc.ctx.runQuery(
+    internal.threads.internal_queries.listThreadsInternal,
+    {
+      userId: rc.user.userId,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
+  return jsonOk(result);
+});
+
+export const createThread = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
+
+  const threadId = await rc.ctx.runMutation(
+    internal.threads.internal_mutations.createChatThreadInternal,
+    {
+      userId: rc.user.userId,
+      title: body.title,
+    },
+  );
+
+  return jsonCreated({ id: threadId });
+});
+
+export const getThread = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id, subPath } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing thread ID', 400);
+  }
+
+  // GET /api/v1/threads/:id/messages
+  if (subPath === 'messages') {
+    const result = await rc.ctx.runQuery(
+      internal.threads.internal_queries.getThreadMessagesInternal,
+      { threadId: id },
+    );
+    return jsonOk(result);
+  }
+
+  if (subPath) {
+    return jsonError(`Unknown sub-resource: ${subPath}`, 404);
+  }
+
+  // GET /api/v1/threads/:id — thread metadata
+  const thread = await rc.ctx.runQuery(
+    internal.threads.internal_queries.getThreadMetadata,
+    { threadId: id },
+  );
+
+  if (!thread) {
+    return jsonError('Thread not found', 404);
+  }
+
+  return jsonOk(thread);
+});
+
+export const patchThread = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing thread ID', 400);
+  }
+
+  const body = await request.json();
+
+  if (!body.title || typeof body.title !== 'string') {
+    return jsonError('Missing or invalid title', 400);
+  }
+
+  await rc.ctx.runMutation(
+    internal.threads.internal_mutations.updateChatThreadInternal,
+    { threadId: id, title: body.title },
+  );
+
+  return jsonNoContent();
+});
+
+export const deleteThread = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing thread ID', 400);
+  }
+
+  await rc.ctx.runMutation(
+    internal.threads.internal_mutations.deleteChatThreadInternal,
+    { threadId: id },
+  );
+
+  return jsonNoContent();
+});
+
+export const threadPostActions = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id, subPath } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing thread ID', 400);
+    }
+
+    if (subPath === 'archive') {
+      await rc.ctx.runMutation(
+        internal.threads.internal_mutations.archiveChatThreadInternal,
+        { threadId: id },
+      );
+      return jsonOk({ status: 'archived' });
+    }
+
+    if (subPath === 'unarchive') {
+      await rc.ctx.runMutation(
+        internal.threads.internal_mutations.unarchiveChatThreadInternal,
+        { threadId: id },
+      );
+      return jsonOk({ status: 'active' });
+    }
+
+    return jsonError(`Unknown action: ${subPath}`, 404);
+  },
+);

--- a/services/platform/convex/vendors/internal_mutations.ts
+++ b/services/platform/convex/vendors/internal_mutations.ts
@@ -1,0 +1,248 @@
+import { v } from 'convex/values';
+
+import type { ConvexJsonValue } from '../../lib/shared/schemas/utils/json-value';
+import { internalMutation } from '../_generated/server';
+import { jsonRecordValidator } from '../lib/validators/json';
+import {
+  vendorSourceValidator,
+  vendorAddressValidator,
+  vendorInputValidator,
+  bulkCreateVendorsResponseValidator,
+} from './validators';
+
+export const createVendor = internalMutation({
+  args: {
+    organizationId: v.string(),
+    name: v.optional(v.string()),
+    email: v.optional(v.string()),
+    phone: v.optional(v.string()),
+    externalId: v.optional(v.union(v.string(), v.number())),
+    source: vendorSourceValidator,
+    locale: v.optional(v.string()),
+    address: v.optional(vendorAddressValidator),
+    tags: v.optional(v.array(v.string())),
+    metadata: v.optional(jsonRecordValidator),
+    notes: v.optional(v.string()),
+  },
+  returns: v.id('vendors'),
+  handler: async (ctx, args) => {
+    const email = args.email?.toLowerCase().trim() || undefined;
+
+    if (email) {
+      const existing = await ctx.db
+        .query('vendors')
+        .withIndex('by_organizationId_and_email', (q) =>
+          q.eq('organizationId', args.organizationId).eq('email', email),
+        )
+        .first();
+
+      if (existing) {
+        throw new Error(`Vendor with email ${email} already exists`);
+      }
+    }
+
+    if (args.externalId) {
+      const existing = await ctx.db
+        .query('vendors')
+        .withIndex('by_organizationId_and_externalId', (q) =>
+          q
+            .eq('organizationId', args.organizationId)
+            .eq('externalId', args.externalId),
+        )
+        .first();
+
+      if (existing) {
+        throw new Error(
+          `Vendor with external ID ${args.externalId} already exists`,
+        );
+      }
+    }
+
+    return await ctx.db.insert('vendors', {
+      ...args,
+      ...(email !== undefined && { email }),
+    });
+  },
+});
+
+export const updateVendor = internalMutation({
+  args: {
+    vendorId: v.id('vendors'),
+    name: v.optional(v.string()),
+    email: v.optional(v.string()),
+    phone: v.optional(v.string()),
+    externalId: v.optional(v.string()),
+    source: v.optional(vendorSourceValidator),
+    locale: v.optional(v.string()),
+    address: v.optional(vendorAddressValidator),
+    tags: v.optional(v.array(v.string())),
+    metadata: v.optional(jsonRecordValidator),
+    notes: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const { vendorId, ...updateData } = args;
+
+    if (updateData.email) {
+      updateData.email = updateData.email.toLowerCase().trim() || undefined;
+    }
+
+    const existingVendor = await ctx.db.get(vendorId);
+    if (!existingVendor) {
+      throw new Error('Vendor not found');
+    }
+
+    const checkEmailConflict =
+      updateData.email && updateData.email !== existingVendor.email;
+    const checkExternalIdConflict =
+      updateData.externalId &&
+      updateData.externalId !== existingVendor.externalId;
+
+    const [emailConflict, externalIdConflict] = await Promise.all([
+      checkEmailConflict
+        ? ctx.db
+            .query('vendors')
+            .withIndex('by_organizationId_and_email', (q) =>
+              q
+                .eq('organizationId', existingVendor.organizationId)
+                .eq('email', updateData.email),
+            )
+            .first()
+        : Promise.resolve(null),
+      checkExternalIdConflict
+        ? ctx.db
+            .query('vendors')
+            .withIndex('by_organizationId_and_externalId', (q) =>
+              q
+                .eq('organizationId', existingVendor.organizationId)
+                .eq('externalId', updateData.externalId),
+            )
+            .first()
+        : Promise.resolve(null),
+    ]);
+
+    if (emailConflict && emailConflict._id !== vendorId) {
+      throw new Error(`Vendor with email ${updateData.email} already exists`);
+    }
+
+    if (externalIdConflict && externalIdConflict._id !== vendorId) {
+      throw new Error(
+        `Vendor with external ID ${updateData.externalId} already exists`,
+      );
+    }
+
+    const cleanUpdateData = Object.fromEntries(
+      Object.entries(updateData).filter(([_, value]) => value !== undefined),
+    );
+
+    await ctx.db.patch(vendorId, cleanUpdateData);
+    return null;
+  },
+});
+
+export const deleteVendor = internalMutation({
+  args: {
+    vendorId: v.id('vendors'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const vendor = await ctx.db.get(args.vendorId);
+    if (!vendor) {
+      throw new Error('Vendor not found');
+    }
+
+    await ctx.db.delete(args.vendorId);
+    return null;
+  },
+});
+
+export const bulkCreateVendors = internalMutation({
+  args: {
+    organizationId: v.string(),
+    vendors: v.array(vendorInputValidator),
+  },
+  returns: bulkCreateVendorsResponseValidator,
+  handler: async (ctx, args) => {
+    class BulkCreateError extends Error {
+      constructor(
+        message: string,
+        readonly errorCode: string,
+      ) {
+        super(message);
+      }
+    }
+
+    const results = {
+      success: 0,
+      failed: 0,
+      errors: [] as Array<{
+        index: number;
+        error: string;
+        errorCode: string;
+        vendor: ConvexJsonValue;
+      }>,
+    };
+
+    for (let i = 0; i < args.vendors.length; i++) {
+      const vendorData = args.vendors[i];
+
+      try {
+        const email = vendorData.email?.toLowerCase().trim();
+
+        if (email) {
+          const existing = await ctx.db
+            .query('vendors')
+            .withIndex('by_organizationId_and_email', (q) =>
+              q.eq('organizationId', args.organizationId).eq('email', email),
+            )
+            .first();
+
+          if (existing) {
+            throw new BulkCreateError(
+              `Vendor with email ${email} already exists`,
+              'duplicate_email',
+            );
+          }
+        }
+
+        if (vendorData.externalId) {
+          const { externalId } = vendorData;
+          const existing = await ctx.db
+            .query('vendors')
+            .withIndex('by_organizationId_and_externalId', (q) =>
+              q
+                .eq('organizationId', args.organizationId)
+                .eq('externalId', externalId),
+            )
+            .first();
+
+          if (existing) {
+            throw new BulkCreateError(
+              `Vendor with external ID ${vendorData.externalId} already exists`,
+              'duplicate_external_id',
+            );
+          }
+        }
+
+        await ctx.db.insert('vendors', {
+          organizationId: args.organizationId,
+          ...vendorData,
+          ...(email !== undefined && { email }),
+        });
+
+        results.success++;
+      } catch (error) {
+        results.failed++;
+        results.errors.push({
+          index: i,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          errorCode:
+            error instanceof BulkCreateError ? error.errorCode : 'unknown',
+          vendor: vendorData,
+        });
+      }
+    }
+
+    return results;
+  },
+});

--- a/services/platform/convex/vendors/internal_queries.ts
+++ b/services/platform/convex/vendors/internal_queries.ts
@@ -1,0 +1,36 @@
+import { v } from 'convex/values';
+
+import type { Doc } from '../_generated/dataModel';
+import { internalQuery } from '../_generated/server';
+import { cursorPaginationOptsValidator } from '../lib/pagination';
+import { listVendorsPaginated } from './list_vendors_paginated';
+import { vendorSourceValidator } from './validators';
+
+export const getVendor = internalQuery({
+  args: {
+    vendorId: v.id('vendors'),
+  },
+  handler: async (ctx, args): Promise<Doc<'vendors'> | null> => {
+    return await ctx.db.get(args.vendorId);
+  },
+});
+
+export const queryVendors = internalQuery({
+  args: {
+    organizationId: v.string(),
+    source: v.optional(vendorSourceValidator),
+    locale: v.optional(v.string()),
+    paginationOpts: cursorPaginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return await listVendorsPaginated(ctx, {
+      organizationId: args.organizationId,
+      source: args.source,
+      locale: args.locale,
+      paginationOpts: {
+        numItems: args.paginationOpts.numItems,
+        cursor: args.paginationOpts.cursor,
+      },
+    });
+  },
+});

--- a/services/platform/convex/vendors/rest_api.ts
+++ b/services/platform/convex/vendors/rest_api.ts
@@ -46,31 +46,28 @@ export const listVendors = withRestAuth('rest:api', async (rc, request) => {
   return jsonOk(result);
 });
 
-export const createVendor = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const body = await request.json();
+export const createVendor = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
 
-    const vendorId = await rc.ctx.runMutation(
-      internal.vendors.internal_mutations.createVendor,
-      {
-        organizationId: rc.org.organizationId,
-        name: body.name,
-        email: body.email,
-        phone: body.phone,
-        externalId: body.externalId,
-        source: body.source,
-        locale: body.locale,
-        address: body.address,
-        tags: body.tags,
-        metadata: body.metadata,
-        notes: body.notes,
-      },
-    );
+  const vendorId = await rc.ctx.runMutation(
+    internal.vendors.internal_mutations.createVendor,
+    {
+      organizationId: rc.org.organizationId,
+      name: body.name,
+      email: body.email,
+      phone: body.phone,
+      externalId: body.externalId,
+      source: body.source,
+      locale: body.locale,
+      address: body.address,
+      tags: body.tags,
+      metadata: body.metadata,
+      notes: body.notes,
+    },
+  );
 
-    return jsonCreated({ id: vendorId });
-  },
-);
+  return jsonCreated({ id: vendorId });
+});
 
 export const bulkCreateVendors = withRestAuth(
   'rest:api',
@@ -140,20 +137,17 @@ export const patchVendor = withRestAuth('rest:api', async (rc, request) => {
   return jsonNoContent();
 });
 
-export const deleteVendor = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const deleteVendor = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing vendor ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing vendor ID', 400);
+  }
 
-    await rc.ctx.runMutation(internal.vendors.internal_mutations.deleteVendor, {
-      vendorId: toId<'vendors'>(id),
-    });
+  await rc.ctx.runMutation(internal.vendors.internal_mutations.deleteVendor, {
+    vendorId: toId<'vendors'>(id),
+  });
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});

--- a/services/platform/convex/vendors/rest_api.ts
+++ b/services/platform/convex/vendors/rest_api.ts
@@ -1,0 +1,159 @@
+/**
+ * Vendors REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/vendors          — List vendors (paginated)
+ *   POST   /api/v1/vendors          — Create single vendor
+ *   POST   /api/v1/vendors/bulk     — Bulk create vendors
+ *   GET    /api/v1/vendors/:id      — Get vendor by ID
+ *   PATCH  /api/v1/vendors/:id      — Update vendor
+ *   DELETE /api/v1/vendors/:id      — Delete vendor
+ */
+
+import type { DataSource } from '../../lib/shared/schemas/common';
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+
+const PREFIX = '/api/v1/vendors/';
+
+export const listVendors = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const source = url.searchParams.get('source') ?? undefined;
+  const locale = url.searchParams.get('locale') ?? undefined;
+
+  const result = await rc.ctx.runQuery(
+    internal.vendors.internal_queries.queryVendors,
+    {
+      organizationId: rc.org.organizationId,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user input validated at runtime
+      source: source as DataSource | undefined,
+      locale,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
+
+  return jsonOk(result);
+});
+
+export const createVendor = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    const vendorId = await rc.ctx.runMutation(
+      internal.vendors.internal_mutations.createVendor,
+      {
+        organizationId: rc.org.organizationId,
+        name: body.name,
+        email: body.email,
+        phone: body.phone,
+        externalId: body.externalId,
+        source: body.source,
+        locale: body.locale,
+        address: body.address,
+        tags: body.tags,
+        metadata: body.metadata,
+        notes: body.notes,
+      },
+    );
+
+    return jsonCreated({ id: vendorId });
+  },
+);
+
+export const bulkCreateVendors = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    if (!Array.isArray(body.vendors)) {
+      return jsonError('Missing or invalid "vendors" array', 400);
+    }
+
+    const result = await rc.ctx.runMutation(
+      internal.vendors.internal_mutations.bulkCreateVendors,
+      {
+        organizationId: rc.org.organizationId,
+        vendors: body.vendors,
+      },
+    );
+
+    return jsonOk(result);
+  },
+);
+
+export const getVendor = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing vendor ID', 400);
+  }
+
+  const vendor = await rc.ctx.runQuery(
+    internal.vendors.internal_queries.getVendor,
+    { vendorId: toId<'vendors'>(id) },
+  );
+
+  if (!vendor) {
+    return jsonError('Vendor not found', 404);
+  }
+
+  return jsonOk(vendor);
+});
+
+export const patchVendor = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing vendor ID', 400);
+  }
+
+  const body = await request.json();
+
+  await rc.ctx.runMutation(internal.vendors.internal_mutations.updateVendor, {
+    vendorId: toId<'vendors'>(id),
+    name: body.name,
+    email: body.email,
+    phone: body.phone,
+    externalId: body.externalId,
+    source: body.source,
+    locale: body.locale,
+    address: body.address,
+    tags: body.tags,
+    metadata: body.metadata,
+    notes: body.notes,
+  });
+
+  return jsonNoContent();
+});
+
+export const deleteVendor = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing vendor ID', 400);
+    }
+
+    await rc.ctx.runMutation(internal.vendors.internal_mutations.deleteVendor, {
+      vendorId: toId<'vendors'>(id),
+    });
+
+    return jsonNoContent();
+  },
+);

--- a/services/platform/convex/websites/internal_queries.ts
+++ b/services/platform/convex/websites/internal_queries.ts
@@ -1,8 +1,10 @@
+import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
 import { internalQuery } from '../_generated/server';
 import { getOrganizationMember } from '../lib/rls';
 import * as WebsitesHelpers from './helpers';
+import { listWebsitesPaginated as listWebsitesPaginatedHelper } from './list_websites_paginated';
 
 export const getWebsite = internalQuery({
   args: {
@@ -48,6 +50,18 @@ export const listWebsitesForSync = internalQuery({
       });
     }
     return results;
+  },
+});
+
+export const listWebsitesPaginated = internalQuery({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    organizationId: v.string(),
+    status: v.optional(v.string()),
+    scanInterval: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await listWebsitesPaginatedHelper(ctx, args);
   },
 });
 

--- a/services/platform/convex/websites/rest_api.ts
+++ b/services/platform/convex/websites/rest_api.ts
@@ -27,65 +27,59 @@ import { toWebsiteDomain } from './create_website';
 
 const PREFIX = '/api/v1/websites/';
 
-export const listWebsites = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const cursor = url.searchParams.get('cursor') ?? null;
-    const limit = parseIntParam(url, 'limit', 25);
-    const status = url.searchParams.get('status') ?? undefined;
-    const scanInterval = url.searchParams.get('scanInterval') ?? undefined;
+export const listWebsites = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor') ?? null;
+  const limit = parseIntParam(url, 'limit', 25);
+  const status = url.searchParams.get('status') ?? undefined;
+  const scanInterval = url.searchParams.get('scanInterval') ?? undefined;
 
-    const result = await rc.ctx.runQuery(
-      internal.websites.internal_queries.listWebsitesPaginated,
-      {
-        organizationId: rc.org.organizationId,
-        status,
-        scanInterval,
-        paginationOpts: { numItems: limit, cursor },
-      },
-    );
+  const result = await rc.ctx.runQuery(
+    internal.websites.internal_queries.listWebsitesPaginated,
+    {
+      organizationId: rc.org.organizationId,
+      status,
+      scanInterval,
+      paginationOpts: { numItems: limit, cursor },
+    },
+  );
 
-    return jsonOk(result);
-  },
-);
+  return jsonOk(result);
+});
 
-export const createWebsite = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const body = await request.json();
+export const createWebsite = withRestAuth('rest:api', async (rc, request) => {
+  const body = await request.json();
 
-    if (!body.domain) {
-      return jsonError('Missing required field: domain', 400);
-    }
-    if (!body.scanInterval) {
-      return jsonError('Missing required field: scanInterval', 400);
-    }
+  if (!body.domain) {
+    return jsonError('Missing required field: domain', 400);
+  }
+  if (!body.scanInterval) {
+    return jsonError('Missing required field: scanInterval', 400);
+  }
 
-    const domain = toWebsiteDomain(body.domain);
+  const domain = toWebsiteDomain(body.domain);
 
-    const websiteId = await rc.ctx.runMutation(
-      internal.websites.internal_mutations.provisionWebsite,
-      {
-        organizationId: rc.org.organizationId,
-        domain,
-        title: body.title,
-        description: body.description,
-        scanInterval: body.scanInterval,
-        status: 'scanning',
-      },
-    );
-
-    // Register with crawler and schedule follow-up sync
-    await rc.ctx.runAction(internal.websites.internal_actions.registerAndSync, {
-      websiteId,
+  const websiteId = await rc.ctx.runMutation(
+    internal.websites.internal_mutations.provisionWebsite,
+    {
+      organizationId: rc.org.organizationId,
       domain,
+      title: body.title,
+      description: body.description,
       scanInterval: body.scanInterval,
-    });
+      status: 'scanning',
+    },
+  );
 
-    return jsonCreated({ id: websiteId });
-  },
-);
+  // Register with crawler and schedule follow-up sync
+  await rc.ctx.runAction(internal.websites.internal_actions.registerAndSync, {
+    websiteId,
+    domain,
+    scanInterval: body.scanInterval,
+  });
+
+  return jsonCreated({ id: websiteId });
+});
 
 export const getWebsite = withRestAuth('rest:api', async (rc, request) => {
   const url = new URL(request.url);
@@ -144,77 +138,67 @@ export const getWebsite = withRestAuth('rest:api', async (rc, request) => {
   return jsonError(`Unknown sub-path: ${subPath}`, 404);
 });
 
-export const patchWebsite = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const patchWebsite = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing website ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing website ID', 400);
+  }
 
-    const website = await rc.ctx.runQuery(
-      internal.websites.internal_queries.getWebsite,
-      { websiteId: toId<'websites'>(id) },
-    );
+  const website = await rc.ctx.runQuery(
+    internal.websites.internal_queries.getWebsite,
+    { websiteId: toId<'websites'>(id) },
+  );
 
-    if (!website) {
-      return jsonError('Website not found', 404);
-    }
+  if (!website) {
+    return jsonError('Website not found', 404);
+  }
 
-    if (website.organizationId !== rc.org.organizationId) {
-      return jsonError('Website not found', 404);
-    }
+  if (website.organizationId !== rc.org.organizationId) {
+    return jsonError('Website not found', 404);
+  }
 
-    const body = await request.json();
+  const body = await request.json();
 
-    await rc.ctx.runMutation(
-      internal.websites.internal_mutations.patchWebsite,
-      {
-        websiteId: toId<'websites'>(id),
-        domain: body.domain,
-        title: body.title,
-        description: body.description,
-        scanInterval: body.scanInterval,
-      },
-    );
+  await rc.ctx.runMutation(internal.websites.internal_mutations.patchWebsite, {
+    websiteId: toId<'websites'>(id),
+    domain: body.domain,
+    title: body.title,
+    description: body.description,
+    scanInterval: body.scanInterval,
+  });
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
-export const deleteWebsite = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id } = extractPathParts(url, PREFIX);
+export const deleteWebsite = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id } = extractPathParts(url, PREFIX);
 
-    if (!id) {
-      return jsonError('Missing website ID', 400);
-    }
+  if (!id) {
+    return jsonError('Missing website ID', 400);
+  }
 
-    const website = await rc.ctx.runQuery(
-      internal.websites.internal_queries.getWebsite,
-      { websiteId: toId<'websites'>(id) },
-    );
+  const website = await rc.ctx.runQuery(
+    internal.websites.internal_queries.getWebsite,
+    { websiteId: toId<'websites'>(id) },
+  );
 
-    if (!website) {
-      return jsonError('Website not found', 404);
-    }
+  if (!website) {
+    return jsonError('Website not found', 404);
+  }
 
-    if (website.organizationId !== rc.org.organizationId) {
-      return jsonError('Website not found', 404);
-    }
+  if (website.organizationId !== rc.org.organizationId) {
+    return jsonError('Website not found', 404);
+  }
 
-    await rc.ctx.runMutation(
-      internal.websites.internal_mutations.deleteWebsite,
-      { websiteId: toId<'websites'>(id) },
-    );
+  await rc.ctx.runMutation(internal.websites.internal_mutations.deleteWebsite, {
+    websiteId: toId<'websites'>(id),
+  });
 
-    return jsonNoContent();
-  },
-);
+  return jsonNoContent();
+});
 
 export const websiteSubActions = withRestAuth(
   'rest:api',

--- a/services/platform/convex/websites/rest_api.ts
+++ b/services/platform/convex/websites/rest_api.ts
@@ -1,0 +1,315 @@
+/**
+ * Websites REST API handlers.
+ *
+ * Endpoints:
+ *   GET    /api/v1/websites             — List websites (paginated)
+ *   POST   /api/v1/websites             — Create website
+ *   GET    /api/v1/websites/:id         — Get website by ID
+ *   GET    /api/v1/websites/:id/pages   — Fetch pages
+ *   PATCH  /api/v1/websites/:id         — Update website
+ *   DELETE /api/v1/websites/:id         — Delete website
+ *   POST   /api/v1/websites/:id/sync    — Sync statuses
+ *   POST   /api/v1/websites/:id/search  — Search content
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+import { toWebsiteDomain } from './create_website';
+
+const PREFIX = '/api/v1/websites/';
+
+export const listWebsites = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor') ?? null;
+    const limit = parseIntParam(url, 'limit', 25);
+    const status = url.searchParams.get('status') ?? undefined;
+    const scanInterval = url.searchParams.get('scanInterval') ?? undefined;
+
+    const result = await rc.ctx.runQuery(
+      internal.websites.internal_queries.listWebsitesPaginated,
+      {
+        organizationId: rc.org.organizationId,
+        status,
+        scanInterval,
+        paginationOpts: { numItems: limit, cursor },
+      },
+    );
+
+    return jsonOk(result);
+  },
+);
+
+export const createWebsite = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const body = await request.json();
+
+    if (!body.domain) {
+      return jsonError('Missing required field: domain', 400);
+    }
+    if (!body.scanInterval) {
+      return jsonError('Missing required field: scanInterval', 400);
+    }
+
+    const domain = toWebsiteDomain(body.domain);
+
+    const websiteId = await rc.ctx.runMutation(
+      internal.websites.internal_mutations.provisionWebsite,
+      {
+        organizationId: rc.org.organizationId,
+        domain,
+        title: body.title,
+        description: body.description,
+        scanInterval: body.scanInterval,
+        status: 'scanning',
+      },
+    );
+
+    // Register with crawler and schedule follow-up sync
+    await rc.ctx.runAction(internal.websites.internal_actions.registerAndSync, {
+      websiteId,
+      domain,
+      scanInterval: body.scanInterval,
+    });
+
+    return jsonCreated({ id: websiteId });
+  },
+);
+
+export const getWebsite = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id, subPath } = extractPathParts(url, PREFIX);
+
+  if (!id) {
+    return jsonError('Missing website ID', 400);
+  }
+
+  if (subPath === null) {
+    const website = await rc.ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    if (!website) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (website.organizationId !== rc.org.organizationId) {
+      return jsonError('Website not found', 404);
+    }
+
+    return jsonOk(website);
+  }
+
+  if (subPath === 'pages') {
+    const offset = parseIntParam(url, 'offset', 0);
+    const limit = parseIntParam(url, 'limit', 100);
+
+    const website = await rc.ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    if (!website) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (website.organizationId !== rc.org.organizationId) {
+      return jsonError('Website not found', 404);
+    }
+
+    const result = await rc.ctx.runAction(
+      internal.websites.internal_actions.fetchWebsitePages,
+      {
+        domain: website.domain,
+        offset,
+        limit,
+      },
+    );
+
+    return jsonOk(result);
+  }
+
+  return jsonError(`Unknown sub-path: ${subPath}`, 404);
+});
+
+export const patchWebsite = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing website ID', 400);
+    }
+
+    const website = await rc.ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    if (!website) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (website.organizationId !== rc.org.organizationId) {
+      return jsonError('Website not found', 404);
+    }
+
+    const body = await request.json();
+
+    await rc.ctx.runMutation(
+      internal.websites.internal_mutations.patchWebsite,
+      {
+        websiteId: toId<'websites'>(id),
+        domain: body.domain,
+        title: body.title,
+        description: body.description,
+        scanInterval: body.scanInterval,
+      },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const deleteWebsite = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing website ID', 400);
+    }
+
+    const website = await rc.ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    if (!website) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (website.organizationId !== rc.org.organizationId) {
+      return jsonError('Website not found', 404);
+    }
+
+    await rc.ctx.runMutation(
+      internal.websites.internal_mutations.deleteWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    return jsonNoContent();
+  },
+);
+
+export const websiteSubActions = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id, subPath } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing website ID', 400);
+    }
+
+    if (subPath === 'pages') {
+      const offset = parseIntParam(url, 'offset', 0);
+      const limit = parseIntParam(url, 'limit', 100);
+
+      const website = await rc.ctx.runQuery(
+        internal.websites.internal_queries.getWebsite,
+        { websiteId: toId<'websites'>(id) },
+      );
+
+      if (!website) {
+        return jsonError('Website not found', 404);
+      }
+
+      if (website.organizationId !== rc.org.organizationId) {
+        return jsonError('Website not found', 404);
+      }
+
+      const result = await rc.ctx.runAction(
+        internal.websites.internal_actions.fetchWebsitePages,
+        {
+          domain: website.domain,
+          offset,
+          limit,
+        },
+      );
+
+      return jsonOk(result);
+    }
+
+    return jsonError(`Unknown sub-path: ${subPath}`, 404);
+  },
+);
+
+export const websitePostActions = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id, subPath } = extractPathParts(url, PREFIX);
+
+    if (!id) {
+      return jsonError('Missing website ID', 400);
+    }
+
+    const website = await rc.ctx.runQuery(
+      internal.websites.internal_queries.getWebsite,
+      { websiteId: toId<'websites'>(id) },
+    );
+
+    if (!website) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (website.organizationId !== rc.org.organizationId) {
+      return jsonError('Website not found', 404);
+    }
+
+    if (subPath === 'sync') {
+      await rc.ctx.runAction(
+        internal.websites.internal_actions.syncWebsiteStatuses,
+        { organizationId: rc.org.organizationId },
+      );
+
+      return jsonOk({ status: 'syncing' });
+    }
+
+    if (subPath === 'search') {
+      const body = await request.json();
+
+      if (!body.query) {
+        return jsonError('Missing required field: query', 400);
+      }
+
+      const result = await rc.ctx.runAction(
+        internal.websites.internal_actions.searchWebsiteContent,
+        {
+          domain: website.domain,
+          query: body.query,
+          limit: body.limit,
+        },
+      );
+
+      return jsonOk(result);
+    }
+
+    return jsonError(`Unknown action: ${subPath}`, 404);
+  },
+);

--- a/services/platform/convex/wf_executions/internal_queries.ts
+++ b/services/platform/convex/wf_executions/internal_queries.ts
@@ -2,7 +2,9 @@ import { v } from 'convex/values';
 
 import { internalQuery } from '../_generated/server';
 import { getExecution as getExecutionHandler } from '../workflows/executions/get_execution';
+import { getExecutionStepJournal as getExecutionStepJournalHelper } from '../workflows/executions/get_execution_step_journal';
 import { getRawExecution as getRawExecutionHandler } from '../workflows/executions/get_raw_execution';
+import { listExecutionsCursor as listExecutionsCursorHelper } from '../workflows/executions/list_executions_cursor';
 
 export const getExecution = internalQuery({
   args: {
@@ -21,5 +23,30 @@ export const getRawExecution = internalQuery({
   },
   handler: async (ctx, args) => {
     return await getRawExecutionHandler(ctx, args.executionId);
+  },
+});
+
+export const listExecutionsCursorInternal = internalQuery({
+  args: {
+    wfDefinitionId: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.optional(v.number()),
+    status: v.optional(v.array(v.string())),
+    dateFrom: v.optional(v.string()),
+    dateTo: v.optional(v.string()),
+    searchTerm: v.optional(v.string()),
+    triggeredBy: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await listExecutionsCursorHelper(ctx, args);
+  },
+});
+
+export const getExecutionStepJournalInternal = internalQuery({
+  args: {
+    executionId: v.id('wfExecutions'),
+  },
+  handler: async (ctx, args) => {
+    return await getExecutionStepJournalHelper(ctx, args);
   },
 });

--- a/services/platform/convex/workflows/rest_api.ts
+++ b/services/platform/convex/workflows/rest_api.ts
@@ -38,235 +38,221 @@ const PREFIX = '/api/v1/workflows/';
 // GET /api/v1/workflows/* (pathPrefix handler)
 // ---------------------------------------------------------------------------
 
-export const getWorkflow = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
+export const getWorkflow = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
 
-    if (!firstSegment) {
-      return jsonError('Missing workflow slug or resource type', 400);
+  if (!firstSegment) {
+    return jsonError('Missing workflow slug or resource type', 400);
+  }
+
+  // GET /api/v1/workflows/executions/:id — get execution details
+  if (firstSegment === 'executions' && subPath) {
+    const executionId = subPath.split('/')[0];
+    const execution = await rc.ctx.runQuery(
+      internal.wf_executions.internal_queries.getExecutionStepJournalInternal,
+      { executionId: toId<'wfExecutions'>(executionId) },
+    );
+    if (!execution) {
+      return jsonError('Execution not found', 404);
     }
+    return jsonOk(execution);
+  }
 
-    // GET /api/v1/workflows/executions/:id — get execution details
-    if (firstSegment === 'executions' && subPath) {
-      const executionId = subPath.split('/')[0];
-      const execution = await rc.ctx.runQuery(
-        internal.wf_executions.internal_queries.getExecutionStepJournalInternal,
-        { executionId: toId<'wfExecutions'>(executionId) },
-      );
-      if (!execution) {
-        return jsonError('Execution not found', 404);
-      }
-      return jsonOk(execution);
-    }
+  // Remaining routes are /api/v1/workflows/:slug/:resource
+  const slug = firstSegment;
+  const resource = subPath?.split('/')[0];
 
-    // Remaining routes are /api/v1/workflows/:slug/:resource
-    const slug = firstSegment;
-    const resource = subPath?.split('/')[0];
+  if (resource === 'schedules') {
+    const schedules = await rc.ctx.runQuery(
+      internal.workflows.triggers.internal_queries.getSchedulesBySlugInternal,
+      {
+        organizationId: rc.org.organizationId,
+        workflowSlug: slug,
+      },
+    );
+    return jsonOk(schedules);
+  }
 
-    if (resource === 'schedules') {
-      const schedules = await rc.ctx.runQuery(
-        internal.workflows.triggers.internal_queries.getSchedulesBySlugInternal,
-        {
-          organizationId: rc.org.organizationId,
-          workflowSlug: slug,
-        },
-      );
-      return jsonOk(schedules);
-    }
+  if (resource === 'webhooks') {
+    const webhooks = await rc.ctx.runQuery(
+      internal.workflows.triggers.internal_queries.getWebhooksBySlugInternal,
+      {
+        organizationId: rc.org.organizationId,
+        workflowSlug: slug,
+      },
+    );
+    return jsonOk(webhooks);
+  }
 
-    if (resource === 'webhooks') {
-      const webhooks = await rc.ctx.runQuery(
-        internal.workflows.triggers.internal_queries.getWebhooksBySlugInternal,
-        {
-          organizationId: rc.org.organizationId,
-          workflowSlug: slug,
-        },
-      );
-      return jsonOk(webhooks);
-    }
+  if (resource === 'logs') {
+    const logs = await rc.ctx.runQuery(
+      internal.workflows.triggers.internal_queries.getTriggerLogsBySlugInternal,
+      {
+        organizationId: rc.org.organizationId,
+        workflowSlug: slug,
+      },
+    );
+    return jsonOk(logs);
+  }
 
-    if (resource === 'logs') {
-      const logs = await rc.ctx.runQuery(
-        internal.workflows.triggers.internal_queries
-          .getTriggerLogsBySlugInternal,
-        {
-          organizationId: rc.org.organizationId,
-          workflowSlug: slug,
-        },
-      );
-      return jsonOk(logs);
-    }
+  if (resource === 'executions') {
+    const cursor = url.searchParams.get('cursor') ?? null;
+    const numItems = parseIntParam(url, 'limit', 25);
+    const statusParam = url.searchParams.get('status');
+    const status = statusParam ? statusParam.split(',') : undefined;
+    const dateFrom = url.searchParams.get('dateFrom') ?? undefined;
+    const dateTo = url.searchParams.get('dateTo') ?? undefined;
 
-    if (resource === 'executions') {
-      const cursor = url.searchParams.get('cursor') ?? null;
-      const numItems = parseIntParam(url, 'limit', 25);
-      const statusParam = url.searchParams.get('status');
-      const status = statusParam ? statusParam.split(',') : undefined;
-      const dateFrom = url.searchParams.get('dateFrom') ?? undefined;
-      const dateTo = url.searchParams.get('dateTo') ?? undefined;
+    const executions = await rc.ctx.runQuery(
+      internal.wf_executions.internal_queries.listExecutionsCursorInternal,
+      {
+        wfDefinitionId: slug,
+        cursor,
+        numItems,
+        status,
+        dateFrom,
+        dateTo,
+      },
+    );
+    return jsonOk(executions);
+  }
 
-      const executions = await rc.ctx.runQuery(
-        internal.wf_executions.internal_queries.listExecutionsCursorInternal,
-        {
-          wfDefinitionId: slug,
-          cursor,
-          numItems,
-          status,
-          dateFrom,
-          dateTo,
-        },
-      );
-      return jsonOk(executions);
-    }
-
-    return jsonError(`Unknown resource: ${resource}`, 404);
-  },
-);
+  return jsonError(`Unknown resource: ${resource}`, 404);
+});
 
 // ---------------------------------------------------------------------------
 // POST /api/v1/workflows/* (pathPrefix handler)
 // ---------------------------------------------------------------------------
 
-export const postWorkflow = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
+export const postWorkflow = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
 
-    if (!firstSegment) {
-      return jsonError('Missing workflow slug or resource type', 400);
-    }
+  if (!firstSegment) {
+    return jsonError('Missing workflow slug or resource type', 400);
+  }
 
-    // POST /api/v1/workflows/executions/:id/cancel
-    if (firstSegment === 'executions' && subPath) {
-      const parts = subPath.split('/');
-      const executionId = parts[0];
-      const action = parts[1];
+  // POST /api/v1/workflows/executions/:id/cancel
+  if (firstSegment === 'executions' && subPath) {
+    const parts = subPath.split('/');
+    const executionId = parts[0];
+    const action = parts[1];
 
-      if (action === 'cancel') {
-        await rc.ctx.runMutation(
-          internal.workflows.triggers.internal_mutations
-            .cancelExecutionInternal,
-          { executionId: toId<'wfExecutions'>(executionId) },
-        );
-        return jsonOk({ status: 'canceled' });
-      }
-
-      return jsonError(`Unknown action: ${action}`, 404);
-    }
-
-    // Remaining routes are /api/v1/workflows/:slug/:resource
-    const slug = firstSegment;
-    const resource = subPath?.split('/')[0];
-
-    if (resource === 'schedules') {
-      const body = await request.json();
-      const scheduleId = await rc.ctx.runMutation(
-        internal.workflows.triggers.internal_mutations.createScheduleInternal,
-        {
-          organizationId: rc.org.organizationId,
-          workflowSlug: slug,
-          cronExpression: body.cronExpression,
-          timezone: body.timezone,
-          createdBy: rc.user.email,
-        },
+    if (action === 'cancel') {
+      await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.cancelExecutionInternal,
+        { executionId: toId<'wfExecutions'>(executionId) },
       );
-      return jsonCreated({ id: scheduleId });
+      return jsonOk({ status: 'canceled' });
     }
 
-    if (resource === 'webhooks') {
-      const result = await rc.ctx.runMutation(
-        internal.workflows.triggers.internal_mutations.createWebhookInternal,
-        {
-          organizationId: rc.org.organizationId,
-          workflowSlug: slug,
-          createdBy: rc.user.email,
-        },
-      );
-      return jsonCreated({ id: result._id, token: result.token });
-    }
+    return jsonError(`Unknown action: ${action}`, 404);
+  }
 
-    if (resource === 'run') {
-      const body = await request.json();
-      const executionId = await rc.ctx.runAction(
-        internal.workflow_engine.helpers.engine.start_workflow_from_file
-          .startWorkflowFromFile,
-        {
-          organizationId: rc.org.organizationId,
-          orgSlug: rc.org.orgSlug,
-          workflowSlug: slug,
-          input: body.input,
-          triggeredBy: 'api',
-          triggerData: body.triggerData,
-          userId: rc.user.userId,
-        },
-      );
-      return jsonOk({ status: 'accepted', executionId });
-    }
+  // Remaining routes are /api/v1/workflows/:slug/:resource
+  const slug = firstSegment;
+  const resource = subPath?.split('/')[0];
 
-    return jsonError(`Unknown resource: ${resource}`, 404);
-  },
-);
+  if (resource === 'schedules') {
+    const body = await request.json();
+    const scheduleId = await rc.ctx.runMutation(
+      internal.workflows.triggers.internal_mutations.createScheduleInternal,
+      {
+        organizationId: rc.org.organizationId,
+        workflowSlug: slug,
+        cronExpression: body.cronExpression,
+        timezone: body.timezone,
+        createdBy: rc.user.email,
+      },
+    );
+    return jsonCreated({ id: scheduleId });
+  }
+
+  if (resource === 'webhooks') {
+    const result = await rc.ctx.runMutation(
+      internal.workflows.triggers.internal_mutations.createWebhookInternal,
+      {
+        organizationId: rc.org.organizationId,
+        workflowSlug: slug,
+        createdBy: rc.user.email,
+      },
+    );
+    return jsonCreated({ id: result._id, token: result.token });
+  }
+
+  if (resource === 'run') {
+    const body = await request.json();
+    const executionId = await rc.ctx.runAction(
+      internal.workflow_engine.helpers.engine.start_workflow_from_file
+        .startWorkflowFromFile,
+      {
+        organizationId: rc.org.organizationId,
+        orgSlug: rc.org.orgSlug,
+        workflowSlug: slug,
+        input: body.input,
+        triggeredBy: 'api',
+        triggerData: body.triggerData,
+        userId: rc.user.userId,
+      },
+    );
+    return jsonOk({ status: 'accepted', executionId });
+  }
+
+  return jsonError(`Unknown resource: ${resource}`, 404);
+});
 
 // ---------------------------------------------------------------------------
 // PATCH /api/v1/workflows/* (pathPrefix handler)
 // ---------------------------------------------------------------------------
 
-export const patchWorkflow = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
+export const patchWorkflow = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
 
-    if (resourceType === 'schedules' && subPath) {
-      const scheduleId = subPath.split('/')[0];
-      const body = await request.json();
-      await rc.ctx.runMutation(
-        internal.workflows.triggers.internal_mutations.updateScheduleInternal,
-        {
-          scheduleId: toId<'wfSchedules'>(scheduleId),
-          cronExpression: body.cronExpression,
-          timezone: body.timezone,
-          isActive: body.isActive,
-        },
-      );
-      return jsonNoContent();
-    }
+  if (resourceType === 'schedules' && subPath) {
+    const scheduleId = subPath.split('/')[0];
+    const body = await request.json();
+    await rc.ctx.runMutation(
+      internal.workflows.triggers.internal_mutations.updateScheduleInternal,
+      {
+        scheduleId: toId<'wfSchedules'>(scheduleId),
+        cronExpression: body.cronExpression,
+        timezone: body.timezone,
+        isActive: body.isActive,
+      },
+    );
+    return jsonNoContent();
+  }
 
-    return jsonError('Unknown resource', 404);
-  },
-);
+  return jsonError('Unknown resource', 404);
+});
 
 // ---------------------------------------------------------------------------
 // DELETE /api/v1/workflows/* (pathPrefix handler)
 // ---------------------------------------------------------------------------
 
-export const deleteWorkflow = withRestAuth(
-  'rest:api',
-  async (rc, request) => {
-    const url = new URL(request.url);
-    const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
+export const deleteWorkflow = withRestAuth('rest:api', async (rc, request) => {
+  const url = new URL(request.url);
+  const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
 
-    if (resourceType === 'schedules' && subPath) {
-      const scheduleId = subPath.split('/')[0];
-      await rc.ctx.runMutation(
-        internal.workflows.triggers.internal_mutations.deleteScheduleInternal,
-        { scheduleId: toId<'wfSchedules'>(scheduleId) },
-      );
-      return jsonNoContent();
-    }
+  if (resourceType === 'schedules' && subPath) {
+    const scheduleId = subPath.split('/')[0];
+    await rc.ctx.runMutation(
+      internal.workflows.triggers.internal_mutations.deleteScheduleInternal,
+      { scheduleId: toId<'wfSchedules'>(scheduleId) },
+    );
+    return jsonNoContent();
+  }
 
-    if (resourceType === 'webhooks' && subPath) {
-      const webhookId = subPath.split('/')[0];
-      await rc.ctx.runMutation(
-        internal.workflows.triggers.internal_mutations.deleteWebhookInternal,
-        { webhookId: toId<'wfWebhooks'>(webhookId) },
-      );
-      return jsonNoContent();
-    }
+  if (resourceType === 'webhooks' && subPath) {
+    const webhookId = subPath.split('/')[0];
+    await rc.ctx.runMutation(
+      internal.workflows.triggers.internal_mutations.deleteWebhookInternal,
+      { webhookId: toId<'wfWebhooks'>(webhookId) },
+    );
+    return jsonNoContent();
+  }
 
-    return jsonError('Unknown resource', 404);
-  },
-);
+  return jsonError('Unknown resource', 404);
+});

--- a/services/platform/convex/workflows/rest_api.ts
+++ b/services/platform/convex/workflows/rest_api.ts
@@ -1,0 +1,272 @@
+/**
+ * Workflows REST API handlers.
+ *
+ * Triggers:
+ *   GET    /api/v1/workflows/:slug/schedules   — List schedules
+ *   POST   /api/v1/workflows/:slug/schedules   — Create schedule
+ *   GET    /api/v1/workflows/:slug/webhooks    — List webhooks
+ *   POST   /api/v1/workflows/:slug/webhooks    — Create webhook
+ *   GET    /api/v1/workflows/:slug/logs        — Get trigger logs
+ *   POST   /api/v1/workflows/:slug/run         — Trigger workflow manually
+ *
+ * Trigger resources:
+ *   PATCH  /api/v1/workflows/schedules/:id     — Update schedule
+ *   DELETE /api/v1/workflows/schedules/:id     — Delete schedule
+ *   DELETE /api/v1/workflows/webhooks/:id      — Delete webhook
+ *
+ * Executions:
+ *   GET    /api/v1/workflows/:slug/executions          — List executions
+ *   GET    /api/v1/workflows/executions/:id             — Get execution details
+ *   POST   /api/v1/workflows/executions/:id/cancel      — Cancel execution
+ */
+
+import { internal } from '../_generated/api';
+import {
+  extractPathParts,
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseIntParam,
+  withRestAuth,
+} from '../lib/rest/helpers';
+import { toId } from '../lib/type_cast_helpers';
+
+const PREFIX = '/api/v1/workflows/';
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/workflows/* (pathPrefix handler)
+// ---------------------------------------------------------------------------
+
+export const getWorkflow = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
+
+    if (!firstSegment) {
+      return jsonError('Missing workflow slug or resource type', 400);
+    }
+
+    // GET /api/v1/workflows/executions/:id — get execution details
+    if (firstSegment === 'executions' && subPath) {
+      const executionId = subPath.split('/')[0];
+      const execution = await rc.ctx.runQuery(
+        internal.wf_executions.internal_queries.getExecutionStepJournalInternal,
+        { executionId: toId<'wfExecutions'>(executionId) },
+      );
+      if (!execution) {
+        return jsonError('Execution not found', 404);
+      }
+      return jsonOk(execution);
+    }
+
+    // Remaining routes are /api/v1/workflows/:slug/:resource
+    const slug = firstSegment;
+    const resource = subPath?.split('/')[0];
+
+    if (resource === 'schedules') {
+      const schedules = await rc.ctx.runQuery(
+        internal.workflows.triggers.internal_queries.getSchedulesBySlugInternal,
+        {
+          organizationId: rc.org.organizationId,
+          workflowSlug: slug,
+        },
+      );
+      return jsonOk(schedules);
+    }
+
+    if (resource === 'webhooks') {
+      const webhooks = await rc.ctx.runQuery(
+        internal.workflows.triggers.internal_queries.getWebhooksBySlugInternal,
+        {
+          organizationId: rc.org.organizationId,
+          workflowSlug: slug,
+        },
+      );
+      return jsonOk(webhooks);
+    }
+
+    if (resource === 'logs') {
+      const logs = await rc.ctx.runQuery(
+        internal.workflows.triggers.internal_queries
+          .getTriggerLogsBySlugInternal,
+        {
+          organizationId: rc.org.organizationId,
+          workflowSlug: slug,
+        },
+      );
+      return jsonOk(logs);
+    }
+
+    if (resource === 'executions') {
+      const cursor = url.searchParams.get('cursor') ?? null;
+      const numItems = parseIntParam(url, 'limit', 25);
+      const statusParam = url.searchParams.get('status');
+      const status = statusParam ? statusParam.split(',') : undefined;
+      const dateFrom = url.searchParams.get('dateFrom') ?? undefined;
+      const dateTo = url.searchParams.get('dateTo') ?? undefined;
+
+      const executions = await rc.ctx.runQuery(
+        internal.wf_executions.internal_queries.listExecutionsCursorInternal,
+        {
+          wfDefinitionId: slug,
+          cursor,
+          numItems,
+          status,
+          dateFrom,
+          dateTo,
+        },
+      );
+      return jsonOk(executions);
+    }
+
+    return jsonError(`Unknown resource: ${resource}`, 404);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/workflows/* (pathPrefix handler)
+// ---------------------------------------------------------------------------
+
+export const postWorkflow = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id: firstSegment, subPath } = extractPathParts(url, PREFIX);
+
+    if (!firstSegment) {
+      return jsonError('Missing workflow slug or resource type', 400);
+    }
+
+    // POST /api/v1/workflows/executions/:id/cancel
+    if (firstSegment === 'executions' && subPath) {
+      const parts = subPath.split('/');
+      const executionId = parts[0];
+      const action = parts[1];
+
+      if (action === 'cancel') {
+        await rc.ctx.runMutation(
+          internal.workflows.triggers.internal_mutations
+            .cancelExecutionInternal,
+          { executionId: toId<'wfExecutions'>(executionId) },
+        );
+        return jsonOk({ status: 'canceled' });
+      }
+
+      return jsonError(`Unknown action: ${action}`, 404);
+    }
+
+    // Remaining routes are /api/v1/workflows/:slug/:resource
+    const slug = firstSegment;
+    const resource = subPath?.split('/')[0];
+
+    if (resource === 'schedules') {
+      const body = await request.json();
+      const scheduleId = await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.createScheduleInternal,
+        {
+          organizationId: rc.org.organizationId,
+          workflowSlug: slug,
+          cronExpression: body.cronExpression,
+          timezone: body.timezone,
+          createdBy: rc.user.email,
+        },
+      );
+      return jsonCreated({ id: scheduleId });
+    }
+
+    if (resource === 'webhooks') {
+      const result = await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.createWebhookInternal,
+        {
+          organizationId: rc.org.organizationId,
+          workflowSlug: slug,
+          createdBy: rc.user.email,
+        },
+      );
+      return jsonCreated({ id: result._id, token: result.token });
+    }
+
+    if (resource === 'run') {
+      const body = await request.json();
+      const executionId = await rc.ctx.runAction(
+        internal.workflow_engine.helpers.engine.start_workflow_from_file
+          .startWorkflowFromFile,
+        {
+          organizationId: rc.org.organizationId,
+          orgSlug: rc.org.orgSlug,
+          workflowSlug: slug,
+          input: body.input,
+          triggeredBy: 'api',
+          triggerData: body.triggerData,
+          userId: rc.user.userId,
+        },
+      );
+      return jsonOk({ status: 'accepted', executionId });
+    }
+
+    return jsonError(`Unknown resource: ${resource}`, 404);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/workflows/* (pathPrefix handler)
+// ---------------------------------------------------------------------------
+
+export const patchWorkflow = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
+
+    if (resourceType === 'schedules' && subPath) {
+      const scheduleId = subPath.split('/')[0];
+      const body = await request.json();
+      await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.updateScheduleInternal,
+        {
+          scheduleId: toId<'wfSchedules'>(scheduleId),
+          cronExpression: body.cronExpression,
+          timezone: body.timezone,
+          isActive: body.isActive,
+        },
+      );
+      return jsonNoContent();
+    }
+
+    return jsonError('Unknown resource', 404);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/workflows/* (pathPrefix handler)
+// ---------------------------------------------------------------------------
+
+export const deleteWorkflow = withRestAuth(
+  'rest:api',
+  async (rc, request) => {
+    const url = new URL(request.url);
+    const { id: resourceType, subPath } = extractPathParts(url, PREFIX);
+
+    if (resourceType === 'schedules' && subPath) {
+      const scheduleId = subPath.split('/')[0];
+      await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.deleteScheduleInternal,
+        { scheduleId: toId<'wfSchedules'>(scheduleId) },
+      );
+      return jsonNoContent();
+    }
+
+    if (resourceType === 'webhooks' && subPath) {
+      const webhookId = subPath.split('/')[0];
+      await rc.ctx.runMutation(
+        internal.workflows.triggers.internal_mutations.deleteWebhookInternal,
+        { webhookId: toId<'wfWebhooks'>(webhookId) },
+      );
+      return jsonNoContent();
+    }
+
+    return jsonError('Unknown resource', 404);
+  },
+);

--- a/services/platform/convex/workflows/triggers/internal_mutations.ts
+++ b/services/platform/convex/workflows/triggers/internal_mutations.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 
 import type { Id } from '../../_generated/dataModel';
 import { internalMutation } from '../../_generated/server';
+import { generateToken } from './helpers/crypto';
 import { processEventHandler } from './process_event';
 
 export const updateScheduleLastTriggered = internalMutation({
@@ -117,4 +118,113 @@ export const processEvent = internalMutation({
   },
   returns: v.null(),
   handler: processEventHandler,
+});
+
+// ---------------------------------------------------------------------------
+// REST API helpers — CRUD for schedules, webhooks
+// ---------------------------------------------------------------------------
+
+export const createScheduleInternal = internalMutation({
+  args: {
+    organizationId: v.string(),
+    workflowSlug: v.string(),
+    cronExpression: v.string(),
+    timezone: v.string(),
+    createdBy: v.string(),
+  },
+  returns: v.id('wfSchedules'),
+  handler: async (ctx, args): Promise<Id<'wfSchedules'>> => {
+    return await ctx.db.insert('wfSchedules', {
+      organizationId: args.organizationId,
+      workflowSlug: args.workflowSlug,
+      cronExpression: args.cronExpression,
+      timezone: args.timezone,
+      isActive: true,
+      createdAt: Date.now(),
+      createdBy: args.createdBy,
+    });
+  },
+});
+
+export const updateScheduleInternal = internalMutation({
+  args: {
+    scheduleId: v.id('wfSchedules'),
+    cronExpression: v.optional(v.string()),
+    timezone: v.optional(v.string()),
+    isActive: v.optional(v.boolean()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { scheduleId, ...patch } = args;
+    const updates: Record<string, unknown> = {};
+    if (patch.cronExpression !== undefined)
+      updates.cronExpression = patch.cronExpression;
+    if (patch.timezone !== undefined) updates.timezone = patch.timezone;
+    if (patch.isActive !== undefined) updates.isActive = patch.isActive;
+    if (Object.keys(updates).length > 0) {
+      await ctx.db.patch(scheduleId, updates);
+    }
+    return null;
+  },
+});
+
+export const deleteScheduleInternal = internalMutation({
+  args: { scheduleId: v.id('wfSchedules') },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await ctx.db.delete(args.scheduleId);
+    return null;
+  },
+});
+
+export const createWebhookInternal = internalMutation({
+  args: {
+    organizationId: v.string(),
+    workflowSlug: v.string(),
+    createdBy: v.string(),
+  },
+  returns: v.object({ _id: v.id('wfWebhooks'), token: v.string() }),
+  handler: async (ctx, args) => {
+    const token = generateToken();
+    const id = await ctx.db.insert('wfWebhooks', {
+      organizationId: args.organizationId,
+      workflowSlug: args.workflowSlug,
+      token,
+      isActive: true,
+      createdAt: Date.now(),
+      createdBy: args.createdBy,
+    });
+    return { _id: id, token };
+  },
+});
+
+export const deleteWebhookInternal = internalMutation({
+  args: { webhookId: v.id('wfWebhooks') },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await ctx.db.delete(args.webhookId);
+    return null;
+  },
+});
+
+export const cancelExecutionInternal = internalMutation({
+  args: { executionId: v.id('wfExecutions') },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const execution = await ctx.db.get(args.executionId);
+    if (
+      execution &&
+      (execution.status === 'running' || execution.status === 'pending')
+    ) {
+      await ctx.db.patch(args.executionId, {
+        status: 'failed',
+        updatedAt: Date.now(),
+        metadata: JSON.stringify({
+          error: 'Cancelled via REST API',
+          cancelledAt: Date.now(),
+        }),
+      });
+    }
+    return null;
+  },
 });

--- a/services/platform/convex/workflows/triggers/internal_queries.ts
+++ b/services/platform/convex/workflows/triggers/internal_queries.ts
@@ -56,3 +56,68 @@ export const getApiKeyByHash = internalQuery({
       .first();
   },
 });
+
+// ---------------------------------------------------------------------------
+// REST API helpers
+// ---------------------------------------------------------------------------
+
+export const getSchedulesBySlugInternal = internalQuery({
+  args: {
+    organizationId: v.string(),
+    workflowSlug: v.string(),
+  },
+  handler: async (ctx, args): Promise<Doc<'wfSchedules'>[]> => {
+    const results: Doc<'wfSchedules'>[] = [];
+    for await (const schedule of ctx.db
+      .query('wfSchedules')
+      .withIndex('by_workflowSlug', (q) =>
+        q.eq('workflowSlug', args.workflowSlug),
+      )) {
+      if (schedule.organizationId === args.organizationId) {
+        results.push(schedule);
+      }
+    }
+    return results;
+  },
+});
+
+export const getWebhooksBySlugInternal = internalQuery({
+  args: {
+    organizationId: v.string(),
+    workflowSlug: v.string(),
+  },
+  handler: async (ctx, args): Promise<Doc<'wfWebhooks'>[]> => {
+    const results: Doc<'wfWebhooks'>[] = [];
+    for await (const webhook of ctx.db
+      .query('wfWebhooks')
+      .withIndex('by_workflowSlug', (q) =>
+        q.eq('workflowSlug', args.workflowSlug),
+      )) {
+      if (webhook.organizationId === args.organizationId) {
+        results.push(webhook);
+      }
+    }
+    return results;
+  },
+});
+
+export const getTriggerLogsBySlugInternal = internalQuery({
+  args: {
+    organizationId: v.string(),
+    workflowSlug: v.string(),
+  },
+  handler: async (ctx, args): Promise<Doc<'wfTriggerLogs'>[]> => {
+    const results: Doc<'wfTriggerLogs'>[] = [];
+    for await (const log of ctx.db
+      .query('wfTriggerLogs')
+      .withIndex('by_workflowSlug', (q) =>
+        q.eq('workflowSlug', args.workflowSlug),
+      )
+      .order('desc')) {
+      if (log.organizationId === args.organizationId) {
+        results.push(log);
+      }
+    }
+    return results;
+  },
+});

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1575,7 +1575,8 @@
         }
       },
       "never": "Nie",
-      "neverUsed": "Nie verwendet"
+      "neverUsed": "Nie verwendet",
+      "docsGuide": "Verwenden Sie API-Schlüssel für den Zugriff auf die REST-API. Verfügbare Endpunkte finden Sie in der API-Dokumentation."
     },
     "apiDocs": {
       "title": "API-Dokumentation",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1579,7 +1579,8 @@
         }
       },
       "never": "Never",
-      "neverUsed": "Never used"
+      "neverUsed": "Never used",
+      "docsGuide": "Use API keys to access the REST API. View available endpoints in the API documentation."
     },
     "apiDocs": {
       "title": "API documentation",

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Tale Public API",
     "version": "1.0.0",
-    "description": "Tale Public API — OpenAI-compatible Chat Completions interface.\n\n## Authentication\n\nUse a Bearer token with your API key:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n    default_headers={\"X-Organization-Slug\": \"default\"},\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```"
+    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```"
   },
   "servers": [
     {
@@ -19,7 +19,9 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "Create chat completion",
         "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
@@ -29,15 +31,6 @@
           }
         ],
         "parameters": [
-          {
-            "name": "X-Organization-Slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Organization slug. Auto-resolved if user belongs to one org."
-          },
           {
             "name": "X-Thread-Id",
             "in": "header",
@@ -98,7 +91,9 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -107,17 +102,7 @@
             "bearerAuth": []
           }
         ],
-        "parameters": [
-          {
-            "name": "X-Organization-Slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Organization slug."
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "List of models",
@@ -134,6 +119,2785 @@
           }
         }
       }
+    },
+    "/api/v1/documents": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "List documents",
+        "operationId": "listDocuments",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "sourceProvider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source provider"
+          },
+          {
+            "name": "folderId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by folder ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of documents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Create document",
+        "operationId": "createDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{id}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Get document",
+        "operationId": "getDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Document ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Update document",
+        "operationId": "updateDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Document ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Delete document",
+        "operationId": "deleteDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Document ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{id}/retry-indexing": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Retry RAG indexing",
+        "operationId": "retryDocumentIndexing",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Document ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indexing retried"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/websites": {
+      "get": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "List websites",
+        "operationId": "listWebsites",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by status"
+          },
+          {
+            "name": "scanInterval",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by scan interval"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of websites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebsiteList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Create website",
+        "operationId": "createWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebsiteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created website",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Website"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/websites/{id}": {
+      "get": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Get website",
+        "operationId": "getWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Website details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Website"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Update website",
+        "operationId": "updateWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebsiteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated website",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Website"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Delete website",
+        "operationId": "deleteWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Website deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/websites/{id}/pages": {
+      "get": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Fetch pages",
+        "operationId": "listWebsitePages",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Pagination offset"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of pages to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebsitePageList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/websites/{id}/sync": {
+      "post": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Sync statuses",
+        "operationId": "syncWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync initiated"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/websites/{id}/search": {
+      "post": {
+        "tags": [
+          "Websites"
+        ],
+        "summary": "Search content",
+        "operationId": "searchWebsite",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Website ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebsiteSearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebsiteSearchResults"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/products": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "List products",
+        "operationId": "listProducts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by status"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by category"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of products",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Create product",
+        "operationId": "createProduct",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/products/{id}": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Get product",
+        "operationId": "getProduct",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Product ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Update product",
+        "operationId": "updateProduct",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Product ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Delete product",
+        "operationId": "deleteProduct",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Product ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/customers": {
+      "get": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "List customers",
+        "operationId": "listCustomers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by status"
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source"
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by locale"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of customers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "Create customer",
+        "operationId": "createCustomer",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created customer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/customers/{id}": {
+      "get": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "Get customer",
+        "operationId": "getCustomer",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Customer ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Customer details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "Update customer",
+        "operationId": "updateCustomer",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Customer ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated customer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "Delete customer",
+        "operationId": "deleteCustomer",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Customer ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Customer deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/vendors": {
+      "get": {
+        "tags": [
+          "Vendors"
+        ],
+        "summary": "List vendors",
+        "operationId": "listVendors",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source"
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by locale"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of vendors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VendorList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Vendors"
+        ],
+        "summary": "Create vendor",
+        "operationId": "createVendor",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVendorRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created vendor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/vendors/{id}": {
+      "get": {
+        "tags": [
+          "Vendors"
+        ],
+        "summary": "Get vendor",
+        "operationId": "getVendor",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Vendor ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vendor details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Vendors"
+        ],
+        "summary": "Update vendor",
+        "operationId": "updateVendor",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Vendor ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVendorRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated vendor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Vendors"
+        ],
+        "summary": "Delete vendor",
+        "operationId": "deleteVendor",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Vendor ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vendor deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/agents": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List agents",
+        "operationId": "listAgents",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of agents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/agents/tools": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List available tools",
+        "operationId": "listAgentTools",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available tools"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/agents/integrations": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List available integrations",
+        "operationId": "listAgentIntegrations",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available integrations"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{slug}": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get agent config and binding",
+        "operationId": "getAgent",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Agent slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent configuration and binding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Update agent binding",
+        "operationId": "updateAgentBinding",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Agent slug"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentBindingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated agent binding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/{slug}/schedules": {
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "List schedules",
+        "operationId": "listWorkflowSchedules",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of schedules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Create schedule",
+        "operationId": "createWorkflowSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScheduleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created schedule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schedule"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/schedules/{id}": {
+      "patch": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Update schedule",
+        "operationId": "updateWorkflowSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Schedule ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated schedule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schedule"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Delete schedule",
+        "operationId": "deleteWorkflowSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Schedule ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schedule deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/{slug}/webhooks": {
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "List webhooks",
+        "operationId": "listWorkflowWebhooks",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of webhooks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Create webhook",
+        "operationId": "createWorkflowWebhook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Created webhook",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/webhooks/{id}": {
+      "delete": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Delete webhook",
+        "operationId": "deleteWorkflowWebhook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Webhook ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/{slug}/logs": {
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Get trigger logs",
+        "operationId": "getWorkflowLogs",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trigger logs"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/{slug}/executions": {
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "List executions",
+        "operationId": "listWorkflowExecutions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by execution status"
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter from date (ISO 8601)"
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter to date (ISO 8601)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of executions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/executions/{id}": {
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Get execution details",
+        "operationId": "getWorkflowExecution",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Execution ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Execution details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Execution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/executions/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Cancel execution",
+        "operationId": "cancelWorkflowExecution",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Execution ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Execution cancelled"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/workflows/{slug}/run": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Trigger workflow",
+        "operationId": "triggerWorkflow",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow triggered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Execution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/threads": {
+      "get": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "List threads",
+        "operationId": "listThreads",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor from a previous response"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum number of items to return"
+          },
+          {
+            "name": "archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set to \"true\" to list archived threads"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated thread list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Create thread",
+        "operationId": "createThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created thread",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedResource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/threads/{id}": {
+      "get": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Get thread",
+        "operationId": "getThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Update thread title",
+        "operationId": "updateThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateThreadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Updated"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Delete thread",
+        "operationId": "deleteThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/threads/{id}/messages": {
+      "get": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Get thread messages",
+        "operationId": "getThreadMessages",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadMessages"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/threads/{id}/archive": {
+      "post": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Archive thread",
+        "operationId": "archiveThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread archived"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/threads/{id}/unarchive": {
+      "post": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Unarchive thread",
+        "operationId": "unarchiveThread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Thread ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread unarchived"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -147,7 +2911,10 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -205,7 +2972,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object"]
+                "enum": [
+                  "text",
+                  "json_object"
+                ]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -221,14 +2991,20 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["auto", "required", "none"]
+                "enum": [
+                  "auto",
+                  "required",
+                  "none"
+                ]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["function"]
+                    "enum": [
+                      "function"
+                    ]
                   },
                   "function": {
                     "type": "object",
@@ -237,7 +3013,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"]
+                    "required": [
+                      "name"
+                    ]
                   }
                 }
               }
@@ -255,7 +3033,9 @@
           },
           "object": {
             "type": "string",
-            "enum": ["chat.completion"]
+            "enum": [
+              "chat.completion"
+            ]
           },
           "created": {
             "type": "integer"
@@ -276,7 +3056,11 @@
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": ["stop", "length", "tool_calls"]
+                  "enum": [
+                    "stop",
+                    "length",
+                    "tool_calls"
+                  ]
                 }
               }
             }
@@ -302,7 +3086,9 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": ["list"]
+            "enum": [
+              "list"
+            ]
           },
           "data": {
             "type": "array",
@@ -315,7 +3101,9 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": ["model"]
+                  "enum": [
+                    "model"
+                  ]
                 },
                 "created": {
                   "type": "integer"
@@ -328,13 +3116,901 @@
           }
         }
       },
+      "DocumentList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateDocumentRequest": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "teamId": {
+            "type": "string"
+          },
+          "folderId": {
+            "type": "string"
+          }
+        }
+      },
+      "Document": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "teamId": {
+            "type": "string"
+          },
+          "folderId": {
+            "type": "string"
+          },
+          "sourceProvider": {
+            "type": "string"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "teamId": {
+            "type": "string"
+          },
+          "folderId": {
+            "type": "string"
+          }
+        }
+      },
+      "WebsiteList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Website"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateWebsiteRequest": {
+        "type": "object",
+        "required": [
+          "domain",
+          "scanInterval"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "scanInterval": {
+            "type": "string"
+          }
+        }
+      },
+      "Website": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "scanInterval": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateWebsiteRequest": {
+        "type": "object",
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "scanInterval": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "WebsitePageList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebsitePage"
+            }
+          },
+          "total": {
+            "type": "integer"
+          }
+        }
+      },
+      "WebsiteSearchRequest": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "integer"
+          }
+        }
+      },
+      "WebsiteSearchResults": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "snippet": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProductList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Product"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateProductRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "stock": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "Product": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "stock": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateProductRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "stock": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "CustomerList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Customer"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateCustomerRequest": {
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "VendorList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Vendor"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateVendorRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "Vendor": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateVendorRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      },
+      "AgentList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Agent"
+            }
+          }
+        }
+      },
+      "Agent": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "teamId": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateAgentBindingRequest": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "string"
+          }
+        }
+      },
+      "ScheduleList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Schedule"
+            }
+          }
+        }
+      },
+      "CreateScheduleRequest": {
+        "type": "object",
+        "required": [
+          "cronExpression",
+          "timezone"
+        ],
+        "properties": {
+          "cronExpression": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          }
+        }
+      },
+      "Schedule": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "cronExpression": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "UpdateScheduleRequest": {
+        "type": "object",
+        "properties": {
+          "cronExpression": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WebhookList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Webhook"
+            }
+          }
+        }
+      },
+      "Webhook": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "ExecutionList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Execution"
+            }
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Execution": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "number"
+          },
+          "completedAt": {
+            "type": "number"
+          },
+          "input": {
+            "type": "object"
+          },
+          "output": {
+            "type": "object"
+          },
+          "_creationTime": {
+            "type": "number"
+          }
+        }
+      },
+      "TriggerWorkflowRequest": {
+        "type": "object",
+        "properties": {
+          "input": {
+            "type": "object",
+            "description": "Input data for the workflow"
+          },
+          "triggerData": {
+            "type": "object",
+            "description": "Trigger-specific metadata"
+          }
+        }
+      },
+      "ThreadList": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Thread"
+            }
+          },
+          "isDone": {
+            "type": "boolean"
+          },
+          "continueCursor": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateThreadRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Thread title (defaults to \"New Chat\")"
+          }
+        }
+      },
+      "Thread": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "archived",
+              "deleted"
+            ]
+          },
+          "chatType": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "generationStatus": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateThreadRequest": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "ThreadMessages": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "_id": {
+                  "type": "string"
+                },
+                "_creationTime": {
+                  "type": "number"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ]
+                },
+                "content": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
       "ChatMessage": {
         "type": "object",
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["system", "user", "assistant", "tool"]
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool"
+            ]
           },
           "content": {
             "oneOf": [
@@ -362,15 +4038,22 @@
       },
       "ToolDefinition": {
         "type": "object",
-        "required": ["type", "function"],
+        "required": [
+          "type",
+          "function"
+        ],
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string"
@@ -386,6 +4069,40 @@
           }
         }
       },
+      "WebsitePage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "zip": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          }
+        }
+      },
       "ToolCall": {
         "type": "object",
         "properties": {
@@ -394,7 +4111,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",
@@ -414,8 +4133,40 @@
   },
   "tags": [
     {
+      "name": "Agents",
+      "description": "View and configure AI agents."
+    },
+    {
+      "name": "Customers",
+      "description": "Manage customer records."
+    },
+    {
+      "name": "Documents",
+      "description": "Manage documents for RAG knowledge base."
+    },
+    {
       "name": "OpenAI Compatible",
       "description": "OpenAI Chat Completions compatible API. Use any OpenAI SDK by pointing base_url to this server."
+    },
+    {
+      "name": "Products",
+      "description": "Manage product catalog entries."
+    },
+    {
+      "name": "Threads",
+      "description": "Manage AI chat threads — create, list, archive, and retrieve messages."
+    },
+    {
+      "name": "Vendors",
+      "description": "Manage vendor records."
+    },
+    {
+      "name": "Websites",
+      "description": "Manage website sources for crawling and indexing."
+    },
+    {
+      "name": "Workflows",
+      "description": "Manage workflow schedules, webhooks, executions, and triggers."
     }
   ]
 }

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -19,9 +19,7 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "Create chat completion",
         "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
@@ -91,9 +89,7 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -122,9 +118,7 @@
     },
     "/api/v1/documents": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "List documents",
         "operationId": "listDocuments",
         "security": [
@@ -196,9 +190,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Create document",
         "operationId": "createDocument",
         "security": [
@@ -244,9 +236,7 @@
     },
     "/api/v1/documents/{id}": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Get document",
         "operationId": "getDocument",
         "security": [
@@ -291,9 +281,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Update document",
         "operationId": "updateDocument",
         "security": [
@@ -348,9 +336,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Delete document",
         "operationId": "deleteDocument",
         "security": [
@@ -390,9 +376,7 @@
     },
     "/api/v1/documents/{id}/retry-indexing": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Retry RAG indexing",
         "operationId": "retryDocumentIndexing",
         "security": [
@@ -432,9 +416,7 @@
     },
     "/api/v1/websites": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "List websites",
         "operationId": "listWebsites",
         "security": [
@@ -506,9 +488,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Create website",
         "operationId": "createWebsite",
         "security": [
@@ -554,9 +534,7 @@
     },
     "/api/v1/websites/{id}": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Get website",
         "operationId": "getWebsite",
         "security": [
@@ -601,9 +579,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Update website",
         "operationId": "updateWebsite",
         "security": [
@@ -658,9 +634,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Delete website",
         "operationId": "deleteWebsite",
         "security": [
@@ -700,9 +674,7 @@
     },
     "/api/v1/websites/{id}/pages": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Fetch pages",
         "operationId": "listWebsitePages",
         "security": [
@@ -767,9 +739,7 @@
     },
     "/api/v1/websites/{id}/sync": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Sync statuses",
         "operationId": "syncWebsite",
         "security": [
@@ -809,9 +779,7 @@
     },
     "/api/v1/websites/{id}/search": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Search content",
         "operationId": "searchWebsite",
         "security": [
@@ -868,9 +836,7 @@
     },
     "/api/v1/products": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "List products",
         "operationId": "listProducts",
         "security": [
@@ -942,9 +908,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Create product",
         "operationId": "createProduct",
         "security": [
@@ -990,9 +954,7 @@
     },
     "/api/v1/products/{id}": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Get product",
         "operationId": "getProduct",
         "security": [
@@ -1037,9 +999,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Update product",
         "operationId": "updateProduct",
         "security": [
@@ -1094,9 +1054,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Delete product",
         "operationId": "deleteProduct",
         "security": [
@@ -1136,9 +1094,7 @@
     },
     "/api/v1/customers": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "List customers",
         "operationId": "listCustomers",
         "security": [
@@ -1219,9 +1175,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "security": [
@@ -1267,9 +1221,7 @@
     },
     "/api/v1/customers/{id}": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Get customer",
         "operationId": "getCustomer",
         "security": [
@@ -1314,9 +1266,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "security": [
@@ -1371,9 +1321,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "security": [
@@ -1413,9 +1361,7 @@
     },
     "/api/v1/vendors": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "List vendors",
         "operationId": "listVendors",
         "security": [
@@ -1487,9 +1433,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Create vendor",
         "operationId": "createVendor",
         "security": [
@@ -1535,9 +1479,7 @@
     },
     "/api/v1/vendors/{id}": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Get vendor",
         "operationId": "getVendor",
         "security": [
@@ -1582,9 +1524,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Update vendor",
         "operationId": "updateVendor",
         "security": [
@@ -1639,9 +1579,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Delete vendor",
         "operationId": "deleteVendor",
         "security": [
@@ -1681,9 +1619,7 @@
     },
     "/api/v1/agents": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List agents",
         "operationId": "listAgents",
         "security": [
@@ -1719,9 +1655,7 @@
     },
     "/api/v1/agents/tools": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available tools",
         "operationId": "listAgentTools",
         "security": [
@@ -1750,9 +1684,7 @@
     },
     "/api/v1/agents/integrations": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available integrations",
         "operationId": "listAgentIntegrations",
         "security": [
@@ -1781,9 +1713,7 @@
     },
     "/api/v1/agents/{slug}": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Get agent config and binding",
         "operationId": "getAgent",
         "security": [
@@ -1828,9 +1758,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Update agent binding",
         "operationId": "updateAgentBinding",
         "security": [
@@ -1887,9 +1815,7 @@
     },
     "/api/v1/workflows/{slug}/schedules": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List schedules",
         "operationId": "listWorkflowSchedules",
         "security": [
@@ -1934,9 +1860,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create schedule",
         "operationId": "createWorkflowSchedule",
         "security": [
@@ -1993,9 +1917,7 @@
     },
     "/api/v1/workflows/schedules/{id}": {
       "patch": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Update schedule",
         "operationId": "updateWorkflowSchedule",
         "security": [
@@ -2050,9 +1972,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete schedule",
         "operationId": "deleteWorkflowSchedule",
         "security": [
@@ -2092,9 +2012,7 @@
     },
     "/api/v1/workflows/{slug}/webhooks": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List webhooks",
         "operationId": "listWorkflowWebhooks",
         "security": [
@@ -2139,9 +2057,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create webhook",
         "operationId": "createWorkflowWebhook",
         "security": [
@@ -2188,9 +2104,7 @@
     },
     "/api/v1/workflows/webhooks/{id}": {
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete webhook",
         "operationId": "deleteWorkflowWebhook",
         "security": [
@@ -2230,9 +2144,7 @@
     },
     "/api/v1/workflows/{slug}/logs": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get trigger logs",
         "operationId": "getWorkflowLogs",
         "security": [
@@ -2272,9 +2184,7 @@
     },
     "/api/v1/workflows/{slug}/executions": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List executions",
         "operationId": "listWorkflowExecutions",
         "security": [
@@ -2366,9 +2276,7 @@
     },
     "/api/v1/workflows/executions/{id}": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get execution details",
         "operationId": "getWorkflowExecution",
         "security": [
@@ -2415,9 +2323,7 @@
     },
     "/api/v1/workflows/executions/{id}/cancel": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Cancel execution",
         "operationId": "cancelWorkflowExecution",
         "security": [
@@ -2457,9 +2363,7 @@
     },
     "/api/v1/workflows/{slug}/run": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Trigger workflow",
         "operationId": "triggerWorkflow",
         "security": [
@@ -2516,9 +2420,7 @@
     },
     "/api/v1/threads": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "List threads",
         "operationId": "listThreads",
         "security": [
@@ -2581,9 +2483,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Create thread",
         "operationId": "createThread",
         "security": [
@@ -2629,9 +2529,7 @@
     },
     "/api/v1/threads/{id}": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread",
         "operationId": "getThread",
         "security": [
@@ -2676,9 +2574,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Update thread title",
         "operationId": "updateThread",
         "security": [
@@ -2726,9 +2622,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Delete thread",
         "operationId": "deleteThread",
         "security": [
@@ -2768,9 +2662,7 @@
     },
     "/api/v1/threads/{id}/messages": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread messages",
         "operationId": "getThreadMessages",
         "security": [
@@ -2817,9 +2709,7 @@
     },
     "/api/v1/threads/{id}/archive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Archive thread",
         "operationId": "archiveThread",
         "security": [
@@ -2859,9 +2749,7 @@
     },
     "/api/v1/threads/{id}/unarchive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Unarchive thread",
         "operationId": "unarchiveThread",
         "security": [
@@ -2911,10 +2799,7 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -2972,10 +2857,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object"
-                ]
+                "enum": ["text", "json_object"]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -2991,20 +2873,14 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "required",
-                  "none"
-                ]
+                "enum": ["auto", "required", "none"]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "function"
-                    ]
+                    "enum": ["function"]
                   },
                   "function": {
                     "type": "object",
@@ -3013,9 +2889,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name"
-                    ]
+                    "required": ["name"]
                   }
                 }
               }
@@ -3033,9 +2907,7 @@
           },
           "object": {
             "type": "string",
-            "enum": [
-              "chat.completion"
-            ]
+            "enum": ["chat.completion"]
           },
           "created": {
             "type": "integer"
@@ -3056,11 +2928,7 @@
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": [
-                    "stop",
-                    "length",
-                    "tool_calls"
-                  ]
+                  "enum": ["stop", "length", "tool_calls"]
                 }
               }
             }
@@ -3086,9 +2954,7 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": [
-              "list"
-            ]
+            "enum": ["list"]
           },
           "data": {
             "type": "array",
@@ -3101,9 +2967,7 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": [
-                    "model"
-                  ]
+                  "enum": ["model"]
                 },
                 "created": {
                   "type": "integer"
@@ -3135,9 +2999,7 @@
       },
       "CreateDocumentRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -3248,10 +3110,7 @@
       },
       "CreateWebsiteRequest": {
         "type": "object",
-        "required": [
-          "domain",
-          "scanInterval"
-        ],
+        "required": ["domain", "scanInterval"],
         "properties": {
           "domain": {
             "type": "string"
@@ -3329,9 +3188,7 @@
       },
       "WebsiteSearchRequest": {
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {
             "type": "string"
@@ -3385,9 +3242,7 @@
       },
       "CreateProductRequest": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -3525,9 +3380,7 @@
       },
       "CreateCustomerRequest": {
         "type": "object",
-        "required": [
-          "email"
-        ],
+        "required": ["email"],
         "properties": {
           "email": {
             "type": "string"
@@ -3769,10 +3622,7 @@
       },
       "CreateScheduleRequest": {
         "type": "object",
-        "required": [
-          "cronExpression",
-          "timezone"
-        ],
+        "required": ["cronExpression", "timezone"],
         "properties": {
           "cronExpression": {
             "type": "string"
@@ -3937,11 +3787,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "archived",
-              "deleted"
-            ]
+            "enum": ["active", "archived", "deleted"]
           },
           "chatType": {
             "type": "string"
@@ -3959,9 +3805,7 @@
       },
       "UpdateThreadRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -3984,10 +3828,7 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "user",
-                    "assistant"
-                  ]
+                  "enum": ["user", "assistant"]
                 },
                 "content": {
                   "type": "string"
@@ -3999,18 +3840,11 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "tool"
-            ]
+            "enum": ["system", "user", "assistant", "tool"]
           },
           "content": {
             "oneOf": [
@@ -4038,22 +3872,15 @@
       },
       "ToolDefinition": {
         "type": "object",
-        "required": [
-          "type",
-          "function"
-        ],
+        "required": ["type", "function"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "name": {
                 "type": "string"
@@ -4111,9 +3938,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -73,14 +73,6 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
       security: [{ bearerAuth: [] }],
       parameters: [
         {
-          name: 'X-Organization-Slug',
-          in: 'header',
-          required: false,
-          schema: { type: 'string' },
-          description:
-            'Organization slug. Auto-resolved if user belongs to one org.',
-        },
-        {
           name: 'X-Thread-Id',
           in: 'header',
           required: false,
@@ -133,15 +125,7 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
         'List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.',
       operationId: 'listModels',
       security: [{ bearerAuth: [] }],
-      parameters: [
-        {
-          name: 'X-Organization-Slug',
-          in: 'header',
-          required: false,
-          schema: { type: 'string' },
-          description: 'Organization slug.',
-        },
-      ],
+      parameters: [],
       responses: {
         '200': {
           description: 'List of models',
@@ -349,6 +333,1305 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
   };
 }
 
+// ── Shared response helpers ──────────────────────────────────────────────────
+
+const errorResponses = {
+  '400': { description: 'Bad request' },
+  '401': { description: 'Unauthorized' },
+  '404': { description: 'Not found' },
+  '500': { description: 'Internal server error' },
+};
+
+function jsonBody(schemaRef: string, required = true) {
+  return {
+    required,
+    content: {
+      'application/json': {
+        schema: { $ref: `#/components/schemas/${schemaRef}` },
+      },
+    },
+  };
+}
+
+function jsonResponse(description: string, schemaRef?: string) {
+  if (!schemaRef) return { description };
+  return {
+    description,
+    content: {
+      'application/json': {
+        schema: { $ref: `#/components/schemas/${schemaRef}` },
+      },
+    },
+  };
+}
+
+function pathParam(name: string, description: string) {
+  return {
+    name,
+    in: 'path' as const,
+    required: true,
+    schema: { type: 'string' },
+    description,
+  };
+}
+
+function queryParam(
+  name: string,
+  description: string,
+  opts?: { type?: string; required?: boolean },
+) {
+  return {
+    name,
+    in: 'query' as const,
+    required: opts?.required ?? false,
+    schema: { type: opts?.type ?? 'string' },
+    description,
+  };
+}
+
+const paginationParams = [
+  queryParam('cursor', 'Pagination cursor from a previous response'),
+  queryParam('limit', 'Maximum number of items to return', { type: 'integer' }),
+];
+
+const sec = [{ bearerAuth: [] }];
+
+// ── REST API endpoint definitions ───────────────────────────────────────────
+
+function injectRestApiPaths(spec: OpenApiSpec) {
+  const schemas = spec.components.schemas;
+
+  // ── Documents ─────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/documents'] = {
+    get: {
+      tags: ['Documents'],
+      summary: 'List documents',
+      operationId: 'listDocuments',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('sourceProvider', 'Filter by source provider'),
+        queryParam('folderId', 'Filter by folder ID'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of documents', 'DocumentList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Documents'],
+      summary: 'Create document',
+      operationId: 'createDocument',
+      security: sec,
+      requestBody: jsonBody('CreateDocumentRequest'),
+      responses: {
+        '200': jsonResponse('Created document', 'Document'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/documents/{id}'] = {
+    get: {
+      tags: ['Documents'],
+      summary: 'Get document',
+      operationId: 'getDocument',
+      security: sec,
+      parameters: [pathParam('id', 'Document ID')],
+      responses: {
+        '200': jsonResponse('Document details', 'Document'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Documents'],
+      summary: 'Update document',
+      operationId: 'updateDocument',
+      security: sec,
+      parameters: [pathParam('id', 'Document ID')],
+      requestBody: jsonBody('UpdateDocumentRequest'),
+      responses: {
+        '200': jsonResponse('Updated document', 'Document'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Documents'],
+      summary: 'Delete document',
+      operationId: 'deleteDocument',
+      security: sec,
+      parameters: [pathParam('id', 'Document ID')],
+      responses: {
+        '200': jsonResponse('Document deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/documents/{id}/retry-indexing'] = {
+    post: {
+      tags: ['Documents'],
+      summary: 'Retry RAG indexing',
+      operationId: 'retryDocumentIndexing',
+      security: sec,
+      parameters: [pathParam('id', 'Document ID')],
+      responses: {
+        '200': jsonResponse('Indexing retried'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Document = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      title: { type: 'string' },
+      content: { type: 'string' },
+      fileId: { type: 'string' },
+      mimeType: { type: 'string' },
+      extension: { type: 'string' },
+      metadata: { type: 'object' },
+      teamId: { type: 'string' },
+      folderId: { type: 'string' },
+      sourceProvider: { type: 'string' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.DocumentList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Document' } },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.CreateDocumentRequest = {
+    type: 'object',
+    required: ['title'],
+    properties: {
+      title: { type: 'string' },
+      content: { type: 'string' },
+      fileId: { type: 'string' },
+      mimeType: { type: 'string' },
+      extension: { type: 'string' },
+      metadata: { type: 'object' },
+      teamId: { type: 'string' },
+      folderId: { type: 'string' },
+    },
+  };
+
+  schemas.UpdateDocumentRequest = {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      content: { type: 'string' },
+      metadata: { type: 'object' },
+      mimeType: { type: 'string' },
+      extension: { type: 'string' },
+      teamId: { type: 'string' },
+      folderId: { type: 'string' },
+    },
+  };
+
+  // ── Websites ──────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/websites'] = {
+    get: {
+      tags: ['Websites'],
+      summary: 'List websites',
+      operationId: 'listWebsites',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('status', 'Filter by status'),
+        queryParam('scanInterval', 'Filter by scan interval'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of websites', 'WebsiteList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Websites'],
+      summary: 'Create website',
+      operationId: 'createWebsite',
+      security: sec,
+      requestBody: jsonBody('CreateWebsiteRequest'),
+      responses: {
+        '200': jsonResponse('Created website', 'Website'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/websites/{id}'] = {
+    get: {
+      tags: ['Websites'],
+      summary: 'Get website',
+      operationId: 'getWebsite',
+      security: sec,
+      parameters: [pathParam('id', 'Website ID')],
+      responses: {
+        '200': jsonResponse('Website details', 'Website'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Websites'],
+      summary: 'Update website',
+      operationId: 'updateWebsite',
+      security: sec,
+      parameters: [pathParam('id', 'Website ID')],
+      requestBody: jsonBody('UpdateWebsiteRequest'),
+      responses: {
+        '200': jsonResponse('Updated website', 'Website'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Websites'],
+      summary: 'Delete website',
+      operationId: 'deleteWebsite',
+      security: sec,
+      parameters: [pathParam('id', 'Website ID')],
+      responses: {
+        '200': jsonResponse('Website deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/websites/{id}/pages'] = {
+    get: {
+      tags: ['Websites'],
+      summary: 'Fetch pages',
+      operationId: 'listWebsitePages',
+      security: sec,
+      parameters: [
+        pathParam('id', 'Website ID'),
+        queryParam('offset', 'Pagination offset', { type: 'integer' }),
+        queryParam('limit', 'Maximum number of pages to return', {
+          type: 'integer',
+        }),
+      ],
+      responses: {
+        '200': jsonResponse('List of pages', 'WebsitePageList'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/websites/{id}/sync'] = {
+    post: {
+      tags: ['Websites'],
+      summary: 'Sync statuses',
+      operationId: 'syncWebsite',
+      security: sec,
+      parameters: [pathParam('id', 'Website ID')],
+      responses: {
+        '200': jsonResponse('Sync initiated'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/websites/{id}/search'] = {
+    post: {
+      tags: ['Websites'],
+      summary: 'Search content',
+      operationId: 'searchWebsite',
+      security: sec,
+      parameters: [pathParam('id', 'Website ID')],
+      requestBody: jsonBody('WebsiteSearchRequest'),
+      responses: {
+        '200': jsonResponse('Search results', 'WebsiteSearchResults'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Website = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      domain: { type: 'string' },
+      title: { type: 'string' },
+      description: { type: 'string' },
+      scanInterval: { type: 'string' },
+      status: { type: 'string' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.WebsiteList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Website' } },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.CreateWebsiteRequest = {
+    type: 'object',
+    required: ['domain', 'scanInterval'],
+    properties: {
+      domain: { type: 'string' },
+      title: { type: 'string' },
+      description: { type: 'string' },
+      scanInterval: { type: 'string' },
+    },
+  };
+
+  schemas.UpdateWebsiteRequest = {
+    type: 'object',
+    properties: {
+      domain: { type: 'string' },
+      title: { type: 'string' },
+      description: { type: 'string' },
+      scanInterval: { type: 'string' },
+      status: { type: 'string' },
+    },
+  };
+
+  schemas.WebsitePage = {
+    type: 'object',
+    properties: {
+      url: { type: 'string' },
+      title: { type: 'string' },
+      status: { type: 'string' },
+    },
+  };
+
+  schemas.WebsitePageList = {
+    type: 'object',
+    properties: {
+      data: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/WebsitePage' },
+      },
+      total: { type: 'integer' },
+    },
+  };
+
+  schemas.WebsiteSearchRequest = {
+    type: 'object',
+    required: ['query'],
+    properties: {
+      query: { type: 'string' },
+      limit: { type: 'integer' },
+    },
+  };
+
+  schemas.WebsiteSearchResults = {
+    type: 'object',
+    properties: {
+      results: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            title: { type: 'string' },
+            snippet: { type: 'string' },
+            score: { type: 'number' },
+          },
+        },
+      },
+    },
+  };
+
+  // ── Products ──────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/products'] = {
+    get: {
+      tags: ['Products'],
+      summary: 'List products',
+      operationId: 'listProducts',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('status', 'Filter by status'),
+        queryParam('category', 'Filter by category'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of products', 'ProductList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Products'],
+      summary: 'Create product',
+      operationId: 'createProduct',
+      security: sec,
+      requestBody: jsonBody('CreateProductRequest'),
+      responses: {
+        '200': jsonResponse('Created product', 'Product'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/products/{id}'] = {
+    get: {
+      tags: ['Products'],
+      summary: 'Get product',
+      operationId: 'getProduct',
+      security: sec,
+      parameters: [pathParam('id', 'Product ID')],
+      responses: {
+        '200': jsonResponse('Product details', 'Product'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Products'],
+      summary: 'Update product',
+      operationId: 'updateProduct',
+      security: sec,
+      parameters: [pathParam('id', 'Product ID')],
+      requestBody: jsonBody('UpdateProductRequest'),
+      responses: {
+        '200': jsonResponse('Updated product', 'Product'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Products'],
+      summary: 'Delete product',
+      operationId: 'deleteProduct',
+      security: sec,
+      parameters: [pathParam('id', 'Product ID')],
+      responses: {
+        '200': jsonResponse('Product deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Product = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      name: { type: 'string' },
+      description: { type: 'string' },
+      price: { type: 'number' },
+      currency: { type: 'string' },
+      stock: { type: 'integer' },
+      category: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      status: { type: 'string' },
+      imageUrl: { type: 'string' },
+      metadata: { type: 'object' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.ProductList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Product' } },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.CreateProductRequest = {
+    type: 'object',
+    required: ['name'],
+    properties: {
+      name: { type: 'string' },
+      description: { type: 'string' },
+      price: { type: 'number' },
+      currency: { type: 'string' },
+      stock: { type: 'integer' },
+      category: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      status: { type: 'string' },
+      imageUrl: { type: 'string' },
+      metadata: { type: 'object' },
+    },
+  };
+
+  schemas.UpdateProductRequest = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      description: { type: 'string' },
+      price: { type: 'number' },
+      currency: { type: 'string' },
+      stock: { type: 'integer' },
+      category: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      status: { type: 'string' },
+      imageUrl: { type: 'string' },
+      metadata: { type: 'object' },
+    },
+  };
+
+  // ── Customers ─────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/customers'] = {
+    get: {
+      tags: ['Customers'],
+      summary: 'List customers',
+      operationId: 'listCustomers',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('status', 'Filter by status'),
+        queryParam('source', 'Filter by source'),
+        queryParam('locale', 'Filter by locale'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of customers', 'CustomerList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Customers'],
+      summary: 'Create customer',
+      operationId: 'createCustomer',
+      security: sec,
+      requestBody: jsonBody('CreateCustomerRequest'),
+      responses: {
+        '200': jsonResponse('Created customer', 'Customer'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/customers/{id}'] = {
+    get: {
+      tags: ['Customers'],
+      summary: 'Get customer',
+      operationId: 'getCustomer',
+      security: sec,
+      parameters: [pathParam('id', 'Customer ID')],
+      responses: {
+        '200': jsonResponse('Customer details', 'Customer'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Customers'],
+      summary: 'Update customer',
+      operationId: 'updateCustomer',
+      security: sec,
+      parameters: [pathParam('id', 'Customer ID')],
+      requestBody: jsonBody('UpdateCustomerRequest'),
+      responses: {
+        '200': jsonResponse('Updated customer', 'Customer'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Customers'],
+      summary: 'Delete customer',
+      operationId: 'deleteCustomer',
+      security: sec,
+      parameters: [pathParam('id', 'Customer ID')],
+      responses: {
+        '200': jsonResponse('Customer deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Address = {
+    type: 'object',
+    properties: {
+      street: { type: 'string' },
+      city: { type: 'string' },
+      state: { type: 'string' },
+      zip: { type: 'string' },
+      country: { type: 'string' },
+    },
+  };
+
+  schemas.Customer = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      email: { type: 'string' },
+      name: { type: 'string' },
+      status: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      metadata: { type: 'object' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.CustomerList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Customer' } },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.CreateCustomerRequest = {
+    type: 'object',
+    required: ['email'],
+    properties: {
+      email: { type: 'string' },
+      name: { type: 'string' },
+      status: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      metadata: { type: 'object' },
+    },
+  };
+
+  schemas.UpdateCustomerRequest = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      email: { type: 'string' },
+      status: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      metadata: { type: 'object' },
+    },
+  };
+
+  // ── Vendors ───────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/vendors'] = {
+    get: {
+      tags: ['Vendors'],
+      summary: 'List vendors',
+      operationId: 'listVendors',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('source', 'Filter by source'),
+        queryParam('locale', 'Filter by locale'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of vendors', 'VendorList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Vendors'],
+      summary: 'Create vendor',
+      operationId: 'createVendor',
+      security: sec,
+      requestBody: jsonBody('CreateVendorRequest'),
+      responses: {
+        '200': jsonResponse('Created vendor', 'Vendor'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/vendors/{id}'] = {
+    get: {
+      tags: ['Vendors'],
+      summary: 'Get vendor',
+      operationId: 'getVendor',
+      security: sec,
+      parameters: [pathParam('id', 'Vendor ID')],
+      responses: {
+        '200': jsonResponse('Vendor details', 'Vendor'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Vendors'],
+      summary: 'Update vendor',
+      operationId: 'updateVendor',
+      security: sec,
+      parameters: [pathParam('id', 'Vendor ID')],
+      requestBody: jsonBody('UpdateVendorRequest'),
+      responses: {
+        '200': jsonResponse('Updated vendor', 'Vendor'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Vendors'],
+      summary: 'Delete vendor',
+      operationId: 'deleteVendor',
+      security: sec,
+      parameters: [pathParam('id', 'Vendor ID')],
+      responses: {
+        '200': jsonResponse('Vendor deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Vendor = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      name: { type: 'string' },
+      email: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      tags: { type: 'array', items: { type: 'string' } },
+      metadata: { type: 'object' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.VendorList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Vendor' } },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.CreateVendorRequest = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      email: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      tags: { type: 'array', items: { type: 'string' } },
+      metadata: { type: 'object' },
+    },
+  };
+
+  schemas.UpdateVendorRequest = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      email: { type: 'string' },
+      source: { type: 'string' },
+      locale: { type: 'string' },
+      address: { $ref: '#/components/schemas/Address' },
+      tags: { type: 'array', items: { type: 'string' } },
+      metadata: { type: 'object' },
+    },
+  };
+
+  // ── Agents ────────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/agents'] = {
+    get: {
+      tags: ['Agents'],
+      summary: 'List agents',
+      operationId: 'listAgents',
+      security: sec,
+      responses: {
+        '200': jsonResponse('List of agents', 'AgentList'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/agents/tools'] = {
+    get: {
+      tags: ['Agents'],
+      summary: 'List available tools',
+      operationId: 'listAgentTools',
+      security: sec,
+      responses: {
+        '200': jsonResponse('List of available tools'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/agents/integrations'] = {
+    get: {
+      tags: ['Agents'],
+      summary: 'List available integrations',
+      operationId: 'listAgentIntegrations',
+      security: sec,
+      responses: {
+        '200': jsonResponse('List of available integrations'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/agents/{slug}'] = {
+    get: {
+      tags: ['Agents'],
+      summary: 'Get agent config and binding',
+      operationId: 'getAgent',
+      security: sec,
+      parameters: [pathParam('slug', 'Agent slug')],
+      responses: {
+        '200': jsonResponse('Agent configuration and binding', 'Agent'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Agents'],
+      summary: 'Update agent binding',
+      operationId: 'updateAgentBinding',
+      security: sec,
+      parameters: [pathParam('slug', 'Agent slug')],
+      requestBody: jsonBody('UpdateAgentBindingRequest'),
+      responses: {
+        '200': jsonResponse('Updated agent binding', 'Agent'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Agent = {
+    type: 'object',
+    properties: {
+      slug: { type: 'string' },
+      name: { type: 'string' },
+      description: { type: 'string' },
+      teamId: { type: 'string' },
+    },
+  };
+
+  schemas.AgentList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Agent' } },
+    },
+  };
+
+  schemas.UpdateAgentBindingRequest = {
+    type: 'object',
+    properties: {
+      teamId: { type: 'string' },
+    },
+  };
+
+  // ── Workflows ─────────────────────────────────────────────────────────────
+
+  // Schedules
+  spec.paths['/api/v1/workflows/{slug}/schedules'] = {
+    get: {
+      tags: ['Workflows'],
+      summary: 'List schedules',
+      operationId: 'listWorkflowSchedules',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      responses: {
+        '200': jsonResponse('List of schedules', 'ScheduleList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Workflows'],
+      summary: 'Create schedule',
+      operationId: 'createWorkflowSchedule',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      requestBody: jsonBody('CreateScheduleRequest'),
+      responses: {
+        '200': jsonResponse('Created schedule', 'Schedule'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/workflows/schedules/{id}'] = {
+    patch: {
+      tags: ['Workflows'],
+      summary: 'Update schedule',
+      operationId: 'updateWorkflowSchedule',
+      security: sec,
+      parameters: [pathParam('id', 'Schedule ID')],
+      requestBody: jsonBody('UpdateScheduleRequest'),
+      responses: {
+        '200': jsonResponse('Updated schedule', 'Schedule'),
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: ['Workflows'],
+      summary: 'Delete schedule',
+      operationId: 'deleteWorkflowSchedule',
+      security: sec,
+      parameters: [pathParam('id', 'Schedule ID')],
+      responses: {
+        '200': jsonResponse('Schedule deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Schedule = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      cronExpression: { type: 'string' },
+      timezone: { type: 'string' },
+      isActive: { type: 'boolean' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.ScheduleList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Schedule' } },
+    },
+  };
+
+  schemas.CreateScheduleRequest = {
+    type: 'object',
+    required: ['cronExpression', 'timezone'],
+    properties: {
+      cronExpression: { type: 'string' },
+      timezone: { type: 'string' },
+    },
+  };
+
+  schemas.UpdateScheduleRequest = {
+    type: 'object',
+    properties: {
+      cronExpression: { type: 'string' },
+      timezone: { type: 'string' },
+      isActive: { type: 'boolean' },
+    },
+  };
+
+  // Webhooks
+  spec.paths['/api/v1/workflows/{slug}/webhooks'] = {
+    get: {
+      tags: ['Workflows'],
+      summary: 'List webhooks',
+      operationId: 'listWorkflowWebhooks',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      responses: {
+        '200': jsonResponse('List of webhooks', 'WebhookList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Workflows'],
+      summary: 'Create webhook',
+      operationId: 'createWorkflowWebhook',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      responses: {
+        '200': jsonResponse('Created webhook', 'Webhook'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/workflows/webhooks/{id}'] = {
+    delete: {
+      tags: ['Workflows'],
+      summary: 'Delete webhook',
+      operationId: 'deleteWorkflowWebhook',
+      security: sec,
+      parameters: [pathParam('id', 'Webhook ID')],
+      responses: {
+        '200': jsonResponse('Webhook deleted'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Webhook = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      url: { type: 'string' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.WebhookList = {
+    type: 'object',
+    properties: {
+      data: { type: 'array', items: { $ref: '#/components/schemas/Webhook' } },
+    },
+  };
+
+  // Logs
+  spec.paths['/api/v1/workflows/{slug}/logs'] = {
+    get: {
+      tags: ['Workflows'],
+      summary: 'Get trigger logs',
+      operationId: 'getWorkflowLogs',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      responses: {
+        '200': jsonResponse('Trigger logs'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  // Executions
+  spec.paths['/api/v1/workflows/{slug}/executions'] = {
+    get: {
+      tags: ['Workflows'],
+      summary: 'List executions',
+      operationId: 'listWorkflowExecutions',
+      security: sec,
+      parameters: [
+        pathParam('slug', 'Workflow slug'),
+        ...paginationParams,
+        queryParam('status', 'Filter by execution status'),
+        queryParam('dateFrom', 'Filter from date (ISO 8601)'),
+        queryParam('dateTo', 'Filter to date (ISO 8601)'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated list of executions', 'ExecutionList'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/workflows/executions/{id}'] = {
+    get: {
+      tags: ['Workflows'],
+      summary: 'Get execution details',
+      operationId: 'getWorkflowExecution',
+      security: sec,
+      parameters: [pathParam('id', 'Execution ID')],
+      responses: {
+        '200': jsonResponse('Execution details', 'Execution'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/workflows/executions/{id}/cancel'] = {
+    post: {
+      tags: ['Workflows'],
+      summary: 'Cancel execution',
+      operationId: 'cancelWorkflowExecution',
+      security: sec,
+      parameters: [pathParam('id', 'Execution ID')],
+      responses: {
+        '200': jsonResponse('Execution cancelled'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  // Run
+  spec.paths['/api/v1/workflows/{slug}/run'] = {
+    post: {
+      tags: ['Workflows'],
+      summary: 'Trigger workflow',
+      operationId: 'triggerWorkflow',
+      security: sec,
+      parameters: [pathParam('slug', 'Workflow slug')],
+      requestBody: jsonBody('TriggerWorkflowRequest', false),
+      responses: {
+        '200': jsonResponse('Workflow triggered', 'Execution'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Execution = {
+    type: 'object',
+    properties: {
+      _id: { type: 'string' },
+      status: { type: 'string' },
+      startedAt: { type: 'number' },
+      completedAt: { type: 'number' },
+      input: { type: 'object' },
+      output: { type: 'object' },
+      _creationTime: { type: 'number' },
+    },
+  };
+
+  schemas.ExecutionList = {
+    type: 'object',
+    properties: {
+      data: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/Execution' },
+      },
+      cursor: { type: 'string' },
+      hasMore: { type: 'boolean' },
+    },
+  };
+
+  schemas.TriggerWorkflowRequest = {
+    type: 'object',
+    properties: {
+      input: { type: 'object', description: 'Input data for the workflow' },
+      triggerData: { type: 'object', description: 'Trigger-specific metadata' },
+    },
+  };
+
+  // ── Threads ──────────────────────────────────────────────────────────────
+
+  spec.paths['/api/v1/threads'] = {
+    get: {
+      tags: ['Threads'],
+      summary: 'List threads',
+      operationId: 'listThreads',
+      security: sec,
+      parameters: [
+        ...paginationParams,
+        queryParam('archived', 'Set to "true" to list archived threads'),
+      ],
+      responses: {
+        '200': jsonResponse('Paginated thread list', 'ThreadList'),
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Threads'],
+      summary: 'Create thread',
+      operationId: 'createThread',
+      security: sec,
+      requestBody: jsonBody('CreateThreadRequest'),
+      responses: {
+        '201': jsonResponse('Created thread', 'CreatedResource'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/threads/{id}'] = {
+    get: {
+      tags: ['Threads'],
+      summary: 'Get thread',
+      operationId: 'getThread',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      responses: {
+        '200': jsonResponse('Thread metadata', 'Thread'),
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Threads'],
+      summary: 'Update thread title',
+      operationId: 'updateThread',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      requestBody: jsonBody('UpdateThreadRequest'),
+      responses: { '204': { description: 'Updated' }, ...errorResponses },
+    },
+    delete: {
+      tags: ['Threads'],
+      summary: 'Delete thread',
+      operationId: 'deleteThread',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      responses: { '204': { description: 'Deleted' }, ...errorResponses },
+    },
+  };
+
+  spec.paths['/api/v1/threads/{id}/messages'] = {
+    get: {
+      tags: ['Threads'],
+      summary: 'Get thread messages',
+      operationId: 'getThreadMessages',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      responses: {
+        '200': jsonResponse('Thread messages', 'ThreadMessages'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/threads/{id}/archive'] = {
+    post: {
+      tags: ['Threads'],
+      summary: 'Archive thread',
+      operationId: 'archiveThread',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      responses: {
+        '200': jsonResponse('Thread archived'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  spec.paths['/api/v1/threads/{id}/unarchive'] = {
+    post: {
+      tags: ['Threads'],
+      summary: 'Unarchive thread',
+      operationId: 'unarchiveThread',
+      security: sec,
+      parameters: [pathParam('id', 'Thread ID')],
+      responses: {
+        '200': jsonResponse('Thread unarchived'),
+        ...errorResponses,
+      },
+    },
+  };
+
+  schemas.Thread = {
+    type: 'object',
+    properties: {
+      threadId: { type: 'string' },
+      userId: { type: 'string' },
+      title: { type: 'string' },
+      status: { type: 'string', enum: ['active', 'archived', 'deleted'] },
+      chatType: { type: 'string' },
+      createdAt: { type: 'number' },
+      updatedAt: { type: 'number' },
+      generationStatus: { type: 'string' },
+    },
+  };
+  schemas.ThreadList = {
+    type: 'object',
+    properties: {
+      page: { type: 'array', items: { $ref: '#/components/schemas/Thread' } },
+      isDone: { type: 'boolean' },
+      continueCursor: { type: 'string' },
+    },
+  };
+  schemas.CreateThreadRequest = {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        description: 'Thread title (defaults to "New Chat")',
+      },
+    },
+  };
+  schemas.UpdateThreadRequest = {
+    type: 'object',
+    required: ['title'],
+    properties: {
+      title: { type: 'string' },
+    },
+  };
+  schemas.ThreadMessages = {
+    type: 'object',
+    properties: {
+      messages: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            _creationTime: { type: 'number' },
+            role: { type: 'string', enum: ['user', 'assistant'] },
+            content: { type: 'string' },
+          },
+        },
+      },
+    },
+  };
+}
+
 function main() {
   const tempYamlPath = join(platformDir, 'convex-openapi-temp.yaml');
   const outputPath = join(platformDir, 'public', 'openapi.json');
@@ -431,9 +1714,43 @@ All endpoints accept POST requests with JSON body containing an \`args\` object:
 
   spec.tags = [
     {
+      name: 'Agents',
+      description: 'View and configure AI agents.',
+    },
+    {
+      name: 'Customers',
+      description: 'Manage customer records.',
+    },
+    {
+      name: 'Documents',
+      description: 'Manage documents for RAG knowledge base.',
+    },
+    {
       name: 'OpenAI Compatible',
       description:
         'OpenAI Chat Completions compatible API. Use any OpenAI SDK by pointing base_url to this server.',
+    },
+    {
+      name: 'Products',
+      description: 'Manage product catalog entries.',
+    },
+    {
+      name: 'Threads',
+      description:
+        'Manage AI chat threads — create, list, archive, and retrieve messages.',
+    },
+    {
+      name: 'Vendors',
+      description: 'Manage vendor records.',
+    },
+    {
+      name: 'Websites',
+      description: 'Manage website sources for crawling and indexing.',
+    },
+    {
+      name: 'Workflows',
+      description:
+        'Manage workflow schedules, webhooks, executions, and triggers.',
     },
     { name: 'query', description: 'Read-only functions that fetch data' },
     { name: 'mutation', description: 'Functions that modify data' },
@@ -442,6 +1759,9 @@ All endpoints accept POST requests with JSON body containing an \`args\` object:
 
   // Inject OpenAI-compatible endpoints (custom HTTP routes not covered by convex-helpers)
   injectOpenAICompatPaths(spec);
+
+  // Inject REST API endpoints
+  injectRestApiPaths(spec);
 
   const outputDir = dirname(outputPath);
   if (!existsSync(outputDir)) {
@@ -462,41 +1782,8 @@ All endpoints accept POST requests with JSON body containing an \`args\` object:
  * Swagger UI. Only endpoints matching these prefixes are shown.
  */
 const PUBLIC_ENDPOINT_PREFIXES = [
-  // OpenAI-compatible API (custom HTTP routes)
+  // All manually maintained REST API endpoints live under /api/v1/
   '/api/v1/',
-
-  // Documents
-  '/api/run/documents/queries/',
-  '/api/run/documents/mutations/',
-  '/api/run/documents/actions/',
-
-  // Websites
-  '/api/run/websites/queries/',
-  '/api/run/websites/mutations/',
-  '/api/run/websites/actions/',
-
-  // Products
-  '/api/run/products/queries/',
-  '/api/run/products/mutations/',
-
-  // Customers
-  '/api/run/customers/queries/',
-  '/api/run/customers/mutations/',
-
-  // Vendors
-  '/api/run/vendors/queries/',
-  '/api/run/vendors/mutations/',
-
-  // Agents
-  '/api/run/agents/file_actions/',
-  '/api/run/agents/queries/',
-  '/api/run/agents/mutations/',
-  '/api/run/agents/webhooks/queries/',
-  '/api/run/agents/webhooks/mutations/',
-
-  // Workflows / Automations
-  '/api/run/workflows/triggers/slug_queries/',
-  '/api/run/workflows/triggers/slug_mutations/',
 ];
 
 /**
@@ -550,11 +1837,11 @@ function generatePublicSpec(fullSpec: OpenApiSpec): OpenApiSpec {
       title: 'Tale Public API',
       version: '1.0.0',
       description: `
-Tale Public API — OpenAI-compatible Chat Completions interface.
+Tale Platform REST API.
 
 ## Authentication
 
-Use a Bearer token with your API key:
+All endpoints require a Bearer token:
 
 \`\`\`
 Authorization: Bearer tale_...
@@ -562,7 +1849,23 @@ Authorization: Bearer tale_...
 
 Create API keys in **Settings > API Keys**.
 
-## Quick start
+## Quick start — REST API
+
+\`\`\`bash
+# List documents
+curl -H "Authorization: Bearer tale_..." https://your-instance.com/api/v1/documents
+
+# Create a product
+curl -X POST -H "Authorization: Bearer tale_..." \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "New Product", "price": 9.99}' \\
+  https://your-instance.com/api/v1/products
+
+# List chat threads
+curl -H "Authorization: Bearer tale_..." https://your-instance.com/api/v1/threads
+\`\`\`
+
+## Quick start — OpenAI Compatible
 
 \`\`\`python
 from openai import OpenAI
@@ -570,7 +1873,6 @@ from openai import OpenAI
 client = OpenAI(
     base_url="https://your-instance.com/api/v1",
     api_key="tale_...",
-    default_headers={"X-Organization-Slug": "default"},
 )
 
 response = client.chat.completions.create(
@@ -593,7 +1895,19 @@ response = client.chat.completions.create(
       },
       schemas: publicSchemas,
     },
-    tags: (fullSpec.tags ?? []).filter((t) => t.name === 'OpenAI Compatible'),
+    tags: (fullSpec.tags ?? []).filter((t) =>
+      [
+        'OpenAI Compatible',
+        'Documents',
+        'Websites',
+        'Products',
+        'Customers',
+        'Vendors',
+        'Agents',
+        'Threads',
+        'Workflows',
+      ].includes(t.name),
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- Implement public REST API endpoints for agents, customers, documents, products, threads, vendors, websites, and workflows
- Add shared REST helpers library (`convex/lib/rest/`) with auth, pagination, and error handling
- Add rate limiting for API endpoints and OpenAPI spec generation
- Update API keys management UI and add docs route

Closes https://github.com/tale-project/tale/issues/1229

## Test plan

- [ ] Verify each REST endpoint returns correct responses for CRUD operations
- [ ] Confirm API key authentication works and rejects invalid keys
- [ ] Validate rate limiting triggers appropriately
- [ ] Check OpenAPI spec is accurate and serves correctly at `/docs`
- [ ] Test API keys table UI displays and manages keys properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * REST API v1 now available for managing agents, customers, documents, products, threads, vendors, and workflows with full CRUD operations.
  * Bearer token authentication for API access.
  * Rate limiting enabled (120 requests/minute with burst capacity).

* **Documentation**
  * OpenAPI specification updated with complete REST API endpoint documentation.
  * API documentation links added to API keys guidance.
  * Swagger UI enhanced with improved navigation and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->