### PR TITLE
feat(platform): wire dictation button into chat input

### DIFF
--- a/services/platform/app/features/chat/components/__tests__/dictation-button.test.tsx
+++ b/services/platform/app/features/chat/components/__tests__/dictation-button.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, screen } from '@/test/utils/render';
 
 import { DictationButton } from '../dictation-button';
 
@@ -11,23 +12,128 @@ vi.mock('@/lib/i18n/client', () => ({
       const translations: Record<string, string> = {
         'dictation.start': 'Start dictation',
         'dictation.stop': 'Stop dictation',
+        'dictation.permissionDenied': 'Microphone access denied',
       };
       return translations[key] ?? key;
     },
   }),
 }));
 
-vi.mock('../../hooks/use-speech-to-text', () => ({
-  useSpeechToText: () => ({
-    isListening: false,
-    isSupported: true,
-    error: null,
-    startListening: vi.fn(),
-    stopListening: vi.fn(),
-  }),
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+  useToast: () => ({ toast: vi.fn() }),
 }));
 
+const mockStartListening = vi.fn();
+const mockStopListening = vi.fn();
+
+let mockIsListening = false;
+let mockIsSupported = true;
+let mockError: string | null = null;
+
+vi.mock('../../hooks/use-speech-to-text', () => ({
+  useSpeechToText: (opts: { onTranscript: (t: string) => void }) => {
+    mockOnTranscriptRef = opts.onTranscript;
+    return {
+      isListening: mockIsListening,
+      isSupported: mockIsSupported,
+      error: mockError,
+      startListening: mockStartListening,
+      stopListening: mockStopListening,
+    };
+  },
+}));
+
+let mockOnTranscriptRef: ((t: string) => void) | null = null;
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsListening = false;
+  mockIsSupported = true;
+  mockError = null;
+  mockOnTranscriptRef = null;
+});
+
 describe('DictationButton', () => {
+  describe('rendering', () => {
+    it('renders microphone button when supported', () => {
+      render(<DictationButton onTranscript={vi.fn()} />);
+      expect(screen.getByLabelText('Start dictation')).toBeInTheDocument();
+    });
+
+    it('returns null when speech recognition is not supported', () => {
+      mockIsSupported = false;
+      const { container } = render(<DictationButton onTranscript={vi.fn()} />);
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('shows stop label when listening', () => {
+      mockIsListening = true;
+      render(<DictationButton onTranscript={vi.fn()} />);
+      expect(screen.getByLabelText('Stop dictation')).toBeInTheDocument();
+    });
+  });
+
+  describe('interaction', () => {
+    it('calls startListening on click when not listening', async () => {
+      const { user } = render(<DictationButton onTranscript={vi.fn()} />);
+
+      await user.click(screen.getByLabelText('Start dictation'));
+
+      expect(mockStartListening).toHaveBeenCalled();
+    });
+
+    it('calls stopListening on click when listening', async () => {
+      mockIsListening = true;
+      const { user } = render(<DictationButton onTranscript={vi.fn()} />);
+
+      await user.click(screen.getByLabelText('Stop dictation'));
+
+      expect(mockStopListening).toHaveBeenCalled();
+    });
+
+    it('does not call startListening when disabled', async () => {
+      const { user } = render(
+        <DictationButton onTranscript={vi.fn()} disabled />,
+      );
+
+      const button = screen.getByLabelText('Start dictation');
+      await user.click(button);
+
+      expect(mockStartListening).not.toHaveBeenCalled();
+    });
+
+    it('forwards transcript to onTranscript prop', () => {
+      const onTranscript = vi.fn();
+      render(<DictationButton onTranscript={onTranscript} />);
+
+      mockOnTranscriptRef?.('hello world');
+
+      expect(onTranscript).toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  describe('aria-pressed', () => {
+    it('sets aria-pressed to false when not listening', () => {
+      render(<DictationButton onTranscript={vi.fn()} />);
+      expect(screen.getByLabelText('Start dictation')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('sets aria-pressed to true when listening', () => {
+      mockIsListening = true;
+      render(<DictationButton onTranscript={vi.fn()} />);
+      expect(screen.getByLabelText('Stop dictation')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<DictationButton onTranscript={vi.fn()} />);
@@ -38,6 +144,12 @@ describe('DictationButton', () => {
       const { container } = render(
         <DictationButton onTranscript={vi.fn()} disabled />,
       );
+      await checkAccessibility(container);
+    });
+
+    it('passes axe audit when listening', async () => {
+      mockIsListening = true;
+      const { container } = render(<DictationButton onTranscript={vi.fn()} />);
       await checkAccessibility(container);
     });
   });

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { X, Paperclip, ArrowUp, CircleStop, Loader } from 'lucide-react';
-import { ComponentPropsWithoutRef, useRef, useMemo, useState } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  useCallback,
+  useRef,
+  useMemo,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { EnterKeyIcon } from '@/app/components/icons/enter-key-icon';
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
@@ -22,8 +29,16 @@ import { AgentSelector } from './agent-selector';
 import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaModeToggle } from './arena/arena-mode-toggle';
 import { ArenaModelSelector } from './arena/arena-model-selector';
+import { DictationButton } from './dictation-button';
 import { ImagePreviewDialog } from './message-bubble';
 import { ModelSelector } from './model-selector';
+
+const LOCALE_TO_BCP47: Record<string, string> = {
+  en: 'en-US',
+  de: 'de-DE',
+  'de-AT': 'de-AT',
+  'de-CH': 'de-CH',
+};
 
 interface ChatInputProps extends Omit<
   ComponentPropsWithoutRef<'div'>,
@@ -73,8 +88,11 @@ export function ChatInput({
 }: ChatInputProps) {
   const { t: tChat } = useT('chat');
   const { t: tDialogs } = useT('dialogs');
+  const { i18n } = useTranslation();
   const arenaContext = useArenaModeOptional();
   const isArenaMode = arenaContext?.isArenaMode ?? false;
+
+  const speechLang = LOCALE_TO_BCP47[i18n.language] ?? 'en-US';
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -117,6 +135,14 @@ export function ChatInput({
   const handleInputChange = (newValue: string) => {
     onChange?.(newValue);
   };
+
+  const handleTranscript = useCallback(
+    (transcript: string) => {
+      const separator = value.length > 0 && !value.endsWith(' ') ? ' ' : '';
+      onChange?.(value + separator + transcript);
+    },
+    [value, onChange],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -366,6 +392,11 @@ export function ChatInput({
                   </Button>
                 </Tooltip>
               )}
+              <DictationButton
+                disabled={inputDisabled}
+                lang={speechLang}
+                onTranscript={handleTranscript}
+              />
               <ArenaModeToggle disabled={isLoading} />
               {isArenaMode ? (
                 <ArenaModelSelector organizationId={organizationId} />

--- a/services/platform/app/features/chat/components/dictation-button.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { Mic } from 'lucide-react';
-import { useCallback, memo } from 'react';
+import { useCallback, useEffect, useRef, memo } from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { Button } from '@/app/components/ui/primitives/button';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -12,11 +13,13 @@ import { useSpeechToText } from '../hooks/use-speech-to-text';
 
 interface DictationButtonProps {
   disabled?: boolean;
+  lang?: string;
   onTranscript: (transcript: string) => void;
 }
 
 function DictationButtonComponent({
   disabled = false,
+  lang,
   onTranscript,
 }: DictationButtonProps) {
   const { t } = useT('chat');
@@ -28,10 +31,24 @@ function DictationButtonComponent({
     [onTranscript],
   );
 
-  const { isListening, isSupported, startListening, stopListening } =
+  const { isListening, isSupported, error, startListening, stopListening } =
     useSpeechToText({
+      lang,
       onTranscript: handleTranscript,
     });
+
+  const prevErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) {
+      const message =
+        error === 'not-allowed'
+          ? t('dictation.permissionDenied')
+          : t('dictation.notSupported');
+      toast({ title: message, variant: 'destructive' });
+    }
+    prevErrorRef.current = error;
+  }, [error, t]);
 
   if (!isSupported) return null;
 

--- a/services/platform/app/features/chat/hooks/__tests__/use-speech-to-text.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-speech-to-text.test.ts
@@ -1,0 +1,384 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSpeechToText } from '../use-speech-to-text';
+
+interface MockSpeechRecognition {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  _fireEvent: (type: string, event?: unknown) => void;
+}
+
+const instances: MockSpeechRecognition[] = [];
+
+function getLatest(): MockSpeechRecognition {
+  const instance = instances.at(-1);
+  if (!instance) throw new Error('No SpeechRecognition instance created');
+  return instance;
+}
+
+function createMockRecognition(): MockSpeechRecognition {
+  const listeners: Record<string, Array<(event: unknown) => void>> = {};
+
+  return {
+    continuous: false,
+    interimResults: false,
+    lang: '',
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    addEventListener: vi.fn(
+      (type: string, handler: (event: unknown) => void) => {
+        if (!listeners[type]) listeners[type] = [];
+        listeners[type].push(handler);
+      },
+    ),
+    removeEventListener: vi.fn(),
+    _fireEvent(type: string, event?: unknown) {
+      for (const handler of listeners[type] ?? []) {
+        handler(event ?? {});
+      }
+    },
+  };
+}
+
+function createRecognitionProxy() {
+  return new Proxy(
+    function SpeechRecognition() {
+      /* noop */
+    },
+    {
+      construct() {
+        const instance = createMockRecognition();
+        instances.push(instance);
+        return instance;
+      },
+    },
+  );
+}
+
+function createThrowingRecognitionProxy() {
+  return new Proxy(
+    function SpeechRecognition() {
+      /* noop */
+    },
+    {
+      construct() {
+        const instance = createMockRecognition();
+        instance.start = vi.fn(() => {
+          throw new Error('Permission denied');
+        });
+        instances.push(instance);
+        return instance;
+      },
+    },
+  );
+}
+
+beforeEach(() => {
+  instances.length = 0;
+  Object.defineProperty(window, 'SpeechRecognition', {
+    value: createRecognitionProxy(),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'webkitSpeechRecognition', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'SpeechRecognition', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'webkitSpeechRecognition', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('useSpeechToText', () => {
+  describe('isSupported', () => {
+    it('returns true when SpeechRecognition is available', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it('returns true when only webkitSpeechRecognition is available', () => {
+      Object.defineProperty(window, 'SpeechRecognition', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'webkitSpeechRecognition', {
+        value: createRecognitionProxy(),
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it('returns false when neither API is available', () => {
+      Object.defineProperty(window, 'SpeechRecognition', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  describe('startListening / stopListening', () => {
+    it('initializes with isListening false', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+      expect(result.current.isListening).toBe(false);
+    });
+
+    it('sets isListening to true when recognition starts', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('start');
+      });
+
+      expect(result.current.isListening).toBe(true);
+    });
+
+    it('sets isListening to false when recognition ends', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('start');
+      });
+
+      act(() => {
+        getLatest()._fireEvent('end');
+      });
+
+      expect(result.current.isListening).toBe(false);
+    });
+
+    it('calls stop on the recognition instance when stopListening is called', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        result.current.stopListening();
+      });
+
+      expect(getLatest().stop).toHaveBeenCalled();
+    });
+
+    it('configures recognition with default lang en-US', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      expect(getLatest().lang).toBe('en-US');
+      expect(getLatest().continuous).toBe(true);
+      expect(getLatest().interimResults).toBe(true);
+    });
+
+    it('uses provided lang option', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn(), lang: 'de-DE' }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      expect(getLatest().lang).toBe('de-DE');
+    });
+
+    it('aborts previous session before starting a new one', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      const firstInstance = getLatest();
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      expect(firstInstance.abort).toHaveBeenCalled();
+    });
+  });
+
+  describe('transcript', () => {
+    it('calls onTranscript with final transcript', () => {
+      const onTranscript = vi.fn();
+      const { result } = renderHook(() => useSpeechToText({ onTranscript }));
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('result', {
+          resultIndex: 0,
+          results: {
+            length: 1,
+            0: {
+              isFinal: true,
+              0: { transcript: 'hello world', confidence: 0.95 },
+              length: 1,
+            },
+          },
+        });
+      });
+
+      expect(onTranscript).toHaveBeenCalledWith('hello world');
+    });
+
+    it('ignores interim results', () => {
+      const onTranscript = vi.fn();
+      const { result } = renderHook(() => useSpeechToText({ onTranscript }));
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('result', {
+          resultIndex: 0,
+          results: {
+            length: 1,
+            0: {
+              isFinal: false,
+              0: { transcript: 'hel', confidence: 0.5 },
+              length: 1,
+            },
+          },
+        });
+      });
+
+      expect(onTranscript).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('sets error on recognition error', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('error', { error: 'not-allowed' });
+      });
+
+      expect(result.current.error).toBe('not-allowed');
+      expect(result.current.isListening).toBe(false);
+    });
+
+    it('ignores aborted errors', () => {
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      act(() => {
+        getLatest()._fireEvent('start');
+      });
+
+      act(() => {
+        getLatest()._fireEvent('error', { error: 'aborted' });
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('sets error to not-allowed when start() throws', () => {
+      Object.defineProperty(window, 'SpeechRecognition', {
+        value: createThrowingRecognitionProxy(),
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      expect(result.current.error).toBe('not-allowed');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('aborts recognition on unmount', () => {
+      const { result, unmount } = renderHook(() =>
+        useSpeechToText({ onTranscript: vi.fn() }),
+      );
+
+      act(() => {
+        result.current.startListening();
+      });
+
+      const instance = getLatest();
+      unmount();
+
+      expect(instance.abort).toHaveBeenCalled();
+    });
+  });
+});

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2722,6 +2722,12 @@
       "submitComment": "Senden",
       "cancel": "Abbrechen"
     },
+    "dictation": {
+      "start": "Diktat starten",
+      "stop": "Diktat stoppen",
+      "notSupported": "Spracherkennung wird in diesem Browser nicht unterstützt",
+      "permissionDenied": "Mikrofonzugriff wurde verweigert. Bitte erlaube den Mikrofonzugriff in den Browsereinstellungen."
+    },
     "shareBoundary": "Nachrichten oben stammen aus einem geteilten Chat",
     "forkBoundary": "Von Ihrem eigenen Chat geforkt",
     "notFound": "Dieser Chat ist nicht verfügbar.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2734,7 +2734,8 @@
     "dictation": {
       "start": "Start dictation",
       "stop": "Stop dictation",
-      "notSupported": "Speech recognition is not supported in this browser"
+      "notSupported": "Speech recognition is not supported in this browser",
+      "permissionDenied": "Microphone access was denied. Please allow microphone access in your browser settings."
     },
     "citations": {
       "source": "Source {number}",


### PR DESCRIPTION
## Summary

- Wires the `DictationButton` component into the chat input toolbar, enabling speech-to-text dictation via the Web Speech API
- Adds locale-aware recognition with BCP 47 mapping (en-US, de-DE, de-AT, de-CH) based on the user's current i18n language
- Includes error handling with toast notifications for permission denied and unsupported browser scenarios
- Adds comprehensive test suites for both `DictationButton` and `useSpeechToText` hook, including accessibility audits

## Test plan

- [ ] Verify the microphone button appears in the chat input toolbar
- [ ] Click the microphone button and verify speech recognition starts (browser permission prompt)
- [ ] Speak and confirm transcribed text is appended to the message input
- [ ] Click again to stop dictation
- [ ] Verify the button is hidden in browsers without Web Speech API support
- [ ] Deny microphone permission and verify a destructive toast appears
- [ ] Verify the button is disabled when chat input is disabled or loading
- [ ] Switch language to German and verify recognition uses `de-DE`
- [ ] Run `bunx vitest --run --project client` and confirm all tests pass

Closes #1332