### PR TITLE
fix(platform): enforce team access control on prompt templates

### DIFF
--- a/services/platform/convex/lib/rls/helpers/rls_rules.ts
+++ b/services/platform/convex/lib/rls/helpers/rls_rules.ts
@@ -489,11 +489,12 @@ export async function rlsRules(
       },
     },
 
-    // Prompt Templates - organization-scoped
+    // Prompt Templates - organization-scoped, team-filtered
     promptTemplates: {
       read: async (_, prompt) => {
         if (!user) return false;
         if (!userOrgIds.has(prompt.organizationId)) return false;
+        if (!hasTeamAccess(prompt, userTeamIds)) return false;
         const membership = userOrganizations.find(
           (m) => m.organizationId === prompt.organizationId,
         );
@@ -502,6 +503,7 @@ export async function rlsRules(
       modify: async (_, prompt) => {
         if (!user) return false;
         if (!userOrgIds.has(prompt.organizationId)) return false;
+        if (!hasTeamAccess(prompt, userTeamIds)) return false;
         const membership = userOrganizations.find(
           (m) => m.organizationId === prompt.organizationId,
         );

--- a/services/platform/convex/prompts/queries.ts
+++ b/services/platform/convex/prompts/queries.ts
@@ -1,8 +1,10 @@
 import { v } from 'convex/values';
 
+import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { queryWithRLS } from '../lib/rls/helpers/query_with_rls';
 import { getUserOrganizations } from '../lib/rls/organization/get_user_organizations';
+import { hasTeamAccess } from '../lib/team_access';
 import { promptScopeValidator, promptTemplateValidator } from './validators';
 
 export const listPrompts = queryWithRLS({
@@ -21,6 +23,7 @@ export const listPrompts = queryWithRLS({
     );
     if (!membership) return [];
 
+    const userTeamIds = await getUserTeamIds(ctx, user.userId);
     const results = [];
 
     const { scope } = args;
@@ -31,6 +34,9 @@ export const listPrompts = queryWithRLS({
           q.eq('organizationId', args.organizationId).eq('scope', scope),
         )) {
         if (scope === 'personal' && prompt.createdBy !== user.userId) {
+          continue;
+        }
+        if (!hasTeamAccess(prompt, userTeamIds)) {
           continue;
         }
         if (prompt.isPublished || prompt.createdBy === user.userId) {
@@ -44,6 +50,9 @@ export const listPrompts = queryWithRLS({
           q.eq('organizationId', args.organizationId),
         )) {
         if (prompt.scope === 'personal' && prompt.createdBy !== user.userId) {
+          continue;
+        }
+        if (!hasTeamAccess(prompt, userTeamIds)) {
           continue;
         }
         if (prompt.isPublished || prompt.createdBy === user.userId) {
@@ -70,6 +79,11 @@ export const getPrompt = queryWithRLS({
 
     if (prompt.scope === 'personal' && prompt.createdBy !== user.userId) {
       return null;
+    }
+
+    if (prompt.scope === 'team') {
+      const userTeamIds = await getUserTeamIds(ctx, user.userId);
+      if (!hasTeamAccess(prompt, userTeamIds)) return null;
     }
 
     return prompt;


### PR DESCRIPTION
## Summary
- Team-scoped prompt templates were visible to all org members regardless of team membership
- Added `hasTeamAccess` checks to RLS rules (`read` and `modify`) for `promptTemplates`
- Added team filtering in `listPrompts` and `getPrompt` query handlers

## Test plan
- [ ] Create a team-scoped prompt in Team A
- [ ] Log in as a member who only belongs to Team B
- [ ] Verify the prompt is **not** visible in the Prompt Library
- [ ] Verify the prompt creator and Team A members can still see it
- [ ] Verify global and personal scoped prompts are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access Control**
  * Prompts now enforce team-level authorization checks in addition to organization membership for read and modify operations.
  * Added team-based filtering to prompt retrieval, ensuring users can only access prompts within their authorized teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->