### PR TITLE
feat(platform): add chat export as PDF and Markdown

### DIFF
--- a/services/platform/app/features/chat/components/chat-header.tsx
+++ b/services/platform/app/features/chat/components/chat-header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useNavigate } from '@tanstack/react-router';
-import { Clock, Search, Share, Plus } from 'lucide-react';
+import { Clock, Download, Search, Share, Plus } from 'lucide-react';
 import { useEffect, useState, useCallback } from 'react';
 
 import { AdaptiveHeaderRoot } from '@/app/components/layout/adaptive-header';
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils/cn';
 
 import { ChatHistorySidebar } from './chat-history-sidebar';
 import { ChatSearchDialog } from './chat-search-dialog';
+import { ExportChatDialog } from './export-chat-dialog';
 import { ShareChatDialog } from './share-chat-dialog';
 interface ChatHeaderProps {
   organizationId: string;
@@ -26,6 +27,7 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isMobileHistoryOpen, setIsMobileHistoryOpen] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
+  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isMac, setIsMac] = useState(false);
 
   const { t: tChat } = useT('chat');
@@ -191,6 +193,16 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
             <Button
               variant="ghost"
               size="sm"
+              onClick={() => setIsExportDialogOpen(true)}
+              aria-label={tChat('export.button')}
+              className="text-muted-foreground gap-1.5"
+            >
+              <Download className="size-4" />
+              {tChat('export.button')}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setIsShareDialogOpen(true)}
               aria-label={tChat('share.button')}
               className="text-muted-foreground gap-1.5"
@@ -221,16 +233,27 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
             <Search className={baseIconClasses} />
           </Button>
           {threadId && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setIsShareDialogOpen(true)}
-              aria-label={tChat('share.button')}
-              className="text-muted-foreground gap-1.5"
-            >
-              <Share className="size-4" />
-              {tChat('share.button')}
-            </Button>
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsExportDialogOpen(true)}
+                aria-label={tChat('export.button')}
+                className="text-muted-foreground gap-1.5"
+              >
+                <Download className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsShareDialogOpen(true)}
+                aria-label={tChat('share.button')}
+                className="text-muted-foreground gap-1.5"
+              >
+                <Share className="size-4" />
+                {tChat('share.button')}
+              </Button>
+            </>
           )}
           <Button
             size="icon"
@@ -250,12 +273,20 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
       />
 
       {threadId && (
-        <ShareChatDialog
-          open={isShareDialogOpen}
-          onOpenChange={setIsShareDialogOpen}
-          threadId={threadId}
-          organizationId={organizationId}
-        />
+        <>
+          <ExportChatDialog
+            open={isExportDialogOpen}
+            onOpenChange={setIsExportDialogOpen}
+            threadId={threadId}
+            organizationId={organizationId}
+          />
+          <ShareChatDialog
+            open={isShareDialogOpen}
+            onOpenChange={setIsShareDialogOpen}
+            threadId={threadId}
+            organizationId={organizationId}
+          />
+        </>
       )}
     </>
   );

--- a/services/platform/app/features/chat/components/export-chat-dialog.tsx
+++ b/services/platform/app/features/chat/components/export-chat-dialog.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { Download, FileText } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Dialog } from '@/app/components/ui/dialog/dialog';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+import { useT } from '@/lib/i18n/client';
+
+interface ExportChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  threadId: string;
+  organizationId: string;
+}
+
+interface ExportMessage {
+  _id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** Strip internal structural markers that the UI already filters during rendering */
+const INTERNAL_MARKER_REGEX =
+  /\[\[(CONCLUSION|KEY_POINTS|DETAILS|QUESTIONS|NEXT_STEPS)\]\]\n?/g;
+
+function stripMarkers(text: string) {
+  return text.replace(INTERNAL_MARKER_REGEX, '');
+}
+
+function getSelectedMessages(
+  messages: ExportMessage[],
+  effectiveSelected: Set<string>,
+) {
+  return messages.filter((m) => effectiveSelected.has(m._id));
+}
+
+function formatMessagesAsMarkdown(
+  messages: ExportMessage[],
+  youLabel: string,
+  assistantLabel: string,
+) {
+  const lines = [];
+  for (const msg of messages) {
+    const roleLabel =
+      msg.role === 'user' ? `**${youLabel}:**` : `**${assistantLabel}:**`;
+    lines.push(`${roleLabel}\n\n${stripMarkers(msg.content)}\n\n---\n`);
+  }
+  return lines.join('\n');
+}
+
+function triggerFileDownload(content: string, filename: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function escapeHtml(text: string) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function printViaIframe(
+  messages: ExportMessage[],
+  title: string,
+  youLabel: string,
+  assistantLabel: string,
+) {
+  const messagesHtml = messages
+    .map((msg) => {
+      const role = msg.role === 'user' ? youLabel : assistantLabel;
+      const content = escapeHtml(stripMarkers(msg.content)).replace(
+        /\n/g,
+        '<br/>',
+      );
+      return `<div class="message"><div class="role">${escapeHtml(role)}</div><div class="content">${content}</div></div>`;
+    })
+    .join('<hr/>');
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>${escapeHtml(title)}</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 0 auto; padding: 40px 20px; color: #1a1a1a; line-height: 1.6; }
+  h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+  hr { border: none; border-top: 1px solid #e5e5e5; margin: 1.5rem 0; }
+  .role { font-weight: 600; margin-bottom: 0.5rem; }
+  .content { white-space: pre-wrap; word-break: break-word; }
+  .message { margin: 1rem 0; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(title)}</h1>
+<hr/>
+${messagesHtml}
+</body>
+</html>`;
+
+  const iframe = document.createElement('iframe');
+  iframe.style.position = 'fixed';
+  iframe.style.inset = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = 'none';
+  document.body.appendChild(iframe);
+
+  const iframeDoc = iframe.contentDocument ?? iframe.contentWindow?.document;
+  if (!iframeDoc) {
+    document.body.removeChild(iframe);
+    return;
+  }
+
+  iframeDoc.open();
+  iframeDoc.write(html);
+  iframeDoc.close();
+
+  const cleanup = () => {
+    document.body.removeChild(iframe);
+  };
+
+  // Delay to allow iframe content to render, then print
+  setTimeout(() => {
+    iframe.contentWindow?.print();
+    // Clean up after print dialog closes
+    iframe.contentWindow?.addEventListener('afterprint', cleanup);
+    // Fallback: clean up after timeout in case afterprint doesn't fire
+    setTimeout(cleanup, 60_000);
+  }, 300);
+}
+
+function ExportChatDialogContent({
+  open,
+  onOpenChange,
+  threadId,
+}: ExportChatDialogProps) {
+  const { t } = useT('chat');
+
+  const { data } = useConvexQuery(api.threads.queries.getThreadMessages, {
+    threadId,
+  });
+
+  const messages: ExportMessage[] = useMemo(
+    () =>
+      (data?.messages ?? [])
+        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .map((m) => ({ _id: m._id, role: m.role, content: m.content })),
+    [data?.messages],
+  );
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+
+  // Sync selection with messages once loaded (default all selected)
+  const allIds = useMemo(() => new Set(messages.map((m) => m._id)), [messages]);
+  const effectiveSelected = useMemo(() => {
+    if (selectedIds.size === 0 && messages.length > 0) {
+      return allIds;
+    }
+    // Remove stale IDs that no longer exist
+    const valid = new Set<string>();
+    for (const id of selectedIds) {
+      if (allIds.has(id)) valid.add(id);
+    }
+    return valid;
+  }, [selectedIds, allIds, messages.length]);
+
+  const allSelected = effectiveSelected.size === messages.length;
+  const noneSelected = effectiveSelected.size === 0;
+
+  const handleToggleAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(messages.map((m) => m._id)));
+    }
+  }, [allSelected, messages]);
+
+  const handleToggleMessage = useCallback(
+    (id: string) => {
+      setSelectedIds((prev) => {
+        const base =
+          prev.size === 0 && messages.length > 0
+            ? new Set(messages.map((m) => m._id))
+            : new Set(prev);
+        if (base.has(id)) {
+          base.delete(id);
+        } else {
+          base.add(id);
+        }
+        return base;
+      });
+    },
+    [messages],
+  );
+
+  const youLabel = t('export.you');
+  const assistantLabel = t('export.assistant');
+
+  const handleExportPdf = useCallback(() => {
+    const selected = getSelectedMessages(messages, effectiveSelected);
+    if (selected.length === 0) return;
+    printViaIframe(selected, t('export.title'), youLabel, assistantLabel);
+    onOpenChange(false);
+  }, [messages, effectiveSelected, onOpenChange, t, youLabel, assistantLabel]);
+
+  const handleExportMarkdown = useCallback(() => {
+    const selected = getSelectedMessages(messages, effectiveSelected);
+    if (selected.length === 0) return;
+    const markdown = formatMessagesAsMarkdown(
+      selected,
+      youLabel,
+      assistantLabel,
+    );
+    triggerFileDownload(
+      markdown,
+      'chat-export.md',
+      'text/markdown;charset=utf-8',
+    );
+    onOpenChange(false);
+  }, [messages, effectiveSelected, onOpenChange, youLabel, assistantLabel]);
+
+  const truncate = (text: string, maxLen = 80) =>
+    text.length > maxLen ? `${text.slice(0, maxLen)}...` : text;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('export.title')}
+      description={t('export.description')}
+      icon={<Download className="text-muted-foreground size-5" />}
+      size="lg"
+      footer={
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleExportMarkdown}
+            disabled={noneSelected}
+            className="gap-1.5"
+          >
+            <FileText className="size-3.5" />
+            {t('export.downloadMarkdown')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleExportPdf}
+            disabled={noneSelected}
+            className="gap-1.5"
+          >
+            <FileText className="size-3.5" />
+            {t('export.downloadPdf')}
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <Text variant="label" className="text-sm">
+            {t('export.messagesCount', {
+              count: effectiveSelected.size,
+              total: messages.length,
+            })}
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleToggleAll}
+            className="text-xs"
+          >
+            {allSelected ? t('export.deselectAll') : t('export.selectAll')}
+          </Button>
+        </div>
+
+        <div className="border-border max-h-80 overflow-y-auto rounded-lg border">
+          {messages.map((msg) => (
+            <button
+              key={msg._id}
+              type="button"
+              className="hover:bg-accent flex w-full cursor-pointer items-start gap-3 border-b px-3 py-2 text-left last:border-b-0"
+              onClick={() => handleToggleMessage(msg._id)}
+            >
+              <div className="pointer-events-none mt-0.5">
+                <Checkbox
+                  checked={effectiveSelected.has(msg._id)}
+                  tabIndex={-1}
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <Text variant="label" className="text-xs">
+                  {msg.role === 'user'
+                    ? t('export.you')
+                    : t('export.assistant')}
+                </Text>
+                <Text
+                  variant="muted"
+                  className="line-clamp-2 text-xs leading-relaxed"
+                >
+                  {truncate(msg.content, 120)}
+                </Text>
+              </div>
+            </button>
+          ))}
+          {messages.length === 0 && (
+            <div className="px-3 py-4 text-center">
+              <Text variant="muted" className="text-sm">
+                {t('export.noMessages')}
+              </Text>
+            </div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+export function ExportChatDialog(props: ExportChatDialogProps) {
+  if (!props.open) return null;
+  return <ExportChatDialogContent {...props} />;
+}

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -5,6 +5,7 @@ import { v } from 'convex/values';
 import { components } from '../_generated/api';
 import { query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls';
+import { getThreadMessages as getThreadMessagesHelper } from './get_thread_messages';
 import { getThreadMessagesStreaming as getThreadMessagesStreamingHelper } from './get_thread_messages_streaming';
 import { listArchivedThreads as listArchivedThreadsHelper } from './list_archived_threads';
 import { listThreads as listThreadsHelper } from './list_threads';
@@ -81,6 +82,17 @@ export const isThreadGenerating = query({
     }
 
     return true;
+  },
+});
+
+export const getThreadMessages = query({
+  args: { threadId: v.string() },
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      return { messages: [] };
+    }
+    return await getThreadMessagesHelper(ctx, args.threadId);
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2730,6 +2730,19 @@
       "backToChat": "Zurück zum Chat",
       "inputPlaceholder": "Nachricht senden, um diese Unterhaltung fortzusetzen...",
       "inputHint": "Das Senden einer Nachricht erstellt Ihre eigene Kopie dieses Chats"
+    },
+    "export": {
+      "button": "Exportieren",
+      "title": "Chat exportieren",
+      "description": "Nachrichten auswählen und im gewünschten Format herunterladen.",
+      "selectAll": "Alle auswählen",
+      "deselectAll": "Alle abwählen",
+      "messagesCount": "{count} von {total} Nachrichten ausgewählt",
+      "downloadPdf": "PDF herunterladen",
+      "downloadMarkdown": "Markdown herunterladen",
+      "noMessages": "Keine Nachrichten zum Exportieren",
+      "you": "Sie",
+      "assistant": "Assistent"
     }
   },
   "documents": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2769,6 +2769,19 @@
       "inputPlaceholder": "Send a message to continue this conversation...",
       "inputHint": "Sending a message will create your own copy of this chat"
     },
+    "export": {
+      "button": "Export",
+      "title": "Export chat",
+      "description": "Select messages and download in your preferred format.",
+      "selectAll": "Select all",
+      "deselectAll": "Deselect all",
+      "messagesCount": "{count} of {total} messages selected",
+      "downloadPdf": "Download PDF",
+      "downloadMarkdown": "Download Markdown",
+      "noMessages": "No messages to export",
+      "you": "You",
+      "assistant": "Assistant"
+    },
     "arena": {
       "title": "Arena Mode",
       "enable": "Enable Arena Mode",


### PR DESCRIPTION
## Summary
- Add export/download button to the chat header (desktop + mobile) next to the Share button
- Export dialog with message selection: all messages checked by default, users can deselect individual messages or toggle select/deselect all
- Two export formats: **PDF** (via browser print dialog) and **Markdown** (instant client-side download)
- Internal structural markers (`[[CONCLUSION]]`, `[[KEY_POINTS]]`, `[[DETAILS]]`, etc.) are stripped from exported content
- i18n support for English and German

Closes #1189

## Test plan
- [ ] Open a chat with messages, click "Export" button in the header
- [ ] Verify all messages are selected by default in the dialog
- [ ] Deselect some messages, click "Download PDF" — verify browser print dialog opens with only selected messages
- [ ] Verify Chinese/CJK text renders correctly in the PDF (uses system fonts)
- [ ] Click "Download Markdown" — verify `.md` file downloads with correct content
- [ ] Verify "Select all" / "Deselect all" toggle works
- [ ] Verify export button appears on both desktop and mobile layouts
- [ ] Verify exported content does not contain `[[CONCLUSION]]`, `[[KEY_POINTS]]` markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat export feature now available—download conversations as Markdown or PDF format files
  * Selectively choose which messages to include in your export with checkbox controls
  * Option to select or deselect all messages with a single action
  * Available in English and German language interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->