### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: Bug report
 description: Something is broken or not working as expected.
 title: "Bug: "
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something is broken or not working as expected.
-title: "Bug: "
+title: "bug: "
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something is broken or not working as expected.
-title: "bug: "
+title: "Bug: "
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Something is broken or not working as expected.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "e.g. When I click 'Send' in the chat, nothing happens and the message disappears."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do to trigger this?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+      placeholder: "e.g. The message should appear in the chat and the agent should respond."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Affected service
+      description: Which part of Tale is affected?
+      options:
+        - Platform
+        - RAG
+        - Crawler
+        - Database
+        - Graph DB
+        - Operator
+        - Proxy
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Which version or commit SHA are you running?
+      placeholder: "e.g. 0.1.0 or abc1234"
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and OS
+      description: Only needed for UI bugs.
+      placeholder: "e.g. Chrome 124 on macOS 15.4"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any error messages or logs.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: Drag and drop images or paste links. Especially helpful for UI issues.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/tale-project/tale/discussions
+    about: Ask questions, share ideas, or start a discussion.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,6 +1,6 @@
 name: Documentation
 description: Report missing, incorrect, or unclear documentation.
-title: "Docs: "
+title: "docs: "
 labels: ["docs"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,6 +1,6 @@
 name: Documentation
 description: Report missing, incorrect, or unclear documentation.
-title: "docs: "
+title: "Docs: "
 labels: ["docs"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,38 @@
+name: Documentation
+description: Report missing, incorrect, or unclear documentation.
+title: "Docs: "
+labels: ["docs"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong or missing?
+      description: Describe the documentation issue.
+      placeholder: "e.g. The setup guide doesn't mention the required environment variables for the RAG service."
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Which page or section?
+      description: Link or path to the affected documentation.
+      placeholder: "e.g. docs/getting-started.md or https://docs.tale.dev/setup"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: How should the documentation be changed?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature Request
+description: Suggest a new feature or capability.
+title: "Feature: "
+labels: ["feat"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature you'd like to see.
+      placeholder: "e.g. I'd like to be able to export conversation history as a PDF."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why do you need this?
+      description: What problem does this solve or what use case does it enable?
+      placeholder: "e.g. Our team needs to archive conversations for compliance."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Affected service
+      description: Which part of Tale would this affect?
+      options:
+        - Platform
+        - RAG
+        - Crawler
+        - Database
+        - Graph DB
+        - Operator
+        - Proxy
+        - Not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any workarounds or alternative solutions?
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or mockups
+      description: Drag and drop images or paste links to illustrate the idea.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been requested yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or capability.
-title: "feature: "
+title: "Feature: "
 labels: ["feat"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: Feature request
 description: Suggest a new feature or capability.
 title: "Feature: "
 labels: ["feat"]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or capability.
-title: "Feature: "
+title: "feature: "
 labels: ["feat"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,6 +1,6 @@
 name: Improvement
 description: Suggest an enhancement to an existing feature.
-title: "improvement: "
+title: "Improvement: "
 labels: ["improvement"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,56 @@
+name: Improvement
+description: Suggest an enhancement to an existing feature.
+title: "Improvement: "
+labels: ["improvement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What should be improved?
+      description: Which existing feature could be better?
+      placeholder: "e.g. The document preview should support syntax highlighting for more languages."
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      description: How does it work today?
+      placeholder: "e.g. Only JavaScript and Python files get syntax highlighting in the preview."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed change
+      description: What would the improved behavior look like?
+      placeholder: "e.g. Add highlighting for Go, Rust, and YAML files using the existing Shiki setup."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Affected service
+      description: Which part of Tale would this affect?
+      options:
+        - Platform
+        - RAG
+        - Crawler
+        - Database
+        - Graph DB
+        - Operator
+        - Proxy
+        - Not sure
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been suggested yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,6 +1,6 @@
 name: Improvement
 description: Suggest an enhancement to an existing feature.
-title: "Improvement: "
+title: "improvement: "
 labels: ["improvement"]
 body:
   - type: textarea

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,48 @@
+name: Issue service labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Apply service label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const match = body.match(/### Affected service\s*\n\s*(.+)/);
+            if (!match) return;
+
+            const selection = match[1].trim();
+            const mapping = {
+              'Platform': 'service: platform',
+              'RAG': 'service: rag',
+              'Crawler': 'service: crawler',
+              'Database': 'service: db',
+              'Graph DB': 'service: graph-db',
+              'Operator': 'service: operator',
+              'Proxy': 'service: proxy',
+            };
+
+            const label = mapping[selection];
+            if (!label) return;
+
+            const issueNumber = context.issue.number;
+            const { owner, repo } = context.repo;
+
+            const currentLabels = context.payload.issue.labels.map(l => l.name);
+            const serviceLabels = Object.values(mapping);
+
+            const staleLabels = currentLabels.filter(l => serviceLabels.includes(l) && l !== label);
+            for (const stale of staleLabels) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: stale });
+            }
+
+            if (!currentLabels.includes(label)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [label] });
+            }


### PR DESCRIPTION
## Summary

- Add structured YAML-based issue forms: bug report, feature request, improvement, and documentation
- Disable freeform issues — questions are routed to GitHub Discussions
- Service dropdown maps to existing `service: *` labels for easy triage
- All templates require a duplicate-check before submission

## Test plan

- [ ] Visit https://github.com/tale-project/tale/issues/new/choose and verify all 4 templates appear
- [ ] Verify freeform issue option is hidden and Discussions link is shown
- [ ] Fill out each form and confirm required fields are enforced
- [ ] Submit a test issue and verify the correct label is auto-applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced structured GitHub issue templates for bug reports, feature requests, documentation feedback, and improvement suggestions
  * Each template includes guided fields to standardize issue reporting and gather necessary information
  * Disabled blank issues and added contact link to direct general questions to the Discussions section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->