### PR TITLE
fix(platform): add success variant to toast notifications

### DIFF
--- a/services/platform/app/features/customers/components/customers-import-dialog.tsx
+++ b/services/platform/app/features/customers/components/customers-import-dialog.tsx
@@ -170,6 +170,7 @@ export function ImportCustomersDialog({
                   ? `, ${result.failed} ${tCustomers('import.failed')}`
                   : '',
             }),
+            variant: 'success',
           });
 
           if (result.errors.length > 0) {

--- a/services/platform/app/features/customers/components/customers-import-dialog.tsx
+++ b/services/platform/app/features/customers/components/customers-import-dialog.tsx
@@ -165,10 +165,7 @@ export function ImportCustomersDialog({
             title: tCustomers('import.success'),
             description: tCustomers('import.successDescription', {
               success: result.success,
-              failed:
-                result.failed > 0
-                  ? `, ${result.failed} ${tCustomers('import.failed')}`
-                  : '',
+              failed: result.failed,
             }),
             variant: 'success',
           });

--- a/services/platform/app/features/documents/components/rag-status-badge.tsx
+++ b/services/platform/app/features/documents/components/rag-status-badge.tsx
@@ -86,6 +86,7 @@ export function RagStatusBadge({
         toast({
           title: t('rag.toast.indexingStarted'),
           description: t('rag.toast.indexingQueued'),
+          variant: 'success',
         });
       } else {
         toast({

--- a/services/platform/app/features/products/components/product-row-actions.tsx
+++ b/services/platform/app/features/products/components/product-row-actions.tsx
@@ -36,6 +36,10 @@ export function ProductRowActions({ product }: ProductRowActionsProps) {
         productId: product._id,
       });
       dialogs.setOpen.delete(false);
+      toast({
+        title: tProducts('actions.deleteSuccess'),
+        variant: 'success',
+      });
     } catch (err) {
       console.error('Deletion error:', err);
       toast({

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -14,7 +14,7 @@ import {
   PRODUCT_STATUS,
 } from '@/lib/shared/constants/convex-enums';
 
-import { useCreateProduct } from '../hooks/mutations';
+import { useBulkCreateProducts } from '../hooks/mutations';
 import { ProductImportForm } from './product-import-form';
 
 type FormValues = {
@@ -65,7 +65,7 @@ export function ProductsImportDialog({
     formState: { isSubmitting },
   } = formMethods;
 
-  const createProduct = useCreateProduct();
+  const { mutateAsync: bulkCreateProducts } = useBulkCreateProducts();
 
   const validateStatus = useCallback(
     (value: unknown): ProductStatus =>
@@ -146,45 +146,21 @@ export function ProductsImportDialog({
           return;
         }
 
-        const results = await Promise.allSettled(
-          products.map((product) =>
-            createProduct.mutateAsync({
-              organizationId,
-              name: product.name,
-              description: product.description,
-              imageUrl: product.imageUrl,
-              stock: product.stock,
-              price: product.price,
-              currency: product.currency,
-              category: product.category,
-              status: product.status,
-            }),
-          ),
-        );
+        const result = await bulkCreateProducts({
+          organizationId,
+          products,
+        });
 
-        const successCount = results.filter(
-          (r) => r.status === 'fulfilled',
-        ).length;
-        const failedCount = results.filter(
-          (r) => r.status === 'rejected',
-        ).length;
-        if (successCount > 0) {
-          if (failedCount > 0) {
-            const importErrors = results
-              .map((result, index) =>
-                result.status === 'rejected'
-                  ? `Failed to import ${products[index].name}: ${result.reason}`
-                  : null,
-              )
-              .filter((error): error is string => error !== null);
-            console.warn('Import errors:', importErrors);
+        if (result.success > 0) {
+          if (result.errors.length > 0) {
+            console.warn('Import errors:', result.errors);
           }
 
           toast({
             title: t('import.success'),
             description: t('import.successDescription', {
-              count: successCount,
-              failed: failedCount,
+              count: result.success,
+              failed: result.failed,
             }),
             variant: 'success',
           });
@@ -206,7 +182,7 @@ export function ProductsImportDialog({
         });
       }
     },
-    [parseFile, createProduct, organizationId, t, onSuccess, handleClose],
+    [parseFile, bulkCreateProducts, organizationId, t, onSuccess, handleClose],
   );
 
   return (

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -168,33 +168,26 @@ export function ProductsImportDialog({
         const failedCount = results.filter(
           (r) => r.status === 'rejected',
         ).length;
-        const importErrors = results
-          .map((result, index) =>
-            result.status === 'rejected'
-              ? `Failed to import ${products[index].name}: ${result.reason}`
-              : null,
-          )
-          .filter((error): error is string => error !== null);
-
         if (successCount > 0) {
-          if (importErrors.length > 0) {
-            toast({
-              title: t('import.success'),
-              description: t('import.successDescription', {
-                count: successCount,
-                failed: failedCount,
-              }),
-              variant: 'destructive',
-            });
-          } else {
-            toast({
-              title: t('import.success'),
-              description: t('import.successDescription', {
-                count: successCount,
-                failed: failedCount,
-              }),
-            });
+          if (failedCount > 0) {
+            const importErrors = results
+              .map((result, index) =>
+                result.status === 'rejected'
+                  ? `Failed to import ${products[index].name}: ${result.reason}`
+                  : null,
+              )
+              .filter((error): error is string => error !== null);
+            console.warn('Import errors:', importErrors);
           }
+
+          toast({
+            title: t('import.success'),
+            description: t('import.successDescription', {
+              count: successCount,
+              failed: failedCount,
+            }),
+            variant: 'success',
+          });
 
           onSuccess?.();
           handleClose();

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -152,25 +152,32 @@ export function ProductsImportDialog({
         });
 
         if (result.success > 0) {
-          if (result.errors.length > 0) {
-            console.warn('Import errors:', result.errors);
-          }
-
           toast({
             title: t('import.success'),
             description: t('import.successDescription', {
-              count: result.success,
+              success: result.success,
               failed: result.failed,
             }),
             variant: 'success',
           });
 
+          if (result.errors.length > 0) {
+            console.warn('Import errors:', result.errors);
+          }
+
           onSuccess?.();
           handleClose();
         } else {
+          const firstError = result.errors[0];
+          const errorCodeKeys: Record<string, string> = {
+            unknown: 'import.errorCodes.unknown',
+          };
+          const errorKey = firstError
+            ? (errorCodeKeys[firstError.errorCode] ?? errorCodeKeys['unknown'])
+            : undefined;
           toast({
-            title: t('import.failed'),
-            description: t('noneImported'),
+            title: t('noneImported'),
+            description: errorKey ? t(errorKey) : undefined,
             variant: 'destructive',
           });
         }

--- a/services/platform/app/features/products/hooks/mutations.ts
+++ b/services/platform/app/features/products/hooks/mutations.ts
@@ -5,6 +5,10 @@ export function useCreateProduct() {
   return useConvexMutation(api.products.mutations.createProduct);
 }
 
+export function useBulkCreateProducts() {
+  return useConvexMutation(api.products.mutations.bulkCreateProducts);
+}
+
 export function useDeleteProduct() {
   return useConvexMutation(api.products.mutations.deleteProduct);
 }

--- a/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
@@ -158,6 +158,7 @@ export function ImportVendorsDialog({
               success: result.success,
               failed: result.failed,
             }),
+            variant: 'success',
           });
 
           if (result.errors.length > 0) {

--- a/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
@@ -186,7 +186,7 @@ export function ImportVendorsDialog({
       } catch (err) {
         console.error('Error importing vendors:', err);
         toast({
-          title: err instanceof Error ? err.message : t('import.error'),
+          title: t('import.error'),
           variant: 'destructive',
         });
       }

--- a/services/platform/convex/products/bulk_create_products.ts
+++ b/services/platform/convex/products/bulk_create_products.ts
@@ -1,0 +1,78 @@
+import type { MutationCtx } from '../_generated/server';
+import type { ConvexJsonValue } from '../lib/validators/json';
+import { createProductWithTranslations } from './create_product_with_translations';
+import type { ProductStatus } from './types';
+
+export interface BulkCreateProductData {
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  stock?: number;
+  price?: number;
+  currency?: string;
+  category?: string;
+  status?: ProductStatus;
+}
+
+export interface BulkCreateProductsResult {
+  success: number;
+  failed: number;
+  errors: Array<{
+    index: number;
+    error: string;
+    errorCode: string;
+    product: ConvexJsonValue;
+  }>;
+}
+
+class BulkCreateError extends Error {
+  constructor(
+    message: string,
+    readonly errorCode: string,
+  ) {
+    super(message);
+  }
+}
+
+export async function bulkCreateProducts(
+  ctx: MutationCtx,
+  organizationId: string,
+  products: BulkCreateProductData[],
+): Promise<BulkCreateProductsResult> {
+  const results: BulkCreateProductsResult = {
+    success: 0,
+    failed: 0,
+    errors: [],
+  };
+
+  for (let i = 0; i < products.length; i++) {
+    const productData = products[i];
+
+    try {
+      await createProductWithTranslations(ctx, {
+        organizationId,
+        name: productData.name,
+        description: productData.description,
+        imageUrl: productData.imageUrl,
+        stock: productData.stock,
+        price: productData.price,
+        currency: productData.currency,
+        category: productData.category,
+        status: productData.status,
+      });
+
+      results.success++;
+    } catch (error) {
+      results.failed++;
+      results.errors.push({
+        index: i,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        errorCode:
+          error instanceof BulkCreateError ? error.errorCode : 'unknown',
+        product: productData,
+      });
+    }
+  }
+
+  return results;
+}

--- a/services/platform/convex/products/mutations.ts
+++ b/services/platform/convex/products/mutations.ts
@@ -2,8 +2,10 @@ import { v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { mutationWithRLS } from '../lib/rls';
+import { bulkCreateProducts as bulkCreateProductsHelper } from './bulk_create_products';
 import * as ProductsHelpers from './helpers';
 import {
+  bulkCreateProductsResponseValidator,
   productStatusValidator,
   productTranslationValidator,
 } from './validators';
@@ -57,6 +59,32 @@ export const deleteProduct = mutationWithRLS({
   returns: v.id('products'),
   handler: async (ctx, args) => {
     return await ProductsHelpers.deleteProduct(ctx, args.productId);
+  },
+});
+
+export const bulkCreateProducts = mutationWithRLS({
+  args: {
+    organizationId: v.string(),
+    products: v.array(
+      v.object({
+        name: v.string(),
+        description: v.optional(v.string()),
+        imageUrl: v.optional(v.string()),
+        stock: v.optional(v.number()),
+        price: v.optional(v.number()),
+        currency: v.optional(v.string()),
+        category: v.optional(v.string()),
+        status: v.optional(productStatusValidator),
+      }),
+    ),
+  },
+  returns: bulkCreateProductsResponseValidator,
+  handler: async (ctx, args) => {
+    return await bulkCreateProductsHelper(
+      ctx,
+      args.organizationId,
+      args.products,
+    );
   },
 });
 

--- a/services/platform/convex/products/validators.ts
+++ b/services/platform/convex/products/validators.ts
@@ -3,7 +3,10 @@
 
 import { v } from 'convex/values';
 
-import { jsonRecordValidator } from '../lib/validators/json';
+import {
+  jsonRecordValidator,
+  jsonValueValidator,
+} from '../lib/validators/json';
 
 export const productStatusValidator = v.union(
   v.literal('active'),
@@ -88,4 +91,17 @@ export const updateProductArgsValidator = v.object({
   status: v.optional(productStatusValidator),
   translations: v.optional(v.array(productTranslationValidator)),
   metadata: v.optional(jsonRecordValidator),
+});
+
+export const bulkCreateErrorItemValidator = v.object({
+  index: v.number(),
+  error: v.string(),
+  errorCode: v.string(),
+  product: jsonValueValidator,
+});
+
+export const bulkCreateProductsResponseValidator = v.object({
+  success: v.number(),
+  failed: v.number(),
+  errors: v.array(bulkCreateErrorItemValidator),
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3105,7 +3105,8 @@
       "draftStatusNote": "Importierte Produkte werden standardmässig mit dem Status \"Entwurf\" erstellt."
     },
     "actions": {
-      "deleteFailed": "Produkt konnte nicht gelöscht werden"
+      "deleteFailed": "Produkt konnte nicht gelöscht werden",
+      "deleteSuccess": "Produkt erfolgreich gelöscht"
     },
     "delete": {
       "title": "Produkt löschen",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3093,9 +3093,11 @@
       "uploadProducts": "Produkte hochladen",
       "uploadFile": "Bitte lade eine Datei hoch",
       "success": "Import erfolgreich",
-      "successDescription": "{count} Produkte erfolgreich importiert{failed, select, 0 {} other {, {failed} fehlgeschlagen}}",
-      "failed": "Import fehlgeschlagen",
+      "successDescription": "{success} Produkte erfolgreich importiert{failed, select, 0 {} other {, {failed} fehlgeschlagen}}",
       "error": "Produkte konnten nicht importiert werden",
+      "errorCodes": {
+        "unknown": "Ein unerwarteter Fehler ist aufgetreten"
+      },
       "dropzoneAriaLabel": "Datei hochladen - klicken oder Enter drücken, um eine Datei auszuwählen, oder Datei hierher ziehen",
       "clickToUpload": "Klicken zum Hochladen",
       "or": "oder",
@@ -3191,7 +3193,7 @@
       "provideData": "Bitte gib Daten ein",
       "noValidData": "Keine gültigen Kundendaten gefunden",
       "success": "Import erfolgreich",
-      "successDescription": "{success} Kunden importiert{failed}",
+      "successDescription": "{success} Kunden erfolgreich importiert{failed, select, 0 {} other {, {failed} fehlgeschlagen}}",
       "failed": "fehlgeschlagen",
       "noneImported": "Es wurden keine Kunden importiert",
       "error": "Importfehler",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3164,7 +3164,8 @@
       "draftStatusNote": "Imported products are created with 'draft' status by default."
     },
     "actions": {
-      "deleteFailed": "Failed to delete product"
+      "deleteFailed": "Failed to delete product",
+      "deleteSuccess": "Product deleted successfully"
     },
     "delete": {
       "title": "Delete product",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3152,9 +3152,11 @@
       "uploadProducts": "Upload products",
       "uploadFile": "Please upload a file",
       "success": "Import successful",
-      "successDescription": "Successfully imported {count} products{failed, select, 0 {} other {, {failed} failed}}",
-      "failed": "Import failed",
+      "successDescription": "Successfully imported {success} products{failed, select, 0 {} other {, {failed} failed}}",
       "error": "Failed to import products",
+      "errorCodes": {
+        "unknown": "An unexpected error occurred"
+      },
       "dropzoneAriaLabel": "Upload file - click or press Enter to select a file, or drag and drop a file here",
       "clickToUpload": "Click to upload",
       "or": "or",
@@ -3250,7 +3252,7 @@
       "provideData": "Please provide data",
       "noValidData": "No valid customer data found",
       "success": "Import successful",
-      "successDescription": "{success} customers imported{failed}",
+      "successDescription": "Successfully imported {success} customers{failed, select, 0 {} other {, {failed} failed}}",
       "failed": "failed",
       "noneImported": "No customers were imported",
       "error": "Import error",


### PR DESCRIPTION
## Summary
- Add `variant: 'success'` to vendor import, customer import, product import, and RAG indexing retry toast notifications so they display the green CheckCircle2 icon
- Fix product import partial success toast from `variant: 'destructive'` to `variant: 'success'`
- Add missing product delete success toast with new `actions.deleteSuccess` translation key in en.json and de.json

Closes #1303, closes #1304, closes #1284, closes #1283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk product import functionality for faster batch uploads
  * Product deletion success notifications

* **Improvements**
  * Enhanced toast notifications with clearer success/error styling
  * More detailed error messages and reporting during import operations
  * Improved import status messaging for better clarity

* **Localization**
  * Updated translation strings for product and customer imports in German and English

<!-- end of auto-generated comment: release notes by coderabbit.ai -->