### PR TITLE
fix(platform): add aria-labelledby to chat interface for WCAG 2.1

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ComponentPropsWithoutRef,
   useCallback,
+  useId,
   useRef,
   useMemo,
   useState,
@@ -130,6 +131,8 @@ export function ChatInput({
     return policyLimits.allowedExtensions.map((ext) => `.${ext}`).join(',');
   }, [policyLimits]);
 
+  const textareaId = useId();
+  const textareaLabelId = `${textareaId}-label`;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState<{
@@ -376,7 +379,15 @@ export function ChatInput({
           )}
 
           <div className="relative">
+            <label
+              id={textareaLabelId}
+              htmlFor={textareaId}
+              className="sr-only"
+            >
+              {tChat('aria.chatInput')}
+            </label>
             <Textarea
+              id={textareaId}
               ref={textareaRef}
               value={value}
               onChange={(e) => handleInputChange(e.target.value)}
@@ -385,7 +396,7 @@ export function ChatInput({
               className="text-foreground placeholder:text-muted-foreground relative min-h-[100px] resize-none border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               disabled={inputDisabled}
               placeholder=""
-              aria-label={defaultPlaceholder}
+              aria-labelledby={textareaLabelId}
             />
             {value.length === 0 && !inputDisabled && (
               <Text

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -3,7 +3,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { m, AnimatePresence } from 'framer-motion';
 import { AlertTriangle, Archive, ArrowDown, Share, X } from 'lucide-react';
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useId, useState, useCallback } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
@@ -79,6 +79,7 @@ export function ChatInterface({
   readOnly = false,
 }: ChatInterfaceProps) {
   const { t } = useT('chat');
+  const chatRegionLabelId = useId();
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user } = useAuth();
@@ -607,11 +608,16 @@ export function ChatInterface({
   return (
     <div
       ref={containerRef}
+      role="region"
+      aria-labelledby={chatRegionLabelId}
       className={cn(
         'flex h-full min-h-0 flex-1 flex-col',
         !showArena && 'overflow-y-auto scroll-smooth will-change-transform',
       )}
     >
+      <h2 id={chatRegionLabelId} className="sr-only">
+        {t('aria.chatRegion')}
+      </h2>
       {budgetStatus && !budgetWarningDismissed && !threadId && (
         <div
           className={cn(

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -3,6 +3,7 @@
 import type { UIMessage } from '@convex-dev/agent/react';
 import { AlertTriangle, Loader2, CheckCircle2, Lock } from 'lucide-react';
 import {
+  useId,
   useMemo,
   useRef,
   useLayoutEffect,
@@ -149,6 +150,7 @@ export function ChatMessages({
   hideFeedback,
 }: ChatMessagesProps) {
   const { t } = useT('chat');
+  const messageHistoryLabelId = useId();
   const { branches, activeBranchThreadId } = useBranchContext();
   const editInputScrollRef = useRef<HTMLDivElement>(null);
 
@@ -457,8 +459,11 @@ export function ChatMessages({
       className="mx-auto flex w-full max-w-(--chat-max-width) flex-col"
       role="log"
       aria-live="polite"
-      aria-label={t('aria.messageHistory')}
+      aria-labelledby={messageHistoryLabelId}
     >
+      <h2 id={messageHistoryLabelId} className="sr-only">
+        {t('aria.messageHistory')}
+      </h2>
       <div className="flex flex-col gap-3 pt-6">
         {(canLoadMore || isLoadingMore) && (
           <div className="flex justify-center py-2">

--- a/services/platform/app/features/chat/components/shared-chat-view.tsx
+++ b/services/platform/app/features/chat/components/shared-chat-view.tsx
@@ -2,7 +2,7 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import { GitFork, ArrowLeft, Loader2 } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useId, useState } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
@@ -31,6 +31,7 @@ export function SharedChatView({
   shareToken,
 }: SharedChatViewProps) {
   const { t } = useT('chat');
+  const messageHistoryLabelId = useId();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [inputValue, setInputValue] = useState('');
@@ -182,7 +183,11 @@ export function SharedChatView({
             className="mx-auto flex w-full max-w-(--chat-max-width) flex-col gap-3 pt-6"
             role="log"
             aria-live="polite"
+            aria-labelledby={messageHistoryLabelId}
           >
+            <h2 id={messageHistoryLabelId} className="sr-only">
+              {t('aria.messageHistory')}
+            </h2>
             {sharedThread.messages.map(
               (message: {
                 _id: string;

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2787,7 +2787,9 @@
     },
     "aria": {
       "messageHistory": "Nachrichtenverlauf",
-      "scrollToBottom": "Nach unten scrollen"
+      "scrollToBottom": "Nach unten scrollen",
+      "chatRegion": "Chat",
+      "chatInput": "Nachrichteneingabe"
     },
     "structured": {
       "nextSteps": "Vorgeschlagene Folgefragen"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2802,7 +2802,9 @@
     },
     "aria": {
       "messageHistory": "Message history",
-      "scrollToBottom": "Scroll to bottom"
+      "scrollToBottom": "Scroll to bottom",
+      "chatRegion": "Chat",
+      "chatInput": "Message input"
     },
     "structured": {
       "nextSteps": "Suggested follow-ups"


### PR DESCRIPTION
## Summary
- Replace `aria-label` with `aria-labelledby` on the chat message history (`role="log"`), textarea input, and overall chat region container to establish explicit semantic relationships between UI elements and their labels
- Add the missing label to the shared chat view's message log, which had no accessible label at all
- Add visually hidden headings and label elements using `useId()` for unique, stable IDs

Closes #1415

## Test plan
- [ ] Verify screen reader announces "Message history" when entering the chat message log region
- [ ] Verify screen reader announces "Message input" when focusing the chat textarea
- [ ] Verify screen reader announces "Chat" when entering the chat region
- [ ] Verify shared chat view message log is also properly labeled
- [ ] Verify keyboard navigation (tab flow) still works correctly
- [ ] Run `npm run lint --workspace=@tale/platform` — passes with 0 warnings/errors
- [ ] Run TypeScript type check — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced chat interface with improved screen reader support through proper accessible region labels.
  * Added explicit accessibility labels for message input and chat history containers.
  * Extended localization with new ARIA labels in German and English for better assistive technology integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->