### PR TITLE
fix: citations display and source card file preview

### DIFF
--- a/packages/tale_knowledge/src/tale_knowledge/chunking/splitter.py
+++ b/packages/tale_knowledge/src/tale_knowledge/chunking/splitter.py
@@ -12,7 +12,7 @@ from semantic_text_splitter import MarkdownSplitter
 
 CHUNK_SIZE = 2048
 CHUNK_OVERLAP = 200
-MIN_CHUNK_LENGTH = 100
+MIN_CHUNK_LENGTH = 10
 
 
 @dataclass

--- a/packages/tale_knowledge/tests/test_splitter.py
+++ b/packages/tale_knowledge/tests/test_splitter.py
@@ -52,9 +52,16 @@ class TestChunkContent:
         assert "https://example.com" in chunks[0].content
 
     def test_min_chunk_length_filter(self):
-        text = "Hi"  # Shorter than MIN_CHUNK_LENGTH
+        text = "Hi"  # Shorter than MIN_CHUNK_LENGTH (10)
         chunks = chunk_content(text)
         assert chunks == []
+
+    def test_short_valid_content_indexed(self):
+        text = "2025年我们的销售额度是1000万"
+        chunks = chunk_content(text)
+        assert len(chunks) == 1
+        assert chunks[0].content == text
+        assert chunks[0].index == 0
 
     def test_custom_chunk_size(self):
         text = "word " * 1000
@@ -65,7 +72,7 @@ class TestChunkContent:
     def test_default_values(self):
         assert CHUNK_SIZE == 2048
         assert CHUNK_OVERLAP == 200
-        assert MIN_CHUNK_LENGTH == 100
+        assert MIN_CHUNK_LENGTH == 10
 
     def test_long_content_multiple_chunks(self):
         # Generate content that's definitely larger than one chunk

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -143,7 +143,7 @@ function MessageBubbleComponent({
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const { metadata } = useMessageMetadata(message.id, message.threadId);
-  const { citations, hasCitations } = useCitations(metadata?.toolsUsage);
+  const { citations, hasCitations } = useCitations(metadata?.citations);
   const citationNumbers = useMemo(() => new Set(citations.keys()), [citations]);
   const citationsContextValue = useMemo(() => ({ citations }), [citations]);
   const galleryImages = useMessageGallery(message);
@@ -469,7 +469,7 @@ function MessageBubbleComponent({
         )}
 
         {!isUser && hasCitations && !isAssistantStreaming && (
-          <SourceCards citations={citations} />
+          <SourceCards citations={citations} organizationId={organizationId} />
         )}
 
         <MessageInfoDialog

--- a/services/platform/app/features/chat/components/source-cards.tsx
+++ b/services/platform/app/features/chat/components/source-cards.tsx
@@ -3,8 +3,8 @@
 import { FileText, Globe, ChevronDown, ChevronUp } from 'lucide-react';
 import { memo, useState, useCallback } from 'react';
 
-import { ViewDialog } from '@/app/components/ui/dialog/view-dialog';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import { DocumentPreviewDialog } from '@/app/features/documents/components/document-preview-dialog';
 import { useT } from '@/lib/i18n/client';
 
 import type { CitationInfo } from '../hooks/use-citations';
@@ -35,13 +35,12 @@ function SourceCard({ source, onClick }: SourceCardProps) {
     (source.url
       ? getDomain(source.url)
       : t('citations.source', { number: String(source.number) }));
-  const chunkCount = source.chunks.length;
 
   const tooltipContent = (
     <div className="flex flex-col gap-0.5">
       <span className="font-medium">{title}</span>
-      {chunkCount > 1 && (
-        <span>{t('citations.chunkCount', { count: chunkCount })}</span>
+      {source.chunkCount > 1 && (
+        <span>{t('citations.chunkCount', { count: source.chunkCount })}</span>
       )}
       {source.relevance != null && (
         <span>
@@ -63,9 +62,9 @@ function SourceCard({ source, onClick }: SourceCardProps) {
         <Icon className="text-muted-foreground size-3.5 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="truncate text-xs font-medium">{title}</div>
-          {chunkCount > 1 && (
+          {source.chunkCount > 1 && (
             <div className="text-muted-foreground text-[10px]">
-              {t('citations.chunkCount', { count: chunkCount })}
+              {t('citations.chunkCount', { count: source.chunkCount })}
             </div>
           )}
         </div>
@@ -74,115 +73,12 @@ function SourceCard({ source, onClick }: SourceCardProps) {
   );
 }
 
-interface SourceDetailDialogProps {
-  source: SourceGroup | null;
-  onClose: () => void;
-}
-
-/**
- * Normalize chunk content for display:
- * - Convert literal `\n` sequences to real newlines
- * - Collapse 3+ consecutive blank lines into 2
- */
-function normalizeContent(raw: string): string {
-  return raw
-    .replace(/\\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-function SourceDetailDialog({ source, onClose }: SourceDetailDialogProps) {
-  const { t } = useT('chat');
-  if (!source) return null;
-
-  const title =
-    source.filename ??
-    (source.url
-      ? getDomain(source.url)
-      : t('citations.source', { number: String(source.number) }));
-
-  const chunkCount = source.chunks.length;
-
-  return (
-    <ViewDialog
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-      title={title}
-      size="xl"
-      className="overflow-x-hidden"
-    >
-      <div className="flex min-w-0 flex-col gap-4 overflow-hidden">
-        {/* Metadata */}
-        <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-          {source.relevance != null && (
-            <span>
-              {t('citations.relevance', {
-                score: String(Math.round(source.relevance)),
-              })}
-            </span>
-          )}
-          {source.pages.length > 0 && (
-            <span>
-              {source.pages
-                .map((p) => t('citations.page', { page: String(p) }))
-                .join(', ')}
-            </span>
-          )}
-          {chunkCount > 1 && (
-            <span>{t('citations.chunkCount', { count: chunkCount })}</span>
-          )}
-        </div>
-
-        {/* Chunk contents */}
-        <div className="flex flex-col gap-3">
-          {source.chunks.map((chunk) => (
-            <div key={chunk.number} className="bg-background/50 rounded-lg p-3">
-              {chunkCount > 1 && (
-                <div className="text-muted-foreground mb-2 flex items-center gap-2 text-[11px]">
-                  <span className="bg-muted rounded px-1.5 py-0.5 font-medium">
-                    [{chunk.number}]
-                  </span>
-                  {chunk.page != null && (
-                    <span>
-                      {t('citations.page', { page: String(chunk.page) })}
-                    </span>
-                  )}
-                  {chunk.relevance != null && (
-                    <span>
-                      {t('citations.relevance', {
-                        score: String(Math.round(chunk.relevance)),
-                      })}
-                    </span>
-                  )}
-                </div>
-              )}
-              {chunk.content ? (
-                <div
-                  className="text-foreground/90 max-h-[300px] overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap"
-                  style={{ overflowWrap: 'anywhere' }}
-                >
-                  {normalizeContent(chunk.content)}
-                </div>
-              ) : (
-                <div className="text-muted-foreground text-sm italic">
-                  {t('citations.noContent')}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-    </ViewDialog>
-  );
-}
-
 interface SourceCardsProps {
   citations: Map<number, CitationInfo>;
+  organizationId?: string;
 }
 
-function SourceCardsComponent({ citations }: SourceCardsProps) {
+function SourceCardsComponent({ citations, organizationId }: SourceCardsProps) {
   const { t } = useT('chat');
   const [isExpanded, setIsExpanded] = useState(false);
   const [selectedSource, setSelectedSource] = useState<SourceGroup | null>(
@@ -240,10 +136,17 @@ function SourceCardsComponent({ citations }: SourceCardsProps) {
         </button>
       )}
 
-      <SourceDetailDialog
-        source={selectedSource}
-        onClose={() => setSelectedSource(null)}
-      />
+      {selectedSource && organizationId && (
+        <DocumentPreviewDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setSelectedSource(null);
+          }}
+          organizationId={organizationId}
+          fileId={selectedSource.fileId}
+          fileName={selectedSource.filename}
+        />
+      )}
     </div>
   );
 }

--- a/services/platform/app/features/chat/components/source-cards.tsx
+++ b/services/platform/app/features/chat/components/source-cards.tsx
@@ -35,7 +35,7 @@ function SourceCard({ source, onClick }: SourceCardProps) {
     (source.url
       ? getDomain(source.url)
       : t('citations.source', { number: String(source.number) }));
-  const chunkCount = source.chunkNumbers.length;
+  const chunkCount = source.chunks.length;
 
   const tooltipContent = (
     <div className="flex flex-col gap-0.5">

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -537,6 +537,16 @@ export interface ContextStats {
   hasRag: boolean;
 }
 
+export interface StructuredCitation {
+  index: number;
+  type: 'rag' | 'web';
+  source: string;
+  fileId?: string;
+  url?: string;
+  page?: number;
+  relevance?: number;
+}
+
 export interface MessageMetadata {
   model: string;
   provider: string;
@@ -552,6 +562,7 @@ export interface MessageMetadata {
   contextWindow?: string;
   contextStats?: ContextStats;
   costEstimateCents?: number;
+  citations?: StructuredCitation[];
 }
 
 export function useMessageError(threadId: string | null) {
@@ -589,6 +600,7 @@ export function useMessageMetadata(
           contextWindow: metadata.contextWindow,
           contextStats: metadata.contextStats,
           costEstimateCents: metadata.costEstimateCents,
+          citations: metadata.citations,
         }
       : undefined,
     isLoading,

--- a/services/platform/app/features/chat/hooks/use-citations.ts
+++ b/services/platform/app/features/chat/hooks/use-citations.ts
@@ -8,249 +8,22 @@ export interface CitationInfo {
   relevance?: number;
   url?: string;
   type: 'rag' | 'web';
-  /** Chunk text content extracted from tool output. */
-  content?: string;
 }
 
-interface ToolUsageInput {
-  toolName: string;
-  input?: string;
-  output?: string;
-}
-
-const RAG_CITATION_PATTERN =
-  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[Page:\s*(\d+)\])?(?:\s*\[(?:Modified|Created):\s*[^\]]+\])?(?:\s*\[FileID:\s*([^\]]+)\])?/g;
-
-const WEB_CITATION_PATTERN =
-  /\[(\d+)\]\s*\(Relevance:\s*([\d.]+)%\)(?:\s*\[Source:\s*([^\]]+)\])?(?:\s*\[URL:\s*([^\]]+)\])?/g;
-
-/**
- * Parse citation metadata and chunk content from RAG search result text.
- *
- * The RAG output format is:
- * ```
- * [1] (Relevance: 87.3%) [Source: report.pdf] [Page: 5] [FileID: abc]
- * <chunk content>
- *
- * ---
- *
- * [2] (Relevance: 72.1%) [Source: memo.docx] [FileID: def]
- * <chunk content>
- * ```
- */
-export function parseRagCitations(text: string): Map<number, CitationInfo> {
-  const citations = new Map<number, CitationInfo>();
-
-  // Split by chunk separator to get individual chunks
-  const chunks = text.split(/\n\n---\n\n/);
-
-  for (const chunk of chunks) {
-    RAG_CITATION_PATTERN.lastIndex = 0;
-    const match = RAG_CITATION_PATTERN.exec(chunk);
-    if (!match) continue;
-
-    const num = parseInt(match[1], 10);
-    // Content is everything after the metadata line
-    const metadataEnd = (match.index ?? 0) + match[0].length;
-    const content = chunk.slice(metadataEnd).trim() || undefined;
-
-    citations.set(num, {
-      number: num,
-      relevance: parseFloat(match[2]),
-      filename: match[3] || undefined,
-      page: match[4] ? parseInt(match[4], 10) : undefined,
-      fileId: match[5] || undefined,
-      type: 'rag',
-      content,
-    });
-  }
-  return citations;
-}
-
-/**
- * Parse citation metadata from web search result text.
- */
-export function parseWebCitations(text: string): Map<number, CitationInfo> {
-  const citations = new Map<number, CitationInfo>();
-  let match;
-  WEB_CITATION_PATTERN.lastIndex = 0;
-  while ((match = WEB_CITATION_PATTERN.exec(text)) !== null) {
-    const num = parseInt(match[1], 10);
-    citations.set(num, {
-      number: num,
-      relevance: parseFloat(match[2]),
-      filename: match[3] || undefined,
-      url: match[4] || undefined,
-      type: 'web',
-    });
-  }
-  return citations;
-}
-
-/**
- * Try to unwrap safeStringify'd output — handles both JSON-wrapped
- * strings and nested objects with a `response` or `output` field.
- */
-function unwrapOutput(raw: string): string {
-  let output = raw;
-
-  // Unwrap JSON-wrapped string: "\"...\""
-  if (output.startsWith('"') && output.endsWith('"')) {
-    try {
-      const parsed: unknown = JSON.parse(output);
-      if (typeof parsed === 'string') {
-        output = parsed;
-      }
-    } catch {
-      // use as-is
-    }
-  }
-
-  return output;
-}
-
-function isPlainObject(val: unknown): val is Record<string, unknown> {
-  return val !== null && typeof val === 'object' && !Array.isArray(val);
-}
-
-interface JsonFieldsResult {
-  response?: string;
-  filename?: string;
+interface StructuredCitation {
+  index: number;
+  type: 'rag' | 'web';
+  source: string;
   fileId?: string;
-}
-
-/**
- * Extract metadata fields from a JSON tool output string.
- * Handles both direct objects and nested `{ value: { ... } }` wrappers.
- */
-function extractJsonFields(output: string): JsonFieldsResult | undefined {
-  try {
-    const parsed: unknown = JSON.parse(output);
-    if (!isPlainObject(parsed)) return undefined;
-
-    // Check nested value wrapper (tool-result shape)
-    const obj = isPlainObject(parsed.value) ? parsed.value : parsed;
-
-    const response =
-      typeof obj.response === 'string'
-        ? obj.response
-        : typeof obj.output === 'string'
-          ? obj.output
-          : undefined;
-    // filename field (retrieve), or title as fallback
-    const filename =
-      typeof obj.filename === 'string'
-        ? obj.filename
-        : typeof obj.title === 'string'
-          ? obj.title
-          : undefined;
-    const fileId = typeof obj.fileId === 'string' ? obj.fileId : undefined;
-
-    return response || filename || fileId
-      ? { response, filename, fileId }
-      : undefined;
-  } catch {
-    // not JSON
-  }
-  return undefined;
-}
-
-/**
- * Detect whether a rag_search tool call is a 'retrieve' operation
- * by examining its input. Returns parsed input data if it is.
- */
-function parseRetrieveInput(
-  inputStr: string | undefined,
-): { fileId: string } | undefined {
-  if (!inputStr) return undefined;
-  try {
-    const parsed: unknown = JSON.parse(inputStr);
-    if (
-      isPlainObject(parsed) &&
-      parsed.operation === 'retrieve' &&
-      typeof parsed.fileId === 'string'
-    ) {
-      return { fileId: parsed.fileId };
-    }
-  } catch {
-    // not JSON
-  }
-  return undefined;
-}
-
-/**
- * Parse citations from tool usage records.
- *
- * Processes RAG search and retrieve operations plus web tool outputs,
- * offsetting citation numbers between successive calls to avoid collisions.
- */
-export function parseCitationsFromToolsUsage(
-  toolsUsage: ToolUsageInput[],
-): Map<number, CitationInfo> {
-  const allCitations = new Map<number, CitationInfo>();
-  let nextNumber = 1;
-
-  for (const usage of toolsUsage) {
-    if (!usage.output) continue;
-
-    const output = unwrapOutput(usage.output);
-
-    if (usage.toolName === 'rag_search') {
-      const fields = extractJsonFields(output);
-      // First try to parse as formatted search results ([N] Relevance: ...)
-      const responseText = fields?.response ?? output;
-      const ragCitations = parseRagCitations(responseText);
-
-      if (ragCitations.size > 0) {
-        // Offset all numbers so successive rag_search calls don't collide
-        const offset = nextNumber - 1;
-        for (const [, citation] of ragCitations) {
-          const newNum = citation.number + offset;
-          allCitations.set(newNum, { ...citation, number: newNum });
-          if (newNum >= nextNumber) nextNumber = newNum + 1;
-        }
-      } else {
-        // No formatted citations — could be a retrieve operation
-        const retrieveInput = parseRetrieveInput(usage.input);
-        if (retrieveInput) {
-          const content = fields?.response ?? output;
-          if (content && content !== 'Document has no text content.') {
-            allCitations.set(nextNumber, {
-              number: nextNumber,
-              fileId: fields?.fileId ?? retrieveInput.fileId,
-              filename: fields?.filename ?? undefined,
-              type: 'rag',
-              content,
-            });
-            nextNumber++;
-          }
-        }
-      }
-    } else if (usage.toolName === 'web') {
-      const webCitations = parseWebCitations(output);
-      const offset = nextNumber - 1;
-      for (const [, citation] of webCitations) {
-        const newNum = citation.number + offset;
-        allCitations.set(newNum, { ...citation, number: newNum });
-        if (newNum >= nextNumber) nextNumber = newNum + 1;
-      }
-    }
-  }
-
-  return allCitations;
-}
-
-/**
- * Legacy parser for backward compatibility with contextText.
- */
-export function parseCitations(contextText: string): Map<number, CitationInfo> {
-  return parseRagCitations(contextText);
+  url?: string;
+  page?: number;
+  relevance?: number;
 }
 
 /**
  * Deduplicate citations by source identity (fileId or url).
- * Keeps the first occurrence of each unique source and builds a
- * number remapping so inline [N] markers still resolve correctly.
+ * Keeps the first occurrence of each unique source and maps
+ * duplicate numbers to the existing citation.
  */
 function deduplicateCitations(
   citations: Map<number, CitationInfo>,
@@ -259,17 +32,13 @@ function deduplicateCitations(
   const deduped = new Map<number, CitationInfo>();
 
   for (const [num, citation] of citations) {
-    // Include a content fingerprint so different chunks from the same
-    // file/page are kept as separate entries.
-    const contentKey = citation.content?.slice(0, 80) ?? '';
     const sourceKey =
       citation.type === 'rag'
-        ? `rag:${citation.fileId ?? ''}:${citation.page ?? ''}:${contentKey}`
+        ? `rag:${citation.fileId ?? ''}:${citation.page ?? ''}`
         : `web:${citation.url ?? ''}`;
 
     const existingNum = seen.get(sourceKey);
     if (existingNum !== undefined) {
-      // Map this duplicate number to the existing citation
       const existing = deduped.get(existingNum);
       if (existing) deduped.set(num, existing);
     } else {
@@ -281,13 +50,6 @@ function deduplicateCitations(
   return deduped;
 }
 
-export interface ChunkDetail {
-  number: number;
-  page?: number;
-  relevance?: number;
-  content?: string;
-}
-
 export interface SourceGroup {
   /** The first citation number (used for ordering and as key). */
   number: number;
@@ -297,12 +59,10 @@ export interface SourceGroup {
   type: 'rag' | 'web';
   /** All inline citation numbers that reference this source. */
   chunkNumbers: number[];
-  /** All distinct page numbers referenced (RAG only). */
-  pages: number[];
+  /** Number of distinct chunks/citations referencing this source. */
+  chunkCount: number;
   /** Highest relevance score among the grouped citations. */
   relevance?: number;
-  /** Individual chunk details with content for display. */
-  chunks: ChunkDetail[];
 }
 
 /**
@@ -314,10 +74,7 @@ export function getUniqueSources(
   citations: Map<number, CitationInfo>,
 ): SourceGroup[] {
   const groups = new Map<string, SourceGroup>();
-  // Track which original citation numbers we've already added as chunks
-  // to avoid duplicating content when deduplicateCitations maps multiple
-  // keys to the same citation object.
-  const addedChunkIds = new Map<string, Set<number>>();
+  const seenNumbers = new Map<string, Set<number>>();
 
   for (const [mapKey, citation] of citations) {
     const sourceKey =
@@ -325,32 +82,18 @@ export function getUniqueSources(
         ? `rag:${citation.fileId ?? ''}`
         : `web:${citation.url ?? ''}`;
 
-    // Use the Map key as the inline reference number (the [N] in the text),
-    // since deduplicateCitations may remap multiple keys to the same citation.
-    const inlineNumber = mapKey;
-
     const existing = groups.get(sourceKey);
     if (existing) {
-      existing.chunkNumbers.push(inlineNumber);
+      existing.chunkNumbers.push(mapKey);
 
-      // Only add chunk detail if this is a genuinely different chunk
-      // (not a remapped duplicate pointing to the same original citation)
-      let chunkSet = addedChunkIds.get(sourceKey);
-      if (!chunkSet) {
-        chunkSet = new Set();
-        addedChunkIds.set(sourceKey, chunkSet);
+      let numSet = seenNumbers.get(sourceKey);
+      if (!numSet) {
+        numSet = new Set();
+        seenNumbers.set(sourceKey, numSet);
       }
-      if (!chunkSet.has(citation.number)) {
-        chunkSet.add(citation.number);
-        existing.chunks.push({
-          number: citation.number,
-          page: citation.page,
-          relevance: citation.relevance,
-          content: citation.content,
-        });
-        if (citation.page != null && !existing.pages.includes(citation.page)) {
-          existing.pages.push(citation.page);
-        }
+      if (!numSet.has(citation.number)) {
+        numSet.add(citation.number);
+        existing.chunkCount++;
         if (
           citation.relevance != null &&
           (existing.relevance == null ||
@@ -360,25 +103,16 @@ export function getUniqueSources(
         }
       }
     } else {
-      const chunkSet = new Set([citation.number]);
-      addedChunkIds.set(sourceKey, chunkSet);
+      seenNumbers.set(sourceKey, new Set([citation.number]));
       groups.set(sourceKey, {
-        number: inlineNumber,
+        number: mapKey,
         filename: citation.filename,
         fileId: citation.fileId,
         url: citation.url,
         type: citation.type,
-        chunkNumbers: [inlineNumber],
-        pages: citation.page != null ? [citation.page] : [],
+        chunkNumbers: [mapKey],
+        chunkCount: 1,
         relevance: citation.relevance,
-        chunks: [
-          {
-            number: citation.number,
-            page: citation.page,
-            relevance: citation.relevance,
-            content: citation.content,
-          },
-        ],
       });
     }
   }
@@ -387,26 +121,32 @@ export function getUniqueSources(
 }
 
 /**
- * Hook that provides citation lookup from message metadata.
- *
- * Prefers structured tool usage data when available, falling back
- * to raw context text for older messages.
+ * Hook that provides citation lookup from structured citation metadata.
+ * Citations are grouped by source identity (fileId for RAG, url for web).
  */
-export function useCitations(
-  toolsUsage?: ToolUsageInput[],
-  contextText?: string,
-) {
+export function useCitations(structuredCitations?: StructuredCitation[]) {
   const citations = useMemo(() => {
-    let raw: Map<number, CitationInfo>;
-    if (toolsUsage && toolsUsage.length > 0) {
-      raw = parseCitationsFromToolsUsage(toolsUsage);
-    } else if (contextText) {
-      raw = parseCitations(contextText);
-    } else {
+    if (!structuredCitations || structuredCitations.length === 0) {
       return new Map<number, CitationInfo>();
     }
+
+    const raw = new Map<number, CitationInfo>();
+
+    for (const c of structuredCitations) {
+      raw.set(c.index, {
+        number: c.index,
+        type: c.type,
+        filename: c.source,
+        fileId: c.fileId,
+        url: c.url,
+        page: c.page,
+        relevance:
+          c.relevance != null ? Math.round(c.relevance * 100) : undefined,
+      });
+    }
+
     return deduplicateCitations(raw);
-  }, [toolsUsage, contextText]);
+  }, [structuredCitations]);
 
   return { citations, hasCitations: citations.size > 0 };
 }

--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -12,10 +12,12 @@ import { Button } from '@/app/components/ui/primitives/button';
 import { IconButton } from '@/app/components/ui/primitives/icon-button';
 import { Heading } from '@/app/components/ui/typography/heading';
 import { Text } from '@/app/components/ui/typography/text';
+import { useFileUrl } from '@/app/features/chat/hooks/queries';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useLocale } from '@/app/hooks/use-locale';
 import { useToast } from '@/app/hooks/use-toast';
+import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 import { formatBytes } from '@/lib/utils/format/number';
 
@@ -29,6 +31,8 @@ interface DocumentPreviewDialogProps {
   onOpenChange: (open: boolean) => void;
   organizationId: string;
   documentId?: string;
+  /** Convex storage ID — used when documentId is not available (e.g. citation source cards). */
+  fileId?: string;
   fileName?: string;
 }
 
@@ -156,28 +160,40 @@ export function DocumentPreviewDialog({
   onOpenChange,
   organizationId,
   documentId,
+  fileId,
   fileName,
 }: DocumentPreviewDialogProps) {
   const { t } = useT('documents');
   const [isDownloading, setIsDownloading] = useState(false);
   const { toast } = useToast();
 
-  const { documents, isLoading } = useDocuments(organizationId);
+  const { documents, isLoading: isLoadingDocs } = useDocuments(organizationId);
 
   const doc = useMemo(() => {
-    if (!documents || !open || !documentId) return undefined;
-    return documents.find((d: Document) => d.id === documentId);
+    if (!documents || !open) return undefined;
+    if (documentId) {
+      return documents.find((d: Document) => d.id === documentId);
+    }
+    return undefined;
   }, [documents, open, documentId]);
 
+  // When no documentId is available, resolve fileId (storage ID) directly to a URL
+  const { data: storageUrl, isLoading: isLoadingUrl } = useFileUrl(
+    !documentId && fileId ? toId<'_storage'>(fileId) : undefined,
+    !open,
+  );
+
+  const resolvedUrl = doc?.url ?? storageUrl ?? undefined;
+  const isLoading = documentId ? isLoadingDocs : isLoadingUrl;
   const displayName = fileName || doc?.name || t('preview.document');
 
   const handleDownload = async () => {
-    if (!doc?.url) return;
+    if (!resolvedUrl) return;
 
     try {
       setIsDownloading(true);
 
-      const response = await fetch(doc.url);
+      const response = await fetch(resolvedUrl);
       if (!response.ok) throw new Error(t('preview.downloadFailed'));
 
       const blob = await response.blob();
@@ -225,7 +241,7 @@ export function DocumentPreviewDialog({
           </Heading>
 
           <ActionRow gap={2}>
-            {doc?.url && (
+            {resolvedUrl && (
               <Button
                 variant="secondary"
                 size="sm"
@@ -257,19 +273,19 @@ export function DocumentPreviewDialog({
           </Text>
         </div>
       )}
-      {!isLoading && !doc && open && (
+      {!isLoading && !resolvedUrl && open && (
         <div className="grid flex-1 place-items-center p-6">
           <Text as="div" variant="error">
             {t('preview.failedToLoad')}
           </Text>
         </div>
       )}
-      {!isLoading && doc?.url && (
+      {!isLoading && resolvedUrl && (
         <div className="flex min-h-0 flex-1 gap-5 px-5 pb-5">
           <div className="flex min-w-0 flex-1 flex-col">
-            <DocumentPreview url={doc.url} fileName={displayName} />
+            <DocumentPreview url={resolvedUrl} fileName={displayName} />
           </div>
-          <DetailsSidebar doc={doc} />
+          {doc && <DetailsSidebar doc={doc} />}
         </div>
       )}
     </Dialog>

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -237,9 +237,19 @@ RESPONSE (list_indexed):
           hasMore,
         });
 
+        const citations = [
+          {
+            index: 1,
+            type: 'rag' as const,
+            source: result.title ?? 'Unknown',
+            fileId: result.file_id,
+          },
+        ];
+
         return {
           success: true,
           response: text || 'Document has no text content.',
+          citations,
           fileId: result.file_id,
           filename: result.title,
           sourceCreatedAt: result.source_created_at,
@@ -302,6 +312,37 @@ RESPONSE (list_indexed):
           formatSearchResults(result.results) ??
           'No relevant results found in the knowledge base.';
 
+        // Merge citations by fileId — keep one entry per file with highest relevance
+        const citationsByFile = new Map<
+          string,
+          { source: string; fileId?: string; relevance?: number }
+        >();
+        for (const r of result.results) {
+          const key =
+            r.file_id ?? r.filename ?? `unknown-${citationsByFile.size}`;
+          const existing = citationsByFile.get(key);
+          if (
+            !existing ||
+            (r.score != null &&
+              (existing.relevance == null || r.score > existing.relevance))
+          ) {
+            citationsByFile.set(key, {
+              source: r.filename ?? 'Unknown',
+              fileId: r.file_id,
+              relevance: r.score,
+            });
+          }
+        }
+        const citations = Array.from(citationsByFile.values()).map(
+          (c, idx) => ({
+            index: idx + 1,
+            type: 'rag' as const,
+            source: c.source,
+            fileId: c.fileId,
+            relevance: c.relevance,
+          }),
+        );
+
         debugLog('tool:rag_search success', {
           query: args.query,
           resultCount: result.total_results,
@@ -312,7 +353,7 @@ RESPONSE (list_indexed):
         return {
           success: true,
           response: formatted,
-          output: formatted,
+          citations,
           ...(result.usage && {
             usage: {
               inputTokens: result.usage.input_tokens,

--- a/services/platform/convex/agent_tools/web/helpers/search_pages.ts
+++ b/services/platform/convex/agent_tools/web/helpers/search_pages.ts
@@ -58,10 +58,23 @@ async function fetchSearch(
   return response.json();
 }
 
+interface Citation {
+  index: number;
+  type: 'web';
+  source: string;
+  url: string;
+  relevance: number;
+}
+
+interface SearchPagesResult {
+  text: string;
+  citations: Citation[];
+}
+
 export async function searchPages(
   ctx: ToolCtx,
   args: { query: string; domain?: string },
-): Promise<string> {
+): Promise<SearchPagesResult> {
   let validDomain: string | undefined;
 
   if (args.domain && isValidDomain(args.domain) && ctx.organizationId) {
@@ -71,7 +84,10 @@ export async function searchPages(
     );
 
     if (!website) {
-      return `The website "${args.domain}" is not in your knowledge base. Ask the user to add it via the Websites settings page, or provide a specific URL to fetch content directly.`;
+      return {
+        text: `The website "${args.domain}" is not in your knowledge base. Ask the user to add it via the Websites settings page, or provide a specific URL to fetch content directly.`,
+        citations: [],
+      };
     }
 
     validDomain = args.domain;
@@ -83,7 +99,10 @@ export async function searchPages(
   });
 
   if (!args.query.trim() && validDomain) {
-    return 'Please provide a search query along with the domain filter.';
+    return {
+      text: 'Please provide a search query along with the domain filter.',
+      citations: [],
+    };
   }
 
   const crawlerUrl = getCrawlerServiceUrl();
@@ -104,7 +123,10 @@ export async function searchPages(
 
   if (!results || results.length === 0) {
     debugLog('web:search_pages no results', { query: args.query });
-    return 'No matching website pages found for your query. Try rephrasing, or suggest the user add the relevant website to their knowledge base.';
+    return {
+      text: 'No matching website pages found for your query. Try rephrasing, or suggest the user add the relevant website to their knowledge base.',
+      citations: [],
+    };
   }
 
   debugLog('web:search_pages success', {
@@ -135,9 +157,20 @@ export async function searchPages(
 
   const output = formatWebResults(pages) ?? '';
 
+  const citations = pages.map((p, idx) => ({
+    index: idx + 1,
+    type: 'web' as const,
+    source: p.title,
+    url: p.url,
+    relevance: p.score,
+  }));
+
   if (domainFallback) {
-    return `No results found on ${validDomain}. Showing results from all indexed websites:\n\n${output}`;
+    return {
+      text: `No results found on ${validDomain}. Showing results from all indexed websites:\n\n${output}`,
+      citations,
+    };
   }
 
-  return output;
+  return { text: output, citations };
 }

--- a/services/platform/convex/agent_tools/web/web_tool.ts
+++ b/services/platform/convex/agent_tools/web/web_tool.ts
@@ -106,7 +106,6 @@ EXAMPLES:
         return {
           success: true,
           response: responseText,
-          output: responseText,
           ...(result.usage && {
             usage: {
               inputTokens: result.usage.input_tokens,
@@ -118,11 +117,11 @@ EXAMPLES:
         };
       }
 
-      const searchResult = await searchPages(ctx, {
+      const { text: searchResult, citations } = await searchPages(ctx, {
         query: args.query,
         domain: args.domain,
       });
-      return { success: true, response: searchResult, output: searchResult };
+      return { success: true, response: searchResult, citations };
     },
   }),
 };

--- a/services/platform/convex/lib/agent_completion/on_agent_complete.ts
+++ b/services/platform/convex/lib/agent_completion/on_agent_complete.ts
@@ -44,6 +44,15 @@ export interface AgentResponseResult {
     input?: string;
     output?: string;
   }>;
+  citations?: Array<{
+    index: number;
+    type: 'rag' | 'web';
+    source: string;
+    fileId?: string;
+    url?: string;
+    page?: number;
+    relevance?: number;
+  }>;
   contextWindow?: string;
   contextStats?: {
     totalTokens: number;
@@ -113,6 +122,10 @@ export async function onAgentComplete(
     const messageId = result.messageId;
 
     if (messageId) {
+      console.log('[onAgentComplete] DEBUG citations:', {
+        hasCitations: !!result.citations,
+        citationsLength: result.citations?.length,
+      });
       promises.push(
         ctx
           .runMutation(
@@ -131,6 +144,7 @@ export async function onAgentComplete(
               durationMs: result.durationMs,
               timeToFirstTokenMs: result.timeToFirstTokenMs,
               toolsUsage: result.toolsUsage,
+              citations: result.citations,
               contextWindow: result.contextWindow,
               contextStats: result.contextStats,
               error: result.error,

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -23,7 +23,6 @@ import {
 } from '@convex-dev/agent';
 import type { StreamMessage } from '@convex-dev/agent/validators';
 import type { ModelMessage } from 'ai';
-import { isUndefined, omitBy } from 'lodash';
 
 import { isRecord, getString } from '../../../lib/utils/type-guards';
 import { components, internal } from '../../_generated/api';
@@ -2033,32 +2032,13 @@ function extractToolCallsFromSteps(steps: unknown[]): {
       // Extract structured citations from raw tool result before safeStringify truncation.
       // The result may be the direct return value, or wrapped as {value: {...}} by @convex-dev/agent.
       const rawOutput = matchingResult?.output ?? matchingResult?.result;
-      console.log('[extractToolCalls] DEBUG tool:', toolCall.toolName, {
-        hasMatchingResult: !!matchingResult,
-        rawOutputType: typeof rawOutput,
-        rawOutputIsRecord: isRecord(rawOutput),
-        rawOutputKeys: isRecord(rawOutput) ? Object.keys(rawOutput) : [],
-        hasCitationsDirect:
-          isRecord(rawOutput) && Array.isArray(rawOutput.citations),
-        hasValue: isRecord(rawOutput) && isRecord(rawOutput.value),
-        valueKeys:
-          isRecord(rawOutput) && isRecord(rawOutput.value)
-            ? Object.keys(rawOutput.value as Record<string, unknown>)
-            : [],
-        hasValueCitations:
-          isRecord(rawOutput) &&
-          isRecord(rawOutput.value) &&
-          Array.isArray((rawOutput.value as Record<string, unknown>).citations),
-      });
       const citationSource =
         isRecord(rawOutput) && Array.isArray(rawOutput.citations)
           ? rawOutput.citations
           : isRecord(rawOutput) &&
               isRecord(rawOutput.value) &&
-              Array.isArray(
-                (rawOutput.value as Record<string, unknown>).citations,
-              )
-            ? (rawOutput.value as Record<string, unknown>).citations
+              Array.isArray(rawOutput.value.citations)
+            ? rawOutput.value.citations
             : undefined;
       if (Array.isArray(citationSource)) {
         for (const c of citationSource) {
@@ -2070,21 +2050,16 @@ function extractToolCallsFromSteps(steps: unknown[]): {
           ) {
             const citationType: 'rag' | 'web' = c.type;
             // Convex validators reject explicit `undefined` — omit undefined fields
-            allCitations.push(
-              omitBy(
-                {
-                  index: typeof c.index === 'number' ? c.index : 0,
-                  type: citationType,
-                  source: typeof c.source === 'string' ? c.source : 'Unknown',
-                  fileId: typeof c.fileId === 'string' ? c.fileId : undefined,
-                  url: typeof c.url === 'string' ? c.url : undefined,
-                  page: typeof c.page === 'number' ? c.page : undefined,
-                  relevance:
-                    typeof c.relevance === 'number' ? c.relevance : undefined,
-                },
-                isUndefined,
-              ) as (typeof allCitations)[number],
-            );
+            const entry: (typeof allCitations)[number] = {
+              index: typeof c.index === 'number' ? c.index : 0,
+              type: citationType,
+              source: typeof c.source === 'string' ? c.source : 'Unknown',
+            };
+            if (typeof c.fileId === 'string') entry.fileId = c.fileId;
+            if (typeof c.url === 'string') entry.url = c.url;
+            if (typeof c.page === 'number') entry.page = c.page;
+            if (typeof c.relevance === 'number') entry.relevance = c.relevance;
+            allCitations.push(entry);
           }
         }
       }
@@ -2096,7 +2071,7 @@ function extractToolCallsFromSteps(steps: unknown[]): {
       // Unwrap {value: {...}} wrapper if present (from @convex-dev/agent)
       const unwrapped =
         isRecord(rawForOutput) && isRecord(rawForOutput.value)
-          ? (rawForOutput.value as Record<string, unknown>)
+          ? rawForOutput.value
           : isRecord(rawForOutput)
             ? rawForOutput
             : undefined;
@@ -2200,12 +2175,6 @@ function extractToolCallsFromSteps(steps: unknown[]): {
     }
   }
 
-  console.log('[extractToolCalls] DEBUG final:', {
-    toolCallCount: toolCalls.length,
-    toolsUsageCount: toolsUsage.length,
-    citationsCount: allCitations.length,
-    citations: allCitations.slice(0, 3),
-  });
   return { toolCalls, toolsUsage, citations: allCitations };
 }
 

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -23,6 +23,7 @@ import {
 } from '@convex-dev/agent';
 import type { StreamMessage } from '@convex-dev/agent/validators';
 import type { ModelMessage } from 'ai';
+import { isUndefined, omitBy } from 'lodash';
 
 import { isRecord, getString } from '../../../lib/utils/type-guards';
 import { components, internal } from '../../_generated/api';
@@ -1386,7 +1387,7 @@ export async function generateAgentResponse(
     });
 
     // Extract tool calls from steps
-    const { toolCalls, toolsUsage } = extractToolCallsFromSteps(
+    const { toolCalls, toolsUsage, citations } = extractToolCallsFromSteps(
       result.steps ?? [],
     );
 
@@ -1457,6 +1458,7 @@ export async function generateAgentResponse(
       timeToFirstTokenMs,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       toolsUsage: toolsUsage.length > 0 ? toolsUsage : undefined,
+      citations: citations.length > 0 ? citations : undefined,
       contextWindow: completeContextWindow,
       contextStats,
       model: actualModel,
@@ -1492,6 +1494,7 @@ export async function generateAgentResponse(
         timeToFirstTokenMs,
         toolCalls: responseResult.toolCalls,
         toolsUsage: responseResult.toolsUsage,
+        citations: responseResult.citations,
         contextWindow: completeContextWindow,
         contextStats: responseResult.contextStats,
       },
@@ -1834,7 +1837,7 @@ export async function generateAgentResponse(
     if (metadataMessageId) {
       try {
         const durationMs = Date.now() - startTime;
-        const { toolCalls, toolsUsage } = extractToolCallsFromSteps(
+        const { toolCalls, toolsUsage, citations } = extractToolCallsFromSteps(
           result.steps ?? [],
         );
         const contextWindowParts: string[] = [];
@@ -1866,6 +1869,7 @@ export async function generateAgentResponse(
               : undefined,
             toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
             toolsUsage: toolsUsage.length > 0 ? toolsUsage : undefined,
+            citations: citations.length > 0 ? citations : undefined,
             contextWindow:
               contextWindowParts.length > 0
                 ? contextWindowParts.join('\n\n')
@@ -1941,6 +1945,15 @@ function extractToolCallsFromSteps(steps: unknown[]): {
     output?: string;
     costEstimateCents?: number;
   }>;
+  citations: Array<{
+    index: number;
+    type: 'rag' | 'web';
+    source: string;
+    fileId?: string;
+    url?: string;
+    page?: number;
+    relevance?: number;
+  }>;
 } {
   type StepWithTools = {
     toolCalls?: Array<{
@@ -1970,6 +1983,15 @@ function extractToolCallsFromSteps(steps: unknown[]): {
     input?: string;
     output?: string;
     costEstimateCents?: number;
+  }> = [];
+  const allCitations: Array<{
+    index: number;
+    type: 'rag' | 'web';
+    source: string;
+    fileId?: string;
+    url?: string;
+    page?: number;
+    relevance?: number;
   }> = [];
 
   for (const rawStep of steps) {
@@ -2008,9 +2030,84 @@ function extractToolCallsFromSteps(steps: unknown[]): {
         status: isSuccess ? 'completed' : 'failed',
       });
 
+      // Extract structured citations from raw tool result before safeStringify truncation.
+      // The result may be the direct return value, or wrapped as {value: {...}} by @convex-dev/agent.
+      const rawOutput = matchingResult?.output ?? matchingResult?.result;
+      console.log('[extractToolCalls] DEBUG tool:', toolCall.toolName, {
+        hasMatchingResult: !!matchingResult,
+        rawOutputType: typeof rawOutput,
+        rawOutputIsRecord: isRecord(rawOutput),
+        rawOutputKeys: isRecord(rawOutput) ? Object.keys(rawOutput) : [],
+        hasCitationsDirect:
+          isRecord(rawOutput) && Array.isArray(rawOutput.citations),
+        hasValue: isRecord(rawOutput) && isRecord(rawOutput.value),
+        valueKeys:
+          isRecord(rawOutput) && isRecord(rawOutput.value)
+            ? Object.keys(rawOutput.value as Record<string, unknown>)
+            : [],
+        hasValueCitations:
+          isRecord(rawOutput) &&
+          isRecord(rawOutput.value) &&
+          Array.isArray((rawOutput.value as Record<string, unknown>).citations),
+      });
+      const citationSource =
+        isRecord(rawOutput) && Array.isArray(rawOutput.citations)
+          ? rawOutput.citations
+          : isRecord(rawOutput) &&
+              isRecord(rawOutput.value) &&
+              Array.isArray(
+                (rawOutput.value as Record<string, unknown>).citations,
+              )
+            ? (rawOutput.value as Record<string, unknown>).citations
+            : undefined;
+      if (Array.isArray(citationSource)) {
+        for (const c of citationSource) {
+          if (
+            isRecord(c) &&
+            typeof c.index === 'number' &&
+            typeof c.type === 'string' &&
+            (c.type === 'rag' || c.type === 'web')
+          ) {
+            const citationType: 'rag' | 'web' = c.type;
+            // Convex validators reject explicit `undefined` — omit undefined fields
+            allCitations.push(
+              omitBy(
+                {
+                  index: typeof c.index === 'number' ? c.index : 0,
+                  type: citationType,
+                  source: typeof c.source === 'string' ? c.source : 'Unknown',
+                  fileId: typeof c.fileId === 'string' ? c.fileId : undefined,
+                  url: typeof c.url === 'string' ? c.url : undefined,
+                  page: typeof c.page === 'number' ? c.page : undefined,
+                  relevance:
+                    typeof c.relevance === 'number' ? c.relevance : undefined,
+                },
+                isUndefined,
+              ) as (typeof allCitations)[number],
+            );
+          }
+        }
+      }
+
       const inputStr = safeStringify(toolCall.input ?? toolCall.args);
+      // Serialize only fields needed by downstream consumers (citation content parsing, debug display).
+      // Strips duplicate `output`, `usage`, `model`, `citations` to reduce truncation.
+      const rawForOutput = matchingResult?.output ?? matchingResult?.result;
+      // Unwrap {value: {...}} wrapper if present (from @convex-dev/agent)
+      const unwrapped =
+        isRecord(rawForOutput) && isRecord(rawForOutput.value)
+          ? (rawForOutput.value as Record<string, unknown>)
+          : isRecord(rawForOutput)
+            ? rawForOutput
+            : undefined;
       const outputStr = safeStringify(
-        matchingResult?.output ?? matchingResult?.result,
+        unwrapped
+          ? {
+              response: unwrapped.response,
+              fileId: unwrapped.fileId,
+              filename: unwrapped.filename ?? unwrapped.title,
+            }
+          : rawForOutput,
       );
 
       const usageEntry: (typeof toolsUsage)[number] = {
@@ -2103,7 +2200,13 @@ function extractToolCallsFromSteps(steps: unknown[]): {
     }
   }
 
-  return { toolCalls, toolsUsage };
+  console.log('[extractToolCalls] DEBUG final:', {
+    toolCallCount: toolCalls.length,
+    toolsUsageCount: toolsUsage.length,
+    citationsCount: allCitations.length,
+    citations: allCitations.slice(0, 3),
+  });
+  return { toolCalls, toolsUsage, citations: allCitations };
 }
 
 /**

--- a/services/platform/convex/lib/agent_response/types.ts
+++ b/services/platform/convex/lib/agent_response/types.ts
@@ -183,6 +183,15 @@ export interface GenerateResponseResult {
     input?: string;
     output?: string;
   }>;
+  citations?: Array<{
+    index: number;
+    type: 'rag' | 'web';
+    source: string;
+    fileId?: string;
+    url?: string;
+    page?: number;
+    relevance?: number;
+  }>;
   contextWindow?: string;
   contextStats?: {
     totalTokens: number;

--- a/services/platform/convex/message_metadata/internal_mutations.ts
+++ b/services/platform/convex/message_metadata/internal_mutations.ts
@@ -4,6 +4,7 @@ import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
 import {
   toolUsageItemValidator,
+  citationItemValidator,
   contextStatsValidator,
 } from '../streaming/validators';
 
@@ -25,6 +26,7 @@ export const saveMessageMetadata = internalMutation({
     durationMs: v.optional(v.number()),
     timeToFirstTokenMs: v.optional(v.number()),
     toolsUsage: v.optional(v.array(toolUsageItemValidator)),
+    citations: v.optional(v.array(citationItemValidator)),
     contextWindow: v.optional(v.string()),
     contextStats: v.optional(contextStatsValidator),
     error: v.optional(v.string()),
@@ -32,6 +34,11 @@ export const saveMessageMetadata = internalMutation({
   },
   returns: v.id('messageMetadata'),
   handler: async (ctx, args) => {
+    console.log('[saveMessageMetadata] DEBUG citations:', {
+      hasCitations: !!args.citations,
+      citationsLength: args.citations?.length,
+      firstCitation: args.citations?.[0],
+    });
     let contextWindow = args.contextWindow;
     if (contextWindow && contextWindow.length > MAX_CONTEXT_WINDOW_CHARS) {
       console.warn(
@@ -61,6 +68,7 @@ export const saveMessageMetadata = internalMutation({
         timeToFirstTokenMs:
           args.timeToFirstTokenMs ?? existing.timeToFirstTokenMs,
         toolsUsage: args.toolsUsage ?? existing.toolsUsage,
+        citations: args.citations ?? existing.citations,
         contextWindow: contextWindow ?? existing.contextWindow,
         contextStats: args.contextStats ?? existing.contextStats,
         error: args.error ?? existing.error,
@@ -84,6 +92,7 @@ export const saveMessageMetadata = internalMutation({
       durationMs: args.durationMs,
       timeToFirstTokenMs: args.timeToFirstTokenMs,
       toolsUsage: args.toolsUsage,
+      citations: args.citations,
       contextWindow,
       contextStats: args.contextStats,
       error: args.error,

--- a/services/platform/convex/openai_compat/http_actions.ts
+++ b/services/platform/convex/openai_compat/http_actions.ts
@@ -24,7 +24,31 @@ import {
 } from '../lib/rate_limiter/helpers';
 import { persistentStreaming } from '../streaming/helpers';
 import { extractClientIp } from '../workflows/triggers/helpers/validate';
-import { parseCitationsFromToolsUsage } from './citations';
+import type { Citation } from './citations';
+
+/** Map structured citation metadata to the Citation interface used by response formatting. */
+function toApiCitations(
+  raw?: Array<{
+    index: number;
+    type: 'rag' | 'web';
+    source: string;
+    fileId?: string;
+    url?: string;
+    page?: number;
+    relevance?: number;
+  }>,
+): Citation[] {
+  if (!raw) return [];
+  return raw.map((c) => ({
+    index: c.index,
+    type: c.type,
+    source: c.source,
+    fileId: c.fileId,
+    url: c.url,
+    page: c.page,
+    relevance: c.relevance ?? 0,
+  }));
+}
 import {
   buildChatCompletion,
   buildChatCompletionChunk,
@@ -686,13 +710,12 @@ async function pollOpenAIResponse(
     const body = await persistentStreaming.getStreamBody(ctx, streamId);
 
     if (body.status === 'done') {
-      const toolsUsage = await ctx.runQuery(
+      const result = await ctx.runQuery(
         internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
         { threadId: chatResult.threadId },
       );
-      const citations = toolsUsage
-        ? parseCitationsFromToolsUsage(toolsUsage)
-        : [];
+      // Use structured citations directly if available
+      const citations = toApiCitations(result?.citations);
 
       const response = buildChatCompletion(
         chatResult.streamId,
@@ -796,13 +819,12 @@ async function streamOpenAIResponse(
         );
         await writer.write(encoder.encode(formatSSEChunk(finalChunk)));
 
-        const toolsUsage = await ctx.runQuery(
+        const result = await ctx.runQuery(
           internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
           { threadId: chatResult.threadId },
         );
-        const citations = toolsUsage
-          ? parseCitationsFromToolsUsage(toolsUsage)
-          : [];
+        // Use structured citations directly if available
+        const citations = toApiCitations(result?.citations);
         if (citations.length > 0) {
           await writer.write(encoder.encode(formatSSECitations(citations)));
         }

--- a/services/platform/convex/openai_compat/internal_queries.ts
+++ b/services/platform/convex/openai_compat/internal_queries.ts
@@ -10,6 +10,7 @@ import { v } from 'convex/values';
 import { isRecord, getString } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { internalQuery } from '../_generated/server';
+import { citationItemValidator } from '../streaming/validators';
 
 /**
  * Resolve the user's organization.
@@ -99,12 +100,15 @@ export const getLatestThreadToolsUsage = internalQuery({
     threadId: v.string(),
   },
   returns: v.union(
-    v.array(
-      v.object({
-        toolName: v.string(),
-        output: v.optional(v.string()),
-      }),
-    ),
+    v.object({
+      toolsUsage: v.array(
+        v.object({
+          toolName: v.string(),
+          output: v.optional(v.string()),
+        }),
+      ),
+      citations: v.optional(v.array(citationItemValidator)),
+    }),
     v.null(),
   ),
   handler: async (ctx, args) => {
@@ -116,9 +120,12 @@ export const getLatestThreadToolsUsage = internalQuery({
 
     if (!metadata?.toolsUsage) return null;
 
-    return metadata.toolsUsage.map((t) => ({
-      toolName: t.toolName,
-      output: t.output,
-    }));
+    return {
+      toolsUsage: metadata.toolsUsage.map((t) => ({
+        toolName: t.toolName,
+        output: t.output,
+      })),
+      citations: metadata.citations,
+    };
   },
 });

--- a/services/platform/convex/streaming/schema.ts
+++ b/services/platform/convex/streaming/schema.ts
@@ -49,6 +49,19 @@ export const messageMetadataTable = defineTable({
       }),
     ),
   ),
+  citations: v.optional(
+    v.array(
+      v.object({
+        index: v.number(),
+        type: v.union(v.literal('rag'), v.literal('web')),
+        source: v.string(),
+        fileId: v.optional(v.string()),
+        url: v.optional(v.string()),
+        page: v.optional(v.number()),
+        relevance: v.optional(v.number()),
+      }),
+    ),
+  ),
   // Structured context window for debugging (XML-like formatted)
   contextWindow: v.optional(v.string()),
   contextStats: v.optional(

--- a/services/platform/convex/streaming/validators.ts
+++ b/services/platform/convex/streaming/validators.ts
@@ -28,6 +28,16 @@ export const contextStatsValidator = v.object({
   hasIntegrations: v.optional(v.boolean()),
 });
 
+export const citationItemValidator = v.object({
+  index: v.number(),
+  type: v.union(v.literal('rag'), v.literal('web')),
+  source: v.string(),
+  fileId: v.optional(v.string()),
+  url: v.optional(v.string()),
+  page: v.optional(v.number()),
+  relevance: v.optional(v.number()),
+});
+
 export const messageMetadataValidator = v.object({
   _id: v.id('messageMetadata'),
   _creationTime: v.number(),
@@ -46,6 +56,7 @@ export const messageMetadataValidator = v.object({
   timeToFirstTokenMs: v.optional(v.number()),
   subAgentUsage: v.optional(v.array(toolUsageItemValidator)),
   toolsUsage: v.optional(v.array(toolUsageItemValidator)),
+  citations: v.optional(v.array(citationItemValidator)),
   contextWindow: v.optional(v.string()),
   contextStats: v.optional(contextStatsValidator),
   error: v.optional(v.string()),

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2821,8 +2821,7 @@
       "visitPage": "Visit page",
       "showAllSources": "Show all {count} sources",
       "hideSources": "Hide sources",
-      "chunkCount": "{count, plural, one {# chunk} other {# chunks}}",
-      "noContent": "Content not available"
+      "chunkCount": "{count, plural, one {# chunk} other {# chunks}}"
     },
     "feedback": {
       "thumbsUp": "Helpful",


### PR DESCRIPTION
## Summary
- Fix citations being dropped in the success-path `onAgentComplete` call (missing `citations` field)
- Merge RAG citations by `fileId` at the tool level — one entry per file with highest relevance instead of duplicate entries per chunk
- Remove broken content extraction from truncated tool output JSON that caused repeated `JSON.parse` errors on the frontend
- Replace chunk detail dialog with `DocumentPreviewDialog` for direct file preview and download
- Extend `DocumentPreviewDialog` to accept `fileId` (storage ID) for direct URL resolution without requiring a document table lookup
- Lower `MIN_CHUNK_LENGTH` to 10 and fix source card chunk count

## Test plan
- [ ] Send a RAG query referencing a PDF, verify source cards appear below the response
- [ ] Click a source card — should open `DocumentPreviewDialog` with file preview and download button
- [ ] Verify no `[use-citations] Failed to parse tool output JSON` console errors
- [ ] Verify citations metadata is saved (check `[onAgentComplete] DEBUG citations` log shows `hasCitations: true`)
- [ ] Verify web citations still open in new tab
- [ ] Verify multi-file queries show one source card per unique file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented structured citation tracking system with source attribution for both RAG and web search results in chat messages
  * Extended document preview functionality to support direct file ID loading

* **Bug Fixes**
  * Adjusted content chunking thresholds to process shorter text segments

* **Tests**
  * Updated test coverage and assertions to reflect revised chunking size thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->