### PR TITLE
feat(platform): add editing support to Canvas with apply-back to message

### DIFF
--- a/services/platform/app/features/chat/components/canvas/__tests__/canvas-pane.test.tsx
+++ b/services/platform/app/features/chat/components/canvas/__tests__/canvas-pane.test.tsx
@@ -8,6 +8,14 @@ import { checkAccessibility } from '@/test/utils/a11y';
 import { CanvasProvider, useCanvas } from '../canvas-context';
 import { CanvasPane } from '../canvas-pane';
 
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({
     t: (key: string) => {

--- a/services/platform/app/features/chat/components/canvas/canvas-context.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-context.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMutation } from 'convex/react';
 import {
   createContext,
   useContext,
@@ -9,6 +10,12 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useToast } from '@/app/hooks/use-toast';
+import { api } from '@/convex/_generated/api';
+import { useT } from '@/lib/i18n/client';
+
+import { replaceCodeBlock } from '../../utils/replace-code-block';
+
 export type CanvasContentType =
   | 'code'
   | 'html'
@@ -16,12 +23,20 @@ export type CanvasContentType =
   | 'svg'
   | 'markdown';
 
+export interface CanvasSource {
+  messageId: string;
+  messageContent: string;
+  threadId?: string;
+}
+
 interface CanvasState {
   isCanvasOpen: boolean;
   canvasContent: string;
   canvasType: CanvasContentType;
   canvasTitle: string;
   canvasLanguage?: string;
+  originalCanvasContent: string;
+  source?: CanvasSource;
 }
 
 interface CanvasContextType extends CanvasState {
@@ -30,9 +45,14 @@ interface CanvasContextType extends CanvasState {
     type: CanvasContentType,
     title: string,
     language?: string,
+    source?: CanvasSource,
   ) => void;
   closeCanvas: () => void;
   updateCanvasContent: (content: string) => void;
+  applyCanvasContent: () => Promise<void>;
+  isDirty: boolean;
+  canApply: boolean;
+  isApplying: boolean;
 }
 
 const CanvasContext = createContext<CanvasContextType | null>(null);
@@ -53,14 +73,25 @@ interface CanvasProviderProps {
   children: ReactNode;
 }
 
+const INITIAL_STATE: CanvasState = {
+  isCanvasOpen: false,
+  canvasContent: '',
+  canvasType: 'code',
+  canvasTitle: '',
+  canvasLanguage: undefined,
+  originalCanvasContent: '',
+  source: undefined,
+};
+
 export function CanvasProvider({ children }: CanvasProviderProps) {
-  const [state, setState] = useState<CanvasState>({
-    isCanvasOpen: false,
-    canvasContent: '',
-    canvasType: 'code',
-    canvasTitle: '',
-    canvasLanguage: undefined,
-  });
+  const { t } = useT('chat');
+  const { toast } = useToast();
+  const [state, setState] = useState(INITIAL_STATE);
+  const [isApplying, setIsApplying] = useState(false);
+  const updateMessage = useMutation(api.threads.mutations.updateMessageContent);
+
+  const isDirty = state.canvasContent !== state.originalCanvasContent;
+  const canApply = isDirty && !!state.source?.messageId;
 
   const openCanvas = useCallback(
     (
@@ -68,6 +99,7 @@ export function CanvasProvider({ children }: CanvasProviderProps) {
       type: CanvasContentType,
       title: string,
       language?: string,
+      source?: CanvasSource,
     ) => {
       setState({
         isCanvasOpen: true,
@@ -75,6 +107,8 @@ export function CanvasProvider({ children }: CanvasProviderProps) {
         canvasType: type,
         canvasTitle: title,
         canvasLanguage: language,
+        originalCanvasContent: content,
+        source,
       });
     },
     [],
@@ -88,14 +122,67 @@ export function CanvasProvider({ children }: CanvasProviderProps) {
     setState((prev) => ({ ...prev, canvasContent: content }));
   }, []);
 
+  const applyCanvasContent = useCallback(async () => {
+    if (!state.source?.messageId || !state.source.messageContent) return;
+    if (state.canvasContent === state.originalCanvasContent) return;
+
+    setIsApplying(true);
+    try {
+      const { markdown: updatedMarkdown, replaced } = replaceCodeBlock(
+        state.source.messageContent,
+        state.originalCanvasContent,
+        state.canvasContent,
+      );
+
+      if (!replaced) {
+        toast({ title: t('canvas.applyFailed'), variant: 'destructive' });
+        return;
+      }
+
+      await updateMessage({
+        messageId: state.source.messageId,
+        content: updatedMarkdown,
+      });
+
+      // Only update state on success
+      setState((prev) => ({
+        ...prev,
+        originalCanvasContent: prev.canvasContent,
+        source: prev.source
+          ? { ...prev.source, messageContent: updatedMarkdown }
+          : undefined,
+      }));
+
+      toast({ title: t('canvas.applied'), variant: 'success' });
+    } catch (err) {
+      console.error('Failed to apply canvas content:', err);
+      toast({ title: t('canvas.applyFailed'), variant: 'destructive' });
+    } finally {
+      setIsApplying(false);
+    }
+  }, [state, updateMessage, t, toast]);
+
   const value = useMemo(
     () => ({
       ...state,
       openCanvas,
       closeCanvas,
       updateCanvasContent,
+      applyCanvasContent,
+      isDirty,
+      canApply,
+      isApplying,
     }),
-    [state, openCanvas, closeCanvas, updateCanvasContent],
+    [
+      state,
+      openCanvas,
+      closeCanvas,
+      updateCanvasContent,
+      applyCanvasContent,
+      isDirty,
+      canApply,
+      isApplying,
+    ],
   );
 
   return (

--- a/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
@@ -2,11 +2,19 @@
 
 import { memo, useMemo } from 'react';
 
+import { cn } from '@/lib/utils/cn';
+
 interface CanvasHtmlRendererProps {
   html: string;
+  isEditing: boolean;
+  onContentChange: (content: string) => void;
 }
 
-function CanvasHtmlRendererComponent({ html }: CanvasHtmlRendererProps) {
+function CanvasHtmlRendererComponent({
+  html,
+  isEditing,
+  onContentChange,
+}: CanvasHtmlRendererProps) {
   const srcDoc = useMemo(
     () =>
       `<!DOCTYPE html>
@@ -22,6 +30,21 @@ function CanvasHtmlRendererComponent({ html }: CanvasHtmlRendererProps) {
 </html>`,
     [html],
   );
+
+  if (isEditing) {
+    return (
+      <textarea
+        value={html}
+        onChange={(e) => onContentChange(e.target.value)}
+        className={cn(
+          'bg-muted text-foreground h-full w-full resize-none p-4 font-mono text-xs leading-relaxed',
+          'focus:outline-none',
+        )}
+        spellCheck={false}
+        aria-label="HTML editor"
+      />
+    );
+  }
 
   return (
     <iframe

--- a/services/platform/app/features/chat/components/canvas/canvas-mermaid-renderer.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-mermaid-renderer.tsx
@@ -6,9 +6,12 @@ import { useTheme } from '@/app/components/theme/theme-provider';
 import { Spinner } from '@/app/components/ui/feedback/spinner';
 import { Text } from '@/app/components/ui/typography/text';
 import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
 
 interface CanvasMermaidRendererProps {
   code: string;
+  isEditing: boolean;
+  onContentChange: (content: string) => void;
 }
 
 type MermaidApi = {
@@ -26,7 +29,11 @@ async function getMermaid(): Promise<MermaidApi> {
   return mermaidDefault;
 }
 
-function CanvasMermaidRendererComponent({ code }: CanvasMermaidRendererProps) {
+function CanvasMermaidRendererComponent({
+  code,
+  isEditing,
+  onContentChange,
+}: CanvasMermaidRendererProps) {
   const { t } = useT('chat');
   const containerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,6 +76,30 @@ function CanvasMermaidRendererComponent({ code }: CanvasMermaidRendererProps) {
       }
     })();
   }, [code, resolvedTheme, t]);
+
+  if (isEditing) {
+    return (
+      <div className="flex h-full flex-col">
+        <textarea
+          value={code}
+          onChange={(e) => onContentChange(e.target.value)}
+          className={cn(
+            'bg-muted text-foreground min-h-0 flex-1 resize-none p-4 font-mono text-xs leading-relaxed',
+            'focus:outline-none',
+          )}
+          spellCheck={false}
+          aria-label="Mermaid editor"
+        />
+        {error && (
+          <div className="border-border bg-destructive/10 border-t px-4 py-2">
+            <Text variant="muted" className="text-destructive text-xs">
+              {error}
+            </Text>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   if (error) {
     return (

--- a/services/platform/app/features/chat/components/canvas/canvas-pane.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-pane.tsx
@@ -12,6 +12,8 @@ import {
   Globe,
   GitBranch,
   Image,
+  Save,
+  Loader2,
 } from 'lucide-react';
 import { useState, useCallback, useRef, useEffect, memo } from 'react';
 
@@ -77,6 +79,9 @@ function CanvasPaneComponent() {
     canvasLanguage,
     closeCanvas,
     updateCanvasContent,
+    applyCanvasContent,
+    canApply,
+    isApplying,
   } = useCanvas();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -172,7 +177,6 @@ function CanvasPaneComponent() {
   if (!isCanvasOpen) return null;
 
   const TypeIcon = TYPE_ICONS[canvasType];
-  const canEdit = canvasType === 'code' || canvasType === 'markdown';
 
   return (
     <div
@@ -198,22 +202,39 @@ function CanvasPaneComponent() {
         </div>
 
         <div className="flex items-center gap-1">
-          {canEdit && (
-            <Tooltip
-              content={isEditing ? t('canvas.preview') : t('canvas.edit')}
-              side="bottom"
+          <Tooltip
+            content={isEditing ? t('canvas.preview') : t('canvas.edit')}
+            side="bottom"
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={toggleEdit}
+              aria-label={isEditing ? t('canvas.preview') : t('canvas.edit')}
             >
+              {isEditing ? (
+                <Eye className="size-3.5" />
+              ) : (
+                <Pencil className="size-3.5" />
+              )}
+            </Button>
+          </Tooltip>
+
+          {canApply && (
+            <Tooltip content={t('canvas.apply')} side="bottom">
               <Button
                 variant="ghost"
                 size="icon"
                 className="size-7"
-                onClick={toggleEdit}
-                aria-label={isEditing ? t('canvas.preview') : t('canvas.edit')}
+                onClick={applyCanvasContent}
+                disabled={isApplying}
+                aria-label={t('canvas.apply')}
               >
-                {isEditing ? (
-                  <Eye className="size-3.5" />
+                {isApplying ? (
+                  <Loader2 className="size-3.5 animate-spin" />
                 ) : (
-                  <Pencil className="size-3.5" />
+                  <Save className="size-3.5" />
                 )}
               </Button>
             </Tooltip>
@@ -273,10 +294,26 @@ function CanvasPaneComponent() {
             onContentChange={updateCanvasContent}
           />
         )}
-        {canvasType === 'html' && <CanvasHtmlRenderer html={canvasContent} />}
-        {canvasType === 'svg' && <CanvasHtmlRenderer html={canvasContent} />}
+        {canvasType === 'html' && (
+          <CanvasHtmlRenderer
+            html={canvasContent}
+            isEditing={isEditing}
+            onContentChange={updateCanvasContent}
+          />
+        )}
+        {canvasType === 'svg' && (
+          <CanvasHtmlRenderer
+            html={canvasContent}
+            isEditing={isEditing}
+            onContentChange={updateCanvasContent}
+          />
+        )}
         {canvasType === 'mermaid' && (
-          <CanvasMermaidRenderer code={canvasContent} />
+          <CanvasMermaidRenderer
+            code={canvasContent}
+            isEditing={isEditing}
+            onContentChange={updateCanvasContent}
+          />
         )}
         {canvasType === 'markdown' && (
           <CanvasMarkdownRenderer

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -39,6 +39,7 @@ import {
   ImagePreviewDialog,
   type GalleryImage,
 } from './message-bubble/image-preview-dialog';
+import { MessageContentContext } from './message-bubble/message-content-context';
 import type { Message } from './message-bubble/types';
 import { MessageFeedback } from './message-feedback';
 import { MessageInfoDialog } from './message-info-dialog';
@@ -146,6 +147,14 @@ function MessageBubbleComponent({
   const { citations, hasCitations } = useCitations(metadata?.citations);
   const citationNumbers = useMemo(() => new Set(citations.keys()), [citations]);
   const citationsContextValue = useMemo(() => ({ citations }), [citations]);
+  const messageContentContextValue = useMemo(
+    () => ({
+      messageId: message.id,
+      messageContent: message.content,
+      threadId: message.threadId,
+    }),
+    [message.id, message.content, message.threadId],
+  );
   const galleryImages = useMessageGallery(message);
 
   const displayContent = message.content ?? '';
@@ -262,13 +271,17 @@ function MessageBubbleComponent({
                   {displayContent}
                 </p>
               ) : (
-                <CitationsContext.Provider value={citationsContextValue}>
-                  <StructuredMessage
-                    text={assistantContent}
-                    isStreaming={!!isAssistantStreaming}
-                    onSendFollowUp={onSendFollowUp}
-                  />
-                </CitationsContext.Provider>
+                <MessageContentContext.Provider
+                  value={messageContentContextValue}
+                >
+                  <CitationsContext.Provider value={citationsContextValue}>
+                    <StructuredMessage
+                      text={assistantContent}
+                      isStreaming={!!isAssistantStreaming}
+                      onSendFollowUp={onSendFollowUp}
+                    />
+                  </CitationsContext.Provider>
+                </MessageContentContext.Provider>
               )}
             </div>
             {isUser && (isOverflowing || isExpanded) && (

--- a/services/platform/app/features/chat/components/message-bubble/__tests__/code-block.test.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/__tests__/code-block.test.tsx
@@ -8,6 +8,14 @@ import { checkAccessibility } from '@/test/utils/a11y';
 import { CanvasProvider } from '../../canvas/canvas-context';
 import { CodeBlock, HighlightedCode } from '../code-block';
 
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
 // Mock Shiki — returns a predictable HTML string
 vi.mock('@/lib/utils/shiki', () => ({
   highlightCode: vi.fn((code: string) =>

--- a/services/platform/app/features/chat/components/message-bubble/code-block.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/code-block.tsx
@@ -20,6 +20,7 @@ import {
   useCanvasOptional,
   type CanvasContentType,
 } from '../canvas/canvas-context';
+import { useMessageContentOptional } from './message-content-context';
 
 function resolveCanvasType(language?: string): CanvasContentType {
   if (!language) return 'code';
@@ -93,6 +94,7 @@ export function CodeBlock({
   const preRef = useRef<HTMLPreElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const canvasContext = useCanvasOptional();
+  const messageContext = useMessageContentOptional();
 
   useEffect(() => {
     return () => {
@@ -121,8 +123,20 @@ export function CodeBlock({
     if (!canvasContext) return;
     const textContent = preRef.current?.textContent ?? '';
     const canvasType = resolveCanvasType(lang);
-    canvasContext.openCanvas(textContent, canvasType, lang ?? 'code', lang);
-  }, [canvasContext, lang]);
+    canvasContext.openCanvas(
+      textContent,
+      canvasType,
+      lang ?? 'code',
+      lang,
+      messageContext
+        ? {
+            messageId: messageContext.messageId,
+            messageContent: messageContext.messageContent,
+            threadId: messageContext.threadId,
+          }
+        : undefined,
+    );
+  }, [canvasContext, lang, messageContext]);
 
   return (
     <div className="border-border bg-background my-4 overflow-hidden rounded-lg border">

--- a/services/platform/app/features/chat/components/message-bubble/message-content-context.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/message-content-context.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface MessageContentContextType {
+  messageId: string;
+  messageContent: string;
+  threadId?: string;
+}
+
+export const MessageContentContext =
+  createContext<MessageContentContextType | null>(null);
+
+export function useMessageContentOptional() {
+  return useContext(MessageContentContext);
+}

--- a/services/platform/app/features/chat/utils/replace-code-block.ts
+++ b/services/platform/app/features/chat/utils/replace-code-block.ts
@@ -1,0 +1,36 @@
+/**
+ * Replaces a specific code block's content within a markdown string.
+ *
+ * Matches code blocks by comparing their trimmed content against the
+ * original content. Preserves the language tag and fence style.
+ *
+ * Returns `{ markdown, replaced }` where `replaced` indicates whether
+ * the target code block was found and updated.
+ */
+export function replaceCodeBlock(
+  markdown: string,
+  originalContent: string,
+  newContent: string,
+): { markdown: string; replaced: boolean } {
+  const trimmedOriginal = originalContent.trim();
+
+  // Match fenced code blocks: ```lang\n...content...\n```
+  // Supports variable-length fences (3+ backticks)
+  const fencePattern = /^(`{3,})([^\n]*)\n([\s\S]*?)\n\1\s*$/gm;
+
+  let replaced = false;
+
+  const result = markdown.replace(
+    fencePattern,
+    (match, fence, lang, content) => {
+      if (replaced) return match;
+      if (content.trim() === trimmedOriginal) {
+        replaced = true;
+        return `${fence}${lang}\n${newContent}\n${fence}`;
+      }
+      return match;
+    },
+  );
+
+  return { markdown: result, replaced };
+}

--- a/services/platform/convex/threads/mutations.ts
+++ b/services/platform/convex/threads/mutations.ts
@@ -236,6 +236,32 @@ export const createArenaBranchLink = internalMutation({
   },
 });
 
+/**
+ * Updates the content of an assistant message in a thread.
+ * Used by the Canvas "Apply" feature to write edited content back.
+ */
+export const updateMessageContent = mutation({
+  args: {
+    messageId: v.string(),
+    content: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) {
+      throw new Error('Unauthenticated');
+    }
+
+    await ctx.runMutation(components.agent.messages.updateMessage, {
+      messageId: args.messageId,
+      patch: {
+        message: { role: 'assistant', content: args.content },
+      },
+    });
+    return null;
+  },
+});
+
 export { shareThread, unshareThread } from './share_thread';
 export { forkThread } from './fork_thread';
 export { forkOwnThread } from './fork_own_thread';

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -80,7 +80,10 @@
     "fileSizeExceededMultiple": "{names} überschreitet das Dateigrössenlimit von {maxSize} MB.",
     "canvas": {
       "close": "Canvas schliessen",
-      "resizeHandle": "Canvas-Grösse ändern"
+      "resizeHandle": "Canvas-Grösse ändern",
+      "apply": "Änderige übernäh",
+      "applied": "Änderige übernoh",
+      "applyFailed": "Änderige händ nöd chönne übernoh wärde"
     }
   },
   "documents": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2893,7 +2893,10 @@
       "download": "Herunterladen",
       "copied": "Kopiert!",
       "mermaidError": "Diagramm konnte nicht gerendert werden",
-      "resizeHandle": "Canvas-Größe ändern"
+      "resizeHandle": "Canvas-Größe ändern",
+      "apply": "Änderungen übernehmen",
+      "applied": "Änderungen übernommen",
+      "applyFailed": "Änderungen konnten nicht übernommen werden"
     },
     "promptLibrary": "Prompt-Bibliothek",
     "saveAsPrompt": "Als Prompt speichern"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2918,7 +2918,10 @@
       "download": "Download",
       "copied": "Copied!",
       "mermaidError": "Failed to render diagram",
-      "resizeHandle": "Resize canvas"
+      "resizeHandle": "Resize canvas",
+      "apply": "Apply changes",
+      "applied": "Changes applied",
+      "applyFailed": "Failed to apply changes"
     },
     "promptLibrary": "Prompt library",
     "saveAsPrompt": "Save as prompt"


### PR DESCRIPTION
## Summary

- Enable direct editing of all 5 Canvas content types (code, HTML, SVG, Mermaid, markdown) — previously only code and markdown had edit mode
- Add "Apply" button that writes edited content back to the original assistant message via `updateMessageContent` Convex mutation
- Track source message context (messageId, content, threadId) through `MessageContentContext` so Canvas knows which message and code block to update
- Dirty state management with `canApply` guard — Apply button only appears when content changed and source is available, and only clears dirty state after successful mutation

## Key files

| File | Change |
|------|--------|
| `app/features/chat/utils/replace-code-block.ts` | New utility: finds and replaces a code block in markdown by content matching |
| `app/features/chat/components/message-bubble/message-content-context.tsx` | New context: provides messageId/content/threadId to CodeBlock descendants |
| `app/features/chat/components/canvas/canvas-context.tsx` | Extended with source tracking, dirty state, `applyCanvasContent()` |
| `app/features/chat/components/canvas/canvas-pane.tsx` | All types editable, Apply button added |
| `app/features/chat/components/canvas/canvas-html-renderer.tsx` | Added textarea edit mode |
| `app/features/chat/components/canvas/canvas-mermaid-renderer.tsx` | Added textarea edit mode with inline error display |
| `convex/threads/mutations.ts` | Added `updateMessageContent` mutation |

## Lessons from PR #1422

This PR addresses the same issue as the closed PR #1422 but fixes the problems identified in its review:
- Apply clears dirty state **only after successful** mutation (not before)
- Apply button guarded by `canApply` (hidden when no source or not dirty)
- No stale closure risk — mutation called directly in context provider
- All 5 content types supported (not just code)
- Writes back to original message instead of sending as new chat message

## Test plan

- [ ] Open Canvas from a code block → toggle edit → modify code → click Apply → verify original message updates
- [ ] Open Canvas from an HTML code block → edit source → verify iframe preview updates live → Apply
- [ ] Open Canvas from a Mermaid code block → edit source → verify diagram re-renders → Apply
- [ ] Open Canvas from SVG/Markdown blocks → edit → Apply
- [ ] Verify Apply button only appears when content is dirty and source exists
- [ ] Verify Apply button shows spinner during save and error toast on failure
- [ ] Close Canvas with unsaved changes → reopen from same block → content is original
- [ ] Open Canvas from shared/read-only view → verify no Apply button (no source)
- [ ] Run `npm run lint --workspace=@tale/platform` — clean
- [ ] Run `npx tsc --noEmit` — clean
- [ ] Run `npx vitest run` for canvas and code-block tests — 336 pass

Closes #1413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canvas editor now supports edit mode for HTML, SVG, and Mermaid content with an apply button to save changes.
  * Added change tracking to detect modified canvas content.
  * Added localized strings for canvas apply workflow in German locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->