### PR TITLE
feat(platform): add citation support for context retrieval mode

### DIFF
--- a/services/platform/convex/agent_tools/rag/format_search_results.test.ts
+++ b/services/platform/convex/agent_tools/rag/format_search_results.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSearchResults } from './format_search_results';
+import {
+  extractCitationsFromSearchResults,
+  formatSearchResults,
+} from './format_search_results';
 
 describe('formatSearchResults', () => {
   it('returns undefined for empty results', () => {
@@ -137,5 +140,104 @@ describe('formatSearchResults', () => {
       { content: 'Content', score: 0.8, filename: undefined },
     ]);
     expect(result).toBe('[1] (Relevance: 80.0%)\nContent');
+  });
+});
+
+describe('extractCitationsFromSearchResults', () => {
+  it('returns empty array for empty results', () => {
+    expect(extractCitationsFromSearchResults([])).toEqual([]);
+  });
+
+  it('extracts citation from a single result with all metadata', () => {
+    const citations = extractCitationsFromSearchResults([
+      {
+        content: 'Hello world',
+        score: 0.873,
+        file_id: 'doc-123',
+        filename: 'report.pdf',
+      },
+    ]);
+    expect(citations).toEqual([
+      {
+        index: 1,
+        type: 'rag',
+        source: 'report.pdf',
+        fileId: 'doc-123',
+        relevance: 0.873,
+      },
+    ]);
+  });
+
+  it('extracts citations from multiple results with correct indices', () => {
+    const citations = extractCitationsFromSearchResults([
+      { content: 'A', score: 0.9, file_id: 'doc-1', filename: 'a.pdf' },
+      { content: 'B', score: 0.7, file_id: 'doc-2', filename: 'b.pdf' },
+    ]);
+    expect(citations).toHaveLength(2);
+    expect(citations[0].index).toBe(1);
+    expect(citations[1].index).toBe(2);
+    expect(citations[0].source).toBe('a.pdf');
+    expect(citations[1].source).toBe('b.pdf');
+  });
+
+  it('deduplicates by file_id and keeps highest score', () => {
+    const citations = extractCitationsFromSearchResults([
+      {
+        content: 'Chunk 1',
+        score: 0.85,
+        file_id: 'doc-123',
+        filename: 'report.pdf',
+      },
+      {
+        content: 'Chunk 2',
+        score: 0.72,
+        file_id: 'doc-456',
+        filename: 'memo.docx',
+      },
+      {
+        content: 'Chunk 3',
+        score: 0.9,
+        file_id: 'doc-123',
+        filename: 'report.pdf',
+      },
+    ]);
+    expect(citations).toHaveLength(2);
+    expect(citations[0]).toEqual({
+      index: 1,
+      type: 'rag',
+      source: 'report.pdf',
+      fileId: 'doc-123',
+      relevance: 0.9,
+    });
+    expect(citations[1].source).toBe('memo.docx');
+  });
+
+  it('falls back to filename then unknown-N when file_id is missing', () => {
+    const citations = extractCitationsFromSearchResults([
+      { content: 'A', score: 0.8, filename: 'report.pdf' },
+      { content: 'B', score: 0.7 },
+    ]);
+    expect(citations).toHaveLength(2);
+    expect(citations[0].source).toBe('report.pdf');
+    expect(citations[0]).not.toHaveProperty('fileId');
+    expect(citations[1].source).toBe('Unknown');
+  });
+
+  it('preserves relevance of 0 (not filtered by falsy check)', () => {
+    const citations = extractCitationsFromSearchResults([
+      { content: 'A', score: 0, file_id: 'doc-1', filename: 'a.pdf' },
+    ]);
+    expect(citations[0].relevance).toBe(0);
+  });
+
+  it('omits undefined optional fields for Convex compatibility', () => {
+    const citations = extractCitationsFromSearchResults([
+      { content: 'A', score: 0.5 },
+    ]);
+    expect(citations[0]).not.toHaveProperty('fileId');
+    // relevance is always set from score
+    expect(citations[0].relevance).toBe(0.5);
+    expect(citations[0]).not.toHaveProperty('url');
+    expect(citations[0]).not.toHaveProperty('page');
   });
 });

--- a/services/platform/convex/agent_tools/rag/format_search_results.ts
+++ b/services/platform/convex/agent_tools/rag/format_search_results.ts
@@ -48,6 +48,65 @@ export interface SearchResponse {
  *
  * Returns `undefined` when there are no results.
  */
+/**
+ * Structured citation metadata extracted from search results.
+ * Shape matches `citationItemValidator` in streaming/validators.ts.
+ */
+export interface ContextCitation {
+  index: number;
+  type: 'rag' | 'web';
+  source: string;
+  fileId?: string;
+  url?: string;
+  page?: number;
+  relevance?: number;
+}
+
+/**
+ * Extract deduplicated citation metadata from RAG search results.
+ * Groups by file_id (one citation per unique document), keeping the
+ * highest relevance score when multiple chunks match the same file.
+ *
+ * Logic mirrors rag_search_tool.ts lines 315-344.
+ */
+export function extractCitationsFromSearchResults(
+  results: SearchResult[],
+): ContextCitation[] {
+  if (results.length === 0) return [];
+
+  const citationsByFile = new Map<
+    string,
+    { source: string; fileId?: string; relevance?: number }
+  >();
+
+  for (const r of results) {
+    const key = r.file_id ?? r.filename ?? `unknown-${citationsByFile.size}`;
+    const existing = citationsByFile.get(key);
+    if (
+      !existing ||
+      (r.score != null &&
+        (existing.relevance == null || r.score > existing.relevance))
+    ) {
+      citationsByFile.set(key, {
+        source: r.filename ?? 'Unknown',
+        fileId: r.file_id,
+        relevance: r.score,
+      });
+    }
+  }
+
+  return Array.from(citationsByFile.values()).map((c, idx) => {
+    const entry: ContextCitation = {
+      index: idx + 1,
+      type: 'rag' as const,
+      source: c.source,
+    };
+    if (c.fileId !== undefined) entry.fileId = c.fileId;
+    if (c.relevance !== undefined) entry.relevance = c.relevance;
+    return entry;
+  });
+}
+
 export function formatSearchResults(
   results: SearchResult[],
 ): string | undefined {

--- a/services/platform/convex/agent_tools/rag/query_rag_context.ts
+++ b/services/platform/convex/agent_tools/rag/query_rag_context.ts
@@ -13,7 +13,9 @@ import { fetchJson } from '../../../lib/utils/type-cast-helpers';
 import { createDebugLog } from '../../lib/debug_log';
 import { getRagConfig } from '../../lib/helpers/rag_config';
 import {
+  extractCitationsFromSearchResults,
   formatSearchResults,
+  type ContextCitation,
   type SearchResponse,
 } from './format_search_results';
 
@@ -114,6 +116,15 @@ Current question: ${currentQuery}`;
 }
 
 /**
+ * Result from a RAG context query, containing both the formatted
+ * text for injection and structured citation metadata.
+ */
+export interface RagContextResult {
+  text: string;
+  citations: ContextCitation[];
+}
+
+/**
  * Options for RAG context queries.
  */
 export interface RagContextOptions {
@@ -140,7 +151,7 @@ export async function queryRagContext(
   signal?: AbortSignal,
   recentMessages?: RecentMessage[],
   options?: RagContextOptions,
-): Promise<string | undefined> {
+): Promise<RagContextResult | undefined> {
   try {
     const ragServiceUrl = getRagConfig().serviceUrl;
     const url = `${ragServiceUrl}/api/v1/search`;
@@ -209,14 +220,18 @@ export async function queryRagContext(
       }
 
       const ragContext = formatSearchResults(result.results);
+      if (!ragContext) return undefined;
+
+      const citations = extractCitationsFromSearchResults(result.results);
 
       debugLog('RAG context retrieved', {
         resultCount: result.total_results,
-        contextLength: ragContext?.length ?? 0,
+        contextLength: ragContext.length,
+        citationCount: citations.length,
         processingTimeMs: result.processing_time_ms,
       });
 
-      return ragContext;
+      return { text: ragContext, citations };
     } catch (fetchError) {
       clearTimeout(timeoutId);
 

--- a/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
+++ b/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
@@ -32,17 +32,34 @@ interface SearchApiResponse {
   total: number;
 }
 
+interface WebContextCitation {
+  index: number;
+  type: 'web';
+  source: string;
+  url: string;
+  relevance: number;
+}
+
 /**
- * Query crawled website pages and return formatted context string.
+ * Result from a web context query, containing both the formatted
+ * text for injection and structured citation metadata.
+ */
+export interface WebContextResult {
+  text: string;
+  citations: WebContextCitation[];
+}
+
+/**
+ * Query crawled website pages and return formatted context with citations.
  *
- * @returns Formatted context string or undefined if no results / on failure
+ * @returns Formatted context with citation metadata, or undefined if no results / on failure
  */
 export async function queryWebContext(
   _ctx: ActionCtx,
   _organizationId: string,
   query: string,
   limit = DEFAULT_LIMIT,
-): Promise<string | undefined> {
+): Promise<WebContextResult | undefined> {
   try {
     debugLog('Querying web context', {
       query: query.slice(0, 100),
@@ -102,15 +119,25 @@ export async function queryWebContext(
         })
         .sort((a, b) => b.score - a.score);
 
-      const webContext = formatWebResults(pages) ?? '';
+      const webContext = formatWebResults(pages);
+      if (!webContext) return undefined;
+
+      const citations: WebContextCitation[] = pages.map((p, idx) => ({
+        index: idx + 1,
+        type: 'web' as const,
+        source: p.title,
+        url: p.url,
+        relevance: p.score,
+      }));
 
       debugLog('Web context retrieved', {
         resultCount: results.length,
         pageCount: byUrl.size,
         contextLength: webContext.length,
+        citationCount: citations.length,
       });
 
-      return webContext;
+      return { text: webContext, citations };
     } catch (fetchError) {
       clearTimeout(timeoutId);
 

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -307,15 +307,37 @@ export const runAgentGeneration = internalAction({
 
           // Create agent factory function from serializable config
           const createAgent = () => {
+            // Filter tools: exclude rag_search/web when their retrieval mode
+            // is 'context' or 'off' (tool should only be available in 'tool'/'both').
+            const knowledgeMode = agentConfig.knowledgeMode ?? 'off';
+            const webSearchMode = agentConfig.webSearchMode ?? 'off';
+            const filteredToolNames = agentConfig.convexToolNames?.filter(
+              (n): n is ToolName => {
+                if (!(TOOL_NAMES as readonly string[]).includes(n))
+                  return false;
+                if (
+                  n === 'rag_search' &&
+                  knowledgeMode !== 'tool' &&
+                  knowledgeMode !== 'both'
+                )
+                  return false;
+                if (
+                  n === 'web' &&
+                  webSearchMode !== 'tool' &&
+                  webSearchMode !== 'both'
+                )
+                  return false;
+                return true;
+              },
+            );
             const config = createAgentConfig({
               name: agentConfig.name,
               instructions: finalInstructions,
               languageModel,
-              convexToolNames: agentConfig.convexToolNames
-                ? agentConfig.convexToolNames.filter((n): n is ToolName =>
-                    (TOOL_NAMES as readonly string[]).includes(n),
-                  )
-                : undefined,
+              convexToolNames:
+                filteredToolNames && filteredToolNames.length > 0
+                  ? filteredToolNames
+                  : undefined,
               extraTools: allExtraTools,
               maxSteps: agentConfig.maxSteps,
               outputFormat: agentConfig.outputFormat,

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -437,7 +437,12 @@ export async function generateAgentResponse(
       webSearchMode === 'context' || webSearchMode === 'both';
 
     // Start context injection queries (non-blocking) for context/both modes
-    let knowledgeContextPromise: Promise<string | undefined> | undefined;
+    let knowledgeContextPromise:
+      | Promise<
+          | import('../../agent_tools/rag/query_rag_context').RagContextResult
+          | undefined
+        >
+      | undefined;
     if (needsKnowledgeContext && organizationId && promptMessage) {
       const accessibleFileIds: string[] = await ctx.runQuery(
         internal.documents.internal_queries.getAgentScopedFileIds,
@@ -468,7 +473,12 @@ export async function generateAgentResponse(
       }
     }
 
-    let webContextPromise: Promise<string | undefined> | undefined;
+    let webContextPromise:
+      | Promise<
+          | import('../../agent_tools/web/helpers/query_web_context').WebContextResult
+          | undefined
+        >
+      | undefined;
     if (needsWebContext && organizationId && promptMessage) {
       webContextPromise = queryWebContext(ctx, organizationId, promptMessage);
       debugLog('Web context query started', {
@@ -495,13 +505,15 @@ export async function generateAgentResponse(
 
     if (knowledgeContextResult) {
       debugLog('Knowledge context injected', {
-        contextLength: knowledgeContextResult.length,
+        contextLength: knowledgeContextResult.text.length,
+        citationCount: knowledgeContextResult.citations.length,
         elapsedMs: Date.now() - startTime,
       });
     }
     if (webContextResult) {
       debugLog('Web context injected', {
-        contextLength: webContextResult.length,
+        contextLength: webContextResult.text.length,
+        citationCount: webContextResult.citations.length,
         elapsedMs: Date.now() - startTime,
       });
     }
@@ -535,8 +547,8 @@ export async function generateAgentResponse(
       additionalContext,
       parentThreadId,
       maxHistoryTokens: effectiveMaxHistoryTokens,
-      ragContext: knowledgeContextResult ?? hookData?.ragContext,
-      webContext: webContextResult,
+      ragContext: knowledgeContextResult?.text ?? hookData?.ragContext,
+      webContext: webContextResult?.text,
     });
     const contextBuildMs = Date.now() - contextBuildStart;
 
@@ -1377,8 +1389,8 @@ export async function generateAgentResponse(
       totalMs: durationMs,
       ttftMs: timeToFirstTokenMs,
       contextBuildMs,
-      ragContextLength: knowledgeContextResult?.length ?? 0,
-      webContextLength: webContextResult?.length ?? 0,
+      ragContextLength: knowledgeContextResult?.text?.length ?? 0,
+      webContextLength: webContextResult?.text?.length ?? 0,
       contextTokens: structuredThreadContext.stats.totalTokens,
       messageCount: structuredThreadContext.stats.messageCount,
       inputTokens: result.usage?.inputTokens,
@@ -1386,9 +1398,22 @@ export async function generateAgentResponse(
     });
 
     // Extract tool calls from steps
-    const { toolCalls, toolsUsage, citations } = extractToolCallsFromSteps(
-      result.steps ?? [],
-    );
+    const {
+      toolCalls,
+      toolsUsage,
+      citations: toolCitations,
+    } = extractToolCallsFromSteps(result.steps ?? []);
+
+    // Context-mode citations (known before generation, from RAG/web injection)
+    const contextCitations = [
+      ...(knowledgeContextResult?.citations ?? []),
+      ...(webContextResult?.citations ?? []),
+    ];
+
+    // Simple selection: tool citations are authoritative when tools were called;
+    // fall back to context citations when no tool calls produced citations.
+    const citations =
+      toolCitations.length > 0 ? toolCitations : contextCitations;
 
     // ── Response cache store ──
     if (cacheKey && result.text?.trim()) {


### PR DESCRIPTION
## Summary

- When `knowledgeMode` is set to `context` or `both`, RAG/web results are injected into the system prompt but structured citation metadata was discarded — the frontend's SourceCards could not display source attributions
- Add `extractCitationsFromSearchResults()` to extract structured citation metadata from RAG search results, and return `{ text, citations }` from both `queryRagContext()` and `queryWebContext()`
- Add citation selection logic: use tool citations when tools were called, fall back to context citations otherwise
- Fix tool registration: filter `rag_search`/`web` tools when retrieval mode is `context` or `off` (previously tools were still available even in context-only mode)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint --workspace=@tale/platform` passes (0 warnings, 0 errors)
- [x] `npx vitest run format_search_results` — 20/20 tests pass (13 existing + 7 new)
- [ ] Manual: set agent knowledge mode to "Context", send a message, verify source cards appear at bottom of response
- [ ] Manual: set agent knowledge mode to "Tool", verify existing behavior unchanged
- [ ] Manual: set agent knowledge mode to "Both", verify tool citations take priority when agent calls tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added citation extraction and attribution for RAG and web search results.
  * Citations now deduplicated by source, retaining highest-relevance entries.
  * Structured context responses now include citation metadata alongside search results.

* **Bug Fixes**
  * Improved handling of missing or empty search result contexts.

* **Chores**
  * Refined tool filtering logic based on knowledge and search modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->