### PR TITLE
feat(platform): wire message feedback into chat bubbles

### DIFF
--- a/services/platform/app/features/chat/components/__tests__/message-feedback.test.tsx
+++ b/services/platform/app/features/chat/components/__tests__/message-feedback.test.tsx
@@ -1,9 +1,14 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, screen, waitFor } from '@/test/utils/render';
 
 import { MessageFeedback } from '../message-feedback';
+
+let mockSubmitFeedback: Mock;
+let mockRemoveFeedback: Mock;
+let mockFeedback: { rating: 'positive' | 'negative'; comment?: string } | null =
+  null;
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({
@@ -11,7 +16,7 @@ vi.mock('@/lib/i18n/client', () => ({
       const translations: Record<string, string> = {
         'feedback.thumbsUp': 'Thumbs up',
         'feedback.thumbsDown': 'Thumbs down',
-        'feedback.commentPlaceholder': 'Add a comment...',
+        'feedback.commentPlaceholder': 'What could be improved?',
         'feedback.submitComment': 'Submit',
         'feedback.cancel': 'Cancel',
       };
@@ -22,24 +27,319 @@ vi.mock('@/lib/i18n/client', () => ({
 
 vi.mock('../../hooks/use-message-feedback', () => ({
   useMessageFeedback: () => ({
-    feedback: null,
+    feedback: mockFeedback,
     isLoading: false,
-    submitFeedback: vi.fn(),
-    removeFeedback: vi.fn(),
+    submitFeedback: mockSubmitFeedback,
+    removeFeedback: mockRemoveFeedback,
   }),
 }));
 
+const defaultProps = {
+  messageId: 'msg-1',
+  threadId: 'thread-1',
+  organizationId: 'org-1',
+};
+
 describe('MessageFeedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeedback = null;
+    mockSubmitFeedback = vi.fn().mockResolvedValue(undefined);
+    mockRemoveFeedback = vi.fn().mockResolvedValue(undefined);
+  });
+
+  describe('rendering', () => {
+    it('renders thumbs up and thumbs down buttons', () => {
+      render(<MessageFeedback {...defaultProps} />);
+
+      expect(
+        screen.getByRole('button', { name: 'Thumbs up' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Thumbs down' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show comment box by default', () => {
+      render(<MessageFeedback {...defaultProps} />);
+
+      expect(
+        screen.queryByPlaceholderText('What could be improved?'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('positive feedback', () => {
+    it('calls submitFeedback with positive when clicking thumbs up', async () => {
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+      await waitFor(() => {
+        expect(mockSubmitFeedback).toHaveBeenCalledWith('positive');
+      });
+    });
+
+    it('calls removeFeedback when clicking active thumbs up', async () => {
+      mockFeedback = { rating: 'positive' };
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+      await waitFor(() => {
+        expect(mockRemoveFeedback).toHaveBeenCalled();
+      });
+    });
+
+    it('shows filled state when positive feedback exists', () => {
+      mockFeedback = { rating: 'positive' };
+      render(<MessageFeedback {...defaultProps} />);
+
+      const thumbsUpBtn = screen.getByRole('button', { name: 'Thumbs up' });
+      expect(thumbsUpBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  describe('negative feedback', () => {
+    it('calls submitFeedback with negative when clicking thumbs down', async () => {
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      await waitFor(() => {
+        expect(mockSubmitFeedback).toHaveBeenCalledWith('negative');
+      });
+    });
+
+    it('shows comment box after clicking thumbs down', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockImplementation(async (rating: string) => {
+          mockFeedback = {
+            rating: rating === 'positive' ? 'positive' : 'negative',
+          };
+        });
+
+      const { user, rerender } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      rerender(<MessageFeedback {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText('What could be improved?'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('calls removeFeedback when clicking active thumbs down', async () => {
+      mockFeedback = { rating: 'negative' };
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      await waitFor(() => {
+        expect(mockRemoveFeedback).toHaveBeenCalled();
+      });
+    });
+
+    it('shows filled state when negative feedback exists', () => {
+      mockFeedback = { rating: 'negative' };
+      render(<MessageFeedback {...defaultProps} />);
+
+      const thumbsDownBtn = screen.getByRole('button', {
+        name: 'Thumbs down',
+      });
+      expect(thumbsDownBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  describe('comment submission', () => {
+    it('submits comment with negative feedback', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockImplementation(async (rating: string) => {
+          mockFeedback = {
+            rating: rating === 'positive' ? 'positive' : 'negative',
+          };
+        });
+
+      const { user, rerender } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      rerender(<MessageFeedback {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText('What could be improved?'),
+        ).toBeInTheDocument();
+      });
+
+      await user.type(
+        screen.getByPlaceholderText('What could be improved?'),
+        'Response was inaccurate',
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(mockSubmitFeedback).toHaveBeenCalledWith(
+          'negative',
+          'Response was inaccurate',
+        );
+      });
+    });
+
+    it('hides comment box when cancel is clicked', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockImplementation(async (rating: string) => {
+          mockFeedback = {
+            rating: rating === 'positive' ? 'positive' : 'negative',
+          };
+        });
+
+      const { user, rerender } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      rerender(<MessageFeedback {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText('What could be improved?'),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(
+        screen.queryByPlaceholderText('What could be improved?'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('disables submit button when comment is empty', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockImplementation(async (rating: string) => {
+          mockFeedback = {
+            rating: rating === 'positive' ? 'positive' : 'negative',
+          };
+        });
+
+      const { user, rerender } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      rerender(<MessageFeedback {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+      });
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables buttons while submitting', async () => {
+      mockSubmitFeedback = vi.fn().mockReturnValue(new Promise(() => {}));
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Thumbs up' }),
+        ).toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: 'Thumbs down' }),
+        ).toBeDisabled();
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('re-enables buttons after submitFeedback rejects', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Thumbs up' }),
+        ).not.toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: 'Thumbs down' }),
+        ).not.toBeDisabled();
+      });
+    });
+
+    it('re-enables buttons after removeFeedback rejects', async () => {
+      mockFeedback = { rating: 'positive' };
+      mockRemoveFeedback = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+      const { user } = render(<MessageFeedback {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Thumbs up' }),
+        ).not.toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: 'Thumbs down' }),
+        ).not.toBeDisabled();
+      });
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
-      const { container } = render(
-        <MessageFeedback
-          messageId="msg-1"
-          threadId="thread-1"
-          organizationId="org-1"
-        />,
-      );
+      const { container } = render(<MessageFeedback {...defaultProps} />);
       await checkAccessibility(container);
+    });
+
+    it('passes axe audit with comment box open', async () => {
+      mockSubmitFeedback = vi
+        .fn()
+        .mockImplementation(async (rating: string) => {
+          mockFeedback = {
+            rating: rating === 'positive' ? 'positive' : 'negative',
+          };
+        });
+
+      const { user, container, rerender } = render(
+        <MessageFeedback {...defaultProps} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Thumbs down' }));
+
+      rerender(<MessageFeedback {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText('What could be improved?'),
+        ).toBeInTheDocument();
+      });
+
+      await checkAccessibility(container);
+    });
+
+    it('has correct aria-pressed attributes', () => {
+      render(<MessageFeedback {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Thumbs up' })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+      expect(
+        screen.getByRole('button', { name: 'Thumbs down' }),
+      ).toHaveAttribute('aria-pressed', 'false');
     });
   });
 });

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -637,6 +637,7 @@ export function ChatInterface({
               onEditCancel={
                 isArchived ? undefined : () => setEditingMessage(null)
               }
+              hideFeedback={isArchived}
             />
           )}
         </div>

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -98,6 +98,7 @@ interface ChatMessagesProps {
   onEditSubmit?: (newContent: string) => Promise<void>;
   onEditCancel?: () => void;
   hideBranchNavigator?: boolean;
+  hideFeedback?: boolean;
 }
 
 /**
@@ -139,6 +140,7 @@ export function ChatMessages({
   onEditSubmit,
   onEditCancel,
   hideBranchNavigator,
+  hideFeedback,
 }: ChatMessagesProps) {
   const { t } = useT('chat');
   const { branches, activeBranchThreadId } = useBranchContext();
@@ -375,6 +377,8 @@ export function ChatMessages({
               role: isUserMessage ? 'user' : 'assistant',
               threadId: threadId,
             }}
+            organizationId={organizationId}
+            hideFeedback={hideFeedback}
             onSendFollowUp={onSendFollowUp}
             onRetry={
               message.isFailed && message.key === latestFailedAssistantKey

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -40,6 +40,7 @@ import {
   type GalleryImage,
 } from './message-bubble/image-preview-dialog';
 import type { Message } from './message-bubble/types';
+import { MessageFeedback } from './message-feedback';
 import { MessageInfoDialog } from './message-info-dialog';
 import { SourceCards } from './source-cards';
 import { StructuredMessage } from './structured-message/structured-message';
@@ -48,6 +49,8 @@ export { ImagePreviewDialog } from './message-bubble/image-preview-dialog';
 
 interface MessageBubbleProps extends ComponentPropsWithoutRef<'div'> {
   message: Message;
+  organizationId?: string;
+  hideFeedback?: boolean;
   onSendFollowUp?: (message: string) => void;
   onRetry?: () => void;
   onEdit?: (messageId: string, content: string) => void;
@@ -107,6 +110,8 @@ function useMessageGallery(message: Message) {
 function MessageBubbleComponent({
   message,
   className,
+  organizationId,
+  hideFeedback,
   onSendFollowUp,
   onRetry,
   onEdit,
@@ -441,6 +446,13 @@ function MessageBubbleComponent({
                 </Button>
               </Tooltip>
             )}
+            {!hideFeedback && organizationId && message.threadId && (
+              <MessageFeedback
+                messageId={message.id}
+                threadId={message.threadId}
+                organizationId={organizationId}
+              />
+            )}
           </div>
         )}
 
@@ -500,7 +512,10 @@ export const MessageBubble = memo(
       prevProps.message.isFailed === nextProps.message.isFailed &&
       prevProps.message.attachments === nextProps.message.attachments &&
       prevProps.message.fileParts === nextProps.message.fileParts &&
+      prevProps.message.threadId === nextProps.message.threadId &&
       prevProps.className === nextProps.className &&
+      prevProps.organizationId === nextProps.organizationId &&
+      prevProps.hideFeedback === nextProps.hideFeedback &&
       prevProps.onSendFollowUp === nextProps.onSendFollowUp &&
       prevProps.onRetry === nextProps.onRetry &&
       prevProps.onEdit === nextProps.onEdit &&

--- a/services/platform/app/features/chat/components/message-feedback.tsx
+++ b/services/platform/app/features/chat/components/message-feedback.tsx
@@ -45,6 +45,8 @@ export function MessageFeedback({
         setShowCommentBox(false);
         setComment('');
       }
+    } catch {
+      // Silently handle feedback errors — UI re-enables via finally
     } finally {
       setIsSubmitting(false);
     }
@@ -58,6 +60,8 @@ export function MessageFeedback({
         await removeFeedback();
         setShowCommentBox(false);
         setComment('');
+      } catch {
+        // Silently handle feedback errors — UI re-enables via finally
       } finally {
         setIsSubmitting(false);
       }
@@ -66,6 +70,8 @@ export function MessageFeedback({
       try {
         await submitFeedback('negative');
         setShowCommentBox(true);
+      } catch {
+        // Silently handle feedback errors — UI re-enables via finally
       } finally {
         setIsSubmitting(false);
       }
@@ -79,6 +85,8 @@ export function MessageFeedback({
       await submitFeedback('negative', comment.trim());
       setShowCommentBox(false);
       setComment('');
+    } catch {
+      // Silently handle feedback errors — UI re-enables via finally
     } finally {
       setIsSubmitting(false);
     }

--- a/services/platform/app/features/chat/components/shared-chat-view.tsx
+++ b/services/platform/app/features/chat/components/shared-chat-view.tsx
@@ -198,6 +198,7 @@ export function SharedChatView({
                     content: message.content,
                     timestamp: new Date(message._creationTime),
                   }}
+                  hideFeedback
                 />
               ),
             )}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2715,6 +2715,13 @@
     "structured": {
       "nextSteps": "Vorgeschlagene Folgefragen"
     },
+    "feedback": {
+      "thumbsUp": "Hilfreich",
+      "thumbsDown": "Nicht hilfreich",
+      "commentPlaceholder": "Was kann verbessert werden?",
+      "submitComment": "Senden",
+      "cancel": "Abbrechen"
+    },
     "shareBoundary": "Nachrichten oben stammen aus einem geteilten Chat",
     "forkBoundary": "Von Ihrem eigenen Chat geforkt",
     "notFound": "Dieser Chat ist nicht verfügbar.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2748,12 +2748,11 @@
       "noContent": "Content not available"
     },
     "feedback": {
-      "helpful": "Helpful",
-      "notHelpful": "Not helpful",
+      "thumbsUp": "Helpful",
+      "thumbsDown": "Not helpful",
       "commentPlaceholder": "What could be improved?",
-      "submit": "Submit feedback",
-      "submitted": "Feedback submitted",
-      "removed": "Feedback removed"
+      "submitComment": "Submit",
+      "cancel": "Cancel"
     },
     "shareBoundary": "Messages above are from a shared chat",
     "forkBoundary": "Forked from your own chat",


### PR DESCRIPTION
## Summary

- Wires the existing `MessageFeedback` component (thumbs up/down) into the assistant message toolbar in `MessageBubble`. The backend schema, mutations, queries, and the component itself were all built previously but never connected to the chat UI.
- Fixes i18n key mismatch between the component and `en.json`, adds German translations to `de.json`.
- Hides feedback buttons on archived chats and shared chat views.
- Adds 16 functional tests covering render, submit, toggle, remove, comment, disabled state, and accessibility.

## Changes

| File | Change |
|------|--------|
| `message-bubble.tsx` | Add `organizationId` + `hideFeedback` props, import and render `MessageFeedback` in assistant toolbar, update memo comparator |
| `chat-messages.tsx` | Thread `organizationId` and `hideFeedback` to `MessageBubble` |
| `chat-interface.tsx` | Pass `hideFeedback={isArchived}` to `ChatMessages` |
| `shared-chat-view.tsx` | Pass `hideFeedback` to `MessageBubble` |
| `en.json` | Replace unused feedback keys with keys the component actually references |
| `de.json` | Add `chat.feedback` namespace with German translations |
| `message-feedback.test.tsx` | Expand from 1 accessibility test to 16 tests covering all feedback flows |

## Test plan

- [x] Lint passes (`bun run --filter @tale/platform lint`)
- [x] Typecheck passes (`bun run --filter @tale/platform typecheck`)
- [x] Server tests pass (156 tests)
- [x] Client tests pass (1867 tests including 16 new feedback tests)
- [ ] Manual: send a message in chat, verify thumbs up/down appear below assistant responses
- [ ] Manual: click thumbs up, verify it toggles on/off and persists after reload
- [ ] Manual: click thumbs down, verify comment box appears, submit comment
- [ ] Manual: verify no feedback buttons appear in archived chats
- [ ] Manual: verify no feedback buttons appear in shared chat view

Closes #1334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced message feedback with thumbs up/down ratings and optional comment submissions
  * Feedback controls disabled in archived chat threads

* **Tests**
  * Expanded message feedback test coverage for UI interactions and accessibility compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->