### PR TITLE
fix(platform): enforce budget max request limits for all period types

### DIFF
--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -157,7 +157,15 @@ export function UserButton({
               {
                 type: 'radio-group',
                 value: selectedTeamId ?? '',
-                onValueChange: (val) => setSelectedTeamId?.(val || null),
+                onValueChange: (val) => {
+                  setSelectedTeamId?.(val || null);
+                  if (organizationId) {
+                    void navigate({
+                      to: '/dashboard/$id/chat',
+                      params: { id: organizationId },
+                    });
+                  }
+                },
                 options: [
                   { value: '', label: tNav('teamFilter.allTeams') },
                   ...teams.map((team) => ({

--- a/services/platform/app/features/chat/components/budget-banner.tsx
+++ b/services/platform/app/features/chat/components/budget-banner.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -10,7 +11,11 @@ import { useMyBudgetStatus } from '../../settings/governance/hooks/queries';
 
 export function BudgetBanner({ organizationId }: { organizationId: string }) {
   const { t } = useT('chat');
-  const { data: budgetStatus } = useMyBudgetStatus(organizationId);
+  const teamFilter = useOptionalTeamFilter();
+  const { data: budgetStatus } = useMyBudgetStatus(
+    organizationId,
+    teamFilter?.selectedTeamId,
+  );
   // Derive a stable key so dismissed state resets only when the status meaningfully changes,
   // not on every Convex subscription tick (which creates new object references).
   const budgetStatusKey = useMemo(

--- a/services/platform/app/features/chat/components/budget-banner.tsx
+++ b/services/platform/app/features/chat/components/budget-banner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AlertTriangle, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -11,12 +11,22 @@ import { useMyBudgetStatus } from '../../settings/governance/hooks/queries';
 export function BudgetBanner({ organizationId }: { organizationId: string }) {
   const { t } = useT('chat');
   const { data: budgetStatus } = useMyBudgetStatus(organizationId);
+  // Derive a stable key so dismissed state resets only when the status meaningfully changes,
+  // not on every Convex subscription tick (which creates new object references).
+  const budgetStatusKey = useMemo(
+    () =>
+      budgetStatus
+        ? `${budgetStatus.exceeded}-${budgetStatus.code}-${budgetStatus.period}-${budgetStatus.warnings?.map((w) => `${w.code}:${w.percent}`).join(',')}`
+        : null,
+    [budgetStatus],
+  );
   const [dismissed, setDismissed] = useState(false);
+  const [prevKey, setPrevKey] = useState(budgetStatusKey);
 
-  // Reset dismissed state when budget status changes (e.g. new period or threshold crossed)
-  useEffect(() => {
+  if (budgetStatusKey !== prevKey) {
+    setPrevKey(budgetStatusKey);
     setDismissed(false);
-  }, [budgetStatus]);
+  }
 
   if (!budgetStatus || dismissed) return null;
 

--- a/services/platform/app/features/chat/components/budget-banner.tsx
+++ b/services/platform/app/features/chat/components/budget-banner.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { AlertTriangle, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { useMyBudgetStatus } from '../../settings/governance/hooks/queries';
+
+export function BudgetBanner({ organizationId }: { organizationId: string }) {
+  const { t } = useT('chat');
+  const { data: budgetStatus } = useMyBudgetStatus(organizationId);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Reset dismissed state when budget status changes (e.g. new period or threshold crossed)
+  useEffect(() => {
+    setDismissed(false);
+  }, [budgetStatus]);
+
+  if (!budgetStatus || dismissed) return null;
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 border-b px-4 py-2',
+        budgetStatus.exceeded
+          ? 'bg-destructive/10 border-destructive/30'
+          : 'bg-warning/10 border-warning/30',
+      )}
+    >
+      <AlertTriangle
+        className={cn(
+          'size-4 shrink-0',
+          budgetStatus.exceeded ? 'text-destructive' : 'text-warning',
+        )}
+      />
+      <span
+        className={cn(
+          'flex-1 text-sm',
+          budgetStatus.exceeded ? 'text-destructive' : 'text-foreground',
+        )}
+      >
+        {budgetStatus.exceeded
+          ? (() => {
+              const isCost = budgetStatus.code === 'COST_LIMIT';
+              const used =
+                isCost && budgetStatus.used != null
+                  ? `$${(budgetStatus.used / 100).toFixed(2)}`
+                  : budgetStatus.used?.toLocaleString();
+              const limit =
+                isCost && budgetStatus.limit != null
+                  ? `$${(budgetStatus.limit / 100).toFixed(2)}`
+                  : budgetStatus.limit?.toLocaleString();
+              const type = isCost
+                ? t('budgetWarningTypeCost')
+                : budgetStatus.code === 'TOKEN_LIMIT'
+                  ? t('budgetWarningTypeTokens')
+                  : t('budgetWarningTypeRequests');
+              return used != null && limit != null
+                ? t('budgetExceededDetail', {
+                    type,
+                    period: budgetStatus.period ?? 'monthly',
+                    used,
+                    limit,
+                  })
+                : t('budgetExceededDefault');
+            })()
+          : budgetStatus.warnings
+              ?.map((w) => {
+                const type =
+                  w.code === 'TOKEN_WARNING'
+                    ? t('budgetWarningTypeTokens')
+                    : w.code === 'COST_WARNING'
+                      ? t('budgetWarningTypeCost')
+                      : t('budgetWarningTypeRequests');
+                const used =
+                  w.code === 'COST_WARNING'
+                    ? `$${(w.used / 100).toFixed(2)}`
+                    : w.used.toLocaleString();
+                const limit =
+                  w.code === 'COST_WARNING'
+                    ? `$${(w.limit / 100).toFixed(2)}`
+                    : w.limit.toLocaleString();
+                return t('budgetWarning', {
+                  percent: w.percent,
+                  period: w.period,
+                  type,
+                  used,
+                  limit,
+                });
+              })
+              .join(' · ')}
+      </span>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="text-muted-foreground hover:text-foreground shrink-0"
+        aria-label={t('budgetWarningDismiss')}
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import { m, AnimatePresence } from 'framer-motion';
-import { Archive, ArrowDown, Share, X } from 'lucide-react';
+import { Archive, ArrowDown, Share } from 'lucide-react';
 import { useRef, useEffect, useId, useState, useCallback } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import { m, AnimatePresence } from 'framer-motion';
-import { AlertTriangle, Archive, ArrowDown, Share, X } from 'lucide-react';
+import { Archive, ArrowDown, Share, X } from 'lucide-react';
 import { useRef, useEffect, useId, useState, useCallback } from 'react';
 
 import { PanelFooter } from '@/app/components/layout/panel-footer';
@@ -18,10 +18,7 @@ import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
-import {
-  useMyBudgetStatus,
-  useMyFeatureFlags,
-} from '../../settings/governance/hooks/queries';
+import { useMyFeatureFlags } from '../../settings/governance/hooks/queries';
 import { useBranchContext } from '../context/branch-context';
 import { useChatLayout } from '../context/chat-layout-context';
 import { useEditAndBranch, useForkOwnThread } from '../hooks/mutations';
@@ -157,14 +154,6 @@ export function ChatInterface({
 
   const { data: featureFlags } = useMyFeatureFlags(organizationId);
   const fileUploadDisabled = featureFlags?.fileUpload === false;
-
-  const { data: budgetStatus } = useMyBudgetStatus(organizationId);
-  const [budgetWarningDismissed, setBudgetWarningDismissed] = useState(false);
-
-  // Reset dismissed state when budget status changes (e.g. new period or threshold crossed)
-  useEffect(() => {
-    setBudgetWarningDismissed(false);
-  }, [budgetStatus]);
 
   usePersistedAttachments({
     userId: user?.userId,
@@ -668,90 +657,6 @@ export function ChatInterface({
       <h2 id={chatRegionLabelId} className="sr-only">
         {t('aria.chatRegion')}
       </h2>
-      {budgetStatus && !budgetWarningDismissed && !threadId && (
-        <div
-          className={cn(
-            'flex items-center gap-2 border-b px-4 py-2',
-            budgetStatus.exceeded
-              ? 'bg-destructive/10 border-destructive/30'
-              : 'bg-warning/10 border-warning/30',
-          )}
-        >
-          <AlertTriangle
-            className={cn(
-              'size-4 shrink-0',
-              budgetStatus.exceeded ? 'text-destructive' : 'text-warning',
-            )}
-          />
-          <span
-            className={cn(
-              'flex-1 text-sm',
-              budgetStatus.exceeded ? 'text-destructive' : 'text-foreground',
-            )}
-          >
-            {budgetStatus.exceeded
-              ? (() => {
-                  const isCost = budgetStatus.code === 'COST_LIMIT';
-                  const used =
-                    isCost && budgetStatus.used != null
-                      ? `$${(budgetStatus.used / 100).toFixed(2)}`
-                      : budgetStatus.used?.toLocaleString();
-                  const limit =
-                    isCost && budgetStatus.limit != null
-                      ? `$${(budgetStatus.limit / 100).toFixed(2)}`
-                      : budgetStatus.limit?.toLocaleString();
-                  const type = isCost
-                    ? t('budgetWarningTypeCost')
-                    : budgetStatus.code === 'TOKEN_LIMIT'
-                      ? t('budgetWarningTypeTokens')
-                      : t('budgetWarningTypeRequests');
-                  return used != null && limit != null
-                    ? t('budgetExceededDetail', {
-                        type,
-                        period: budgetStatus.period ?? 'monthly',
-                        used,
-                        limit,
-                      })
-                    : t('budgetExceededDefault');
-                })()
-              : budgetStatus.warnings
-                  ?.map((w) => {
-                    const type =
-                      w.code === 'TOKEN_WARNING'
-                        ? t('budgetWarningTypeTokens')
-                        : w.code === 'COST_WARNING'
-                          ? t('budgetWarningTypeCost')
-                          : t('budgetWarningTypeRequests');
-                    const used =
-                      w.code === 'COST_WARNING'
-                        ? `$${(w.used / 100).toFixed(2)}`
-                        : w.used.toLocaleString();
-                    const limit =
-                      w.code === 'COST_WARNING'
-                        ? `$${(w.limit / 100).toFixed(2)}`
-                        : w.limit.toLocaleString();
-                    return t('budgetWarning', {
-                      percent: w.percent,
-                      period: w.period,
-                      type,
-                      used,
-                      limit,
-                    });
-                  })
-                  .join(' · ')}
-          </span>
-          {!budgetStatus.exceeded && (
-            <button
-              type="button"
-              onClick={() => setBudgetWarningDismissed(true)}
-              className="text-muted-foreground hover:text-foreground shrink-0"
-              aria-label={t('budgetWarningDismiss')}
-            >
-              <X className="size-4" />
-            </button>
-          )}
-        </div>
-      )}
       {showArena ? (
         <ArenaSplitView organizationId={organizationId} />
       ) : (

--- a/services/platform/app/features/settings/governance/hooks/queries.ts
+++ b/services/platform/app/features/settings/governance/hooks/queries.ts
@@ -27,9 +27,13 @@ export function useMyFeatureFlags(organizationId: string) {
   });
 }
 
-export function useMyBudgetStatus(organizationId: string) {
+export function useMyBudgetStatus(
+  organizationId: string,
+  selectedTeamId?: string | null,
+) {
   return useConvexQuery(api.governance.queries.getMyBudgetStatus, {
     organizationId,
+    selectedTeamId: selectedTeamId ?? null,
   });
 }
 

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -10,6 +10,7 @@ import { PanelFooter } from '@/app/components/layout/panel-footer';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Button } from '@/app/components/ui/primitives/button';
 import { ArenaModeProvider } from '@/app/features/chat/components/arena/arena-mode-context';
+import { BudgetBanner } from '@/app/features/chat/components/budget-banner';
 import { CanvasProvider } from '@/app/features/chat/components/canvas/canvas-context';
 import { ChatHeader } from '@/app/features/chat/components/chat-header';
 import { ChatHistorySidebar } from '@/app/features/chat/components/chat-history-sidebar';
@@ -260,6 +261,7 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
         </AnimatePresence>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <BudgetBanner organizationId={organizationId} />
           <LayoutErrorBoundary organizationId={organizationId}>
             <ThreadGate
               organizationId={organizationId}

--- a/services/platform/convex/governance/__tests__/budget_enforcement.test.ts
+++ b/services/platform/convex/governance/__tests__/budget_enforcement.test.ts
@@ -400,4 +400,97 @@ describe('resolveEffectiveLimits', () => {
     expect(result.orgMaxTokens).toBe(50_000_000);
     expect(result.orgMaxCostCents).toBe(100_000);
   });
+
+  it('resolves limits independently across different periods', () => {
+    const rules: BudgetRule[] = [
+      { scope: 'default', period: 'daily', maxRequests: 10 },
+      { scope: 'default', period: 'monthly', maxTokens: 500_000 },
+    ];
+    const dailyResult = resolveEffectiveLimits(
+      rules.filter((r) => r.period === 'daily'),
+      'user-1',
+      [],
+      'member',
+    );
+    const monthlyResult = resolveEffectiveLimits(
+      rules.filter((r) => r.period === 'monthly'),
+      'user-1',
+      [],
+      'member',
+    );
+    expect(dailyResult.maxRequests).toBe(10);
+    expect(dailyResult.maxTokens).toBeUndefined();
+    expect(monthlyResult.maxTokens).toBe(500_000);
+    expect(monthlyResult.maxRequests).toBeUndefined();
+  });
+});
+
+describe('checkRuleAgainstUsage — multi-period scenarios', () => {
+  it('enforces daily request limit', () => {
+    const rule: BudgetRule = {
+      scope: 'default',
+      period: 'daily',
+      maxRequests: 2,
+    };
+    const result = checkRuleAgainstUsage(rule, {
+      totalTokens: 0,
+      costEstimate: 0,
+      requestCount: 2,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.allowed).toBe(false);
+    expect(result?.code).toBe('REQUEST_LIMIT');
+    expect(result?.period).toBe('daily');
+  });
+
+  it('enforces weekly token limit', () => {
+    const rule: BudgetRule = {
+      scope: 'default',
+      period: 'weekly',
+      maxTokens: 50_000,
+    };
+    const result = checkRuleAgainstUsage(rule, {
+      totalTokens: 50_000,
+      costEstimate: 0,
+      requestCount: 0,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe('TOKEN_LIMIT');
+    expect(result?.period).toBe('weekly');
+  });
+
+  it('allows request under daily limit', () => {
+    const rule: BudgetRule = {
+      scope: 'default',
+      period: 'daily',
+      maxRequests: 5,
+    };
+    const result = checkRuleAgainstUsage(rule, {
+      totalTokens: 0,
+      costEstimate: 0,
+      requestCount: 4,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('collectAllApplicableRules — mixed periods', () => {
+  it('collects rules across different periods for the same user', () => {
+    const rules: BudgetRule[] = [
+      { scope: 'default', period: 'daily', maxRequests: 10 },
+      { scope: 'default', period: 'monthly', maxTokens: 500_000 },
+      {
+        scope: 'user',
+        scopeId: 'user-1',
+        period: 'weekly',
+        maxCostCents: 1000,
+      },
+    ];
+    const result = collectAllApplicableRules(rules, 'user-1', [], 'member');
+    expect(result).toHaveLength(3);
+    const periods = result.map((r) => r.period);
+    expect(periods).toContain('daily');
+    expect(periods).toContain('weekly');
+    expect(periods).toContain('monthly');
+  });
 });

--- a/services/platform/convex/governance/budget_enforcement.ts
+++ b/services/platform/convex/governance/budget_enforcement.ts
@@ -206,25 +206,26 @@ async function getUserPeriodUsage(
   userId: string,
   periodKey: string,
 ): Promise<UsageTotals> {
-  const entry = await ctx.db
+  const totals: UsageTotals = {
+    totalTokens: 0,
+    costEstimate: 0,
+    requestCount: 0,
+  };
+
+  for await (const entry of ctx.db
     .query('usageLedger')
     .withIndex('by_org_user_period', (q) =>
       q
         .eq('organizationId', organizationId)
         .eq('userId', userId)
         .eq('periodKey', periodKey),
-    )
-    .first();
-
-  if (!entry) {
-    return { totalTokens: 0, costEstimate: 0, requestCount: 0 };
+    )) {
+    totals.totalTokens += entry.totalTokens;
+    totals.costEstimate += entry.costEstimate;
+    totals.requestCount += entry.requestCount;
   }
 
-  return {
-    totalTokens: entry.totalTokens,
-    costEstimate: entry.costEstimate,
-    requestCount: entry.requestCount,
-  };
+  return totals;
 }
 
 /**

--- a/services/platform/convex/governance/internal_mutations.ts
+++ b/services/platform/convex/governance/internal_mutations.ts
@@ -18,76 +18,96 @@ export const incrementUsageLedger = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const period = args.period ?? 'monthly';
-    const periodKey = buildPeriodKeyFromTimestamp(period, args.timestamp);
+    const ALL_PERIODS = ['daily', 'weekly', 'monthly'] as const;
     const totalTokens = args.inputTokens + args.outputTokens;
 
-    const existing = await ctx.db
-      .query('usageLedger')
-      .withIndex('by_org_user_period', (q) =>
-        q
-          .eq('organizationId', args.organizationId)
-          .eq('userId', args.userId)
-          .eq('periodKey', periodKey),
-      )
-      .first();
+    for (const period of ALL_PERIODS) {
+      const periodKey = buildPeriodKeyFromTimestamp(period, args.timestamp);
 
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        inputTokens: existing.inputTokens + args.inputTokens,
-        outputTokens: existing.outputTokens + args.outputTokens,
-        totalTokens: existing.totalTokens + totalTokens,
-        costEstimate: existing.costEstimate + args.costEstimateCents,
-        requestCount: existing.requestCount + 1,
-        // Backfill teamId if the existing entry has none and we now have one
-        ...(args.teamId && !existing.teamId ? { teamId: args.teamId } : {}),
-      });
-    } else {
-      await ctx.db.insert('usageLedger', {
-        organizationId: args.organizationId,
-        userId: args.userId,
-        teamId: args.teamId,
-        periodKey,
-        inputTokens: args.inputTokens,
-        outputTokens: args.outputTokens,
-        totalTokens,
-        costEstimate: args.costEstimateCents,
-        requestCount: 1,
-      });
-
-      // Guard against duplicate-insert race: if two concurrent mutations
-      // both saw existing===null and inserted, merge into the older row.
-      const dupQuery = ctx.db
+      const existing = await ctx.db
         .query('usageLedger')
         .withIndex('by_org_user_period', (q) =>
           q
             .eq('organizationId', args.organizationId)
             .eq('userId', args.userId)
             .eq('periodKey', periodKey),
-        );
-      const allEntries = [];
-      for await (const entry of dupQuery) {
-        allEntries.push(entry);
-      }
+        )
+        .first();
 
-      if (allEntries.length > 1) {
-        // Keep the oldest entry, merge the rest into it
-        const sorted = allEntries.sort(
-          (a, b) => a._creationTime - b._creationTime,
-        );
-        const keep = sorted[0];
-        if (!keep) return null;
-        for (let i = 1; i < sorted.length; i++) {
-          const dup = sorted[i];
-          if (!dup) continue;
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          inputTokens: existing.inputTokens + args.inputTokens,
+          outputTokens: existing.outputTokens + args.outputTokens,
+          totalTokens: existing.totalTokens + totalTokens,
+          costEstimate: existing.costEstimate + args.costEstimateCents,
+          requestCount: existing.requestCount + 1,
+          // Backfill teamId if the existing entry has none and we now have one
+          ...(args.teamId && !existing.teamId ? { teamId: args.teamId } : {}),
+        });
+      } else {
+        await ctx.db.insert('usageLedger', {
+          organizationId: args.organizationId,
+          userId: args.userId,
+          teamId: args.teamId,
+          periodKey,
+          inputTokens: args.inputTokens,
+          outputTokens: args.outputTokens,
+          totalTokens,
+          costEstimate: args.costEstimateCents,
+          requestCount: 1,
+        });
+
+        // Guard against duplicate-insert race: if two concurrent mutations
+        // both saw existing===null and inserted, merge into the older row.
+        const dupQuery = ctx.db
+          .query('usageLedger')
+          .withIndex('by_org_user_period', (q) =>
+            q
+              .eq('organizationId', args.organizationId)
+              .eq('userId', args.userId)
+              .eq('periodKey', periodKey),
+          );
+        const allEntries = [];
+        for await (const entry of dupQuery) {
+          allEntries.push(entry);
+        }
+
+        if (allEntries.length > 1) {
+          // Keep the oldest entry, sum all entries, then patch once.
+          // We must NOT read from the local `keep` object after patching
+          // because ctx.db.patch does not update the in-memory reference.
+          const sorted = allEntries.sort(
+            (a, b) => a._creationTime - b._creationTime,
+          );
+          const keep = sorted[0];
+          if (!keep) return null;
+
+          let sumInput = 0;
+          let sumOutput = 0;
+          let sumTotal = 0;
+          let sumCost = 0;
+          let sumRequests = 0;
+          for (const entry of sorted) {
+            sumInput += entry.inputTokens;
+            sumOutput += entry.outputTokens;
+            sumTotal += entry.totalTokens;
+            sumCost += entry.costEstimate;
+            sumRequests += entry.requestCount;
+          }
+
           await ctx.db.patch(keep._id, {
-            inputTokens: keep.inputTokens + dup.inputTokens,
-            outputTokens: keep.outputTokens + dup.outputTokens,
-            totalTokens: keep.totalTokens + dup.totalTokens,
-            costEstimate: keep.costEstimate + dup.costEstimate,
-            requestCount: keep.requestCount + dup.requestCount,
+            inputTokens: sumInput,
+            outputTokens: sumOutput,
+            totalTokens: sumTotal,
+            costEstimate: sumCost,
+            requestCount: sumRequests,
           });
-          await ctx.db.delete(dup._id);
+
+          for (let i = 1; i < sorted.length; i++) {
+            const dup = sorted[i];
+            if (!dup) continue;
+            await ctx.db.delete(dup._id);
+          }
         }
       }
     }

--- a/services/platform/convex/governance/internal_mutations.ts
+++ b/services/platform/convex/governance/internal_mutations.ts
@@ -80,7 +80,7 @@ export const incrementUsageLedger = internalMutation({
             (a, b) => a._creationTime - b._creationTime,
           );
           const keep = sorted[0];
-          if (!keep) return null;
+          if (!keep) continue;
 
           let sumInput = 0;
           let sumOutput = 0;

--- a/services/platform/convex/governance/internal_mutations.ts
+++ b/services/platform/convex/governance/internal_mutations.ts
@@ -26,11 +26,12 @@ export const incrementUsageLedger = internalMutation({
 
       const existing = await ctx.db
         .query('usageLedger')
-        .withIndex('by_org_user_period', (q) =>
+        .withIndex('by_org_user_period_team', (q) =>
           q
             .eq('organizationId', args.organizationId)
             .eq('userId', args.userId)
-            .eq('periodKey', periodKey),
+            .eq('periodKey', periodKey)
+            .eq('teamId', args.teamId),
         )
         .first();
 
@@ -41,8 +42,6 @@ export const incrementUsageLedger = internalMutation({
           totalTokens: existing.totalTokens + totalTokens,
           costEstimate: existing.costEstimate + args.costEstimateCents,
           requestCount: existing.requestCount + 1,
-          // Backfill teamId if the existing entry has none and we now have one
-          ...(args.teamId && !existing.teamId ? { teamId: args.teamId } : {}),
         });
       } else {
         await ctx.db.insert('usageLedger', {
@@ -61,11 +60,12 @@ export const incrementUsageLedger = internalMutation({
         // both saw existing===null and inserted, merge into the older row.
         const dupQuery = ctx.db
           .query('usageLedger')
-          .withIndex('by_org_user_period', (q) =>
+          .withIndex('by_org_user_period_team', (q) =>
             q
               .eq('organizationId', args.organizationId)
               .eq('userId', args.userId)
-              .eq('periodKey', periodKey),
+              .eq('periodKey', periodKey)
+              .eq('teamId', args.teamId),
           );
         const allEntries = [];
         for await (const entry of dupQuery) {

--- a/services/platform/convex/governance/queries.ts
+++ b/services/platform/convex/governance/queries.ts
@@ -188,6 +188,7 @@ export const getMyFeatureFlags = query({
 export const getMyBudgetStatus = query({
   args: {
     organizationId: v.string(),
+    selectedTeamId: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authUser = await authComponent.getAuthUser(ctx);
@@ -202,30 +203,45 @@ export const getMyBudgetStatus = query({
       name: authUser.name,
     });
 
-    const teamIds = await getUserTeamIds(ctx, userId);
-    const result = await checkBudget(
+    const allTeamIds = await getUserTeamIds(ctx, userId);
+
+    // For exceeded checks, always use all teams so hard blocks are never hidden
+    const fullResult = await checkBudget(
       ctx,
       args.organizationId,
       userId,
-      teamIds,
+      allTeamIds,
       member.role,
     );
 
-    // Budget exceeded — return the violation so the UI can show a hard limit banner
-    if (!result.allowed) {
+    // Budget exceeded — always show regardless of team selection
+    if (!fullResult.allowed) {
       return {
         exceeded: true as const,
-        code: result.code ?? null,
-        period: result.period ?? null,
-        used: result.used ?? null,
-        limit: result.limit ?? null,
-        reason: result.reason ?? null,
+        code: fullResult.code ?? null,
+        period: fullResult.period ?? null,
+        used: fullResult.used ?? null,
+        limit: fullResult.limit ?? null,
+        reason: fullResult.reason ?? null,
         warnings: null,
       };
     }
 
-    // Approaching limit — return warnings
-    if (result.warnings && result.warnings.length > 0) {
+    // For warnings, filter by selected team context
+    const displayTeamIds =
+      args.selectedTeamId && allTeamIds.includes(args.selectedTeamId)
+        ? [args.selectedTeamId]
+        : [];
+    const displayResult = await checkBudget(
+      ctx,
+      args.organizationId,
+      userId,
+      displayTeamIds,
+      member.role,
+    );
+
+    // Approaching limit — return warnings scoped to team selection
+    if (displayResult.warnings && displayResult.warnings.length > 0) {
       return {
         exceeded: false as const,
         code: null,
@@ -233,7 +249,7 @@ export const getMyBudgetStatus = query({
         used: null,
         limit: null,
         reason: null,
-        warnings: result.warnings,
+        warnings: displayResult.warnings,
       };
     }
 

--- a/services/platform/convex/governance/schema.ts
+++ b/services/platform/convex/governance/schema.ts
@@ -42,5 +42,11 @@ export const usageLedgerTable = defineTable({
   requestCount: v.number(),
 })
   .index('by_org_user_period', ['organizationId', 'userId', 'periodKey'])
+  .index('by_org_user_period_team', [
+    'organizationId',
+    'userId',
+    'periodKey',
+    'teamId',
+  ])
   .index('by_org_team_period', ['organizationId', 'teamId', 'periodKey'])
   .index('by_org_period', ['organizationId', 'periodKey']);

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -150,6 +150,7 @@ export const runAgentGeneration = internalAction({
     deadlineMs: v.optional(v.number()),
     generationParams: v.optional(v.any()),
     maxContextTokens: v.optional(v.number()),
+    threadTeamId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const actionStartTime = Date.now();
@@ -380,11 +381,7 @@ export const runAgentGeneration = internalAction({
               organizationId,
               userId,
               agentSlug: args.agentSlug,
-              teamIds:
-                agentConfig.agentTeamIds ??
-                (agentConfig.agentTeamId
-                  ? [agentConfig.agentTeamId]
-                  : undefined),
+              teamIds: args.threadTeamId ? [args.threadTeamId] : undefined,
               providerCost:
                 modelData.inputCentsPerMillion != null
                   ? {

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -348,6 +348,7 @@ export async function startAgentChat(
       deadlineMs,
       generationParams: args.generationParams,
       maxContextTokens: governanceMaxContextTokens,
+      threadTeamId: threadMeta?.teamId,
     },
   );
 

--- a/services/platform/convex/lib/agent_completion/on_agent_complete.ts
+++ b/services/platform/convex/lib/agent_completion/on_agent_complete.ts
@@ -180,32 +180,30 @@ export async function onAgentComplete(
   if (totalTokens > 0 && organizationId && userId && costCents != null) {
     const timestamp = Date.now();
 
-    const ledgerTeamIds = teamIds && teamIds.length > 0 ? teamIds : [undefined];
+    const teamId = teamIds?.[0];
 
-    for (const teamId of ledgerTeamIds) {
-      promises.push(
-        ctx
-          .runMutation(
-            internal.governance.internal_mutations.incrementUsageLedger,
-            {
-              organizationId,
-              userId,
-              teamId,
-              inputTokens: msgInputTokens,
-              outputTokens: msgOutputTokens,
-              costEstimateCents: costCents,
-              timestamp,
-            },
-          )
-          .catch((error) => {
-            console.error(`[${agentType}] Failed to increment usage ledger:`, {
-              threadId,
-              teamId,
-              error,
-            });
-          }),
-      );
-    }
+    promises.push(
+      ctx
+        .runMutation(
+          internal.governance.internal_mutations.incrementUsageLedger,
+          {
+            organizationId,
+            userId,
+            teamId,
+            inputTokens: msgInputTokens,
+            outputTokens: msgOutputTokens,
+            costEstimateCents: costCents,
+            timestamp,
+          },
+        )
+        .catch((error) => {
+          console.error(`[${agentType}] Failed to increment usage ledger:`, {
+            threadId,
+            teamId,
+            error,
+          });
+        }),
+    );
 
     // AI audit log for usage tracking
     promises.push(


### PR DESCRIPTION
## Summary

Closes #1452, closes #1450, closes #1456

Budget rules with `maxRequests` limits were not blocking users who exceeded the limit.

- **Root cause:** `incrementUsageLedger` only recorded usage under the monthly period key, so daily/weekly budget rules always found zero usage and passed
- **Fix:** Record usage for all three periods (daily, weekly, monthly) in a single atomic mutation
- **Bonus fix:** Corrected stale-reference bug in the dedup merge loop that could undercount usage when 3+ duplicate ledger rows existed
- **Bonus fix:** Use the thread's team context (user-selected team) for usage attribution instead of the agent's configured team list, fixing N-times inflation for multi-team agents
- **UI:** Extract budget banner into standalone component, show on both chat start and thread pages, always dismissible

## Test plan

- [ ] Create a daily budget rule with `maxRequests: 2`, send 3 messages → verify 3rd is blocked
- [ ] Create a weekly budget rule with `maxRequests: 5` → verify enforcement after 5 requests
- [ ] Verify monthly budget rules still work (regression)
- [ ] Verify budget warning banner appears on both new chat and thread pages
- [ ] Verify banner is dismissible (including exceeded state)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint --workspace=@tale/platform` passes
- [ ] Unit tests pass (`npx vitest run convex/governance/__tests__/`)