### PR TITLE
fix(rag): apply similarity threshold as vector pre-filter before RRF merge

### DIFF
--- a/services/rag/app/config.py
+++ b/services/rag/app/config.py
@@ -34,8 +34,7 @@ class Settings(BaseServiceSettings):
     chunk_size: int = 2048
     chunk_overlap: int = 200
     top_k: int = 5
-    similarity_threshold: float = 0.0
-    vector_quality_threshold: float = 0.25
+    similarity_threshold: float = 0.3
     max_document_size_mb: int = 100
     ingestion_timeout_seconds: int = 10800
 

--- a/services/rag/app/models.py
+++ b/services/rag/app/models.py
@@ -179,8 +179,8 @@ class QueryRequest(BaseModel):
     top_k: int | None = Field(
         default=None, ge=1, le=1000, description="Number of results to return (overrides default)"
     )
-    similarity_threshold: float | None = Field(
-        default=None, ge=0.0, le=1.0, description="Minimum similarity score (overrides default)"
+    similarity_threshold: float = Field(
+        default=0.3, ge=0.0, le=1.0, description="Minimum cosine similarity for vector results (pre-RRF filtering)"
     )
     include_metadata: bool = Field(default=True, description="Whether to include metadata in results")
     file_ids: list[str] = Field(

--- a/services/rag/app/services/rag_service.py
+++ b/services/rag/app/services/rag_service.py
@@ -296,12 +296,10 @@ class RagService:
             query,
             file_ids=file_ids,
             top_k=effective_top_k,
+            similarity_threshold=threshold,
         )
 
         self.last_search_usage = getattr(self._search_service, "last_search_usage", None)
-
-        if threshold > 0:
-            results = [r for r in results if r.get("score", 0) >= threshold]
 
         # If no results and some files are still indexing, wait and retry once
         if not results and file_ids:
@@ -314,10 +312,9 @@ class RagService:
                     query,
                     file_ids=file_ids,
                     top_k=effective_top_k,
+                    similarity_threshold=threshold,
                 )
                 self.last_search_usage = getattr(self._search_service, "last_search_usage", None)
-                if threshold > 0:
-                    results = [r for r in results if r.get("score", 0) >= threshold]
 
         return results
 

--- a/services/rag/app/services/search_service.py
+++ b/services/rag/app/services/search_service.py
@@ -97,7 +97,9 @@ class RagSearchService:
             vec_ms = (time.time() - vec_t0) * 1000
             logger.debug("PERF vector search: {:.1f}ms", vec_ms)
 
-            # Pre-filter vector results by cosine similarity to reject clearly irrelevant content
+            # Pre-filter vector results by cosine similarity to reject clearly irrelevant content.
+            # If ALL vector results are below threshold, the query is semantically irrelevant
+            # to the indexed documents — discard FTS results too (they are keyword noise).
             if similarity_threshold > 0:
                 pre_count = len(vector_results)
                 vector_results = [r for r in vector_results if r["score"] >= similarity_threshold]
@@ -108,6 +110,8 @@ class RagSearchService:
                         pre_count,
                         similarity_threshold,
                     )
+                if pre_count > 0 and not vector_results:
+                    return []
 
             if not fts_results and not vector_results:
                 return []

--- a/services/rag/app/services/search_service.py
+++ b/services/rag/app/services/search_service.py
@@ -46,6 +46,7 @@ class RagSearchService:
         *,
         file_ids: list[str] | None = None,
         top_k: int = 10,
+        similarity_threshold: float = 0.0,
     ) -> list[dict[str, Any]]:
         """Hybrid BM25 + vector search with document scoping.
 
@@ -53,6 +54,8 @@ class RagSearchService:
             query: Search query text.
             file_ids: Optional file IDs to restrict search to.
             top_k: Maximum number of results to return.
+            similarity_threshold: Minimum cosine similarity for vector results.
+                Results below this threshold are discarded before RRF merge.
 
         Returns:
             List of result dicts with content, score, file_id.
@@ -95,15 +98,15 @@ class RagSearchService:
             logger.debug("PERF vector search: {:.1f}ms", vec_ms)
 
             # Pre-filter vector results by cosine similarity to reject clearly irrelevant content
-            if settings.vector_quality_threshold > 0:
+            if similarity_threshold > 0:
                 pre_count = len(vector_results)
-                vector_results = [r for r in vector_results if r["score"] >= settings.vector_quality_threshold]
+                vector_results = [r for r in vector_results if r["score"] >= similarity_threshold]
                 if pre_count != len(vector_results):
                     logger.debug(
                         "Vector pre-filter: {}/{} results passed threshold {}",
                         len(vector_results),
                         pre_count,
-                        settings.vector_quality_threshold,
+                        similarity_threshold,
                     )
 
             if not fts_results and not vector_results:

--- a/services/rag/tests/test_rag_service.py
+++ b/services/rag/tests/test_rag_service.py
@@ -163,25 +163,25 @@ class TestSearch:
             "test query",
             file_ids=["doc-1"],
             top_k=10,
+            similarity_threshold=0.0,
         )
 
     async def test_applies_similarity_threshold(self):
         service = _make_service()
-        service._search_service.search = AsyncMock(
-            return_value=[
-                {"content": "good", "score": 0.9, "file_id": "d1"},
-                {"content": "marginal", "score": 0.5, "file_id": "d2"},
-                {"content": "bad", "score": 0.1, "file_id": "d3"},
-            ]
-        )
+        service._search_service.search = AsyncMock(return_value=[])
 
         with patch("app.services.rag_service.settings") as mock_settings:
             mock_settings.top_k = 10
             mock_settings.similarity_threshold = 0.7
-            results = await service.search("query")
+            await service.search("query")
 
-        assert len(results) == 1
-        assert results[0]["content"] == "good"
+        # Threshold is now passed to search_service for vector pre-filtering
+        service._search_service.search.assert_awaited_once_with(
+            "query",
+            file_ids=None,
+            top_k=10,
+            similarity_threshold=0.7,
+        )
 
     async def test_custom_top_k_overrides_settings(self):
         service = _make_service()
@@ -196,6 +196,7 @@ class TestSearch:
             "query",
             file_ids=None,
             top_k=20,
+            similarity_threshold=0.0,
         )
 
     async def test_custom_threshold_overrides_settings(self):
@@ -242,6 +243,7 @@ class TestSearch:
             "q",
             file_ids=["doc-1", "doc-2"],
             top_k=10,
+            similarity_threshold=0.0,
         )
 
 


### PR DESCRIPTION
## Summary
- Move cosine similarity filtering from post-search (rag_service) into search_service so low-quality vector results are discarded **before** RRF scoring
- Consolidate `vector_quality_threshold` and `similarity_threshold` into a single `similarity_threshold` parameter (default 0.3)
- Update tests to verify threshold is passed through to the search layer

## Test plan
- [ ] Verify existing RAG search tests pass (`pytest services/rag/tests/test_rag_service.py`)
- [ ] Confirm vector results below 0.3 similarity are excluded before RRF merge
- [ ] Validate that per-request `similarity_threshold` override still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Adjusted default minimum similarity threshold for search results from 0.0 to 0.3 to improve filtering of less relevant results
  * Removed a deprecated configuration parameter

* **Improvements**
  * Refined search filtering logic to apply thresholds consistently across all search operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->