### PR TITLE
feat(platform): add language switcher to user dropdown

### DIFF
--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
+import { useLocale } from '@/app/hooks/use-locale';
 import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { toast } from '@/app/hooks/use-toast';
 import { getEnv } from '@/lib/env';
@@ -57,6 +58,7 @@ export function UserButton({
   const params = useParams({ strict: false });
   const organizationId = params.id;
   const { theme, setTheme } = useTheme();
+  const { locale, setLocale } = useLocale();
   const teamFilter = useOptionalTeamFilter();
   const teams = teamFilter?.teams;
   const selectedTeamId = teamFilter?.selectedTeamId ?? null;
@@ -215,6 +217,29 @@ export function UserButton({
           </div>
         ),
       },
+      {
+        type: 'custom',
+        content: (
+          <div className="bg-muted flex items-center justify-between gap-2 rounded-lg p-1">
+            <Button
+              variant={!locale.startsWith('de') ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setLocale('en')}
+              className="flex-1"
+            >
+              EN
+            </Button>
+            <Button
+              variant={locale.startsWith('de') ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setLocale('de')}
+              className="flex-1"
+            >
+              DE
+            </Button>
+          </div>
+        ),
+      },
     ]);
 
     groups.push([
@@ -246,11 +271,13 @@ export function UserButton({
     teams,
     selectedTeamId,
     theme,
+    locale,
     t,
     tNav,
     navigate,
     onNavigate,
     setTheme,
+    setLocale,
     setSelectedTeamId,
     handleSignOutClick,
   ]);

--- a/services/platform/app/hooks/use-locale.ts
+++ b/services/platform/app/hooks/use-locale.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { i18n } from '@/lib/i18n/i18n';
 import { loadDayjsLocale } from '@/lib/utils/date/format';
 import { isValidLocale } from '@/lib/utils/intl/is-valid-locale';
 import { parseAcceptLanguage } from '@/lib/utils/intl/parse-accept-language';
@@ -29,6 +30,9 @@ export function useLocale(defaultLocale = 'en-US') {
   const [locale, setLocaleState] = useState(() => detectLocale(defaultLocale));
 
   useEffect(() => {
+    if (i18n.language !== locale) {
+      void i18n.changeLanguage(locale);
+    }
     void loadDayjsLocale(locale).then(() => setLocaleState(locale));
   }, [locale]);
 
@@ -37,6 +41,7 @@ export function useLocale(defaultLocale = 'en-US') {
       if (isValidLocale(newLocale)) {
         setLocaleState(newLocale);
         localStorage.setItem('user-locale', newLocale);
+        void i18n.changeLanguage(newLocale);
         void loadDayjsLocale(newLocale);
       } else {
         console.warn(
@@ -44,6 +49,7 @@ export function useLocale(defaultLocale = 'en-US') {
         );
         setLocaleState(defaultLocale);
         localStorage.setItem('user-locale', defaultLocale);
+        void i18n.changeLanguage(defaultLocale);
         void loadDayjsLocale(defaultLocale);
       }
     },

--- a/services/platform/lib/i18n/i18n-provider.tsx
+++ b/services/platform/lib/i18n/i18n-provider.tsx
@@ -3,12 +3,24 @@
 import { type ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 
+import { useLocale } from '@/app/hooks/use-locale';
+
 import { i18n } from './i18n';
 
 interface I18nProviderProps {
   children: ReactNode;
 }
 
+function LocaleSync() {
+  useLocale();
+  return null;
+}
+
 export function I18nProvider({ children }: I18nProviderProps) {
-  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+  return (
+    <I18nextProvider i18n={i18n}>
+      <LocaleSync />
+      {children}
+    </I18nextProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- Add EN/DE language toggle buttons to the user dropdown menu, following the same visual pattern as the existing theme switcher
- Fix `useLocale` hook to call `i18n.changeLanguage()` so switching locale actually updates UI translations
- Add root-level `LocaleSync` component in `I18nProvider` to sync browser-detected locale with i18next on app startup

## Test plan
- [ ] Open user dropdown — verify EN/DE toggle appears below theme switcher
- [ ] Click DE — UI switches to German
- [ ] Click EN — UI switches back to English
- [ ] Refresh page — language preference persists (stored in localStorage)
- [ ] Set browser language to German, clear localStorage `user-locale` key, reload — verify auto-detection picks up German

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language switching controls now available in the user menu, enabling selection between English and German.
  * Locale changes synchronize throughout the application and are automatically preserved for future sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->