### PR TITLE
fix(platform): improve model validation and error surfacing for AI failures

### DIFF
--- a/examples/agents/chat-agent.json
+++ b/examples/agents/chat-agent.json
@@ -34,7 +34,6 @@
     "meta-llama/llama-4-scout",
     "qwen/qwen3.5-35b-a3b",
     "qwen/qwen3-next-80b-a3b-instruct",
-    "qwen/qwen3-embedding-4b",
     "qwen/qwen3-vl-32b-instruct"
   ],
   "knowledgeMode": "tool",

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -62,6 +62,22 @@ function InstructionsTab() {
     return map;
   }, [providers]);
 
+  const modelTagsMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const provider of providers) {
+      if (
+        !provider ||
+        !('models' in provider) ||
+        !Array.isArray(provider.models)
+      )
+        continue;
+      for (const model of provider.models) {
+        map.set(model.id, model.tags ?? []);
+      }
+    }
+    return map;
+  }, [providers]);
+
   const availableOptions = useMemo(() => {
     const allModels: { id: string; displayName: string }[] = [];
     for (const provider of providers) {
@@ -79,8 +95,19 @@ function InstructionsTab() {
     const selected = new Set(selectedModels);
     return allModels
       .filter((m) => !selected.has(m.id))
-      .map((m) => ({ value: m.id, label: m.displayName }));
-  }, [providers, selectedModels, config.provider]);
+      .map((m) => {
+        const tags = modelTagsMap.get(m.id) ?? [];
+        const isEmbeddingOnly =
+          tags.includes('embedding') && !tags.includes('chat');
+        return {
+          value: m.id,
+          label: m.displayName,
+          description: isEmbeddingOnly
+            ? t('agents.form.embeddingModelWarning')
+            : undefined,
+        };
+      });
+  }, [providers, selectedModels, config.provider, modelTagsMap, t]);
 
   const getDisplayName = useCallback(
     (modelId: string) =>

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -442,10 +442,51 @@ export const resolveAgentConfig = internalAction({
       },
     );
 
+    // Cross-validate supportedModels against provider model lists so the
+    // user is never presented with models that cannot be resolved.
+    const allModels = await ctx.runAction(
+      internal.providers.file_actions.getAllModelIds,
+      { orgSlug: args.orgSlug },
+    );
+
+    const providerModelIds = new Set<string>();
+    const chatModelIds = new Set<string>();
+    for (const m of allModels) {
+      providerModelIds.add(m.id);
+      if (m.tags.includes('chat')) {
+        chatModelIds.add(m.id);
+      }
+    }
+
+    const validatedModels = result.config.supportedModels.filter((modelId) => {
+      if (!providerModelIds.has(modelId)) {
+        console.warn(
+          `[resolveAgentConfig] Agent "${args.agentSlug}": model "${modelId}" not found in any provider, filtering out.`,
+        );
+        return false;
+      }
+      if (!chatModelIds.has(modelId)) {
+        console.warn(
+          `[resolveAgentConfig] Agent "${args.agentSlug}": model "${modelId}" lacks the "chat" tag, filtering out.`,
+        );
+        return false;
+      }
+      return true;
+    });
+
+    // Use validated models but fall back to original if all were filtered out
+    const effectiveConfig = {
+      ...result.config,
+      supportedModels:
+        validatedModels.length > 0
+          ? validatedModels
+          : result.config.supportedModels,
+    };
+
     const { toSerializableConfig } = await import('./config');
     const config = toSerializableConfig(
       args.agentSlug,
-      result.config,
+      effectiveConfig,
       binding
         ? {
             teamId: binding.teamId ?? undefined,

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -53,7 +53,10 @@ import {
 } from '../context_management/constants';
 import { createAgentConfig } from '../create_agent_config';
 import { createDebugLog } from '../debug_log';
-import { NonRetryableError } from '../error_classification';
+import {
+  NonRetryableError,
+  classifyProviderError,
+} from '../error_classification';
 
 const debugLog = createDebugLog('DEBUG_CHAT_AGENT', '[runAgentGeneration]');
 
@@ -626,16 +629,16 @@ export const runAgentGeneration = internalAction({
         );
         const hasFailedAssistant = newestAssistant?.status === 'failed';
         if (!hasFailedAssistant) {
+          const providerError = classifyProviderError(error);
           await saveMessage(ctx, components.agent, {
             threadId,
             message: {
               role: 'assistant',
-              content:
-                'I was unable to complete your request. Please try again.',
+              content: providerError.userMessage,
             },
             metadata: {
               status: 'failed',
-              error: getString(err, 'message') ?? 'Unknown error',
+              error: `[${providerError.errorType}] ${getString(err, 'message') ?? 'Unknown error'}`,
             },
           });
         }

--- a/services/platform/convex/lib/error_classification.test.ts
+++ b/services/platform/convex/lib/error_classification.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyError,
+  classifyProviderError,
+  NonRetryableError,
+} from './error_classification';
+
+describe('classifyError', () => {
+  it('classifies 400 as non-retryable bad_request', () => {
+    const result = classifyError({ status: 400, message: 'Bad request' });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.reason).toBe('bad_request');
+  });
+
+  it('classifies 401 as non-retryable auth_error', () => {
+    const result = classifyError({ status: 401, message: 'Unauthorized' });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.reason).toBe('auth_error');
+  });
+
+  it('classifies 403 as non-retryable auth_error', () => {
+    const result = classifyError({ status: 403, message: 'Forbidden' });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.reason).toBe('auth_error');
+  });
+
+  it('classifies 404 as non-retryable not_found', () => {
+    const result = classifyError({ status: 404, message: 'Not found' });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.reason).toBe('not_found');
+  });
+
+  it('classifies 429 as retryable rate_limit', () => {
+    const result = classifyError({ status: 429, message: 'Too many requests' });
+    expect(result.shouldRetry).toBe(true);
+    expect(result.reason).toBe('rate_limit');
+  });
+
+  it('classifies 502 as retryable server_error', () => {
+    const result = classifyError({ status: 502, message: 'Bad gateway' });
+    expect(result.shouldRetry).toBe(true);
+    expect(result.reason).toBe('server_error');
+  });
+
+  it('classifies "model not found" message as non-retryable', () => {
+    const result = classifyError({ message: 'model not found on provider' });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.reason).toBe('invalid_model');
+  });
+});
+
+describe('classifyProviderError', () => {
+  it('returns model_not_found for 404 errors', () => {
+    const result = classifyProviderError({
+      status: 404,
+      message: 'Not found',
+    });
+    expect(result.errorType).toBe('model_not_found');
+    expect(result.userMessage).toContain('not found');
+  });
+
+  it('returns auth_failed for 401 errors', () => {
+    const result = classifyProviderError({
+      status: 401,
+      message: 'Unauthorized',
+    });
+    expect(result.errorType).toBe('auth_failed');
+    expect(result.userMessage).toContain('API key');
+  });
+
+  it('returns auth_failed for 403 errors', () => {
+    const result = classifyProviderError({
+      status: 403,
+      message: 'Forbidden',
+    });
+    expect(result.errorType).toBe('auth_failed');
+    expect(result.userMessage).toContain('access');
+  });
+
+  it('returns rate_limited for 429 errors', () => {
+    const result = classifyProviderError({
+      status: 429,
+      message: 'Rate limit exceeded',
+    });
+    expect(result.errorType).toBe('rate_limited');
+    expect(result.userMessage).toContain('rate limit');
+  });
+
+  it('returns bad_request for 400 errors', () => {
+    const result = classifyProviderError({
+      status: 400,
+      message: 'Invalid request',
+    });
+    expect(result.errorType).toBe('bad_request');
+  });
+
+  it('returns provider_error for 500+ errors', () => {
+    const result = classifyProviderError({
+      status: 502,
+      message: 'Bad gateway',
+    });
+    expect(result.errorType).toBe('provider_error');
+  });
+
+  it('returns model_not_found for "model not found" message regardless of status', () => {
+    const result = classifyProviderError({
+      message: 'Model "test/model" not found in any provider',
+    });
+    expect(result.errorType).toBe('model_not_found');
+  });
+
+  it('returns unknown for unrecognized errors', () => {
+    const result = classifyProviderError({
+      message: 'Something unexpected happened',
+    });
+    expect(result.errorType).toBe('unknown');
+  });
+
+  it('handles non-object errors gracefully', () => {
+    const result = classifyProviderError('string error');
+    expect(result.errorType).toBe('unknown');
+  });
+
+  it('handles null error gracefully', () => {
+    const result = classifyProviderError(null);
+    expect(result.errorType).toBe('unknown');
+  });
+
+  it('returns provider_error for 503 errors', () => {
+    const result = classifyProviderError({
+      status: 503,
+      message: 'Service unavailable',
+    });
+    expect(result.errorType).toBe('provider_error');
+    expect(result.userMessage).toContain('experiencing issues');
+  });
+
+  it('uses statusCode property when status is absent', () => {
+    const result = classifyProviderError({
+      statusCode: 429,
+      message: 'Rate limit',
+    });
+    expect(result.errorType).toBe('rate_limited');
+  });
+});
+
+describe('NonRetryableError', () => {
+  it('preserves original error and reason', () => {
+    const original = new Error('original');
+    const err = new NonRetryableError('wrapped', original, 'bad_request');
+    expect(err.message).toBe('wrapped');
+    expect(err.originalError).toBe(original);
+    expect(err.errorReason).toBe('bad_request');
+    expect(err.isNonRetryable).toBe(true);
+  });
+});

--- a/services/platform/convex/lib/error_classification.ts
+++ b/services/platform/convex/lib/error_classification.ts
@@ -231,6 +231,105 @@ export class NonRetryableError extends Error {
 }
 
 /**
+ * Provider error classification for user-facing messages.
+ *
+ * Maps HTTP status codes and error patterns to actionable descriptions
+ * that tell the user what went wrong and what to do about it.
+ */
+export interface ProviderErrorClassification {
+  errorType:
+    | 'model_not_found'
+    | 'auth_failed'
+    | 'rate_limited'
+    | 'bad_request'
+    | 'provider_error'
+    | 'unknown';
+  userMessage: string;
+}
+
+export function classifyProviderError(
+  error: unknown,
+): ProviderErrorClassification {
+  const isObject = (val: unknown): val is Record<string, unknown> =>
+    val !== null && typeof val === 'object';
+
+  const err = isObject(error) ? error : {};
+
+  const status =
+    typeof err.status === 'number'
+      ? err.status
+      : typeof err.statusCode === 'number'
+        ? err.statusCode
+        : undefined;
+  const message = (
+    typeof err.message === 'string' ? err.message : ''
+  ).toLowerCase();
+
+  // Check message-based patterns first (more specific than status code)
+  if (message.includes('model') && message.includes('not found')) {
+    return {
+      errorType: 'model_not_found',
+      userMessage:
+        'The selected model was not found on the provider. It may have been renamed or is not available.',
+    };
+  }
+
+  if (status === 404) {
+    return {
+      errorType: 'model_not_found',
+      userMessage:
+        'The selected model was not found on the provider. It may have been renamed or is not available.',
+    };
+  }
+
+  if (status === 401) {
+    return {
+      errorType: 'auth_failed',
+      userMessage:
+        'The API key is invalid or expired. Check your provider configuration.',
+    };
+  }
+
+  if (status === 403) {
+    return {
+      errorType: 'auth_failed',
+      userMessage:
+        'The API key does not have access to this model. Check your provider permissions.',
+    };
+  }
+
+  if (status === 429) {
+    return {
+      errorType: 'rate_limited',
+      userMessage:
+        'The rate limit was exceeded for this model. Try again later or switch to a different model.',
+    };
+  }
+
+  if (status === 400) {
+    return {
+      errorType: 'bad_request',
+      userMessage:
+        'The model rejected the request. This may be a compatibility issue with the current tools or message format.',
+    };
+  }
+
+  if (status !== undefined && status >= 500) {
+    return {
+      errorType: 'provider_error',
+      userMessage:
+        'The model provider is experiencing issues. Try again later or switch to a different model.',
+    };
+  }
+
+  return {
+    errorType: 'unknown',
+    userMessage:
+      'An unexpected error occurred. Try again or switch to a different model.',
+  };
+}
+
+/**
  * Wraps an error based on its classification.
  * Non-retryable errors are wrapped in NonRetryableError.
  * Retryable errors are returned as-is.

--- a/services/platform/convex/providers/errors.test.ts
+++ b/services/platform/convex/providers/errors.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTransientProviderError, ProviderUnavailableError } from './errors';
+
+describe('isTransientProviderError', () => {
+  it('returns null for null/undefined', () => {
+    expect(isTransientProviderError(null)).toBeNull();
+    expect(isTransientProviderError(undefined)).toBeNull();
+  });
+
+  it('detects 429 as transient', () => {
+    const result = isTransientProviderError({ status: 429 });
+    expect(result).not.toBeNull();
+    expect(result?.statusCode).toBe(429);
+    expect(result?.isTimeout).toBe(false);
+  });
+
+  it('detects 502 as transient', () => {
+    const result = isTransientProviderError({ status: 502 });
+    expect(result).not.toBeNull();
+    expect(result?.statusCode).toBe(502);
+  });
+
+  it('detects 503 as transient', () => {
+    const result = isTransientProviderError({ status: 503 });
+    expect(result).not.toBeNull();
+  });
+
+  it('detects 504 as transient', () => {
+    const result = isTransientProviderError({ status: 504 });
+    expect(result).not.toBeNull();
+  });
+
+  it('does not detect 400 as transient', () => {
+    expect(isTransientProviderError({ status: 400 })).toBeNull();
+  });
+
+  it('does not detect 401 as transient', () => {
+    expect(isTransientProviderError({ status: 401 })).toBeNull();
+  });
+
+  it('does not detect 404 as transient', () => {
+    expect(isTransientProviderError({ status: 404 })).toBeNull();
+  });
+
+  it('detects timeout messages', () => {
+    const result = isTransientProviderError({ message: 'Request timed out' });
+    expect(result).not.toBeNull();
+    expect(result?.isTimeout).toBe(true);
+  });
+
+  it('detects ETIMEDOUT code', () => {
+    const result = isTransientProviderError({ code: 'ETIMEDOUT' });
+    expect(result).not.toBeNull();
+    expect(result?.isTimeout).toBe(true);
+  });
+
+  it('detects rate limit messages', () => {
+    const result = isTransientProviderError({
+      message: 'rate limit exceeded',
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('detects overloaded messages', () => {
+    const result = isTransientProviderError({
+      message: 'server is overloaded',
+    });
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('ProviderUnavailableError', () => {
+  it('stores provider and model info', () => {
+    const err = new ProviderUnavailableError(
+      'test error',
+      'openrouter',
+      'test/model',
+      502,
+    );
+    expect(err.provider).toBe('openrouter');
+    expect(err.model).toBe('test/model');
+    expect(err.statusCode).toBe(502);
+    expect(err.name).toBe('ProviderUnavailableError');
+  });
+});

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -301,7 +301,9 @@ export const resolveModelData = internalAction({
           modelId: args.modelId,
           maxOutputTokens: definition.maxOutputTokens,
           supportsStructuredOutputs:
-            provider.config.supportsStructuredOutputs ?? false,
+            definition.supportsStructuredOutputs ??
+            provider.config.supportsStructuredOutputs ??
+            false,
           inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
           outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
         };
@@ -371,7 +373,9 @@ export const resolveModelByTag = internalAction({
             dimensions: definition.dimensions,
             maxOutputTokens: definition.maxOutputTokens,
             supportsStructuredOutputs:
-              provider.config.supportsStructuredOutputs ?? false,
+              definition.supportsStructuredOutputs ??
+              provider.config.supportsStructuredOutputs ??
+              false,
             inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
             outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
           };
@@ -393,7 +397,9 @@ export const resolveModelByTag = internalAction({
           dimensions: definition.dimensions,
           maxOutputTokens: definition.maxOutputTokens,
           supportsStructuredOutputs:
-            provider.config.supportsStructuredOutputs ?? false,
+            definition.supportsStructuredOutputs ??
+            provider.config.supportsStructuredOutputs ??
+            false,
           inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
           outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
         };
@@ -403,6 +409,36 @@ export const resolveModelByTag = internalAction({
     throw new Error(
       `No model with tag "${args.tag}" found${args.providerName ? ` in provider "${args.providerName}"` : ' in any provider'}.`,
     );
+  },
+});
+
+/**
+ * Get all model IDs with their tags across all providers.
+ * Used for cross-validation of agent supportedModels at config time.
+ */
+export const getAllModelIds = internalAction({
+  args: { orgSlug: v.optional(v.string()) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      tags: v.array(v.string()),
+    }),
+  ),
+  handler: async (_ctx, args) => {
+    const orgSlug = args.orgSlug ?? 'default';
+    let providers: ProviderWithSecrets[];
+    try {
+      providers = await loadAllProviders(orgSlug);
+    } catch {
+      return [];
+    }
+    const models: Array<{ id: string; tags: string[] }> = [];
+    for (const provider of providers) {
+      for (const m of provider.config.models) {
+        models.push({ id: m.id, tags: [...m.tags] });
+      }
+    }
+    return models;
   },
 });
 

--- a/services/platform/lib/shared/schemas/providers.test.ts
+++ b/services/platform/lib/shared/schemas/providers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { providerJsonSchema } from './providers';
+
+describe('providerJsonSchema', () => {
+  const baseProvider = {
+    displayName: 'Test Provider',
+    baseUrl: 'https://api.example.com/v1',
+    models: [
+      {
+        id: 'test/model-1',
+        displayName: 'Test Model 1',
+        tags: ['chat'],
+      },
+    ],
+  };
+
+  describe('supportsStructuredOutputs', () => {
+    it('accepts provider-level supportsStructuredOutputs', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        supportsStructuredOutputs: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts per-model supportsStructuredOutputs', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        supportsStructuredOutputs: true,
+        models: [
+          {
+            id: 'test/model-1',
+            displayName: 'Test Model 1',
+            tags: ['chat'],
+            supportsStructuredOutputs: false,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.models[0].supportsStructuredOutputs).toBe(false);
+      }
+    });
+
+    it('defaults per-model supportsStructuredOutputs to undefined when not set', () => {
+      const result = providerJsonSchema.safeParse(baseProvider);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.models[0].supportsStructuredOutputs).toBeUndefined();
+      }
+    });
+  });
+
+  describe('model ID uniqueness', () => {
+    it('rejects duplicate model IDs', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        models: [
+          { id: 'test/model-1', displayName: 'Model A', tags: ['chat'] },
+          { id: 'test/model-1', displayName: 'Model B', tags: ['chat'] },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('defaults validation', () => {
+    it('rejects defaults referencing unknown model IDs', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        defaults: { chat: 'nonexistent/model' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects defaults referencing model without matching tag', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        models: [
+          { id: 'test/embed', displayName: 'Embed', tags: ['embedding'] },
+        ],
+        defaults: { chat: 'test/embed' },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -11,6 +11,7 @@ const modelDefinitionSchema = z.object({
   tags: z.array(modelTagSchema).min(1),
   dimensions: z.number().int().positive().optional(),
   maxOutputTokens: z.number().int().positive().optional(),
+  supportsStructuredOutputs: z.boolean().optional(),
   fallbackModelId: z.string().min(1).max(200).optional(),
   cost: z
     .object({

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -867,6 +867,7 @@
         "searchModels": "Modelle suchen…",
         "noModelsFound": "Keine Modelle gefunden",
         "removeModel": "Entfernen",
+        "embeddingModelWarning": "Nur Embedding-Modell — nicht für Chat nutzbar",
         "modelSelector": {
           "moveUp": "Modell nach oben verschieben",
           "moveDown": "Modell nach unten verschieben",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -870,6 +870,7 @@
         "searchModels": "Search models…",
         "noModelsFound": "No models found",
         "removeModel": "Remove",
+        "embeddingModelWarning": "Embedding-only model — not usable for chat",
         "modelSelector": {
           "moveUp": "Move model up",
           "moveDown": "Move model down",


### PR DESCRIPTION
## Summary

- Remove invalid `qwen/qwen3-embedding-4b` from chat agent's `supportedModels` (embedding model with mismatched ID)
- Add cross-validation in `resolveAgentConfig` that filters out models not found in any provider or lacking the `chat` tag
- Classify provider errors by HTTP status code (404/401/403/429/400/5xx) and surface actionable user-facing messages instead of the generic "I was unable to complete your request"
- Add per-model `supportsStructuredOutputs` override in the provider schema, falling back to provider-level setting
- Show an "Embedding-only model" warning in the agent instructions model selector for non-chat models
- Add `getAllModelIds` internal action for cross-validation of agent models against provider configs

Closes #1289
Closes #1288

## Test plan

- [x] Lint passes (0 warnings, 0 errors)
- [x] Typecheck passes
- [x] Server tests pass (159 files, 1994 tests)
- [x] Client tests pass (404 files, 3846 tests)
- [ ] Verify `qwen/qwen3-embedding-4b` no longer appears in chat model selector
- [ ] Verify embedding-only models show warning description in model selector dropdown
- [ ] Verify failed model requests show specific error messages (not generic)
- [ ] Verify cross-validation filters out invalid models from agent config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Models are now validated for chat capability; embedding-only models are identified with a warning message before use.
  * Enhanced error handling and user-facing messages for provider-related issues.

* **Bug Fixes**
  * Removed unsupported model from the default list to prevent configuration errors.

* **Documentation**
  * Added German and English localization for embedding-model warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->