### PR TITLE
fix(platform): clear isPending on successful message send

### DIFF
--- a/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
@@ -132,6 +132,58 @@ describe('useSendMessage — error handling', () => {
     expect(params.setIsPending).not.toHaveBeenCalled();
   });
 
+  it('clears isPending on successful send', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.setIsPending).toHaveBeenCalledWith(true);
+    expect(params.setIsPending).toHaveBeenCalledWith(false);
+  });
+
+  it('clears isPending after successful thread creation and send', async () => {
+    mockCreateThread.mockResolvedValue('new_thread_id');
+    const params = createParams({ threadId: undefined });
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.setIsPending).toHaveBeenCalledWith(true);
+    expect(params.setIsPending).toHaveBeenCalledWith(false);
+  });
+
+  it('clears isPending on successful arena send', async () => {
+    mockCreateThread
+      .mockResolvedValueOnce('arena_a')
+      .mockResolvedValueOnce('arena_b');
+    mockArenaChat.mockResolvedValue(undefined);
+
+    const params = createParams({
+      arena: {
+        isArenaMode: true,
+        modelA: 'model-a',
+        modelB: 'model-b',
+        arenaThreadIdA: null,
+        arenaThreadIdB: null,
+        setArenaThreadIdA: vi.fn(),
+        setArenaThreadIdB: vi.fn(),
+      },
+    });
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(params.setIsPending).toHaveBeenCalledWith(true);
+    expect(params.setIsPending).toHaveBeenCalledWith(false);
+  });
+
   it('allows sending a new message after a previous error', async () => {
     mockChatWithAgent
       .mockRejectedValueOnce(new Error('Credit error'))

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -180,6 +180,8 @@ export function useSendMessage({
             copyHistoryToB: needsCopyHistory || undefined,
           });
 
+          setIsPending(false);
+
           // Navigate AFTER arena chat completes — split view is already
           // showing, so this just updates the URL without visual change.
           setPendingMessage({
@@ -274,6 +276,8 @@ export function useSendMessage({
                 }
               : undefined,
           });
+
+          setIsPending(false);
         }
       } catch (error) {
         console.error('Failed to send message:', error);


### PR DESCRIPTION
## Summary

- Fix chat input becoming stuck/disabled after sending a message by adding explicit `setIsPending(false)` calls in the success paths of `useSendMessage`
- The catch block already cleared pending state via `clearChatState()`, but the success paths relied solely on the reactive handoff in `useChatLoadingState`, which could miss on slow networks or when React batched state updates
- Add tests verifying `isPending` is cleared on successful standard send, new thread creation send, and arena mode send

## Test plan

- [x] Lint passes (`bun run --filter @tale/platform lint`)
- [x] Typecheck passes (`bun run --filter @tale/platform typecheck`)
- [x] Server tests pass (156 files, 1955 tests)
- [x] Client tests pass (245 files, 1855 tests)
- [ ] Manual: send a message and verify the input field re-enables after the AI response begins
- [ ] Manual: send a message on a slow network and verify the input does not stay stuck
- [ ] Manual: send a message in arena mode and verify both panels load and input re-enables

Closes #1339