### PR TITLE
fix(platform): fix vendor list UI with pagination and split columns

### DIFF
--- a/services/platform/app/features/vendors/components/vendors-table.tsx
+++ b/services/platform/app/features/vendors/components/vendors-table.tsx
@@ -140,6 +140,7 @@ export function VendorsTable({
       isLoading: paginatedResult.isLoading,
     },
     pageSize,
+    displayMode: 'pagination',
     search: {
       fields: ['name', 'email', 'externalId'],
       placeholder: searchPlaceholder,

--- a/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
+++ b/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Stack } from '@/app/components/ui/layout/layout';
 import { Text } from '@/app/components/ui/typography/text';
 import { createTableConfigHook } from '@/app/hooks/use-table-config-factory';
 
@@ -15,16 +14,21 @@ export const useVendorsTableConfig = createTableConfigHook<'vendors'>(
     {
       accessorKey: 'name',
       header: tTables('headers.name'),
-      size: 408,
+      size: 200,
       cell: ({ row }) => (
-        <Stack gap={0}>
-          <Text as="span" variant="label" className="block">
-            {row.original.name || ''}
-          </Text>
-          <Text as="span" variant="caption" className="block">
-            {row.original.email || tTables('cells.noEmail')}
-          </Text>
-        </Stack>
+        <Text as="span" variant="label">
+          {row.original.name || ''}
+        </Text>
+      ),
+    },
+    {
+      accessorKey: 'email',
+      header: tTables('headers.email'),
+      size: 240,
+      cell: ({ row }) => (
+        <Text as="span" variant="body">
+          {row.original.email || tTables('cells.noEmail')}
+        </Text>
       ),
     },
     builders.createSourceColumn(tTables),


### PR DESCRIPTION
## Summary
- Split the combined name/email column into two separate columns matching the customer table pattern (name with `variant="label"`, email with `variant="body"`)
- Added `displayMode: 'pagination'` to `useListPage` for proper pagination controls
- Removed unused `Stack` import from vendor table config

Closes #1305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email column to the vendors table to display vendor contact information

* **UI Changes**
  * Reorganized the vendors table with optimized column sizing and layout adjustments
  * Implemented explicit pagination display mode for navigating the vendors list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->