### PR TITLE
fix(platform): use forkedAt timestamp for fork divider and fix order source

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-split-view.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-split-view.tsx
@@ -177,6 +177,7 @@ function ArenaColumn({
             lastForkedMessageOrder={
               forkInfo?.lastForkedMessageOrder ?? undefined
             }
+            forkedAt={forkInfo?.forkedAt ?? undefined}
             forkedFromShare={forkInfo?.forkedFromShare}
             hideBranchNavigator
           />

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -788,6 +788,7 @@ export function ChatInterface({
               lastForkedMessageOrder={
                 forkInfo?.lastForkedMessageOrder ?? undefined
               }
+              forkedAt={forkInfo?.forkedAt ?? undefined}
               forkedFromShare={forkInfo?.forkedFromShare}
               onHumanInputResponseSubmitted={handleHumanInputResponseSubmitted}
               onSendFollowUp={

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -94,6 +94,7 @@ interface ChatMessagesProps {
   activeApproval: ChatItem | null;
   forkedMessageCount?: number;
   lastForkedMessageOrder?: number;
+  forkedAt?: number;
   forkedFromShare?: boolean;
   onHumanInputResponseSubmitted?: () => void;
   onSendFollowUp?: (message: string) => void;
@@ -137,6 +138,7 @@ export function ChatMessages({
   activeApproval,
   forkedMessageCount,
   lastForkedMessageOrder,
+  forkedAt,
   forkedFromShare,
   onHumanInputResponseSubmitted,
   onSendFollowUp,
@@ -411,12 +413,25 @@ export function ChatMessages({
   };
 
   // Compute fork divider position: after the last forked message.
-  // Prefer lastForkedMessageOrder (order-based, immune to UIMessage ID
-  // mismatches caused by excludeToolMessages — see get_thread_messages_streaming.ts)
-  // with forkedMessageCount as fallback for older threads.
+  // Priority: forkedAt (timestamp) > lastForkedMessageOrder > forkedMessageCount.
   const forkDividerAfterIdx = useMemo(() => {
+    // Preferred: timestamp-based — all copied messages have _creationTime <= forkedAt
+    if (forkedAt !== undefined) {
+      let lastMatch = -1;
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (
+          item.type === 'message' &&
+          item.data._creationTime !== undefined &&
+          item.data._creationTime <= forkedAt
+        ) {
+          lastMatch = i;
+        }
+      }
+      if (lastMatch >= 0) return lastMatch;
+    }
+    // Fallback: order-based for threads created before forkedAt existed
     if (lastForkedMessageOrder !== undefined) {
-      // Find the last message item whose order <= lastForkedMessageOrder
       let lastMatch = -1;
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
@@ -430,7 +445,7 @@ export function ChatMessages({
       }
       if (lastMatch >= 0) return lastMatch;
     }
-    // Fallback: count-based for threads forked before lastForkedMessageOrder existed
+    // Fallback: count-based for oldest threads
     if (!forkedMessageCount || forkedMessageCount <= 0) return -1;
     let msgCount = 0;
     for (let i = 0; i < items.length; i++) {
@@ -440,7 +455,7 @@ export function ChatMessages({
       }
     }
     return -1;
-  }, [items, lastForkedMessageOrder, forkedMessageCount]);
+  }, [items, forkedAt, lastForkedMessageOrder, forkedMessageCount]);
 
   const forkDivider =
     forkDividerAfterIdx >= 0 ? (

--- a/services/platform/convex/threads/__tests__/fork_thread.test.ts
+++ b/services/platform/convex/threads/__tests__/fork_thread.test.ts
@@ -73,6 +73,14 @@ describe('forkThread', () => {
     mockGetAuthUser.mockResolvedValue({ _id: 'user_2' });
     mockIsOrgMember.mockResolvedValue(true);
     mockCreateThread.mockResolvedValue('new_thread_1');
+    let orderCounter = 0;
+    mockSaveMessage.mockImplementation(() => {
+      orderCounter += 1;
+      return Promise.resolve({
+        messageId: `saved_msg_${orderCounter}`,
+        message: { order: orderCounter },
+      });
+    });
     mockGetThreadMessages.mockResolvedValue({
       messages: [
         { _id: 'msg_1', _creationTime: 1000, role: 'user', content: 'hello' },

--- a/services/platform/convex/threads/fork_own_thread.ts
+++ b/services/platform/convex/threads/fork_own_thread.ts
@@ -58,6 +58,19 @@ export const forkOwnThread = mutation({
       threadId: newThreadId,
     });
 
+    let lastSavedOrder: number | undefined;
+    for (const msg of messages) {
+      const result = await saveMessage(ctx, components.agent, {
+        threadId: newThreadId,
+        userId,
+        message: {
+          role: msg.role,
+          content: msg.content,
+        },
+      });
+      lastSavedOrder = result.message.order;
+    }
+
     const createdAt = thread?._creationTime ?? Date.now();
     await ctx.db.insert('threadMetadata', {
       threadId: newThreadId,
@@ -69,20 +82,10 @@ export const forkOwnThread = mutation({
       updatedAt: createdAt,
       forkedFrom: metadata.threadId,
       forkedMessageCount: messages.length,
-      lastForkedMessageOrder: messages.at(-1)?.order,
+      lastForkedMessageOrder: lastSavedOrder,
+      forkedAt: Date.now(),
       ...(metadata.teamId && { teamId: metadata.teamId }),
     });
-
-    for (const msg of messages) {
-      await saveMessage(ctx, components.agent, {
-        threadId: newThreadId,
-        userId,
-        message: {
-          role: msg.role,
-          content: msg.content,
-        },
-      });
-    }
 
     return newThreadId;
   },

--- a/services/platform/convex/threads/fork_thread.ts
+++ b/services/platform/convex/threads/fork_thread.ts
@@ -69,6 +69,19 @@ export const forkThread = mutation({
       threadId: newThreadId,
     });
 
+    let lastSavedOrder: number | undefined;
+    for (const msg of messages) {
+      const result = await saveMessage(ctx, components.agent, {
+        threadId: newThreadId,
+        userId,
+        message: {
+          role: msg.role,
+          content: msg.content,
+        },
+      });
+      lastSavedOrder = result.message.order;
+    }
+
     const createdAt = thread?._creationTime ?? Date.now();
     await ctx.db.insert('threadMetadata', {
       threadId: newThreadId,
@@ -81,22 +94,12 @@ export const forkThread = mutation({
       forkedFrom: metadata.threadId,
       forkedFromShare: true,
       forkedMessageCount: messages.length,
-      lastForkedMessageOrder: messages.at(-1)?.order,
+      lastForkedMessageOrder: lastSavedOrder,
+      forkedAt: Date.now(),
       ...(metadata.organizationId && {
         organizationId: metadata.organizationId,
       }),
     });
-
-    for (const msg of messages) {
-      await saveMessage(ctx, components.agent, {
-        threadId: newThreadId,
-        userId,
-        message: {
-          role: msg.role,
-          content: msg.content,
-        },
-      });
-    }
 
     return newThreadId;
   },

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -403,6 +403,7 @@ export const getThreadForkInfo = query({
       forkedFromShare: metadata.forkedFromShare ?? false,
       forkedMessageCount: metadata.forkedMessageCount ?? null,
       lastForkedMessageOrder: metadata.lastForkedMessageOrder ?? null,
+      forkedAt: metadata.forkedAt ?? null,
     };
   },
 });

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -32,6 +32,7 @@ export const threadMetadataTable = defineTable({
   forkedFromShare: v.optional(v.boolean()),
   forkedMessageCount: v.optional(v.number()),
   lastForkedMessageOrder: v.optional(v.number()),
+  forkedAt: v.optional(v.number()),
   // Arena mode fields
   arenaGroupId: v.optional(v.string()),
   arenaModelId: v.optional(v.string()),


### PR DESCRIPTION
## Summary
- `lastForkedMessageOrder` was storing the **source thread's** order value, but copied messages get new sequential orders in the destination thread. This mismatch caused the fork divider to appear in the wrong position after sending new messages.
- Added `forkedAt` timestamp field to `threadMetadata` — all copied messages have `_creationTime <= forkedAt`, making the divider position reliable regardless of order gaps.
- Fixed `lastForkedMessageOrder` to use the actual order from the **new thread** (via `saveMessage` return value) as a secondary fallback.
- Frontend priority: `forkedAt` > `lastForkedMessageOrder` > `forkedMessageCount` for backward compatibility.

## Test plan
- [ ] Fork a thread that has tool messages (order gaps) and verify divider appears at the correct position
- [ ] Send new messages after forking and verify the divider does not move
- [ ] Verify older forked threads (without `forkedAt`) still show the divider correctly via fallback logic
- [ ] Fork a shared thread and verify the divider works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fork timestamp tracking for improved accuracy in displaying where conversations were split.
  * Enhanced fork information with precise timestamps to better locate conversation split points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->