### PR TITLE
fix(platform): preserve first data row in manual CSV import

### DIFF
--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -15,6 +15,8 @@ type CSVParseOptions = {
   delimiter?: string;
   /** Skip empty lines (default: true) */
   skipEmptyLines?: boolean;
+  /** Whether the first row contains column headers (default: true) */
+  hasHeaders?: boolean;
 };
 
 type CSVParseOutput = {
@@ -92,7 +94,7 @@ function parseCSVText(
   }
 
   let headers: string[] | null = null;
-  if (rows.length > 0) {
+  if (options.hasHeaders !== false && rows.length > 0) {
     headers = rows.shift()?.map((h) => h.toLowerCase()) ?? null;
   }
 
@@ -112,7 +114,10 @@ export function parseCSVWithMapper<T>(
   } = {},
 ): FileParseResult<T> {
   const { recordMapper, ...csvOptions } = options;
-  const { headers, rows } = parseCSVText(csvText, csvOptions);
+  const { headers, rows } = parseCSVText(csvText, {
+    ...csvOptions,
+    hasHeaders: !!recordMapper,
+  });
   const data: T[] = [];
   const errors: string[] = [];
 


### PR DESCRIPTION
Closes #1448

## Summary
- **Bug**: Typing `moh.ramadan8h@gmail.com,Rama` in the "Add customers" textarea and clicking Import showed "No valid customer data found"
- **Root cause**: `parseCSVText` unconditionally stripped the first row as headers — even for the manual textarea path where no `recordMapper` is provided and headers are never used. The first customer/vendor entry was silently discarded.
- **Fix**: Derive `hasHeaders` from the presence of `recordMapper` so the textarea path (`hasHeaders: false`) keeps all rows as data, while the file-upload path (`hasHeaders: true`) continues to strip and use real headers.

## Test plan
- [x] Existing 23 `use-file-import` tests pass
- [ ] Manual textarea: enter `moh.ramadan8h@gmail.com,Rama` → should import 1 customer
- [ ] Manual textarea: enter multiple lines → all rows imported (first row no longer dropped)
- [ ] File upload CSV with headers (`email,name,locale`) → headers stripped, data parsed via recordMapper as before
- [ ] Vendor import textarea behaves the same (shares `parseCSVText`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV file parsing to correctly handle both header and non-header files. Header detection now works more reliably, particularly when using record mapping functionality for transforming CSV data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->