### PR TITLE
feat(cli): add `tale auth reset-owner` command

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,6 +20,7 @@ export default {
         '!convex/betterAuth/_generated/**',
         'scripts/**/*.ts',
         'server.ts',
+        'reset-owner.ts',
       ],
       project: ['**/*.{ts,tsx}'],
       ignoreDependencies: ['convex-test', 'mermaid'],

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -66,6 +66,8 @@ COPY services/platform/vite-plugins ./services/platform/vite-plugins
 
 COPY services/platform/docker-entrypoint.sh \
      services/platform/generate-admin-key.sh \
+     services/platform/reset-owner.sh \
+     services/platform/reset-owner.ts \
      services/platform/env.sh \
      ./services/platform/
 
@@ -233,9 +235,9 @@ COPY --from=pruner --chown=app:app /app/services/platform/convex ./convex
 COPY --from=pruner --chown=app:app /app/services/platform/lib ./lib
 COPY --from=pruner --chown=app:app /app/node_modules ./node_modules
 COPY --from=pruner --chown=app:app /app/services/platform/package.json ./
-COPY --from=pruner --chown=app:app /app/services/platform/docker-entrypoint.sh /app/services/platform/generate-admin-key.sh /app/services/platform/env.sh ./
+COPY --from=pruner --chown=app:app /app/services/platform/docker-entrypoint.sh /app/services/platform/generate-admin-key.sh /app/services/platform/reset-owner.sh /app/services/platform/reset-owner.ts /app/services/platform/env.sh ./
 
-RUN chmod +x ./docker-entrypoint.sh ./generate-admin-key.sh
+RUN chmod +x ./docker-entrypoint.sh ./generate-admin-key.sh ./reset-owner.sh
 
 EXPOSE 3000 3210 3211 6791
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api/health || exit 1

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -649,8 +649,10 @@ import type * as users_create_user_without_session from "../users/create_user_wi
 import type * as users_get_user_by_email from "../users/get_user_by_email.js";
 import type * as users_has_any_users from "../users/has_any_users.js";
 import type * as users_helpers from "../users/helpers.js";
+import type * as users_internal_mutations from "../users/internal_mutations.js";
 import type * as users_mutations from "../users/mutations.js";
 import type * as users_queries from "../users/queries.js";
+import type * as users_reset_owner from "../users/reset_owner.js";
 import type * as users_set_member_password from "../users/set_member_password.js";
 import type * as users_types from "../users/types.js";
 import type * as users_update_user_name from "../users/update_user_name.js";
@@ -1561,8 +1563,10 @@ declare const fullApi: ApiFromModules<{
   "users/get_user_by_email": typeof users_get_user_by_email;
   "users/has_any_users": typeof users_has_any_users;
   "users/helpers": typeof users_helpers;
+  "users/internal_mutations": typeof users_internal_mutations;
   "users/mutations": typeof users_mutations;
   "users/queries": typeof users_queries;
+  "users/reset_owner": typeof users_reset_owner;
   "users/set_member_password": typeof users_set_member_password;
   "users/types": typeof users_types;
   "users/update_user_name": typeof users_update_user_name;

--- a/services/platform/convex/users/internal_mutations.ts
+++ b/services/platform/convex/users/internal_mutations.ts
@@ -1,0 +1,21 @@
+/**
+ * Users Internal Mutations
+ *
+ * Internal mutations for user operations that require admin-level access.
+ * These are not callable from the frontend — only via admin-authenticated clients.
+ */
+
+import { v } from 'convex/values';
+
+import { internalMutation } from '../_generated/server';
+import { resetOwner as resetOwnerHelper } from './reset_owner';
+
+export const resetOwner = internalMutation({
+  args: {
+    newEmail: v.optional(v.string()),
+    newPassword: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await resetOwnerHelper(ctx, args);
+  },
+});

--- a/services/platform/convex/users/reset_owner.ts
+++ b/services/platform/convex/users/reset_owner.ts
@@ -1,0 +1,191 @@
+/**
+ * Reset owner credentials - Business logic
+ *
+ * Resets the owner's email and/or password. Called only via admin-authenticated
+ * path (CLI → container script → internalMutation). No session auth check needed.
+ */
+
+import { hashPassword } from 'better-auth/crypto';
+
+import { isPasswordValid } from '../../lib/shared/schemas/password';
+import { isRecord, getString } from '../../lib/utils/type-guards';
+import { components } from '../_generated/api';
+import { MutationCtx } from '../_generated/server';
+
+export interface ResetOwnerArgs {
+  newEmail?: string;
+  newPassword?: string;
+}
+
+export interface ResetOwnerResult {
+  email: string;
+  updated: { email: boolean; password: boolean };
+}
+
+export async function resetOwner(
+  ctx: MutationCtx,
+  args: ResetOwnerArgs,
+): Promise<ResetOwnerResult> {
+  if (!args.newEmail && !args.newPassword) {
+    throw new Error('At least one of newEmail or newPassword is required');
+  }
+
+  // Find the owner member
+  const memberRes = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'member',
+    paginationOpts: { cursor: null, numItems: 10 },
+    where: [{ field: 'role', value: 'owner', operator: 'eq' }],
+  });
+
+  const ownerMember = memberRes?.page?.find(
+    (m: unknown) =>
+      isRecord(m) && getString(m, 'role')?.toLowerCase() === 'owner',
+  );
+  if (!isRecord(ownerMember)) {
+    throw new Error('No owner found in the organization');
+  }
+
+  const ownerUserId = getString(ownerMember, 'userId');
+  if (!ownerUserId) {
+    throw new Error('Owner member missing userId');
+  }
+
+  // Look up the owner's user record
+  const userRes = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'user',
+    paginationOpts: { cursor: null, numItems: 1 },
+    where: [{ field: '_id', value: ownerUserId, operator: 'eq' }],
+  });
+  const ownerUser = userRes?.page?.[0];
+  if (!isRecord(ownerUser)) {
+    throw new Error('Owner user record not found');
+  }
+
+  let currentEmail = getString(ownerUser, 'email') ?? '';
+  let updatedEmail = false;
+  let updatedPassword = false;
+
+  // Update email if requested
+  if (args.newEmail) {
+    // Check email uniqueness
+    const existingRes = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'user',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [{ field: 'email', value: args.newEmail, operator: 'eq' }],
+      },
+    );
+    const existingUser = existingRes?.page?.[0];
+    if (
+      isRecord(existingUser) &&
+      getString(existingUser, '_id') !== ownerUserId
+    ) {
+      throw new Error(
+        `Email "${args.newEmail}" is already in use by another user`,
+      );
+    }
+
+    const ownerId = getString(ownerUser, '_id');
+    if (!ownerId) throw new Error('Owner user missing _id');
+
+    await ctx.runMutation(components.betterAuth.adapter.updateMany, {
+      input: {
+        model: 'user',
+        where: [{ field: '_id', value: ownerId, operator: 'eq' }],
+        update: {
+          email: args.newEmail,
+          updatedAt: Date.now(),
+        },
+      },
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    currentEmail = args.newEmail;
+    updatedEmail = true;
+  }
+
+  // Update password if requested
+  if (args.newPassword) {
+    if (!isPasswordValid(args.newPassword)) {
+      throw new Error(
+        'Password must be at least 8 characters with lowercase, uppercase, number, and special character',
+      );
+    }
+
+    const passwordHash = await hashPassword(args.newPassword);
+
+    // Find existing credential account
+    const accountRes = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'account',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [
+          { field: 'userId', value: ownerUserId, operator: 'eq' },
+          { field: 'providerId', value: 'credential', operator: 'eq' },
+        ],
+      },
+    );
+    const existingCredential = accountRes?.page?.[0];
+
+    if (isRecord(existingCredential)) {
+      const credentialId = getString(existingCredential, '_id');
+      if (!credentialId) throw new Error('Credential account missing _id');
+
+      await ctx.runMutation(components.betterAuth.adapter.updateMany, {
+        input: {
+          model: 'account',
+          where: [{ field: '_id', value: credentialId, operator: 'eq' }],
+          update: {
+            password: passwordHash,
+            updatedAt: Date.now(),
+          },
+        },
+        paginationOpts: { cursor: null, numItems: 1 },
+      });
+    } else {
+      // Create credential account for OAuth-only owner
+      await ctx.runMutation(components.betterAuth.adapter.create, {
+        input: {
+          model: 'account',
+          data: {
+            userId: ownerUserId,
+            providerId: 'credential',
+            accountId: ownerUserId,
+            password: passwordHash,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+      });
+    }
+    updatedPassword = true;
+  }
+
+  // Invalidate all sessions for the owner
+  const SESSION_BATCH_SIZE = 100;
+  let hasMoreSessions = true;
+  while (hasMoreSessions) {
+    await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+      input: {
+        model: 'session',
+        where: [{ field: 'userId', value: ownerUserId, operator: 'eq' }],
+      },
+      paginationOpts: { cursor: null, numItems: SESSION_BATCH_SIZE },
+    });
+    const remaining = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'session',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [{ field: 'userId', value: ownerUserId, operator: 'eq' }],
+      },
+    );
+    hasMoreSessions = (remaining?.page?.length ?? 0) > 0;
+  }
+
+  return {
+    email: currentEmail,
+    updated: { email: updatedEmail, password: updatedPassword },
+  };
+}

--- a/services/platform/reset-owner.sh
+++ b/services/platform/reset-owner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# ============================================================================
+# Reset Owner Credentials
+# ============================================================================
+# Resets the owner's email and/or password via an internal Convex mutation.
+#
+# Usage (called by CLI via docker exec):
+#   docker exec -e RESET_EMAIL=new@example.com -e RESET_PASSWORD='NewP@ss1' \
+#     tale-platform-blue ./reset-owner.sh
+# ============================================================================
+
+set -e
+
+# Load centralized env normalization
+source "$(dirname "$0")/env.sh"
+env_normalize_common
+ensure_hex_instance_secret
+
+# Generate ephemeral admin key (never leaves the container)
+ADMIN_KEY=$(generate_key "$INSTANCE_NAME" "$INSTANCE_SECRET")
+
+# Run the Bun script with admin key and Convex URL
+ADMIN_KEY="$ADMIN_KEY" \
+CONVEX_URL="http://localhost:${CONVEX_PORT:-3210}" \
+RESET_EMAIL="${RESET_EMAIL:-}" \
+RESET_PASSWORD="${RESET_PASSWORD:-}" \
+bun ./reset-owner.ts

--- a/services/platform/reset-owner.ts
+++ b/services/platform/reset-owner.ts
@@ -27,7 +27,11 @@ if (!newEmail && !newPassword) {
 }
 
 const client = new ConvexHttpClient(convexUrl);
-client.setAdminAuth(adminKey);
+// setAdminAuth is @internal in Convex types but exists at runtime —
+// it enables calling internal functions with the admin key.
+(client as unknown as { setAdminAuth(token: string): void }).setAdminAuth(
+  adminKey,
+);
 
 try {
   const result = await client.mutation(

--- a/services/platform/reset-owner.ts
+++ b/services/platform/reset-owner.ts
@@ -26,12 +26,14 @@ if (!newEmail && !newPassword) {
   process.exit(1);
 }
 
+// setAdminAuth exists at runtime but is @internal (not in public types).
+// We need it to send the `Convex <adminKey>` auth header for internal functions.
 const client = new ConvexHttpClient(convexUrl);
-// setAdminAuth is @internal in Convex types but exists at runtime —
-// it enables calling internal functions with the admin key.
-(client as unknown as { setAdminAuth(token: string): void }).setAdminAuth(
-  adminKey,
-);
+// oxlint-disable-next-line no-unsafe-type-assertion
+const setAdminAuth = Reflect.get(client, 'setAdminAuth') as (
+  token: string,
+) => void;
+setAdminAuth.call(client, adminKey);
 
 try {
   const result = await client.mutation(

--- a/services/platform/reset-owner.ts
+++ b/services/platform/reset-owner.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env bun
+
+/**
+ * Reset owner credentials via admin-authenticated Convex HTTP client.
+ *
+ * Reads ADMIN_KEY, CONVEX_URL, RESET_EMAIL, RESET_PASSWORD from env.
+ * Outputs JSON result to stdout for the CLI to parse.
+ */
+
+import { ConvexHttpClient } from 'convex/browser';
+import { anyApi } from 'convex/server';
+
+const adminKey = process.env.ADMIN_KEY;
+const convexUrl = process.env.CONVEX_URL;
+
+if (!adminKey || !convexUrl) {
+  console.error('Missing ADMIN_KEY or CONVEX_URL environment variables');
+  process.exit(1);
+}
+
+const newEmail = process.env.RESET_EMAIL || undefined;
+const newPassword = process.env.RESET_PASSWORD || undefined;
+
+if (!newEmail && !newPassword) {
+  console.error('At least one of RESET_EMAIL or RESET_PASSWORD must be set');
+  process.exit(1);
+}
+
+const client = new ConvexHttpClient(convexUrl);
+client.setAdminAuth(adminKey);
+
+try {
+  const result = await client.mutation(
+    anyApi.users.internal_mutations.resetOwner,
+    {
+      newEmail,
+      newPassword,
+    },
+  );
+  console.log(JSON.stringify(result));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/tools/cli/src/commands/auth.ts
+++ b/tools/cli/src/commands/auth.ts
@@ -1,0 +1,64 @@
+import { Command } from 'commander';
+
+import { resetOwner } from '../lib/actions/reset-owner';
+import * as logger from '../utils/logger';
+
+export function createAuthCommand(): Command {
+  const authCmd = new Command('auth').description('Authentication management');
+
+  authCmd
+    .command('reset-owner')
+    .description('Reset the owner email and/or password')
+    .option('-e, --email <email>', 'New owner email address')
+    .option('-p, --password <password>', 'New owner password')
+    .action(async (options: { email?: string; password?: string }) => {
+      try {
+        let { email, password } = options;
+
+        // Interactive prompts when flags are not provided
+        if (
+          !email &&
+          !password &&
+          process.stdin.isTTY &&
+          process.stdout.isTTY
+        ) {
+          const { input, password: passwordPrompt } =
+            await import('@inquirer/prompts');
+
+          email = await input({
+            message: 'New owner email (leave empty to skip):',
+          });
+          if (!email) email = undefined;
+
+          const pw = await passwordPrompt({
+            message: 'New owner password (leave empty to skip):',
+            mask: '*',
+          });
+
+          if (pw) {
+            const pwConfirm = await passwordPrompt({
+              message: 'Confirm new password:',
+              mask: '*',
+            });
+            if (pw !== pwConfirm) {
+              logger.error('Passwords do not match');
+              process.exit(1);
+            }
+            password = pw;
+          }
+
+          if (!email && !password) {
+            logger.error('At least one of --email or --password is required');
+            process.exit(1);
+          }
+        }
+
+        await resetOwner({ email, password });
+      } catch (err) {
+        logger.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  return authCmd;
+}

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { program } from 'commander';
 
 import pkg from '../package.json';
+import { createAuthCommand } from './commands/auth';
 import { createCleanupCommand } from './commands/cleanup';
 import { createConfigCommand } from './commands/config';
 import { createConvexCommand } from './commands/convex';
@@ -32,6 +33,7 @@ program
   .description('Tale CLI - deployment and management tools')
   .version(pkg.version);
 
+program.addCommand(createAuthCommand());
 program.addCommand(createInitCommand());
 program.addCommand(createStartCommand());
 program.addCommand(createUpgradeCommand());

--- a/tools/cli/src/lib/actions/convex-admin.ts
+++ b/tools/cli/src/lib/actions/convex-admin.ts
@@ -1,28 +1,6 @@
 import * as logger from '../../utils/logger';
 import { docker } from '../docker/docker';
-import { isContainerRunning } from '../docker/is-container-running';
-import { listContainers } from '../docker/list-containers';
-
-async function findPlatformContainer(): Promise<string> {
-  if (await isContainerRunning('tale-platform-blue')) {
-    return 'tale-platform-blue';
-  }
-  if (await isContainerRunning('tale-platform-green')) {
-    return 'tale-platform-green';
-  }
-
-  const containers = await listContainers('name=tale');
-  const platform = containers.find(
-    (c) => /platform/.test(c.name) && c.status.startsWith('Up'),
-  );
-  if (platform) {
-    return platform.name;
-  }
-
-  throw new Error(
-    'No platform container is running. Start the platform first with: tale deploy',
-  );
-}
+import { findPlatformContainer } from '../docker/find-platform-container';
 
 export async function convexAdmin(): Promise<void> {
   logger.step('Detecting platform container...');

--- a/tools/cli/src/lib/actions/reset-owner.ts
+++ b/tools/cli/src/lib/actions/reset-owner.ts
@@ -1,0 +1,69 @@
+import * as logger from '../../utils/logger';
+import { docker } from '../docker/docker';
+import { findPlatformContainer } from '../docker/find-platform-container';
+
+export interface ResetOwnerOptions {
+  email?: string;
+  password?: string;
+}
+
+export async function resetOwner(options: ResetOwnerOptions): Promise<void> {
+  const { email, password } = options;
+
+  if (!email && !password) {
+    throw new Error('At least one of --email or --password is required');
+  }
+
+  logger.step('Detecting platform container...');
+  const container = await findPlatformContainer();
+  logger.info(`Using container: ${container}`);
+
+  logger.step('Resetting owner credentials...');
+
+  const args = [
+    'exec',
+    ...(email ? ['-e', `RESET_EMAIL=${email}`] : []),
+    ...(password ? ['-e', `RESET_PASSWORD=${password}`] : []),
+    container,
+    './reset-owner.sh',
+  ];
+
+  const result = await docker(...args);
+  if (!result.success) {
+    // Extract the meaningful error message from Convex stack traces
+    const stderr = result.stderr || '';
+    const uncaughtMatch = stderr.match(/Uncaught Error: (.+)/);
+    const message =
+      uncaughtMatch?.[1] || stderr || 'Failed to reset owner credentials';
+    throw new Error(message);
+  }
+
+  // Parse the JSON output from the container script
+  const stdout = result.stdout.trim();
+  try {
+    const output = JSON.parse(stdout) as {
+      email: string;
+      updated: { email: boolean; password: boolean };
+    };
+
+    logger.blank();
+    logger.success('Owner credentials updated successfully');
+    logger.blank();
+
+    if (output.updated.email) {
+      logger.info(`  Email:    ${output.email}`);
+    }
+    if (output.updated.password) {
+      logger.info('  Password: ********');
+    }
+
+    logger.blank();
+    logger.info('All existing sessions have been invalidated.');
+    logger.info('The owner must log in again with the new credentials.');
+  } catch {
+    // If JSON parsing fails, just show the raw output
+    if (stdout) {
+      console.log(stdout);
+    }
+  }
+}

--- a/tools/cli/src/lib/actions/reset-owner.ts
+++ b/tools/cli/src/lib/actions/reset-owner.ts
@@ -2,7 +2,7 @@ import * as logger from '../../utils/logger';
 import { docker } from '../docker/docker';
 import { findPlatformContainer } from '../docker/find-platform-container';
 
-export interface ResetOwnerOptions {
+interface ResetOwnerOptions {
   email?: string;
   password?: string;
 }

--- a/tools/cli/src/lib/docker/find-platform-container.ts
+++ b/tools/cli/src/lib/docker/find-platform-container.ts
@@ -1,0 +1,23 @@
+import { isContainerRunning } from './is-container-running';
+import { listContainers } from './list-containers';
+
+export async function findPlatformContainer(): Promise<string> {
+  if (await isContainerRunning('tale-platform-blue')) {
+    return 'tale-platform-blue';
+  }
+  if (await isContainerRunning('tale-platform-green')) {
+    return 'tale-platform-green';
+  }
+
+  const containers = await listContainers('name=tale');
+  const platform = containers.find(
+    (c) => /platform/.test(c.name) && c.status.startsWith('Up'),
+  );
+  if (platform) {
+    return platform.name;
+  }
+
+  throw new Error(
+    'No platform container is running. Start the platform first with: tale deploy',
+  );
+}


### PR DESCRIPTION
## Summary
- Add `tale auth reset-owner` CLI command that resets the owner's email and/or password for self-hosted deployments where email-based password recovery is impractical
- Supports both flag-based (`--email`, `--password`) and interactive mode with masked password prompts
- Uses docker exec to run an admin-authenticated internal Convex mutation inside the platform container, then invalidates all owner sessions
- Extracts `findPlatformContainer` into a shared utility for reuse across CLI actions

Closes #1263
Closes #1262

## Test plan
- [x] `tale auth reset-owner --help` displays correct usage
- [x] `tale auth reset-owner` without args in non-TTY errors with clear message
- [x] `tale auth reset-owner --email new@example.com --password 'NewP@ss1'` updates both
- [x] `tale auth reset-owner --password 'NewP@ss1'` updates password only
- [x] `tale auth reset-owner --email new@example.com` updates email only
- [x] Weak password (`weak`) is rejected with validation message
- [x] All owner sessions are invalidated after reset
- [x] Interactive mode prompts for email and password when run in TTY
- [ ] Verify login works with new credentials via web UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `auth reset-owner` CLI command for resetting the owner's email and/or password.
  * Interactive prompts guide users through credential updates when values are not provided via command flags.
  * Password confirmation validation ensures accuracy when updating credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->