### PR TITLE
fix(platform): add missing import guidance for customers and vendors

### DIFF
--- a/services/platform/app/features/customers/components/customer-import-form.tsx
+++ b/services/platform/app/features/customers/components/customer-import-form.tsx
@@ -135,7 +135,7 @@ export function CustomerImportForm({
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.formatHint')}</li>
               <li>{t('importForm.localeHint')}</li>
-              <li>{t('importForm.statusNote')}</li>
+              <li className="text-blue-600">{t('importForm.statusNote')}</li>
             </ul>
           </Text>
         </FormSection>
@@ -170,7 +170,7 @@ export function CustomerImportForm({
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
               <li>{t('importForm.localeHint')}</li>
-              <li>{t('importForm.statusNote')}</li>
+              <li className="text-blue-600">{t('importForm.statusNote')}</li>
             </ul>
           </Text>
           {fileValue && (

--- a/services/platform/app/features/vendors/components/vendor-import-form.tsx
+++ b/services/platform/app/features/vendors/components/vendor-import-form.tsx
@@ -93,6 +93,7 @@ export function VendorImportForm({
           />
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
+              <li>{t('importForm.formatHint')}</li>
               <li>{t('importForm.localeHint')}</li>
             </ul>
           </Text>
@@ -127,6 +128,7 @@ export function VendorImportForm({
           </FileUpload.Root>
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
+              <li>{t('importForm.formatHint')}</li>
               <li>{t('importForm.localeHint')}</li>
             </ul>
           </Text>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3213,6 +3213,7 @@
     "importForm": {
       "manualEntry": "Manuelle Eingabe",
       "upload": "Upload",
+      "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Anbieter pro Zeile.",
       "localeHint": "Du kannst die folgenden unterstützten Sprachen verwenden: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH."
     },
     "editVendor": "Lieferant bearbeiten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3272,6 +3272,7 @@
     "importForm": {
       "manualEntry": "Manual entry",
       "upload": "Upload",
+      "formatHint": "Format: email, name (optional), locale (optional). One vendor per line.",
       "localeHint": "You can use the following supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH."
     },
     "editVendor": "Edit vendor",


### PR DESCRIPTION
## Summary
- Add format hint bullet to vendor import form in both manual entry and file upload tabs
- Highlight customer import status note in blue to match product import pattern
- Add `formatHint` translation key for vendors in en.json and de.json

Closes #1301, closes #1302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vendor import forms now display formatting guidance to help users properly structure bulk import data (email, name, locale).

* **Style**
  * Enhanced visual prominence of status notes in customer import form with improved text highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->