### PR TITLE
fix(platform): correct first-message layout shift on new thread creation

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -451,7 +451,9 @@ export function ChatInterface({
     message: string,
     sentAttachments?: FileAttachment[],
   ) => {
-    scrollingToBottomBehaviorRef.current = 'smooth';
+    // Instant for new threads (no content to scroll past, avoids layout shift
+    // during the budget-banner → thread transition). Smooth for existing threads.
+    scrollingToBottomBehaviorRef.current = threadId ? 'smooth' : 'instant';
     clearInputValue();
     await sendMessage(message, sentAttachments);
   };
@@ -469,10 +471,10 @@ export function ChatInterface({
 
   const handleSendMessageDirect = useCallback(
     (message: string) => {
-      scrollingToBottomBehaviorRef.current = 'smooth';
+      scrollingToBottomBehaviorRef.current = threadId ? 'smooth' : 'instant';
       void sendMessage(message);
     },
-    [sendMessage],
+    [sendMessage, threadId],
   );
 
   // Edit message → open dialog → create branch on submit

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -61,11 +61,17 @@ function computeResponseMinHeight(
   const gap = flexParent
     ? parseFloat(getComputedStyle(flexParent).gap) || 0
     : 0;
-  const contentWrapper = container.firstElementChild;
-  const padBottom =
-    contentWrapper instanceof HTMLElement
-      ? parseFloat(getComputedStyle(contentWrapper).paddingBottom) || 0
-      : 0;
+  // Walk up from responseArea to find the content wrapper (direct child of
+  // container). Using container.firstElementChild is unreliable because
+  // conditional siblings (e.g. budget warning banner) can appear before the
+  // content wrapper when there is no threadId.
+  let contentWrapper: HTMLElement | null = responseArea;
+  while (contentWrapper && contentWrapper.parentElement !== container) {
+    contentWrapper = contentWrapper.parentElement;
+  }
+  const padBottom = contentWrapper
+    ? parseFloat(getComputedStyle(contentWrapper).paddingBottom) || 0
+    : 0;
 
   return Math.max(
     0,


### PR DESCRIPTION
## Summary
- Fix `computeResponseMinHeight` using `container.firstElementChild` which incorrectly picked up the budget warning banner (padBottom=8) instead of the content wrapper (padBottom=24), making min-height 16px too large and pushing the user message flush against the viewport top
- Walk up from `responseArea` to find the actual content wrapper (direct child of container) for reliable padding measurement
- Use instant scroll for new-thread sends to prevent smooth scroll from amplifying the layout shift during the banner-to-thread transition

## Test plan
- [ ] New chat: send a message → user message should appear with proper top margin, no wobble/slide
- [ ] Existing thread: send a message → should still smooth-scroll correctly
- [ ] Navigate to a thread via sidebar → should instant-scroll to bottom
- [ ] Edit-and-branch flow → scroll behavior should be unchanged
- [ ] Test with and without budget warning banner visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scroll-to-bottom behavior when sending messages with context-aware animation smoothness that improves responsiveness
  * Fixed message display layout calculations to properly handle padding and spacing when conditional UI elements like banners are present
  * Improved overall visual consistency and alignment in the chat interface across different conversation types and configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->