### PR TITLE
feat(platform): add auto model selection and expand error categories

### DIFF
--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -23,6 +23,8 @@ import { useDefaultModel } from '../hooks/use-default-model';
 import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { ModelTagIcons } from './model-tag-icons';
 
+const AUTO_MODEL = 'auto';
+
 interface ModelSelectorProps {
   organizationId: string;
 }
@@ -102,25 +104,13 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   );
 
   const currentModelId = useMemo(() => {
-    // 1. User's explicit override (localStorage) takes highest priority
+    // User's explicit override (localStorage) takes highest priority
     if (effectiveAgent?.name && selectedModelOverrides[effectiveAgent.name]) {
       return selectedModelOverrides[effectiveAgent.name];
     }
-    // 2. Governance team/role default (if model is in agent's supported list)
-    if (
-      governanceDefault?.modelId &&
-      filteredModels.includes(governanceDefault.modelId)
-    ) {
-      return governanceDefault.modelId;
-    }
-    // 3. Agent's primary model
-    return filteredModels[0] ?? null;
-  }, [
-    effectiveAgent?.name,
-    selectedModelOverrides,
-    governanceDefault,
-    filteredModels,
-  ]);
+    // No override → Auto mode
+    return AUTO_MODEL;
+  }, [effectiveAgent?.name, selectedModelOverrides]);
 
   // Clear stale override when agent changes
   useEffect(() => {
@@ -139,30 +129,21 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const handleSelect = useCallback(
     (modelId: string) => {
       if (!effectiveAgent?.name) return;
-      // Only clear the override when the user picks the effective default
-      // (governance default if present, otherwise the agent's primary model).
-      const effectiveDefault =
-        governanceDefault?.modelId &&
-        filteredModels.includes(governanceDefault.modelId)
-          ? governanceDefault.modelId
-          : filteredModels[0];
-      if (modelId === effectiveDefault) {
+      if (modelId === AUTO_MODEL) {
         setSelectedModelOverride(effectiveAgent.name, null);
       } else {
         setSelectedModelOverride(effectiveAgent.name, modelId);
       }
     },
-    [
-      effectiveAgent?.name,
-      filteredModels,
-      governanceDefault,
-      setSelectedModelOverride,
-    ],
+    [effectiveAgent?.name, setSelectedModelOverride],
   );
 
-  if (!currentModelId) return null;
+  if (!filteredModels.length) return null;
 
-  const currentLabel = getDisplayName(currentModelId);
+  const currentLabel =
+    currentModelId === AUTO_MODEL
+      ? t('modelSelector.auto')
+      : getDisplayName(currentModelId);
 
   // Single model — show as read-only text
   if (filteredModels.length <= 1) {
@@ -174,11 +155,19 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
     );
   }
 
-  const options = filteredModels.map((modelId) => ({
+  const autoOption: SearchableSelectOption = {
+    value: AUTO_MODEL,
+    label: t('modelSelector.auto'),
+    description: t('modelSelector.autoDescription'),
+  };
+
+  const modelOptions = filteredModels.map((modelId) => ({
     value: modelId,
     label: getDisplayName(modelId),
     description: modelInfoMap.get(modelId)?.description,
   }));
+
+  const options = [autoOption, ...modelOptions];
 
   return (
     <SearchableSelect

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -19,7 +19,6 @@ import { useT } from '@/lib/i18n/client';
 
 import { useChatLayout } from '../context/chat-layout-context';
 import { useChatAgents } from '../hooks/queries';
-import { useDefaultModel } from '../hooks/use-default-model';
 import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { ModelTagIcons } from './model-tag-icons';
 
@@ -40,7 +39,6 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const { agents } = useChatAgents(organizationId);
   const { providers } = useListProviders('default');
   const { selectedModelOverrides, setSelectedModelOverride } = useChatLayout();
-  const { data: governanceDefault } = useDefaultModel(organizationId);
   const [open, setOpen] = useState(false);
 
   const supportedModels = useMemo(() => {

--- a/services/platform/app/features/chat/context/chat-layout-context.tsx
+++ b/services/platform/app/features/chat/context/chat-layout-context.tsx
@@ -38,6 +38,14 @@ export interface SelectedAgent {
   displayName: string;
 }
 
+/** Internal storage shape — includes expiry timestamp per override. */
+interface ModelOverrideEntry {
+  modelId: string;
+  expiresAt: number;
+}
+
+const MODEL_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 interface ChatLayoutContextType {
   isPending: boolean;
   setIsPending: (pending: boolean) => void;
@@ -89,21 +97,43 @@ export function ChatLayoutProvider({
   const modelOverridesKey = user?.userId
     ? `selected-models-${user.userId}-${organizationId}`
     : `selected-models-${organizationId}`;
-  const [selectedModelOverrides, setSelectedModelOverrides] = usePersistedState<
-    Record<string, string>
+  const [rawModelOverrides, setRawModelOverrides] = usePersistedState<
+    Record<string, ModelOverrideEntry | string>
   >(modelOverridesKey, {});
+
+  // Expose a flat Record<string, string> to consumers, filtering out expired entries.
+  const selectedModelOverrides = useMemo(() => {
+    const now = Date.now();
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(rawModelOverrides)) {
+      if (typeof value === 'string') {
+        // Legacy format (no expiry) — treat as expired
+        continue;
+      }
+      if (value.expiresAt > now) {
+        result[key] = value.modelId;
+      }
+    }
+    return result;
+  }, [rawModelOverrides]);
 
   const setSelectedModelOverride = useCallback(
     (agentName: string, modelId: string | null) => {
-      setSelectedModelOverrides((prev) => {
+      setRawModelOverrides((prev) => {
         if (modelId === null) {
           const { [agentName]: _, ...rest } = prev;
           return rest;
         }
-        return { ...prev, [agentName]: modelId };
+        return {
+          ...prev,
+          [agentName]: {
+            modelId,
+            expiresAt: Date.now() + MODEL_OVERRIDE_TTL_MS,
+          },
+        };
       });
     },
-    [setSelectedModelOverrides],
+    [setRawModelOverrides],
   );
 
   const clearChatState = useCallback(() => {

--- a/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
+++ b/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
@@ -32,7 +32,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError(raw)).toEqual({
         category: 'creditExhausted',
         i18nKey: 'errorHintCreditExhausted',
-        rawMessage: raw,
       });
     });
 
@@ -40,7 +39,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('can only afford 500 tokens')).toEqual({
         category: 'creditExhausted',
         i18nKey: 'errorHintCreditExhausted',
-        rawMessage: 'can only afford 500 tokens',
       });
     });
 
@@ -48,15 +46,33 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Credit insufficient for request')).toEqual({
         category: 'creditExhausted',
         i18nKey: 'errorHintCreditExhausted',
-        rawMessage: 'Credit insufficient for request',
       });
+    });
+
+    it('matches "Insufficient credits" phrasing', () => {
+      expect(
+        sanitizeChatError(
+          'Insufficient credits. This account never purchased credits. Make sure your key is on the correct account or org.',
+        ),
+      ).toEqual({
+        category: 'creditExhausted',
+        i18nKey: 'errorHintCreditExhausted',
+      });
+    });
+
+    it('matches "never purchased credits" phrasing', () => {
+      expect(sanitizeChatError('This account never purchased credits')).toEqual(
+        {
+          category: 'creditExhausted',
+          i18nKey: 'errorHintCreditExhausted',
+        },
+      );
     });
 
     it('matches HTTP 402 error', () => {
       expect(sanitizeChatError('Error 402: payment required')).toEqual({
         category: 'creditExhausted',
         i18nKey: 'errorHintCreditExhausted',
-        rawMessage: 'Error 402: payment required',
       });
     });
 
@@ -64,7 +80,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Provider credit limit reached')).toEqual({
         category: 'creditExhausted',
         i18nKey: 'errorHintCreditExhausted',
-        rawMessage: 'Provider credit limit reached',
       });
     });
 
@@ -77,6 +92,102 @@ describe('sanitizeChatError', () => {
     });
   });
 
+  describe('auth errors', () => {
+    it('matches HTTP 401 error', () => {
+      expect(sanitizeChatError('Error 401: unauthorized')).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('matches HTTP 403 error', () => {
+      expect(sanitizeChatError('Error 403: forbidden')).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('matches invalid key error', () => {
+      expect(sanitizeChatError('Invalid key provided for this model')).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('matches expired key error', () => {
+      expect(sanitizeChatError('Your expired key cannot be used')).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('matches authentication failed error', () => {
+      expect(
+        sanitizeChatError('Authentication failed for this request'),
+      ).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('matches "User not found" error from invalid API key', () => {
+      const raw = `Uncaught Error: User not found.
+    at <anonymous> (../../../../node_modules/ai/src/ui/process-ui-message-stream.ts:776:14)`;
+      expect(sanitizeChatError(raw)).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
+    it('does not false-positive on numbers containing 401', () => {
+      expect(sanitizeChatError('Error code 14013 encountered')).toEqual({
+        category: 'generic',
+        i18nKey: 'errorGeneratingDescription',
+        rawMessage: 'Error code 14013 encountered',
+      });
+    });
+  });
+
+  describe('model not found errors', () => {
+    it('matches model not found error', () => {
+      expect(
+        sanitizeChatError('The model was not found on this provider'),
+      ).toEqual({
+        category: 'modelNotFound',
+        i18nKey: 'errorHintModelNotFound',
+      });
+    });
+
+    it('matches model not available error', () => {
+      expect(sanitizeChatError('Model gpt-5 is not available')).toEqual({
+        category: 'modelNotFound',
+        i18nKey: 'errorHintModelNotFound',
+      });
+    });
+
+    it('matches invalid model error', () => {
+      expect(sanitizeChatError('Invalid model specified')).toEqual({
+        category: 'modelNotFound',
+        i18nKey: 'errorHintModelNotFound',
+      });
+    });
+
+    it('matches HTTP 404 error', () => {
+      expect(sanitizeChatError('Error 404: not found')).toEqual({
+        category: 'modelNotFound',
+        i18nKey: 'errorHintModelNotFound',
+      });
+    });
+
+    it('does not false-positive on numbers containing 404', () => {
+      expect(sanitizeChatError('Error code 14043 encountered')).toEqual({
+        category: 'generic',
+        i18nKey: 'errorGeneratingDescription',
+        rawMessage: 'Error code 14043 encountered',
+      });
+    });
+  });
+
   describe('token limit errors', () => {
     it('matches fewer max_tokens error', () => {
       const raw =
@@ -84,7 +195,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError(raw)).toEqual({
         category: 'tokenLimit',
         i18nKey: 'errorHintTokenLimit',
-        rawMessage: raw,
       });
     });
 
@@ -92,7 +202,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Exceeded token limit for this model')).toEqual({
         category: 'tokenLimit',
         i18nKey: 'errorHintTokenLimit',
-        rawMessage: 'Exceeded token limit for this model',
       });
     });
 
@@ -100,7 +209,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('max_tokens exceeded')).toEqual({
         category: 'tokenLimit',
         i18nKey: 'errorHintTokenLimit',
-        rawMessage: 'max_tokens exceeded',
       });
     });
   });
@@ -110,7 +218,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('context_length exceeded')).toEqual({
         category: 'contextLength',
         i18nKey: 'errorHintContextLength',
-        rawMessage: 'context_length exceeded',
       });
     });
 
@@ -118,7 +225,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Exceeded context window limit')).toEqual({
         category: 'contextLength',
         i18nKey: 'errorHintContextLength',
-        rawMessage: 'Exceeded context window limit',
       });
     });
 
@@ -128,7 +234,6 @@ describe('sanitizeChatError', () => {
       ).toEqual({
         category: 'contextLength',
         i18nKey: 'errorHintContextLength',
-        rawMessage: 'maximum context length is 128000 tokens',
       });
     });
   });
@@ -138,7 +243,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Rate limit exceeded')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
-        rawMessage: 'Rate limit exceeded',
       });
     });
 
@@ -146,7 +250,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Too many requests, please slow down')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
-        rawMessage: 'Too many requests, please slow down',
       });
     });
 
@@ -154,7 +257,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Error 429: rate limited')).toEqual({
         category: 'rateLimited',
         i18nKey: 'errorHintRateLimited',
-        rawMessage: 'Error 429: rate limited',
       });
     });
   });
@@ -164,7 +266,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Content filter triggered')).toEqual({
         category: 'contentFilter',
         i18nKey: 'errorHintContentFilter',
-        rawMessage: 'Content filter triggered',
       });
     });
 
@@ -172,7 +273,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Violated content policy')).toEqual({
         category: 'contentFilter',
         i18nKey: 'errorHintContentFilter',
-        rawMessage: 'Violated content policy',
       });
     });
 
@@ -181,7 +281,6 @@ describe('sanitizeChatError', () => {
         {
           category: 'contentFilter',
           i18nKey: 'errorHintContentFilter',
-          rawMessage: 'Request flagged by moderation system',
         },
       );
     });
@@ -192,7 +291,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Tool error: customer_read failed')).toEqual({
         category: 'toolFailure',
         i18nKey: 'errorHintToolFailure',
-        rawMessage: 'Tool error: customer_read failed',
       });
     });
 
@@ -200,7 +298,6 @@ describe('sanitizeChatError', () => {
       expect(sanitizeChatError('Tool execution failed')).toEqual({
         category: 'toolFailure',
         i18nKey: 'errorHintToolFailure',
-        rawMessage: 'Tool execution failed',
       });
     });
 
@@ -210,18 +307,64 @@ describe('sanitizeChatError', () => {
       ).toEqual({
         category: 'toolFailure',
         i18nKey: 'errorHintToolFailure',
-        rawMessage: 'Unable to complete the requested operation',
       });
     });
   });
 
-  it('includes rawMessage alongside i18n key for categorized errors', () => {
+  describe('provider errors', () => {
+    it('matches 500 server error', () => {
+      expect(sanitizeChatError('Error 500: internal server error')).toEqual({
+        category: 'providerError',
+        i18nKey: 'errorHintProviderError',
+      });
+    });
+
+    it('matches 502 bad gateway', () => {
+      expect(sanitizeChatError('Error 502: bad gateway')).toEqual({
+        category: 'providerError',
+        i18nKey: 'errorHintProviderError',
+      });
+    });
+
+    it('matches 503 service unavailable', () => {
+      expect(sanitizeChatError('Error 503: service unavailable')).toEqual({
+        category: 'providerError',
+        i18nKey: 'errorHintProviderError',
+      });
+    });
+
+    it('matches overloaded error', () => {
+      expect(sanitizeChatError('The model is currently overloaded')).toEqual({
+        category: 'providerError',
+        i18nKey: 'errorHintProviderError',
+      });
+    });
+
+    it('matches capacity error', () => {
+      expect(sanitizeChatError('No capacity available for this model')).toEqual(
+        {
+          category: 'providerError',
+          i18nKey: 'errorHintProviderError',
+        },
+      );
+    });
+
+    it('does not false-positive on numbers containing 500', () => {
+      expect(sanitizeChatError('Processed 15003 items')).toEqual({
+        category: 'generic',
+        i18nKey: 'errorGeneratingDescription',
+        rawMessage: 'Processed 15003 items',
+      });
+    });
+  });
+
+  it('does not include rawMessage for categorized errors', () => {
     const rawWithStack = `Uncaught Error: This request requires more credits.
     at <anonymous> (../../node_modules/ai/dist/index.mjs:5758:14)
     at runUpdateMessageJob (../../node_modules/ai/dist/index.mjs:8306:10)`;
     const result = sanitizeChatError(rawWithStack);
     expect(result.i18nKey).toBe('errorHintCreditExhausted');
-    expect(result.rawMessage).toBe(rawWithStack);
+    expect(result.rawMessage).toBeUndefined();
   });
 
   it('prioritizes credit exhausted over token limit for combined errors', () => {

--- a/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
+++ b/services/platform/app/features/chat/utils/__tests__/sanitize-chat-error.test.ts
@@ -130,6 +130,15 @@ describe('sanitizeChatError', () => {
       });
     });
 
+    it('matches "Missing Authentication header" error', () => {
+      const raw = `Uncaught Error: Missing Authentication header
+    at <anonymous> (../../../../node_modules/ai/src/ui/process-ui-message-stream.ts:776:14)`;
+      expect(sanitizeChatError(raw)).toEqual({
+        category: 'authError',
+        i18nKey: 'errorHintAuthError',
+      });
+    });
+
     it('matches "User not found" error from invalid API key', () => {
       const raw = `Uncaught Error: User not found.
     at <anonymous> (../../../../node_modules/ai/src/ui/process-ui-message-stream.ts:776:14)`;

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.ts
@@ -1,10 +1,13 @@
 type ErrorCategory =
   | 'creditExhausted'
+  | 'authError'
+  | 'modelNotFound'
   | 'tokenLimit'
   | 'rateLimited'
   | 'contentFilter'
   | 'contextLength'
   | 'toolFailure'
+  | 'providerError'
   | 'generic';
 
 interface SanitizedError {
@@ -16,8 +19,17 @@ interface SanitizedError {
 const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
   {
     pattern:
-      /more credits|can only afford|credit.*insufficient|credit.*limit|credit.*reached|\b402\b/i,
+      /more credits|can only afford|credit.*insufficient|insufficient.*credit|never purchased credits|credit.*limit|credit.*reached|\b402\b/i,
     category: 'creditExhausted',
+  },
+  {
+    pattern:
+      /\b401\b|\b403\b|invalid.*key|expired.*key|api.?key.*invalid|unauthorized|forbidden|authentication.*fail|user not found/i,
+    category: 'authError',
+  },
+  {
+    pattern: /model.*not found|model.*not available|invalid model|\b404\b/i,
+    category: 'modelNotFound',
   },
   {
     pattern: /fewer max_tokens|token.*limit|max_tokens/i,
@@ -39,21 +51,30 @@ const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
     pattern: /tool.*error|tool.*fail|unable to complete/i,
     category: 'toolFailure',
   },
+  {
+    pattern:
+      /\b5\d{2}\b|server error|overloaded|capacity|service.*unavailable|internal.*error/i,
+    category: 'providerError',
+  },
 ];
 
 const CATEGORY_I18N_KEY: Record<ErrorCategory, string> = {
   creditExhausted: 'errorHintCreditExhausted',
+  authError: 'errorHintAuthError',
+  modelNotFound: 'errorHintModelNotFound',
   tokenLimit: 'errorHintTokenLimit',
   rateLimited: 'errorHintRateLimited',
   contentFilter: 'errorHintContentFilter',
   contextLength: 'errorHintContextLength',
   toolFailure: 'errorHintToolFailure',
+  providerError: 'errorHintProviderError',
   generic: 'errorGeneratingDescription',
 };
 
 /**
  * Classify a raw error string from the AI provider into a user-friendly
- * i18n key. Stack traces and internal paths are never surfaced.
+ * i18n key. For known error types, only the i18n message is shown.
+ * For unknown errors, the raw message is preserved so users have context.
  */
 export function sanitizeChatError(
   rawError: string | undefined,
@@ -67,7 +88,6 @@ export function sanitizeChatError(
       return {
         category,
         i18nKey: CATEGORY_I18N_KEY[category],
-        rawMessage: rawError,
       };
     }
   }

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.ts
@@ -24,7 +24,7 @@ const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
   },
   {
     pattern:
-      /\b401\b|\b403\b|invalid.*key|expired.*key|api.?key.*invalid|unauthorized|forbidden|authentication.*fail|user not found/i,
+      /\b401\b|\b403\b|invalid.*key|expired.*key|api.?key.*invalid|unauthorized|forbidden|authentication.*fail|user not found|missing.*authentication/i,
     category: 'authError',
   },
   {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2664,7 +2664,9 @@
     "modelSelector": {
       "label": "Modell auswählen",
       "searchPlaceholder": "Modelle suchen...",
-      "noResults": "Keine Modelle gefunden"
+      "noResults": "Keine Modelle gefunden",
+      "auto": "Auto",
+      "autoDescription": "Wählt automatisch das beste verfügbare Modell mit Fallback"
     },
     "searchChat": "Chat durchsuchen",
     "hideSearch": "Suche ausblenden",
@@ -2687,6 +2689,9 @@
     "errorHintRateLimited": "Zu viele Anfragen. Bitte warte einen Moment und versuche es erneut.",
     "errorHintContentFilter": "Die Nachricht wurde vom Inhaltsfilter markiert. Versuche, deine Nachricht umzuformulieren.",
     "errorHintToolFailure": "Der Agent hat beim Datenzugriff einen Fehler festgestellt. Versuche, deine Anfrage umzuformulieren oder weniger Daten anzufordern.",
+    "errorHintAuthError": "Der API-Schlüssel ist ungültig oder hat keinen Zugriff auf dieses Modell. Kontaktiere deinen Administrator.",
+    "errorHintModelNotFound": "Das ausgewählte Modell wurde nicht gefunden oder ist nicht verfügbar. Kontaktiere deinen Administrator.",
+    "errorHintProviderError": "Der KI-Anbieter hat vorübergehend technische Probleme. Bitte versuche es in einem Moment erneut.",
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
     "editMessage": "Nachricht bearbeiten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2669,6 +2669,8 @@
       "label": "Select model",
       "searchPlaceholder": "Search models...",
       "noResults": "No models found",
+      "auto": "Auto",
+      "autoDescription": "Automatically selects the best available model with fallback",
       "tags": {
         "chat": "Chat",
         "vision": "Vision",
@@ -2696,6 +2698,9 @@
     "errorHintRateLimited": "Too many requests. Please wait a moment and try again.",
     "errorHintContentFilter": "The message was flagged by the content filter. Try rephrasing your message.",
     "errorHintToolFailure": "The agent encountered an error while accessing data. Try rephrasing your request or asking for a smaller set of data.",
+    "errorHintAuthError": "The API key is invalid or does not have access to this model. Contact your administrator.",
+    "errorHintModelNotFound": "The selected model was not found or is unavailable. Contact your administrator.",
+    "errorHintProviderError": "The AI provider is temporarily experiencing issues. Please try again in a moment.",
     "showMore": "Show more",
     "showLess": "Show less",
     "editMessage": "Edit message",


### PR DESCRIPTION
Closes #1432

## Summary
- Add "Auto" option to the model selector that automatically picks the best available model with fallback, replacing the previous governance-default logic. Model overrides now expire after 24 hours to prevent stale selections.
- Expand chat error sanitization with three new categories: auth errors (401/403, invalid keys), model-not-found (404, unavailable models), and provider errors (5xx, overloaded). Known error types no longer expose `rawMessage` to avoid leaking stack traces to the UI.
- Add i18n strings for new error categories and auto-model in both `en` and `de` locales.

## Test plan
- [ ] Verify "Auto" appears as the default option in the model selector dropdown
- [ ] Select a specific model, confirm it persists, then verify it resets after 24h (or clear localStorage to simulate)
- [ ] Trigger auth/model-not-found/provider errors and confirm user-friendly messages are shown without raw stack traces
- [ ] Run `sanitize-chat-error` unit tests pass with new categories and no-rawMessage assertions