### PR TITLE
fix(rag): resolve duplicate key violation on concurrent file ingestion

### DIFF
--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -133,7 +133,9 @@ async def _insert_processing_row(
             INSERT INTO {SCHEMA}.documents (file_id, filename, status)
             VALUES ($1, $2, 'processing')
             ON CONFLICT (file_id, COALESCE(team_id, ''))
-            DO UPDATE SET status = 'processing', error = NULL, chunks_count = 0, updated_at = NOW()
+            DO UPDATE SET status = 'processing', error = NULL, chunks_count = 0,
+                         progress_phase = NULL, progress_detail = NULL,
+                         updated_at = NOW()
             """,
             file_id,
             filename,
@@ -153,7 +155,9 @@ async def _record_failure(
             INSERT INTO {SCHEMA}.documents (file_id, filename, status, error)
             VALUES ($1, $2, 'failed', $3)
             ON CONFLICT (file_id, COALESCE(team_id, ''))
-            DO UPDATE SET status = 'failed', error = EXCLUDED.error, chunks_count = 0, updated_at = NOW()
+            DO UPDATE SET status = 'failed', error = EXCLUDED.error, chunks_count = 0,
+                         progress_phase = NULL, progress_detail = NULL,
+                         updated_at = NOW()
             """,
             file_id,
             filename,

--- a/services/rag/app/services/indexing_service.py
+++ b/services/rag/app/services/indexing_service.py
@@ -304,8 +304,6 @@ async def clone_from_existing(
             "skip_reason": "content_unchanged",
         }
 
-    existing_id = existing["id"] if existing else None
-
     for attempt in range(2):
         try:
             result = await _do_clone(
@@ -314,7 +312,6 @@ async def clone_from_existing(
                 file_id,
                 filename,
                 content_hash,
-                existing_id,
                 source_created_at=source_created_at,
                 source_modified_at=source_modified_at,
             )
@@ -340,14 +337,15 @@ async def _do_clone(
     file_id: str,
     filename: str,
     content_hash: str,
-    existing_id: uuid.UUID | None,
     *,
     source_created_at: dt.datetime | None = None,
     source_modified_at: dt.datetime | None = None,
 ) -> dict[str, Any] | None:
     """Clone chunks from source document in a single transaction.
 
-    Returns None if the source document has no chunks (e.g. deleted concurrently).
+    Uses ON CONFLICT to atomically handle concurrent writes for the same
+    file_id.  Returns None if the source document has no chunks (e.g.
+    deleted concurrently).
     """
     async with acquire_with_retry(pool) as conn, conn.transaction():
         source = await conn.fetchrow(
@@ -358,17 +356,25 @@ async def _do_clone(
         if not source:
             return None
 
-        if existing_id is not None:
-            await conn.execute(f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1", existing_id)
-            await conn.execute(f"DELETE FROM {SCHEMA}.documents WHERE id = $1", existing_id)
-
         doc_row = await conn.fetchrow(
             f"""
             INSERT INTO {SCHEMA}.documents
                 (file_id, filename, content_hash, status, chunks_count,
                  source_created_at, source_modified_at)
             VALUES ($1, $2, $3, 'completed', $4, $5, $6)
-            RETURNING id
+            ON CONFLICT (file_id, COALESCE(team_id, ''))
+            DO UPDATE SET
+                filename = EXCLUDED.filename,
+                content_hash = EXCLUDED.content_hash,
+                status = 'completed',
+                chunks_count = EXCLUDED.chunks_count,
+                source_created_at = EXCLUDED.source_created_at,
+                source_modified_at = EXCLUDED.source_modified_at,
+                error = NULL,
+                progress_phase = NULL,
+                progress_detail = NULL,
+                updated_at = NOW()
+            RETURNING id, (xmax = 0) AS is_insert
             """,
             file_id,
             filename,
@@ -377,7 +383,14 @@ async def _do_clone(
             source_created_at or source["source_created_at"],
             source_modified_at or source["source_modified_at"],
         )
-        new_doc_uuid = doc_row["id"]
+        doc_uuid = doc_row["id"]
+
+        # On UPDATE (not a fresh insert), remove old chunks first
+        if not doc_row["is_insert"]:
+            await conn.execute(
+                f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1",
+                doc_uuid,
+            )
 
         chunks_created = await conn.fetchval(
             f"""
@@ -391,7 +404,7 @@ async def _do_clone(
             )
             SELECT count(*) FROM inserted
             """,
-            new_doc_uuid,
+            doc_uuid,
             source_doc_id,
         )
 
@@ -417,21 +430,39 @@ async def _do_store(
     file_id: str,
     filename: str,
     prepared: PreparedDocument,
-    existing_id: uuid.UUID | None,
 ) -> dict[str, Any]:
-    """Execute the delete-old + insert-new DB operations in a single transaction."""
-    async with acquire_with_retry(pool) as conn, conn.transaction():
-        if existing_id is not None:
-            await conn.execute(f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1", existing_id)
-            await conn.execute(f"DELETE FROM {SCHEMA}.documents WHERE id = $1", existing_id)
+    """Upsert document and replace chunks in a single transaction.
 
+    Uses ON CONFLICT to atomically handle concurrent writes for the same
+    file_id.  A WHERE clause on content_hash skips the update (and chunk
+    replacement) when the content hasn't changed — this is the atomic
+    equivalent of the old pre-transaction dedup SELECT.
+
+    When the WHERE filters out the update, RETURNING yields no rows —
+    we treat that as "content unchanged, skip".
+    """
+    async with acquire_with_retry(pool) as conn, conn.transaction():
         doc_row = await conn.fetchrow(
             f"""
                 INSERT INTO {SCHEMA}.documents
                     (file_id, filename, content_hash, status, chunks_count,
                      source_created_at, source_modified_at, ocr_applied)
                 VALUES ($1, $2, $3, 'completed', $4, $5, $6, $7)
-                RETURNING id
+                ON CONFLICT (file_id, COALESCE(team_id, ''))
+                DO UPDATE SET
+                    filename = EXCLUDED.filename,
+                    content_hash = EXCLUDED.content_hash,
+                    status = 'completed',
+                    chunks_count = EXCLUDED.chunks_count,
+                    source_created_at = EXCLUDED.source_created_at,
+                    source_modified_at = EXCLUDED.source_modified_at,
+                    ocr_applied = EXCLUDED.ocr_applied,
+                    error = NULL,
+                    progress_phase = NULL,
+                    progress_detail = NULL,
+                    updated_at = NOW()
+                WHERE {SCHEMA}.documents.content_hash IS DISTINCT FROM EXCLUDED.content_hash
+                RETURNING id, (xmax = 0) AS is_insert
                 """,
             file_id,
             filename,
@@ -441,7 +472,25 @@ async def _do_store(
             prepared.source_modified_at,
             prepared.vision_used,
         )
+
+        # No row returned → content_hash matched, nothing to do
+        if doc_row is None:
+            return {
+                "success": True,
+                "file_id": file_id,
+                "chunks_created": 0,
+                "skipped": True,
+                "skip_reason": "content_unchanged",
+            }
+
         doc_uuid = doc_row["id"]
+
+        # On UPDATE (not a fresh insert), remove old chunks first
+        if not doc_row["is_insert"]:
+            await conn.execute(
+                f"DELETE FROM {SCHEMA}.chunks WHERE document_id = $1",
+                doc_uuid,
+            )
 
         chunk_rows = [
             (
@@ -480,43 +529,21 @@ async def store_prepared_document(
 ) -> dict[str, Any]:
     """Store a pre-processed document.
 
-    Handles dedup check, old-version replacement, and HNSW index self-healing.
+    Content-hash dedup is handled atomically inside _do_store's UPSERT
+    (WHERE content_hash IS DISTINCT FROM).  HNSW index self-healing is
+    retained via the retry loop.
     """
-    async with acquire_with_retry(pool) as conn:
-        existing = await conn.fetchrow(
-            f"SELECT id, content_hash FROM {SCHEMA}.documents WHERE file_id = $1",
-            file_id,
-        )
-
-    if existing and existing["content_hash"] == prepared.content_hash:
-        logger.info("Document {} content unchanged, skipping", file_id)
-        return {
-            "success": True,
-            "file_id": file_id,
-            "chunks_created": 0,
-            "skipped": True,
-            "skip_reason": "content_unchanged",
-        }
-
-    if existing:
-        logger.info("Document {} content changed, replacing", file_id)
-
-    existing_id = existing["id"] if existing else None
-
     for attempt in range(2):
         try:
-            result = await _do_store(
-                pool,
-                file_id,
-                filename,
-                prepared,
-                existing_id,
-            )
-            logger.info(
-                "Indexed document {}: {} chunks",
-                file_id,
-                result["chunks_created"],
-            )
+            result = await _do_store(pool, file_id, filename, prepared)
+            if result["skipped"]:
+                logger.info("Document {} content unchanged, skipping", file_id)
+            else:
+                logger.info(
+                    "Indexed document {}: {} chunks",
+                    file_id,
+                    result["chunks_created"],
+                )
             return result
         except asyncpg.exceptions.InternalServerError as exc:
             if _HNSW_CORRUPTION_MARKER in str(exc) and attempt == 0:

--- a/services/rag/tests/test_file_dates.py
+++ b/services/rag/tests/test_file_dates.py
@@ -276,7 +276,8 @@ class TestIndexDocumentDatesThreaded:
         caller_created = dt.datetime(2022, 6, 1, tzinfo=dt.UTC)
 
         mock_conn = AsyncMock()
-        mock_conn.fetchrow = AsyncMock(side_effect=[None, None, {"id": "uuid-1"}])
+        # fetchrow calls: 1) early-dedup check → None, 2) UPSERT → id
+        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "uuid-1", "is_insert": True}])
         mock_conn.executemany = AsyncMock()
         mock_tx = AsyncMock()
         mock_tx.__aenter__ = AsyncMock(return_value=mock_tx)
@@ -317,11 +318,11 @@ class TestIndexDocumentDatesThreaded:
 
         assert result["success"] is True
 
-        # The INSERT query has 7 positional args:
+        # The UPSERT query has 7 positional args:
         # $1=file_id, $2=filename, $3=content_hash, $4=chunks_count,
         # $5=source_created_at, $6=source_modified_at, $7=ocr_applied
-        # call_args_list[0] = early-dedup check, [1] = cross-scope dedup, [2] = INSERT
-        insert_call = mock_conn.fetchrow.call_args_list[2]
+        # call_args_list[0] = early-dedup check, [1] = UPSERT
+        insert_call = mock_conn.fetchrow.call_args_list[1]
         args = insert_call[0]
         # args[0] is the SQL string, positional params start at args[1]
         source_created_arg = args[5]  # $5
@@ -347,7 +348,7 @@ class TestCloneDateOverride:
                     "source_created_at": source_created,
                     "source_modified_at": source_modified,
                 },
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": True},
             ]
         )
         mock_conn.fetchval = AsyncMock(return_value=5)
@@ -371,7 +372,6 @@ class TestCloneDateOverride:
                 file_id="clone-test",
                 filename="test.pdf",
                 content_hash="hash456",
-                existing_id=None,
                 source_created_at=caller_created,
                 source_modified_at=caller_modified,
             )
@@ -400,7 +400,7 @@ class TestCloneDateOverride:
                     "source_created_at": source_created,
                     "source_modified_at": source_modified,
                 },
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": True},
             ]
         )
         mock_conn.fetchval = AsyncMock(return_value=5)
@@ -424,7 +424,6 @@ class TestCloneDateOverride:
                 file_id="clone-test",
                 filename="test.pdf",
                 content_hash="hash456",
-                existing_id=None,
             )
 
         assert result is not None

--- a/services/rag/tests/test_indexing_service.py
+++ b/services/rag/tests/test_indexing_service.py
@@ -53,8 +53,7 @@ def _mock_pool(
     mock_conn.fetchrow = AsyncMock(
         side_effect=[
             None,  # early-dedup check (no existing row with same content)
-            existing_row,
-            {"id": inserted_doc_id},
+            {"id": inserted_doc_id, "is_insert": existing_row is None},
         ]
     )
     mock_conn.execute = AsyncMock()
@@ -283,13 +282,11 @@ class TestContentHashDedup:
 
         # The connection is used multiple times:
         # 1. fetchrow for early-dedup check -> returns row with different hash
-        # 2. fetchrow for cross-scope dedup -> returns existing row
-        # 3. fetchrow for INSERT new doc RETURNING id
+        # 2. fetchrow for UPSERT RETURNING id, is_insert
         mock_conn.fetchrow = AsyncMock(
             side_effect=[
                 {"content_hash": DIFFERENT_HASH, "chunk_count": 3},
-                existing,
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": False},
             ]
         )
 
@@ -322,7 +319,7 @@ class TestContentHashDedup:
 class TestExplicitChunkDeletion:
     """Chunks must be deleted explicitly before documents to prevent BM25 index corruption."""
 
-    async def test_replacement_deletes_chunks_before_document(self):
+    async def test_replacement_deletes_chunks_before_inserting_new(self):
         from app.services.indexing_service import index_document
 
         existing = {"id": "existing-uuid", "content_hash": DIFFERENT_HASH}
@@ -333,8 +330,7 @@ class TestExplicitChunkDeletion:
         mock_conn.fetchrow = AsyncMock(
             side_effect=[
                 {"content_hash": DIFFERENT_HASH, "chunk_count": 3},
-                existing,
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": False},
             ]
         )
 
@@ -344,8 +340,6 @@ class TestExplicitChunkDeletion:
         async def track_execute(sql, *args, **kwargs):
             if "DELETE" in sql and "chunks" in sql:
                 call_order.append("delete_chunks")
-            elif "DELETE" in sql and "documents" in sql:
-                call_order.append("delete_documents")
             return await original_execute(sql, *args, **kwargs)
 
         mock_conn.execute = AsyncMock(side_effect=track_execute)
@@ -368,7 +362,8 @@ class TestExplicitChunkDeletion:
                 embedding_service=mock_embed,
             )
 
-        assert call_order == ["delete_chunks", "delete_documents"]
+        # UPSERT updates document in place; only chunks are deleted before re-insertion
+        assert call_order == ["delete_chunks"]
 
     async def test_replacement_uses_transaction(self):
         from app.services.indexing_service import index_document
@@ -381,8 +376,7 @@ class TestExplicitChunkDeletion:
         mock_conn.fetchrow = AsyncMock(
             side_effect=[
                 {"content_hash": DIFFERENT_HASH, "chunk_count": 3},
-                existing,
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": False},
             ]
         )
 
@@ -565,8 +559,13 @@ class TestHnswIndexSelfHealing:
         from app.services.indexing_service import store_prepared_document, PreparedDocument
 
         pool, mock_conn = _mock_pool(existing_row=None)
-        # fetchrow: SELECT (dedup) → None, INSERT (attempt 1) → id, INSERT (attempt 2) → id
-        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "uuid-1"}, {"id": "uuid-2"}])
+        # fetchrow: UPSERT (attempt 1) → id, UPSERT (attempt 2) → id
+        mock_conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"id": "uuid-1", "is_insert": True},
+                {"id": "uuid-2", "is_insert": True},
+            ]
+        )
 
         prepared = PreparedDocument(
             content_hash=SAMPLE_HASH,
@@ -612,8 +611,13 @@ class TestHnswIndexSelfHealing:
         from app.services.indexing_service import store_prepared_document, PreparedDocument
 
         pool, mock_conn = _mock_pool(existing_row=None)
-        # fetchrow: SELECT (dedup) → None, INSERT (attempt 1) → id, INSERT (attempt 2) → id
-        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "uuid-1"}, {"id": "uuid-2"}])
+        # fetchrow: UPSERT (attempt 1) → id, UPSERT (attempt 2) → id
+        mock_conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"id": "uuid-1", "is_insert": True},
+                {"id": "uuid-2", "is_insert": True},
+            ]
+        )
 
         prepared = PreparedDocument(
             content_hash=SAMPLE_HASH,
@@ -643,8 +647,8 @@ class TestHnswIndexSelfHealing:
         from app.services.indexing_service import store_prepared_document, PreparedDocument
 
         pool, mock_conn = _mock_pool(existing_row=None)
-        # store_prepared_document calls _do_store directly (no early-dedup)
-        mock_conn.fetchrow = AsyncMock(side_effect=[None, {"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}])
+        # store_prepared_document calls _do_store directly (UPSERT)
+        mock_conn.fetchrow = AsyncMock(return_value={"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "is_insert": True})
 
         prepared = PreparedDocument(
             content_hash=SAMPLE_HASH,
@@ -724,12 +728,12 @@ class TestCrossHashClone:
         from app.services.indexing_service import clone_from_existing
 
         pool, mock_conn = _mock_pool()
-        # fetchrow calls: 1) dedup check → None, 2) source check → exists, 3) INSERT doc → id
+        # fetchrow calls: 1) dedup check → None, 2) source check → exists, 3) UPSERT doc → id
         mock_conn.fetchrow = AsyncMock(
             side_effect=[
                 None,
                 {"chunks_count": 5, "source_created_at": None, "source_modified_at": None},
-                {"id": "new-uuid"},
+                {"id": "new-uuid", "is_insert": True},
             ]
         )
         mock_conn.fetchval = AsyncMock(return_value=5)


### PR DESCRIPTION
## Summary

- Replace DELETE+INSERT with atomic UPSERT (`ON CONFLICT DO UPDATE`) in `_do_store()` and `_do_clone()` to eliminate the race condition where concurrent requests for the same `file_id` violate the `idx_pk_docs_unique_scope` unique constraint
- Fold content-hash dedup into the UPSERT's `WHERE content_hash IS DISTINCT FROM` clause, removing the TOCTOU-vulnerable pre-transaction SELECT in `store_prepared_document()`
- Clear `progress_phase`/`progress_detail` in `_insert_processing_row()` and `_record_failure()` ON CONFLICT clauses (pre-existing bug fix)

## Test plan

- [x] All 74 existing RAG unit tests pass
- [x] 10x concurrent upload of same file — 10/10 success, no constraint violations
- [x] 10x concurrent search — 10/10 success
- [x] 5x upload + 5x search mixed concurrency — 10/10 success
- [x] Document status shows `completed` with clean `progress_phase: null`
- [x] RAG container logs show no errors after concurrent operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document state management with proper clearing of progress indicators during state transitions

* **Improvements**
  * Optimized document storage to skip unnecessary updates when content remains unchanged
  * Enhanced atomic database operations for more reliable duplicate content detection
  * Streamlined document indexing workflow for better efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->