### PR TITLE
fix(platform): prevent Swagger docs page from redirecting on click

### DIFF
--- a/services/platform/app/routes/docs.tsx
+++ b/services/platform/app/routes/docs.tsx
@@ -60,8 +60,8 @@ function ApiDocsPage() {
 
   // Prevent TanStack Router from intercepting Swagger UI internal link clicks
   const handleClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const anchor = target.closest('a');
+    if (!(e.target instanceof HTMLElement)) return;
+    const anchor = e.target.closest('a');
     if (anchor && anchor.getAttribute('href')?.startsWith('#')) {
       e.stopPropagation();
     }

--- a/services/platform/app/routes/docs.tsx
+++ b/services/platform/app/routes/docs.tsx
@@ -45,7 +45,7 @@ function ApiDocsPage() {
       showCommonExtensions: true,
       tryItOutEnabled: true,
       persistAuthorization: true,
-      deepLinking: true,
+      deepLinking: false,
       tagsSorter: 'alpha' as const,
       operationsSorter: 'alpha' as const,
       requestInterceptor: (req: Record<string, unknown>) => {
@@ -58,8 +58,17 @@ function ApiDocsPage() {
     [],
   );
 
+  // Prevent TanStack Router from intercepting Swagger UI internal link clicks
+  const handleClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const anchor = target.closest('a');
+    if (anchor && anchor.getAttribute('href')?.startsWith('#')) {
+      e.stopPropagation();
+    }
+  };
+
   return (
-    <div className="bg-background min-h-screen">
+    <div className="bg-background min-h-screen" onClickCapture={handleClick}>
       <main className="swagger-ui-standalone">
         <Suspense fallback={<SwaggerSkeleton />}>
           <SwaggerUI {...swaggerConfig} />

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -19,9 +19,7 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "Create chat completion",
         "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
@@ -91,9 +89,7 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -122,9 +118,7 @@
     },
     "/api/v1/documents": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "List documents",
         "operationId": "listDocuments",
         "security": [
@@ -196,9 +190,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Create document",
         "operationId": "createDocument",
         "security": [
@@ -244,9 +236,7 @@
     },
     "/api/v1/documents/{id}": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Get document",
         "operationId": "getDocument",
         "security": [
@@ -291,9 +281,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Update document",
         "operationId": "updateDocument",
         "security": [
@@ -348,9 +336,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Delete document",
         "operationId": "deleteDocument",
         "security": [
@@ -390,9 +376,7 @@
     },
     "/api/v1/documents/{id}/retry-indexing": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Retry RAG indexing",
         "operationId": "retryDocumentIndexing",
         "security": [
@@ -432,9 +416,7 @@
     },
     "/api/v1/websites": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "List websites",
         "operationId": "listWebsites",
         "security": [
@@ -506,9 +488,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Create website",
         "operationId": "createWebsite",
         "security": [
@@ -554,9 +534,7 @@
     },
     "/api/v1/websites/{id}": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Get website",
         "operationId": "getWebsite",
         "security": [
@@ -601,9 +579,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Update website",
         "operationId": "updateWebsite",
         "security": [
@@ -658,9 +634,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Delete website",
         "operationId": "deleteWebsite",
         "security": [
@@ -700,9 +674,7 @@
     },
     "/api/v1/websites/{id}/pages": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Fetch pages",
         "operationId": "listWebsitePages",
         "security": [
@@ -767,9 +739,7 @@
     },
     "/api/v1/websites/{id}/sync": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Sync statuses",
         "operationId": "syncWebsite",
         "security": [
@@ -809,9 +779,7 @@
     },
     "/api/v1/websites/{id}/search": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Search content",
         "operationId": "searchWebsite",
         "security": [
@@ -868,9 +836,7 @@
     },
     "/api/v1/products": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "List products",
         "operationId": "listProducts",
         "security": [
@@ -942,9 +908,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Create product",
         "operationId": "createProduct",
         "security": [
@@ -990,9 +954,7 @@
     },
     "/api/v1/products/{id}": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Get product",
         "operationId": "getProduct",
         "security": [
@@ -1037,9 +999,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Update product",
         "operationId": "updateProduct",
         "security": [
@@ -1094,9 +1054,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Delete product",
         "operationId": "deleteProduct",
         "security": [
@@ -1136,9 +1094,7 @@
     },
     "/api/v1/customers": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "List customers",
         "operationId": "listCustomers",
         "security": [
@@ -1219,9 +1175,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "security": [
@@ -1267,9 +1221,7 @@
     },
     "/api/v1/customers/{id}": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Get customer",
         "operationId": "getCustomer",
         "security": [
@@ -1314,9 +1266,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "security": [
@@ -1371,9 +1321,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "security": [
@@ -1413,9 +1361,7 @@
     },
     "/api/v1/vendors": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "List vendors",
         "operationId": "listVendors",
         "security": [
@@ -1487,9 +1433,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Create vendor",
         "operationId": "createVendor",
         "security": [
@@ -1535,9 +1479,7 @@
     },
     "/api/v1/vendors/{id}": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Get vendor",
         "operationId": "getVendor",
         "security": [
@@ -1582,9 +1524,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Update vendor",
         "operationId": "updateVendor",
         "security": [
@@ -1639,9 +1579,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Delete vendor",
         "operationId": "deleteVendor",
         "security": [
@@ -1681,9 +1619,7 @@
     },
     "/api/v1/agents": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List agents",
         "operationId": "listAgents",
         "security": [
@@ -1719,9 +1655,7 @@
     },
     "/api/v1/agents/tools": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available tools",
         "operationId": "listAgentTools",
         "security": [
@@ -1750,9 +1684,7 @@
     },
     "/api/v1/agents/integrations": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available integrations",
         "operationId": "listAgentIntegrations",
         "security": [
@@ -1781,9 +1713,7 @@
     },
     "/api/v1/agents/{slug}": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Get agent config and binding",
         "operationId": "getAgent",
         "security": [
@@ -1828,9 +1758,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Update agent binding",
         "operationId": "updateAgentBinding",
         "security": [
@@ -1887,9 +1815,7 @@
     },
     "/api/v1/workflows/{slug}/schedules": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List schedules",
         "operationId": "listWorkflowSchedules",
         "security": [
@@ -1934,9 +1860,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create schedule",
         "operationId": "createWorkflowSchedule",
         "security": [
@@ -1993,9 +1917,7 @@
     },
     "/api/v1/workflows/schedules/{id}": {
       "patch": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Update schedule",
         "operationId": "updateWorkflowSchedule",
         "security": [
@@ -2050,9 +1972,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete schedule",
         "operationId": "deleteWorkflowSchedule",
         "security": [
@@ -2092,9 +2012,7 @@
     },
     "/api/v1/workflows/{slug}/webhooks": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List webhooks",
         "operationId": "listWorkflowWebhooks",
         "security": [
@@ -2139,9 +2057,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create webhook",
         "operationId": "createWorkflowWebhook",
         "security": [
@@ -2188,9 +2104,7 @@
     },
     "/api/v1/workflows/webhooks/{id}": {
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete webhook",
         "operationId": "deleteWorkflowWebhook",
         "security": [
@@ -2230,9 +2144,7 @@
     },
     "/api/v1/workflows/{slug}/logs": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get trigger logs",
         "operationId": "getWorkflowLogs",
         "security": [
@@ -2272,9 +2184,7 @@
     },
     "/api/v1/workflows/{slug}/executions": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List executions",
         "operationId": "listWorkflowExecutions",
         "security": [
@@ -2366,9 +2276,7 @@
     },
     "/api/v1/workflows/executions/{id}": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get execution details",
         "operationId": "getWorkflowExecution",
         "security": [
@@ -2415,9 +2323,7 @@
     },
     "/api/v1/workflows/executions/{id}/cancel": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Cancel execution",
         "operationId": "cancelWorkflowExecution",
         "security": [
@@ -2457,9 +2363,7 @@
     },
     "/api/v1/workflows/{slug}/run": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Trigger workflow",
         "operationId": "triggerWorkflow",
         "security": [
@@ -2516,9 +2420,7 @@
     },
     "/api/v1/threads": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "List threads",
         "operationId": "listThreads",
         "security": [
@@ -2581,9 +2483,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Create thread",
         "operationId": "createThread",
         "security": [
@@ -2629,9 +2529,7 @@
     },
     "/api/v1/threads/{id}": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread",
         "operationId": "getThread",
         "security": [
@@ -2676,9 +2574,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Update thread title",
         "operationId": "updateThread",
         "security": [
@@ -2726,9 +2622,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Delete thread",
         "operationId": "deleteThread",
         "security": [
@@ -2768,9 +2662,7 @@
     },
     "/api/v1/threads/{id}/messages": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread messages",
         "operationId": "getThreadMessages",
         "security": [
@@ -2817,9 +2709,7 @@
     },
     "/api/v1/threads/{id}/archive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Archive thread",
         "operationId": "archiveThread",
         "security": [
@@ -2859,9 +2749,7 @@
     },
     "/api/v1/threads/{id}/unarchive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Unarchive thread",
         "operationId": "unarchiveThread",
         "security": [
@@ -2911,10 +2799,7 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -2972,10 +2857,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object"
-                ]
+                "enum": ["text", "json_object"]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -2991,20 +2873,14 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "required",
-                  "none"
-                ]
+                "enum": ["auto", "required", "none"]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "function"
-                    ]
+                    "enum": ["function"]
                   },
                   "function": {
                     "type": "object",
@@ -3013,9 +2889,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name"
-                    ]
+                    "required": ["name"]
                   }
                 }
               }
@@ -3033,9 +2907,7 @@
           },
           "object": {
             "type": "string",
-            "enum": [
-              "chat.completion"
-            ]
+            "enum": ["chat.completion"]
           },
           "created": {
             "type": "integer"
@@ -3056,11 +2928,7 @@
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": [
-                    "stop",
-                    "length",
-                    "tool_calls"
-                  ]
+                  "enum": ["stop", "length", "tool_calls"]
                 }
               }
             }
@@ -3086,9 +2954,7 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": [
-              "list"
-            ]
+            "enum": ["list"]
           },
           "data": {
             "type": "array",
@@ -3101,9 +2967,7 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": [
-                    "model"
-                  ]
+                  "enum": ["model"]
                 },
                 "created": {
                   "type": "integer"
@@ -3135,9 +2999,7 @@
       },
       "CreateDocumentRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -3248,10 +3110,7 @@
       },
       "CreateWebsiteRequest": {
         "type": "object",
-        "required": [
-          "domain",
-          "scanInterval"
-        ],
+        "required": ["domain", "scanInterval"],
         "properties": {
           "domain": {
             "type": "string"
@@ -3329,9 +3188,7 @@
       },
       "WebsiteSearchRequest": {
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {
             "type": "string"
@@ -3385,9 +3242,7 @@
       },
       "CreateProductRequest": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -3525,9 +3380,7 @@
       },
       "CreateCustomerRequest": {
         "type": "object",
-        "required": [
-          "email"
-        ],
+        "required": ["email"],
         "properties": {
           "email": {
             "type": "string"
@@ -3769,10 +3622,7 @@
       },
       "CreateScheduleRequest": {
         "type": "object",
-        "required": [
-          "cronExpression",
-          "timezone"
-        ],
+        "required": ["cronExpression", "timezone"],
         "properties": {
           "cronExpression": {
             "type": "string"
@@ -3946,11 +3796,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "archived",
-              "deleted"
-            ]
+            "enum": ["active", "archived", "deleted"]
           },
           "chatType": {
             "type": "string"
@@ -3968,9 +3814,7 @@
       },
       "UpdateThreadRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -3993,10 +3837,7 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "user",
-                    "assistant"
-                  ]
+                  "enum": ["user", "assistant"]
                 },
                 "content": {
                   "type": "string"
@@ -4008,18 +3849,11 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "tool"
-            ]
+            "enum": ["system", "user", "assistant", "tool"]
           },
           "content": {
             "oneOf": [
@@ -4047,22 +3881,15 @@
       },
       "ToolDefinition": {
         "type": "object",
-        "required": [
-          "type",
-          "function"
-        ],
+        "required": ["type", "function"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "name": {
                 "type": "string"
@@ -4120,9 +3947,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -19,7 +19,9 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "Create chat completion",
         "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
@@ -89,7 +91,9 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -118,7 +122,9 @@
     },
     "/api/v1/documents": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "List documents",
         "operationId": "listDocuments",
         "security": [
@@ -190,7 +196,9 @@
         }
       },
       "post": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Create document",
         "operationId": "createDocument",
         "security": [
@@ -236,7 +244,9 @@
     },
     "/api/v1/documents/{id}": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Get document",
         "operationId": "getDocument",
         "security": [
@@ -281,7 +291,9 @@
         }
       },
       "patch": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Update document",
         "operationId": "updateDocument",
         "security": [
@@ -336,7 +348,9 @@
         }
       },
       "delete": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Delete document",
         "operationId": "deleteDocument",
         "security": [
@@ -376,7 +390,9 @@
     },
     "/api/v1/documents/{id}/retry-indexing": {
       "post": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Retry RAG indexing",
         "operationId": "retryDocumentIndexing",
         "security": [
@@ -416,7 +432,9 @@
     },
     "/api/v1/websites": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "List websites",
         "operationId": "listWebsites",
         "security": [
@@ -488,7 +506,9 @@
         }
       },
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Create website",
         "operationId": "createWebsite",
         "security": [
@@ -534,7 +554,9 @@
     },
     "/api/v1/websites/{id}": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Get website",
         "operationId": "getWebsite",
         "security": [
@@ -579,7 +601,9 @@
         }
       },
       "patch": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Update website",
         "operationId": "updateWebsite",
         "security": [
@@ -634,7 +658,9 @@
         }
       },
       "delete": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Delete website",
         "operationId": "deleteWebsite",
         "security": [
@@ -674,7 +700,9 @@
     },
     "/api/v1/websites/{id}/pages": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Fetch pages",
         "operationId": "listWebsitePages",
         "security": [
@@ -739,7 +767,9 @@
     },
     "/api/v1/websites/{id}/sync": {
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Sync statuses",
         "operationId": "syncWebsite",
         "security": [
@@ -779,7 +809,9 @@
     },
     "/api/v1/websites/{id}/search": {
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Search content",
         "operationId": "searchWebsite",
         "security": [
@@ -836,7 +868,9 @@
     },
     "/api/v1/products": {
       "get": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "List products",
         "operationId": "listProducts",
         "security": [
@@ -908,7 +942,9 @@
         }
       },
       "post": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Create product",
         "operationId": "createProduct",
         "security": [
@@ -954,7 +990,9 @@
     },
     "/api/v1/products/{id}": {
       "get": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Get product",
         "operationId": "getProduct",
         "security": [
@@ -999,7 +1037,9 @@
         }
       },
       "patch": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Update product",
         "operationId": "updateProduct",
         "security": [
@@ -1054,7 +1094,9 @@
         }
       },
       "delete": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Delete product",
         "operationId": "deleteProduct",
         "security": [
@@ -1094,7 +1136,9 @@
     },
     "/api/v1/customers": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "List customers",
         "operationId": "listCustomers",
         "security": [
@@ -1175,7 +1219,9 @@
         }
       },
       "post": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "security": [
@@ -1221,7 +1267,9 @@
     },
     "/api/v1/customers/{id}": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Get customer",
         "operationId": "getCustomer",
         "security": [
@@ -1266,7 +1314,9 @@
         }
       },
       "patch": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "security": [
@@ -1321,7 +1371,9 @@
         }
       },
       "delete": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "security": [
@@ -1361,7 +1413,9 @@
     },
     "/api/v1/vendors": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "List vendors",
         "operationId": "listVendors",
         "security": [
@@ -1433,7 +1487,9 @@
         }
       },
       "post": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Create vendor",
         "operationId": "createVendor",
         "security": [
@@ -1479,7 +1535,9 @@
     },
     "/api/v1/vendors/{id}": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Get vendor",
         "operationId": "getVendor",
         "security": [
@@ -1524,7 +1582,9 @@
         }
       },
       "patch": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Update vendor",
         "operationId": "updateVendor",
         "security": [
@@ -1579,7 +1639,9 @@
         }
       },
       "delete": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Delete vendor",
         "operationId": "deleteVendor",
         "security": [
@@ -1619,7 +1681,9 @@
     },
     "/api/v1/agents": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List agents",
         "operationId": "listAgents",
         "security": [
@@ -1655,7 +1719,9 @@
     },
     "/api/v1/agents/tools": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List available tools",
         "operationId": "listAgentTools",
         "security": [
@@ -1684,7 +1750,9 @@
     },
     "/api/v1/agents/integrations": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List available integrations",
         "operationId": "listAgentIntegrations",
         "security": [
@@ -1713,7 +1781,9 @@
     },
     "/api/v1/agents/{slug}": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "Get agent config and binding",
         "operationId": "getAgent",
         "security": [
@@ -1758,7 +1828,9 @@
         }
       },
       "patch": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "Update agent binding",
         "operationId": "updateAgentBinding",
         "security": [
@@ -1815,7 +1887,9 @@
     },
     "/api/v1/workflows/{slug}/schedules": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List schedules",
         "operationId": "listWorkflowSchedules",
         "security": [
@@ -1860,7 +1934,9 @@
         }
       },
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Create schedule",
         "operationId": "createWorkflowSchedule",
         "security": [
@@ -1917,7 +1993,9 @@
     },
     "/api/v1/workflows/schedules/{id}": {
       "patch": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Update schedule",
         "operationId": "updateWorkflowSchedule",
         "security": [
@@ -1972,7 +2050,9 @@
         }
       },
       "delete": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Delete schedule",
         "operationId": "deleteWorkflowSchedule",
         "security": [
@@ -2012,7 +2092,9 @@
     },
     "/api/v1/workflows/{slug}/webhooks": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List webhooks",
         "operationId": "listWorkflowWebhooks",
         "security": [
@@ -2057,7 +2139,9 @@
         }
       },
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Create webhook",
         "operationId": "createWorkflowWebhook",
         "security": [
@@ -2104,7 +2188,9 @@
     },
     "/api/v1/workflows/webhooks/{id}": {
       "delete": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Delete webhook",
         "operationId": "deleteWorkflowWebhook",
         "security": [
@@ -2144,7 +2230,9 @@
     },
     "/api/v1/workflows/{slug}/logs": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Get trigger logs",
         "operationId": "getWorkflowLogs",
         "security": [
@@ -2184,7 +2272,9 @@
     },
     "/api/v1/workflows/{slug}/executions": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List executions",
         "operationId": "listWorkflowExecutions",
         "security": [
@@ -2276,7 +2366,9 @@
     },
     "/api/v1/workflows/executions/{id}": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Get execution details",
         "operationId": "getWorkflowExecution",
         "security": [
@@ -2323,7 +2415,9 @@
     },
     "/api/v1/workflows/executions/{id}/cancel": {
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Cancel execution",
         "operationId": "cancelWorkflowExecution",
         "security": [
@@ -2363,7 +2457,9 @@
     },
     "/api/v1/workflows/{slug}/run": {
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Trigger workflow",
         "operationId": "triggerWorkflow",
         "security": [
@@ -2420,7 +2516,9 @@
     },
     "/api/v1/threads": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "List threads",
         "operationId": "listThreads",
         "security": [
@@ -2483,7 +2581,9 @@
         }
       },
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Create thread",
         "operationId": "createThread",
         "security": [
@@ -2529,7 +2629,9 @@
     },
     "/api/v1/threads/{id}": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Get thread",
         "operationId": "getThread",
         "security": [
@@ -2574,7 +2676,9 @@
         }
       },
       "patch": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Update thread title",
         "operationId": "updateThread",
         "security": [
@@ -2622,7 +2726,9 @@
         }
       },
       "delete": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Delete thread",
         "operationId": "deleteThread",
         "security": [
@@ -2662,7 +2768,9 @@
     },
     "/api/v1/threads/{id}/messages": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Get thread messages",
         "operationId": "getThreadMessages",
         "security": [
@@ -2709,7 +2817,9 @@
     },
     "/api/v1/threads/{id}/archive": {
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Archive thread",
         "operationId": "archiveThread",
         "security": [
@@ -2749,7 +2859,9 @@
     },
     "/api/v1/threads/{id}/unarchive": {
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Unarchive thread",
         "operationId": "unarchiveThread",
         "security": [
@@ -2799,7 +2911,10 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -2857,7 +2972,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object"]
+                "enum": [
+                  "text",
+                  "json_object"
+                ]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -2873,14 +2991,20 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["auto", "required", "none"]
+                "enum": [
+                  "auto",
+                  "required",
+                  "none"
+                ]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["function"]
+                    "enum": [
+                      "function"
+                    ]
                   },
                   "function": {
                     "type": "object",
@@ -2889,7 +3013,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"]
+                    "required": [
+                      "name"
+                    ]
                   }
                 }
               }
@@ -2907,7 +3033,9 @@
           },
           "object": {
             "type": "string",
-            "enum": ["chat.completion"]
+            "enum": [
+              "chat.completion"
+            ]
           },
           "created": {
             "type": "integer"
@@ -2928,7 +3056,11 @@
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": ["stop", "length", "tool_calls"]
+                  "enum": [
+                    "stop",
+                    "length",
+                    "tool_calls"
+                  ]
                 }
               }
             }
@@ -2954,7 +3086,9 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": ["list"]
+            "enum": [
+              "list"
+            ]
           },
           "data": {
             "type": "array",
@@ -2967,7 +3101,9 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": ["model"]
+                  "enum": [
+                    "model"
+                  ]
                 },
                 "created": {
                   "type": "integer"
@@ -2999,7 +3135,9 @@
       },
       "CreateDocumentRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string"
@@ -3110,7 +3248,10 @@
       },
       "CreateWebsiteRequest": {
         "type": "object",
-        "required": ["domain", "scanInterval"],
+        "required": [
+          "domain",
+          "scanInterval"
+        ],
         "properties": {
           "domain": {
             "type": "string"
@@ -3188,7 +3329,9 @@
       },
       "WebsiteSearchRequest": {
         "type": "object",
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "properties": {
           "query": {
             "type": "string"
@@ -3242,7 +3385,9 @@
       },
       "CreateProductRequest": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -3380,7 +3525,9 @@
       },
       "CreateCustomerRequest": {
         "type": "object",
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "properties": {
           "email": {
             "type": "string"
@@ -3622,7 +3769,10 @@
       },
       "CreateScheduleRequest": {
         "type": "object",
-        "required": ["cronExpression", "timezone"],
+        "required": [
+          "cronExpression",
+          "timezone"
+        ],
         "properties": {
           "cronExpression": {
             "type": "string"
@@ -3773,6 +3923,15 @@
           }
         }
       },
+      "CreatedResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the created resource"
+          }
+        }
+      },
       "Thread": {
         "type": "object",
         "properties": {
@@ -3787,7 +3946,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "deleted"]
+            "enum": [
+              "active",
+              "archived",
+              "deleted"
+            ]
           },
           "chatType": {
             "type": "string"
@@ -3805,7 +3968,9 @@
       },
       "UpdateThreadRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string"
@@ -3828,7 +3993,10 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["user", "assistant"]
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ]
                 },
                 "content": {
                   "type": "string"
@@ -3840,11 +4008,18 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["system", "user", "assistant", "tool"]
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool"
+            ]
           },
           "content": {
             "oneOf": [
@@ -3872,15 +4047,22 @@
       },
       "ToolDefinition": {
         "type": "object",
-        "required": ["type", "function"],
+        "required": [
+          "type",
+          "function"
+        ],
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string"
@@ -3938,7 +4120,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -1613,6 +1613,12 @@ function injectRestApiPaths(spec: OpenApiSpec) {
       title: { type: 'string' },
     },
   };
+  schemas.CreatedResource = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', description: 'ID of the created resource' },
+    },
+  };
   schemas.ThreadMessages = {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary
- Fix Swagger UI `/docs` page redirecting to `/log-in` when clicking on API operations — caused by TanStack Router intercepting Swagger's deep-link anchor tags
- Add missing `CreatedResource` schema referenced by `POST /api/v1/threads` 201 response, which caused a resolver error in Swagger UI

## Changes
- **docs.tsx**: Disable `deepLinking` and add `onClickCapture` handler to stop hash-link propagation to TanStack Router
- **generate-openapi.ts**: Add `CreatedResource` schema definition (`{ id: string }`)
- **openapi.json**: Regenerated

Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Swagger UI navigation to prevent external routing from intercepting internal fragment navigation.

* **Documentation**
  * Updated API specification to properly document resource creation response schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->