### PR TITLE
fix(platform): make archived chats fully read-only

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -47,7 +47,6 @@ import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaSplitView } from './arena/arena-split-view';
 import { ChatInput } from './chat-input';
 import { ChatMessages } from './chat-messages';
-import { EditMessageDialog } from './edit-message-dialog';
 import { WelcomeView } from './welcome-view';
 
 function chatDraftKey(
@@ -169,7 +168,9 @@ export function ChatInterface({
   const hasNoAgents = agents !== undefined && agents.length === 0;
 
   // Thread status — disable input for archived threads
-  const threadStatus = useThreadStatus(dataThreadId);
+  // Always check the URL threadId (root thread), not dataThreadId (which may
+  // be a branch thread that wasn't individually archived).
+  const threadStatus = useThreadStatus(threadId);
   const isArchived = threadStatus === 'archived';
 
   const { mutate: unarchiveThread, isPending: isUnarchiving } =
@@ -352,14 +353,18 @@ export function ChatInterface({
     prevDataThreadIdRef.current !== dataThreadId &&
     prevDataThreadIdRef.current !== undefined
   ) {
-    branchScrollSaveRef.current = containerRef.current?.scrollTop ?? null;
-    // Clear after content settles
-    if (branchScrollTimerRef.current)
-      clearTimeout(branchScrollTimerRef.current);
-    branchScrollTimerRef.current = setTimeout(() => {
-      branchScrollSaveRef.current = null;
-      branchScrollTimerRef.current = null;
-    }, 2000);
+    // Skip scroll preservation for edit-and-branch — we want scroll-to-bottom
+    // so the edited message and incoming AI response are visible.
+    if (!pendingMessage?.editedMessageId) {
+      branchScrollSaveRef.current = containerRef.current?.scrollTop ?? null;
+      // Clear after content settles
+      if (branchScrollTimerRef.current)
+        clearTimeout(branchScrollTimerRef.current);
+      branchScrollTimerRef.current = setTimeout(() => {
+        branchScrollSaveRef.current = null;
+        branchScrollTimerRef.current = null;
+      }, 2000);
+    }
   }
   prevDataThreadIdRef.current = dataThreadId;
 
@@ -455,6 +460,21 @@ export function ChatInterface({
         ? selectedModelOverrides[effectiveAgent.name]
         : undefined;
 
+      // Optimistic: show edited content immediately, truncate messages after it.
+      // Cleared by usePendingMessages when dataThreadId changes (branch loads).
+      setPendingMessage({
+        content: newContent,
+        threadId: dataThreadId,
+        timestamp: new Date(),
+        editedMessageId: editingMessage.id,
+      });
+
+      // Close inline editor so the optimistic content is visible
+      setEditingMessage(null);
+
+      // Scroll to bottom so the edited message + incoming AI response are visible
+      scrollingToBottomBehaviorRef.current = 'smooth';
+
       const result = await editAndBranchAction({
         sourceThreadId: dataThreadId,
         rootThreadId: rootThreadId ?? dataThreadId,
@@ -478,6 +498,7 @@ export function ChatInterface({
       userContext,
       editAndBranchAction,
       selectNewBranch,
+      setPendingMessage,
     ],
   );
 
@@ -500,7 +521,7 @@ export function ChatInterface({
               to: '/dashboard/$id/chat/$threadId',
               params: { id: organizationId, threadId: newThreadId },
             });
-            toast({ title: t('forkSuccess') });
+            toast({ title: t('forkSuccess'), variant: 'success' });
           },
           onError: (error) => {
             console.error('Failed to fork chat:', error);
@@ -578,10 +599,18 @@ export function ChatInterface({
               forkedMessageCount={forkInfo?.forkedMessageCount ?? undefined}
               forkedFromShare={forkInfo?.forkedFromShare}
               onHumanInputResponseSubmitted={handleHumanInputResponseSubmitted}
-              onSendFollowUp={handleSendFollowUp}
-              onSendMessage={handleSendMessageDirect}
-              onEditMessage={handleEditClick}
-              onForkAtMessage={handleForkAtMessage}
+              onSendFollowUp={isArchived ? undefined : handleSendFollowUp}
+              onSendMessage={isArchived ? undefined : handleSendMessageDirect}
+              onEditMessage={isArchived ? undefined : handleEditClick}
+              onForkAtMessage={isArchived ? undefined : handleForkAtMessage}
+              editingMessageId={isArchived ? undefined : editingMessage?.id}
+              editingMessageContent={
+                isArchived ? undefined : editingMessage?.content
+              }
+              onEditSubmit={isArchived ? undefined : handleEditSubmit}
+              onEditCancel={
+                isArchived ? undefined : () => setEditingMessage(null)
+              }
             />
           )}
         </div>
@@ -658,15 +687,6 @@ export function ChatInterface({
           </FileUpload.Root>
         )}
       </PanelFooter>
-
-      <EditMessageDialog
-        open={editingMessage !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditingMessage(null);
-        }}
-        messageContent={editingMessage?.content ?? ''}
-        onSubmit={handleEditSubmit}
-      />
     </div>
   );
 }

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -364,6 +364,14 @@ export function ChatInterface({
         branchScrollSaveRef.current = null;
         branchScrollTimerRef.current = null;
       }, 2000);
+    } else {
+      // Clear any stale scroll position from a prior branch switch so
+      // onContentChange doesn't override the intended scroll-to-bottom.
+      branchScrollSaveRef.current = null;
+      if (branchScrollTimerRef.current) {
+        clearTimeout(branchScrollTimerRef.current);
+        branchScrollTimerRef.current = null;
+      }
     }
   }
   prevDataThreadIdRef.current = dataThreadId;

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -18,6 +18,7 @@ import type { ChatItem } from '../hooks/use-merged-chat-items';
 import { ApprovalCardRenderer } from './approval-card-renderer';
 import { BranchNavigator } from './branch-navigator';
 import { CollapsibleSystemMessage } from './collapsible-system-message';
+import { InlineEditInput } from './inline-edit-input';
 import { MessageBubble } from './message-bubble';
 import { ThinkingAnimation } from './thinking-animation';
 
@@ -91,6 +92,10 @@ interface ChatMessagesProps {
   onSendMessage?: (message: string) => void;
   onEditMessage?: (messageId: string, content: string) => void;
   onForkAtMessage?: (messageId: string) => void;
+  editingMessageId?: string;
+  editingMessageContent?: string;
+  onEditSubmit?: (newContent: string) => Promise<void>;
+  onEditCancel?: () => void;
   hideBranchNavigator?: boolean;
 }
 
@@ -127,10 +132,30 @@ export function ChatMessages({
   onSendMessage,
   onEditMessage,
   onForkAtMessage,
+  editingMessageId,
+  editingMessageContent,
+  onEditSubmit,
+  onEditCancel,
   hideBranchNavigator,
 }: ChatMessagesProps) {
   const { t } = useT('chat');
   const { branches, activeBranchThreadId } = useBranchContext();
+  const editInputScrollRef = useRef<HTMLDivElement>(null);
+
+  // Scroll the inline edit input into view when it appears.
+  // Double-RAF ensures the ChatInterface scroll system (MutationObserver /
+  // ResizeObserver) fires first, then we override with the correct position.
+  useEffect(() => {
+    if (!editingMessageId) return;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        editInputScrollRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      });
+    });
+  }, [editingMessageId]);
   const responseAreaRef = useRef<HTMLDivElement>(null);
 
   // Split items: find the last user message index for layout purposes.
@@ -307,29 +332,43 @@ export function ChatMessages({
       message.order !== undefined &&
       forkPointOrders.has(message.order);
 
+    const isEditing = isUserMessage && message.id === editingMessageId;
+
     return (
       <div
         key={reactKey}
         ref={isLastUserMessage ? lastUserMessageRef : undefined}
         className={isLastUserMessage ? 'scroll-mt-6' : undefined}
       >
-        <MessageBubble
-          message={{
-            ...message,
-            role: isUserMessage ? 'user' : 'assistant',
-            threadId: threadId,
-          }}
-          onSendFollowUp={onSendFollowUp}
-          onEdit={isUserMessage ? onEditMessage : undefined}
-          onFork={onForkAtMessage}
-          toolbarExtra={
-            !hideBranchNavigator &&
-            hasBranches &&
-            message.order !== undefined ? (
-              <BranchNavigator forkOrder={message.order} />
-            ) : undefined
-          }
-        />
+        {isEditing && onEditSubmit && onEditCancel ? (
+          <div className="flex justify-end" ref={editInputScrollRef}>
+            <div className="w-full max-w-[85%]">
+              <InlineEditInput
+                messageContent={editingMessageContent ?? message.content}
+                onSubmit={onEditSubmit}
+                onCancel={onEditCancel}
+              />
+            </div>
+          </div>
+        ) : (
+          <MessageBubble
+            message={{
+              ...message,
+              role: isUserMessage ? 'user' : 'assistant',
+              threadId: threadId,
+            }}
+            onSendFollowUp={onSendFollowUp}
+            onEdit={isUserMessage ? onEditMessage : undefined}
+            onFork={onForkAtMessage}
+            toolbarExtra={
+              !hideBranchNavigator &&
+              hasBranches &&
+              message.order !== undefined ? (
+                <BranchNavigator forkOrder={message.order} />
+              ) : undefined
+            }
+          />
+        )}
       </div>
     );
   };

--- a/services/platform/app/features/chat/components/inline-edit-input.tsx
+++ b/services/platform/app/features/chat/components/inline-edit-input.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+import { Button } from '@/app/components/ui/primitives/button';
+import { useT } from '@/lib/i18n/client';
+
+interface InlineEditInputProps {
+  messageContent: string;
+  onSubmit: (newContent: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function InlineEditInput({
+  messageContent,
+  onSubmit,
+  onCancel,
+}: InlineEditInputProps) {
+  const { t } = useT('common');
+  const { t: tChat } = useT('chat');
+  const [value, setValue] = useState(messageContent);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      const len = textareaRef.current.value.length;
+      textareaRef.current.setSelectionRange(len, len);
+    }
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === messageContent || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [value, messageContent, isSubmitting, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        void handleSubmit();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [handleSubmit, onCancel],
+  );
+
+  const canSubmit = !!value.trim() && value.trim() !== messageContent;
+
+  return (
+    <div className="bg-muted/50 border-border flex flex-col gap-3 rounded-2xl border p-4">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          e.target.style.height = 'auto';
+          e.target.style.height = `${e.target.scrollHeight}px`;
+        }}
+        onKeyDown={handleKeyDown}
+        disabled={isSubmitting}
+        className="text-foreground min-h-[2.5rem] w-full resize-none bg-transparent text-sm leading-6 focus:outline-none disabled:opacity-50"
+        rows={1}
+      />
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="rounded-full"
+        >
+          {t('actions.cancel')}
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => void handleSubmit()}
+          disabled={!canSubmit || isSubmitting}
+          className="rounded-full"
+        >
+          {isSubmitting && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+          {tChat('editSend')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/chat/components/inline-edit-input.tsx
+++ b/services/platform/app/features/chat/components/inline-edit-input.tsx
@@ -73,6 +73,7 @@ export function InlineEditInput({
         }}
         onKeyDown={handleKeyDown}
         disabled={isSubmitting}
+        aria-label={tChat('editMessage')}
         className="text-foreground min-h-[2.5rem] w-full resize-none bg-transparent text-sm leading-6 focus:outline-none disabled:opacity-50"
         rows={1}
       />

--- a/services/platform/app/features/chat/components/shared-chat-view.tsx
+++ b/services/platform/app/features/chat/components/shared-chat-view.tsx
@@ -65,7 +65,7 @@ export function SharedChatView({
             to: '/dashboard/$id/chat/$threadId',
             params: { id: organizationId, threadId: newThreadId },
           });
-          toast({ title: t('share.forkSuccess') });
+          toast({ title: t('share.forkSuccess'), variant: 'success' });
         },
         onError: () => {
           toast({ title: t('share.forkFailed'), variant: 'destructive' });

--- a/services/platform/app/features/chat/context/branch-context.tsx
+++ b/services/platform/app/features/chat/context/branch-context.tsx
@@ -48,9 +48,15 @@ interface BranchProviderProps {
   children: ReactNode;
 }
 
+/** Sentinel value indicating the user explicitly selected the original (parent) thread. */
+const ORIGINAL_SELECTION = '__original__';
+
 /**
  * Resolves the active branch thread ID by walking the branch chain
  * from the root thread through the user's branch selections.
+ *
+ * When no selection exists for a fork point, defaults to the latest branch
+ * (highest branchIndex) so the user sees the most recent edit.
  */
 function resolveActiveBranch(
   rootThreadId: string | undefined,
@@ -64,16 +70,45 @@ function resolveActiveBranch(
   let changed = true;
   while (changed) {
     changed = false;
-    for (const branch of branches) {
-      const key = String(branch.forkOrder);
-      if (
-        branch.parentThreadId === currentThreadId &&
-        selections[key] === branch.branchThreadId
-      ) {
-        currentThreadId = branch.branchThreadId;
-        changed = true;
-        break;
+
+    // Find branches forking from the current thread
+    const children = branches.filter(
+      (b) => b.parentThreadId === currentThreadId,
+    );
+    if (children.length === 0) break;
+
+    // Group by forkOrder and pick the earliest fork point
+    const forkOrders = [...new Set(children.map((b) => b.forkOrder))].sort(
+      (a, b) => a - b,
+    );
+
+    for (const forkOrder of forkOrders) {
+      const key = String(forkOrder);
+      const siblingsAtFork = children.filter((b) => b.forkOrder === forkOrder);
+
+      // Explicit selection: original or a specific branch
+      if (key in selections) {
+        if (selections[key] === ORIGINAL_SELECTION) {
+          // User explicitly chose the original — stay on parent, stop walking
+          break;
+        }
+        const selected = siblingsAtFork.find(
+          (b) => b.branchThreadId === selections[key],
+        );
+        if (selected) {
+          currentThreadId = selected.branchThreadId;
+          changed = true;
+          break;
+        }
       }
+
+      // No selection: default to the latest branch (highest branchIndex)
+      const latest = siblingsAtFork.reduce((a, b) =>
+        b.branchIndex > a.branchIndex ? b : a,
+      );
+      currentThreadId = latest.branchThreadId;
+      changed = true;
+      break;
     }
   }
 
@@ -159,13 +194,10 @@ export function BranchProvider({ threadId, children }: BranchProviderProps) {
   const switchBranch = useCallback(
     (forkOrder: string, branchThreadId: string | null) => {
       setBranchSelections((prev) => {
-        let next: Record<string, string>;
-        if (branchThreadId === null) {
-          const { [forkOrder]: _, ...rest } = prev;
-          next = rest;
-        } else {
-          next = { ...prev, [forkOrder]: branchThreadId };
-        }
+        const next = {
+          ...prev,
+          [forkOrder]: branchThreadId ?? ORIGINAL_SELECTION,
+        };
         persistSelections(next);
         return next;
       });

--- a/services/platform/app/features/chat/context/chat-layout-context.tsx
+++ b/services/platform/app/features/chat/context/chat-layout-context.tsx
@@ -25,6 +25,12 @@ export interface PendingMessage {
   attachments?: PendingMessageAttachment[];
   timestamp: Date;
   lastMessageKey?: string;
+  /**
+   * When set, this is an edit-and-branch operation: replace the message with
+   * this ID and truncate everything after it, instead of appending a new message.
+   * Cleared when dataThreadId changes (branch subscription caught up).
+   */
+  editedMessageId?: string;
 }
 
 export interface SelectedAgent {

--- a/services/platform/app/features/chat/hooks/use-pending-messages.ts
+++ b/services/platform/app/features/chat/hooks/use-pending-messages.ts
@@ -21,6 +21,10 @@ interface UsePendingMessagesParams {
  * real message is in-flight. Uses `lastMessageKey` (captured at send time) to
  * detect when the real message arrives — when the last key in realMessages
  * changes from the baseline, the optimistic message is dropped.
+ *
+ * For EDIT-AND-BRANCH: replaces the edited message's content and truncates
+ * messages after it. Cleared when dataThreadId changes from the source thread
+ * (the branch subscription caught up and real messages are now from the branch).
  */
 export function usePendingMessages({
   threadId,
@@ -37,6 +41,15 @@ export function usePendingMessages({
   // Clear pending message once the real message arrives
   useEffect(() => {
     if (!pendingMessage) return;
+
+    // Edit-and-branch: clear when dataThreadId diverges from the source thread
+    // (branch subscription delivered the new branch, messages are now from it)
+    if (pendingMessage.editedMessageId) {
+      if (threadId !== pendingMessage.threadId) {
+        setPendingMessage(null);
+      }
+      return;
+    }
 
     // Only clear for matching thread
     const isMatchingThread =
@@ -72,13 +85,31 @@ export function usePendingMessages({
   ]);
 
   return useMemo(() => {
+    if (!pendingMessage) return realMessages;
+
+    // Edit-and-branch: replace the edited message and truncate after it
+    if (pendingMessage.editedMessageId) {
+      if (threadId !== pendingMessage.threadId) return realMessages;
+
+      const editIdx = realMessages.findIndex(
+        (m) => m.id === pendingMessage.editedMessageId,
+      );
+      if (editIdx === -1) return realMessages;
+
+      const before = realMessages.slice(0, editIdx);
+      const edited: ChatMessage = {
+        ...realMessages[editIdx],
+        content: pendingMessage.content,
+      };
+      return [...before, edited];
+    }
+
     const isMatchingThread =
-      pendingMessage &&
-      (pendingMessage.threadId === threadId ||
-        (threadId === undefined && pendingMessage.threadId === 'pending') ||
-        (threadId === undefined &&
-          pendingThreadId !== null &&
-          pendingMessage.threadId === pendingThreadId));
+      pendingMessage.threadId === threadId ||
+      (threadId === undefined && pendingMessage.threadId === 'pending') ||
+      (threadId === undefined &&
+        pendingThreadId !== null &&
+        pendingMessage.threadId === pendingThreadId);
 
     if (!isMatchingThread) return realMessages;
 

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -16,6 +16,7 @@ import { useMembers } from '@/app/features/settings/organization/hooks/queries';
 import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useToast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
 import {
   budgetConfigSchema,
   type BudgetConfig,
@@ -314,6 +315,7 @@ function formatCost(cents: number): string {
 }
 
 export function BudgetEditor({ organizationId }: BudgetEditorProps) {
+  const { t } = useT('governance');
   const { toast } = useToast();
   const ability = useAbility();
 
@@ -372,7 +374,7 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
           policyType: 'budgets',
           config: configToSave,
         });
-        toast({ title: 'Budget configuration saved', variant: 'success' });
+        toast({ title: t('budgets.saved'), variant: 'success' });
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : 'Failed to save';

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -381,7 +381,7 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
         toast({ title: message, variant: 'destructive' });
       }
     },
-    [organizationId, upsertMutation, toast],
+    [organizationId, upsertMutation, toast, t],
   );
 
   const handleToggleEnabled = useCallback(

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -372,7 +372,7 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
           policyType: 'budgets',
           config: configToSave,
         });
-        toast({ title: 'Budget configuration saved' });
+        toast({ title: 'Budget configuration saved', variant: 'success' });
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : 'Failed to save';

--- a/services/platform/app/features/settings/organization/components/transfer-ownership-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/transfer-ownership-dialog.tsx
@@ -43,6 +43,7 @@ export function TransferOwnershipDialog({
 
       toast({
         title: t('organization.ownershipTransferred'),
+        variant: 'success',
       });
       onOpenChange(false);
     } catch (error) {

--- a/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
@@ -140,7 +140,7 @@ function ConfigurationPage() {
 
       setHasChanges(false);
       await refetch();
-      toast({ title: tToast('success.saved') });
+      toast({ title: tToast('success.saved'), variant: 'success' });
     } catch (error) {
       console.error('Failed to save configuration:', error);
       toast({

--- a/services/platform/convex/threads/list_threads.test.ts
+++ b/services/platform/convex/threads/list_threads.test.ts
@@ -99,6 +99,7 @@ function makeMockCtx(rows: ThreadMetadataRow[]): QueryCtx {
 
   const queryChain = {
     withIndex: () => queryChain,
+    filter: () => queryChain,
     order: () => queryChain,
     paginate,
   };

--- a/services/platform/convex/threads/list_threads.ts
+++ b/services/platform/convex/threads/list_threads.ts
@@ -39,20 +39,19 @@ export async function listThreads(
         .eq('chatType', 'general')
         .eq('status', 'active'),
     )
+    .filter((q) => q.neq(q.field('isBranch'), true))
     .order('desc')
     .paginate(args.paginationOpts);
 
   return {
-    page: result.page
-      .filter((row) => !row.isBranch)
-      .map((row) => ({
-        _id: row.threadId,
-        _creationTime: row.updatedAt ?? row.createdAt,
-        title: row.title,
-        status: row.status,
-        userId: row.userId,
-        generationStatus: row.generationStatus,
-      })),
+    page: result.page.map((row) => ({
+      _id: row.threadId,
+      _creationTime: row.updatedAt ?? row.createdAt,
+      title: row.title,
+      status: row.status,
+      userId: row.userId,
+      generationStatus: row.generationStatus,
+    })),
     isDone: result.isDone,
     continueCursor: result.continueCursor,
   };


### PR DESCRIPTION
## Summary
- Check archive status using the root thread ID instead of the active branch thread ID, fixing archived chats with branches still appearing editable
- Disable all interactive actions (edit, fork, follow-up suggestions, send message) on archived chat messages
- Chat input is already correctly hidden for archived threads; this ensures message-level actions are also disabled

## Test plan
- [ ] Archive a chat that has message branches (edit history)
- [ ] Open the archived chat — verify no chat input, no edit/fork buttons on messages
- [ ] Unarchive the chat — verify all interactive features return
- [ ] Open a non-archived chat — verify normal functionality unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Inline chat message editing with auto-expanding textarea and keyboard shortcuts (Enter to submit, Escape to cancel).
- Edit-and-branch operation to modify messages while simultaneously creating conversation branches.

**Bug Fixes**
- Fixed archival status detection to properly prevent editing and actions in archived conversations.
- Branch threads now correctly excluded from conversation list.

**Improvements**
- Enhanced success toast notifications across actions (fork, save, transfer).
- Improved scroll preservation during message editing and branch switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->