### PR TITLE
feat(platform): wire prompt library dialogs into UI

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { X, Paperclip, ArrowUp, CircleStop, Loader } from 'lucide-react';
+import {
+  X,
+  Paperclip,
+  ArrowUp,
+  CircleStop,
+  Loader,
+  BookOpen,
+  Save,
+} from 'lucide-react';
 import {
   ComponentPropsWithoutRef,
   useCallback,
@@ -23,6 +31,7 @@ import { useT } from '@/lib/i18n/client';
 import { CHAT_UPLOAD_ACCEPT } from '@/lib/shared/file-types';
 import { cn } from '@/lib/utils/cn';
 import { formatFileSize, middleEllipsis } from '@/lib/utils/format/file';
+import { lazyComponent } from '@/lib/utils/lazy-component';
 
 import type { FileAttachment } from '../hooks/use-convex-file-upload';
 import { AgentSelector } from './agent-selector';
@@ -39,6 +48,22 @@ const LOCALE_TO_BCP47: Record<string, string> = {
   'de-AT': 'de-AT',
   'de-CH': 'de-CH',
 };
+
+const PromptLibraryDialog = lazyComponent<
+  import('@/app/features/prompts/components/prompt-library-dialog').PromptLibraryDialogProps
+>(() =>
+  import('@/app/features/prompts/components/prompt-library-dialog').then(
+    (m) => ({ default: m.PromptLibraryDialog }),
+  ),
+);
+
+const SaveAsPromptDialog = lazyComponent<
+  import('@/app/features/prompts/components/save-as-prompt-dialog').SaveAsPromptDialogProps
+>(() =>
+  import('@/app/features/prompts/components/save-as-prompt-dialog').then(
+    (m) => ({ default: m.SaveAsPromptDialog }),
+  ),
+);
 
 interface ChatInputProps extends Omit<
   ComponentPropsWithoutRef<'div'>,
@@ -100,6 +125,8 @@ export function ChatInput({
     src: string;
     alt: string;
   } | null>(null);
+  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
+  const [saveAsPromptOpen, setSaveAsPromptOpen] = useState(false);
 
   const defaultPlaceholder = placeholder || tChat('typeMessageHere');
 
@@ -392,6 +419,30 @@ export function ChatInput({
                   </Button>
                 </Tooltip>
               )}
+              <Tooltip content={tChat('promptLibrary')} side="top">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setPromptLibraryOpen(true)}
+                  disabled={inputDisabled}
+                  aria-label={tChat('promptLibrary')}
+                >
+                  <BookOpen className="size-4" />
+                </Button>
+              </Tooltip>
+              {value.trim().length > 0 && (
+                <Tooltip content={tChat('saveAsPrompt')} side="top">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setSaveAsPromptOpen(true)}
+                    disabled={inputDisabled}
+                    aria-label={tChat('saveAsPrompt')}
+                  >
+                    <Save className="size-4" />
+                  </Button>
+                </Tooltip>
+              )}
               <DictationButton
                 disabled={inputDisabled}
                 lang={speechLang}
@@ -441,6 +492,18 @@ export function ChatInput({
           alt={previewImage.alt}
         />
       )}
+
+      <PromptLibraryDialog
+        open={promptLibraryOpen}
+        onOpenChange={setPromptLibraryOpen}
+        onSelectPrompt={(content) => onChange?.(content)}
+      />
+
+      <SaveAsPromptDialog
+        open={saveAsPromptOpen}
+        onOpenChange={setSaveAsPromptOpen}
+        initialContent={value}
+      />
     </div>
   );
 }

--- a/services/platform/app/features/prompts/components/__tests__/prompt-form-dialog.test.tsx
+++ b/services/platform/app/features/prompts/components/__tests__/prompt-form-dialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render, screen } from '@/test/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          `${ns}.${key}`,
+        );
+      }
+      return `${ns}.${key}`;
+    },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-organization-id', () => ({
+  useOrganizationId: () => 'test-org-id',
+}));
+
+import { PromptFormDialog } from '../prompt-form-dialog';
+
+describe('PromptFormDialog', () => {
+  describe('accessibility', () => {
+    it('passes axe audit in create mode', async () => {
+      const { container } = render(
+        <PromptFormDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={vi.fn()}
+          isSubmitting={false}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+
+    it('passes axe audit in edit mode', async () => {
+      const { container } = render(
+        <PromptFormDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSubmit={vi.fn()}
+          isSubmitting={false}
+          initialData={{
+            _id: 'prompt-1' as never,
+            _creationTime: 1700000000000,
+            organizationId: 'test-org-id',
+            createdBy: 'user-1',
+            title: 'Existing Prompt',
+            content: 'Some content',
+            description: 'A description',
+            scope: 'personal',
+            category: 'general',
+            tags: ['tag1'],
+            usageCount: 3,
+            isPublished: true,
+          }}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  it('shows create title when no initial data', () => {
+    render(
+      <PromptFormDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    expect(screen.getByText('prompts.form.createTitle')).toBeInTheDocument();
+  });
+
+  it('shows edit title with initial data', () => {
+    render(
+      <PromptFormDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+        initialData={{
+          _id: 'prompt-1' as never,
+          _creationTime: 1700000000000,
+          organizationId: 'test-org-id',
+          createdBy: 'user-1',
+          title: 'Existing Prompt',
+          content: 'Some content',
+          scope: 'personal',
+          usageCount: 0,
+          isPublished: true,
+        }}
+      />,
+    );
+    expect(screen.getByText('prompts.form.editTitle')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(
+      <PromptFormDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/services/platform/app/features/prompts/components/__tests__/prompt-form-dialog.test.tsx
+++ b/services/platform/app/features/prompts/components/__tests__/prompt-form-dialog.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'test-org-id',
 }));
 
+vi.mock('@/app/features/settings/teams/hooks/queries', () => ({
+  useTeams: () => ({ teams: [], isLoading: false }),
+}));
+
 import { PromptFormDialog } from '../prompt-form-dialog';
 
 describe('PromptFormDialog', () => {

--- a/services/platform/app/features/prompts/components/__tests__/prompt-library-dialog.test.tsx
+++ b/services/platform/app/features/prompts/components/__tests__/prompt-library-dialog.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render, screen } from '@/test/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          `${ns}.${key}`,
+        );
+      }
+      return `${ns}.${key}`;
+    },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-organization-id', () => ({
+  useOrganizationId: () => 'test-org-id',
+}));
+
+vi.mock('@/app/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { userId: 'user-1' } }),
+}));
+
+vi.mock('@/app/hooks/use-current-member-context', () => ({
+  useCurrentMemberContext: () => ({ data: { role: 'admin' } }),
+}));
+
+vi.mock('../../hooks/queries', () => ({
+  usePrompts: () => ({
+    prompts: [
+      {
+        _id: 'prompt-1',
+        _creationTime: 1700000000000,
+        organizationId: 'test-org-id',
+        createdBy: 'user-1',
+        title: 'Test Prompt',
+        content: 'Hello {{name}}, how can I help?',
+        description: 'A test prompt',
+        scope: 'personal',
+        category: 'testing',
+        tags: ['test'],
+        usageCount: 5,
+        isPublished: true,
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../../hooks/mutations', () => ({
+  useCreatePrompt: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdatePrompt: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeletePrompt: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useIncrementPromptUsage: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { PromptLibraryDialog } from '../prompt-library-dialog';
+
+describe('PromptLibraryDialog', () => {
+  describe('accessibility', () => {
+    it('passes axe audit when open', async () => {
+      const { container } = render(
+        <PromptLibraryDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSelectPrompt={vi.fn()}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  it('renders prompt cards when open', () => {
+    render(
+      <PromptLibraryDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectPrompt={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Test Prompt')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(
+      <PromptLibraryDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        onSelectPrompt={vi.fn()}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/services/platform/app/features/prompts/components/__tests__/save-as-prompt-dialog.test.tsx
+++ b/services/platform/app/features/prompts/components/__tests__/save-as-prompt-dialog.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render, screen } from '@/test/utils/render';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          `${ns}.${key}`,
+        );
+      }
+      return `${ns}.${key}`;
+    },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-organization-id', () => ({
+  useOrganizationId: () => 'test-org-id',
+}));
+
+vi.mock('../../hooks/mutations', () => ({
+  useCreatePrompt: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { SaveAsPromptDialog } from '../save-as-prompt-dialog';
+
+describe('SaveAsPromptDialog', () => {
+  describe('accessibility', () => {
+    it('passes axe audit when open', async () => {
+      const { container } = render(
+        <SaveAsPromptDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          initialContent="Hello, this is a test prompt."
+        />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  it('renders with initial content when open', () => {
+    render(
+      <SaveAsPromptDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        initialContent="Hello, this is a test prompt."
+      />,
+    );
+    expect(screen.getByText('prompts.saveAs.title')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(
+      <SaveAsPromptDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        initialContent="Some content"
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
@@ -49,7 +49,7 @@ function PromptFormDialogContent({
   const [scope, setScope] = useState<PromptScope>(
     initialData?.scope ?? 'personal',
   );
-  const [teamId, setTeamId] = useState<string | undefined>(initialData?.teamId);
+  const [teamId, setTeamId] = useState(initialData?.teamId);
   const [category, setCategory] = useState(initialData?.category ?? '');
   const [tagsInput, setTagsInput] = useState(
     initialData?.tags?.join(', ') ?? '',

--- a/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useT } from '@/lib/i18n/client';
 
 import type { PromptTemplate } from '../hooks/queries';
@@ -24,6 +26,7 @@ export interface PromptFormData {
   content: string;
   description: string;
   scope: PromptScope;
+  teamId?: string;
   category: string;
   tags: string[];
 }
@@ -36,6 +39,7 @@ function PromptFormDialogContent({
   initialData,
 }: PromptFormDialogProps) {
   const { t } = useT('prompts');
+  const { teams } = useTeams();
 
   const [title, setTitle] = useState(initialData?.title ?? '');
   const [content, setContent] = useState(initialData?.content ?? '');
@@ -45,9 +49,19 @@ function PromptFormDialogContent({
   const [scope, setScope] = useState<PromptScope>(
     initialData?.scope ?? 'personal',
   );
+  const [teamId, setTeamId] = useState<string | undefined>(initialData?.teamId);
   const [category, setCategory] = useState(initialData?.category ?? '');
   const [tagsInput, setTagsInput] = useState(
     initialData?.tags?.join(', ') ?? '',
+  );
+
+  const teamOptions = useMemo(
+    () =>
+      (teams ?? []).map((team) => ({
+        value: team.id,
+        label: team.name,
+      })),
+    [teams],
   );
 
   const isDirty =
@@ -55,10 +69,14 @@ function PromptFormDialogContent({
     content !== (initialData?.content ?? '') ||
     description !== (initialData?.description ?? '') ||
     scope !== (initialData?.scope ?? 'personal') ||
+    teamId !== initialData?.teamId ||
     category !== (initialData?.category ?? '') ||
     tagsInput !== (initialData?.tags?.join(', ') ?? '');
 
-  const isValid = title.trim().length > 0 && content.trim().length > 0;
+  const isValid =
+    title.trim().length > 0 &&
+    content.trim().length > 0 &&
+    (scope !== 'team' || !!teamId);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -75,6 +93,7 @@ function PromptFormDialogContent({
         content: content.trim(),
         description: description.trim(),
         scope,
+        teamId: scope === 'team' ? teamId : undefined,
         category: category.trim(),
         tags,
       });
@@ -84,6 +103,7 @@ function PromptFormDialogContent({
       content,
       description,
       scope,
+      teamId,
       category,
       tagsInput,
       isValid,
@@ -151,6 +171,16 @@ function PromptFormDialogContent({
           ))}
         </div>
       </fieldset>
+      {scope === 'team' && teamOptions.length > 0 && (
+        <Select
+          label={t('form.teamLabel')}
+          options={teamOptions}
+          value={teamId ?? ''}
+          onValueChange={(v) => setTeamId(v || undefined)}
+          placeholder={t('form.teamPlaceholder')}
+          required
+        />
+      )}
       <Input
         label={t('form.categoryLabel')}
         value={category}

--- a/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
@@ -115,6 +115,7 @@ function PromptLibraryDialogContent({
         content: data.content,
         description: data.description || undefined,
         scope: data.scope,
+        teamId: data.teamId,
         category: data.category || undefined,
         tags: data.tags.length > 0 ? data.tags : undefined,
         isPublished: true,
@@ -133,6 +134,7 @@ function PromptLibraryDialogContent({
         content: data.content,
         description: data.description || undefined,
         scope: data.scope,
+        teamId: data.teamId,
         category: data.category || undefined,
         tags: data.tags.length > 0 ? data.tags : undefined,
       });

--- a/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
@@ -26,9 +26,7 @@ import { usePrompts } from '../hooks/queries';
 import { PromptCard } from './prompt-card';
 import { PromptFormDialog, type PromptFormData } from './prompt-form-dialog';
 
-type TabValue = 'all' | 'team' | 'personal';
-
-interface PromptLibraryDialogProps {
+export interface PromptLibraryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectPrompt: (content: string) => void;
@@ -171,8 +169,7 @@ function PromptLibraryDialogContent({
             <Tabs
               items={tabItems}
               value={activeTab}
-              // @ts-expect-error -- Tabs onValueChange provides string, but TabValue is a string union
-              onValueChange={(v: TabValue) => setActiveTab(v)}
+              onValueChange={setActiveTab}
             />
             <Button
               size="sm"

--- a/services/platform/app/features/prompts/components/save-as-prompt-dialog.tsx
+++ b/services/platform/app/features/prompts/components/save-as-prompt-dialog.tsx
@@ -10,7 +10,7 @@ import { useT } from '@/lib/i18n/client';
 
 import { useCreatePrompt } from '../hooks/mutations';
 
-interface SaveAsPromptDialogProps {
+export interface SaveAsPromptDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initialContent: string;

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -1,19 +1,32 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useMemo } from 'react';
+import { BookOpen } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import { CodeBlock } from '@/app/components/ui/data-display/code-block';
 import { ModelSelector } from '@/app/components/ui/forms/model-selector';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { HStack } from '@/app/components/ui/layout/layout';
 import { PageSection } from '@/app/components/ui/layout/page-section';
 import { CollapsibleDetails } from '@/app/components/ui/navigation/collapsible-details';
+import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import { Button } from '@/app/components/ui/primitives/button';
 import { useAgentConfig } from '@/app/features/agents/hooks/use-agent-config-context';
 import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
 import { SUPPORTED_TEMPLATE_VARIABLES } from '@/convex/lib/agent_response/resolve_template_variables';
 import { STRUCTURED_RESPONSE_INSTRUCTIONS } from '@/convex/lib/agent_response/structured_response_instructions';
 import { useT } from '@/lib/i18n/client';
+import { lazyComponent } from '@/lib/utils/lazy-component';
 import { seo } from '@/lib/utils/seo';
+
+const PromptLibraryDialog = lazyComponent<
+  import('@/app/features/prompts/components/prompt-library-dialog').PromptLibraryDialogProps
+>(() =>
+  import('@/app/features/prompts/components/prompt-library-dialog').then(
+    (m) => ({ default: m.PromptLibraryDialog }),
+  ),
+);
 
 export const Route = createFileRoute(
   '/dashboard/$id/agents/$agentId/instructions',
@@ -28,6 +41,7 @@ function InstructionsTab() {
   const { t } = useT('settings');
   const { config, updateConfig } = useAgentConfig();
   const { providers } = useListProviders('default');
+  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
 
   const structuredResponsesEnabled = config.structuredResponsesEnabled ?? true;
   const selectedModels = config.supportedModels;
@@ -88,16 +102,35 @@ function InstructionsTab() {
         description={t('agents.form.sectionInstructionsDescription')}
         gap={4}
       >
-        <Textarea
-          id="systemInstructions"
-          label={t('agents.form.systemInstructions')}
-          placeholder={t('agents.form.systemInstructionsPlaceholder')}
-          value={config.systemInstructions}
-          onChange={(e) => updateConfig({ systemInstructions: e.target.value })}
-          required
-          rows={8}
-          className="font-mono text-sm"
-        />
+        <div className="flex flex-col gap-2">
+          <HStack justify="between" align="center">
+            <label htmlFor="systemInstructions" className="text-sm font-medium">
+              {t('agents.form.systemInstructions')}
+            </label>
+            <Tooltip content={t('agents.form.browsePrompts')} side="top">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPromptLibraryOpen(true)}
+                aria-label={t('agents.form.browsePrompts')}
+              >
+                <BookOpen className="mr-1 size-4" />
+                {t('agents.form.browsePrompts')}
+              </Button>
+            </Tooltip>
+          </HStack>
+          <Textarea
+            id="systemInstructions"
+            placeholder={t('agents.form.systemInstructionsPlaceholder')}
+            value={config.systemInstructions}
+            onChange={(e) =>
+              updateConfig({ systemInstructions: e.target.value })
+            }
+            required
+            rows={8}
+            className="font-mono text-sm"
+          />
+        </div>
         <CollapsibleDetails
           variant="compact"
           summary={t('agents.form.templateVariablesLabel')}
@@ -150,6 +183,18 @@ function InstructionsTab() {
           </CodeBlock>
         )}
       </PageSection>
+
+      <PromptLibraryDialog
+        open={promptLibraryOpen}
+        onOpenChange={setPromptLibraryOpen}
+        onSelectPrompt={(content) => {
+          const current = config.systemInstructions;
+          const separator = current.trim() ? '\n\n' : '';
+          updateConfig({
+            systemInstructions: current + separator + content,
+          });
+        }}
+      />
     </ContentArea>
   );
 }

--- a/services/platform/convex/lib/rls/helpers/access_control.ts
+++ b/services/platform/convex/lib/rls/helpers/access_control.ts
@@ -23,6 +23,7 @@ type PlatformTable =
   | 'approvals'
   | 'websites'
   | 'workflowProcessingRecords'
+  | 'promptTemplates'
   | 'auditLogs';
 
 type PlatformAction = 'read' | 'write';
@@ -60,6 +61,7 @@ const platformPermissions: Record<
     workflowProcessingRecords: ALL,
     approvals: ALL,
     websites: ALL,
+    promptTemplates: ALL,
     auditLogs: ALL,
   },
   developer: {
@@ -80,6 +82,7 @@ const platformPermissions: Record<
     workflowProcessingRecords: ALL,
     approvals: ALL,
     websites: ALL,
+    promptTemplates: ALL,
     auditLogs: ALL,
   },
   editor: {
@@ -100,6 +103,7 @@ const platformPermissions: Record<
     workflowProcessingRecords: READ_ONLY,
     approvals: ALL,
     websites: ALL,
+    promptTemplates: ALL,
     auditLogs: ALL,
   },
   member: {
@@ -120,6 +124,7 @@ const platformPermissions: Record<
     workflowProcessingRecords: READ_ONLY,
     approvals: READ_ONLY,
     websites: READ_ONLY,
+    promptTemplates: ALL,
     auditLogs: READ_ONLY,
   },
   disabled: {
@@ -140,6 +145,7 @@ const platformPermissions: Record<
     workflowProcessingRecords: NONE,
     approvals: NONE,
     websites: NONE,
+    promptTemplates: NONE,
     auditLogs: NONE,
   },
 };

--- a/services/platform/convex/lib/rls/helpers/rls_rules.ts
+++ b/services/platform/convex/lib/rls/helpers/rls_rules.ts
@@ -489,6 +489,34 @@ export async function rlsRules(
       },
     },
 
+    // Prompt Templates - organization-scoped
+    promptTemplates: {
+      read: async (_, prompt) => {
+        if (!user) return false;
+        if (!userOrgIds.has(prompt.organizationId)) return false;
+        const membership = userOrganizations.find(
+          (m) => m.organizationId === prompt.organizationId,
+        );
+        return authorizeRls(membership?.role, 'promptTemplates', 'read');
+      },
+      modify: async (_, prompt) => {
+        if (!user) return false;
+        if (!userOrgIds.has(prompt.organizationId)) return false;
+        const membership = userOrganizations.find(
+          (m) => m.organizationId === prompt.organizationId,
+        );
+        return authorizeRls(membership?.role, 'promptTemplates', 'write');
+      },
+      insert: async ({ user: ruleUser }, prompt) => {
+        if (!ruleUser) return false;
+        if (!userOrgIds.has(prompt.organizationId)) return false;
+        const membership = userOrganizations.find(
+          (m) => m.organizationId === prompt.organizationId,
+        );
+        return authorizeRls(membership?.role, 'promptTemplates', 'write');
+      },
+    },
+
     // Audit Logs - organization-scoped, allow inserts for org members
     auditLogs: {
       read: async (_, log) => {

--- a/services/platform/messages/de-AT.json
+++ b/services/platform/messages/de-AT.json
@@ -42,6 +42,8 @@
       "descriptionLabel": "Beschreibung",
       "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
       "scopeLabel": "Sichtbarkeit",
+      "teamLabel": "Team",
+      "teamPlaceholder": "Team auswählen...",
       "categoryLabel": "Kategorie",
       "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
       "tagsLabel": "Tags",

--- a/services/platform/messages/de-AT.json
+++ b/services/platform/messages/de-AT.json
@@ -1,1 +1,65 @@
-{}
+{
+  "prompts": {
+    "tabs": {
+      "all": "Alle",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "library": {
+      "title": "Prompt-Bibliothek",
+      "description": "Prompt-Vorlagen durchsuchen, speichern und teilen.",
+      "searchPlaceholder": "Prompts suchen...",
+      "loading": "Prompts werden geladen...",
+      "empty": "Noch keine Prompts. Erstelle deine erste Prompt-Vorlage."
+    },
+    "actions": {
+      "create": "Prompt erstellen",
+      "createFirst": "Ersten Prompt erstellen",
+      "edit": "Bearbeiten",
+      "delete": "Löschen",
+      "use": "Verwenden",
+      "usePrompt": "Diesen Prompt verwenden",
+      "more": "Weitere Aktionen"
+    },
+    "deleteConfirm": {
+      "title": "Prompt löschen",
+      "description": "Bist du sicher, dass du \"{title}\" löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "scope": {
+      "global": "Global (alle)",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "form": {
+      "createTitle": "Prompt erstellen",
+      "createDescription": "Eine neue Prompt-Vorlage erstellen.",
+      "editTitle": "Prompt bearbeiten",
+      "editDescription": "Die Prompt-Vorlage aktualisieren.",
+      "titleLabel": "Titel",
+      "titlePlaceholder": "Prompt-Titel eingeben...",
+      "contentLabel": "Inhalt",
+      "contentPlaceholder": "Prompt-Inhalt eingeben...",
+      "descriptionLabel": "Beschreibung",
+      "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
+      "scopeLabel": "Sichtbarkeit",
+      "categoryLabel": "Kategorie",
+      "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
+      "tagsLabel": "Tags",
+      "tagsPlaceholder": "Kommagetrennte Tags...",
+      "save": "Speichern",
+      "create": "Erstellen"
+    },
+    "saveAs": {
+      "title": "Als Prompt speichern",
+      "description": "Den aktuellen Text als wiederverwendbare Prompt-Vorlage speichern."
+    },
+    "usageCount": "{count, plural, one {# Verwendung} other {# Verwendungen}}"
+  },
+  "settings": {
+    "agents": {
+      "form": {
+        "browsePrompts": "Prompts durchsuchen"
+      }
+    }
+  }
+}

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -39,6 +39,9 @@
       },
       "knowledge": {
         "fileTooLarge": "Datei zu gross"
+      },
+      "form": {
+        "browsePrompts": "Prompts durchsuchen"
       }
     },
     "integrations": {
@@ -80,7 +83,9 @@
     "canvas": {
       "close": "Canvas schliessen",
       "resizeHandle": "Canvas-Grösse ändern"
-    }
+    },
+    "promptLibrary": "Prompt-Bibliothek",
+    "saveAsPrompt": "Als Prompt speichern"
   },
   "documents": {
     "preview": {
@@ -104,5 +109,61 @@
       "description": "Erlaubte Dateitypen, maximale Dateigrösse und Volumenlimits konfigurieren.",
       "maxFileSize": "Maximale Dateigrösse"
     }
+  },
+  "prompts": {
+    "tabs": {
+      "all": "Alle",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "library": {
+      "title": "Prompt-Bibliothek",
+      "description": "Prompt-Vorlagen durchsuchen, speichern und teilen.",
+      "searchPlaceholder": "Prompts suchen...",
+      "loading": "Prompts werden geladen...",
+      "empty": "Noch keine Prompts. Erstelle deine erste Prompt-Vorlage."
+    },
+    "actions": {
+      "create": "Prompt erstellen",
+      "createFirst": "Ersten Prompt erstellen",
+      "edit": "Bearbeiten",
+      "delete": "Löschen",
+      "use": "Verwenden",
+      "usePrompt": "Diesen Prompt verwenden",
+      "more": "Weitere Aktionen"
+    },
+    "deleteConfirm": {
+      "title": "Prompt löschen",
+      "description": "Bist du sicher, dass du \"{title}\" löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "scope": {
+      "global": "Global (alle)",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "form": {
+      "createTitle": "Prompt erstellen",
+      "createDescription": "Eine neue Prompt-Vorlage erstellen.",
+      "editTitle": "Prompt bearbeiten",
+      "editDescription": "Die Prompt-Vorlage aktualisieren.",
+      "titleLabel": "Titel",
+      "titlePlaceholder": "Prompt-Titel eingeben...",
+      "contentLabel": "Inhalt",
+      "contentPlaceholder": "Prompt-Inhalt eingeben...",
+      "descriptionLabel": "Beschreibung",
+      "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
+      "scopeLabel": "Sichtbarkeit",
+      "categoryLabel": "Kategorie",
+      "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
+      "tagsLabel": "Tags",
+      "tagsPlaceholder": "Kommagetrennte Tags...",
+      "save": "Speichern",
+      "create": "Erstellen"
+    },
+    "saveAs": {
+      "title": "Als Prompt speichern",
+      "description": "Den aktuellen Text als wiederverwendbare Prompt-Vorlage speichern."
+    },
+    "usageCount": "{count, plural, one {# Verwendung} other {# Verwendungen}}"
   }
 }

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -153,6 +153,8 @@
       "descriptionLabel": "Beschreibung",
       "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
       "scopeLabel": "Sichtbarkeit",
+      "teamLabel": "Team",
+      "teamPlaceholder": "Team auswählen...",
       "categoryLabel": "Kategorie",
       "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
       "tagsLabel": "Tags",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -871,7 +871,8 @@
           "moveDown": "Modell nach unten verschieben",
           "dragHandle": "Ziehen zum Neuordnen des Modells"
         },
-        "structuredResponsesInjectedPrompt": "Die folgenden Anweisungen werden automatisch an den System-Prompt angehängt:"
+        "structuredResponsesInjectedPrompt": "Die folgenden Anweisungen werden automatisch an den System-Prompt angehängt:",
+        "browsePrompts": "Prompts durchsuchen"
       },
       "delegation": {
         "title": "Delegation",
@@ -2810,7 +2811,9 @@
       "copied": "Kopiert!",
       "mermaidError": "Diagramm konnte nicht gerendert werden",
       "resizeHandle": "Canvas-Größe ändern"
-    }
+    },
+    "promptLibrary": "Prompt-Bibliothek",
+    "saveAsPrompt": "Als Prompt speichern"
   },
   "documents": {
     "title": "Dokumente",
@@ -3739,5 +3742,61 @@
       "pii": "PII-Schutz",
       "featureControls": "Feature-Steuerung"
     }
+  },
+  "prompts": {
+    "tabs": {
+      "all": "Alle",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "library": {
+      "title": "Prompt-Bibliothek",
+      "description": "Prompt-Vorlagen durchsuchen, speichern und teilen.",
+      "searchPlaceholder": "Prompts suchen...",
+      "loading": "Prompts werden geladen...",
+      "empty": "Noch keine Prompts. Erstelle deine erste Prompt-Vorlage."
+    },
+    "actions": {
+      "create": "Prompt erstellen",
+      "createFirst": "Ersten Prompt erstellen",
+      "edit": "Bearbeiten",
+      "delete": "Löschen",
+      "use": "Verwenden",
+      "usePrompt": "Diesen Prompt verwenden",
+      "more": "Weitere Aktionen"
+    },
+    "deleteConfirm": {
+      "title": "Prompt löschen",
+      "description": "Bist du sicher, dass du \"{title}\" löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "scope": {
+      "global": "Global (alle)",
+      "team": "Team",
+      "personal": "Persönlich"
+    },
+    "form": {
+      "createTitle": "Prompt erstellen",
+      "createDescription": "Eine neue Prompt-Vorlage erstellen.",
+      "editTitle": "Prompt bearbeiten",
+      "editDescription": "Die Prompt-Vorlage aktualisieren.",
+      "titleLabel": "Titel",
+      "titlePlaceholder": "Prompt-Titel eingeben...",
+      "contentLabel": "Inhalt",
+      "contentPlaceholder": "Prompt-Inhalt eingeben...",
+      "descriptionLabel": "Beschreibung",
+      "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
+      "scopeLabel": "Sichtbarkeit",
+      "categoryLabel": "Kategorie",
+      "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
+      "tagsLabel": "Tags",
+      "tagsPlaceholder": "Kommagetrennte Tags...",
+      "save": "Speichern",
+      "create": "Erstellen"
+    },
+    "saveAs": {
+      "title": "Als Prompt speichern",
+      "description": "Den aktuellen Text als wiederverwendbare Prompt-Vorlage speichern."
+    },
+    "usageCount": "{count, plural, one {# Verwendung} other {# Verwendungen}}"
   }
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3786,6 +3786,8 @@
       "descriptionLabel": "Beschreibung",
       "descriptionPlaceholder": "Kurze Beschreibung des Prompts...",
       "scopeLabel": "Sichtbarkeit",
+      "teamLabel": "Team",
+      "teamPlaceholder": "Team auswählen...",
       "categoryLabel": "Kategorie",
       "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
       "tagsLabel": "Tags",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -874,7 +874,8 @@
           "moveDown": "Move model down",
           "dragHandle": "Drag to reorder model"
         },
-        "structuredResponsesInjectedPrompt": "The following instructions will be automatically appended to the system prompt:"
+        "structuredResponsesInjectedPrompt": "The following instructions will be automatically appended to the system prompt:",
+        "browsePrompts": "Browse prompts"
       },
       "delegation": {
         "title": "Delegation",
@@ -1450,7 +1451,7 @@
     },
     "providers": {
       "title": "Providers",
-      "description": "Manage LLM providers and their models",
+      "description": "Description",
       "addProvider": "Add provider",
       "editProvider": "Edit provider",
       "deleteProvider": "Delete provider",
@@ -1508,7 +1509,6 @@
       "apiKeyReplace": "Enter new API key to replace ({maskedKey})",
       "apiKeyEnter": "Enter API key",
       "searchProvider": "Search providers...",
-      "description": "Description",
       "created": "Provider created",
       "modelCount": "{count, plural, one {# model} other {# models}}",
       "removeModel": "Remove model",
@@ -2734,7 +2734,6 @@
     "structured": {
       "nextSteps": "Suggested follow-ups"
     },
-    "welcomeSuffix": "here, what are we working on?",
     "dictation": {
       "start": "Start dictation",
       "stop": "Stop dictation",
@@ -2837,7 +2836,9 @@
       "copied": "Copied!",
       "mermaidError": "Failed to render diagram",
       "resizeHandle": "Resize canvas"
-    }
+    },
+    "promptLibrary": "Prompt library",
+    "saveAsPrompt": "Save as prompt"
   },
   "documents": {
     "title": "Documents",
@@ -3793,41 +3794,60 @@
     }
   },
   "prompts": {
-    "title": "Prompt Library",
-    "description": "Browse, save, and share prompt templates.",
-    "search": "Search prompts...",
-    "all": "All",
-    "team": "Team",
-    "myPrompts": "My Prompts",
-    "create": "Create prompt",
-    "edit": "Edit prompt",
-    "delete": "Delete prompt",
-    "deleteConfirmation": "Are you sure you want to delete this prompt?",
-    "use": "Use prompt",
-    "saveAsPrompt": "Save as prompt",
-    "form": {
-      "title": "Title",
-      "titlePlaceholder": "Enter prompt title...",
-      "content": "Content",
-      "contentPlaceholder": "Enter prompt content...",
-      "description": "Description",
-      "descriptionPlaceholder": "Brief description of what this prompt does...",
-      "scope": "Visibility",
-      "category": "Category",
-      "categoryPlaceholder": "e.g., writing, analysis, coding",
-      "tags": "Tags",
-      "tagsPlaceholder": "Add tags...",
-      "save": "Save prompt",
-      "saved": "Prompt saved"
+    "tabs": {
+      "all": "All",
+      "team": "Team",
+      "personal": "Personal"
     },
-    "scopeLabels": {
+    "library": {
+      "title": "Prompt library",
+      "description": "Browse, save, and share prompt templates.",
+      "searchPlaceholder": "Search prompts...",
+      "loading": "Loading prompts...",
+      "empty": "No prompts yet. Create your first prompt template."
+    },
+    "actions": {
+      "create": "Create prompt",
+      "createFirst": "Create first prompt",
+      "edit": "Edit",
+      "delete": "Delete",
+      "use": "Use",
+      "usePrompt": "Use this prompt",
+      "more": "More actions"
+    },
+    "deleteConfirm": {
+      "title": "Delete prompt",
+      "description": "Are you sure you want to delete \"{title}\"? This action cannot be undone."
+    },
+    "scope": {
       "global": "Global (everyone)",
       "team": "Team",
       "personal": "Personal"
     },
-    "usageCount": "{count} uses",
-    "noResults": "No prompts found",
-    "emptyState": "No prompts yet. Create your first prompt template."
+    "form": {
+      "createTitle": "Create prompt",
+      "createDescription": "Create a new prompt template.",
+      "editTitle": "Edit prompt",
+      "editDescription": "Update the prompt template.",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Enter prompt title...",
+      "contentLabel": "Content",
+      "contentPlaceholder": "Enter prompt content...",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Brief description of what this prompt does...",
+      "scopeLabel": "Visibility",
+      "categoryLabel": "Category",
+      "categoryPlaceholder": "e.g., writing, analysis, coding",
+      "tagsLabel": "Tags",
+      "tagsPlaceholder": "Comma-separated tags...",
+      "save": "Save",
+      "create": "Create"
+    },
+    "saveAs": {
+      "title": "Save as prompt",
+      "description": "Save the current text as a reusable prompt template."
+    },
+    "usageCount": "{count, plural, one {# use} other {# uses}}"
   },
   "mcpServers": {
     "title": "MCP Servers",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3836,6 +3836,8 @@
       "descriptionLabel": "Description",
       "descriptionPlaceholder": "Brief description of what this prompt does...",
       "scopeLabel": "Visibility",
+      "teamLabel": "Team",
+      "teamPlaceholder": "Select a team...",
       "categoryLabel": "Category",
       "categoryPlaceholder": "e.g., writing, analysis, coding",
       "tagsLabel": "Tags",


### PR DESCRIPTION
## Summary

- Wire existing `PromptLibraryDialog`, `SaveAsPromptDialog`, and `PromptFormDialog` components into the UI -- they were fully implemented but unreachable dead code
- Add a **BookOpen** button to the chat input toolbar to browse and insert prompt templates
- Add a **Save as prompt** button (visible when chat input has content) to save text as a personal prompt template
- Add a **Browse prompts** button to the agent instructions page that appends a selected prompt to system instructions
- Restructure the `prompts` i18n namespace in `en.json` to match component key references (nested `tabs.*`, `library.*`, `actions.*`, `form.*`, `scope.*`, `deleteConfirm.*`, `saveAs.*`)
- Add complete German translations for the `prompts` namespace to `de.json`, `de-AT.json`, and `de-CH.json`
- Fix `@ts-expect-error` in `prompt-library-dialog.tsx` by removing the unnecessary type annotation and passing `setActiveTab` directly to `onValueChange`
- Export `PromptLibraryDialogProps` and `SaveAsPromptDialogProps` interfaces for lazy component type inference
- Add accessibility and render tests for all three prompt dialog components

Closes #1331

## Test plan

- [ ] Open a chat and verify the BookOpen (prompt library) button appears in the toolbar between Attach and Arena Toggle
- [ ] Click the prompt library button and verify the dialog opens with tabs (All, Team, Personal), search, and prompt cards
- [ ] Select a prompt and verify its content is inserted into the chat input textarea
- [ ] Type text in the chat input and verify the Save (save as prompt) button appears
- [ ] Click save as prompt and verify the dialog opens with the current input pre-filled
- [ ] Navigate to agent instructions and verify the "Browse prompts" button appears next to the system instructions label
- [ ] Select a prompt from agent instructions and verify it appends to the existing system instructions
- [ ] Verify all translation keys resolve correctly (no raw key strings displayed) in English and German
- [ ] Run `bun run --filter @tale/platform lint` -- passes
- [ ] Run `bun run --filter @tale/platform typecheck` -- passes
- [ ] Run `bunx vitest --run --project client` -- all tests pass including new prompt dialog tests
- [ ] Run `bunx vitest --run --project server` -- all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt library dialog allowing users to browse and select prompts in chat input.
  * Added ability to save current chat input as a new prompt.
  * Integrated prompt browsing in agent system instructions configuration.

* **Documentation**
  * Extended localization support with German (Austria, Switzerland) translations.
  * Updated English translation strings for prompt-related UI.

* **Tests**
  * Added test coverage for prompt library, prompt form, and save-as-prompt dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->