### PR TITLE
fix(platform): add submit button and auto-close to document upload

### DIFF
--- a/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
@@ -256,13 +256,12 @@ describe('DocumentUploadDialog', () => {
 
     render(<DocumentUploadDialog {...defaultProps} />);
 
-    expect(
-      screen.getByText('documents.upload.uploadDocuments'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument();
+    const uploadButton = screen.getByText('documents.upload.uploadDocuments');
+    expect(uploadButton).toBeInTheDocument();
+    expect(uploadButton.closest('button')).not.toBeDisabled();
   });
 
-  it('does not show upload button while uploading', () => {
+  it('disables upload button while uploading', () => {
     mockHookState = {
       isUploading: true,
       trackedFiles: [
@@ -285,12 +284,11 @@ describe('DocumentUploadDialog', () => {
 
     render(<DocumentUploadDialog {...defaultProps} />);
 
-    expect(
-      screen.queryByText('documents.upload.uploadDocuments'),
-    ).not.toBeInTheDocument();
+    const uploadButton = screen.getByText('documents.upload.uploadDocuments');
+    expect(uploadButton.closest('button')).toBeDisabled();
   });
 
-  it('does not show upload button after all files completed', () => {
+  it('disables upload button after all files completed', () => {
     mockHookState = {
       isUploading: false,
       trackedFiles: [
@@ -313,9 +311,8 @@ describe('DocumentUploadDialog', () => {
 
     render(<DocumentUploadDialog {...defaultProps} />);
 
-    expect(
-      screen.queryByText('documents.upload.uploadDocuments'),
-    ).not.toBeInTheDocument();
+    const uploadButton = screen.getByText('documents.upload.uploadDocuments');
+    expect(uploadButton.closest('button')).toBeDisabled();
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
@@ -230,7 +230,6 @@ describe('DocumentUploadDialog', () => {
     expect(
       screen.getByText('documents.upload.retryUpload'),
     ).toBeInTheDocument();
-    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument();
   });
 
   it('shows upload button when files are staged as pending', () => {

--- a/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/__tests__/document-upload-dialog.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockToast = vi.fn();
+const mockStageFiles = vi.fn();
 const mockUploadFiles = vi.fn().mockResolvedValue({ success: true });
 const mockCancelUpload = vi.fn();
 const mockClearTrackedFiles = vi.fn();
@@ -75,6 +76,7 @@ let mockHookState: {
 
 vi.mock('../../hooks/mutations', () => ({
   useDocumentUpload: () => ({
+    stageFiles: mockStageFiles,
     uploadFiles: mockUploadFiles,
     retryFile: mockRetryFile,
     retryAllFailed: mockRetryAllFailed,
@@ -229,6 +231,91 @@ describe('DocumentUploadDialog', () => {
       screen.getByText('documents.upload.retryUpload'),
     ).toBeInTheDocument();
     expect(screen.getByText('common.actions.cancel')).toBeInTheDocument();
+  });
+
+  it('shows upload button when files are staged as pending', () => {
+    mockHookState = {
+      isUploading: false,
+      trackedFiles: [
+        {
+          id: 'file-1',
+          file: new File(['content'], 'test.pdf', {
+            type: 'application/pdf',
+          }),
+          status: 'pending',
+          bytesLoaded: 0,
+          bytesTotal: 1000,
+        },
+      ],
+      completedCount: 0,
+      failedCount: 0,
+      totalCount: 1,
+      allCompleted: false,
+      hasFailures: false,
+    };
+
+    render(<DocumentUploadDialog {...defaultProps} />);
+
+    expect(
+      screen.getByText('documents.upload.uploadDocuments'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument();
+  });
+
+  it('does not show upload button while uploading', () => {
+    mockHookState = {
+      isUploading: true,
+      trackedFiles: [
+        {
+          id: 'file-1',
+          file: new File(['content'], 'test.pdf', {
+            type: 'application/pdf',
+          }),
+          status: 'uploading',
+          bytesLoaded: 500,
+          bytesTotal: 1000,
+        },
+      ],
+      completedCount: 0,
+      failedCount: 0,
+      totalCount: 1,
+      allCompleted: false,
+      hasFailures: false,
+    };
+
+    render(<DocumentUploadDialog {...defaultProps} />);
+
+    expect(
+      screen.queryByText('documents.upload.uploadDocuments'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show upload button after all files completed', () => {
+    mockHookState = {
+      isUploading: false,
+      trackedFiles: [
+        {
+          id: 'file-1',
+          file: new File(['content'], 'test.pdf', {
+            type: 'application/pdf',
+          }),
+          status: 'completed',
+          bytesLoaded: 1000,
+          bytesTotal: 1000,
+        },
+      ],
+      completedCount: 1,
+      failedCount: 0,
+      totalCount: 1,
+      allCompleted: true,
+      hasFailures: false,
+    };
+
+    render(<DocumentUploadDialog {...defaultProps} />);
+
+    expect(
+      screen.queryByText('documents.upload.uploadDocuments'),
+    ).not.toBeInTheDocument();
   });
 
   describe('accessibility', () => {

--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CircleCheck, RotateCw, Upload } from 'lucide-react';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { Spinner } from '@/app/components/ui/feedback/spinner';
@@ -58,6 +58,7 @@ export function DocumentUploadDialog({
   const { teams, isLoading: isLoadingTeams } = useTeams();
 
   const {
+    stageFiles,
     uploadFiles,
     retryFile,
     retryAllFailed,
@@ -81,6 +82,7 @@ export function DocumentUploadDialog({
   // Derived state
   const hasFiles = trackedFiles.length > 0;
   const isActive = isUploading || hasFiles;
+  const hasPendingFiles = trackedFiles.some((f) => f.status === 'pending');
   const totalSize = useMemo(
     () => trackedFiles.reduce((sum, f) => sum + f.file.size, 0),
     [trackedFiles],
@@ -137,22 +139,15 @@ export function DocumentUploadDialog({
       }
 
       if (validFiles.length > 0) {
-        void uploadFiles(validFiles, {
-          teamIds: selectedTeamIds.length > 0 ? selectedTeamIds : undefined,
-          folderId,
-        });
+        stageFiles(validFiles);
       }
     },
-    [tDocuments, uploadFiles, selectedTeamIds, folderId],
+    [tDocuments, stageFiles],
   );
 
-  const handleTeamSelectionChange = useCallback(
-    (teamIds: string[]) => {
-      setSelectedTeamIds(teamIds);
-      clearTrackedFiles();
-    },
-    [clearTrackedFiles],
-  );
+  const handleTeamSelectionChange = useCallback((teamIds: string[]) => {
+    setSelectedTeamIds(teamIds);
+  }, []);
 
   const handleCancel = useCallback(() => {
     cancelUpload();
@@ -176,6 +171,22 @@ export function DocumentUploadDialog({
     [retryFile, selectedTeamIds, folderId],
   );
 
+  const handleUpload = useCallback(() => {
+    if (!hasPendingFiles) return;
+    void uploadFiles({
+      teamIds: selectedTeamIds.length > 0 ? selectedTeamIds : undefined,
+      folderId,
+    });
+  }, [hasPendingFiles, uploadFiles, selectedTeamIds, folderId]);
+
+  useEffect(() => {
+    if (!allCompleted || completedCount === 0) return undefined;
+    const timer = setTimeout(() => {
+      handleOpenChange(false);
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [allCompleted, completedCount, handleOpenChange]);
+
   const maxSizeMB = DOCUMENT_MAX_FILE_SIZE / (1024 * 1024);
 
   return (
@@ -192,13 +203,13 @@ export function DocumentUploadDialog({
             onFilesSelected={processFiles}
             accept={DOCUMENT_UPLOAD_ACCEPT}
             multiple
-            disabled={isUploading}
+            disabled={isUploading || allCompleted}
             inputId="document-file-upload"
             className={cn(
               'relative flex flex-col items-center justify-center gap-2 rounded-lg border bg-muted/30 py-8 px-4 text-center cursor-pointer transition-colors',
               'hover:border-primary/40 hover:bg-muted/50',
               'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-              isUploading && 'opacity-50 cursor-not-allowed',
+              (isUploading || allCompleted) && 'opacity-50 cursor-not-allowed',
             )}
           >
             <FileUpload.Overlay className="rounded-lg" />
@@ -229,7 +240,7 @@ export function DocumentUploadDialog({
               selectedTeamIds={selectedTeamIds}
               onSelectionChange={handleTeamSelectionChange}
               orgWideLabel={tDocuments('teamTags.orgWide')}
-              disabled={isUploading}
+              disabled={isUploading || allCompleted}
             />
           )}
         </div>
@@ -291,7 +302,22 @@ export function DocumentUploadDialog({
         {/* Footer actions */}
         {isActive && (
           <div className="flex items-center justify-end gap-2">
-            {hasFailures && !isUploading && (
+            {hasPendingFiles && !isUploading && !allCompleted && (
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  {tCommon('actions.cancel')}
+                </Button>
+                <Button type="button" size="sm" onClick={handleUpload}>
+                  {tDocuments('upload.uploadDocuments')}
+                </Button>
+              </>
+            )}
+            {hasFailures && !isUploading && !hasPendingFiles && (
               <>
                 <Button
                   type="button"

--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -81,7 +81,6 @@ export function DocumentUploadDialog({
 
   // Derived state
   const hasFiles = trackedFiles.length > 0;
-  const isActive = isUploading || hasFiles;
   const hasPendingFiles = trackedFiles.some((f) => f.status === 'pending');
   const totalSize = useMemo(
     () => trackedFiles.reduce((sum, f) => sum + f.file.size, 0),
@@ -300,56 +299,37 @@ export function DocumentUploadDialog({
         )}
 
         {/* Footer actions */}
-        {isActive && (
-          <div className="flex items-center justify-end gap-2">
-            {hasPendingFiles && !isUploading && !allCompleted && (
-              <>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleOpenChange(false)}
-                >
-                  {tCommon('actions.cancel')}
-                </Button>
-                <Button type="button" size="sm" onClick={handleUpload}>
-                  {tDocuments('upload.uploadDocuments')}
-                </Button>
-              </>
-            )}
-            {hasFailures && !isUploading && !hasPendingFiles && (
-              <>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleOpenChange(false)}
-                >
-                  {tCommon('actions.cancel')}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={handleRetryAll}
-                  className="gap-1.5"
-                >
-                  <RotateCw className="size-3.5" />
-                  {tDocuments('upload.retryUpload')}
-                </Button>
-              </>
-            )}
-            {isUploading && (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={handleCancel}
-              >
-                {tDocuments('upload.cancelUpload')}
-              </Button>
-            )}
-          </div>
-        )}
+        <div className="flex items-center justify-end gap-2">
+          {hasFailures && !isUploading && !hasPendingFiles && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleRetryAll}
+              className="gap-1.5"
+            >
+              <RotateCw className="size-3.5" />
+              {tDocuments('upload.retryUpload')}
+            </Button>
+          )}
+          {isUploading && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleCancel}
+            >
+              {tDocuments('upload.cancelUpload')}
+            </Button>
+          )}
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleUpload}
+            disabled={!hasPendingFiles || isUploading || allCompleted}
+          >
+            {tDocuments('upload.uploadDocuments')}
+          </Button>
+        </div>
       </div>
     </Dialog>
   );

--- a/services/platform/app/features/documents/hooks/mutations.ts
+++ b/services/platform/app/features/documents/hooks/mutations.ts
@@ -7,10 +7,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
-import {
-  DOCUMENT_MAX_FILE_SIZE,
-  resolveFileType,
-} from '@/lib/shared/file-types';
+import { resolveFileType } from '@/lib/shared/file-types';
 import { calculateFileHash } from '@/lib/utils/file-hash';
 
 // ---------------------------------------------------------------------------
@@ -142,6 +139,17 @@ export function useDocumentUpload(options: UploadOptions) {
     setTrackedFiles([]);
   }, []);
 
+  const stageFiles = useCallback((files: File[]) => {
+    const newTracked: TrackedFile[] = files.map((file) => ({
+      id: generateFileId(),
+      file,
+      status: 'pending' as const,
+      bytesLoaded: 0,
+      bytesTotal: file.size,
+    }));
+    setTrackedFiles((prev) => [...prev, ...newTracked]);
+  }, []);
+
   const uploadSingleFile = useCallback(
     async (
       tracked: TrackedFile,
@@ -248,10 +256,7 @@ export function useDocumentUpload(options: UploadOptions) {
   );
 
   const uploadFiles = useCallback(
-    async (
-      files: File[],
-      uploadOptions?: UploadFilesOptions,
-    ): Promise<UploadResult> => {
+    async (uploadOptions?: UploadFilesOptions): Promise<UploadResult> => {
       if (isUploading) {
         toast({
           title: t('upload.uploadInProgress'),
@@ -260,7 +265,8 @@ export function useDocumentUpload(options: UploadOptions) {
         return { success: false, error: 'Upload already in progress' };
       }
 
-      if (!files || files.length === 0) {
+      const pendingFiles = trackedFiles.filter((f) => f.status === 'pending');
+      if (pendingFiles.length === 0) {
         const error = t('upload.noFilesSelected');
         toast({
           title: t('upload.uploadFailed'),
@@ -270,43 +276,13 @@ export function useDocumentUpload(options: UploadOptions) {
         return { success: false, error };
       }
 
-      // Validate file sizes
-      for (const file of files) {
-        if (file.size > DOCUMENT_MAX_FILE_SIZE) {
-          const maxSizeMB = DOCUMENT_MAX_FILE_SIZE / (1024 * 1024);
-          const fileSizeMB = (file.size / (1024 * 1024)).toFixed(1);
-          toast({
-            title: t('upload.fileTooLarge'),
-            description: t('upload.fileSizeExceeded', {
-              name: file.name,
-              maxSize: maxSizeMB,
-              currentSize: fileSizeMB,
-            }),
-            variant: 'destructive',
-          });
-          return { success: false, error: t('upload.fileTooLarge') };
-        }
-      }
-
       abortControllerRef.current = new AbortController();
-
-      // Create tracked files
-      const newTracked: TrackedFile[] = files.map((file) => ({
-        id: generateFileId(),
-        file,
-        status: 'pending' as const,
-        bytesLoaded: 0,
-        bytesTotal: file.size,
-      }));
-
-      setTrackedFiles(newTracked);
       setIsUploading(true);
 
       try {
         let allSuccess = true;
 
-        // Upload sequentially so we can show individual progress
-        for (const tracked of newTracked) {
+        for (const tracked of pendingFiles) {
           if (abortControllerRef.current?.signal.aborted) break;
           const success = await uploadSingleFile(tracked, uploadOptions);
           if (!success) allSuccess = false;
@@ -314,9 +290,9 @@ export function useDocumentUpload(options: UploadOptions) {
 
         if (allSuccess) {
           options.onSuccess?.({
-            name: files[0].name,
+            name: pendingFiles[0].file.name,
             storagePath: '',
-            size: files[0].size,
+            size: pendingFiles[0].file.size,
           });
         }
 
@@ -344,7 +320,7 @@ export function useDocumentUpload(options: UploadOptions) {
         abortControllerRef.current = null;
       }
     },
-    [isUploading, t, uploadSingleFile, options],
+    [isUploading, t, trackedFiles, uploadSingleFile, options],
   );
 
   const retryFile = useCallback(
@@ -403,6 +379,7 @@ export function useDocumentUpload(options: UploadOptions) {
   const hasFailures = failedCount > 0;
 
   return {
+    stageFiles,
     uploadFiles,
     retryFile,
     retryAllFailed,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2903,7 +2903,8 @@
       "retry": "Erneut versuchen",
       "documentsUploadedSuccessfully": "{count} {count, plural, one {Dokument} other {Dokumente}} erfolgreich hochgeladen",
       "unsupportedFileType": "Nicht unterstützter Dateityp",
-      "unsupportedFileTypeDescription": "{name} ist kein unterstütztes Format. Unterstützte Formate: PDF, DOCX, XLSX, CSV, TXT, PPTX, Bilder."
+      "unsupportedFileTypeDescription": "{name} ist kein unterstütztes Format. Unterstützte Formate: PDF, DOCX, XLSX, CSV, TXT, PPTX, Bilder.",
+      "uploadDocuments": "Hochladen"
     },
     "import": {
       "noResponseBody": "Kein Antwortinhalt erhalten"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2962,7 +2962,8 @@
       "retry": "Retry",
       "documentsUploadedSuccessfully": "{count} {count, plural, one {document} other {documents}} uploaded successfully",
       "unsupportedFileType": "Unsupported file type",
-      "unsupportedFileTypeDescription": "{name} is not a supported format. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images."
+      "unsupportedFileTypeDescription": "{name} is not a supported format. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images.",
+      "uploadDocuments": "Upload"
     },
     "import": {
       "noResponseBody": "No response body received"


### PR DESCRIPTION
## Summary
- Restructure document upload into a two-step flow: files are staged on selection/drop and only uploaded when the user clicks the Upload button, preventing accidental uploads with wrong team assignments
- Auto-close the upload dialog ~1.5s after all files complete so users don't interact with stale state
- Disable team selection and drop zone during upload and after completion

Closes #1297, closes #1299