### PR TITLE
fix(cli): defer release creation until images are pullable

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -132,6 +132,26 @@ jobs:
       - name: List artifacts
         run: find artifacts -type f
 
+      - name: Wait for release to exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.release_tag }}"
+          REPO="${{ github.repository }}"
+          MAX_ATTEMPTS=10
+          DELAY=15
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            if gh release view "$TAG" --repo "$REPO" > /dev/null 2>&1; then
+              echo "Release $TAG found."
+              exit 0
+            fi
+            echo "Release $TAG not found yet (attempt $i/$MAX_ATTEMPTS). Waiting ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2 > 120 ? 120 : DELAY * 2))
+          done
+          echo "::error::Release $TAG not found after $MAX_ATTEMPTS attempts."
+          exit 1
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
   create-release:
     name: Create release
-    needs: prepare
+    needs: [prepare, manifest]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
@@ -247,7 +247,7 @@ jobs:
 
   trigger-cli:
     name: Trigger CLI build
-    needs: [prepare, create-release]
+    needs: [prepare, manifest]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:

--- a/tools/cli/src/lib/docker/pull-image.test.ts
+++ b/tools/cli/src/lib/docker/pull-image.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { pullImage } from './pull-image';
+
+const dockerMock = mock();
+
+mock.module('./docker', () => ({
+  docker: dockerMock,
+}));
+
+const errorSpy = mock();
+const infoSpy = mock();
+
+mock.module('../../utils/logger', () => ({
+  info: infoSpy,
+  error: errorSpy,
+  debug: mock(),
+}));
+
+afterEach(() => {
+  dockerMock.mockReset();
+  errorSpy.mockReset();
+  infoSpy.mockReset();
+});
+
+describe('pullImage', () => {
+  test('returns true on successful pull', async () => {
+    dockerMock.mockResolvedValue({ success: true, stdout: '', stderr: '' });
+
+    const result = await pullImage(
+      'ghcr.io/tale-project/tale/tale-crawler:0.2.16',
+    );
+
+    expect(result).toBe(true);
+    expect(dockerMock).toHaveBeenCalledWith(
+      'pull',
+      'ghcr.io/tale-project/tale/tale-crawler:0.2.16',
+    );
+  });
+
+  test('returns false on failed pull', async () => {
+    dockerMock.mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr: 'connection refused',
+    });
+
+    const result = await pullImage(
+      'ghcr.io/tale-project/tale/tale-crawler:0.2.16',
+    );
+
+    expect(result).toBe(false);
+  });
+
+  test('shows timing hint when image is not found', async () => {
+    dockerMock.mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr:
+        'Error response from daemon: manifest for ghcr.io/tale-project/tale/tale-crawler:0.2.16 not found',
+    });
+
+    await pullImage('ghcr.io/tale-project/tale/tale-crawler:0.2.16');
+
+    const messages = errorSpy.mock.calls.map((c: string[]) => c[0]);
+    expect(messages.some((m: string) => m.includes('still be building'))).toBe(
+      true,
+    );
+  });
+
+  test('shows timing hint for manifest unknown error', async () => {
+    dockerMock.mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr: 'manifest unknown: manifest unknown',
+    });
+
+    await pullImage('ghcr.io/example/image:1.0.0');
+
+    const messages = errorSpy.mock.calls.map((c: string[]) => c[0]);
+    expect(messages.some((m: string) => m.includes('still be building'))).toBe(
+      true,
+    );
+  });
+
+  test('shows timing hint for name unknown error', async () => {
+    dockerMock.mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr: 'name unknown: repository name not known to registry',
+    });
+
+    await pullImage('ghcr.io/example/image:1.0.0');
+
+    const messages = errorSpy.mock.calls.map((c: string[]) => c[0]);
+    expect(messages.some((m: string) => m.includes('still be building'))).toBe(
+      true,
+    );
+  });
+
+  test('shows raw stderr for non-not-found errors', async () => {
+    dockerMock.mockResolvedValue({
+      success: false,
+      stdout: '',
+      stderr: 'unauthorized: authentication required',
+    });
+
+    await pullImage('ghcr.io/example/image:1.0.0');
+
+    const messages = errorSpy.mock.calls.map((c: string[]) => c[0]);
+    expect(
+      messages.some((m: string) => m.includes('authentication required')),
+    ).toBe(true);
+    expect(messages.some((m: string) => m.includes('still be building'))).toBe(
+      false,
+    );
+  });
+
+  test('returns false and logs error on exception', async () => {
+    dockerMock.mockRejectedValue(new Error('Docker not installed'));
+
+    const result = await pullImage('ghcr.io/example/image:1.0.0');
+
+    expect(result).toBe(false);
+    const messages = errorSpy.mock.calls.map((c: string[]) => c[0]);
+    expect(
+      messages.some((m: string) => m.includes('Docker not installed')),
+    ).toBe(true);
+  });
+});

--- a/tools/cli/src/lib/docker/pull-image.ts
+++ b/tools/cli/src/lib/docker/pull-image.ts
@@ -15,6 +15,9 @@ export async function pullImage(image: string): Promise<boolean> {
         logger.error(
           'The image does not exist in the registry. If this is a recent release, the images may still be building. Wait a few minutes and try again.',
         );
+        if (result.stderr) {
+          logger.error(result.stderr);
+        }
       } else {
         logger.error(result.stderr);
       }

--- a/tools/cli/src/lib/docker/pull-image.ts
+++ b/tools/cli/src/lib/docker/pull-image.ts
@@ -1,13 +1,23 @@
 import * as logger from '../../utils/logger';
 import { docker } from './docker';
 
+function isNotFoundError(stderr: string): boolean {
+  return /not found|manifest unknown|name unknown/i.test(stderr);
+}
+
 export async function pullImage(image: string): Promise<boolean> {
   logger.info(`Pulling image: ${image}`);
   try {
     const result = await docker('pull', image);
     if (!result.success) {
       logger.error(`Failed to pull image: ${image}`);
-      logger.error(result.stderr);
+      if (isNotFoundError(result.stderr)) {
+        logger.error(
+          'The image does not exist in the registry. If this is a recent release, the images may still be building. Wait a few minutes and try again.',
+        );
+      } else {
+        logger.error(result.stderr);
+      }
       return false;
     }
     return true;

--- a/tools/cli/src/lib/registry/get-available-versions.test.ts
+++ b/tools/cli/src/lib/registry/get-available-versions.test.ts
@@ -211,4 +211,46 @@ describe('getAvailableVersions', () => {
 
     expect(result.versions.length).toBeLessThanOrEqual(3);
   });
+
+  test('backfills past missing manifests to satisfy limit', async () => {
+    // Newest 3 tags have no manifest; the next 3 do.
+    // With limit=3 the result must skip the broken tags and return the older valid ones.
+    const tagsWithMissing = [
+      '0.4.0',
+      '0.3.2',
+      '0.3.1',
+      '0.3.0',
+      '0.2.16',
+      '0.2.15',
+    ];
+    const missingManifestTags = new Set(['0.4.0', '0.3.2', '0.3.1']);
+
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(mockTagsResponse(tagsWithMissing));
+      }
+
+      if (options?.method === 'HEAD') {
+        for (const tag of missingManifestTags) {
+          if (urlStr.includes(`/${tag}`)) {
+            return Promise.resolve(mockManifestHead(null));
+          }
+        }
+        return Promise.resolve(mockManifestHead('sha256:valid'));
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 3);
+
+    const tags = result.versions.map((v) => v.tag);
+    expect(tags).toEqual(['0.3.0', '0.2.16', '0.2.15']);
+  });
 });

--- a/tools/cli/src/lib/registry/get-available-versions.test.ts
+++ b/tools/cli/src/lib/registry/get-available-versions.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { getAvailableVersions } from './get-available-versions';
+
+const fetchMock = mock();
+// @ts-expect-error -- Bun mock does not satisfy the full fetch type signature
+globalThis.fetch = fetchMock;
+
+mock.module('../../utils/logger', () => ({
+  info: mock(),
+  error: mock(),
+  debug: mock(),
+  warn: mock(),
+}));
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+function mockTokenResponse() {
+  return Response.json({ token: 'ghp_fake_token_with_enough_length_to_pass' });
+}
+
+function mockTagsResponse(tags: string[]) {
+  return Response.json({ name: 'tale-project/tale/tale-platform', tags });
+}
+
+function mockManifestHead(digest: string | null) {
+  if (!digest) {
+    return new Response(null, { status: 404 });
+  }
+  return new Response(null, {
+    status: 200,
+    headers: { 'docker-content-digest': digest },
+  });
+}
+
+describe('getAvailableVersions', () => {
+  test('returns empty list for unparseable registry', async () => {
+    const result = await getAvailableVersions('invalid-registry', 10);
+
+    expect(result.versions).toEqual([]);
+    expect(result.error).toBe('unknown');
+  });
+
+  test('returns network error when token fetch fails', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 403 }));
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 10);
+
+    expect(result.versions).toEqual([]);
+    expect(result.error).toBe('network');
+  });
+
+  test('filters out versions without a manifest', async () => {
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      // Token request
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      // Tags list
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(
+          mockTagsResponse([
+            '0.2.16',
+            '0.2.16-amd64',
+            '0.2.16-arm64',
+            '0.2.15',
+            '0.2.15-amd64',
+            '0.2.15-arm64',
+            '0.2.14',
+          ]),
+        );
+      }
+
+      // Manifest HEAD requests
+      if (options?.method === 'HEAD') {
+        // 0.2.16 has no manifest yet (still building)
+        if (urlStr.includes('/0.2.16')) {
+          return Promise.resolve(mockManifestHead(null));
+        }
+        // 0.2.15 has a manifest
+        if (urlStr.includes('/0.2.15')) {
+          return Promise.resolve(mockManifestHead('sha256:abc'));
+        }
+        // 0.2.14 has a manifest
+        if (urlStr.includes('/0.2.14')) {
+          return Promise.resolve(mockManifestHead('sha256:def'));
+        }
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 10);
+
+    const tags = result.versions.map((v) => v.tag);
+    expect(tags).not.toContain('0.2.16');
+    expect(tags).toContain('0.2.15');
+    expect(tags).toContain('0.2.14');
+  });
+
+  test('includes versions with valid manifests', async () => {
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(mockTagsResponse(['0.2.16', '0.2.15']));
+      }
+
+      if (options?.method === 'HEAD') {
+        return Promise.resolve(mockManifestHead('sha256:valid'));
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 10);
+
+    const tags = result.versions.map((v) => v.tag);
+    expect(tags).toContain('0.2.16');
+    expect(tags).toContain('0.2.15');
+  });
+
+  test('filters out arch-suffixed tags from version list', async () => {
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(
+          mockTagsResponse(['0.2.16', '0.2.16-amd64', '0.2.16-arm64']),
+        );
+      }
+
+      if (options?.method === 'HEAD') {
+        return Promise.resolve(mockManifestHead('sha256:valid'));
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 10);
+
+    const tags = result.versions.map((v) => v.tag);
+    expect(tags).not.toContain('0.2.16-amd64');
+    expect(tags).not.toContain('0.2.16-arm64');
+    expect(tags).toContain('0.2.16');
+  });
+
+  test('includes latest tag with alias when digest matches', async () => {
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(
+          mockTagsResponse(['latest', '0.2.16', '0.2.15']),
+        );
+      }
+
+      if (options?.method === 'HEAD') {
+        return Promise.resolve(mockManifestHead('sha256:same'));
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 10);
+
+    const latestEntry = result.versions.find((v) => v.tag === 'latest');
+    expect(latestEntry).toBeDefined();
+    expect(latestEntry?.aliases).toContain('0.2.16');
+  });
+
+  test('respects limit parameter', async () => {
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes('/token')) {
+        return Promise.resolve(mockTokenResponse());
+      }
+
+      if (urlStr.includes('/tags/list')) {
+        return Promise.resolve(
+          mockTagsResponse(['0.3.0', '0.2.16', '0.2.15', '0.2.14', '0.2.13']),
+        );
+      }
+
+      if (options?.method === 'HEAD') {
+        return Promise.resolve(mockManifestHead('sha256:valid'));
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    const result = await getAvailableVersions('ghcr.io/tale-project/tale', 3);
+
+    expect(result.versions.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/tools/cli/src/lib/registry/get-available-versions.ts
+++ b/tools/cli/src/lib/registry/get-available-versions.ts
@@ -153,18 +153,16 @@ export async function getAvailableVersions(
       );
     }
 
-    // Verify manifests exist for the top semantic versions (filters out
-    // versions still being built where only arch-specific tags exist)
-    const candidateCount = Math.min(sortedSemanticTags.length, limit + 1);
-    const manifestChecks = await Promise.all(
-      sortedSemanticTags.slice(0, candidateCount).map(async (tag) => ({
-        tag,
-        hasManifest: !!(await getManifestDigest(image, tag, token)),
-      })),
-    );
-    const publishedVersions = new Set(
-      manifestChecks.filter((c) => c.hasManifest).map((c) => c.tag),
-    );
+    // Verify manifests exist by lazily probing tags until we have enough
+    // published versions (handles runs of recent tags with missing manifests)
+    const publishedVersions = new Set<string>();
+    for (const tag of sortedSemanticTags) {
+      if (publishedVersions.size >= limit) break;
+      const hasManifest = !!(await getManifestDigest(image, tag, token));
+      if (hasManifest) {
+        publishedVersions.add(tag);
+      }
+    }
 
     // Build version list
     if (hasLatest) {

--- a/tools/cli/src/lib/registry/get-available-versions.ts
+++ b/tools/cli/src/lib/registry/get-available-versions.ts
@@ -153,6 +153,19 @@ export async function getAvailableVersions(
       );
     }
 
+    // Verify manifests exist for the top semantic versions (filters out
+    // versions still being built where only arch-specific tags exist)
+    const candidateCount = Math.min(sortedSemanticTags.length, limit + 1);
+    const manifestChecks = await Promise.all(
+      sortedSemanticTags.slice(0, candidateCount).map(async (tag) => ({
+        tag,
+        hasManifest: !!(await getManifestDigest(image, tag, token)),
+      })),
+    );
+    const publishedVersions = new Set(
+      manifestChecks.filter((c) => c.hasManifest).map((c) => c.tag),
+    );
+
     // Build version list
     if (hasLatest) {
       const aliases: string[] = [];
@@ -169,6 +182,7 @@ export async function getAvailableVersions(
       i < sortedSemanticTags.length && versionInfos.length < limit;
       i++
     ) {
+      if (!publishedVersions.has(sortedSemanticTags[i])) continue;
       versionInfos.push({ tag: sortedSemanticTags[i], aliases: [] });
     }
 


### PR DESCRIPTION
## Summary
- Reorder release pipeline so the GitHub release is only created after all multi-arch manifests are pushed, eliminating the 15-20 minute window where a release is visible but container images cannot be pulled
- Add user-friendly error message in `pullImage()` when an image is not found in the registry, suggesting the user wait if it is a recent release
- Filter unpublished versions (those without a manifest) from the CLI version selector so users cannot select a version that is still being built

## Changes
- `.github/workflows/release.yml`: `create-release` now depends on `[prepare, manifest]` instead of `[prepare]`; `trigger-cli` now depends on `[prepare, manifest]` instead of `[prepare, create-release]`
- `tools/cli/src/lib/docker/pull-image.ts`: detect not-found/manifest-unknown errors and show a timing-aware hint
- `tools/cli/src/lib/registry/get-available-versions.ts`: verify manifest existence via HEAD requests before listing versions
- Added tests for both CLI changes (14 tests total)

## Testing
- [x] 14 unit tests pass (`pull-image.test.ts`, `get-available-versions.test.ts`)
- [x] Lint passes
- [x] Typecheck passes (pre-existing errors in `fetch-reference.ts` unrelated)
- [ ] Pipeline logic verified on next release
- [ ] No regressions in CI config

## Related issues
Closes #1349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Docker image pull error handling with clearer error messaging for "image not found" scenarios, helping users troubleshoot pull failures.
  * Enhanced version discovery to verify manifest availability, ensuring only published versions are displayed in available versions lists.

* **Tests**
  * Added comprehensive test coverage for Docker image operations and registry version lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->