### PR TITLE
feat(platform): expose RAG citations in OpenAI-compatible API

### DIFF
--- a/services/platform/convex/openai_compat/citations.test.ts
+++ b/services/platform/convex/openai_compat/citations.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCitationsFromToolsUsage } from './citations';
+
+describe('parseCitationsFromToolsUsage', () => {
+  it('parses RAG citations from tool output', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output:
+          '[1] (Relevance: 87.3%) [Source: report.pdf] [Page: 42] [Modified: 2023-06-15] [FileID: doc-123]\nSome content here\n\n---\n\n[2] (Relevance: 72.1%) [Source: memo.docx] [Created: 2024-01-01] [FileID: doc-456]\nOther content',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      index: 1,
+      type: 'rag',
+      source: 'report.pdf',
+      fileId: 'doc-123',
+      page: 42,
+      relevance: 0.873,
+    });
+    expect(result[1]).toEqual({
+      index: 2,
+      type: 'rag',
+      source: 'memo.docx',
+      fileId: 'doc-456',
+      page: undefined,
+      relevance: 0.721,
+    });
+  });
+
+  it('parses web citations from tool output', () => {
+    const toolsUsage = [
+      {
+        toolName: 'web',
+        output:
+          '[1] (Relevance: 85.2%) [Source: Example Page] [URL: https://example.com]\nPage content\n\n---\n\n[2] (Relevance: 65.0%) [Source: Another Page] [URL: https://other.com/path]\nMore content',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      index: 1,
+      type: 'web',
+      source: 'Example Page',
+      url: 'https://example.com',
+      relevance: 0.852,
+    });
+    expect(result[1]).toEqual({
+      index: 2,
+      type: 'web',
+      source: 'Another Page',
+      url: 'https://other.com/path',
+      relevance: 0.65,
+    });
+  });
+
+  it('offsets web citation indices after RAG citations', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output:
+          '[1] (Relevance: 90.0%) [Source: doc.pdf] [FileID: doc-1]\nContent\n\n---\n\n[2] (Relevance: 80.0%) [Source: doc2.pdf] [FileID: doc-2]\nContent',
+      },
+      {
+        toolName: 'web',
+        output:
+          '[1] (Relevance: 75.0%) [Source: Web Page] [URL: https://web.com]\nContent',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].index).toBe(1);
+    expect(result[0].type).toBe('rag');
+    expect(result[1].index).toBe(2);
+    expect(result[1].type).toBe('rag');
+    expect(result[2].index).toBe(3);
+    expect(result[2].type).toBe('web');
+  });
+
+  it('returns empty array for empty toolsUsage', () => {
+    expect(parseCitationsFromToolsUsage([])).toEqual([]);
+  });
+
+  it('returns empty array when no tools have output', () => {
+    const toolsUsage = [
+      { toolName: 'rag_search', output: undefined },
+      { toolName: 'web', output: '' },
+    ];
+
+    expect(parseCitationsFromToolsUsage(toolsUsage)).toEqual([]);
+  });
+
+  it('ignores tools that are not rag_search or web', () => {
+    const toolsUsage = [
+      {
+        toolName: 'some_other_tool',
+        output: '[1] (Relevance: 50.0%) [Source: test] [FileID: x]\nContent',
+      },
+    ];
+
+    expect(parseCitationsFromToolsUsage(toolsUsage)).toEqual([]);
+  });
+
+  it('unwraps JSON-stringified output', () => {
+    const rawOutput =
+      '[1] (Relevance: 87.3%) [Source: report.pdf] [FileID: doc-123]\nContent';
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output: JSON.stringify(rawOutput),
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('report.pdf');
+  });
+
+  it('deduplicates citations with same source identity', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output:
+          '[1] (Relevance: 90.0%) [Source: doc.pdf] [Page: 1] [FileID: doc-1]\nContent\n\n---\n\n[2] (Relevance: 85.0%) [Source: doc.pdf] [Page: 1] [FileID: doc-1]\nMore content from same page',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].index).toBe(1);
+  });
+
+  it('keeps citations from same file but different pages', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output:
+          '[1] (Relevance: 90.0%) [Source: doc.pdf] [Page: 1] [FileID: doc-1]\nContent\n\n---\n\n[2] (Relevance: 85.0%) [Source: doc.pdf] [Page: 5] [FileID: doc-1]\nContent from different page',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('deduplicates web citations with same URL', () => {
+    const toolsUsage = [
+      {
+        toolName: 'web',
+        output:
+          '[1] (Relevance: 90.0%) [Source: Page A] [URL: https://example.com]\nContent\n\n---\n\n[2] (Relevance: 80.0%) [Source: Page B] [URL: https://example.com]\nDuplicate URL content',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('Page A');
+  });
+
+  it('sorts citations by index', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output:
+          '[3] (Relevance: 70.0%) [Source: c.pdf] [FileID: doc-3]\nC\n\n---\n\n[1] (Relevance: 90.0%) [Source: a.pdf] [FileID: doc-1]\nA\n\n---\n\n[2] (Relevance: 80.0%) [Source: b.pdf] [FileID: doc-2]\nB',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result.map((c) => c.index)).toEqual([1, 2, 3]);
+  });
+
+  it('handles RAG citation without optional fields', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output: '[1] (Relevance: 50.0%)\nMinimal content',
+      },
+    ];
+
+    const result = parseCitationsFromToolsUsage(toolsUsage);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      index: 1,
+      type: 'rag',
+      source: 'Unknown',
+      fileId: undefined,
+      page: undefined,
+      relevance: 0.5,
+    });
+  });
+
+  it('handles malformed output gracefully', () => {
+    const toolsUsage = [
+      {
+        toolName: 'rag_search',
+        output: 'This is not a citation format at all',
+      },
+    ];
+
+    expect(parseCitationsFromToolsUsage(toolsUsage)).toEqual([]);
+  });
+});

--- a/services/platform/convex/openai_compat/citations.ts
+++ b/services/platform/convex/openai_compat/citations.ts
@@ -1,0 +1,145 @@
+/**
+ * Server-side citation parser for OpenAI-compatible API responses.
+ *
+ * Extracts structured citation metadata from tool usage output strings
+ * produced by rag_search and web search tools.
+ *
+ * The regex patterns here MUST match the format produced by:
+ * - convex/agent_tools/rag/format_search_results.ts (RAG format)
+ * - convex/agent_tools/web/helpers/format_web_results.ts (web format)
+ */
+
+export interface Citation {
+  index: number;
+  type: 'rag' | 'web';
+  source: string;
+  fileId?: string;
+  url?: string;
+  page?: number;
+  relevance: number;
+}
+
+interface ToolUsageInput {
+  toolName: string;
+  output?: string;
+}
+
+const RAG_CITATION_PATTERN =
+  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[Page:\s*(\d+)\])?(?:\s*\[(?:Modified|Created):\s*[^\]]+\])?(?:\s*\[FileID:\s*([^\]]+)\])?/g;
+
+const WEB_CITATION_PATTERN =
+  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[URL:\s*([^\]]+)\])?/g;
+
+function parseRagCitations(text: string): Citation[] {
+  const citations: Citation[] = [];
+  let match;
+  RAG_CITATION_PATTERN.lastIndex = 0;
+  while ((match = RAG_CITATION_PATTERN.exec(text)) !== null) {
+    citations.push({
+      index: parseInt(match[1], 10),
+      type: 'rag',
+      source: match[3] || 'Unknown',
+      fileId: match[5] || undefined,
+      page: match[4] ? parseInt(match[4], 10) : undefined,
+      relevance: parseFloat(match[2]) / 100,
+    });
+  }
+  return citations;
+}
+
+function parseWebCitations(text: string): Citation[] {
+  const citations: Citation[] = [];
+  let match;
+  WEB_CITATION_PATTERN.lastIndex = 0;
+  while ((match = WEB_CITATION_PATTERN.exec(text)) !== null) {
+    citations.push({
+      index: parseInt(match[1], 10),
+      type: 'web',
+      source: match[3] || 'Unknown',
+      url: match[4] || undefined,
+      relevance: parseFloat(match[2]) / 100,
+    });
+  }
+  return citations;
+}
+
+/**
+ * Unwrap a JSON-stringified output value.
+ *
+ * toolsUsage.output is safeStringify'd, so it may be wrapped
+ * in an extra layer of JSON string quotes.
+ */
+function unwrapOutput(output: string): string {
+  if (output.startsWith('"') && output.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(output);
+      if (typeof parsed === 'string') {
+        return parsed;
+      }
+    } catch {
+      // use as-is
+    }
+  }
+  return output;
+}
+
+/**
+ * Parse citations from tool usage records.
+ *
+ * Processes RAG and web tool outputs in order, offsetting web citation
+ * numbers by the max RAG citation number to avoid collisions.
+ * Returns a deduplicated, sorted array of Citation objects.
+ */
+export function parseCitationsFromToolsUsage(
+  toolsUsage: ToolUsageInput[],
+): Citation[] {
+  const allCitations: Citation[] = [];
+  let maxRagIndex = 0;
+
+  for (const usage of toolsUsage) {
+    if (!usage.output) continue;
+
+    const output = unwrapOutput(usage.output);
+
+    if (usage.toolName === 'rag_search') {
+      const ragCitations = parseRagCitations(output);
+      for (const citation of ragCitations) {
+        allCitations.push(citation);
+        if (citation.index > maxRagIndex) maxRagIndex = citation.index;
+      }
+    } else if (usage.toolName === 'web') {
+      const webCitations = parseWebCitations(output);
+      for (const citation of webCitations) {
+        allCitations.push({
+          ...citation,
+          index: citation.index + maxRagIndex,
+        });
+      }
+    }
+  }
+
+  return deduplicateAndSort(allCitations);
+}
+
+/**
+ * Deduplicate citations by source identity (same fileId+page or same URL).
+ * Keeps the first occurrence of each unique source.
+ */
+function deduplicateAndSort(citations: Citation[]): Citation[] {
+  const seen = new Set<string>();
+  const deduped: Citation[] = [];
+
+  for (const citation of citations) {
+    const sourceKey =
+      citation.type === 'rag'
+        ? `rag:${citation.fileId ?? ''}:${citation.page ?? ''}`
+        : `web:${citation.url ?? ''}`;
+
+    if (!seen.has(sourceKey)) {
+      seen.add(sourceKey);
+      deduped.push(citation);
+    }
+  }
+
+  return deduped.sort((a, b) => a.index - b.index);
+}

--- a/services/platform/convex/openai_compat/http_actions.ts
+++ b/services/platform/convex/openai_compat/http_actions.ts
@@ -24,10 +24,12 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { persistentStreaming } from '../streaming/helpers';
 import { extractClientIp } from '../workflows/triggers/helpers/validate';
+import { parseCitationsFromToolsUsage } from './citations';
 import {
   buildChatCompletion,
   buildChatCompletionChunk,
   buildChatCompletionWithToolCalls,
+  formatSSECitations,
   formatSSEChunk,
   formatSSEDone,
   openAIErrorResponse,
@@ -684,11 +686,20 @@ async function pollOpenAIResponse(
     const body = await persistentStreaming.getStreamBody(ctx, streamId);
 
     if (body.status === 'done') {
+      const toolsUsage = await ctx.runQuery(
+        internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
+        { threadId: chatResult.threadId },
+      );
+      const citations = toolsUsage
+        ? parseCitationsFromToolsUsage(toolsUsage)
+        : [];
+
       const response = buildChatCompletion(
         chatResult.streamId,
         model,
         body.text,
         created,
+        citations,
       );
       return new Response(JSON.stringify(response), {
         status: 200,
@@ -784,6 +795,17 @@ async function streamOpenAIResponse(
           created,
         );
         await writer.write(encoder.encode(formatSSEChunk(finalChunk)));
+
+        const toolsUsage = await ctx.runQuery(
+          internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
+          { threadId: chatResult.threadId },
+        );
+        const citations = toolsUsage
+          ? parseCitationsFromToolsUsage(toolsUsage)
+          : [];
+        if (citations.length > 0) {
+          await writer.write(encoder.encode(formatSSECitations(citations)));
+        }
       }
 
       await writer.write(encoder.encode(formatSSEDone()));

--- a/services/platform/convex/openai_compat/internal_queries.ts
+++ b/services/platform/convex/openai_compat/internal_queries.ts
@@ -1,7 +1,8 @@
 /**
  * Internal queries for OpenAI-compatible endpoint.
  *
- * Provides organization resolution from API key user context.
+ * Provides organization resolution and metadata queries
+ * for the API key user context.
  */
 
 import { v } from 'convex/values';
@@ -83,5 +84,41 @@ export const resolveUserOrganization = internalQuery({
     }
 
     return { organizationId: orgId, orgSlug: slug };
+  },
+});
+
+/**
+ * Fetch the latest toolsUsage for a thread.
+ *
+ * In agent mode, each request creates a single assistant message.
+ * This query retrieves the most recent messageMetadata for the thread
+ * and returns its toolsUsage array (used to build API citation data).
+ */
+export const getLatestThreadToolsUsage = internalQuery({
+  args: {
+    threadId: v.string(),
+  },
+  returns: v.union(
+    v.array(
+      v.object({
+        toolName: v.string(),
+        output: v.optional(v.string()),
+      }),
+    ),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const metadata = await ctx.db
+      .query('messageMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
+      .order('desc')
+      .first();
+
+    if (!metadata?.toolsUsage) return null;
+
+    return metadata.toolsUsage.map((t) => ({
+      toolName: t.toolName,
+      output: t.output,
+    }));
   },
 });

--- a/services/platform/convex/openai_compat/response_format.test.ts
+++ b/services/platform/convex/openai_compat/response_format.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Citation } from './citations';
+import {
+  buildChatCompletion,
+  formatSSECitations,
+  formatSSEChunk,
+  formatSSEDone,
+} from './response_format';
+
+describe('buildChatCompletion', () => {
+  it('includes citations array when provided', () => {
+    const citations: Citation[] = [
+      {
+        index: 1,
+        type: 'rag',
+        source: 'report.pdf',
+        fileId: 'doc-123',
+        page: 42,
+        relevance: 0.87,
+      },
+      {
+        index: 2,
+        type: 'web',
+        source: 'Example Page',
+        url: 'https://example.com',
+        relevance: 0.72,
+      },
+    ];
+
+    const result = buildChatCompletion(
+      'test-id',
+      'my-agent',
+      'Response with [1] and [2]',
+      1700000000,
+      citations,
+    );
+
+    expect(result.citations).toEqual(citations);
+    expect(result.choices[0].message.content).toBe('Response with [1] and [2]');
+  });
+
+  it('includes empty citations array when no citations provided', () => {
+    const result = buildChatCompletion(
+      'test-id',
+      'my-agent',
+      'Simple response',
+      1700000000,
+    );
+
+    expect(result.citations).toEqual([]);
+  });
+
+  it('includes empty citations array when explicit empty array provided', () => {
+    const result = buildChatCompletion(
+      'test-id',
+      'my-agent',
+      'Response',
+      1700000000,
+      [],
+    );
+
+    expect(result.citations).toEqual([]);
+  });
+});
+
+describe('formatSSECitations', () => {
+  it('formats citations as an SSE data line', () => {
+    const citations: Citation[] = [
+      {
+        index: 1,
+        type: 'rag',
+        source: 'report.pdf',
+        fileId: 'doc-123',
+        relevance: 0.87,
+      },
+    ];
+
+    const result = formatSSECitations(citations);
+
+    expect(result).toMatch(/^data: /);
+    expect(result).toMatch(/\n\n$/);
+
+    const jsonStr = result.replace(/^data: /, '').replace(/\n\n$/, '');
+    const parsed = JSON.parse(jsonStr);
+    expect(parsed).toEqual({ citations });
+  });
+
+  it('produces valid JSON in SSE format', () => {
+    const citations: Citation[] = [
+      {
+        index: 1,
+        type: 'rag',
+        source: 'report.pdf',
+        relevance: 0.9,
+      },
+      {
+        index: 2,
+        type: 'web',
+        source: 'Web Page',
+        url: 'https://example.com',
+        relevance: 0.8,
+      },
+    ];
+
+    const result = formatSSECitations(citations);
+    const jsonStr = result.replace(/^data: /, '').replace(/\n\n$/, '');
+    const parsed = JSON.parse(jsonStr);
+
+    expect(parsed.citations).toHaveLength(2);
+    expect(parsed.citations[0].type).toBe('rag');
+    expect(parsed.citations[1].type).toBe('web');
+  });
+});
+
+describe('SSE format consistency', () => {
+  it('formatSSEChunk and formatSSECitations share the same data: prefix pattern', () => {
+    const chunk = formatSSEChunk({ test: true });
+    const citations = formatSSECitations([]);
+
+    expect(chunk.startsWith('data: ')).toBe(true);
+    expect(citations.startsWith('data: ')).toBe(true);
+    expect(chunk.endsWith('\n\n')).toBe(true);
+    expect(citations.endsWith('\n\n')).toBe(true);
+  });
+
+  it('formatSSEDone follows the SSE pattern', () => {
+    const done = formatSSEDone();
+    expect(done).toBe('data: [DONE]\n\n');
+  });
+});

--- a/services/platform/convex/openai_compat/response_format.ts
+++ b/services/platform/convex/openai_compat/response_format.ts
@@ -5,6 +5,8 @@
  * for both streaming (SSE) and non-streaming modes.
  */
 
+import type { Citation } from './citations';
+
 // ---------------------------------------------------------------------------
 // Non-streaming response
 // ---------------------------------------------------------------------------
@@ -36,6 +38,7 @@ interface ChatCompletionResponse {
     completion_tokens: number;
     total_tokens: number;
   };
+  citations: Citation[];
 }
 
 export function buildChatCompletion(
@@ -43,6 +46,7 @@ export function buildChatCompletion(
   model: string,
   content: string,
   created: number,
+  citations: Citation[] = [],
 ): ChatCompletionResponse {
   return {
     id: `chatcmpl-${id}`,
@@ -57,6 +61,7 @@ export function buildChatCompletion(
       },
     ],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    citations,
   };
 }
 
@@ -83,6 +88,7 @@ export function buildChatCompletionWithToolCalls(
       },
     ],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    citations: [],
   };
 }
 
@@ -139,6 +145,10 @@ export function formatSSEChunk(data: unknown): string {
 
 export function formatSSEDone(): string {
   return 'data: [DONE]\n\n';
+}
+
+export function formatSSECitations(citations: Citation[]): string {
+  return `data: ${JSON.stringify({ citations })}\n\n`;
 }
 
 // ---------------------------------------------------------------------------

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Tale Public API",
     "version": "1.0.0",
-    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```"
+    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```\n\n## Citations\n\nAgent mode responses include a `citations` array when knowledge tools (RAG search, web search) are used:\n\n```python\nresponse = client.chat.completions.create(\n    model=\"my-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"What does the policy say about returns?\"}],\n)\n\n# Access citations\nfor citation in response.model_extra.get(\"citations\", []):\n    print(f\"[{citation['index']}] {citation['source']} (relevance: {citation['relevance']})\")\n```\n\nFor streaming, citations arrive as a separate SSE event before `[DONE]`."
   },
   "servers": [
     {
@@ -21,7 +21,7 @@
       "post": {
         "tags": ["OpenAI Compatible"],
         "summary": "Create chat completion",
-        "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
+        "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them. Response includes `citations` array when knowledge tools (RAG, web search) were used.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
         "security": [
           {
@@ -2946,6 +2946,48 @@
                 "type": "integer"
               }
             }
+          },
+          "citations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "description": "Source citations referenced in the response text via [N] markers. Empty array when no knowledge tools were used."
+          }
+        }
+      },
+      "Citation": {
+        "type": "object",
+        "required": ["index", "type", "source", "relevance"],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The [N] citation marker number in the response text"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["rag", "web"],
+            "description": "Source type"
+          },
+          "source": {
+            "type": "string",
+            "description": "Filename (rag) or page title (web)"
+          },
+          "fileId": {
+            "type": "string",
+            "description": "Document file ID (rag only)"
+          },
+          "url": {
+            "type": "string",
+            "description": "Source URL (web only)"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Page number within document (rag only)"
+          },
+          "relevance": {
+            "type": "number",
+            "description": "Relevance score (0-1)"
           }
         }
       },

--- a/services/platform/scripts/test_openai_compat.py
+++ b/services/platform/scripts/test_openai_compat.py
@@ -18,6 +18,7 @@ Tests:
   14. Error: invalid API key (401)
   15. Error: missing messages (400)
   16. Error: no user message (400)
+  17. Citations field present in agent mode response
 """
 
 import json
@@ -526,6 +527,34 @@ except Exception as e:
         ok(f"{s[:80]}")
     else:
         fail(f"Unexpected: {s[:80]}")
+
+# =========================================================================
+# 17. Citations field present in agent mode response
+# =========================================================================
+test("17. Citations field present in agent mode response")
+try:
+    r = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": "Say hello in exactly 2 words."}],
+    )
+    # citations is a non-standard field; access via model_extra
+    citations = r.model_extra.get("citations") if r.model_extra else None
+    print(f"  Citations: {citations}")
+    if citations is not None and isinstance(citations, list):
+        ok(f"citations field present (length: {len(citations)})")
+        # Validate citation shape if any citations are returned
+        for c in citations:
+            assert "index" in c, "Missing 'index' in citation"
+            assert "type" in c, "Missing 'type' in citation"
+            assert c["type"] in ("rag", "web"), f"Invalid type: {c['type']}"
+            assert "source" in c, "Missing 'source' in citation"
+            assert "relevance" in c, "Missing 'relevance' in citation"
+        if citations:
+            ok(f"Citation shape valid for {len(citations)} citation(s)")
+    else:
+        fail("citations field missing or not a list")
+except Exception as e:
+    fail(str(e)[:120])
 
 # =========================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Add structured `citations` array to OpenAI-compatible API responses when the agent invokes knowledge tools (RAG search, web search)
- Non-streaming responses include `citations` at the top level alongside `choices` and `usage`; streaming responses emit a dedicated citation SSE event before `[DONE]`
- Add server-side citation parser (`citations.ts`) extracted from the client-side `use-citations.ts` hook, with full unit tests
- Document the `Citation` schema and usage examples in `openapi.json`

Closes #1333

## Test plan

- [x] Unit tests for `parseCitationsFromToolsUsage()` covering RAG, web, mixed, empty, malformed, and deduplicated inputs (citations.test.ts)
- [x] Unit tests for `buildChatCompletion` with citations and `formatSSECitations` (response_format.test.ts)
- [x] E2E test script validates `citations` field presence and shape in agent mode responses (test_openai_compat.py test 17)
- [x] Lint passes (`npm run lint --workspace=@tale/platform`)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] All server tests pass (158 files, 1975 tests)
- [x] All client tests pass (245 files, 1852 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent-mode responses now include a `citations` field with source attribution and relevance information for knowledge tool results.

* **Documentation**
  * Updated API documentation to describe the new `citations` field in chat completion responses.

* **Tests**
  * Added test coverage for citation parsing and response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->