### PR TITLE
fix(platform): add thread ownership checks to prevent unauthorized access

### DIFF
--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, useMatch } from '@tanstack/react-router';
+import { createFileRoute, useMatch, useNavigate } from '@tanstack/react-router';
+import { useQuery } from 'convex/react';
 import { m, AnimatePresence } from 'framer-motion';
 import { PanelLeftClose } from 'lucide-react';
 import { Suspense, useState, useEffect, useRef } from 'react';
@@ -7,6 +8,7 @@ import { LayoutErrorBoundary } from '@/app/components/error-boundaries/boundarie
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
+import { Button } from '@/app/components/ui/primitives/button';
 import { ChatHeader } from '@/app/features/chat/components/chat-header';
 import { ChatHistorySidebar } from '@/app/features/chat/components/chat-history-sidebar';
 import { ChatInterface } from '@/app/features/chat/components/chat-interface';
@@ -17,6 +19,7 @@ import {
   ChatLayoutProvider,
   useChatLayout,
 } from '@/app/features/chat/context/chat-layout-context';
+import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
@@ -50,6 +53,87 @@ function ChatSkeleton() {
       </div>
       <ChatInputSkeleton />
     </div>
+  );
+}
+
+/**
+ * Gates ChatInterface behind a thread ownership check.
+ * When a threadId is present, waits for getThreadStatus to resolve:
+ * - null while loading → show skeleton
+ * - null after load (unauthorized / missing) → show "not found"
+ * - valid status → render ChatInterface
+ * When no threadId, renders ChatInterface immediately (new chat).
+ */
+function ThreadGate({
+  organizationId,
+  threadId,
+  newChatCount,
+}: {
+  organizationId: string;
+  threadId: string | undefined;
+  newChatCount: number;
+}) {
+  const { t: tChat } = useT('chat');
+  const navigate = useNavigate();
+
+  // Raw Convex query — stable subscription, no suspense, no react-query wrapper.
+  // Returns undefined while loading, null if thread not found / not owned.
+  const threadStatus = useQuery(
+    api.threads.queries.getThreadStatus,
+    threadId ? { threadId } : 'skip',
+  );
+
+  // No threadId → new chat, render immediately
+  if (!threadId) {
+    return (
+      <BranchProvider threadId={threadId}>
+        <Suspense fallback={<ChatSkeleton />}>
+          <ChatInterface
+            key={`chat-${newChatCount}`}
+            organizationId={organizationId}
+            threadId={threadId}
+          />
+        </Suspense>
+      </BranchProvider>
+    );
+  }
+
+  // Still loading
+  if (threadStatus === undefined) {
+    return <ChatSkeleton />;
+  }
+
+  // Loaded but thread not found / not authorized
+  if (threadStatus === null) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
+        <p className="text-muted-foreground text-sm">{tChat('notFound')}</p>
+        <Button
+          variant="secondary"
+          onClick={() =>
+            void navigate({
+              to: '/dashboard/$id/chat',
+              params: { id: organizationId },
+            })
+          }
+        >
+          {tChat('newChat')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Thread is accessible — render ChatInterface
+  return (
+    <BranchProvider threadId={threadId}>
+      <Suspense fallback={<ChatSkeleton />}>
+        <ChatInterface
+          key={`chat-${newChatCount}`}
+          organizationId={organizationId}
+          threadId={threadId}
+        />
+      </Suspense>
+    </BranchProvider>
   );
 }
 
@@ -147,15 +231,11 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <LayoutErrorBoundary organizationId={organizationId}>
-            <BranchProvider threadId={threadId}>
-              <Suspense fallback={<ChatSkeleton />}>
-                <ChatInterface
-                  key={`chat-${newChatCount}`}
-                  organizationId={organizationId}
-                  threadId={threadId}
-                />
-              </Suspense>
-            </BranchProvider>
+            <ThreadGate
+              organizationId={organizationId}
+              threadId={threadId}
+              newChatCount={newChatCount}
+            />
           </LayoutErrorBoundary>
         </div>
       </div>

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -542,6 +542,7 @@ import type * as organizations_helpers from "../organizations/helpers.js";
 import type * as organizations_queries from "../organizations/queries.js";
 import type * as organizations_update_organization from "../organizations/update_organization.js";
 import type * as organizations_validators from "../organizations/validators.js";
+import type * as products_bulk_create_products from "../products/bulk_create_products.js";
 import type * as products_create_product from "../products/create_product.js";
 import type * as products_create_product_with_translations from "../products/create_product_with_translations.js";
 import type * as products_delete_product from "../products/delete_product.js";
@@ -1467,6 +1468,7 @@ declare const fullApi: ApiFromModules<{
   "organizations/queries": typeof organizations_queries;
   "organizations/update_organization": typeof organizations_update_organization;
   "organizations/validators": typeof organizations_validators;
+  "products/bulk_create_products": typeof products_bulk_create_products;
   "products/create_product": typeof products_create_product;
   "products/create_product_with_translations": typeof products_create_product_with_translations;
   "products/delete_product": typeof products_delete_product;

--- a/services/platform/convex/threads/__tests__/is_thread_generating.test.ts
+++ b/services/platform/convex/threads/__tests__/is_thread_generating.test.ts
@@ -18,15 +18,17 @@ const isThreadGenerating = isThreadGeneratingQuery as unknown as (
 
 function createMockCtx(
   threadMeta?: {
+    userId?: string;
     generationStatus?: string;
     generationStartTime?: number;
   } | null,
 ) {
+  const meta = threadMeta ? { userId: 'user_1', ...threadMeta } : null;
   return {
     db: {
       query: () => ({
         withIndex: () => ({
-          first: vi.fn().mockResolvedValue(threadMeta ?? null),
+          first: vi.fn().mockResolvedValue(meta),
         }),
       }),
     },

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -70,7 +70,8 @@ export const isThreadGenerating = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    if (metadata?.generationStatus !== 'generating') return false;
+    if (!metadata || metadata.userId !== authUser.userId) return false;
+    if (metadata.generationStatus !== 'generating') return false;
 
     // Guard against stuck generationStatus: if the action crashed without
     // cleanup, the generation start time lets us detect staleness and
@@ -124,6 +125,20 @@ export const getThreadMessagesStreaming = query({
       };
     }
 
+    const metadata = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
+      .first();
+
+    if (!metadata || metadata.userId !== authUser.userId) {
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: '',
+        streams: { value: null },
+      };
+    }
+
     return await getThreadMessagesStreamingHelper(ctx, {
       threadId: args.threadId,
       paginationOpts: args.paginationOpts,
@@ -142,6 +157,13 @@ export const getFailedMessageErrors = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return {};
+
+    const metadata = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
+      .first();
+
+    if (!metadata || metadata.userId !== authUser.userId) return {};
 
     const result = await listMessages(ctx, components.agent, {
       threadId: args.threadId,
@@ -169,7 +191,9 @@ export const getThreadStatus = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    return metadata?.status ?? null;
+    if (!metadata || metadata.userId !== authUser.userId) return null;
+
+    return metadata.status ?? null;
   },
 });
 
@@ -180,6 +204,13 @@ export const getThreadBranches = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return [];
+
+    const rootMetadata = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.rootThreadId))
+      .first();
+
+    if (!rootMetadata || rootMetadata.userId !== authUser.userId) return [];
 
     const branches: Array<{
       branchThreadId: string;
@@ -222,7 +253,9 @@ export const getThreadBranchSelections = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    return metadata?.branchSelections ?? null;
+    if (!metadata || metadata.userId !== authUser.userId) return null;
+
+    return metadata.branchSelections ?? null;
   },
 });
 
@@ -239,7 +272,7 @@ export const getThreadShareStatus = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    if (!metadata) {
+    if (!metadata || metadata.userId !== authUser.userId) {
       return { isShared: false, shareToken: null };
     }
 
@@ -264,7 +297,11 @@ export const getThreadForkInfo = query({
       .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
       .first();
 
-    if (!metadata || !metadata.forkedFrom) {
+    if (
+      !metadata ||
+      metadata.userId !== authUser.userId ||
+      !metadata.forkedFrom
+    ) {
       return null;
     }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2700,6 +2700,7 @@
     },
     "shareBoundary": "Nachrichten oben stammen aus einem geteilten Chat",
     "forkBoundary": "Von Ihrem eigenen Chat geforkt",
+    "notFound": "Dieser Chat ist nicht verfügbar.",
     "forkChat": "Chat forken",
     "forkSuccess": "Chat erfolgreich geforkt",
     "forkFailed": "Chat konnte nicht geforkt werden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2738,6 +2738,7 @@
     },
     "shareBoundary": "Messages above are from a shared chat",
     "forkBoundary": "Forked from your own chat",
+    "notFound": "This chat is not available.",
     "forkChat": "Fork chat",
     "forkSuccess": "Chat forked successfully",
     "forkFailed": "Failed to fork chat",


### PR DESCRIPTION
## Summary
- Add `userId` ownership checks to all 8 thread read queries (`isThreadGenerating`, `getThreadMessagesStreaming`, `getFailedMessageErrors`, `getThreadStatus`, `getThreadBranches`, `getThreadBranchSelections`, `getThreadShareStatus`, `getThreadForkInfo`) — previously only checked authentication, not authorization
- Add `ThreadGate` component in the chat layout that blocks `ChatInterface` from mounting when the thread is not owned by the current user, showing a "This chat is not available" message instead
- Add `chat.notFound` i18n key in en/de

## Test plan
- [ ] Log in as user A, create a chat thread, copy the thread URL
- [ ] Log in as user B, paste the URL — should see "This chat is not available." with a "New chat" button (no flickering, no blank page)
- [ ] Verify user A can still access their own thread normally
- [ ] Verify new chat (no threadId) still works
- [ ] Verify shared chat via share token still works (unaffected by ownership checks)

Closes #1175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented authorization checks to restrict chat access to thread owners only.
  * Users now see a "not available" message with navigation option when accessing restricted chats.
  * Added localized error messages in English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->