### PR TITLE
fix(cli): find latest release with CLI binaries instead of blindly using latest

### DIFF
--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -20,14 +20,22 @@ if ($existing) {
     $InstallDir = $existingDir
 }
 
-# Fetch latest release tag
-Write-Info "Fetching latest version..."
+# Find latest release that has the CLI binary asset
+# This handles the window where a release exists but CLI binaries haven't been uploaded yet
+Write-Info "Fetching latest version with CLI binary..."
+$tag = $null
 try {
-    $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ "User-Agent" = "tale-installer/1.0" }
+    $releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases" -Headers @{ "User-Agent" = "tale-installer/1.0" }
+    foreach ($rel in $releases) {
+        if ($rel.assets.name -contains "tale_windows.exe") {
+            $tag = $rel.tag_name
+            break
+        }
+    }
 } catch {
-    Write-Err "Failed to fetch latest release. $_"
+    Write-Err "Failed to fetch releases. $_"
 }
-$tag = $release.tag_name
+if (-not $tag) { Write-Err "No release found with tale_windows.exe binary" }
 Write-Info "Latest version: $tag"
 
 # Download binary

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -41,14 +41,25 @@ download() {
 }
 
 get_latest_tag() {
-    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
-    local tag
+    local api_url="https://api.github.com/repos/${REPO}/releases"
+    local asset_name="${BINARY_NAME}_${PLATFORM}"
+    local releases_json
+
     if [ "$DOWNLOADER" = "curl" ]; then
-        tag=$(curl -fsSL "$api_url" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        releases_json=$(curl -fsSL "$api_url")
     else
-        tag=$(wget -qO- "$api_url" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        releases_json=$(wget -qO- "$api_url")
     fi
-    [ -z "$tag" ] && error "Failed to fetch latest version"
+
+    [ -z "$releases_json" ] && error "Failed to fetch releases"
+
+    # Find first release that has our platform binary in its assets.
+    # Iterates the JSON line-by-line: remembers the most recent tag_name,
+    # and prints it on the first occurrence of the expected asset filename.
+    local tag=""
+    tag=$(echo "$releases_json" | sed -n '/"tag_name"/{ s/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/; h; }; /'"$asset_name"'/{ g; p; q; }')
+
+    [ -z "$tag" ] && error "No release found with ${asset_name} binary"
     echo "$tag"
 }
 


### PR DESCRIPTION
## Summary
- Install scripts (`install-cli.sh`, `install-cli.ps1`) now query the `/releases` list and pick the first release that actually contains the expected platform binary asset
- Fixes 404 errors during the window between GitHub Release creation and CLI binary upload (async `cli.yml` workflow)

## Test plan
- [x] Ran `bash -x scripts/install-cli.sh` end-to-end — correctly resolved `v0.2.26` via asset matching and installed successfully
- [ ] Verify PowerShell script on Windows (`irm ... | iex`)
- [ ] Verify fallback works by checking that a release without CLI assets is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation scripts now verify that selected releases contain the appropriate platform-specific binary before download. Enhanced error handling distinguishes between unavailable releases and missing platform binaries, improving installation reliability across different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->