### PR TITLE
docs: add external database guide

### DIFF
--- a/docs/environment-reference.md
+++ b/docs/environment-reference.md
@@ -45,10 +45,14 @@ AI provider configuration (API keys, base URLs, models) is managed through provi
 
 ## Database
 
-| Variable       | Required | Default | Description                                                                |
-| -------------- | -------- | ------- | -------------------------------------------------------------------------- |
-| `DB_PASSWORD`  | Yes      |         | Password for the self-hosted PostgreSQL database                           |
-| `POSTGRES_URL` | No       |         | Override the auto-generated database connection URL. If not set, constructed as `postgresql://tale:${DB_PASSWORD}@db:5432` |
+| Variable               | Required | Default | Description                                                                |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------- |
+| `DB_PASSWORD`          | Yes      |         | Password for the self-hosted PostgreSQL database                           |
+| `POSTGRES_URL`         | No       |         | Override the auto-generated database connection URL. If not set, constructed as `postgresql://tale:${DB_PASSWORD}@db:5432` |
+| `RAG_DATABASE_URL`     | No       |         | Override database URL for the RAG service (must include database name, e.g. `postgresql://...host/tale_knowledge`) |
+| `CRAWLER_DATABASE_URL` | No       |         | Override database URL for the Crawler service (must include database name, e.g. `postgresql://...host/tale_knowledge`) |
+
+To use an external PostgreSQL instance instead of the bundled container, see [Using an external database](/production-deployment#using-an-external-database).
 
 ## Error tracking
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -244,6 +244,73 @@ location /tale/ {
 **Known limitations:**
 - Convex Dashboard (`/convex-dashboard`) is not accessible under subpath deployments
 
+## Using an external database
+
+Tale ships a bundled ParadeDB (PostgreSQL 16 + pgvector + pg_search) container, but the architecture supports connecting to any external PostgreSQL instance instead. This is useful when your organization requires a managed database, needs to comply with data residency policies, or wants to use an existing PostgreSQL cluster.
+
+### Requirements
+
+Your external PostgreSQL instance must meet these requirements:
+
+| Requirement | Details |
+|-------------|---------|
+| PostgreSQL version | 16+ |
+| pgvector extension | Required for vector/semantic search |
+| pg_search extension (ParadeDB) | Optional — BM25 full-text search is disabled gracefully if unavailable |
+| Databases | `tale` (platform data) and `tale_knowledge` (RAG + crawler data) |
+| Schemas in `tale_knowledge` | `public_web` (crawler) and `private_knowledge` (RAG) |
+
+### Configuration
+
+Set `POSTGRES_URL` in your `.env` to point all services at the external database:
+
+```dotenv
+POSTGRES_URL=postgresql://tale:your-password@your-db-host:5432
+```
+
+You can also override individual service connections if needed:
+
+| Variable | Service | Description |
+|----------|---------|-------------|
+| `POSTGRES_URL` | All | Base connection URL (without database name) |
+| `RAG_DATABASE_URL` | RAG | Full URL including database name, overrides `POSTGRES_URL` for RAG |
+| `CRAWLER_DATABASE_URL` | Crawler | Full URL including database name, overrides `POSTGRES_URL` for Crawler |
+
+When using service-specific URLs, include the database name:
+
+```dotenv
+RAG_DATABASE_URL=postgresql://tale:your-password@your-db-host:5432/tale_knowledge
+CRAWLER_DATABASE_URL=postgresql://tale:your-password@your-db-host:5432/tale_knowledge
+```
+
+### Database initialization
+
+The bundled DB container runs initialization scripts automatically on first start. With an external database, you must run them manually. The scripts are in `services/db/init-scripts/` and are numbered to execute in order:
+
+```bash
+for f in services/db/init-scripts/*.sql; do
+  psql -h your-db-host -U postgres -f "$f"
+done
+```
+
+Then apply any pending migrations:
+
+```bash
+dbmate -u "postgresql://tale:your-password@your-db-host:5432/tale_knowledge" -d services/db/migrations/db/migrations up
+```
+
+### Disabling the bundled DB container
+
+After configuring the external database, you can prevent the bundled `db` container from starting. Create a `compose.override.yml` in your deployment directory:
+
+```yaml
+services:
+  db:
+    profiles: ["disabled"]
+```
+
+This keeps the service definition (so `depends_on` references don't break) but prevents it from starting unless you explicitly request the `disabled` profile.
+
 ## Vulnerability scanning
 
 All Tale images are scanned for vulnerabilities during the CI/CD release pipeline using [Trivy](https://trivy.dev/). Scan results are uploaded to the GitHub Security tab for each release.


### PR DESCRIPTION
## Summary
- Adds "Using an external database" section to the production deployment guide covering requirements, configuration, initialization, and how to disable the bundled DB container
- Documents `RAG_DATABASE_URL` and `CRAWLER_DATABASE_URL` overrides in the environment reference

Closes #1194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variable reference with new optional configuration options for connecting external PostgreSQL instances
  * Added comprehensive production deployment guide for external database setup, covering PostgreSQL requirements, necessary schemas, initialization procedures, and instructions for disabling the bundled database container

<!-- end of auto-generated comment: release notes by coderabbit.ai -->