### PR TITLE
feat(platform): add team-based workspace chat filtering

### DIFF
--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -18,6 +18,7 @@ import {
 import { Stack } from '@/app/components/ui/layout/layout';
 import { Heading } from '@/app/components/ui/typography/heading';
 import { Text } from '@/app/components/ui/typography/text';
+import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -69,19 +70,22 @@ export function ChatHistorySidebar({
   const isMounted = useIsMounted();
   const { toast } = useToast();
 
+  const teamFilter = useOptionalTeamFilter();
+  const selectedTeamId = teamFilter?.selectedTeamId ?? undefined;
+
   const {
     threads: threadsData,
     canLoadMore,
     isLoadingMore,
     loadMore,
-  } = useThreads();
+  } = useThreads({ teamId: selectedTeamId });
 
   const {
     threads: archivedThreadsData,
     canLoadMore: canLoadMoreArchived,
     isLoadingMore: isLoadingMoreArchived,
     loadMore: loadMoreArchived,
-  } = useArchivedThreads();
+  } = useArchivedThreads({ teamId: selectedTeamId });
 
   const { approvals } = useActiveApprovals(organizationId);
 

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -12,6 +12,7 @@ import { useAutoScroll } from '@/app/hooks/use-auto-scroll';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
+import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
@@ -421,6 +422,7 @@ export function ChatInterface({
   );
 
   const userContext = useUserContext();
+  const teamFilter = useOptionalTeamFilter();
 
   const { sendMessage } = useSendMessage({
     organizationId,
@@ -440,6 +442,7 @@ export function ChatInterface({
       : undefined,
     userContext,
     arena: arenaContext ?? undefined,
+    teamId: teamFilter?.selectedTeamId ?? undefined,
   });
 
   const handleSendMessage = async (

--- a/services/platform/app/features/chat/components/chat-search-dialog.tsx
+++ b/services/platform/app/features/chat/components/chat-search-dialog.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/app/components/ui/forms/input';
 import { Text } from '@/app/components/ui/typography/text';
 import { useDebounce } from '@/app/hooks/use-debounce';
 import { useFormatDate } from '@/app/hooks/use-format-date';
+import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { filterByTextSearch } from '@/lib/utils/filtering';
@@ -37,8 +38,13 @@ export function ChatSearchDialog({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const debouncedQuery = useDebounce(query, 300);
+  const teamFilter = useOptionalTeamFilter();
+  const selectedTeamId = teamFilter?.selectedTeamId ?? undefined;
 
-  const { threads: allThreads } = useThreads({ skip: !isOpen });
+  const { threads: allThreads } = useThreads({
+    skip: !isOpen,
+    teamId: selectedTeamId,
+  });
 
   const threadsData = useMemo(() => {
     if (!allThreads) return null;

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -29,17 +29,22 @@ export interface Thread {
   status: 'active' | 'archived' | 'deleted';
   userId?: string;
   generationStatus?: 'generating' | 'idle';
+  teamId?: string;
 }
 
 const THREADS_PAGE_SIZE = 20;
 
-export function useThreads({ skip = false } = {}) {
+export function useThreads({
+  skip = false,
+  teamId,
+}: { skip?: boolean; teamId?: string | null } = {}) {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- paginationOpts is optional to handle Convex reconnection replays; usePaginatedQuery always provides it at runtime
   const listThreadsQuery = api.threads.queries
     .listThreads as unknown as Parameters<typeof useCachedPaginatedQuery>[0];
+  const queryArgs = skip ? ('skip' as const) : teamId ? { teamId } : {};
   const { results, status, loadMore, isLoading } = useCachedPaginatedQuery(
     listThreadsQuery,
-    skip ? 'skip' : {},
+    queryArgs,
     { initialNumItems: THREADS_PAGE_SIZE },
   );
 
@@ -57,15 +62,19 @@ export function useThreads({ skip = false } = {}) {
   };
 }
 
-export function useArchivedThreads({ skip = false } = {}) {
+export function useArchivedThreads({
+  skip = false,
+  teamId,
+}: { skip?: boolean; teamId?: string | null } = {}) {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- paginationOpts is optional to handle Convex reconnection replays; usePaginatedQuery always provides it at runtime
   const listArchivedThreadsQuery = api.threads.queries
     .listArchivedThreads as unknown as Parameters<
     typeof useCachedPaginatedQuery
   >[0];
+  const queryArgs = skip ? ('skip' as const) : teamId ? { teamId } : {};
   const { results, status, loadMore, isLoading } = useCachedPaginatedQuery(
     listArchivedThreadsQuery,
-    skip ? 'skip' : {},
+    queryArgs,
     { initialNumItems: THREADS_PAGE_SIZE },
   );
 

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -46,6 +46,7 @@ interface UseSendMessageParams {
   modelId?: string;
   userContext?: UserContext;
   arena?: ArenaParams;
+  teamId?: string;
 }
 
 /**
@@ -66,6 +67,7 @@ export function useSendMessage({
   modelId,
   userContext,
   arena,
+  teamId,
 }: UseSendMessageParams) {
   const { t } = useT('chat');
   const navigate = useNavigate();
@@ -165,6 +167,7 @@ export function useSendMessage({
               arenaModelId: modelB,
               isBranch: true,
               forkedFrom: tIdA,
+              teamId,
             });
             tIdB = newB;
             currentArena.setArenaThreadIdB(newB);
@@ -176,6 +179,7 @@ export function useSendMessage({
               chatType: 'general',
               arenaGroupId,
               arenaModelId: modelA,
+              teamId,
             });
             const newB = await createThread({
               organizationId,
@@ -185,6 +189,7 @@ export function useSendMessage({
               arenaModelId: modelB,
               isBranch: true,
               forkedFrom: newA,
+              teamId,
             });
 
             tIdA = newA;
@@ -252,6 +257,7 @@ export function useSendMessage({
               organizationId,
               title,
               chatType: 'general',
+              teamId,
             });
             currentThreadId = newThreadId;
             isFirstMessage = true;
@@ -342,6 +348,7 @@ export function useSendMessage({
       navigate,
       t,
       convexClient,
+      teamId,
     ],
   );
 

--- a/services/platform/convex/threads/create_branch_thread.ts
+++ b/services/platform/convex/threads/create_branch_thread.ts
@@ -69,6 +69,7 @@ export const createBranchThread = internalMutation({
       agentSlug: sourceMetadata.agentSlug,
       isBranch: true,
       forkedFrom: args.sourceThreadId,
+      ...(sourceMetadata.teamId && { teamId: sourceMetadata.teamId }),
     });
 
     // Create threadBranches record

--- a/services/platform/convex/threads/create_chat_thread.ts
+++ b/services/platform/convex/threads/create_chat_thread.ts
@@ -15,6 +15,7 @@ export async function createChatThread(
     isBranch?: boolean;
     forkedFrom?: string;
   },
+  teamId?: string,
 ): Promise<string> {
   const summary = JSON.stringify({ chatType });
   const resolvedTitle = title ?? 'New Chat';
@@ -38,6 +39,7 @@ export async function createChatThread(
     title: resolvedTitle,
     createdAt,
     updatedAt: createdAt,
+    ...(teamId && { teamId }),
     ...(arena && {
       arenaGroupId: arena.arenaGroupId,
       arenaModelId: arena.arenaModelId,

--- a/services/platform/convex/threads/fork_own_thread.ts
+++ b/services/platform/convex/threads/fork_own_thread.ts
@@ -65,6 +65,7 @@ export const forkOwnThread = mutation({
       updatedAt: createdAt,
       forkedFrom: metadata.threadId,
       forkedMessageCount: messages.length,
+      ...(metadata.teamId && { teamId: metadata.teamId }),
     });
 
     for (const msg of messages) {

--- a/services/platform/convex/threads/list_archived_threads.ts
+++ b/services/platform/convex/threads/list_archived_threads.ts
@@ -14,6 +14,7 @@ export async function listArchivedThreads(
   args: {
     userId: string;
     paginationOpts: PaginationOptions;
+    teamId?: string;
   },
 ): Promise<ListArchivedThreadsPaginatedResult> {
   const result = await ctx.db
@@ -24,6 +25,10 @@ export async function listArchivedThreads(
         .eq('chatType', 'general')
         .eq('status', 'archived'),
     )
+    .filter((q) => {
+      if (!args.teamId) return true;
+      return q.eq(q.field('teamId'), args.teamId);
+    })
     .order('desc')
     .paginate(args.paginationOpts);
 
@@ -35,6 +40,7 @@ export async function listArchivedThreads(
       status: row.status,
       userId: row.userId,
       generationStatus: row.generationStatus,
+      teamId: row.teamId,
     })),
     isDone: result.isDone,
     continueCursor: result.continueCursor,

--- a/services/platform/convex/threads/list_threads.test.ts
+++ b/services/platform/convex/threads/list_threads.test.ts
@@ -59,6 +59,7 @@ interface ThreadMetadataRow {
   title?: string;
   createdAt: number;
   updatedAt?: number;
+  teamId?: string;
 }
 
 let idCounter = 0;
@@ -68,6 +69,7 @@ function makeRow(overrides: {
   title?: string;
   createdAt?: number;
   updatedAt?: number;
+  teamId?: string;
 }): ThreadMetadataRow {
   idCounter++;
   const createdAt = overrides.createdAt ?? Date.now() - idCounter * 1000;
@@ -81,6 +83,7 @@ function makeRow(overrides: {
     title: overrides.title ?? `Thread ${overrides.threadId}`,
     createdAt,
     updatedAt: overrides.updatedAt,
+    teamId: overrides.teamId,
   };
 }
 
@@ -170,7 +173,7 @@ describe('listThreads', () => {
     expect(thread._creationTime).toBe(5000);
   });
 
-  it('should only include _id, _creationTime, title, status, userId, generationStatus in results', async () => {
+  it('should only include _id, _creationTime, title, status, userId, generationStatus, teamId in results', async () => {
     const ctx = makeMockCtx([
       makeRow({ threadId: 't1', title: 'Test Thread' }),
     ]);
@@ -186,6 +189,7 @@ describe('listThreads', () => {
       '_id',
       'generationStatus',
       'status',
+      'teamId',
       'title',
       'userId',
     ]);
@@ -254,5 +258,27 @@ describe('listThreads', () => {
 
     expect(result.page).toHaveLength(2);
     expect(result.isDone).toBe(true);
+  });
+
+  it('should return teamId in thread results', async () => {
+    const ctx = makeMockCtx([makeRow({ threadId: 't1', teamId: 'team_abc' })]);
+
+    const result = await listThreads(ctx, {
+      userId: 'user1',
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(result.page[0].teamId).toBe('team_abc');
+  });
+
+  it('should return undefined teamId for threads without team', async () => {
+    const ctx = makeMockCtx([makeRow({ threadId: 't1' })]);
+
+    const result = await listThreads(ctx, {
+      userId: 'user1',
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(result.page[0].teamId).toBeUndefined();
   });
 });

--- a/services/platform/convex/threads/list_threads.ts
+++ b/services/platform/convex/threads/list_threads.ts
@@ -29,6 +29,7 @@ export async function listThreads(
   ctx: QueryCtx,
   args: Pick<ListThreadsArgs, 'userId'> & {
     paginationOpts: PaginationOptions;
+    teamId?: string;
   },
 ): Promise<ListThreadsPaginatedResult> {
   const result = await ctx.db
@@ -39,7 +40,11 @@ export async function listThreads(
         .eq('chatType', 'general')
         .eq('status', 'active'),
     )
-    .filter((q) => q.neq(q.field('isBranch'), true))
+    .filter((q) => {
+      const notBranch = q.neq(q.field('isBranch'), true);
+      if (!args.teamId) return notBranch;
+      return q.and(notBranch, q.eq(q.field('teamId'), args.teamId));
+    })
     .order('desc')
     .paginate(args.paginationOpts);
 
@@ -51,6 +56,7 @@ export async function listThreads(
       status: row.status,
       userId: row.userId,
       generationStatus: row.generationStatus,
+      teamId: row.teamId,
     })),
     isDone: result.isDone,
     continueCursor: result.continueCursor,

--- a/services/platform/convex/threads/mutations.ts
+++ b/services/platform/convex/threads/mutations.ts
@@ -29,6 +29,7 @@ export const createChatThread = mutation({
     arenaModelId: v.optional(v.string()),
     isBranch: v.optional(v.boolean()),
     forkedFrom: v.optional(v.string()),
+    teamId: v.optional(v.string()),
   },
   returns: v.string(),
   handler: async (ctx, args) => {
@@ -50,6 +51,7 @@ export const createChatThread = mutation({
             forkedFrom: args.forkedFrom,
           }
         : undefined,
+      args.teamId,
     );
   },
 });

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -13,6 +13,7 @@ import { listThreads as listThreadsHelper } from './list_threads';
 export const listThreads = query({
   args: {
     paginationOpts: v.optional(paginationOptsValidator),
+    teamId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
@@ -27,6 +28,7 @@ export const listThreads = query({
     return await listThreadsHelper(ctx, {
       userId: authUser.userId,
       paginationOpts: args.paginationOpts ?? { cursor: null, numItems: 20 },
+      teamId: args.teamId,
     });
   },
 });
@@ -34,6 +36,7 @@ export const listThreads = query({
 export const listArchivedThreads = query({
   args: {
     paginationOpts: v.optional(paginationOptsValidator),
+    teamId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
@@ -48,6 +51,7 @@ export const listArchivedThreads = query({
     return await listArchivedThreadsHelper(ctx, {
       userId: authUser.userId,
       paginationOpts: args.paginationOpts ?? { cursor: null, numItems: 20 },
+      teamId: args.teamId,
     });
   },
 });

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -36,6 +36,8 @@ export const threadMetadataTable = defineTable({
   updatedAt: v.optional(v.number()),
   isBranch: v.optional(v.boolean()),
   branchSelections: v.optional(v.string()),
+  // Team/workspace assignment
+  teamId: v.optional(v.string()),
 })
   .index('by_threadId', ['threadId'])
   .index('by_userId_chatType_status', [

--- a/services/platform/convex/threads/types.ts
+++ b/services/platform/convex/threads/types.ts
@@ -23,6 +23,7 @@ export interface Thread {
   generationStatus?: 'generating' | 'idle';
   cancelledAt?: number;
   generationStartTime?: number;
+  teamId?: string;
 }
 
 export interface ThreadMessage {

--- a/services/platform/convex/threads/validators.ts
+++ b/services/platform/convex/threads/validators.ts
@@ -40,6 +40,7 @@ export const threadListItemValidator = v.object({
   title: v.optional(v.string()),
   status: threadStatusValidator,
   userId: v.optional(v.string()),
+  teamId: v.optional(v.string()),
 });
 
 export const latestToolMessageValidator = v.object({


### PR DESCRIPTION
## Summary

- Add `teamId` field to thread metadata schema so chats can be associated with a team/workspace
- Wire `teamId` through the full stack: schema, validators, types, queries, mutations, and frontend hooks
- Chat sidebar, search dialog, and thread list queries now filter by the active team when one is selected via the existing `TeamFilterProvider`
- New threads created from the chat interface inherit the currently selected team
- Forked and branched threads inherit `teamId` from their source thread

## Test plan

- [x] Server tests pass (`vitest run --project server`) -- 1957 tests
- [x] Client tests pass (`vitest run --project client`) -- 1852 tests
- [x] Lint passes (`bun run --filter @tale/platform lint`)
- [x] Typecheck passes (`bun run --filter @tale/platform typecheck`)
- [ ] Verify in browser: select a team in the sidebar filter, create a new chat -- it should appear only when that team is selected
- [ ] Verify in browser: with no team selected (All), all chats are visible regardless of teamId
- [ ] Verify in browser: forking a thread preserves the teamId from the source
- [ ] Verify in browser: archived threads respect the team filter
- [ ] Verify in browser: chat search dialog respects the team filter

Closes #1214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team-based filtering for chat threads—both active and archived threads now respect the currently selected team context.
  * Chat messages and new threads are now scoped to the selected team when available.
  * Team context is applied to chat search results for improved organization and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->