### PR TITLE
feat(platform): refactor OpenAI-compat API as direct model gateway

### DIFF
--- a/services/platform/convex/openai_compat/http_actions.ts
+++ b/services/platform/convex/openai_compat/http_actions.ts
@@ -35,7 +35,7 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
   'Access-Control-Allow-Headers':
-    'Content-Type, Authorization, X-Organization-Slug, X-Thread-Id',
+    'Content-Type, Authorization, X-Organization-Slug',
 };
 
 // ---------------------------------------------------------------------------
@@ -320,10 +320,6 @@ export const chatCompletionsHandler = httpAction(async (ctx, request) => {
   const shouldStream = body.stream === true;
   const includeUsage =
     shouldStream && body.stream_options?.include_usage === true;
-  const threadId =
-    request.headers.get('x-thread-id') ??
-    request.headers.get('X-Thread-Id') ??
-    undefined;
   const generationParams = buildGenerationParams(body);
   const responseFormat = body.response_format?.type;
 
@@ -354,7 +350,6 @@ export const chatCompletionsHandler = httpAction(async (ctx, request) => {
     toolChoice: body.tool_choice,
     shouldStream,
     includeUsage,
-    threadId,
     generationParams,
     responseFormat,
     conversationMessages,
@@ -390,7 +385,6 @@ async function handleDirectModelMode(
     toolChoice?: unknown;
     shouldStream: boolean;
     includeUsage: boolean;
-    threadId?: string;
     generationParams?: Record<string, unknown>;
     responseFormat?: string;
     conversationMessages?: Array<Record<string, unknown>>;
@@ -401,7 +395,7 @@ async function handleDirectModelMode(
   const created = Math.floor(Date.now() / 1000);
 
   let result: {
-    threadId: string;
+    requestId: string;
     text: string | null;
     toolCalls: OpenAIToolCall[] | null;
     finishReason: string;
@@ -421,7 +415,6 @@ async function handleDirectModelMode(
         userEmail: opts.user.email,
         userName: opts.user.name,
         message: opts.lastUserMessage,
-        threadId: opts.threadId,
         tools: opts.tools,
         toolChoice: opts.toolChoice,
         conversationMessages: opts.conversationMessages,
@@ -433,7 +426,7 @@ async function handleDirectModelMode(
     return handleChatError(error, opts.model);
   }
 
-  const completionId = result.threadId;
+  const completionId = result.requestId;
   const responseModel = result.resolvedModel ?? opts.model;
   const usage: OpenAIUsage = {
     prompt_tokens: result.inputTokens,
@@ -449,7 +442,6 @@ async function handleDirectModelMode(
         responseModel,
         result.toolCalls,
         result.text,
-        result.threadId,
         created,
         opts.includeUsage ? usage : undefined,
       );
@@ -463,7 +455,7 @@ async function handleDirectModelMode(
       result.text,
       usage,
     );
-    return jsonResponseWithThreadId(response, result.threadId);
+    return jsonResponse(response);
   }
 
   // No tool calls — return text
@@ -472,7 +464,6 @@ async function handleDirectModelMode(
       completionId,
       responseModel,
       result.text ?? '',
-      result.threadId,
       created,
       opts.includeUsage ? usage : undefined,
     );
@@ -486,16 +477,15 @@ async function handleDirectModelMode(
     [],
     usage,
   );
-  return jsonResponseWithThreadId(response, result.threadId);
+  return jsonResponse(response);
 }
 
-function jsonResponseWithThreadId(body: unknown, threadId: string): Response {
+function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
-      'X-Thread-Id': threadId,
     },
   });
 }
@@ -509,7 +499,6 @@ function streamToolCallsResponse(
   model: string,
   toolCalls: OpenAIToolCall[],
   text: string | null,
-  threadId: string,
   created: number,
   usage?: OpenAIUsage,
 ): Response {
@@ -593,7 +582,6 @@ function streamToolCallsResponse(
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
-      'X-Thread-Id': threadId,
       ...CORS_HEADERS,
     },
   });
@@ -607,7 +595,6 @@ function streamDirectTextResponse(
   completionId: string,
   model: string,
   text: string,
-  threadId: string,
   created: number,
   usage?: OpenAIUsage,
 ): Response {
@@ -671,7 +658,6 @@ function streamDirectTextResponse(
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
-      'X-Thread-Id': threadId,
       ...CORS_HEADERS,
     },
   });

--- a/services/platform/convex/openai_compat/http_actions.ts
+++ b/services/platform/convex/openai_compat/http_actions.ts
@@ -7,12 +7,8 @@
  *   GET     /api/v1/models
  *   OPTIONS /api/v1/models
  *
- * Two modes:
- * - Agent mode (no `tools` param): uses server-side agent tools, async generation
- * - Client tool mode (`tools` param present): uses client-defined tools, direct streamText
+ * Direct model gateway: routes requests to providers by model ID.
  */
-
-import type { StreamId } from '@convex-dev/persistent-text-streaming';
 
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
@@ -22,46 +18,18 @@ import {
   checkIpRateLimit,
   RateLimitExceededError,
 } from '../lib/rate_limiter/helpers';
-import { persistentStreaming } from '../streaming/helpers';
 import { extractClientIp } from '../workflows/triggers/helpers/validate';
-import type { Citation } from './citations';
-
-/** Map structured citation metadata to the Citation interface used by response formatting. */
-function toApiCitations(
-  raw?: Array<{
-    index: number;
-    type: 'rag' | 'web';
-    source: string;
-    fileId?: string;
-    url?: string;
-    page?: number;
-    relevance?: number;
-  }>,
-): Citation[] {
-  if (!raw) return [];
-  return raw.map((c) => ({
-    index: c.index,
-    type: c.type,
-    source: c.source,
-    fileId: c.fileId,
-    url: c.url,
-    page: c.page,
-    relevance: c.relevance ?? 0,
-  }));
-}
 import {
   buildChatCompletion,
   buildChatCompletionChunk,
   buildChatCompletionWithToolCalls,
-  formatSSECitations,
+  buildStreamingUsageChunk,
   formatSSEChunk,
   formatSSEDone,
   openAIErrorResponse,
   type OpenAIToolCall,
+  type OpenAIUsage,
 } from './response_format';
-
-const MAX_POLL_MS = 540_000;
-const POLL_INTERVAL_MS = 100;
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -101,6 +69,7 @@ interface ChatCompletionsRequestBody {
     function: { name: string; description?: string; parameters?: unknown };
   }>;
   tool_choice?: unknown;
+  stream_options?: { include_usage?: boolean } | null;
   seed?: number;
   n?: number;
 }
@@ -349,87 +318,86 @@ export const chatCompletionsHandler = httpAction(async (ctx, request) => {
   }
 
   const shouldStream = body.stream === true;
+  const includeUsage =
+    shouldStream && body.stream_options?.include_usage === true;
   const threadId =
     request.headers.get('x-thread-id') ??
     request.headers.get('X-Thread-Id') ??
     undefined;
   const generationParams = buildGenerationParams(body);
   const responseFormat = body.response_format?.type;
-  const hasClientTools = Array.isArray(body.tools) && body.tools.length > 0;
 
   // -----------------------------------------------------------------------
-  // Client tool mode: direct streamText with client-defined tools
+  // Direct model mode: route to provider via model ID
   // -----------------------------------------------------------------------
-  if (hasClientTools) {
-    return handleToolCallingMode(ctx, {
-      model,
-      messages,
-      lastUserMessage: lastUserMessage.content,
-      tools: body.tools ?? [],
-      toolChoice: body.tool_choice,
-      shouldStream,
-      threadId,
-      generationParams,
-      responseFormat,
-      orgInfo,
-      user,
-    });
-  }
+  const isContinuation = hasToolInteraction(messages);
+  const conversationMessages = isContinuation
+    ? convertToModelMessages(messages)
+    : undefined;
 
-  // -----------------------------------------------------------------------
-  // Agent mode: server-side tools, async generation via persistent stream
-  // -----------------------------------------------------------------------
-  let chatResult: { threadId: string; streamId: string };
-  try {
-    chatResult = await ctx.runAction(
-      internal.openai_compat.internal_actions.chatViaOpenAI,
-      {
-        agentSlug: model,
-        organizationId: orgInfo.organizationId,
-        userId: user.userId,
-        userEmail: user.email,
-        userName: user.name,
-        message: lastUserMessage.content,
-        threadId,
-        enableStreaming: shouldStream,
-        generationParams,
-        responseFormat,
-      },
-    );
-  } catch (error) {
-    return handleChatError(error, model);
-  }
+  // Strip $-prefixed keys from tool parameters (Convex reserves $ prefix)
+  const tools = body.tools?.map((t) => ({
+    ...t,
+    function: {
+      ...t.function,
+      parameters: t.function.parameters
+        ? stripDollarKeys(t.function.parameters)
+        : undefined,
+    },
+  }));
 
-  if (shouldStream) {
-    return streamOpenAIResponse(ctx, chatResult, model);
-  }
-  return pollOpenAIResponse(ctx, chatResult, model);
+  return handleDirectModelMode(ctx, {
+    model,
+    messages,
+    lastUserMessage: lastUserMessage.content,
+    tools,
+    toolChoice: body.tool_choice,
+    shouldStream,
+    includeUsage,
+    threadId,
+    generationParams,
+    responseFormat,
+    conversationMessages,
+    orgInfo,
+    user,
+  });
 });
 
+/** Recursively strip keys starting with '$' (Convex reserves this prefix). */
+function stripDollarKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(stripDollarKeys);
+  if (typeof obj === 'object' && obj !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (!k.startsWith('$')) result[k] = stripDollarKeys(v);
+    }
+    return result;
+  }
+  return obj;
+}
+
 // ---------------------------------------------------------------------------
-// Client tool calling mode handler
+// Direct model mode handler
 // ---------------------------------------------------------------------------
 
-async function handleToolCallingMode(
+async function handleDirectModelMode(
   ctx: ActionCtx,
   opts: {
     model: string;
     messages: OpenAIMessage[];
     lastUserMessage: string;
-    tools: ChatCompletionsRequestBody['tools'];
+    tools?: ChatCompletionsRequestBody['tools'];
     toolChoice?: unknown;
     shouldStream: boolean;
+    includeUsage: boolean;
     threadId?: string;
     generationParams?: Record<string, unknown>;
     responseFormat?: string;
+    conversationMessages?: Array<Record<string, unknown>>;
     orgInfo: { organizationId: string; orgSlug: string };
     user: { userId: string; email: string; name: string };
   },
 ) {
-  const isContinuation = hasToolInteraction(opts.messages);
-  const conversationMessages = isContinuation
-    ? convertToModelMessages(opts.messages)
-    : undefined;
   const created = Math.floor(Date.now() / 1000);
 
   let result: {
@@ -437,13 +405,17 @@ async function handleToolCallingMode(
     text: string | null;
     toolCalls: OpenAIToolCall[] | null;
     finishReason: string;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    resolvedModel: string;
   };
 
   try {
     result = await ctx.runAction(
-      internal.openai_compat.internal_actions.chatViaOpenAIWithTools,
+      internal.openai_compat.internal_actions.chatDirectModel,
       {
-        agentSlug: opts.model,
+        modelId: opts.model,
         organizationId: opts.orgInfo.organizationId,
         userId: opts.user.userId,
         userEmail: opts.user.email,
@@ -452,7 +424,7 @@ async function handleToolCallingMode(
         threadId: opts.threadId,
         tools: opts.tools,
         toolChoice: opts.toolChoice,
-        conversationMessages,
+        conversationMessages: opts.conversationMessages,
         generationParams: opts.generationParams,
         responseFormat: opts.responseFormat,
       },
@@ -462,26 +434,34 @@ async function handleToolCallingMode(
   }
 
   const completionId = result.threadId;
+  const responseModel = result.resolvedModel ?? opts.model;
+  const usage: OpenAIUsage = {
+    prompt_tokens: result.inputTokens,
+    completion_tokens: result.outputTokens,
+    total_tokens: result.totalTokens,
+  };
 
   // Tool calls returned — return them to client
   if (result.toolCalls && result.toolCalls.length > 0) {
     if (opts.shouldStream) {
       return streamToolCallsResponse(
         completionId,
-        opts.model,
+        responseModel,
         result.toolCalls,
         result.text,
         result.threadId,
         created,
+        opts.includeUsage ? usage : undefined,
       );
     }
 
     const response = buildChatCompletionWithToolCalls(
       completionId,
-      opts.model,
+      responseModel,
       result.toolCalls,
       created,
       result.text,
+      usage,
     );
     return jsonResponseWithThreadId(response, result.threadId);
   }
@@ -490,18 +470,21 @@ async function handleToolCallingMode(
   if (opts.shouldStream) {
     return streamDirectTextResponse(
       completionId,
-      opts.model,
+      responseModel,
       result.text ?? '',
       result.threadId,
       created,
+      opts.includeUsage ? usage : undefined,
     );
   }
 
   const response = buildChatCompletion(
     completionId,
-    opts.model,
+    responseModel,
     result.text ?? '',
     created,
+    [],
+    usage,
   );
   return jsonResponseWithThreadId(response, result.threadId);
 }
@@ -528,6 +511,7 @@ function streamToolCallsResponse(
   text: string | null,
   threadId: string,
   created: number,
+  usage?: OpenAIUsage,
 ): Response {
   const encoder = new TextEncoder();
   const { readable, writable } = new TransformStream();
@@ -584,6 +568,17 @@ function streamToolCallsResponse(
       );
       await writer.write(encoder.encode(formatSSEChunk(finishChunk)));
 
+      // Usage chunk (only when stream_options.include_usage is true)
+      if (usage) {
+        const usageChunk = buildStreamingUsageChunk(
+          completionId,
+          model,
+          usage,
+          created,
+        );
+        await writer.write(encoder.encode(formatSSEChunk(usageChunk)));
+      }
+
       await writer.write(encoder.encode(formatSSEDone()));
     } catch (error) {
       console.error('[openai_compat] Tool calls stream error:', error);
@@ -614,6 +609,7 @@ function streamDirectTextResponse(
   text: string,
   threadId: string,
   created: number,
+  usage?: OpenAIUsage,
 ): Response {
   const encoder = new TextEncoder();
   const { readable, writable } = new TransformStream();
@@ -649,6 +645,17 @@ function streamDirectTextResponse(
         created,
       );
       await writer.write(encoder.encode(formatSSEChunk(finishChunk)));
+
+      // Usage chunk (only when stream_options.include_usage is true)
+      if (usage) {
+        const usageChunk = buildStreamingUsageChunk(
+          completionId,
+          model,
+          usage,
+          created,
+        );
+        await writer.write(encoder.encode(formatSSEChunk(usageChunk)));
+      }
 
       await writer.write(encoder.encode(formatSSEDone()));
     } catch (error) {
@@ -693,170 +700,12 @@ function handleChatError(error: unknown, model: string): Response {
 }
 
 // ---------------------------------------------------------------------------
-// Agent mode: poll until done (non-streaming)
-// ---------------------------------------------------------------------------
-
-async function pollOpenAIResponse(
-  ctx: ActionCtx,
-  chatResult: { threadId: string; streamId: string },
-  model: string,
-) {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- StreamId is a branded string from the persistent-streaming SDK; runMutation returns plain string
-  const streamId = chatResult.streamId as StreamId;
-  const maxPolls = Math.ceil(MAX_POLL_MS / POLL_INTERVAL_MS);
-  const created = Math.floor(Date.now() / 1000);
-
-  for (let i = 0; i < maxPolls; i++) {
-    const body = await persistentStreaming.getStreamBody(ctx, streamId);
-
-    if (body.status === 'done') {
-      const result = await ctx.runQuery(
-        internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
-        { threadId: chatResult.threadId },
-      );
-      // Use structured citations directly if available
-      const citations = toApiCitations(result?.citations);
-
-      const response = buildChatCompletion(
-        chatResult.streamId,
-        model,
-        body.text,
-        created,
-        citations,
-      );
-      return new Response(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-        },
-      });
-    }
-
-    if (body.status === 'error' || body.status === 'timeout') {
-      return openAIErrorResponse('Generation failed', 'server_error', 500);
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
-
-  return openAIErrorResponse(
-    'Response timed out',
-    'server_error',
-    504,
-    'timeout',
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Agent mode: SSE streaming
-// ---------------------------------------------------------------------------
-
-async function streamOpenAIResponse(
-  ctx: ActionCtx,
-  chatResult: { threadId: string; streamId: string },
-  model: string,
-) {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- StreamId is a branded string from the persistent-streaming SDK; runMutation returns plain string
-  const streamId = chatResult.streamId as StreamId;
-  const encoder = new TextEncoder();
-  const maxPolls = Math.ceil(MAX_POLL_MS / POLL_INTERVAL_MS);
-  const created = Math.floor(Date.now() / 1000);
-  const completionId = chatResult.streamId;
-
-  const { readable, writable } = new TransformStream();
-  const writer = writable.getWriter();
-
-  void (async () => {
-    try {
-      const roleChunk = buildChatCompletionChunk(
-        completionId,
-        model,
-        { role: 'assistant' },
-        null,
-        created,
-      );
-      await writer.write(encoder.encode(formatSSEChunk(roleChunk)));
-
-      let lastLength = 0;
-      let streamDone = false;
-
-      for (let i = 0; i < maxPolls; i++) {
-        const body = await persistentStreaming.getStreamBody(ctx, streamId);
-
-        if (body.text.length > lastLength) {
-          const delta = body.text.slice(lastLength);
-          const chunk = buildChatCompletionChunk(
-            completionId,
-            model,
-            { content: delta },
-            null,
-            created,
-          );
-          await writer.write(encoder.encode(formatSSEChunk(chunk)));
-          lastLength = body.text.length;
-        }
-
-        if (
-          body.status === 'done' ||
-          body.status === 'error' ||
-          body.status === 'timeout'
-        ) {
-          streamDone = true;
-          break;
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-      }
-
-      if (streamDone) {
-        const finalChunk = buildChatCompletionChunk(
-          completionId,
-          model,
-          {},
-          'stop',
-          created,
-        );
-        await writer.write(encoder.encode(formatSSEChunk(finalChunk)));
-
-        const result = await ctx.runQuery(
-          internal.openai_compat.internal_queries.getLatestThreadToolsUsage,
-          { threadId: chatResult.threadId },
-        );
-        // Use structured citations directly if available
-        const citations = toApiCitations(result?.citations);
-        if (citations.length > 0) {
-          await writer.write(encoder.encode(formatSSECitations(citations)));
-        }
-      }
-
-      await writer.write(encoder.encode(formatSSEDone()));
-    } catch (error) {
-      console.error('[openai_compat] Stream polling error:', error);
-    } finally {
-      await writer.close();
-    }
-  })();
-
-  return new Response(readable, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      ...CORS_HEADERS,
-    },
-  });
-}
-
-// ---------------------------------------------------------------------------
 // GET /api/v1/models
 // ---------------------------------------------------------------------------
 
 export const modelsListHandler = httpAction(async (ctx, request) => {
-  let user: { userId: string; email: string; name: string };
   try {
-    user = await authenticateRequest(ctx, request);
+    await authenticateRequest(ctx, request);
   } catch (error) {
     if (error instanceof AuthError) {
       return openAIErrorResponse(
@@ -869,28 +718,16 @@ export const modelsListHandler = httpAction(async (ctx, request) => {
     throw error;
   }
 
-  const orgSlugHeader =
-    request.headers.get('x-organization-slug') ??
-    request.headers.get('X-Organization-Slug');
-
-  let orgInfo: { organizationId: string; orgSlug: string };
+  let models: Array<{
+    id: string;
+    tags: string[];
+    providerName: string;
+    displayName?: string;
+  }>;
   try {
-    orgInfo = await ctx.runQuery(
-      internal.openai_compat.internal_queries.resolveUserOrganization,
-      { userId: user.userId, orgSlug: orgSlugHeader ?? undefined },
-    );
-  } catch (error) {
-    const msg =
-      error instanceof Error ? error.message : 'Failed to resolve organization';
-    return openAIErrorResponse(msg, 'invalid_request_error', 400);
-  }
-
-  // oxlint-disable-next-line typescript/no-explicit-any -- listVisibleAgents returns v.any(); shape is validated at runtime
-  let agents: any[];
-  try {
-    agents = await ctx.runAction(
-      internal.openai_compat.internal_actions.listVisibleAgents,
-      { orgSlug: orgInfo.orgSlug },
+    models = await ctx.runAction(
+      internal.providers.file_actions.getAllModelIds,
+      {},
     );
   } catch (error) {
     const msg =
@@ -899,11 +736,11 @@ export const modelsListHandler = httpAction(async (ctx, request) => {
   }
 
   const created = Math.floor(Date.now() / 1000);
-  const data = agents.map((agent) => ({
-    id: String(agent.name ?? ''),
+  const data = models.map((m) => ({
+    id: m.id,
     object: 'model' as const,
     created,
-    owned_by: orgInfo.orgSlug,
+    owned_by: m.providerName,
   }));
 
   return new Response(JSON.stringify({ object: 'list', data }), {

--- a/services/platform/convex/openai_compat/internal_actions.ts
+++ b/services/platform/convex/openai_compat/internal_actions.ts
@@ -502,18 +502,9 @@ export const chatDirectModel = internalAction({
       : undefined;
     /* oxlint-enable typescript/no-unsafe-type-assertion */
 
-    // Create or reuse thread, save user message
-    const threadId: string = await ctx.runMutation(
-      internal.openai_compat.internal_mutations.createThreadAndSaveMessage,
-      {
-        organizationId: args.organizationId,
-        userId: args.userId,
-        userEmail: args.userEmail,
-        userName: args.userName,
-        threadId: args.threadId,
-        message,
-      },
-    );
+    // Direct model mode is stateless — no thread/message persistence.
+    // Use a transient ID for usage tracking and audit log correlation.
+    const threadId = args.threadId ?? `direct-${Date.now().toString(36)}`;
 
     // Fetch mandatory system prompt governance policy
     const systemPromptPolicy = await ctx.runQuery(

--- a/services/platform/convex/openai_compat/internal_actions.ts
+++ b/services/platform/convex/openai_compat/internal_actions.ts
@@ -7,20 +7,13 @@
  * and direct tool-calling mode.
  */
 
-import { readdir } from 'node:fs/promises';
-
 import { streamText, type ModelMessage } from 'ai';
 import { v } from 'convex/values';
 
-import { isRecord, getString } from '../../lib/utils/type-guards';
-import { components, internal } from '../_generated/api';
+import { isRecord } from '../../lib/utils/type-guards';
+import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
-import {
-  agentNameFromFileName,
-  resolveAgentsDir,
-  validateAgentName,
-} from '../agents/file_utils';
 import { scrubPii, type PiiConfig } from '../governance/pii';
 import { resolveLanguageModelWithFallback } from '../providers/failover';
 import { convertOpenAITools, generateToolCallId } from './tool_conversion';
@@ -59,20 +52,6 @@ function mapToolChoice(
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-async function resolveOrgSlug(
-  ctx: ActionCtx,
-  organizationId: string,
-): Promise<string> {
-  const org = await ctx.runQuery(components.betterAuth.adapter.findOne, {
-    model: 'organization',
-    where: [{ field: '_id', value: organizationId, operator: 'eq' }],
-  });
-  const orgRecord = isRecord(org) ? org : undefined;
-  const slug = orgRecord ? getString(orgRecord, 'slug') : undefined;
-  if (!slug) throw new Error('Organization not found');
-  return slug;
-}
 
 async function scrubMessagePii(
   ctx: ActionCtx,
@@ -126,79 +105,11 @@ async function scrubMessagePii(
 }
 
 // ---------------------------------------------------------------------------
-// Agent mode: chat via scheduled generation (no client tools)
+// Result type for direct model completions
 // ---------------------------------------------------------------------------
 
-export const chatViaOpenAI = internalAction({
-  args: {
-    agentSlug: v.string(),
-    organizationId: v.string(),
-    userId: v.string(),
-    userEmail: v.optional(v.string()),
-    userName: v.optional(v.string()),
-    message: v.string(),
-    threadId: v.optional(v.string()),
-    enableStreaming: v.optional(v.boolean()),
-    generationParams: v.optional(v.any()),
-    responseFormat: v.optional(v.string()),
-  },
-  returns: v.object({
-    threadId: v.string(),
-    streamId: v.string(),
-  }),
-  handler: async (
-    ctx,
-    args,
-  ): Promise<{ threadId: string; streamId: string }> => {
-    const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
-
-    const message = await scrubMessagePii(
-      ctx,
-      args.message,
-      args.organizationId,
-      args.userId,
-      args.userEmail ?? '',
-      args.agentSlug,
-    );
-
-    const agentConfig = await ctx.runAction(
-      internal.agents.file_actions.resolveAgentConfig,
-      {
-        orgSlug,
-        agentSlug: args.agentSlug,
-        organizationId: args.organizationId,
-      },
-    );
-
-    // Apply response_format override
-    if (args.responseFormat === 'json_object') {
-      agentConfig.outputFormat = 'json';
-    }
-
-    return ctx.runMutation(
-      internal.openai_compat.internal_mutations.startOpenAIChat,
-      {
-        agentSlug: args.agentSlug,
-        organizationId: args.organizationId,
-        userId: args.userId,
-        userEmail: args.userEmail,
-        userName: args.userName,
-        message,
-        threadId: args.threadId,
-        enableStreaming: args.enableStreaming,
-        agentConfig,
-        generationParams: args.generationParams,
-      },
-    );
-  },
-});
-
-// ---------------------------------------------------------------------------
-// Client tool mode: direct streamText with client-defined tools
-// ---------------------------------------------------------------------------
-
-interface ToolCallResult {
-  threadId: string;
+interface DirectModelResult {
+  requestId: string;
   text: string | null;
   toolCalls: Array<{
     id: string;
@@ -212,251 +123,6 @@ interface ToolCallResult {
   resolvedModel: string;
 }
 
-export const chatViaOpenAIWithTools = internalAction({
-  args: {
-    agentSlug: v.string(),
-    organizationId: v.string(),
-    userId: v.string(),
-    userEmail: v.optional(v.string()),
-    userName: v.optional(v.string()),
-    message: v.string(),
-    threadId: v.optional(v.string()),
-    tools: v.any(),
-    toolChoice: v.optional(v.any()),
-    conversationMessages: v.optional(v.any()),
-    generationParams: v.optional(v.any()),
-    responseFormat: v.optional(v.string()),
-  },
-  returns: v.any(),
-  handler: async (ctx, args): Promise<ToolCallResult> => {
-    const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
-
-    const message = await scrubMessagePii(
-      ctx,
-      args.message,
-      args.organizationId,
-      args.userId,
-      args.userEmail ?? '',
-      args.agentSlug,
-    );
-
-    // Resolve agent config (for system prompt + model)
-    // oxlint-disable-next-line typescript/no-explicit-any -- resolveAgentConfig returns v.any(); fields accessed dynamically
-    const agentConfig: any = await ctx.runAction(
-      internal.agents.file_actions.resolveAgentConfig,
-      {
-        orgSlug,
-        agentSlug: args.agentSlug,
-        organizationId: args.organizationId,
-      },
-    );
-
-    if (args.responseFormat === 'json_object') {
-      agentConfig.outputFormat = 'json';
-    }
-
-    // Resolve language model
-    const modelId = String(agentConfig.model ?? 'default');
-    const providerName = agentConfig.provider
-      ? String(agentConfig.provider)
-      : undefined;
-    const resolved = await resolveLanguageModelWithFallback(ctx, {
-      modelId,
-      providerName,
-      tag: 'chat',
-    });
-
-    // Convert client tools to AI SDK format (no execute functions)
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Tool definitions are dynamically converted from OpenAI format; the ToolSet branded type requires exact static shape
-    const aiTools = convertOpenAITools(
-      args.tools ?? [],
-    ) as unknown as Parameters<typeof streamText>[0]['tools'];
-
-    // Create or reuse thread, save user message
-    const threadId: string = await ctx.runMutation(
-      internal.openai_compat.internal_mutations.createThreadAndSaveMessage,
-      {
-        organizationId: args.organizationId,
-        userId: args.userId,
-        userEmail: args.userEmail,
-        userName: args.userName,
-        threadId: args.threadId,
-        message,
-      },
-    );
-
-    // Fetch mandatory system prompt governance policy
-    const systemPromptPolicy = await ctx.runQuery(
-      internal.governance.internal_queries.getSystemPromptPolicyInternal,
-      { organizationId: args.organizationId },
-    );
-
-    // Build system prompt from agent instructions
-    let systemPrompt: string =
-      String(agentConfig.instructions ?? '') ||
-      `You are ${String(agentConfig.name ?? 'assistant')}, a helpful assistant.`;
-
-    // Apply mandatory governance system prompt (non-overridable)
-    if (
-      systemPromptPolicy?.enabled !== false &&
-      isRecord(systemPromptPolicy?.config)
-    ) {
-      const cfg = systemPromptPolicy.config;
-      const prefix =
-        typeof cfg.mandatoryPrefixPrompt === 'string'
-          ? cfg.mandatoryPrefixPrompt.trim()
-          : '';
-      const suffix =
-        typeof cfg.mandatorySuffixPrompt === 'string'
-          ? cfg.mandatorySuffixPrompt.trim()
-          : '';
-      if (prefix) systemPrompt = prefix + '\n\n' + systemPrompt;
-      if (suffix) systemPrompt = systemPrompt + '\n\n' + suffix;
-    }
-
-    // Build generation params
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generationParams is v.any() from Convex validator; shape is controlled by http_actions.ts buildGenerationParams
-    const genParams = (args.generationParams ?? {}) as Record<string, unknown>;
-
-    // Direct streamText call with client tools (no auto-execute)
-    // Always use messages format for proper tool calling support.
-    // For continuation, use the full conversation history from the client.
-    const hasConversation =
-      args.conversationMessages &&
-      Array.isArray(args.conversationMessages) &&
-      args.conversationMessages.length > 0;
-
-    const messages: ModelMessage[] = hasConversation
-      ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- conversationMessages is built by convertToModelMessages in http_actions.ts; shape matches ModelMessage[]
-        (args.conversationMessages as ModelMessage[])
-      : [{ role: 'user' as const, content: message }];
-
-    const result = streamText({
-      model: resolved.languageModel,
-      system: systemPrompt,
-      messages,
-      tools: aiTools,
-      ...(args.toolChoice != null && {
-        toolChoice: mapToolChoice(args.toolChoice),
-      }),
-      ...(genParams.temperature != null && {
-        temperature: Number(genParams.temperature),
-      }),
-      ...(genParams.maxTokens != null && {
-        maxTokens: Number(genParams.maxTokens),
-      }),
-      ...(genParams.topP != null && { topP: Number(genParams.topP) }),
-      ...(genParams.frequencyPenalty != null && {
-        frequencyPenalty: Number(genParams.frequencyPenalty),
-      }),
-      ...(genParams.presencePenalty != null && {
-        presencePenalty: Number(genParams.presencePenalty),
-      }),
-      ...(Array.isArray(genParams.stopSequences) && {
-        stopSequences: genParams.stopSequences,
-      }),
-    });
-
-    const text: string = await result.text;
-    const finishReason: string = await result.finishReason;
-    const steps = await result.steps;
-
-    // Extract tool calls from steps.
-    // AI SDK v6 stores tool calls in step.content[] as { type: "tool-call", toolCallId, toolName, input }
-    interface ToolCallContent {
-      type: string;
-      toolCallId?: string;
-      toolName?: string;
-      input?: unknown;
-    }
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- StepResult serialized to extract tool-call content parts; shape is known from AI SDK v6
-    const rawSteps = JSON.parse(JSON.stringify(steps)) as Array<{
-      content?: ToolCallContent[];
-    }>;
-    const toolCalls = rawSteps
-      .flatMap((step) => step.content ?? [])
-      .filter((part): part is ToolCallContent => part.type === 'tool-call')
-      .map((tc) => ({
-        id: tc.toolCallId ?? generateToolCallId(),
-        type: 'function' as const,
-        function: {
-          name: tc.toolName ?? '',
-          arguments: JSON.stringify(tc.input ?? {}),
-        },
-      }));
-
-    // Track usage for client tool mode (this path bypasses onAgentComplete)
-    const usage = await result.usage;
-    const inputTokens = usage?.inputTokens ?? 0;
-    const outputTokens = usage?.outputTokens ?? 0;
-    const totalTokens = inputTokens + outputTokens;
-
-    if (usage && args.organizationId && (inputTokens > 0 || outputTokens > 0)) {
-      const { estimateCostCents } =
-        await import('../governance/cost_estimation');
-      const costCents = estimateCostCents(modelId, inputTokens, outputTokens);
-      await ctx
-        .runMutation(
-          internal.governance.internal_mutations.incrementUsageLedger,
-          {
-            organizationId: args.organizationId,
-            userId: args.userId ?? 'system',
-            inputTokens,
-            outputTokens,
-            costEstimateCents: costCents,
-            timestamp: Date.now(),
-          },
-        )
-        .catch((error) => {
-          console.error(
-            '[OpenAI-compat:clientTools] Failed to increment usage ledger:',
-            error,
-          );
-        });
-
-      // AI audit log for OpenAI-compat client tool mode
-      await ctx
-        .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
-          organizationId: args.organizationId,
-          actorId: args.userId ?? 'system',
-          actorType: 'api' as const,
-          action: 'ai.completion',
-          category: 'ai' as const,
-          resourceType: 'agent_completion',
-          resourceId: threadId,
-          status: 'success' as const,
-          metadata: {
-            model: modelId,
-            inputTokens,
-            outputTokens,
-            totalTokens,
-            costEstimateCents: costCents,
-            threadId,
-            agentType: 'openai_compat',
-            toolCallCount: toolCalls.length,
-          },
-        })
-        .catch((error) => {
-          console.error(
-            '[OpenAI-compat:clientTools] Failed to write AI audit log:',
-            error,
-          );
-        });
-    }
-
-    return {
-      threadId,
-      text: text || null,
-      toolCalls: toolCalls.length > 0 ? toolCalls : null,
-      finishReason,
-      inputTokens,
-      outputTokens,
-      totalTokens,
-      resolvedModel: resolved.modelData.modelId,
-    };
-  },
-});
-
 // ---------------------------------------------------------------------------
 // Direct model mode: bypass agent pipeline, route to provider directly
 // ---------------------------------------------------------------------------
@@ -469,7 +135,6 @@ export const chatDirectModel = internalAction({
     userEmail: v.optional(v.string()),
     userName: v.optional(v.string()),
     message: v.string(),
-    threadId: v.optional(v.string()),
     tools: v.optional(v.any()),
     toolChoice: v.optional(v.any()),
     conversationMessages: v.optional(v.any()),
@@ -477,7 +142,7 @@ export const chatDirectModel = internalAction({
     responseFormat: v.optional(v.string()),
   },
   returns: v.any(),
-  handler: async (ctx, args): Promise<ToolCallResult> => {
+  handler: async (ctx, args): Promise<DirectModelResult> => {
     const message = await scrubMessagePii(
       ctx,
       args.message,
@@ -503,8 +168,8 @@ export const chatDirectModel = internalAction({
     /* oxlint-enable typescript/no-unsafe-type-assertion */
 
     // Direct model mode is stateless — no thread/message persistence.
-    // Use a transient ID for usage tracking and audit log correlation.
-    const threadId = args.threadId ?? `direct-${Date.now().toString(36)}`;
+    // Transient ID for audit log correlation only.
+    const requestId = `direct-${Date.now().toString(36)}`;
 
     // Fetch mandatory system prompt governance policy
     const systemPromptPolicy = await ctx.runQuery(
@@ -640,7 +305,7 @@ export const chatDirectModel = internalAction({
           action: 'ai.completion',
           category: 'ai' as const,
           resourceType: 'agent_completion',
-          resourceId: threadId,
+          resourceId: requestId,
           status: 'success' as const,
           metadata: {
             model: resolved.modelData.modelId,
@@ -648,7 +313,7 @@ export const chatDirectModel = internalAction({
             outputTokens,
             totalTokens,
             costEstimateCents: costCents,
-            threadId,
+            requestId,
             agentType: 'direct_model',
             toolCallCount: toolCalls.length,
           },
@@ -662,7 +327,7 @@ export const chatDirectModel = internalAction({
     }
 
     return {
-      threadId,
+      requestId,
       text: text || null,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       finishReason,
@@ -671,58 +336,5 @@ export const chatDirectModel = internalAction({
       totalTokens,
       resolvedModel: resolved.modelData.modelId,
     };
-  },
-});
-
-// ---------------------------------------------------------------------------
-// List visible agents (for /api/v1/models) — DEPRECATED: replaced by getAllModelIds
-// ---------------------------------------------------------------------------
-
-export const listVisibleAgents = internalAction({
-  args: {
-    orgSlug: v.string(),
-  },
-  returns: v.any(),
-  handler: async (_ctx, args) => {
-    const dir = resolveAgentsDir(args.orgSlug);
-    let entries: string[];
-    try {
-      entries = await readdir(dir);
-    } catch {
-      return [];
-    }
-
-    const jsonFiles = entries.filter(
-      (e) => e.endsWith('.json') && !e.startsWith('.'),
-    );
-
-    const { readJsonFile } = await import('../lib/file_io');
-    const { parseAgentJson, resolveAgentFilePath, MAX_FILE_SIZE_BYTES } =
-      await import('../agents/file_utils');
-
-    const results = await Promise.all(
-      jsonFiles.map(async (fileName) => {
-        const agentName = agentNameFromFileName(fileName);
-        if (!validateAgentName(agentName)) return null;
-
-        const filePath = resolveAgentFilePath(args.orgSlug, agentName);
-        const result = await readJsonFile(
-          filePath,
-          MAX_FILE_SIZE_BYTES,
-          parseAgentJson,
-        );
-
-        if (!result.ok) return null;
-        if (!result.data.visibleInChat) return null;
-
-        return {
-          name: agentName,
-          displayName: result.data.displayName,
-          description: result.data.description,
-        };
-      }),
-    );
-
-    return results.filter(Boolean);
   },
 });

--- a/services/platform/convex/openai_compat/internal_actions.ts
+++ b/services/platform/convex/openai_compat/internal_actions.ts
@@ -206,6 +206,10 @@ interface ToolCallResult {
     function: { name: string; arguments: string };
   }> | null;
   finishReason: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  resolvedModel: string;
 }
 
 export const chatViaOpenAIWithTools = internalAction({
@@ -383,61 +387,61 @@ export const chatViaOpenAIWithTools = internalAction({
 
     // Track usage for client tool mode (this path bypasses onAgentComplete)
     const usage = await result.usage;
-    if (usage && args.organizationId) {
+    const inputTokens = usage?.inputTokens ?? 0;
+    const outputTokens = usage?.outputTokens ?? 0;
+    const totalTokens = inputTokens + outputTokens;
+
+    if (usage && args.organizationId && (inputTokens > 0 || outputTokens > 0)) {
       const { estimateCostCents } =
         await import('../governance/cost_estimation');
-      const inputTokens = usage.inputTokens ?? 0;
-      const outputTokens = usage.outputTokens ?? 0;
-      if (inputTokens > 0 || outputTokens > 0) {
-        const costCents = estimateCostCents(modelId, inputTokens, outputTokens);
-        await ctx
-          .runMutation(
-            internal.governance.internal_mutations.incrementUsageLedger,
-            {
-              organizationId: args.organizationId,
-              userId: args.userId ?? 'system',
-              inputTokens,
-              outputTokens,
-              costEstimateCents: costCents,
-              timestamp: Date.now(),
-            },
-          )
-          .catch((error) => {
-            console.error(
-              '[OpenAI-compat:clientTools] Failed to increment usage ledger:',
-              error,
-            );
-          });
-
-        // AI audit log for OpenAI-compat client tool mode
-        await ctx
-          .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
+      const costCents = estimateCostCents(modelId, inputTokens, outputTokens);
+      await ctx
+        .runMutation(
+          internal.governance.internal_mutations.incrementUsageLedger,
+          {
             organizationId: args.organizationId,
-            actorId: args.userId ?? 'system',
-            actorType: 'api' as const,
-            action: 'ai.completion',
-            category: 'ai' as const,
-            resourceType: 'agent_completion',
-            resourceId: threadId,
-            status: 'success' as const,
-            metadata: {
-              model: modelId,
-              inputTokens,
-              outputTokens,
-              totalTokens: inputTokens + outputTokens,
-              costEstimateCents: costCents,
-              threadId,
-              agentType: 'openai_compat',
-              toolCallCount: toolCalls.length,
-            },
-          })
-          .catch((error) => {
-            console.error(
-              '[OpenAI-compat:clientTools] Failed to write AI audit log:',
-              error,
-            );
-          });
-      }
+            userId: args.userId ?? 'system',
+            inputTokens,
+            outputTokens,
+            costEstimateCents: costCents,
+            timestamp: Date.now(),
+          },
+        )
+        .catch((error) => {
+          console.error(
+            '[OpenAI-compat:clientTools] Failed to increment usage ledger:',
+            error,
+          );
+        });
+
+      // AI audit log for OpenAI-compat client tool mode
+      await ctx
+        .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
+          organizationId: args.organizationId,
+          actorId: args.userId ?? 'system',
+          actorType: 'api' as const,
+          action: 'ai.completion',
+          category: 'ai' as const,
+          resourceType: 'agent_completion',
+          resourceId: threadId,
+          status: 'success' as const,
+          metadata: {
+            model: modelId,
+            inputTokens,
+            outputTokens,
+            totalTokens,
+            costEstimateCents: costCents,
+            threadId,
+            agentType: 'openai_compat',
+            toolCallCount: toolCalls.length,
+          },
+        })
+        .catch((error) => {
+          console.error(
+            '[OpenAI-compat:clientTools] Failed to write AI audit log:',
+            error,
+          );
+        });
     }
 
     return {
@@ -445,12 +449,242 @@ export const chatViaOpenAIWithTools = internalAction({
       text: text || null,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       finishReason,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      resolvedModel: resolved.modelData.modelId,
     };
   },
 });
 
 // ---------------------------------------------------------------------------
-// List visible agents (for /api/v1/models)
+// Direct model mode: bypass agent pipeline, route to provider directly
+// ---------------------------------------------------------------------------
+
+export const chatDirectModel = internalAction({
+  args: {
+    modelId: v.string(),
+    organizationId: v.string(),
+    userId: v.string(),
+    userEmail: v.optional(v.string()),
+    userName: v.optional(v.string()),
+    message: v.string(),
+    threadId: v.optional(v.string()),
+    tools: v.optional(v.any()),
+    toolChoice: v.optional(v.any()),
+    conversationMessages: v.optional(v.any()),
+    generationParams: v.optional(v.any()),
+    responseFormat: v.optional(v.string()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args): Promise<ToolCallResult> => {
+    const message = await scrubMessagePii(
+      ctx,
+      args.message,
+      args.organizationId,
+      args.userId,
+      args.userEmail ?? '',
+      args.modelId,
+    );
+
+    // Resolve model directly — no agent config
+    const resolved = await resolveLanguageModelWithFallback(ctx, {
+      modelId: args.modelId,
+      tag: 'chat',
+    });
+
+    // Convert client tools to AI SDK format if provided
+    /* oxlint-disable typescript/no-unsafe-type-assertion -- Tool definitions are dynamically converted from OpenAI format; the ToolSet branded type requires exact static shape */
+    const aiTools = args.tools
+      ? (convertOpenAITools(args.tools) as unknown as Parameters<
+          typeof streamText
+        >[0]['tools'])
+      : undefined;
+    /* oxlint-enable typescript/no-unsafe-type-assertion */
+
+    // Create or reuse thread, save user message
+    const threadId: string = await ctx.runMutation(
+      internal.openai_compat.internal_mutations.createThreadAndSaveMessage,
+      {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        userEmail: args.userEmail,
+        userName: args.userName,
+        threadId: args.threadId,
+        message,
+      },
+    );
+
+    // Fetch mandatory system prompt governance policy
+    const systemPromptPolicy = await ctx.runQuery(
+      internal.governance.internal_queries.getSystemPromptPolicyInternal,
+      { organizationId: args.organizationId },
+    );
+
+    // Build system prompt — no agent instructions, only governance
+    let systemPrompt = 'You are a helpful assistant.';
+    if (
+      systemPromptPolicy?.enabled !== false &&
+      isRecord(systemPromptPolicy?.config)
+    ) {
+      const cfg = systemPromptPolicy.config;
+      const prefix =
+        typeof cfg.mandatoryPrefixPrompt === 'string'
+          ? cfg.mandatoryPrefixPrompt.trim()
+          : '';
+      const suffix =
+        typeof cfg.mandatorySuffixPrompt === 'string'
+          ? cfg.mandatorySuffixPrompt.trim()
+          : '';
+      if (prefix) systemPrompt = prefix + '\n\n' + systemPrompt;
+      if (suffix) systemPrompt = systemPrompt + '\n\n' + suffix;
+    }
+
+    // Build generation params
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generationParams is v.any() from Convex validator; shape is controlled by http_actions.ts buildGenerationParams
+    const genParams = (args.generationParams ?? {}) as Record<string, unknown>;
+
+    // Build messages — use full conversation if provided, otherwise single message
+    const hasConversation =
+      args.conversationMessages &&
+      Array.isArray(args.conversationMessages) &&
+      args.conversationMessages.length > 0;
+
+    const messages: ModelMessage[] = hasConversation
+      ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- conversationMessages is built by convertToModelMessages in http_actions.ts; shape matches ModelMessage[]
+        (args.conversationMessages as ModelMessage[])
+      : [{ role: 'user' as const, content: message }];
+
+    const result = streamText({
+      model: resolved.languageModel,
+      system: systemPrompt,
+      messages,
+      ...(aiTools && { tools: aiTools }),
+      ...(args.toolChoice != null && {
+        toolChoice: mapToolChoice(args.toolChoice),
+      }),
+      ...(genParams.temperature != null && {
+        temperature: Number(genParams.temperature),
+      }),
+      ...(genParams.maxTokens != null && {
+        maxTokens: Number(genParams.maxTokens),
+      }),
+      ...(genParams.topP != null && { topP: Number(genParams.topP) }),
+      ...(genParams.frequencyPenalty != null && {
+        frequencyPenalty: Number(genParams.frequencyPenalty),
+      }),
+      ...(genParams.presencePenalty != null && {
+        presencePenalty: Number(genParams.presencePenalty),
+      }),
+      ...(Array.isArray(genParams.stopSequences) && {
+        stopSequences: genParams.stopSequences,
+      }),
+    });
+
+    const text: string = await result.text;
+    const finishReason: string = await result.finishReason;
+    const steps = await result.steps;
+
+    // Extract tool calls from steps
+    interface ToolCallContent {
+      type: string;
+      toolCallId?: string;
+      toolName?: string;
+      input?: unknown;
+    }
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- StepResult serialized to extract tool-call content parts; shape is known from AI SDK v6
+    const rawSteps = JSON.parse(JSON.stringify(steps)) as Array<{
+      content?: ToolCallContent[];
+    }>;
+    const toolCalls = rawSteps
+      .flatMap((step) => step.content ?? [])
+      .filter((part): part is ToolCallContent => part.type === 'tool-call')
+      .map((tc) => ({
+        id: tc.toolCallId ?? generateToolCallId(),
+        type: 'function' as const,
+        function: {
+          name: tc.toolName ?? '',
+          arguments: JSON.stringify(tc.input ?? {}),
+        },
+      }));
+
+    // Track usage
+    const usage = await result.usage;
+    const inputTokens = usage?.inputTokens ?? 0;
+    const outputTokens = usage?.outputTokens ?? 0;
+    const totalTokens = inputTokens + outputTokens;
+
+    if (args.organizationId && (inputTokens > 0 || outputTokens > 0)) {
+      const { estimateCostCents } =
+        await import('../governance/cost_estimation');
+      const costCents = estimateCostCents(
+        resolved.modelData.modelId,
+        inputTokens,
+        outputTokens,
+      );
+      await ctx
+        .runMutation(
+          internal.governance.internal_mutations.incrementUsageLedger,
+          {
+            organizationId: args.organizationId,
+            userId: args.userId ?? 'system',
+            inputTokens,
+            outputTokens,
+            costEstimateCents: costCents,
+            timestamp: Date.now(),
+          },
+        )
+        .catch((error) => {
+          console.error(
+            '[OpenAI-compat:directModel] Failed to increment usage ledger:',
+            error,
+          );
+        });
+
+      await ctx
+        .runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
+          organizationId: args.organizationId,
+          actorId: args.userId ?? 'system',
+          actorType: 'api' as const,
+          action: 'ai.completion',
+          category: 'ai' as const,
+          resourceType: 'agent_completion',
+          resourceId: threadId,
+          status: 'success' as const,
+          metadata: {
+            model: resolved.modelData.modelId,
+            inputTokens,
+            outputTokens,
+            totalTokens,
+            costEstimateCents: costCents,
+            threadId,
+            agentType: 'direct_model',
+            toolCallCount: toolCalls.length,
+          },
+        })
+        .catch((error) => {
+          console.error(
+            '[OpenAI-compat:directModel] Failed to write AI audit log:',
+            error,
+          );
+        });
+    }
+
+    return {
+      threadId,
+      text: text || null,
+      toolCalls: toolCalls.length > 0 ? toolCalls : null,
+      finishReason,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      resolvedModel: resolved.modelData.modelId,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// List visible agents (for /api/v1/models) — DEPRECATED: replaced by getAllModelIds
 // ---------------------------------------------------------------------------
 
 export const listVisibleAgents = internalAction({

--- a/services/platform/convex/openai_compat/internal_queries.ts
+++ b/services/platform/convex/openai_compat/internal_queries.ts
@@ -89,11 +89,12 @@ export const resolveUserOrganization = internalQuery({
 });
 
 /**
- * Fetch the latest toolsUsage for a thread.
+ * Fetch the latest toolsUsage and token counts for a thread.
  *
  * In agent mode, each request creates a single assistant message.
  * This query retrieves the most recent messageMetadata for the thread
- * and returns its toolsUsage array (used to build API citation data).
+ * and returns its toolsUsage array (used to build API citation data)
+ * plus token counts for the usage field in the OpenAI response.
  */
 export const getLatestThreadToolsUsage = internalQuery({
   args: {
@@ -108,6 +109,9 @@ export const getLatestThreadToolsUsage = internalQuery({
         }),
       ),
       citations: v.optional(v.array(citationItemValidator)),
+      inputTokens: v.optional(v.number()),
+      outputTokens: v.optional(v.number()),
+      totalTokens: v.optional(v.number()),
     }),
     v.null(),
   ),
@@ -118,14 +122,17 @@ export const getLatestThreadToolsUsage = internalQuery({
       .order('desc')
       .first();
 
-    if (!metadata?.toolsUsage) return null;
+    if (!metadata) return null;
 
     return {
-      toolsUsage: metadata.toolsUsage.map((t) => ({
+      toolsUsage: (metadata.toolsUsage ?? []).map((t) => ({
         toolName: t.toolName,
         output: t.output,
       })),
       citations: metadata.citations,
+      inputTokens: metadata.inputTokens,
+      outputTokens: metadata.outputTokens,
+      totalTokens: metadata.totalTokens,
     };
   },
 });

--- a/services/platform/convex/openai_compat/response_format.test.ts
+++ b/services/platform/convex/openai_compat/response_format.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from 'vitest';
 import type { Citation } from './citations';
 import {
   buildChatCompletion,
+  buildChatCompletionChunk,
+  buildChatCompletionWithToolCalls,
+  buildStreamingUsageChunk,
   formatSSECitations,
   formatSSEChunk,
   formatSSEDone,
+  type OpenAIUsage,
 } from './response_format';
 
 describe('buildChatCompletion', () => {
@@ -61,6 +65,151 @@ describe('buildChatCompletion', () => {
     );
 
     expect(result.citations).toEqual([]);
+  });
+
+  it('defaults usage to zeros when not provided', () => {
+    const result = buildChatCompletion(
+      'test-id',
+      'my-agent',
+      'Response',
+      1700000000,
+    );
+
+    expect(result.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+
+  it('passes through custom usage values', () => {
+    const usage: OpenAIUsage = {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+    };
+
+    const result = buildChatCompletion(
+      'test-id',
+      'my-agent',
+      'Response',
+      1700000000,
+      [],
+      usage,
+    );
+
+    expect(result.usage).toEqual(usage);
+  });
+});
+
+describe('buildChatCompletionWithToolCalls', () => {
+  const toolCalls = [
+    {
+      id: 'call_1',
+      type: 'function' as const,
+      function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+    },
+  ];
+
+  it('returns correct structure with tool_calls', () => {
+    const result = buildChatCompletionWithToolCalls(
+      'test-id',
+      'my-agent',
+      toolCalls,
+      1700000000,
+    );
+
+    expect(result.id).toBe('chatcmpl-test-id');
+    expect(result.object).toBe('chat.completion');
+    expect(result.choices[0].message.role).toBe('assistant');
+    expect(result.choices[0].message.tool_calls).toEqual(toolCalls);
+    expect(result.choices[0].message.content).toBeNull();
+    expect(result.choices[0].finish_reason).toBe('tool_calls');
+  });
+
+  it('passes through custom usage values', () => {
+    const usage: OpenAIUsage = {
+      prompt_tokens: 200,
+      completion_tokens: 80,
+      total_tokens: 280,
+    };
+
+    const result = buildChatCompletionWithToolCalls(
+      'test-id',
+      'my-agent',
+      toolCalls,
+      1700000000,
+      null,
+      usage,
+    );
+
+    expect(result.usage).toEqual(usage);
+  });
+
+  it('defaults usage to zeros when not provided', () => {
+    const result = buildChatCompletionWithToolCalls(
+      'test-id',
+      'my-agent',
+      toolCalls,
+      1700000000,
+    );
+
+    expect(result.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+});
+
+describe('buildChatCompletionChunk', () => {
+  it('returns correct chunk structure', () => {
+    const result = buildChatCompletionChunk(
+      'test-id',
+      'my-agent',
+      { content: 'hello' },
+      null,
+      1700000000,
+    );
+
+    expect(result.id).toBe('chatcmpl-test-id');
+    expect(result.object).toBe('chat.completion.chunk');
+    expect(result.choices[0].delta).toEqual({ content: 'hello' });
+    expect(result.choices[0].finish_reason).toBeNull();
+  });
+
+  it('includes finish_reason on final chunk', () => {
+    const result = buildChatCompletionChunk(
+      'test-id',
+      'my-agent',
+      {},
+      'stop',
+      1700000000,
+    );
+
+    expect(result.choices[0].finish_reason).toBe('stop');
+  });
+});
+
+describe('buildStreamingUsageChunk', () => {
+  it('returns chunk with empty choices and populated usage', () => {
+    const usage: OpenAIUsage = {
+      prompt_tokens: 50,
+      completion_tokens: 25,
+      total_tokens: 75,
+    };
+
+    const result = buildStreamingUsageChunk(
+      'test-id',
+      'my-agent',
+      usage,
+      1700000000,
+    );
+
+    expect(result.id).toBe('chatcmpl-test-id');
+    expect(result.object).toBe('chat.completion.chunk');
+    expect(result.choices).toEqual([]);
+    expect(result.usage).toEqual(usage);
   });
 });
 

--- a/services/platform/convex/openai_compat/response_format.ts
+++ b/services/platform/convex/openai_compat/response_format.ts
@@ -11,6 +11,18 @@ import type { Citation } from './citations';
 // Non-streaming response
 // ---------------------------------------------------------------------------
 
+export interface OpenAIUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+const ZERO_USAGE: OpenAIUsage = {
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+};
+
 export interface OpenAIToolCall {
   id: string;
   type: 'function';
@@ -33,11 +45,7 @@ interface ChatCompletionResponse {
     };
     finish_reason: FinishReason;
   }>;
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage: OpenAIUsage;
   citations: Citation[];
 }
 
@@ -47,6 +55,7 @@ export function buildChatCompletion(
   content: string,
   created: number,
   citations: Citation[] = [],
+  usage: OpenAIUsage = ZERO_USAGE,
 ): ChatCompletionResponse {
   return {
     id: `chatcmpl-${id}`,
@@ -60,7 +69,7 @@ export function buildChatCompletion(
         finish_reason: 'stop',
       },
     ],
-    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    usage,
     citations,
   };
 }
@@ -74,6 +83,7 @@ export function buildChatCompletionWithToolCalls(
   toolCalls: OpenAIToolCall[],
   created: number,
   content: string | null = null,
+  usage: OpenAIUsage = ZERO_USAGE,
 ): ChatCompletionResponse {
   return {
     id: `chatcmpl-${id}`,
@@ -87,7 +97,7 @@ export function buildChatCompletionWithToolCalls(
         finish_reason: 'tool_calls',
       },
     ],
-    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    usage,
     citations: [],
   };
 }
@@ -117,6 +127,7 @@ interface ChatCompletionChunk {
     delta: ChatCompletionChunkDelta;
     finish_reason: FinishReason | null;
   }>;
+  usage?: OpenAIUsage | null;
 }
 
 export function buildChatCompletionChunk(
@@ -132,6 +143,27 @@ export function buildChatCompletionChunk(
     created,
     model,
     choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+/**
+ * Build a streaming usage-only chunk (emitted as the final chunk before [DONE]
+ * when stream_options.include_usage is true). Per OpenAI spec, this chunk has
+ * an empty choices array and a populated usage field.
+ */
+export function buildStreamingUsageChunk(
+  id: string,
+  model: string,
+  usage: OpenAIUsage,
+  created: number,
+): ChatCompletionChunk {
+  return {
+    id: `chatcmpl-${id}`,
+    object: 'chat.completion.chunk',
+    created,
+    model,
+    choices: [],
+    usage,
   };
 }
 

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -475,6 +475,8 @@ export const getAllModelIds = internalAction({
     v.object({
       id: v.string(),
       tags: v.array(v.string()),
+      providerName: v.string(),
+      displayName: v.optional(v.string()),
     }),
   ),
   handler: async (_ctx, args) => {
@@ -485,10 +487,20 @@ export const getAllModelIds = internalAction({
     } catch {
       return [];
     }
-    const models: Array<{ id: string; tags: string[] }> = [];
+    const models: Array<{
+      id: string;
+      tags: string[];
+      providerName: string;
+      displayName?: string;
+    }> = [];
     for (const provider of providers) {
       for (const m of provider.config.models) {
-        models.push({ id: m.id, tags: [...m.tags] });
+        models.push({
+          id: m.id,
+          tags: [...m.tags],
+          providerName: provider.name,
+          displayName: m.displayName,
+        });
       }
     }
     return models;

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Tale Public API",
     "version": "1.0.0",
-    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```\n\n## Citations\n\nAgent mode responses include a `citations` array when knowledge tools (RAG search, web search) are used:\n\n```python\nresponse = client.chat.completions.create(\n    model=\"my-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"What does the policy say about returns?\"}],\n)\n\n# Access citations\nfor citation in response.model_extra.get(\"citations\", []):\n    print(f\"[{citation['index']}] {citation['source']} (relevance: {citation['relevance']})\")\n```\n\nFor streaming, citations arrive as a separate SSE event before `[DONE]`."
+    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```"
   },
   "servers": [
     {
@@ -19,9 +19,11 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "Create chat completion",
-        "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them. Response includes `citations` array when knowledge tools (RAG, web search) were used.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
+        "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
         "operationId": "createChatCompletion",
         "security": [
           {
@@ -89,7 +91,9 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": ["OpenAI Compatible"],
+        "tags": [
+          "OpenAI Compatible"
+        ],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -118,7 +122,9 @@
     },
     "/api/v1/documents": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "List documents",
         "operationId": "listDocuments",
         "security": [
@@ -190,7 +196,9 @@
         }
       },
       "post": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Create document",
         "operationId": "createDocument",
         "security": [
@@ -236,7 +244,9 @@
     },
     "/api/v1/documents/{id}": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Get document",
         "operationId": "getDocument",
         "security": [
@@ -281,7 +291,9 @@
         }
       },
       "patch": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Update document",
         "operationId": "updateDocument",
         "security": [
@@ -336,7 +348,9 @@
         }
       },
       "delete": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Delete document",
         "operationId": "deleteDocument",
         "security": [
@@ -376,7 +390,9 @@
     },
     "/api/v1/documents/{id}/retry-indexing": {
       "post": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Retry RAG indexing",
         "operationId": "retryDocumentIndexing",
         "security": [
@@ -416,7 +432,9 @@
     },
     "/api/v1/websites": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "List websites",
         "operationId": "listWebsites",
         "security": [
@@ -488,7 +506,9 @@
         }
       },
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Create website",
         "operationId": "createWebsite",
         "security": [
@@ -534,7 +554,9 @@
     },
     "/api/v1/websites/{id}": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Get website",
         "operationId": "getWebsite",
         "security": [
@@ -579,7 +601,9 @@
         }
       },
       "patch": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Update website",
         "operationId": "updateWebsite",
         "security": [
@@ -634,7 +658,9 @@
         }
       },
       "delete": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Delete website",
         "operationId": "deleteWebsite",
         "security": [
@@ -674,7 +700,9 @@
     },
     "/api/v1/websites/{id}/pages": {
       "get": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Fetch pages",
         "operationId": "listWebsitePages",
         "security": [
@@ -739,7 +767,9 @@
     },
     "/api/v1/websites/{id}/sync": {
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Sync statuses",
         "operationId": "syncWebsite",
         "security": [
@@ -779,7 +809,9 @@
     },
     "/api/v1/websites/{id}/search": {
       "post": {
-        "tags": ["Websites"],
+        "tags": [
+          "Websites"
+        ],
         "summary": "Search content",
         "operationId": "searchWebsite",
         "security": [
@@ -836,7 +868,9 @@
     },
     "/api/v1/products": {
       "get": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "List products",
         "operationId": "listProducts",
         "security": [
@@ -908,7 +942,9 @@
         }
       },
       "post": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Create product",
         "operationId": "createProduct",
         "security": [
@@ -954,7 +990,9 @@
     },
     "/api/v1/products/{id}": {
       "get": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Get product",
         "operationId": "getProduct",
         "security": [
@@ -999,7 +1037,9 @@
         }
       },
       "patch": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Update product",
         "operationId": "updateProduct",
         "security": [
@@ -1054,7 +1094,9 @@
         }
       },
       "delete": {
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "summary": "Delete product",
         "operationId": "deleteProduct",
         "security": [
@@ -1094,7 +1136,9 @@
     },
     "/api/v1/customers": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "List customers",
         "operationId": "listCustomers",
         "security": [
@@ -1175,7 +1219,9 @@
         }
       },
       "post": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "security": [
@@ -1221,7 +1267,9 @@
     },
     "/api/v1/customers/{id}": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Get customer",
         "operationId": "getCustomer",
         "security": [
@@ -1266,7 +1314,9 @@
         }
       },
       "patch": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "security": [
@@ -1321,7 +1371,9 @@
         }
       },
       "delete": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "security": [
@@ -1361,7 +1413,9 @@
     },
     "/api/v1/vendors": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "List vendors",
         "operationId": "listVendors",
         "security": [
@@ -1433,7 +1487,9 @@
         }
       },
       "post": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Create vendor",
         "operationId": "createVendor",
         "security": [
@@ -1479,7 +1535,9 @@
     },
     "/api/v1/vendors/{id}": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Get vendor",
         "operationId": "getVendor",
         "security": [
@@ -1524,7 +1582,9 @@
         }
       },
       "patch": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Update vendor",
         "operationId": "updateVendor",
         "security": [
@@ -1579,7 +1639,9 @@
         }
       },
       "delete": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Delete vendor",
         "operationId": "deleteVendor",
         "security": [
@@ -1619,7 +1681,9 @@
     },
     "/api/v1/agents": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List agents",
         "operationId": "listAgents",
         "security": [
@@ -1655,7 +1719,9 @@
     },
     "/api/v1/agents/tools": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List available tools",
         "operationId": "listAgentTools",
         "security": [
@@ -1684,7 +1750,9 @@
     },
     "/api/v1/agents/integrations": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "List available integrations",
         "operationId": "listAgentIntegrations",
         "security": [
@@ -1713,7 +1781,9 @@
     },
     "/api/v1/agents/{slug}": {
       "get": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "Get agent config and binding",
         "operationId": "getAgent",
         "security": [
@@ -1758,7 +1828,9 @@
         }
       },
       "patch": {
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "summary": "Update agent binding",
         "operationId": "updateAgentBinding",
         "security": [
@@ -1815,7 +1887,9 @@
     },
     "/api/v1/workflows/{slug}/schedules": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List schedules",
         "operationId": "listWorkflowSchedules",
         "security": [
@@ -1860,7 +1934,9 @@
         }
       },
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Create schedule",
         "operationId": "createWorkflowSchedule",
         "security": [
@@ -1917,7 +1993,9 @@
     },
     "/api/v1/workflows/schedules/{id}": {
       "patch": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Update schedule",
         "operationId": "updateWorkflowSchedule",
         "security": [
@@ -1972,7 +2050,9 @@
         }
       },
       "delete": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Delete schedule",
         "operationId": "deleteWorkflowSchedule",
         "security": [
@@ -2012,7 +2092,9 @@
     },
     "/api/v1/workflows/{slug}/webhooks": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List webhooks",
         "operationId": "listWorkflowWebhooks",
         "security": [
@@ -2057,7 +2139,9 @@
         }
       },
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Create webhook",
         "operationId": "createWorkflowWebhook",
         "security": [
@@ -2104,7 +2188,9 @@
     },
     "/api/v1/workflows/webhooks/{id}": {
       "delete": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Delete webhook",
         "operationId": "deleteWorkflowWebhook",
         "security": [
@@ -2144,7 +2230,9 @@
     },
     "/api/v1/workflows/{slug}/logs": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Get trigger logs",
         "operationId": "getWorkflowLogs",
         "security": [
@@ -2184,7 +2272,9 @@
     },
     "/api/v1/workflows/{slug}/executions": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "List executions",
         "operationId": "listWorkflowExecutions",
         "security": [
@@ -2276,7 +2366,9 @@
     },
     "/api/v1/workflows/executions/{id}": {
       "get": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Get execution details",
         "operationId": "getWorkflowExecution",
         "security": [
@@ -2323,7 +2415,9 @@
     },
     "/api/v1/workflows/executions/{id}/cancel": {
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Cancel execution",
         "operationId": "cancelWorkflowExecution",
         "security": [
@@ -2363,7 +2457,9 @@
     },
     "/api/v1/workflows/{slug}/run": {
       "post": {
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "summary": "Trigger workflow",
         "operationId": "triggerWorkflow",
         "security": [
@@ -2420,7 +2516,9 @@
     },
     "/api/v1/threads": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "List threads",
         "operationId": "listThreads",
         "security": [
@@ -2483,7 +2581,9 @@
         }
       },
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Create thread",
         "operationId": "createThread",
         "security": [
@@ -2529,7 +2629,9 @@
     },
     "/api/v1/threads/{id}": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Get thread",
         "operationId": "getThread",
         "security": [
@@ -2574,7 +2676,9 @@
         }
       },
       "patch": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Update thread title",
         "operationId": "updateThread",
         "security": [
@@ -2622,7 +2726,9 @@
         }
       },
       "delete": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Delete thread",
         "operationId": "deleteThread",
         "security": [
@@ -2662,7 +2768,9 @@
     },
     "/api/v1/threads/{id}/messages": {
       "get": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Get thread messages",
         "operationId": "getThreadMessages",
         "security": [
@@ -2709,7 +2817,9 @@
     },
     "/api/v1/threads/{id}/archive": {
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Archive thread",
         "operationId": "archiveThread",
         "security": [
@@ -2749,7 +2859,9 @@
     },
     "/api/v1/threads/{id}/unarchive": {
       "post": {
-        "tags": ["Threads"],
+        "tags": [
+          "Threads"
+        ],
         "summary": "Unarchive thread",
         "operationId": "unarchiveThread",
         "security": [
@@ -2799,12 +2911,15 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
-            "description": "Agent slug (e.g., \"chat-agent\").",
-            "example": "chat-agent"
+            "description": "Model ID (e.g., \"claude-sonnet-4-20250514\"). Use GET /api/v1/models to list available models.",
+            "example": "claude-sonnet-4-20250514"
           },
           "messages": {
             "type": "array",
@@ -2857,7 +2972,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object"]
+                "enum": [
+                  "text",
+                  "json_object"
+                ]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -2873,14 +2991,20 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["auto", "required", "none"]
+                "enum": [
+                  "auto",
+                  "required",
+                  "none"
+                ]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["function"]
+                    "enum": [
+                      "function"
+                    ]
                   },
                   "function": {
                     "type": "object",
@@ -2889,12 +3013,25 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"]
+                    "required": [
+                      "name"
+                    ]
                   }
                 }
               }
             ],
             "description": "Controls tool calling behavior."
+          },
+          "stream_options": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "include_usage": {
+                "type": "boolean",
+                "description": "If set, an additional chunk will be streamed before the `[DONE]` message with token usage statistics."
+              }
+            },
+            "description": "Options for streaming. Only applicable when `stream` is true."
           }
         }
       },
@@ -2907,7 +3044,9 @@
           },
           "object": {
             "type": "string",
-            "enum": ["chat.completion"]
+            "enum": [
+              "chat.completion"
+            ]
           },
           "created": {
             "type": "integer"
@@ -2924,11 +3063,15 @@
                   "type": "integer"
                 },
                 "message": {
-                  "$ref": "#/components/schemas/ChatMessage"
+                  "$ref": "#/components/schemas/ChatMessageAssistant"
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": ["stop", "length", "tool_calls"]
+                  "enum": [
+                    "stop",
+                    "length",
+                    "tool_calls"
+                  ]
                 }
               }
             }
@@ -2952,42 +3095,7 @@
             "items": {
               "$ref": "#/components/schemas/Citation"
             },
-            "description": "Source citations referenced in the response text via [N] markers. Empty array when no knowledge tools were used."
-          }
-        }
-      },
-      "Citation": {
-        "type": "object",
-        "required": ["index", "type", "source", "relevance"],
-        "properties": {
-          "index": {
-            "type": "integer",
-            "description": "The [N] citation marker number in the response text"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["rag", "web"],
-            "description": "Source type"
-          },
-          "source": {
-            "type": "string",
-            "description": "Filename (rag) or page title (web)"
-          },
-          "fileId": {
-            "type": "string",
-            "description": "Document file ID (rag only)"
-          },
-          "url": {
-            "type": "string",
-            "description": "Source URL (web only)"
-          },
-          "page": {
-            "type": "integer",
-            "description": "Page number within document (rag only)"
-          },
-          "relevance": {
-            "type": "number",
-            "description": "Relevance score (0-1)"
+            "description": "Source citations referenced in the response text via [N] markers. Present when knowledge tools (RAG, web search) were used."
           }
         }
       },
@@ -2996,7 +3104,9 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": ["list"]
+            "enum": [
+              "list"
+            ]
           },
           "data": {
             "type": "array",
@@ -3009,7 +3119,9 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": ["model"]
+                  "enum": [
+                    "model"
+                  ]
                 },
                 "created": {
                   "type": "integer"
@@ -3041,7 +3153,9 @@
       },
       "CreateDocumentRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string"
@@ -3152,7 +3266,10 @@
       },
       "CreateWebsiteRequest": {
         "type": "object",
-        "required": ["domain", "scanInterval"],
+        "required": [
+          "domain",
+          "scanInterval"
+        ],
         "properties": {
           "domain": {
             "type": "string"
@@ -3230,7 +3347,9 @@
       },
       "WebsiteSearchRequest": {
         "type": "object",
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "properties": {
           "query": {
             "type": "string"
@@ -3284,7 +3403,9 @@
       },
       "CreateProductRequest": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -3422,7 +3543,9 @@
       },
       "CreateCustomerRequest": {
         "type": "object",
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "properties": {
           "email": {
             "type": "string"
@@ -3664,7 +3787,10 @@
       },
       "CreateScheduleRequest": {
         "type": "object",
-        "required": ["cronExpression", "timezone"],
+        "required": [
+          "cronExpression",
+          "timezone"
+        ],
         "properties": {
           "cronExpression": {
             "type": "string"
@@ -3838,7 +3964,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "deleted"]
+            "enum": [
+              "active",
+              "archived",
+              "deleted"
+            ]
           },
           "chatType": {
             "type": "string"
@@ -3856,7 +3986,9 @@
       },
       "UpdateThreadRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string"
@@ -3879,7 +4011,10 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["user", "assistant"]
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ]
                 },
                 "content": {
                   "type": "string"
@@ -3890,48 +4025,48 @@
         }
       },
       "ChatMessage": {
-        "type": "object",
-        "required": ["role"],
-        "properties": {
-          "role": {
-            "type": "string",
-            "enum": ["system", "user", "assistant", "tool"]
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatMessageSystem"
           },
-          "content": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Message content."
+          {
+            "$ref": "#/components/schemas/ChatMessageUser"
           },
-          "tool_calls": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ToolCall"
-            },
-            "description": "Tool calls (assistant messages only)."
+          {
+            "$ref": "#/components/schemas/ChatMessageAssistant"
           },
-          "tool_call_id": {
-            "type": "string",
-            "description": "ID of the tool call this result is for (tool messages only)."
+          {
+            "$ref": "#/components/schemas/ChatMessageTool"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "role",
+          "mapping": {
+            "system": "#/components/schemas/ChatMessageSystem",
+            "user": "#/components/schemas/ChatMessageUser",
+            "assistant": "#/components/schemas/ChatMessageAssistant",
+            "tool": "#/components/schemas/ChatMessageTool"
           }
         }
       },
       "ToolDefinition": {
         "type": "object",
-        "required": ["type", "function"],
+        "required": [
+          "type",
+          "function"
+        ],
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string"
@@ -3944,6 +4079,69 @@
                 "description": "JSON Schema for the function parameters."
               }
             }
+          }
+        }
+      },
+      "ChatMessageAssistant": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "assistant"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true,
+            "description": "Assistant message content."
+          },
+          "tool_calls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            },
+            "description": "Tool calls made by the assistant."
+          }
+        }
+      },
+      "Citation": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "Citation index corresponding to [N] markers in text."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "rag",
+              "web"
+            ],
+            "description": "Source type: RAG knowledge base or web search."
+          },
+          "source": {
+            "type": "string",
+            "description": "Source name or title."
+          },
+          "fileId": {
+            "type": "string",
+            "description": "File ID for RAG citations."
+          },
+          "url": {
+            "type": "string",
+            "description": "URL for web citations."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Page number for document citations."
+          },
+          "relevance": {
+            "type": "number",
+            "description": "Relevance score (0-1)."
           }
         }
       },
@@ -3981,6 +4179,69 @@
           }
         }
       },
+      "ChatMessageSystem": {
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "system"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "description": "System prompt content."
+          }
+        }
+      },
+      "ChatMessageUser": {
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "user"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "description": "User message content."
+          }
+        }
+      },
+      "ChatMessageTool": {
+        "type": "object",
+        "required": [
+          "role",
+          "content",
+          "tool_call_id"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "tool"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true,
+            "description": "Tool result content."
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "ID of the tool call this result is for."
+          }
+        }
+      },
       "ToolCall": {
         "type": "object",
         "properties": {
@@ -3989,7 +4250,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function"]
+            "enum": [
+              "function"
+            ]
           },
           "function": {
             "type": "object",

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Tale Public API",
     "version": "1.0.0",
-    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\nresponse = client.chat.completions.create(\n    model=\"chat-agent\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\n```"
+    "description": "Tale Platform REST API.\n\n## Authentication\n\nAll endpoints require a Bearer token:\n\n```\nAuthorization: Bearer tale_...\n```\n\nCreate API keys in **Settings > API Keys**.\n\n## Quick start — REST API\n\n```bash\n# List documents\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/documents\n\n# Create a product\ncurl -X POST -H \"Authorization: Bearer tale_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"New Product\", \"price\": 9.99}' \\\n  https://your-instance.com/api/v1/products\n\n# List chat threads\ncurl -H \"Authorization: Bearer tale_...\" https://your-instance.com/api/v1/threads\n```\n\n## Quick start — OpenAI Compatible\n\nUse any OpenAI-compatible SDK. List available models with `GET /api/v1/models`.\n\n```python\nfrom openai import OpenAI\n\nclient = OpenAI(\n    base_url=\"https://your-instance.com/api/v1\",\n    api_key=\"tale_...\",\n)\n\n# List available models\nmodels = client.models.list()\nfor m in models.data:\n    print(m.id, m.owned_by)\n\n# Chat completion\nresponse = client.chat.completions.create(\n    model=\"anthropic/claude-sonnet-4.6\",  # Use a model ID from the list above\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n```"
   },
   "servers": [
     {
@@ -3115,7 +3115,7 @@
               "properties": {
                 "id": {
                   "type": "string",
-                  "example": "chat-agent"
+                  "example": "anthropic/claude-sonnet-4.6"
                 },
                 "object": {
                   "type": "string",

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -19,9 +19,7 @@
   "paths": {
     "/api/v1/chat/completions": {
       "post": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "Create chat completion",
         "description": "Send messages to a model and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\nUse `GET /api/v1/models` to list available models. Supports tool calling via the `tools` parameter — the model returns `tool_calls` for client-side execution.",
         "operationId": "createChatCompletion",
@@ -80,9 +78,7 @@
     },
     "/api/v1/models": {
       "get": {
-        "tags": [
-          "OpenAI Compatible"
-        ],
+        "tags": ["OpenAI Compatible"],
         "summary": "List models",
         "description": "List available agents as OpenAI-compatible models. Only agents with `visibleInChat: true` are returned.",
         "operationId": "listModels",
@@ -111,9 +107,7 @@
     },
     "/api/v1/documents": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "List documents",
         "operationId": "listDocuments",
         "security": [
@@ -185,9 +179,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Create document",
         "operationId": "createDocument",
         "security": [
@@ -233,9 +225,7 @@
     },
     "/api/v1/documents/{id}": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Get document",
         "operationId": "getDocument",
         "security": [
@@ -280,9 +270,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Update document",
         "operationId": "updateDocument",
         "security": [
@@ -337,9 +325,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Delete document",
         "operationId": "deleteDocument",
         "security": [
@@ -379,9 +365,7 @@
     },
     "/api/v1/documents/{id}/retry-indexing": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "summary": "Retry RAG indexing",
         "operationId": "retryDocumentIndexing",
         "security": [
@@ -421,9 +405,7 @@
     },
     "/api/v1/websites": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "List websites",
         "operationId": "listWebsites",
         "security": [
@@ -495,9 +477,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Create website",
         "operationId": "createWebsite",
         "security": [
@@ -543,9 +523,7 @@
     },
     "/api/v1/websites/{id}": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Get website",
         "operationId": "getWebsite",
         "security": [
@@ -590,9 +568,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Update website",
         "operationId": "updateWebsite",
         "security": [
@@ -647,9 +623,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Delete website",
         "operationId": "deleteWebsite",
         "security": [
@@ -689,9 +663,7 @@
     },
     "/api/v1/websites/{id}/pages": {
       "get": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Fetch pages",
         "operationId": "listWebsitePages",
         "security": [
@@ -756,9 +728,7 @@
     },
     "/api/v1/websites/{id}/sync": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Sync statuses",
         "operationId": "syncWebsite",
         "security": [
@@ -798,9 +768,7 @@
     },
     "/api/v1/websites/{id}/search": {
       "post": {
-        "tags": [
-          "Websites"
-        ],
+        "tags": ["Websites"],
         "summary": "Search content",
         "operationId": "searchWebsite",
         "security": [
@@ -857,9 +825,7 @@
     },
     "/api/v1/products": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "List products",
         "operationId": "listProducts",
         "security": [
@@ -931,9 +897,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Create product",
         "operationId": "createProduct",
         "security": [
@@ -979,9 +943,7 @@
     },
     "/api/v1/products/{id}": {
       "get": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Get product",
         "operationId": "getProduct",
         "security": [
@@ -1026,9 +988,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Update product",
         "operationId": "updateProduct",
         "security": [
@@ -1083,9 +1043,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "summary": "Delete product",
         "operationId": "deleteProduct",
         "security": [
@@ -1125,9 +1083,7 @@
     },
     "/api/v1/customers": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "List customers",
         "operationId": "listCustomers",
         "security": [
@@ -1208,9 +1164,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "security": [
@@ -1256,9 +1210,7 @@
     },
     "/api/v1/customers/{id}": {
       "get": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Get customer",
         "operationId": "getCustomer",
         "security": [
@@ -1303,9 +1255,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "security": [
@@ -1360,9 +1310,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "security": [
@@ -1402,9 +1350,7 @@
     },
     "/api/v1/vendors": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "List vendors",
         "operationId": "listVendors",
         "security": [
@@ -1476,9 +1422,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Create vendor",
         "operationId": "createVendor",
         "security": [
@@ -1524,9 +1468,7 @@
     },
     "/api/v1/vendors/{id}": {
       "get": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Get vendor",
         "operationId": "getVendor",
         "security": [
@@ -1571,9 +1513,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Update vendor",
         "operationId": "updateVendor",
         "security": [
@@ -1628,9 +1568,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Vendors"
-        ],
+        "tags": ["Vendors"],
         "summary": "Delete vendor",
         "operationId": "deleteVendor",
         "security": [
@@ -1670,9 +1608,7 @@
     },
     "/api/v1/agents": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List agents",
         "operationId": "listAgents",
         "security": [
@@ -1708,9 +1644,7 @@
     },
     "/api/v1/agents/tools": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available tools",
         "operationId": "listAgentTools",
         "security": [
@@ -1739,9 +1673,7 @@
     },
     "/api/v1/agents/integrations": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "List available integrations",
         "operationId": "listAgentIntegrations",
         "security": [
@@ -1770,9 +1702,7 @@
     },
     "/api/v1/agents/{slug}": {
       "get": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Get agent config and binding",
         "operationId": "getAgent",
         "security": [
@@ -1817,9 +1747,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "summary": "Update agent binding",
         "operationId": "updateAgentBinding",
         "security": [
@@ -1876,9 +1804,7 @@
     },
     "/api/v1/workflows/{slug}/schedules": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List schedules",
         "operationId": "listWorkflowSchedules",
         "security": [
@@ -1923,9 +1849,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create schedule",
         "operationId": "createWorkflowSchedule",
         "security": [
@@ -1982,9 +1906,7 @@
     },
     "/api/v1/workflows/schedules/{id}": {
       "patch": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Update schedule",
         "operationId": "updateWorkflowSchedule",
         "security": [
@@ -2039,9 +1961,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete schedule",
         "operationId": "deleteWorkflowSchedule",
         "security": [
@@ -2081,9 +2001,7 @@
     },
     "/api/v1/workflows/{slug}/webhooks": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List webhooks",
         "operationId": "listWorkflowWebhooks",
         "security": [
@@ -2128,9 +2046,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Create webhook",
         "operationId": "createWorkflowWebhook",
         "security": [
@@ -2177,9 +2093,7 @@
     },
     "/api/v1/workflows/webhooks/{id}": {
       "delete": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Delete webhook",
         "operationId": "deleteWorkflowWebhook",
         "security": [
@@ -2219,9 +2133,7 @@
     },
     "/api/v1/workflows/{slug}/logs": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get trigger logs",
         "operationId": "getWorkflowLogs",
         "security": [
@@ -2261,9 +2173,7 @@
     },
     "/api/v1/workflows/{slug}/executions": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "List executions",
         "operationId": "listWorkflowExecutions",
         "security": [
@@ -2355,9 +2265,7 @@
     },
     "/api/v1/workflows/executions/{id}": {
       "get": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Get execution details",
         "operationId": "getWorkflowExecution",
         "security": [
@@ -2404,9 +2312,7 @@
     },
     "/api/v1/workflows/executions/{id}/cancel": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Cancel execution",
         "operationId": "cancelWorkflowExecution",
         "security": [
@@ -2446,9 +2352,7 @@
     },
     "/api/v1/workflows/{slug}/run": {
       "post": {
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "summary": "Trigger workflow",
         "operationId": "triggerWorkflow",
         "security": [
@@ -2505,9 +2409,7 @@
     },
     "/api/v1/threads": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "List threads",
         "operationId": "listThreads",
         "security": [
@@ -2570,9 +2472,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Create thread",
         "operationId": "createThread",
         "security": [
@@ -2618,9 +2518,7 @@
     },
     "/api/v1/threads/{id}": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread",
         "operationId": "getThread",
         "security": [
@@ -2665,9 +2563,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Update thread title",
         "operationId": "updateThread",
         "security": [
@@ -2715,9 +2611,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Delete thread",
         "operationId": "deleteThread",
         "security": [
@@ -2757,9 +2651,7 @@
     },
     "/api/v1/threads/{id}/messages": {
       "get": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Get thread messages",
         "operationId": "getThreadMessages",
         "security": [
@@ -2806,9 +2698,7 @@
     },
     "/api/v1/threads/{id}/archive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Archive thread",
         "operationId": "archiveThread",
         "security": [
@@ -2848,9 +2738,7 @@
     },
     "/api/v1/threads/{id}/unarchive": {
       "post": {
-        "tags": [
-          "Threads"
-        ],
+        "tags": ["Threads"],
         "summary": "Unarchive thread",
         "operationId": "unarchiveThread",
         "security": [
@@ -2900,10 +2788,7 @@
     "schemas": {
       "ChatCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -2961,10 +2846,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object"
-                ]
+                "enum": ["text", "json_object"]
               }
             },
             "description": "Set to `{\"type\": \"json_object\"}` for JSON mode."
@@ -2980,20 +2862,14 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "required",
-                  "none"
-                ]
+                "enum": ["auto", "required", "none"]
               },
               {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "function"
-                    ]
+                    "enum": ["function"]
                   },
                   "function": {
                     "type": "object",
@@ -3002,9 +2878,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name"
-                    ]
+                    "required": ["name"]
                   }
                 }
               }
@@ -3033,9 +2907,7 @@
           },
           "object": {
             "type": "string",
-            "enum": [
-              "chat.completion"
-            ]
+            "enum": ["chat.completion"]
           },
           "created": {
             "type": "integer"
@@ -3056,11 +2928,7 @@
                 },
                 "finish_reason": {
                   "type": "string",
-                  "enum": [
-                    "stop",
-                    "length",
-                    "tool_calls"
-                  ]
+                  "enum": ["stop", "length", "tool_calls"]
                 }
               }
             }
@@ -3093,9 +2961,7 @@
         "properties": {
           "object": {
             "type": "string",
-            "enum": [
-              "list"
-            ]
+            "enum": ["list"]
           },
           "data": {
             "type": "array",
@@ -3108,9 +2974,7 @@
                 },
                 "object": {
                   "type": "string",
-                  "enum": [
-                    "model"
-                  ]
+                  "enum": ["model"]
                 },
                 "created": {
                   "type": "integer"
@@ -3142,9 +3006,7 @@
       },
       "CreateDocumentRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -3255,10 +3117,7 @@
       },
       "CreateWebsiteRequest": {
         "type": "object",
-        "required": [
-          "domain",
-          "scanInterval"
-        ],
+        "required": ["domain", "scanInterval"],
         "properties": {
           "domain": {
             "type": "string"
@@ -3336,9 +3195,7 @@
       },
       "WebsiteSearchRequest": {
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {
             "type": "string"
@@ -3392,9 +3249,7 @@
       },
       "CreateProductRequest": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -3532,9 +3387,7 @@
       },
       "CreateCustomerRequest": {
         "type": "object",
-        "required": [
-          "email"
-        ],
+        "required": ["email"],
         "properties": {
           "email": {
             "type": "string"
@@ -3776,10 +3629,7 @@
       },
       "CreateScheduleRequest": {
         "type": "object",
-        "required": [
-          "cronExpression",
-          "timezone"
-        ],
+        "required": ["cronExpression", "timezone"],
         "properties": {
           "cronExpression": {
             "type": "string"
@@ -3953,11 +3803,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "archived",
-              "deleted"
-            ]
+            "enum": ["active", "archived", "deleted"]
           },
           "chatType": {
             "type": "string"
@@ -3975,9 +3821,7 @@
       },
       "UpdateThreadRequest": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string"
@@ -4000,10 +3844,7 @@
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "user",
-                    "assistant"
-                  ]
+                  "enum": ["user", "assistant"]
                 },
                 "content": {
                   "type": "string"
@@ -4040,22 +3881,15 @@
       },
       "ToolDefinition": {
         "type": "object",
-        "required": [
-          "type",
-          "function"
-        ],
+        "required": ["type", "function"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "name": {
                 "type": "string"
@@ -4073,15 +3907,11 @@
       },
       "ChatMessageAssistant": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "assistant"
-            ]
+            "enum": ["assistant"]
           },
           "content": {
             "type": "string",
@@ -4106,10 +3936,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "rag",
-              "web"
-            ],
+            "enum": ["rag", "web"],
             "description": "Source type: RAG knowledge base or web search."
           },
           "source": {
@@ -4170,16 +3997,11 @@
       },
       "ChatMessageSystem": {
         "type": "object",
-        "required": [
-          "role",
-          "content"
-        ],
+        "required": ["role", "content"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "system"
-            ]
+            "enum": ["system"]
           },
           "content": {
             "type": "string",
@@ -4189,16 +4011,11 @@
       },
       "ChatMessageUser": {
         "type": "object",
-        "required": [
-          "role",
-          "content"
-        ],
+        "required": ["role", "content"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "user"
-            ]
+            "enum": ["user"]
           },
           "content": {
             "type": "string",
@@ -4208,17 +4025,11 @@
       },
       "ChatMessageTool": {
         "type": "object",
-        "required": [
-          "role",
-          "content",
-          "tool_call_id"
-        ],
+        "required": ["role", "content", "tool_call_id"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "tool"
-            ]
+            "enum": ["tool"]
           },
           "content": {
             "type": "string",
@@ -4239,9 +4050,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "function"
-            ]
+            "enum": ["function"]
           },
           "function": {
             "type": "object",

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -30,17 +30,6 @@
             "bearerAuth": []
           }
         ],
-        "parameters": [
-          {
-            "name": "X-Thread-Id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Reuse a conversation thread across requests."
-          }
-        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -23,7 +23,7 @@
           "OpenAI Compatible"
         ],
         "summary": "Create chat completion",
-        "description": "Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\n**Two modes:**\n- **Agent mode** (no `tools`): The agent uses server-side tools and auto-executes them.\n- **Client tool mode** (`tools` provided): Only client-defined tools are used. Returns `tool_calls` for client execution.",
+        "description": "Send messages to a model and receive a response. Fully compatible with the OpenAI Chat Completions API.\n\nUse `GET /api/v1/models` to list available models. Supports tool calling via the `tools` parameter — the model returns `tool_calls` for client-side execution.",
         "operationId": "createChatCompletion",
         "security": [
           {

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -69,15 +69,6 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
 Use \`GET /api/v1/models\` to list available models. Supports tool calling via the \`tools\` parameter — the model returns \`tool_calls\` for client-side execution.`,
       operationId: 'createChatCompletion',
       security: [{ bearerAuth: [] }],
-      parameters: [
-        {
-          name: 'X-Thread-Id',
-          in: 'header',
-          required: false,
-          schema: { type: 'string' },
-          description: 'Reuse a conversation thread across requests.',
-        },
-      ],
       requestBody: {
         required: true,
         content: {

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -424,7 +424,7 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
         items: {
           type: 'object',
           properties: {
-            id: { type: 'string', example: 'chat-agent' },
+            id: { type: 'string', example: 'anthropic/claude-sonnet-4.6' },
             object: { type: 'string', enum: ['model'] },
             created: { type: 'integer' },
             owned_by: { type: 'string' },
@@ -1975,6 +1975,8 @@ curl -H "Authorization: Bearer tale_..." https://your-instance.com/api/v1/thread
 
 ## Quick start — OpenAI Compatible
 
+Use any OpenAI-compatible SDK. List available models with \`GET /api/v1/models\`.
+
 \`\`\`python
 from openai import OpenAI
 
@@ -1983,10 +1985,17 @@ client = OpenAI(
     api_key="tale_...",
 )
 
+# List available models
+models = client.models.list()
+for m in models.data:
+    print(m.id, m.owned_by)
+
+# Chat completion
 response = client.chat.completions.create(
-    model="chat-agent",
+    model="anthropic/claude-sonnet-4.6",  # Use a model ID from the list above
     messages=[{"role": "user", "content": "Hello!"}],
 )
+print(response.choices[0].message.content)
 \`\`\`
 `.trim(),
     },

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -64,11 +64,9 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
     post: {
       tags: [openaiTag],
       summary: 'Create chat completion',
-      description: `Send messages to an agent and receive a response. Fully compatible with the OpenAI Chat Completions API.
+      description: `Send messages to a model and receive a response. Fully compatible with the OpenAI Chat Completions API.
 
-**Two modes:**
-- **Agent mode** (no \`tools\`): The agent uses server-side tools and auto-executes them.
-- **Client tool mode** (\`tools\` provided): Only client-defined tools are used. Returns \`tool_calls\` for client execution.`,
+Use \`GET /api/v1/models\` to list available models. Supports tool calling via the \`tools\` parameter — the model returns \`tool_calls\` for client-side execution.`,
       operationId: 'createChatCompletion',
       security: [{ bearerAuth: [] }],
       parameters: [

--- a/services/platform/scripts/generate-openapi.ts
+++ b/services/platform/scripts/generate-openapi.ts
@@ -149,8 +149,9 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
     properties: {
       model: {
         type: 'string',
-        description: 'Agent slug (e.g., "chat-agent").',
-        example: 'chat-agent',
+        description:
+          'Model ID (e.g., "claude-sonnet-4-20250514"). Use GET /api/v1/models to list available models.',
+        example: 'claude-sonnet-4-20250514',
       },
       messages: {
         type: 'array',
@@ -215,30 +216,90 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
         ],
         description: 'Controls tool calling behavior.',
       },
+      stream_options: {
+        type: 'object',
+        nullable: true,
+        properties: {
+          include_usage: {
+            type: 'boolean',
+            description:
+              'If set, an additional chunk will be streamed before the `[DONE]` message with token usage statistics.',
+          },
+        },
+        description:
+          'Options for streaming. Only applicable when `stream` is true.',
+      },
     },
   };
 
-  schemas.ChatMessage = {
+  // Role-specific message schemas
+  schemas.ChatMessageSystem = {
+    type: 'object',
+    required: ['role', 'content'],
+    properties: {
+      role: { type: 'string', enum: ['system'] },
+      content: { type: 'string', description: 'System prompt content.' },
+    },
+  };
+
+  schemas.ChatMessageUser = {
+    type: 'object',
+    required: ['role', 'content'],
+    properties: {
+      role: { type: 'string', enum: ['user'] },
+      content: { type: 'string', description: 'User message content.' },
+    },
+  };
+
+  schemas.ChatMessageAssistant = {
     type: 'object',
     required: ['role'],
     properties: {
-      role: {
-        type: 'string',
-        enum: ['system', 'user', 'assistant', 'tool'],
-      },
+      role: { type: 'string', enum: ['assistant'] },
       content: {
-        oneOf: [{ type: 'string' }, { type: 'null' }],
-        description: 'Message content.',
+        type: 'string',
+        nullable: true,
+        description: 'Assistant message content.',
       },
       tool_calls: {
         type: 'array',
         items: { $ref: '#/components/schemas/ToolCall' },
-        description: 'Tool calls (assistant messages only).',
+        description: 'Tool calls made by the assistant.',
+      },
+    },
+  };
+
+  schemas.ChatMessageTool = {
+    type: 'object',
+    required: ['role', 'content', 'tool_call_id'],
+    properties: {
+      role: { type: 'string', enum: ['tool'] },
+      content: {
+        type: 'string',
+        nullable: true,
+        description: 'Tool result content.',
       },
       tool_call_id: {
         type: 'string',
-        description:
-          'ID of the tool call this result is for (tool messages only).',
+        description: 'ID of the tool call this result is for.',
+      },
+    },
+  };
+
+  schemas.ChatMessage = {
+    oneOf: [
+      { $ref: '#/components/schemas/ChatMessageSystem' },
+      { $ref: '#/components/schemas/ChatMessageUser' },
+      { $ref: '#/components/schemas/ChatMessageAssistant' },
+      { $ref: '#/components/schemas/ChatMessageTool' },
+    ],
+    discriminator: {
+      propertyName: 'role',
+      mapping: {
+        system: '#/components/schemas/ChatMessageSystem',
+        user: '#/components/schemas/ChatMessageUser',
+        assistant: '#/components/schemas/ChatMessageAssistant',
+        tool: '#/components/schemas/ChatMessageTool',
       },
     },
   };
@@ -294,7 +355,7 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
           type: 'object',
           properties: {
             index: { type: 'integer' },
-            message: { $ref: '#/components/schemas/ChatMessage' },
+            message: { $ref: '#/components/schemas/ChatMessageAssistant' },
             finish_reason: {
               type: 'string',
               enum: ['stop', 'length', 'tool_calls'],
@@ -309,6 +370,47 @@ function injectOpenAICompatPaths(spec: OpenApiSpec) {
           completion_tokens: { type: 'integer' },
           total_tokens: { type: 'integer' },
         },
+      },
+      citations: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/Citation' },
+        description:
+          'Source citations referenced in the response text via [N] markers. Present when knowledge tools (RAG, web search) were used.',
+      },
+    },
+  };
+
+  schemas.Citation = {
+    type: 'object',
+    properties: {
+      index: {
+        type: 'integer',
+        description: 'Citation index corresponding to [N] markers in text.',
+      },
+      type: {
+        type: 'string',
+        enum: ['rag', 'web'],
+        description: 'Source type: RAG knowledge base or web search.',
+      },
+      source: {
+        type: 'string',
+        description: 'Source name or title.',
+      },
+      fileId: {
+        type: 'string',
+        description: 'File ID for RAG citations.',
+      },
+      url: {
+        type: 'string',
+        description: 'URL for web citations.',
+      },
+      page: {
+        type: 'integer',
+        description: 'Page number for document citations.',
+      },
+      relevance: {
+        type: 'number',
+        description: 'Relevance score (0-1).',
       },
     },
   };

--- a/services/platform/scripts/test-openai-compat.ts
+++ b/services/platform/scripts/test-openai-compat.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * Integration test for OpenAI-compatible API using AI SDK v6.
+ * Simulates real user scenarios with @ai-sdk/openai-compatible.
+ *
+ * Usage: bun scripts/test-openai-compat.ts
+ */
+
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText, streamText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+
+const BASE_URL = 'http://localhost:3000/api/v1';
+const API_KEY =
+  'taleDsYqAacBOcFDlGBISiORAmxkQHhNEChqBgagAngCaaReIsBGfAREKtZTckLmyeqn';
+
+const provider = createOpenAICompatible({
+  name: 'tale',
+  baseURL: BASE_URL,
+  headers: { Authorization: `Bearer ${API_KEY}` },
+});
+
+function uid() {
+  return Date.now().toString(36);
+}
+
+// ── Test 1: List models ──────────────────────────────────────────────────────
+
+async function testListModels(): Promise<string> {
+  console.log('\n═══ Test 1: List models ═══');
+
+  const res = await fetch(`${BASE_URL}/models`, {
+    headers: { Authorization: `Bearer ${API_KEY}` },
+  });
+  const body = await res.json();
+
+  console.log(`  Found ${body.data?.length ?? 0} models:`);
+  for (const m of body.data ?? []) {
+    console.log(`    ${m.id} (${m.owned_by})`);
+  }
+
+  const modelId = body.data?.[0]?.id;
+  if (!modelId) throw new Error('No models available');
+  return modelId;
+}
+
+// ── Test 2: generateText ─────────────────────────────────────────────────────
+
+async function testGenerateText(modelId: string) {
+  console.log(`\n═══ Test 2: generateText (model: ${modelId}) ═══`);
+
+  const result = await generateText({
+    model: provider.chatModel(modelId),
+    prompt: `What is 2+2? Answer in one word. (${uid()})`,
+  });
+
+  console.log(`  text: ${result.text}`);
+  console.log(`  finishReason: ${result.finishReason}`);
+  console.log(`  usage: ${JSON.stringify(result.usage)}`);
+}
+
+// ── Test 3: streamText ───────────────────────────────────────────────────────
+
+async function testStreamText(modelId: string) {
+  console.log(`\n═══ Test 3: streamText (model: ${modelId}) ═══`);
+
+  const result = streamText({
+    model: provider.chatModel(modelId),
+    prompt: `Name one color. (${uid()})`,
+  });
+
+  process.stdout.write('  streaming: ');
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  console.log();
+
+  const usage = await result.usage;
+  console.log(`  usage: ${JSON.stringify(usage)}`);
+}
+
+// ── Test 4: Tool calling (single step) ───────────────────────────────────────
+
+async function testToolCalling(modelId: string) {
+  console.log(`\n═══ Test 4: Tool calling (model: ${modelId}) ═══`);
+
+  const result = await generateText({
+    model: provider.chatModel(modelId),
+    prompt: `What is the weather in Berlin? (${uid()})`,
+    tools: {
+      get_weather: tool({
+        description: 'Get current weather for a city',
+        inputSchema: z.object({
+          city: z.string().describe('City name'),
+        }),
+      }),
+    },
+    toolChoice: 'required',
+  });
+
+  console.log(`  finishReason: ${result.finishReason}`);
+  console.log(`  toolCalls: ${JSON.stringify(result.toolCalls, null, 2)}`);
+  console.log(`  usage: ${JSON.stringify(result.usage)}`);
+
+  if (result.toolCalls.length > 0) {
+    const tc = result.toolCalls[0];
+    console.log(`  ✓ Tool called: ${tc.toolName}(${JSON.stringify(tc.input)})`);
+  } else {
+    console.log('  ✗ No tool calls returned');
+  }
+}
+
+// ── Test 5: Multi-turn tool calling with execute ─────────────────────────────
+
+async function testMultiTurnToolCalling(modelId: string) {
+  console.log(`\n═══ Test 5: Multi-turn tool calling (model: ${modelId}) ═══`);
+
+  const result = await generateText({
+    model: provider.chatModel(modelId),
+    prompt: `What is the weather in Tokyo? (${uid()})`,
+    tools: {
+      get_weather: tool({
+        description: 'Get current weather for a city',
+        inputSchema: z.object({
+          city: z.string().describe('City name'),
+        }),
+        execute: async ({ city }) => {
+          console.log(`  [tool executed] get_weather("${city}")`);
+          return { temperature: 22, condition: 'sunny', city };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
+  });
+
+  console.log(`  text: ${result.text}`);
+  console.log(`  finishReason: ${result.finishReason}`);
+  console.log(`  steps: ${result.steps.length}`);
+  console.log(`  usage: ${JSON.stringify(result.usage)}`);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('Testing OpenAI-compatible API with AI SDK v6');
+  console.log(`Base URL: ${BASE_URL}`);
+
+  const modelId = await testListModels();
+  await testGenerateText(modelId);
+  await testStreamText(modelId);
+  await testToolCalling(modelId);
+  await testMultiTurnToolCalling(modelId);
+
+  console.log('\n═══ All tests done ═══\n');
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

Closes #1428

- Refactors `/api/v1/chat/completions` from agent-based routing to a **direct model gateway** — `model` field now accepts real provider model IDs (e.g., `anthropic/claude-sonnet-4.6`) instead of agent slugs
- `/api/v1/models` now returns real provider models with `owned_by` field
- Adds `stream_options.include_usage` support per OpenAI spec (opt-in streaming usage chunk with `choices: []`)
- Returns real token usage in all response paths (non-streaming + streaming)
- Splits OpenAPI `ChatMessage` into role-specific schemas (`ChatMessageSystem`, `ChatMessageUser`, `ChatMessageAssistant`, `ChatMessageTool`) with discriminator
- Backports Citation schema into `generate-openapi.ts` (was previously hand-edited in openapi.json)
- Full governance preserved in direct mode: auth, rate limiting, PII scrubbing, mandatory system prompt, usage ledger, audit log, circuit breaker + failover
- Strips `$`-prefixed keys from tool parameters to work around Convex reserved prefix

## Test plan

- [x] TypeScript: 0 errors
- [x] Lint: 0 errors
- [x] Unit tests: 28/28 passing (includes new usage tests)
- [x] AI SDK v6 integration test: `generateText`, `streamText`, tool calling (single + multi-turn) all passing
- [x] Governance verified: mandatory system prompt (German response) + PII scrubbing (block mode) both working in direct model mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `stream_options.include_usage` parameter to include token usage statistics in streaming responses

* **Improvements**
  * Model listing API now displays available models with provider metadata
  * Chat completions API updated to use model IDs instead of agent identifiers
  * Enhanced token usage tracking with detailed input and output token counts
  * Improved API documentation and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->