### PR TITLE
fix(platform): refine toast icons, CSV header detection, and vendor bulk delete

### DIFF
--- a/services/platform/app/components/ui/entity/entity-delete-dialog.tsx
+++ b/services/platform/app/components/ui/entity/entity-delete-dialog.tsx
@@ -80,7 +80,6 @@ export function EntityDeleteDialog<TEntity>({
       await deleteMutation(entity);
       toast({
         title: translations.successMessage,
-        variant: 'success',
       });
       onClose();
       onSuccess?.();

--- a/services/platform/app/components/ui/entity/entity-delete-dialog.tsx
+++ b/services/platform/app/components/ui/entity/entity-delete-dialog.tsx
@@ -80,6 +80,7 @@ export function EntityDeleteDialog<TEntity>({
       await deleteMutation(entity);
       toast({
         title: translations.successMessage,
+        variant: 'success',
       });
       onClose();
       onSuccess?.();

--- a/services/platform/app/components/ui/feedback/toaster.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.tsx
@@ -2,7 +2,7 @@
 
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cva } from 'class-variance-authority';
-import { X, CheckCircle2, XCircle } from 'lucide-react';
+import { X, CheckCircle2, XCircle, Info } from 'lucide-react';
 
 import { useToast } from '@/app/hooks/use-toast';
 import { cn } from '@/lib/utils/cn';
@@ -34,7 +34,9 @@ function VariantIcon({ variant }: { variant?: ToastVariant }) {
     case 'destructive':
       return <XCircle className="text-destructive size-5" aria-hidden="true" />;
     default:
-      return null;
+      return (
+        <Info className="text-muted-foreground size-5" aria-hidden="true" />
+      );
   }
 }
 
@@ -45,47 +47,29 @@ export function Toaster() {
     <ToastPrimitives.Provider duration={3500}>
       {toasts.map(
         ({ id, title, description, action, variant, className, ...props }) => {
-          const icon = <VariantIcon variant={variant} />;
-          const hasIcon = variant === 'success' || variant === 'destructive';
-
           return (
             <ToastPrimitives.Root
               key={id}
               className={cn(toastVariants({ variant }), className)}
               {...props}
             >
-              {hasIcon ? (
-                <div className="flex items-start space-x-3">
-                  {icon}
-                  <div className="flex-1 pr-4">
-                    <div className="grid gap-1">
-                      {title && (
-                        <ToastPrimitives.Title className="text-sm font-semibold">
-                          {title}
-                        </ToastPrimitives.Title>
-                      )}
-                      {description && (
-                        <ToastPrimitives.Description className="text-sm opacity-90">
-                          {description}
-                        </ToastPrimitives.Description>
-                      )}
-                    </div>
+              <div className="flex items-start space-x-3">
+                <VariantIcon variant={variant} />
+                <div className="flex-1 pr-4">
+                  <div className="grid gap-1">
+                    {title && (
+                      <ToastPrimitives.Title className="text-sm font-semibold">
+                        {title}
+                      </ToastPrimitives.Title>
+                    )}
+                    {description && (
+                      <ToastPrimitives.Description className="text-sm opacity-90">
+                        {description}
+                      </ToastPrimitives.Description>
+                    )}
                   </div>
                 </div>
-              ) : (
-                <div className="grid gap-1">
-                  {title && (
-                    <ToastPrimitives.Title className="text-sm font-semibold">
-                      {title}
-                    </ToastPrimitives.Title>
-                  )}
-                  {description && (
-                    <ToastPrimitives.Description className="text-sm opacity-90">
-                      {description}
-                    </ToastPrimitives.Description>
-                  )}
-                </div>
-              )}
+              </div>
               {action}
               <ToastPrimitives.Close
                 className="text-foreground/50 hover:text-foreground absolute top-2.5 right-2.5 rounded-md p-1 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-2 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600"

--- a/services/platform/app/features/agents/components/agent-delete-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-delete-dialog.tsx
@@ -38,7 +38,6 @@ export function AgentDeleteDialog({
       });
       toast({
         title: t('agents.agentDeleted'),
-        variant: 'success',
       });
       onOpenChange(false);
       onDeleted?.();

--- a/services/platform/app/features/agents/components/agent-delete-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-delete-dialog.tsx
@@ -38,6 +38,7 @@ export function AgentDeleteDialog({
       });
       toast({
         title: t('agents.agentDeleted'),
+        variant: 'success',
       });
       onOpenChange(false);
       onDeleted?.();

--- a/services/platform/app/features/customers/components/customer-import-form.tsx
+++ b/services/platform/app/features/customers/components/customer-import-form.tsx
@@ -169,6 +169,7 @@ export function CustomerImportForm({
           </FileUpload.Root>
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
+              <li>{t('importForm.expectedColumns')}</li>
               <li>{t('importForm.localeHint')}</li>
               <li className="text-blue-600">{t('importForm.statusNote')}</li>
             </ul>

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -77,9 +77,9 @@ export function ProductsImportDialog({
     [],
   );
 
-  const excelMapper = useCallback(
+  const recordMapper = useCallback(
     (record: Record<string, unknown>): ParsedProduct | null => {
-      const result = productMappers.excel(record);
+      const result = productMappers.record(record);
       if (!result) return null;
 
       return {
@@ -90,22 +90,9 @@ export function ProductsImportDialog({
     [validateStatus],
   );
 
-  const csvMapper = useCallback(
-    (row: string[], index: number): ParsedProduct | null => {
-      const result = productMappers.csv(row, index);
-      if (!result) return null;
-
-      return {
-        ...result,
-        status: validateStatus(row[7]),
-      };
-    },
-    [validateStatus],
-  );
-
   const { parseFile } = useFileImport<ParsedProduct>({
-    csvMapper,
-    excelMapper,
+    csvMapper: productMappers.csv,
+    excelMapper: recordMapper,
   });
 
   const resetForm = useCallback(() => {

--- a/services/platform/app/features/settings/api-keys/components/api-key-revoke-dialog.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-key-revoke-dialog.tsx
@@ -35,7 +35,6 @@ export function ApiKeyRevokeDialog({
       onSuccess: () => {
         toast({
           title: tSettings('apiKeys.keyRevoked'),
-          variant: 'success',
         });
         onOpenChange(false);
         onSuccess?.();

--- a/services/platform/app/features/settings/api-keys/components/api-key-revoke-dialog.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-key-revoke-dialog.tsx
@@ -35,6 +35,7 @@ export function ApiKeyRevokeDialog({
       onSuccess: () => {
         toast({
           title: tSettings('apiKeys.keyRevoked'),
+          variant: 'success',
         });
         onOpenChange(false);
         onSuccess?.();

--- a/services/platform/app/features/settings/providers/components/providers-table.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-table.tsx
@@ -90,7 +90,7 @@ export function ProvidersTable({ organizationId }: ProvidersTableProps) {
         orgSlug: 'default',
         providerName: deleteProvider.name,
       });
-      toast({ title: t('providers.deleted') });
+      toast({ title: t('providers.deleted'), variant: 'success' });
       setDeleteProvider(null);
       invalidateProviders();
     } catch {

--- a/services/platform/app/features/settings/providers/components/providers-table.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-table.tsx
@@ -90,7 +90,7 @@ export function ProvidersTable({ organizationId }: ProvidersTableProps) {
         orgSlug: 'default',
         providerName: deleteProvider.name,
       });
-      toast({ title: t('providers.deleted'), variant: 'success' });
+      toast({ title: t('providers.deleted') });
       setDeleteProvider(null);
       invalidateProviders();
     } catch {

--- a/services/platform/app/features/settings/teams/components/team-delete-dialog.tsx
+++ b/services/platform/app/features/settings/teams/components/team-delete-dialog.tsx
@@ -43,6 +43,7 @@ export function TeamDeleteDialog({
 
       toast({
         title: tSettings('teams.teamDeleted'),
+        variant: 'success',
       });
       onOpenChange(false);
       onSuccess?.();

--- a/services/platform/app/features/settings/teams/components/team-delete-dialog.tsx
+++ b/services/platform/app/features/settings/teams/components/team-delete-dialog.tsx
@@ -43,7 +43,6 @@ export function TeamDeleteDialog({
 
       toast({
         title: tSettings('teams.teamDeleted'),
-        variant: 'success',
       });
       onOpenChange(false);
       onSuccess?.();

--- a/services/platform/app/features/vendors/components/vendor-import-form.tsx
+++ b/services/platform/app/features/vendors/components/vendor-import-form.tsx
@@ -128,7 +128,7 @@ export function VendorImportForm({
           </FileUpload.Root>
           <Text as="div" variant="caption" className="leading-relaxed">
             <ul className="list-outside list-disc space-y-2 pl-4">
-              <li>{t('importForm.formatHint')}</li>
+              <li>{t('importForm.expectedColumns')}</li>
               <li>{t('importForm.localeHint')}</li>
             </ul>
           </Text>

--- a/services/platform/app/features/vendors/components/vendors-table.tsx
+++ b/services/platform/app/features/vendors/components/vendors-table.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useNavigate } from '@tanstack/react-router';
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import { Store } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeleteVendor } from '../hooks/mutations';
 import {
   useApproxVendorCount,
   useListVendorsPaginated,
@@ -126,10 +128,24 @@ export function VendorsTable({
   );
 
   const [viewingVendor, setViewingVendor] = useState<Vendor | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const deleteVendor = useDeleteVendor();
 
   const handleRowClick = useCallback((row: Row<Vendor>) => {
     setViewingVendor(row.original);
   }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      const vendorId = id as Doc<'vendors'>['_id'];
+      await deleteVendor.mutateAsync({ vendorId });
+    },
+    [deleteVendor],
+  );
 
   const list = useListPage<Vendor>({
     dataSource: {
@@ -159,12 +175,23 @@ export function VendorsTable({
         columns={columns}
         stickyLayout={stickyLayout}
         onRowClick={handleRowClick}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         actionMenu={<VendorsActionMenu organizationId={organizationId} />}
         emptyState={{
           icon: Store,
           title: tEmpty('vendors.title'),
           description: tEmpty('vendors.description'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
 

--- a/services/platform/app/features/vendors/components/vendors-table.tsx
+++ b/services/platform/app/features/vendors/components/vendors-table.tsx
@@ -141,6 +141,7 @@ export function VendorsTable({
 
   const handleDeleteItem = useCallback(
     async (id: string) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex Id type from row selection key
       const vendorId = id as Doc<'vendors'>['_id'];
       await deleteVendor.mutateAsync({ vendorId });
     },

--- a/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
+++ b/services/platform/app/features/vendors/hooks/use-vendors-table-config.tsx
@@ -11,6 +11,7 @@ export const useVendorsTableConfig = createTableConfigHook<'vendors'>(
     defaultSort: '_creationTime',
   },
   ({ tTables, builders }) => [
+    builders.createSelectColumn(),
     {
       accessorKey: 'name',
       header: tTables('headers.name'),

--- a/services/platform/app/hooks/__tests__/use-file-import.test.ts
+++ b/services/platform/app/hooks/__tests__/use-file-import.test.ts
@@ -155,9 +155,9 @@ describe('customerMappers.excel', () => {
   });
 });
 
-describe('productMappers.excel', () => {
+describe('productMappers.record', () => {
   it('parses record with lowercase keys', () => {
-    const result = productMappers.excel({
+    const result = productMappers.record({
       name: 'Widget',
       description: 'A fine widget',
       price: 9.99,
@@ -178,17 +178,17 @@ describe('productMappers.excel', () => {
   });
 
   it('falls back to title when name is missing', () => {
-    const result = productMappers.excel({ title: 'Gadget', price: 5 });
+    const result = productMappers.record({ title: 'Gadget', price: 5 });
     expect(result).toMatchObject({ name: 'Gadget' });
   });
 
   it('returns null when name and title are missing', () => {
-    const result = productMappers.excel({ description: 'orphan' });
+    const result = productMappers.record({ description: 'orphan' });
     expect(result).toBeNull();
   });
 
   it('defaults stock to 0, price to 0, currency to USD', () => {
-    const result = productMappers.excel({ name: 'Minimal' });
+    const result = productMappers.record({ name: 'Minimal' });
     expect(result).toMatchObject({
       stock: 0,
       price: 0,
@@ -197,7 +197,7 @@ describe('productMappers.excel', () => {
   });
 
   it('resolves imageurl key (normalized from ImageUrl/imageUrl)', () => {
-    const result = productMappers.excel({
+    const result = productMappers.record({
       name: 'Pic',
       imageurl: 'https://example.com/pic.png',
     });

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -227,22 +227,27 @@ export const productMappers = {
     const lowerValue = value.toLowerCase();
     return validStatuses.find((s) => s === lowerValue) ?? defaultStatus;
   },
-  csv: (row: string[], _index: number) => {
-    const name = row[0]?.trim();
-    if (!name) return null;
-
-    return {
-      name,
-      description: row[1]?.trim() || undefined,
-      imageUrl: row[2]?.trim() || undefined,
-      stock: row[3] ? parseInt(row[3], 10) : 0,
-      price: row[4] ? parseFloat(row[4]) : 0,
-      currency: row[5]?.trim() || 'USD',
-      category: row[6]?.trim() || undefined,
-      source: 'manual_import' as const,
-    };
+  /** Expected header names for product imports */
+  expectedHeaders: [
+    'name',
+    'description',
+    'imageurl',
+    'stock',
+    'price',
+    'currency',
+    'category',
+    'status',
+  ] as const,
+  /**
+   * CSV fallback mapper — only runs when headers are NOT detected.
+   * Returns null for every row so the import fails with a clear error
+   * instead of silently misaligning columns by position.
+   */
+  csv: (_row: string[], _index: number) => {
+    return null;
   },
-  excel: (record: Record<string, unknown>) => {
+  /** Record-based mapper used by both CSV (with headers) and Excel imports */
+  record: (record: Record<string, unknown>) => {
     const name = getString(record.name) || getString(record.title);
     if (!name) return null;
 

--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -92,7 +92,7 @@ function parseCSVText(
   }
 
   let headers: string[] | null = null;
-  if (rows.length >= 2) {
+  if (rows.length > 0) {
     headers = rows.shift()?.map((h) => h.toLowerCase()) ?? null;
   }
 

--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -13,56 +13,9 @@ export type FileParseResult<T> = {
 type CSVParseOptions = {
   /** Column delimiter (default: comma) */
   delimiter?: string;
-  /** Whether the first row contains headers (default: false) */
-  hasHeaders?: boolean;
   /** Skip empty lines (default: true) */
   skipEmptyLines?: boolean;
 };
-
-const COMMON_HEADER_NAMES = new Set([
-  'name',
-  'email',
-  'description',
-  'price',
-  'sku',
-  'currency',
-  'category',
-  'stock',
-  'status',
-  'locale',
-  'source',
-  'id',
-  'title',
-  'brand',
-  'type',
-  'phone',
-  'address',
-  'country',
-  'city',
-  'image',
-  'imageurl',
-  'image_url',
-  'first name',
-  'last name',
-  'firstname',
-  'lastname',
-  'customer id',
-  'product',
-  'quantity',
-  'amount',
-  'unit',
-  'vendor',
-  'supplier',
-]);
-
-function isHeaderRow(values: string[]): boolean {
-  const nonEmpty = values.filter((v) => v.length > 0);
-  if (nonEmpty.length === 0) return false;
-  const matches = nonEmpty.filter((v) =>
-    COMMON_HEADER_NAMES.has(v.toLowerCase()),
-  );
-  return matches.length >= Math.ceil(nonEmpty.length / 2);
-}
 
 type CSVParseOutput = {
   headers: string[] | null;
@@ -125,7 +78,7 @@ function parseCSVText(
   csvText: string,
   options: CSVParseOptions = {},
 ): CSVParseOutput {
-  const { delimiter = ',', skipEmptyLines = true, hasHeaders } = options;
+  const { delimiter = ',', skipEmptyLines = true } = options;
 
   const lines = csvText.trim().split('\n');
   const rows: string[][] = [];
@@ -139,7 +92,7 @@ function parseCSVText(
   }
 
   let headers: string[] | null = null;
-  if (hasHeaders !== false && rows.length >= 2 && isHeaderRow(rows[0])) {
+  if (rows.length >= 2) {
     headers = rows.shift()?.map((h) => h.toLowerCase()) ?? null;
   }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3172,7 +3172,8 @@
       "syncBusinessData": "Geschäftsdaten synchronisieren",
       "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Kunde pro Zeile.",
       "localeHint": "Unterstützte Sprachen: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH.",
-      "statusNote": "Importierte Kunden werden als (Aktiv) markiert"
+      "statusNote": "Importierte Kunden werden als (Aktiv) markiert",
+      "expectedColumns": "Erwartete Spalten: email, name, locale"
     },
     "editCustomer": "Kunde bearbeiten",
     "deleteCustomer": "Kunde löschen",
@@ -3230,8 +3231,8 @@
     "importForm": {
       "manualEntry": "Manuelle Eingabe",
       "upload": "Upload",
-      "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Lieferant pro Zeile.",
-      "localeHint": "Du kannst die folgenden unterstützten Sprachen verwenden: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH."
+      "localeHint": "Du kannst die folgenden unterstützten Sprachen verwenden: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH.",
+      "expectedColumns": "Erwartete Spalten: email, name, locale"
     },
     "editVendor": "Lieferant bearbeiten",
     "deleteVendor": "Lieferant löschen",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3171,7 +3171,7 @@
       "fromShopify": "Von Shopify",
       "syncBusinessData": "Geschäftsdaten synchronisieren",
       "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Kunde pro Zeile.",
-      "localeHint": "Unterstützte Sprachen: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH.",
+      "localeHint": "Sprache kann ein beliebiger BCP 47-Tag sein (z. B. en, en-US, de-DE, zh-Hans).",
       "statusNote": "Importierte Kunden werden als (Aktiv) markiert",
       "expectedColumns": "Erwartete Spalten: email, name, locale"
     },
@@ -3231,7 +3231,7 @@
     "importForm": {
       "manualEntry": "Manuelle Eingabe",
       "upload": "Upload",
-      "localeHint": "Du kannst die folgenden unterstützten Sprachen verwenden: en, fr, de, zh, sowie erweiterte Formate wie en-US, de-DE und de-CH.",
+      "localeHint": "Sprache kann ein beliebiger BCP 47-Tag sein (z. B. en, en-US, de-DE, zh-Hans).",
       "expectedColumns": "Erwartete Spalten: email, name, locale"
     },
     "editVendor": "Lieferant bearbeiten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3230,7 +3230,7 @@
       "fromShopify": "From Shopify",
       "syncBusinessData": "Sync business data",
       "formatHint": "Format: email, name (optional), locale (optional). One customer per line.",
-      "localeHint": "Supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH.",
+      "localeHint": "Locale can be any valid BCP 47 tag (e.g. en, en-US, de-DE, zh-Hans).",
       "statusNote": "Imported customers are tagged as (Active)",
       "expectedColumns": "Expected columns: email, name, locale"
     },
@@ -3290,7 +3290,7 @@
     "importForm": {
       "manualEntry": "Manual entry",
       "upload": "Upload",
-      "localeHint": "You can use the following supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH.",
+      "localeHint": "Locale can be any valid BCP 47 tag (e.g. en, en-US, de-DE, zh-Hans).",
       "expectedColumns": "Expected columns: email, name, locale"
     },
     "editVendor": "Edit vendor",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3231,7 +3231,8 @@
       "syncBusinessData": "Sync business data",
       "formatHint": "Format: email, name (optional), locale (optional). One customer per line.",
       "localeHint": "Supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH.",
-      "statusNote": "Imported customers are tagged as (Active)"
+      "statusNote": "Imported customers are tagged as (Active)",
+      "expectedColumns": "Expected columns: email, name, locale"
     },
     "editCustomer": "Edit customer",
     "deleteCustomer": "Delete customer",
@@ -3289,8 +3290,8 @@
     "importForm": {
       "manualEntry": "Manual entry",
       "upload": "Upload",
-      "formatHint": "Format: email, name (optional), locale (optional). One vendor per line.",
-      "localeHint": "You can use the following supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH."
+      "localeHint": "You can use the following supported locales: en, fr, de, zh, as well as extended formats like en-US, de-DE, and de-CH.",
+      "expectedColumns": "Expected columns: email, name, locale"
     },
     "editVendor": "Edit vendor",
     "deleteVendor": "Delete vendor",


### PR DESCRIPTION
## Summary
- Simplify toaster component to always render variant icons (info icon as default) instead of conditional icon/no-icon layout branches
- Remove explicit `success` variant from delete/revoke toasts — the default toast style now handles all cases uniformly
- Replace brittle heuristic-based CSV header detection (`COMMON_HEADER_NAMES` dictionary) with a simpler first-row-is-header approach
- Unify product import mappers: rename `excel` → `record`, make CSV fallback return `null` so headerless files fail clearly instead of silently misaligning columns
- Add `expectedColumns` guidance hints to customer and vendor import forms
- Add bulk delete support to vendors table with row selection

## Test plan
- [ ] Verify toast notifications display correctly with icons for all variants (default, success, destructive)
- [ ] Import a CSV file with headers for customers, vendors, and products — confirm parsing works
- [ ] Import a headerless CSV — confirm it fails with a clear error instead of silently misaligning
- [ ] Import an Excel file for products — confirm the record mapper works
- [ ] Verify vendor bulk delete: select rows, delete, confirm removal
- [ ] Check import forms show "Expected columns" hint text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk deletion functionality for vendors.
  * Introduced expected column hints in customer and vendor import forms.
  * Enhanced toast notifications with default info icon display.

* **Style**
  * Refined toast notification styling for consistency across success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->