### PR TITLE
fix(rag): use correct provider credentials and support local dev config sync

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -169,7 +169,7 @@ services:
     # Persist crawler data (website registry + per-site URL databases)
     volumes:
       - crawler-data:/app/data
-      - platform-data:/app/platform-config:ro
+      - ${PLATFORM_SHARED_CONFIG:-platform-data}:/app/platform-config:ro
 
     # Logging configuration
     logging:
@@ -208,7 +208,7 @@ services:
     # Volume mounts
     volumes:
       - rag-data:/app/data
-      - platform-data:/app/platform-config:ro
+      - ${PLATFORM_SHARED_CONFIG:-platform-data}:/app/platform-config:ro
 
     # Environment file
     # Create a .env file in the project root with your API keys

--- a/services/rag/app/config.py
+++ b/services/rag/app/config.py
@@ -75,7 +75,7 @@ class Settings(BaseServiceSettings):
     def get_llm_config(self) -> dict:
         """Get LLM configuration from provider files."""
         base_url, api_key, model = self.get_chat_config()
-        _emb_base_url, _emb_api_key, embedding_model, _dims = self.get_embedding_config()
+        emb_base_url, emb_api_key, embedding_model, _dims = self.get_embedding_config()
 
         config: dict = {
             "provider": "openai",
@@ -83,6 +83,8 @@ class Settings(BaseServiceSettings):
             "embedding_model": embedding_model,
             "api_key": api_key,
             "base_url": base_url,
+            "embedding_api_key": emb_api_key,
+            "embedding_base_url": emb_base_url,
         }
 
         if self.openai_max_tokens is not None:

--- a/services/rag/app/services/rag_service.py
+++ b/services/rag/app/services/rag_service.py
@@ -96,8 +96,8 @@ class RagService:
         dimensions = settings.get_embedding_dimensions()
 
         self._embedding_service = EmbeddingService(
-            api_key=llm_config["api_key"],
-            base_url=llm_config["base_url"],
+            api_key=llm_config["embedding_api_key"],
+            base_url=llm_config["embedding_base_url"],
             model=embedding_model,
             dimensions=dimensions,
         )
@@ -168,7 +168,7 @@ class RagService:
         # Check chat/embedding config
         new_llm_config = settings.get_llm_config()
         if new_llm_config != self._llm_config:
-            if not new_llm_config.get("api_key"):
+            if not new_llm_config.get("api_key") or not new_llm_config.get("embedding_api_key"):
                 logger.warning("Skipping LLM config reload: empty API key")
             else:
                 new_dims = settings.get_embedding_dimensions()
@@ -181,8 +181,8 @@ class RagService:
                 else:
                     # Prepare new clients before swapping any state
                     new_emb = EmbeddingService(
-                        api_key=new_llm_config["api_key"],
-                        base_url=new_llm_config["base_url"],
+                        api_key=new_llm_config["embedding_api_key"],
+                        base_url=new_llm_config["embedding_base_url"],
                         model=new_llm_config["embedding_model"],
                         dimensions=new_dims,
                     )


### PR DESCRIPTION
## Summary

- **Embedding uses wrong API key in multi-provider setups**: `get_llm_config()` was discarding the embedding provider's `api_key` and `base_url`, always using the chat provider's credentials for `EmbeddingService`. Fixed by adding `embedding_api_key` / `embedding_base_url` to the config dict and using them in both `_do_initialize()` and `_maybe_refresh_clients()`.

- **Local dev config not syncing to RAG/crawler containers**: When platform runs locally via `bun dev`, it writes provider config to `examples/providers/` on the host. RAG/crawler containers were reading from the `platform-data` Docker named volume — a completely different filesystem. Fixed by parameterizing the shared config volume mount with `${PLATFORM_SHARED_CONFIG:-platform-data}`. Set `PLATFORM_SHARED_CONFIG=./examples` in `.env` for local dev.

## Test plan

- [ ] Multi-provider: configure chat on provider A, embedding on provider B → verify RAG uses provider B's key for embeddings
- [ ] Local dev: set `PLATFORM_SHARED_CONFIG=./examples` in `.env`, restart RAG/crawler, change API key in dashboard → verify RAG picks up the new key within 15s
- [ ] Production: leave `PLATFORM_SHARED_CONFIG` unset → verify containers use `platform-data` named volume as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Embedding services can now be configured independently with separate credentials and endpoints, enabling flexible provider selection.

* **Improvements**
  * Deployment configuration is now more flexible through environment variable support for shared platform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->