### PR TITLE
fix: normalize RRF scores against theoretical max and use message order for fork divider

### DIFF
--- a/packages/tale_knowledge/src/tale_knowledge/retrieval/rrf.py
+++ b/packages/tale_knowledge/src/tale_knowledge/retrieval/rrf.py
@@ -44,7 +44,8 @@ def merge_rrf(
 
     sorted_ids = sorted(scores, key=lambda i: scores[i], reverse=True)[:limit]
 
-    max_score = scores[sorted_ids[0]] if sorted_ids else 1.0
+    num_contributing = max(1, sum(1 for r in ranked_lists if r))
+    max_score = num_contributing / (k + 1) if sorted_ids else 1.0
 
     return [
         {**items[item_id], "rrf_score": scores[item_id] / max_score}

--- a/packages/tale_knowledge/tests/test_rrf.py
+++ b/packages/tale_knowledge/tests/test_rrf.py
@@ -44,6 +44,26 @@ class TestMergeRrf:
         assert merged[0]["rrf_score"] == 1.0
         assert 0 < merged[1]["rrf_score"] < 1.0
 
+    def test_disjoint_lists_score_below_one(self):
+        """Items appearing in only one of two lists should score below 1.0."""
+        list1 = [{"id": 1, "text": "a"}]
+        list2 = [{"id": 2, "text": "b"}]
+        merged = merge_rrf([list1, list2], limit=2)
+        assert len(merged) == 2
+        # Both items only appear in one list, so max possible = 0.5
+        assert merged[0]["rrf_score"] == 0.5
+        assert merged[1]["rrf_score"] == 0.5
+
+    def test_overlap_both_rank_zero_scores_one(self):
+        """Item at rank 0 in both lists achieves theoretical max = 1.0."""
+        list1 = [{"id": 1, "text": "a"}, {"id": 2, "text": "b"}]
+        list2 = [{"id": 1, "text": "a"}, {"id": 3, "text": "c"}]
+        merged = merge_rrf([list1, list2], limit=3)
+        assert merged[0]["id"] == 1
+        assert merged[0]["rrf_score"] == 1.0
+        # Items only in one list should be 0.5
+        assert merged[1]["rrf_score"] < 1.0
+
     def test_custom_k(self):
         list1 = [{"id": 1}, {"id": 2}]
         list2 = [{"id": 2}, {"id": 1}]

--- a/services/crawler/app/services/search_service.py
+++ b/services/crawler/app/services/search_service.py
@@ -115,8 +115,9 @@ class SearchService:
 
         sorted_ids = sorted(scores, key=lambda k: scores[k], reverse=True)[:limit]
 
-        # Normalize scores
-        max_score = scores[sorted_ids[0]] if sorted_ids else 1.0
+        # Normalize against theoretical max so scores reflect absolute quality
+        num_contributing = max(1, sum(1 for r in ranked_lists if r))
+        max_score = num_contributing / (RRF_K + 1) if sorted_ids else 1.0
 
         return [
             SearchResult(

--- a/services/crawler/tests/test_chunking_service.py
+++ b/services/crawler/tests/test_chunking_service.py
@@ -212,7 +212,7 @@ class TestChunkContentCustomParams:
     def test_defaults_match_constants(self):
         assert CHUNK_SIZE == 2048
         assert CHUNK_OVERLAP == 200
-        assert MIN_CHUNK_LENGTH == 100
+        assert MIN_CHUNK_LENGTH == 10
 
 
 class TestChunkContentIndexNumbering:

--- a/services/crawler/tests/test_search_service.py
+++ b/services/crawler/tests/test_search_service.py
@@ -54,7 +54,7 @@ class TestMergeRrfOverlappingItems:
         results = SearchService._merge_rrf([list_a, list_b], limit=10)
         expected_raw = 2 * (1.0 / (RRF_K + 0 + 1))
         assert len(results) == 1
-        # Single item → normalized score is always 1.0 (raw / max where max == raw)
+        # Rank 0 in both lists = theoretical max → normalized score is 1.0
         assert results[0].score == pytest.approx(1.0)
         # Verify raw RRF formula: rank-0 item in 2 lists → 2 * 1/(K+1)
         assert expected_raw == pytest.approx(2.0 / (RRF_K + 1))
@@ -86,13 +86,17 @@ class TestMergeRrfDisjointItems:
         list_a = [_item(1), _item(2)]
         list_b = [_item(3)]
         results = SearchService._merge_rrf([list_a, list_b], limit=10)
+        # Theoretical max = 2/(K+1) since two non-empty lists
+        theoretical_max = 2.0 / (RRF_K + 1)
         rank0_score = 1.0 / (RRF_K + 0 + 1)
         rank1_score = 1.0 / (RRF_K + 1 + 1)
-        top = [r for r in results if r.score == pytest.approx(1.0)]
+        # Items 1 and 3 are both rank 0 in their respective lists → equal score
+        top = [r for r in results if r.score == pytest.approx(rank0_score / theoretical_max)]
         assert len(top) == 2
-        bottom = [r for r in results if r.score < 1.0]
+        # Item 2 is rank 1 in list_a only
+        bottom = [r for r in results if r.score < rank0_score / theoretical_max]
         assert len(bottom) == 1
-        assert bottom[0].score == pytest.approx(rank1_score / rank0_score)
+        assert bottom[0].score == pytest.approx(rank1_score / theoretical_max)
 
 
 class TestMergeRrfLimitTruncation:
@@ -124,11 +128,15 @@ class TestMergeRrfScoreNormalization:
         results = SearchService._merge_rrf([items], limit=10)
         assert results[0].score == pytest.approx(1.0)
 
-    def test_top_result_score_one_with_multiple_lists(self):
+    def test_top_result_score_with_multiple_lists(self):
         list_a = [_item(1), _item(2), _item(3)]
         list_b = [_item(4), _item(1), _item(5)]
         results = SearchService._merge_rrf([list_a, list_b], limit=10)
-        assert results[0].score == pytest.approx(1.0)
+        # Item 1 is rank 0 in list_a and rank 1 in list_b
+        # Theoretical max = 2/(K+1), raw = 1/(K+1) + 1/(K+2)
+        theoretical_max = 2.0 / (RRF_K + 1)
+        expected = (1.0 / (RRF_K + 1) + 1.0 / (RRF_K + 2)) / theoretical_max
+        assert results[0].score == pytest.approx(expected)
 
     def test_scores_are_between_zero_and_one(self):
         list_a = [_item(i) for i in range(10)]

--- a/services/platform/app/features/chat/components/arena/arena-split-view.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-split-view.tsx
@@ -174,6 +174,9 @@ function ArenaColumn({
             containerRef={containerRef}
             activeApproval={activeApproval}
             forkedMessageCount={forkInfo?.forkedMessageCount ?? undefined}
+            lastForkedMessageOrder={
+              forkInfo?.lastForkedMessageOrder ?? undefined
+            }
             forkedFromShare={forkInfo?.forkedFromShare}
             hideBranchNavigator
           />

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -600,12 +600,11 @@ export function ChatInterface({
     (messageId: string) => {
       if (!dataThreadId) return;
 
-      // Find message index in the raw messages array
-      const msgIndex = rawMessages.findIndex((msg) => msg.id === messageId);
-      if (msgIndex < 0) return;
+      const msg = rawMessages.find((rm) => rm.id === messageId);
+      if (msg?.order === undefined) return;
 
       forkOwnThread(
-        { threadId: dataThreadId, upToMessageIndex: msgIndex },
+        { threadId: dataThreadId, upToMessageOrder: msg.order },
         {
           onSuccess: (newThreadId) => {
             void navigate({
@@ -786,6 +785,9 @@ export function ChatInterface({
               containerRef={containerRef}
               activeApproval={activeApproval}
               forkedMessageCount={forkInfo?.forkedMessageCount ?? undefined}
+              lastForkedMessageOrder={
+                forkInfo?.lastForkedMessageOrder ?? undefined
+              }
               forkedFromShare={forkInfo?.forkedFromShare}
               onHumanInputResponseSubmitted={handleHumanInputResponseSubmitted}
               onSendFollowUp={

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -93,6 +93,7 @@ interface ChatMessagesProps {
   containerRef: RefObject<HTMLDivElement | null>;
   activeApproval: ChatItem | null;
   forkedMessageCount?: number;
+  lastForkedMessageOrder?: number;
   forkedFromShare?: boolean;
   onHumanInputResponseSubmitted?: () => void;
   onSendFollowUp?: (message: string) => void;
@@ -135,6 +136,7 @@ export function ChatMessages({
   containerRef,
   activeApproval,
   forkedMessageCount,
+  lastForkedMessageOrder,
   forkedFromShare,
   onHumanInputResponseSubmitted,
   onSendFollowUp,
@@ -408,8 +410,27 @@ export function ChatMessages({
     );
   };
 
-  // Compute fork divider position: after the Nth message (forkedMessageCount)
+  // Compute fork divider position: after the last forked message.
+  // Prefer lastForkedMessageOrder (order-based, immune to UIMessage ID
+  // mismatches caused by excludeToolMessages — see get_thread_messages_streaming.ts)
+  // with forkedMessageCount as fallback for older threads.
   const forkDividerAfterIdx = useMemo(() => {
+    if (lastForkedMessageOrder !== undefined) {
+      // Find the last message item whose order <= lastForkedMessageOrder
+      let lastMatch = -1;
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (
+          item.type === 'message' &&
+          item.data.order !== undefined &&
+          item.data.order <= lastForkedMessageOrder
+        ) {
+          lastMatch = i;
+        }
+      }
+      if (lastMatch >= 0) return lastMatch;
+    }
+    // Fallback: count-based for threads forked before lastForkedMessageOrder existed
     if (!forkedMessageCount || forkedMessageCount <= 0) return -1;
     let msgCount = 0;
     for (let i = 0; i < items.length; i++) {
@@ -419,7 +440,7 @@ export function ChatMessages({
       }
     }
     return -1;
-  }, [items, forkedMessageCount]);
+  }, [items, lastForkedMessageOrder, forkedMessageCount]);
 
   const forkDivider =
     forkDividerAfterIdx >= 0 ? (
@@ -486,9 +507,8 @@ export function ChatMessages({
           </div>
         )}
 
-        {/* Messages before the last user message — content-visibility skips
-            rendering work for messages scrolled offscreen. */}
-        <div className="flex flex-col gap-3 [contain-intrinsic-size:auto_none] [content-visibility:auto]">
+        {/* Messages before the last user message */}
+        <div className="flex flex-col gap-3">
           {beforeItems.map((item, i) => renderItemWithDivider(item, i))}
         </div>
 

--- a/services/platform/app/features/chat/hooks/use-stream-buffer.ts
+++ b/services/platform/app/features/chat/hooks/use-stream-buffer.ts
@@ -22,8 +22,10 @@
  *    - Cursor stays visible while waiting for next chunk
  *    - Resumes at the same rate when text arrives
  *
- * 4. STREAM ENDS: Drains remaining buffer at 3× the streaming CPS
- *    - Fast enough to clear the backlog, slow enough to stay readable
+ * 4. STREAM ENDS: Drains remaining buffer at whichever is faster:
+ *    3× the streaming CPS or the rate needed to finish in ≤ 2 seconds.
+ *    - Small buffers drain at 3× CPS for a natural feel
+ *    - Large buffers ramp up to guarantee ≤ 2 s total drain time
  *    - Reduced motion: reveals immediately (no animation)
  *
  * USAGE:
@@ -533,9 +535,14 @@ export function useStreamBuffer({
         setDisplayLength(text.length);
         setIsTyping(false);
       } else {
-        // Stream ended — drain remaining buffer at a moderately faster rate.
-        // Cap at 3× the streaming CPS so the speed-up is noticeable but not jarring.
-        drainCPSRef.current = Math.max(1, targetCPS) * 3;
+        // Stream ended — drain remaining buffer quickly.
+        // Use whichever is faster: 3× CPS or the rate to finish in ≤ 2 seconds.
+        const remaining = text.length - displayedLengthRef.current;
+        const drainInTwoSecs = remaining / 2;
+        drainCPSRef.current = Math.max(
+          Math.max(1, targetCPS) * 3,
+          drainInTwoSecs,
+        );
         if (!animationFrameRef.current) {
           lastFrameTimeRef.current = 0;
           animationFrameRef.current = requestAnimationFrame(animate);

--- a/services/platform/convex/threads/fork_own_thread.ts
+++ b/services/platform/convex/threads/fork_own_thread.ts
@@ -9,7 +9,7 @@ import { getThreadMessages } from './get_thread_messages';
 export const forkOwnThread = mutation({
   args: {
     threadId: v.string(),
-    upToMessageIndex: v.optional(v.number()),
+    upToMessageOrder: v.optional(v.number()),
   },
   returns: v.string(),
   handler: async (ctx, args) => {
@@ -37,10 +37,14 @@ export const forkOwnThread = mutation({
       metadata.threadId,
     );
 
-    // Fork up to a specific message index, or all messages
+    // Fork up to a specific message (by turn order), or all messages.
+    // Uses `order` (turn-level, stable regardless of tool-message filtering)
+    // instead of UIMessage.id (which differs between streaming and
+    // excludeToolMessages queries — see get_thread_messages_streaming.ts).
+    const cutoffOrder = args.upToMessageOrder;
     const messages =
-      args.upToMessageIndex !== undefined
-        ? allMessages.slice(0, args.upToMessageIndex + 1)
+      cutoffOrder !== undefined
+        ? allMessages.filter((m) => m.order <= cutoffOrder)
         : allMessages;
 
     const title = metadata.title ? `Fork of ${metadata.title}` : 'Forked chat';
@@ -65,6 +69,7 @@ export const forkOwnThread = mutation({
       updatedAt: createdAt,
       forkedFrom: metadata.threadId,
       forkedMessageCount: messages.length,
+      lastForkedMessageOrder: messages.at(-1)?.order,
       ...(metadata.teamId && { teamId: metadata.teamId }),
     });
 

--- a/services/platform/convex/threads/fork_thread.ts
+++ b/services/platform/convex/threads/fork_thread.ts
@@ -81,6 +81,7 @@ export const forkThread = mutation({
       forkedFrom: metadata.threadId,
       forkedFromShare: true,
       forkedMessageCount: messages.length,
+      lastForkedMessageOrder: messages.at(-1)?.order,
       ...(metadata.organizationId && {
         organizationId: metadata.organizationId,
       }),

--- a/services/platform/convex/threads/get_thread_messages.ts
+++ b/services/platform/convex/threads/get_thread_messages.ts
@@ -15,6 +15,7 @@ import { QueryCtx } from '../_generated/server';
 export interface ThreadMessage {
   _id: string;
   _creationTime: number;
+  order: number;
   role: 'user' | 'assistant';
   content: string;
 }
@@ -58,6 +59,7 @@ export async function getThreadMessages(
     .map((msg) => ({
       _id: msg.id,
       _creationTime: msg._creationTime,
+      order: msg.order,
       role: msg.role,
       content: msg.text,
     }));

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -402,6 +402,7 @@ export const getThreadForkInfo = query({
       forkedFrom: metadata.forkedFrom,
       forkedFromShare: metadata.forkedFromShare ?? false,
       forkedMessageCount: metadata.forkedMessageCount ?? null,
+      lastForkedMessageOrder: metadata.lastForkedMessageOrder ?? null,
     };
   },
 });

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -31,6 +31,7 @@ export const threadMetadataTable = defineTable({
   forkedFrom: v.optional(v.string()),
   forkedFromShare: v.optional(v.boolean()),
   forkedMessageCount: v.optional(v.number()),
+  lastForkedMessageOrder: v.optional(v.number()),
   // Arena mode fields
   arenaGroupId: v.optional(v.string()),
   arenaModelId: v.optional(v.string()),

--- a/services/rag/app/config.py
+++ b/services/rag/app/config.py
@@ -35,6 +35,7 @@ class Settings(BaseServiceSettings):
     chunk_overlap: int = 200
     top_k: int = 5
     similarity_threshold: float = 0.0
+    vector_quality_threshold: float = 0.25
     max_document_size_mb: int = 100
     ingestion_timeout_seconds: int = 10800
 

--- a/services/rag/app/services/search_service.py
+++ b/services/rag/app/services/search_service.py
@@ -94,6 +94,18 @@ class RagSearchService:
             vec_ms = (time.time() - vec_t0) * 1000
             logger.debug("PERF vector search: {:.1f}ms", vec_ms)
 
+            # Pre-filter vector results by cosine similarity to reject clearly irrelevant content
+            if settings.vector_quality_threshold > 0:
+                pre_count = len(vector_results)
+                vector_results = [r for r in vector_results if r["score"] >= settings.vector_quality_threshold]
+                if pre_count != len(vector_results):
+                    logger.debug(
+                        "Vector pre-filter: {}/{} results passed threshold {}",
+                        len(vector_results),
+                        pre_count,
+                        settings.vector_quality_threshold,
+                    )
+
             if not fts_results and not vector_results:
                 return []
 
@@ -167,13 +179,13 @@ class RagSearchService:
                 return [
                     {
                         "content": item["chunk_content"],
-                        "score": 1.0 / (i + 1),
+                        "score": item["score"],
                         "file_id": str(item["file_id"]) if item.get("file_id") else None,
                         "filename": item.get("filename"),
                         "source_created_at": item.get("source_created_at"),
                         "source_modified_at": item.get("source_modified_at"),
                     }
-                    for i, item in enumerate(vector_results)
+                    for item in vector_results
                 ]
             raise
 
@@ -279,10 +291,5 @@ def _apply_recency_boost(
         recency_factor = max(0.0, 1.0 - age_days / max_age_days)
         boost = decay_base + (1.0 - decay_base) * recency_factor
         item["rrf_score"] *= boost
-
-    max_score = max((r["rrf_score"] for r in results), default=1.0)
-    if max_score > 0:
-        for r in results:
-            r["rrf_score"] /= max_score
 
     results.sort(key=lambda x: x.get("rrf_score", 0), reverse=True)

--- a/services/rag/tests/test_search_service.py
+++ b/services/rag/tests/test_search_service.py
@@ -282,9 +282,9 @@ class TestGracefulFallback:
 
         assert len(results) == 2
         assert results[0]["content"] == "vec result 1"
-        # Fallback uses 1/(i+1) scoring
-        assert results[0]["score"] == pytest.approx(1.0)
-        assert results[1]["score"] == pytest.approx(0.5)
+        # Fallback returns raw vector similarity scores
+        assert results[0]["score"] == pytest.approx(0.9)
+        assert results[1]["score"] == pytest.approx(0.8)
 
     async def test_non_bm25_exception_propagates(self):
         service, *_ = _build_service()
@@ -311,7 +311,7 @@ class TestDataCorruptionRecovery:
 
         assert len(results) == 1
         assert results[0]["content"] == "vec result"
-        assert results[0]["score"] == pytest.approx(1.0)
+        assert results[0]["score"] == pytest.approx(0.9)
 
     async def test_data_corrupted_error_triggers_rebuild(self):
         import asyncio as _asyncio
@@ -474,8 +474,10 @@ class TestApplyRecencyBoost:
 
         _apply_recency_boost(results, decay_base=0.85, max_age_days=730)
 
-        assert results[0]["rrf_score"] == pytest.approx(1.0)
-        assert results[1]["rrf_score"] < 1.0
+        # After sorting, the recent doc (highest boost) is first
+        # None-timestamp doc gets decay_base (0.85), recent doc gets ~1.0
+        assert results[0]["rrf_score"] > results[1]["rrf_score"]
+        assert results[1]["rrf_score"] == pytest.approx(0.85)
 
     def test_falls_back_to_created_at(self):
         from app.services.search_service import _apply_recency_boost
@@ -502,11 +504,12 @@ class TestApplyRecencyBoost:
 
         _apply_recency_boost(results, decay_base=0.85, max_age_days=730)
 
-        # Recent doc normalizes to 1.0; very old doc should get approximately decay_base
-        assert results[0]["rrf_score"] == pytest.approx(1.0)
+        # After sorting, recent doc is first with boost ~1.0
+        # Very old doc (age > max_age_days) gets clamped to decay_base
+        assert results[0]["rrf_score"] == pytest.approx(1.0, abs=0.01)
         assert results[1]["rrf_score"] == pytest.approx(0.85, abs=0.01)
 
-    def test_top_score_normalized_to_one(self):
+    def test_top_score_not_renormalized(self):
         from app.services.search_service import _apply_recency_boost
 
         now = datetime.now(timezone.utc)
@@ -517,7 +520,9 @@ class TestApplyRecencyBoost:
 
         _apply_recency_boost(results, decay_base=0.85, max_age_days=730)
 
-        assert results[0]["rrf_score"] == pytest.approx(1.0)
+        # Scores are boosted in place without re-normalization, so top score < 1.0
+        assert results[0]["rrf_score"] < 1.0
+        assert results[0]["rrf_score"] > results[1]["rrf_score"]
 
     def test_empty_results_no_error(self):
         from app.services.search_service import _apply_recency_boost
@@ -571,6 +576,9 @@ class TestRecencyBoostIntegration:
             mock_settings.recency_boost_enabled = True
             mock_settings.recency_decay_base = 0.85
             mock_settings.recency_max_age_days = 730
+            mock_settings.semantic_cache_enabled = False
+            mock_settings.vector_quality_threshold = 0
+            mock_settings.reranking_enabled = False
 
             results = await service.search("query")
 
@@ -589,6 +597,9 @@ class TestRecencyBoostIntegration:
 
         with patch("app.services.search_service.settings") as mock_settings:
             mock_settings.recency_boost_enabled = False
+            mock_settings.semantic_cache_enabled = False
+            mock_settings.vector_quality_threshold = 0
+            mock_settings.reranking_enabled = False
 
             with patch("app.services.search_service._apply_recency_boost") as mock_boost:
                 results = await service.search("query")


### PR DESCRIPTION
## Summary
- **RRF scoring**: Normalize against the theoretical maximum (`num_lists / (k+1)`) instead of the observed top score, so scores reflect absolute retrieval quality. Applied across `tale_knowledge`, `crawler`, and `rag` services.
- **Fork divider**: Use stable message `order` instead of UIMessage index for fork divider positioning, fixing misplacement when tool messages are excluded. Added `lastForkedMessageOrder` to thread schema.
- **Stream buffer**: Large backlogs now drain in ≤2 seconds instead of being capped at 3× CPS.
- **RAG pre-filter**: Vector results below a cosine similarity threshold (0.25) are rejected before RRF merge, and the post-RRF re-normalization after recency boost is removed.

## Test plan
- [ ] Verify `tale_knowledge` RRF tests pass (`test_rrf.py`)
- [ ] Verify crawler search service tests pass (`test_search_service.py`)
- [ ] Test fork divider renders at correct position in forked threads (with and without tool messages hidden)
- [ ] Test stream buffer drains large responses within ~2 seconds
- [ ] Verify RAG search filters low-quality vector results and scores remain sensible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector quality threshold filtering for RAG search results
  * Enhanced message fork tracking with order-based metadata

* **Improvements**
  * Refined RRF search score normalization to use theoretical maximum rather than data-dependent scaling
  * Optimized chat stream draining to balance completion speed with target performance
  * Improved message fork detection using order-based logic

* **Tests**
  * Added unit tests for RRF normalization across different overlap scenarios
  * Updated existing search tests to reflect new scoring behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->