### PR TITLE
feat(cli): isolate Docker resources per project + host access + compose override

### DIFF
--- a/tools/cli/src/commands/auth.ts
+++ b/tools/cli/src/commands/auth.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 
 import { resetOwner } from '../lib/actions/reset-owner';
+import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import * as logger from '../utils/logger';
 
 export function createAuthCommand(): Command {
@@ -53,6 +55,7 @@ export function createAuthCommand(): Command {
           }
         }
 
+        await resolveProjectContext(requireProject());
         await resetOwner({ email, password });
       } catch (err) {
         logger.error(err instanceof Error ? err.message : String(err));

--- a/tools/cli/src/commands/cleanup.ts
+++ b/tools/cli/src/commands/cleanup.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import { cleanup } from '../lib/actions/cleanup';
 import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import { loadEnv } from '../utils/load-env';
 import * as logger from '../utils/logger';
 
@@ -11,6 +12,7 @@ export function createCleanupCommand(): Command {
     .action(async () => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const env = loadEnv(projectDir);
         await cleanup({ env });
       } catch (err) {

--- a/tools/cli/src/commands/convex.ts
+++ b/tools/cli/src/commands/convex.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 
 import { convexAdmin } from '../lib/actions/convex-admin';
+import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import * as logger from '../utils/logger';
 
 export function createConvexCommand(): Command {
@@ -13,6 +15,7 @@ export function createConvexCommand(): Command {
     .description('Generate admin key for Convex dashboard access')
     .action(async () => {
       try {
+        await resolveProjectContext(requireProject());
         await convexAdmin();
       } catch (err) {
         logger.error(err instanceof Error ? err.message : String(err));

--- a/tools/cli/src/commands/deploy/index.ts
+++ b/tools/cli/src/commands/deploy/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../../lib/compose/types';
 import { ensureEnv } from '../../lib/config/ensure-env';
 import { requireProject } from '../../lib/project/find-project';
+import { resolveProjectContext } from '../../lib/project/project-context';
 import { selectVersion } from '../../lib/registry/select-version';
 import { loadEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
@@ -28,9 +29,15 @@ export function createDeployCommand(): Command {
       'force re-seed builtin agent/workflow/integration configs',
     )
     .option('-q, --quiet', 'Suppress container logs during deployment')
+    .option(
+      '--migrate-volumes',
+      'Migrate legacy Docker volumes before deploying (requires stopping any running legacy containers)',
+      false,
+    )
     .action(async (versionArg: string | undefined, options) => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const { success: envSetupSuccess } = await ensureEnv({
           deployDir: projectDir,
         });
@@ -72,6 +79,7 @@ export function createDeployCommand(): Command {
           services,
           fresh: options.fresh,
           quiet: options.quiet,
+          migrateVolumes: options.migrateVolumes,
         });
       } catch (err) {
         logger.error(err instanceof Error ? err.message : String(err));

--- a/tools/cli/src/commands/deploy/index.ts
+++ b/tools/cli/src/commands/deploy/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/compose/types';
 import { ensureEnv } from '../../lib/config/ensure-env';
 import { requireProject } from '../../lib/project/find-project';
-import { resolveProjectContext } from '../../lib/project/project-context';
+import { resolveOrAssignProjectContext } from '../../lib/project/project-context';
 import { selectVersion } from '../../lib/registry/select-version';
 import { loadEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
@@ -37,7 +37,7 @@ export function createDeployCommand(): Command {
     .action(async (versionArg: string | undefined, options) => {
       try {
         const projectDir = requireProject();
-        await resolveProjectContext(projectDir);
+        await resolveOrAssignProjectContext(projectDir);
         const { success: envSetupSuccess } = await ensureEnv({
           deployDir: projectDir,
         });

--- a/tools/cli/src/commands/logs.ts
+++ b/tools/cli/src/commands/logs.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import { logs } from '../lib/actions/logs';
 import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import { loadEnv } from '../utils/load-env';
 import * as logger from '../utils/logger';
 
@@ -19,6 +20,7 @@ export function createLogsCommand(): Command {
     .action(async (service: string, options) => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const env = loadEnv(projectDir);
 
         if (

--- a/tools/cli/src/commands/reset.ts
+++ b/tools/cli/src/commands/reset.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { reset } from '../lib/actions/reset';
 import { ensureEnv } from '../lib/config/ensure-env';
 import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import { loadEnv } from '../utils/load-env';
 import * as logger from '../utils/logger';
 
@@ -15,6 +16,7 @@ export function createResetCommand(): Command {
     .action(async (options) => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const { success: envSetupSuccess } = await ensureEnv({
           deployDir: projectDir,
         });

--- a/tools/cli/src/commands/rollback.ts
+++ b/tools/cli/src/commands/rollback.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { rollback } from '../lib/actions/rollback';
 import { ensureEnv } from '../lib/config/ensure-env';
 import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import { loadEnv } from '../utils/load-env';
 import * as logger from '../utils/logger';
 
@@ -16,6 +17,7 @@ export function createRollbackCommand(): Command {
     .action(async (options) => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const { success: envSetupSuccess } = await ensureEnv({
           deployDir: projectDir,
         });

--- a/tools/cli/src/commands/status.ts
+++ b/tools/cli/src/commands/status.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import { status } from '../lib/actions/status';
 import { requireProject } from '../lib/project/find-project';
+import { resolveProjectContext } from '../lib/project/project-context';
 import { loadEnv } from '../utils/load-env';
 import * as logger from '../utils/logger';
 
@@ -11,6 +12,7 @@ export function createStatusCommand(): Command {
     .action(async () => {
       try {
         const projectDir = requireProject();
+        await resolveProjectContext(projectDir);
         const env = loadEnv(projectDir);
         await status({
           deployDir: env.DEPLOY_DIR,

--- a/tools/cli/src/lib/actions/cleanup.ts
+++ b/tools/cli/src/lib/actions/cleanup.ts
@@ -1,4 +1,4 @@
-import { PROJECT_NAME, type DeploymentEnv } from '../../utils/load-env';
+import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { ROTATABLE_SERVICES } from '../compose/types';
 import { containerExists } from '../docker/container-exists';
@@ -30,7 +30,7 @@ export async function cleanup(options: CleanupOptions): Promise<void> {
 
     let cleaned = 0;
     for (const service of ROTATABLE_SERVICES) {
-      const containerName = `${PROJECT_NAME}-${service}-${inactiveColor}`;
+      const containerName = `${getProjectId()}-${service}-${inactiveColor}`;
       const exists = await containerExists(containerName);
 
       if (exists) {

--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -95,8 +95,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
         Bun.spawnSync(['docker', 'stop', '-t', '2', name]);
         Bun.spawnSync(['docker', 'rm', '-f', name]);
         logger.info(`Stopped ${name}`);
-      } catch {
-        // best effort
+      } catch (err) {
+        // Best-effort cleanup: log so an operator can follow up manually.
+        logger.warn(
+          `Failed to clean up ${name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
     process.removeListener('SIGINT', onInterrupt);
@@ -123,7 +126,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
             'Volume migration pending. Run "tale deploy --migrate-volumes" to migrate and deploy (includes brief downtime of any legacy tale-* containers).',
           );
         }
-        if (!dryRun) {
+        if (dryRun) {
+          logger.notice(
+            `${prefix}Would stop legacy tale-* containers and migrate legacy volumes. Marker will NOT be cleared in dry-run — run without --dry-run to apply.`,
+          );
+        } else {
           logger.step('Stopping legacy Tale containers before migration...');
           // Stop both prod (tale / tale-blue / tale-green) and dev (tale-dev)
           // projects. Best-effort; non-existent projects fail harmlessly.
@@ -283,7 +290,9 @@ export async function deploy(options: DeployOptions): Promise<void> {
           if (!result.success) {
             logger.error('Failed to deploy stateful services');
             logger.error(result.stderr);
-            throw new Error('Stateful deployment failed');
+            throw new Error(
+              `Stateful deployment failed: ${result.stderr.trim().slice(0, 500) || 'no stderr captured'}`,
+            );
           }
 
           for (const service of statefulToUpdate) {

--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { PROJECT_NAME, type DeploymentEnv } from '../../utils/load-env';
+import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { generateColorCompose } from '../compose/generators/generate-color-compose';
 import { generateStatefulCompose } from '../compose/generators/generate-stateful-compose';
@@ -20,6 +20,11 @@ import { ensureVolumes } from '../docker/ensure-volumes';
 import { exec } from '../docker/exec';
 import { getContainerVersion } from '../docker/get-container-version';
 import { isContainerRunning } from '../docker/is-container-running';
+import {
+  clearMigrationPending,
+  hasPendingMigration,
+  migrateOldVolumes,
+} from '../docker/migrate-volumes';
 import { pullImage } from '../docker/pull-image';
 import { removeContainer } from '../docker/remove-container';
 import { stopContainer } from '../docker/stop-container';
@@ -44,9 +49,9 @@ async function ensureInfrastructure(
   logger.step(`${prefix}Ensuring volumes and network exist...`);
   if (dryRun) {
     for (const vol of REQUIRED_VOLUMES) {
-      logger.info(`${prefix}Would ensure volume: ${PROJECT_NAME}_${vol}`);
+      logger.info(`${prefix}Would ensure volume: ${getProjectId()}_${vol}`);
     }
-    logger.info(`${prefix}Would ensure network: ${PROJECT_NAME}_internal`);
+    logger.info(`${prefix}Would ensure network: ${getProjectId()}_internal`);
     return;
   }
 
@@ -69,6 +74,7 @@ interface DeployOptions {
   services?: ServiceName[];
   fresh?: boolean;
   quiet?: boolean;
+  migrateVolumes?: boolean;
 }
 
 export async function deploy(options: DeployOptions): Promise<void> {
@@ -108,6 +114,52 @@ export async function deploy(options: DeployOptions): Promise<void> {
       const prefix = dryRun ? '[DRY-RUN] ' : '';
       logger.header(`${prefix}Deploying Tale ${version}`);
 
+      // If a legacy-volume migration is pending, require explicit opt-in.
+      // Production deploys are zero-downtime; running migration here stops
+      // legacy containers briefly, so we want the user to acknowledge it.
+      if (hasPendingMigration(env.DEPLOY_DIR)) {
+        if (!options.migrateVolumes) {
+          throw new Error(
+            'Volume migration pending. Run "tale deploy --migrate-volumes" to migrate and deploy (includes brief downtime of any legacy tale-* containers).',
+          );
+        }
+        if (!dryRun) {
+          logger.step('Stopping legacy Tale containers before migration...');
+          // Stop both prod (tale / tale-blue / tale-green) and dev (tale-dev)
+          // projects. Best-effort; non-existent projects fail harmlessly.
+          for (const projectName of [
+            'tale',
+            'tale-blue',
+            'tale-green',
+            'tale-dev',
+          ]) {
+            await exec(
+              'docker',
+              ['compose', '-p', projectName, 'down', '--remove-orphans'],
+              { silent: true },
+            );
+          }
+
+          logger.step('Migrating legacy volumes...');
+          const result = await migrateOldVolumes(
+            getProjectId(),
+            env.DEPLOY_DIR,
+          );
+          if (result.deferred) {
+            throw new Error(
+              'Volume migration could not proceed — legacy containers may still be running.',
+            );
+          }
+          if (result.failed.length > 0) {
+            throw new Error(
+              `Volume migration failed for ${result.failed.length} volume(s). Aborting deploy.`,
+            );
+          }
+          await clearMigrationPending(env.DEPLOY_DIR);
+          logger.success('Volume migration complete.');
+        }
+      }
+
       // Check if this is a first-time deployment
       const currentColor = await getCurrentColor(env.DEPLOY_DIR);
       const isFirstDeploy = currentColor === null;
@@ -135,7 +187,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           // Check if any required stateful services are not running
           const missingStateful: StatefulService[] = [];
           for (const service of STATEFUL_SERVICES) {
-            const containerName = `${PROJECT_NAME}-${service}`;
+            const containerName = `${getProjectId()}-${service}`;
             const running = await isContainerRunning(containerName);
             if (!running) {
               missingStateful.push(service);
@@ -225,7 +277,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           const result = await dockerCompose(
             statefulCompose,
             ['up', '-d', ...statefulToUpdate],
-            { projectName: PROJECT_NAME, cwd: env.DEPLOY_DIR },
+            { projectName: getProjectId(), cwd: env.DEPLOY_DIR },
           );
 
           if (!result.success) {
@@ -235,12 +287,12 @@ export async function deploy(options: DeployOptions): Promise<void> {
           }
 
           for (const service of statefulToUpdate) {
-            startedContainers.push(`${PROJECT_NAME}-${service}`);
+            startedContainers.push(`${getProjectId()}-${service}`);
           }
 
           // Wait for stateful services to be healthy
           for (const service of statefulToUpdate) {
-            const containerName = `${PROJECT_NAME}-${service}`;
+            const containerName = `${getProjectId()}-${service}`;
             const healthy = await waitForHealthy(containerName, {
               timeout: env.HEALTH_CHECK_TIMEOUT,
               streamLogs,
@@ -267,7 +319,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           // Save current version as previous (for rollback)
           if (!dryRun) {
             const currentPlatformVersion = await getContainerVersion(
-              `${PROJECT_NAME}-platform-${currentColor}`,
+              `${getProjectId()}-platform-${currentColor}`,
             );
             if (currentPlatformVersion) {
               await setPreviousVersion(env.DEPLOY_DIR, currentPlatformVersion);
@@ -290,7 +342,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           if (dryRun) {
             for (const service of rotatableToUpdate) {
               logger.info(
-                `${prefix}Would update: ${PROJECT_NAME}-${service}-${currentColor}`,
+                `${prefix}Would update: ${getProjectId()}-${service}-${currentColor}`,
               );
             }
           } else {
@@ -301,14 +353,14 @@ export async function deploy(options: DeployOptions): Promise<void> {
               colorCompose,
               ['up', '-d', ...coloredServices],
               {
-                projectName: `${PROJECT_NAME}-${currentColor}`,
+                projectName: `${getProjectId()}-${currentColor}`,
                 cwd: env.DEPLOY_DIR,
               },
             );
 
             for (const service of rotatableToUpdate) {
               startedContainers.push(
-                `${PROJECT_NAME}-${service}-${currentColor}`,
+                `${getProjectId()}-${service}-${currentColor}`,
               );
             }
 
@@ -321,7 +373,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
             // Wait for services to be healthy
             logger.step('Waiting for services to be healthy...');
             for (const service of rotatableToUpdate) {
-              const containerName = `${PROJECT_NAME}-${service}-${currentColor}`;
+              const containerName = `${getProjectId()}-${service}-${currentColor}`;
               const healthy = await waitForHealthy(containerName, {
                 timeout: env.HEALTH_CHECK_TIMEOUT,
                 streamLogs,
@@ -346,7 +398,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           // Save current version as previous (for rollback)
           if (currentColor && !dryRun) {
             const currentPlatformVersion = await getContainerVersion(
-              `${PROJECT_NAME}-platform-${currentColor}`,
+              `${getProjectId()}-platform-${currentColor}`,
             );
             if (currentPlatformVersion) {
               await setPreviousVersion(env.DEPLOY_DIR, currentPlatformVersion);
@@ -365,10 +417,10 @@ export async function deploy(options: DeployOptions): Promise<void> {
           if (dryRun) {
             for (const service of rotatableToUpdate) {
               logger.info(
-                `${prefix}Would clean up stale: ${PROJECT_NAME}-${service}-${nextColor}`,
+                `${prefix}Would clean up stale: ${getProjectId()}-${service}-${nextColor}`,
               );
               logger.info(
-                `${prefix}Would deploy: ${PROJECT_NAME}-${service}-${nextColor}`,
+                `${prefix}Would deploy: ${getProjectId()}-${service}-${nextColor}`,
               );
             }
             logger.step(`${prefix}Would switch traffic to ${nextColor}`);
@@ -378,14 +430,14 @@ export async function deploy(options: DeployOptions): Promise<void> {
               );
               for (const service of rotatableToUpdate) {
                 logger.info(
-                  `${prefix}Would stop/remove: ${PROJECT_NAME}-${service}-${currentColor}`,
+                  `${prefix}Would stop/remove: ${getProjectId()}-${service}-${currentColor}`,
                 );
               }
             }
           } else {
             // Clean up any stale next-color containers from a previous failed deployment
             for (const service of rotatableToUpdate) {
-              const containerName = `${PROJECT_NAME}-${service}-${nextColor}`;
+              const containerName = `${getProjectId()}-${service}-${nextColor}`;
               const stopped = await stopContainer(containerName);
               if (stopped) {
                 await removeContainer(containerName);
@@ -399,13 +451,15 @@ export async function deploy(options: DeployOptions): Promise<void> {
               colorCompose,
               ['up', '-d', ...coloredServices],
               {
-                projectName: `${PROJECT_NAME}-${nextColor}`,
+                projectName: `${getProjectId()}-${nextColor}`,
                 cwd: env.DEPLOY_DIR,
               },
             );
 
             for (const service of rotatableToUpdate) {
-              startedContainers.push(`${PROJECT_NAME}-${service}-${nextColor}`);
+              startedContainers.push(
+                `${getProjectId()}-${service}-${nextColor}`,
+              );
             }
 
             if (!deployResult.success) {
@@ -417,7 +471,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
             // Wait for new services to be healthy
             logger.step('Waiting for services to be healthy...');
             for (const service of rotatableToUpdate) {
-              const containerName = `${PROJECT_NAME}-${service}-${nextColor}`;
+              const containerName = `${getProjectId()}-${service}-${nextColor}`;
               const healthy = await waitForHealthy(containerName, {
                 timeout: env.HEALTH_CHECK_TIMEOUT,
                 streamLogs,
@@ -445,7 +499,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
               // Stop and remove old color containers (non-fatal - traffic already switched)
               logger.step(`Stopping ${currentColor} services...`);
               for (const service of rotatableToUpdate) {
-                const containerName = `${PROJECT_NAME}-${service}-${currentColor}`;
+                const containerName = `${getProjectId()}-${service}-${currentColor}`;
                 const stopped = await stopContainer(containerName);
                 if (!stopped) {
                   logger.warn(`Failed to stop ${containerName}, continuing...`);
@@ -480,7 +534,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       // Sync project files to the active container
       if (activeColor) {
         await syncProjectFiles(
-          `${PROJECT_NAME}-platform-${activeColor}`,
+          `${getProjectId()}-platform-${activeColor}`,
           env.DEPLOY_DIR,
           dryRun,
           prefix,

--- a/tools/cli/src/lib/actions/init.ts
+++ b/tools/cli/src/lib/actions/init.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 
 import pkg from '../../../package.json';
 import * as logger from '../../utils/logger';
@@ -9,7 +9,14 @@ import {
   fetchReference,
   getEmbeddedExamples,
 } from '../project/fetch-reference';
-import { CURRENT_PROJECT_VERSION, type Checksums } from '../project/types';
+import { generateProjectId } from '../project/generate-project-id';
+import { setProjectId } from '../project/project-context';
+import { readProject } from '../project/read-project';
+import {
+  CURRENT_PROJECT_VERSION,
+  type Checksums,
+  type TaleProject,
+} from '../project/types';
 import { generateAllRules } from '../rules/generators';
 
 interface InitOptions {
@@ -18,7 +25,13 @@ interface InitOptions {
   noEnv?: boolean;
 }
 
-const GITIGNORE_ENTRIES = ['.tale/', '.env', '.history/'];
+const GITIGNORE_ENTRIES = [
+  '.tale/',
+  '.env',
+  '.history/',
+  'compose.override.yml',
+  'compose.override.yaml',
+];
 
 export async function init(options: InitOptions): Promise<void> {
   let directory = options.directory;
@@ -170,14 +183,28 @@ export async function init(options: InitOptions): Promise<void> {
   };
   await writeChecksums(target, checksums);
 
-  // Write tale.json
+  // Write tale.json. On reinit, preserve the existing project id and
+  // createdAt so Docker volumes/containers keyed on the id remain valid.
   logger.step('Writing tale.json...');
-  const project = {
+  let existingProject: TaleProject | null = null;
+  if (existsSync(taleJsonPath)) {
+    try {
+      existingProject = await readProject(target);
+    } catch (err) {
+      logger.debug(`Could not read existing tale.json: ${err}`);
+    }
+  }
+  const projectId = existingProject?.id ?? generateProjectId(basename(target));
+  const project: TaleProject = {
     version: CURRENT_PROJECT_VERSION,
     cliVersion: pkg.version,
-    createdAt: new Date().toISOString(),
+    createdAt: existingProject?.createdAt ?? new Date().toISOString(),
+    id: projectId,
   };
   await Bun.write(taleJsonPath, JSON.stringify(project, null, 2) + '\n');
+
+  // Make the ID available to subsequent steps (ensureEnv uses getProjectId()).
+  setProjectId(projectId);
 
   // Write AI rules files
   logger.step('Writing AI rules files...');

--- a/tools/cli/src/lib/actions/init.ts
+++ b/tools/cli/src/lib/actions/init.ts
@@ -17,6 +17,7 @@ import {
   type Checksums,
   type TaleProject,
 } from '../project/types';
+import { writeProject } from '../project/write-project';
 import { generateAllRules } from '../rules/generators';
 
 interface InitOptions {
@@ -201,7 +202,7 @@ export async function init(options: InitOptions): Promise<void> {
     createdAt: existingProject?.createdAt ?? new Date().toISOString(),
     id: projectId,
   };
-  await Bun.write(taleJsonPath, JSON.stringify(project, null, 2) + '\n');
+  await writeProject(taleJsonPath, project);
 
   // Make the ID available to subsequent steps (ensureEnv uses getProjectId()).
   setProjectId(projectId);

--- a/tools/cli/src/lib/actions/logs.ts
+++ b/tools/cli/src/lib/actions/logs.ts
@@ -1,5 +1,5 @@
 import { isUserInterrupt } from '../../utils/exit-codes';
-import { PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import type { DeploymentColor } from '../compose/types';
 import {
@@ -50,7 +50,7 @@ export async function logs(options: LogsOptions): Promise<void> {
       logger.info(`Auto-detected active color: ${targetColor}`);
     }
 
-    containerName = `${PROJECT_NAME}-${service}-${targetColor}`;
+    containerName = `${getProjectId()}-${service}-${targetColor}`;
   } else {
     // Stateful services don't have colors
     if (color) {
@@ -58,7 +58,7 @@ export async function logs(options: LogsOptions): Promise<void> {
         `Ignoring --color for stateful service ${service} (stateful services don't use blue/green)`,
       );
     }
-    containerName = `${PROJECT_NAME}-${service}`;
+    containerName = `${getProjectId()}-${service}`;
   }
 
   // Check if container exists (docker logs works for both running and stopped containers)

--- a/tools/cli/src/lib/actions/reset.ts
+++ b/tools/cli/src/lib/actions/reset.ts
@@ -102,6 +102,32 @@ export async function reset(options: ResetOptions): Promise<void> {
       );
     }
 
+    // Only prune volumes when the user explicitly asked to include stateful
+    // services — volume data is not recoverable. `includeStateful` is the
+    // `--all` flag, which is the same consent boundary used for removing
+    // db/proxy containers above.
+    if (includeStateful) {
+      logger.step(`${prefix}Pruning unused Docker volumes...`);
+      if (!dryRun) {
+        const result = await docker(
+          'volume',
+          'prune',
+          '-f',
+          '--filter',
+          `label=project=${getProjectId()}`,
+        );
+        if (!result.success) {
+          logger.warn(
+            `Failed to prune project volumes: ${result.stderr.trim()}`,
+          );
+        }
+      } else {
+        logger.info(
+          `${prefix}Would prune unused Docker volumes for project ${getProjectId()}`,
+        );
+      }
+    }
+
     if (dryRun) {
       logger.success(
         `${prefix}Dry-run complete! Would remove all blue-green containers`,

--- a/tools/cli/src/lib/actions/reset.ts
+++ b/tools/cli/src/lib/actions/reset.ts
@@ -1,7 +1,7 @@
 import { unlink } from 'node:fs/promises';
 
 import { confirm } from '../../utils/confirm';
-import { PROJECT_NAME, type DeploymentEnv } from '../../utils/load-env';
+import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import type { DeploymentColor } from '../compose/types';
 import { ROTATABLE_SERVICES, STATEFUL_SERVICES } from '../compose/types';
@@ -42,7 +42,7 @@ export async function reset(options: ResetOptions): Promise<void> {
     for (const color of ['blue', 'green'] as DeploymentColor[]) {
       logger.step(`${prefix}Removing ${color} containers...`);
       for (const service of ROTATABLE_SERVICES) {
-        const containerName = `${PROJECT_NAME}-${service}-${color}`;
+        const containerName = `${getProjectId()}-${service}-${color}`;
         if (dryRun) {
           logger.info(`${prefix}Would remove: ${containerName}`);
         } else {
@@ -55,7 +55,7 @@ export async function reset(options: ResetOptions): Promise<void> {
     if (includeStateful) {
       logger.step(`${prefix}Removing stateful containers...`);
       for (const service of STATEFUL_SERVICES) {
-        const containerName = `${PROJECT_NAME}-${service}`;
+        const containerName = `${getProjectId()}-${service}`;
         if (dryRun) {
           logger.info(`${prefix}Would remove: ${containerName}`);
         } else {
@@ -94,11 +94,11 @@ export async function reset(options: ResetOptions): Promise<void> {
         'prune',
         '-f',
         '--filter',
-        `label=project=${PROJECT_NAME}`,
+        `label=project=${getProjectId()}`,
       );
     } else {
       logger.info(
-        `${prefix}Would prune unused Docker networks for project ${PROJECT_NAME}`,
+        `${prefix}Would prune unused Docker networks for project ${getProjectId()}`,
       );
     }
 

--- a/tools/cli/src/lib/actions/rollback.ts
+++ b/tools/cli/src/lib/actions/rollback.ts
@@ -1,4 +1,4 @@
-import { PROJECT_NAME, type DeploymentEnv } from '../../utils/load-env';
+import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { generateColorCompose } from '../compose/generators/generate-color-compose';
 import { ROTATABLE_SERVICES } from '../compose/types';
@@ -52,7 +52,7 @@ export async function rollback(options: RollbackOptions): Promise<void> {
 
     // Get current version before rollback (for version history)
     const currentVersion = await getContainerVersion(
-      `${PROJECT_NAME}-platform-${currentColor}`,
+      `${getProjectId()}-platform-${currentColor}`,
     );
 
     logger.info(`Current color: ${currentColor}`);
@@ -83,7 +83,7 @@ export async function rollback(options: RollbackOptions): Promise<void> {
     const colorCompose = generateColorCompose(serviceConfig, rollbackColor);
 
     const deployResult = await dockerCompose(colorCompose, ['up', '-d'], {
-      projectName: `${PROJECT_NAME}-${rollbackColor}`,
+      projectName: `${getProjectId()}-${rollbackColor}`,
       cwd: env.DEPLOY_DIR,
     });
 
@@ -96,7 +96,7 @@ export async function rollback(options: RollbackOptions): Promise<void> {
     // Wait for services to be healthy
     logger.step('Waiting for services to be healthy...');
     for (const service of ROTATABLE_SERVICES) {
-      const containerName = `${PROJECT_NAME}-${service}-${rollbackColor}`;
+      const containerName = `${getProjectId()}-${service}-${rollbackColor}`;
       const healthy = await waitForHealthy(containerName, {
         timeout: env.HEALTH_CHECK_TIMEOUT,
       });
@@ -122,7 +122,7 @@ export async function rollback(options: RollbackOptions): Promise<void> {
     // Stop and remove current color containers
     logger.step(`Stopping ${currentColor} services...`);
     for (const service of ROTATABLE_SERVICES) {
-      const containerName = `${PROJECT_NAME}-${service}-${currentColor}`;
+      const containerName = `${getProjectId()}-${service}-${currentColor}`;
       const stopped = await stopContainer(containerName);
       if (!stopped) {
         logger.warn(`Failed to stop ${containerName}`);

--- a/tools/cli/src/lib/actions/rollback.ts
+++ b/tools/cli/src/lib/actions/rollback.ts
@@ -76,6 +76,17 @@ export async function rollback(options: RollbackOptions): Promise<void> {
       }
     }
 
+    // Clean up any stale containers from a previous failed rollback on this
+    // color. Without this, `docker compose up -d` will silently restart the
+    // existing container (possibly with different/old config) and report
+    // success. Deploy does the same cleanup; mirror it here.
+    logger.step(`Cleaning up any stale ${rollbackColor} containers...`);
+    for (const service of ROTATABLE_SERVICES) {
+      const containerName = `${getProjectId()}-${service}-${rollbackColor}`;
+      await stopContainer(containerName);
+      await removeContainer(containerName);
+    }
+
     // Deploy rollback color
     logger.step(
       `Deploying ${rollbackColor} services with version ${rollbackVersion}...`,

--- a/tools/cli/src/lib/actions/start.ts
+++ b/tools/cli/src/lib/actions/start.ts
@@ -3,13 +3,20 @@ import { join } from 'node:path';
 
 import pkg from '../../../package.json';
 import { isUserInterrupt } from '../../utils/exit-codes';
-import { loadEnv, PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId, loadEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { StatusHeader, isHealthCheckLog } from '../../utils/terminal';
+import { findComposeOverride } from '../compose/find-compose-override';
 import { generateDevCompose } from '../compose/generators/generate-dev-compose';
 import { dockerCompose } from '../docker/docker-compose';
 import { exec } from '../docker/exec';
+import {
+  clearMigrationPending,
+  hasPendingMigration,
+  migrateOldVolumes,
+} from '../docker/migrate-volumes';
 import { findProject } from '../project/find-project';
+import { resolveProjectContext } from '../project/project-context';
 import { init } from './init';
 
 async function assertDockerAvailable(): Promise<void> {
@@ -89,7 +96,7 @@ async function waitForHealthAndOpenBrowser(
     await Bun.sleep(1000);
   }
   logger.warn(
-    `Services did not become healthy within ${maxAttempts}s. Check logs: docker compose -p ${PROJECT_NAME}-dev logs`,
+    `Services did not become healthy within ${maxAttempts}s. Check logs: docker compose -p ${getProjectId()}-dev logs`,
   );
   return false;
 }
@@ -135,6 +142,37 @@ export async function start(options: StartOptions): Promise<void> {
 
   await assertDockerAvailable();
 
+  // Resolve project ID from tale.json before any Docker-resource naming
+  await resolveProjectContext(projectDir);
+
+  // Run any pending legacy-volume migration. The marker is written by
+  // `tale upgrade` when it can't migrate safely (e.g. legacy containers were
+  // running at upgrade time).
+  if (hasPendingMigration(projectDir)) {
+    logger.step('Running pending volume migration from legacy project...');
+    // Stop any still-running legacy dev containers before copying volumes.
+    // (We're about to bring up new containers anyway.) Best-effort — if the
+    // legacy compose project doesn't exist, `down` exits non-zero harmlessly.
+    await exec(
+      'docker',
+      ['compose', '-p', 'tale-dev', 'down', '--remove-orphans'],
+      { silent: true },
+    );
+    const result = await migrateOldVolumes(getProjectId(), projectDir);
+    if (result.deferred) {
+      throw new Error(
+        'Volume migration could not proceed. Check Docker availability and stop any running legacy Tale containers.',
+      );
+    }
+    if (result.failed.length > 0) {
+      throw new Error(
+        `Volume migration failed for ${result.failed.length} volume(s). Aborting to avoid starting with inconsistent state.`,
+      );
+    }
+    await clearMigrationPending(projectDir);
+    logger.success('Volume migration complete.');
+  }
+
   const env = loadEnv(projectDir);
   const version = pkg.version.includes('-dev') ? 'latest' : pkg.version;
   const port = options.port ?? 443;
@@ -148,6 +186,11 @@ export async function start(options: StartOptions): Promise<void> {
     port,
     { fresh: options.fresh },
   );
+
+  const overrideFile = findComposeOverride(projectDir);
+  if (overrideFile) {
+    logger.info(`Using compose override: compose.override.yml`);
+  }
 
   const args = ['up', ...(options.detach ? ['-d'] : [])];
 
@@ -166,9 +209,10 @@ export async function start(options: StartOptions): Promise<void> {
     logger.step('Starting services...');
 
     const result = await dockerCompose(compose, args, {
-      projectName: `${PROJECT_NAME}-dev`,
+      projectName: `${getProjectId()}-dev`,
       cwd: projectDir,
       inherit: true,
+      overrideFile: overrideFile ?? undefined,
     });
 
     if (!result.success) {
@@ -187,7 +231,7 @@ export async function start(options: StartOptions): Promise<void> {
     } else {
       logger.warn(
         'Tale is running but services may not be ready yet. Check logs: docker compose -p ' +
-          `${PROJECT_NAME}-dev logs`,
+          `${getProjectId()}-dev logs`,
       );
     }
     logger.blank();
@@ -198,7 +242,7 @@ export async function start(options: StartOptions): Promise<void> {
       'Edits to agents/, workflows/, integrations/, and branding/ will auto-refresh the browser.',
     );
     logger.blank();
-    logger.info(`Stop with: docker compose -p ${PROJECT_NAME}-dev down`);
+    logger.info(`Stop with: docker compose -p ${getProjectId()}-dev down`);
     return;
   }
 
@@ -212,8 +256,9 @@ export async function start(options: StartOptions): Promise<void> {
   const capturedUrls: Record<string, string> = {};
 
   const result = await dockerCompose(compose, args, {
-    projectName: `${PROJECT_NAME}-dev`,
+    projectName: `${getProjectId()}-dev`,
     cwd: projectDir,
+    overrideFile: overrideFile ?? undefined,
     onLine(line) {
       // Filter health check logs
       if (isHealthCheckLog(line)) return;

--- a/tools/cli/src/lib/actions/start.ts
+++ b/tools/cli/src/lib/actions/start.ts
@@ -7,8 +7,11 @@ import { getProjectId, loadEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { StatusHeader, isHealthCheckLog } from '../../utils/terminal';
 import { findComposeOverride } from '../compose/find-compose-override';
+import { DEV_VOLUME_NAMES } from '../compose/generators/constants';
 import { generateDevCompose } from '../compose/generators/generate-dev-compose';
 import { dockerCompose } from '../docker/docker-compose';
+import { ensureNetwork } from '../docker/ensure-network';
+import { ensureVolumes } from '../docker/ensure-volumes';
 import { exec } from '../docker/exec';
 import {
   clearMigrationPending,
@@ -16,7 +19,7 @@ import {
   migrateOldVolumes,
 } from '../docker/migrate-volumes';
 import { findProject } from '../project/find-project';
-import { resolveProjectContext } from '../project/project-context';
+import { resolveOrAssignProjectContext } from '../project/project-context';
 import { init } from './init';
 
 async function assertDockerAvailable(): Promise<void> {
@@ -65,8 +68,12 @@ async function openBrowser(url: string): Promise<void> {
       });
       const exitCode = await proc.exited;
       if (exitCode === 0) return;
-    } catch {
-      // Command not found, try next
+    } catch (err) {
+      // Command not found (ENOENT) is expected as we try each opener in turn;
+      // other errors are worth noting at debug level.
+      logger.debug(
+        `Browser opener ${cmd[0]} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
   logger.warn(`Could not open browser automatically. Visit: ${url}`);
@@ -90,8 +97,13 @@ async function waitForHealthAndOpenBrowser(
         await openBrowser(url);
         return true;
       }
-    } catch {
+    } catch (err) {
       if (signal?.aborted) return false;
+      // Expected during startup (connection refused / timeout); log at debug
+      // level so it's available when diagnosing health-check issues.
+      logger.debug(
+        `Health check attempt ${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     await Bun.sleep(1000);
   }
@@ -142,8 +154,10 @@ export async function start(options: StartOptions): Promise<void> {
 
   await assertDockerAvailable();
 
-  // Resolve project ID from tale.json before any Docker-resource naming
-  await resolveProjectContext(projectDir);
+  // Resolve project ID from tale.json before any Docker-resource naming.
+  // Auto-assign an ID for legacy projects so users don't have to run
+  // `tale upgrade` as a separate step before `tale start` works.
+  await resolveOrAssignProjectContext(projectDir);
 
   // Run any pending legacy-volume migration. The marker is written by
   // `tale upgrade` when it can't migrate safely (e.g. legacy containers were
@@ -171,6 +185,19 @@ export async function start(options: StartOptions): Promise<void> {
     }
     await clearMigrationPending(projectDir);
     logger.success('Volume migration complete.');
+  }
+
+  // Pre-create dev volumes and network with explicit project-scoped names.
+  // The dev compose file references them as external, so they must exist
+  // before `docker compose up`.
+  const devPrefix = `${getProjectId()}-dev_`;
+  const volumesOk = await ensureVolumes([...DEV_VOLUME_NAMES], devPrefix);
+  if (!volumesOk) {
+    throw new Error('Failed to create dev volumes');
+  }
+  const networkOk = await ensureNetwork('internal', devPrefix);
+  if (!networkOk) {
+    throw new Error('Failed to create dev network');
   }
 
   const env = loadEnv(projectDir);

--- a/tools/cli/src/lib/actions/status.ts
+++ b/tools/cli/src/lib/actions/status.ts
@@ -1,4 +1,4 @@
-import { PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import {
   type DeploymentColor,
@@ -93,7 +93,7 @@ export async function status(options: StatusOptions): Promise<void> {
   logger.step('Stateful Services:');
   const statefulResults = await Promise.all(
     STATEFUL_SERVICES.map(async (service) => {
-      const containerName = `${PROJECT_NAME}-${service}`;
+      const containerName = `${getProjectId()}-${service}`;
       const info = await getContainerStatus(containerName);
       return Object.assign({ service }, info);
     }),
@@ -117,7 +117,7 @@ export async function status(options: StatusOptions): Promise<void> {
 
     const rotatableResults = await Promise.all(
       ROTATABLE_SERVICES.map(async (service) => {
-        const containerName = `${PROJECT_NAME}-${service}-${color}`;
+        const containerName = `${getProjectId()}-${service}-${color}`;
         const info = await getContainerStatus(containerName);
         return Object.assign({ service }, info);
       }),
@@ -148,7 +148,7 @@ export async function status(options: StatusOptions): Promise<void> {
   }
 
   // Show all tale containers for reference
-  const containers = await listContainers(`name=${PROJECT_NAME}`);
+  const containers = await listContainers(`name=${getProjectId()}`);
   if (containers.length > 0) {
     logger.step('All Containers:');
     for (const container of containers) {

--- a/tools/cli/src/lib/actions/update.ts
+++ b/tools/cli/src/lib/actions/update.ts
@@ -20,6 +20,7 @@ import { generateProjectId } from '../project/generate-project-id';
 import { setProjectId } from '../project/project-context';
 import { readProject } from '../project/read-project';
 import type { Checksums } from '../project/types';
+import { writeProject } from '../project/write-project';
 import { generateAllRules } from '../rules/generators';
 
 interface UpdateOptions {
@@ -60,10 +61,7 @@ export async function update(options: UpdateOptions): Promise<void> {
     assignedId = generateProjectId(basename(projectDir));
     project.id = assignedId;
     if (!options.dryRun) {
-      await Bun.write(
-        join(projectDir, 'tale.json'),
-        JSON.stringify(project, null, 2) + '\n',
-      );
+      await writeProject(join(projectDir, 'tale.json'), project);
       setProjectId(assignedId);
     }
     logger.blank();
@@ -178,10 +176,7 @@ export async function update(options: UpdateOptions): Promise<void> {
       ...project,
       cliVersion: pkg.version,
     };
-    await Bun.write(
-      join(projectDir, 'tale.json'),
-      JSON.stringify(updatedProject, null, 2) + '\n',
-    );
+    await writeProject(join(projectDir, 'tale.json'), updatedProject);
 
     const checksums: Checksums = {
       cliVersion: pkg.version,

--- a/tools/cli/src/lib/actions/update.ts
+++ b/tools/cli/src/lib/actions/update.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import pkg from '../../../package.json';
 import * as logger from '../../utils/logger';
+import { migrateOldVolumes } from '../docker/migrate-volumes';
 import {
   computeContentHash,
   computeFileHash,
@@ -15,6 +16,8 @@ import {
   getEmbeddedExamples,
 } from '../project/fetch-reference';
 import { findProject } from '../project/find-project';
+import { generateProjectId } from '../project/generate-project-id';
+import { setProjectId } from '../project/project-context';
 import { readProject } from '../project/read-project';
 import type { Checksums } from '../project/types';
 import { generateAllRules } from '../rules/generators';
@@ -47,6 +50,25 @@ export async function update(options: UpdateOptions): Promise<void> {
 
   logger.info(`Current version: ${project.cliVersion}`);
   logger.info(`Target version:  ${pkg.version}`);
+
+  // Legacy projects (pre-ID) get an ID auto-assigned here. We also attempt
+  // volume migration immediately, but the migration function itself defers
+  // (via a marker file) if any legacy containers are running, so production
+  // deployments are never impacted by `tale upgrade`.
+  let assignedId: string | undefined;
+  if (!project.id) {
+    assignedId = generateProjectId(basename(projectDir));
+    project.id = assignedId;
+    if (!options.dryRun) {
+      await Bun.write(
+        join(projectDir, 'tale.json'),
+        JSON.stringify(project, null, 2) + '\n',
+      );
+      setProjectId(assignedId);
+    }
+    logger.blank();
+    logger.info(`Assigned project ID: ${assignedId}`);
+  }
 
   // Update reference code
   logger.step(`${prefix}Updating reference code...`);
@@ -183,5 +205,26 @@ export async function update(options: UpdateOptions): Promise<void> {
     logger.info(
       'Skipped files can be compared against .tale/reference/examples/ to merge changes.',
     );
+  }
+
+  // Attempt to migrate legacy Docker volumes for newly-assigned IDs.
+  // This is safe — the migration function defers if any legacy containers are
+  // running, so production deployments remain untouched by `tale upgrade`.
+  if (assignedId && !options.dryRun) {
+    logger.blank();
+    const result = await migrateOldVolumes(assignedId, projectDir);
+    if (result.deferred) {
+      // Message already logged by migrateOldVolumes
+    } else if (
+      result.migrated.length === 0 &&
+      result.failed.length === 0 &&
+      result.skipped.length === 0
+    ) {
+      // No legacy volumes existed; silent
+    } else {
+      logger.success(
+        `Volume migration: ${result.migrated.length} migrated, ${result.skipped.length} skipped, ${result.failed.length} failed`,
+      );
+    }
   }
 }

--- a/tools/cli/src/lib/compose/find-compose-override.ts
+++ b/tools/cli/src/lib/compose/find-compose-override.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import * as logger from '../../utils/logger';
+
+/**
+ * Check the project directory for a Docker Compose override file.
+ *
+ * Users can drop `compose.override.yml` (or `.yaml`) in their project root
+ * to customize the generated compose config. This is currently dev-only
+ * (tale start) — prod deploys ignore it because service names differ.
+ *
+ * Returns the absolute path to the override file, or null if none exists.
+ * When both extensions are present, prefers `.yml` and warns about the ignored `.yaml`.
+ */
+export function findComposeOverride(projectDir: string): string | null {
+  const ymlPath = join(projectDir, 'compose.override.yml');
+  const yamlPath = join(projectDir, 'compose.override.yaml');
+  const ymlExists = existsSync(ymlPath);
+  const yamlExists = existsSync(yamlPath);
+
+  if (ymlExists && yamlExists) {
+    logger.warn(
+      'Both compose.override.yml and compose.override.yaml exist. Using .yml and ignoring .yaml.',
+    );
+    return ymlPath;
+  }
+  if (ymlExists) return ymlPath;
+  if (yamlExists) return yamlPath;
+  return null;
+}

--- a/tools/cli/src/lib/compose/generators/constants.ts
+++ b/tools/cli/src/lib/compose/generators/constants.ts
@@ -11,3 +11,9 @@ export const VOLUMES = {
 export const NETWORKS = {
   internal: { driver: 'bridge' },
 };
+
+// Enables containers to reach host services (e.g. Ollama on localhost:11434)
+// via `host.docker.internal`. `host-gateway` requires Docker 20.10+ (project
+// already requires 24.0+). Safe on Docker Desktop where host.docker.internal
+// is built-in.
+export const EXTRA_HOSTS = ['host.docker.internal:host-gateway'];

--- a/tools/cli/src/lib/compose/generators/constants.ts
+++ b/tools/cli/src/lib/compose/generators/constants.ts
@@ -1,16 +1,15 @@
-export const VOLUMES = {
-  'db-data': { driver: 'local' },
-  'db-backup': { driver: 'local' },
-  'rag-data': { driver: 'local' },
-  'platform-data': { driver: 'local' },
-  'caddy-data': { driver: 'local' },
-  'caddy-config': { driver: 'local' },
-  'crawler-data': { driver: 'local' },
-};
-
-export const NETWORKS = {
-  internal: { driver: 'bridge' },
-};
+// Logical volume names used in dev compose. Kept as an explicit list so
+// start.ts can pre-create externally-scoped volumes before `docker compose up`
+// and the compose file can reference them as `external: true`.
+export const DEV_VOLUME_NAMES = [
+  'db-data',
+  'db-backup',
+  'rag-data',
+  'platform-data',
+  'caddy-data',
+  'caddy-config',
+  'crawler-data',
+] as const;
 
 // Enables containers to reach host services (e.g. Ollama on localhost:11434)
 // via `host.docker.internal`. `host-gateway` requires Docker 20.10+ (project

--- a/tools/cli/src/lib/compose/generators/generate-color-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-color-compose.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'yaml';
 
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
 import { createCrawlerService } from '../services/create-crawler-service';
 import { createPlatformService } from '../services/create-platform-service';
 import { createRagService } from '../services/create-rag-service';
@@ -32,25 +32,25 @@ export function generateColorCompose(
     volumes: {
       'platform-data': {
         external: true,
-        name: `${PROJECT_NAME}_platform-data`,
+        name: `${getProjectId()}_platform-data`,
       },
       'caddy-data': {
         external: true,
-        name: `${PROJECT_NAME}_caddy-data`,
+        name: `${getProjectId()}_caddy-data`,
       },
       'rag-data': {
         external: true,
-        name: `${PROJECT_NAME}_rag-data`,
+        name: `${getProjectId()}_rag-data`,
       },
       'crawler-data': {
         external: true,
-        name: `${PROJECT_NAME}_crawler-data`,
+        name: `${getProjectId()}_crawler-data`,
       },
     },
     networks: {
       internal: {
         external: true,
-        name: `${PROJECT_NAME}_internal`,
+        name: `${getProjectId()}_internal`,
       },
     },
   };

--- a/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'yaml';
 
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
 import { createCrawlerService } from '../services/create-crawler-service';
 import { createDbService } from '../services/create-db-service';
 import { createPlatformService } from '../services/create-platform-service';
@@ -22,7 +22,7 @@ export function generateDevCompose(
   options: DevComposeOptions = {},
 ): string {
   const platform = createPlatformService(config, DEV_COLOR);
-  platform.container_name = `${PROJECT_NAME}-platform`;
+  platform.container_name = `${getProjectId()}-platform`;
   platform.volumes = [
     'platform-data:/app/data',
     './agents:/app/data/agents',
@@ -42,7 +42,7 @@ export function generateDevCompose(
   platform.depends_on = { db: { condition: 'service_healthy' } };
 
   const rag = createRagService(config, DEV_COLOR);
-  rag.container_name = `${PROJECT_NAME}-rag`;
+  rag.container_name = `${getProjectId()}-rag`;
   rag.depends_on = { db: { condition: 'service_healthy' } };
   rag.volumes = [
     'rag-data:/app/data',
@@ -50,7 +50,7 @@ export function generateDevCompose(
   ];
 
   const crawler = createCrawlerService(config, DEV_COLOR);
-  crawler.container_name = `${PROJECT_NAME}-crawler`;
+  crawler.container_name = `${getProjectId()}-crawler`;
   crawler.volumes = [
     'crawler-data:/app/data',
     './providers:/app/platform-config/providers:ro',

--- a/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
@@ -7,7 +7,7 @@ import { createPlatformService } from '../services/create-platform-service';
 import { createProxyService } from '../services/create-proxy-service';
 import { createRagService } from '../services/create-rag-service';
 import type { ComposeConfig, ServiceConfig } from '../types';
-import { NETWORKS, VOLUMES } from './constants';
+import { DEV_VOLUME_NAMES } from './constants';
 
 const DEV_COLOR = 'blue' as const;
 
@@ -59,6 +59,17 @@ export function generateDevCompose(
   const proxy = createProxyService(config, hostAlias);
   proxy.ports = [`${port}:443`];
 
+  // Scope dev volumes/networks explicitly via `external: true` + `name:`.
+  // Dev volumes live under the `${projectId}-dev_` prefix (matching the
+  // `-p ${projectId}-dev` passed to docker compose). They are pre-created by
+  // `ensureVolumes` / `ensureNetwork` in start.ts so the compose-level
+  // reference is valid even if someone runs `docker compose` by hand.
+  const devPrefix = `${getProjectId()}-dev_`;
+  const volumes: Record<string, { external: true; name: string }> = {};
+  for (const name of DEV_VOLUME_NAMES) {
+    volumes[name] = { external: true, name: `${devPrefix}${name}` };
+  }
+
   const compose: ComposeConfig = {
     services: {
       db: createDbService(config),
@@ -67,8 +78,13 @@ export function generateDevCompose(
       rag,
       crawler,
     },
-    volumes: VOLUMES,
-    networks: NETWORKS,
+    volumes,
+    networks: {
+      internal: {
+        external: true,
+        name: `${devPrefix}internal`,
+      },
+    },
   };
 
   return stringify(compose);

--- a/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
@@ -1,21 +1,29 @@
 import { stringify } from 'yaml';
 
+import { getProjectId } from '../../../utils/load-env';
 import { createDbService } from '../services/create-db-service';
 import { createProxyService } from '../services/create-proxy-service';
 import type { ComposeConfig, ServiceConfig } from '../types';
-import { NETWORKS, VOLUMES } from './constants';
 
 export function generateStatefulCompose(
   config: ServiceConfig,
   hostAlias: string,
 ): string {
+  const prefix = `${getProjectId()}_`;
   const compose: ComposeConfig = {
     services: {
       db: createDbService(config),
       proxy: createProxyService(config, hostAlias),
     },
-    volumes: VOLUMES,
-    networks: NETWORKS,
+    volumes: {
+      'db-data': { external: true, name: `${prefix}db-data` },
+      'db-backup': { external: true, name: `${prefix}db-backup` },
+      'caddy-data': { external: true, name: `${prefix}caddy-data` },
+      'caddy-config': { external: true, name: `${prefix}caddy-config` },
+    },
+    networks: {
+      internal: { external: true, name: `${prefix}internal` },
+    },
   };
 
   return stringify(compose);

--- a/tools/cli/src/lib/compose/services/create-crawler-service.ts
+++ b/tools/cli/src/lib/compose/services/create-crawler-service.ts
@@ -1,4 +1,5 @@
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
+import { EXTRA_HOSTS } from '../generators/constants';
 import type { ComposeService, DeploymentColor, ServiceConfig } from '../types';
 import { DEFAULT_LOGGING } from '../types';
 
@@ -8,7 +9,7 @@ export function createCrawlerService(
 ): ComposeService {
   return {
     image: `${config.registry}/tale-crawler:${config.version}`,
-    container_name: `${PROJECT_NAME}-crawler-${color}`,
+    container_name: `${getProjectId()}-crawler-${color}`,
     env_file: ['.env'],
     restart: 'unless-stopped',
     healthcheck: {
@@ -28,5 +29,6 @@ export function createCrawlerService(
         aliases: ['crawler', `crawler-${color}`],
       },
     },
+    extra_hosts: EXTRA_HOSTS,
   };
 }

--- a/tools/cli/src/lib/compose/services/create-db-service.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.ts
@@ -1,11 +1,11 @@
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
 import type { ComposeService, ServiceConfig } from '../types';
 import { DEFAULT_LOGGING } from '../types';
 
 export function createDbService(config: ServiceConfig): ComposeService {
   return {
     image: `${config.registry}/tale-db:${config.version}`,
-    container_name: `${PROJECT_NAME}-db`,
+    container_name: `${getProjectId()}-db`,
     stop_grace_period: '60s',
     shm_size: '256mb',
     volumes: [

--- a/tools/cli/src/lib/compose/services/create-platform-service.ts
+++ b/tools/cli/src/lib/compose/services/create-platform-service.ts
@@ -1,4 +1,5 @@
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
+import { EXTRA_HOSTS } from '../generators/constants';
 import type { ComposeService, DeploymentColor, ServiceConfig } from '../types';
 import { DEFAULT_LOGGING } from '../types';
 
@@ -8,7 +9,7 @@ export function createPlatformService(
 ): ComposeService {
   return {
     image: `${config.registry}/tale-platform:${config.version}`,
-    container_name: `${PROJECT_NAME}-platform-${color}`,
+    container_name: `${getProjectId()}-platform-${color}`,
     volumes: ['platform-data:/app/data', 'caddy-data:/caddy-data:ro'],
     env_file: ['.env'],
     restart: 'unless-stopped',
@@ -28,5 +29,6 @@ export function createPlatformService(
         aliases: ['platform', `platform-${color}`],
       },
     },
+    extra_hosts: EXTRA_HOSTS,
   };
 }

--- a/tools/cli/src/lib/compose/services/create-proxy-service.ts
+++ b/tools/cli/src/lib/compose/services/create-proxy-service.ts
@@ -1,4 +1,5 @@
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
+import { EXTRA_HOSTS } from '../generators/constants';
 import type { ComposeService, ServiceConfig } from '../types';
 import { DEFAULT_LOGGING } from '../types';
 
@@ -8,7 +9,7 @@ export function createProxyService(
 ): ComposeService {
   return {
     image: `${config.registry}/tale-proxy:${config.version}`,
-    container_name: `${PROJECT_NAME}-proxy`,
+    container_name: `${getProjectId()}-proxy`,
     ports: ['80:80', '443:443'],
     volumes: ['caddy-data:/data', 'caddy-config:/config'],
     env_file: ['.env'],
@@ -33,5 +34,6 @@ export function createProxyService(
         aliases: [hostAlias],
       },
     },
+    extra_hosts: EXTRA_HOSTS,
   };
 }

--- a/tools/cli/src/lib/compose/services/create-rag-service.ts
+++ b/tools/cli/src/lib/compose/services/create-rag-service.ts
@@ -1,4 +1,5 @@
-import { PROJECT_NAME } from '../../../utils/load-env';
+import { getProjectId } from '../../../utils/load-env';
+import { EXTRA_HOSTS } from '../generators/constants';
 import type { ComposeService, DeploymentColor, ServiceConfig } from '../types';
 import { DEFAULT_LOGGING } from '../types';
 
@@ -8,7 +9,7 @@ export function createRagService(
 ): ComposeService {
   return {
     image: `${config.registry}/tale-rag:${config.version}`,
-    container_name: `${PROJECT_NAME}-rag-${color}`,
+    container_name: `${getProjectId()}-rag-${color}`,
     volumes: ['rag-data:/app/data', 'platform-data:/app/platform-config:ro'],
     env_file: ['.env'],
     restart: 'unless-stopped',
@@ -25,5 +26,6 @@ export function createRagService(
         aliases: ['rag', `rag-${color}`],
       },
     },
+    extra_hosts: EXTRA_HOSTS,
   };
 }

--- a/tools/cli/src/lib/compose/types.ts
+++ b/tools/cli/src/lib/compose/types.ts
@@ -31,6 +31,7 @@ export interface ComposeService {
   depends_on?: string[] | Record<string, { condition: string }>;
   logging?: LoggingConfig;
   networks?: string[] | Record<string, { aliases?: string[] }>;
+  extra_hosts?: string[];
 }
 
 export interface ComposeConfig {

--- a/tools/cli/src/lib/config/ensure-env.ts
+++ b/tools/cli/src/lib/config/ensure-env.ts
@@ -4,12 +4,14 @@ import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { deriveAgePublicKey, generateAgeKeypair } from '../crypto/age-keygen';
 
 function listTaleVolumes(): string[] {
   try {
-    const result = execSync('docker volume ls --filter name=tale-dev -q', {
+    const filter = `name=${getProjectId()}-dev`;
+    const result = execSync(`docker volume ls --filter ${filter} -q`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'ignore'],
     });
@@ -303,12 +305,13 @@ async function runEnvSetup(envPath: string): Promise<EnvSetupResult> {
       return { success: false };
     }
     logger.step('Stopping Tale containers...');
+    const composeProject = `${getProjectId()}-dev`;
     try {
-      execSync('docker compose -p tale-dev down --remove-orphans', {
+      execSync(`docker compose -p ${composeProject} down --remove-orphans`, {
         stdio: 'ignore',
       });
     } catch (err) {
-      logger.debug(`Failed to stop tale-dev containers: ${err}`);
+      logger.debug(`Failed to stop ${composeProject} containers: ${err}`);
     }
 
     for (const v of existingVolumes) {

--- a/tools/cli/src/lib/docker/docker-compose.ts
+++ b/tools/cli/src/lib/docker/docker-compose.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 
-import { PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId } from '../../utils/load-env';
 import { type ExecResult, exec } from './exec';
 
 interface DockerComposeOptions {
@@ -9,6 +9,7 @@ interface DockerComposeOptions {
   cwd?: string;
   inherit?: boolean;
   onLine?: (line: string) => void;
+  overrideFile?: string;
 }
 
 export async function pipeLines(
@@ -38,22 +39,29 @@ export async function dockerCompose(
   options: DockerComposeOptions = {},
 ): Promise<ExecResult> {
   const {
-    projectName = PROJECT_NAME,
+    projectName = getProjectId(),
     cwd = process.cwd(),
     inherit = false,
     onLine,
+    overrideFile,
   } = options;
 
   // Write compose file to cwd so env_file paths resolve correctly
   const tempFile = join(cwd, `.tale-deploy-compose-${randomUUID()}.yml`);
   await Bun.write(tempFile, composeContent);
 
+  const composeFlags = ['-p', projectName, '-f', tempFile];
+  if (overrideFile) {
+    composeFlags.push('-f', overrideFile);
+  }
+
   try {
     if (onLine) {
-      const proc = Bun.spawn(
-        ['docker', 'compose', '-p', projectName, '-f', tempFile, ...args],
-        { cwd, stdout: 'pipe', stderr: 'pipe' },
-      );
+      const proc = Bun.spawn(['docker', 'compose', ...composeFlags, ...args], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
       await Promise.all([
         pipeLines(proc.stdout, onLine),
         pipeLines(proc.stderr, onLine),
@@ -64,19 +72,18 @@ export async function dockerCompose(
     }
 
     if (inherit) {
-      const proc = Bun.spawn(
-        ['docker', 'compose', '-p', projectName, '-f', tempFile, ...args],
-        { cwd, stdout: 'inherit', stderr: 'inherit' },
-      );
+      const proc = Bun.spawn(['docker', 'compose', ...composeFlags, ...args], {
+        cwd,
+        stdout: 'inherit',
+        stderr: 'inherit',
+      });
       const exitCode = await proc.exited;
       return { success: exitCode === 0, stdout: '', stderr: '', exitCode };
     }
 
-    return await exec(
-      'docker',
-      ['compose', '-p', projectName, '-f', tempFile, ...args],
-      { cwd },
-    );
+    return await exec('docker', ['compose', ...composeFlags, ...args], {
+      cwd,
+    });
   } finally {
     const { unlink } = await import('node:fs/promises');
     await unlink(tempFile).catch(() => {});

--- a/tools/cli/src/lib/docker/docker-compose.ts
+++ b/tools/cli/src/lib/docker/docker-compose.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 
 import { getProjectId } from '../../utils/load-env';
+import * as logger from '../../utils/logger';
 import { type ExecResult, exec } from './exec';
 
 interface DockerComposeOptions {
@@ -86,6 +87,12 @@ export async function dockerCompose(
     });
   } finally {
     const { unlink } = await import('node:fs/promises');
-    await unlink(tempFile).catch(() => {});
+    await unlink(tempFile).catch((err: NodeJS.ErrnoException) => {
+      if (err.code !== 'ENOENT') {
+        logger.debug(
+          `Failed to remove temp compose file ${tempFile}: ${err.message}`,
+        );
+      }
+    });
   }
 }

--- a/tools/cli/src/lib/docker/ensure-network.ts
+++ b/tools/cli/src/lib/docker/ensure-network.ts
@@ -1,4 +1,4 @@
-import { PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { docker } from './docker';
 
@@ -19,7 +19,7 @@ async function createNetwork(networkName: string): Promise<boolean> {
     'network',
     'create',
     '--label',
-    `project=${PROJECT_NAME}`,
+    `project=${getProjectId()}`,
     networkName,
   );
   if (!result.success) {
@@ -29,6 +29,6 @@ async function createNetwork(networkName: string): Promise<boolean> {
 }
 
 export async function ensureNetwork(networkName: string): Promise<boolean> {
-  const fullName = `${PROJECT_NAME}_${networkName}`;
+  const fullName = `${getProjectId()}_${networkName}`;
   return createNetwork(fullName);
 }

--- a/tools/cli/src/lib/docker/ensure-network.ts
+++ b/tools/cli/src/lib/docker/ensure-network.ts
@@ -23,12 +23,17 @@ async function createNetwork(networkName: string): Promise<boolean> {
     networkName,
   );
   if (!result.success) {
-    logger.error(`Failed to create network: ${networkName}`);
+    logger.error(
+      `Failed to create network ${networkName}: ${result.stderr.trim()}`,
+    );
   }
   return result.success;
 }
 
-export async function ensureNetwork(networkName: string): Promise<boolean> {
-  const fullName = `${getProjectId()}_${networkName}`;
+export async function ensureNetwork(
+  networkName: string,
+  prefix: string = `${getProjectId()}_`,
+): Promise<boolean> {
+  const fullName = `${prefix}${networkName}`;
   return createNetwork(fullName);
 }

--- a/tools/cli/src/lib/docker/ensure-volumes.ts
+++ b/tools/cli/src/lib/docker/ensure-volumes.ts
@@ -1,4 +1,4 @@
-import { PROJECT_NAME } from '../../utils/load-env';
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { docker } from './docker';
 
@@ -21,7 +21,7 @@ async function createVolume(volumeName: string): Promise<boolean> {
 
 export async function ensureVolumes(volumeNames: string[]): Promise<boolean> {
   for (const name of volumeNames) {
-    const fullName = `${PROJECT_NAME}_${name}`;
+    const fullName = `${getProjectId()}_${name}`;
     const success = await createVolume(fullName);
     if (!success) {
       logger.error(`Failed to create volume: ${fullName}`);

--- a/tools/cli/src/lib/docker/ensure-volumes.ts
+++ b/tools/cli/src/lib/docker/ensure-volumes.ts
@@ -15,16 +15,36 @@ async function createVolume(volumeName: string): Promise<boolean> {
   }
 
   logger.info(`Creating volume: ${volumeName}`);
-  const result = await docker('volume', 'create', volumeName);
+  // Label the volume with its project ID so `tale reset` can prune only this
+  // project's volumes (symmetric with network pruning).
+  const result = await docker(
+    'volume',
+    'create',
+    '--label',
+    `project=${getProjectId()}`,
+    volumeName,
+  );
+  if (!result.success) {
+    logger.error(
+      `Failed to create volume ${volumeName}: ${result.stderr.trim()}`,
+    );
+  }
   return result.success;
 }
 
-export async function ensureVolumes(volumeNames: string[]): Promise<boolean> {
+/**
+ * Ensure the named volumes exist, namespaced under the given prefix.
+ * Default prefix is `${projectId}_` (prod); dev should pass `${projectId}-dev_`.
+ */
+export async function ensureVolumes(
+  volumeNames: string[],
+  prefix: string = `${getProjectId()}_`,
+): Promise<boolean> {
   for (const name of volumeNames) {
-    const fullName = `${getProjectId()}_${name}`;
+    const fullName = `${prefix}${name}`;
     const success = await createVolume(fullName);
     if (!success) {
-      logger.error(`Failed to create volume: ${fullName}`);
+      // createVolume already logged the underlying stderr.
       return false;
     }
   }

--- a/tools/cli/src/lib/docker/find-platform-container.ts
+++ b/tools/cli/src/lib/docker/find-platform-container.ts
@@ -1,15 +1,19 @@
+import { getProjectId } from '../../utils/load-env';
 import { isContainerRunning } from './is-container-running';
 import { listContainers } from './list-containers';
 
 export async function findPlatformContainer(): Promise<string> {
-  if (await isContainerRunning('tale-platform-blue')) {
-    return 'tale-platform-blue';
+  const projectId = getProjectId();
+  const blue = `${projectId}-platform-blue`;
+  const green = `${projectId}-platform-green`;
+  if (await isContainerRunning(blue)) {
+    return blue;
   }
-  if (await isContainerRunning('tale-platform-green')) {
-    return 'tale-platform-green';
+  if (await isContainerRunning(green)) {
+    return green;
   }
 
-  const containers = await listContainers('name=tale');
+  const containers = await listContainers(`name=${projectId}`);
   const platform = containers.find(
     (c) => /platform/.test(c.name) && c.status.startsWith('Up'),
   );

--- a/tools/cli/src/lib/docker/find-platform-container.ts
+++ b/tools/cli/src/lib/docker/find-platform-container.ts
@@ -13,9 +13,13 @@ export async function findPlatformContainer(): Promise<string> {
     return green;
   }
 
+  // Fallback: list containers under this project and match ONLY the exact
+  // blue/green platform names. Permissive `/platform/` matching could pick up
+  // unrelated containers such as `${projectId}-platform-build` or
+  // user-created `${projectId}-platform-*` variants.
   const containers = await listContainers(`name=${projectId}`);
   const platform = containers.find(
-    (c) => /platform/.test(c.name) && c.status.startsWith('Up'),
+    (c) => (c.name === blue || c.name === green) && c.status.startsWith('Up'),
   );
   if (platform) {
     return platform.name;

--- a/tools/cli/src/lib/docker/migrate-volumes.ts
+++ b/tools/cli/src/lib/docker/migrate-volumes.ts
@@ -66,6 +66,45 @@ async function volumeHasData(name: string): Promise<boolean> {
   return result.success && result.stdout.trim().length > 0;
 }
 
+// Sentinel file written inside a destination volume once the `cp -a` completes
+// successfully. Presence guarantees a complete migration; absence (with data
+// present) indicates a partial/interrupted copy that must be redone.
+const MIGRATION_SENTINEL = '.tale-migration-complete';
+
+async function volumeHasSentinel(
+  name: string,
+  image: string,
+): Promise<boolean> {
+  const result = await docker(
+    'run',
+    '--rm',
+    '-v',
+    `${name}:/vol:ro`,
+    '--entrypoint',
+    'sh',
+    image,
+    '-c',
+    `test -f /vol/${MIGRATION_SENTINEL}`,
+  );
+  return result.success;
+}
+
+/** Wipe a volume's contents (keeping the volume itself) so a retry can copy cleanly. */
+async function wipeVolume(name: string, image: string): Promise<boolean> {
+  const result = await docker(
+    'run',
+    '--rm',
+    '-v',
+    `${name}:/vol`,
+    '--entrypoint',
+    'sh',
+    image,
+    '-c',
+    'find /vol -mindepth 1 -delete',
+  );
+  return result.success;
+}
+
 /** Find a locally-available image suitable for volume copying. */
 async function resolveMigrationImage(): Promise<string> {
   // Prefer images that are guaranteed present after any prior Tale run.
@@ -142,7 +181,11 @@ export function hasPendingMigration(projectDir: string): boolean {
 }
 
 export async function clearMigrationPending(projectDir: string): Promise<void> {
-  await unlink(markerPath(projectDir)).catch(() => {});
+  await unlink(markerPath(projectDir)).catch((err: NodeJS.ErrnoException) => {
+    if (err.code !== 'ENOENT') {
+      logger.debug(`Failed to clear migration-pending marker: ${err.message}`);
+    }
+  });
 }
 
 /**
@@ -200,6 +243,11 @@ export async function migrateOldVolumes(
 
   if (candidates.length === 0) {
     logger.debug('No legacy volumes found, nothing to migrate.');
+    // Clear any stale marker — there's nothing to migrate, so the pending
+    // state is no longer meaningful. Without this, a marker written during
+    // a previous deferral (e.g. user manually cleaned the legacy volumes)
+    // would trap every subsequent `tale start` in an infinite-defer loop.
+    await clearMigrationPending(projectDir);
     return result;
   }
 
@@ -207,17 +255,33 @@ export async function migrateOldVolumes(
   const image = await resolveMigrationImage();
 
   for (const { oldName, newName } of candidates) {
-    // Idempotency: if destination already has data, skip.
-    if ((await volumeExists(newName)) && (await volumeHasData(newName))) {
-      logger.info(
-        `  ⏭  ${oldName} → ${newName} (destination has data, skipping)`,
-      );
-      result.skipped.push(newName);
-      continue;
-    }
-
-    // Create destination volume if absent
-    if (!(await volumeExists(newName))) {
+    // Idempotency: sentinel file indicates a completed migration. If data is
+    // present but the sentinel is missing, assume a prior copy was
+    // interrupted and wipe so we can retry cleanly.
+    if (await volumeExists(newName)) {
+      const hasData = await volumeHasData(newName);
+      const hasSentinel = hasData && (await volumeHasSentinel(newName, image));
+      if (hasSentinel) {
+        logger.info(
+          `  ⏭  ${oldName} → ${newName} (already migrated, skipping)`,
+        );
+        result.skipped.push(newName);
+        continue;
+      }
+      if (hasData) {
+        logger.warn(
+          `  ⚠  ${newName} has data but no completion marker — treating as partial migration and retrying`,
+        );
+        const wiped = await wipeVolume(newName, image);
+        if (!wiped) {
+          logger.warn(
+            `  ✗ Failed to wipe partial destination ${newName}; aborting this volume`,
+          );
+          result.failed.push(newName);
+          continue;
+        }
+      }
+    } else {
       const created = await docker('volume', 'create', newName);
       if (!created.success) {
         logger.warn(
@@ -228,7 +292,10 @@ export async function migrateOldVolumes(
       }
     }
 
-    // Copy data via a throwaway container. Mount old read-only as safety.
+    // Copy data via a throwaway container, then write the sentinel in the
+    // same shell invocation so the two are atomic from our perspective:
+    // either both happen (complete) or neither (failure → no sentinel, will
+    // be retried next run).
     const copy = await docker(
       'run',
       '--rm',
@@ -240,7 +307,7 @@ export async function migrateOldVolumes(
       'sh',
       image,
       '-c',
-      'cp -a /old/. /new/',
+      `cp -a /old/. /new/ && : > /new/${MIGRATION_SENTINEL}`,
     );
 
     if (copy.success) {
@@ -257,6 +324,28 @@ export async function migrateOldVolumes(
     logger.info('Old volumes preserved. After verifying, reclaim disk with:');
     const oldNames = candidates.map((p) => p.oldName).join(' ');
     logger.info(`  docker volume rm ${oldNames}`);
+
+    // List any stopped legacy containers so the user can clean them up too.
+    const stopped = await docker(
+      'ps',
+      '-a',
+      '--filter',
+      'name=tale-',
+      '--format',
+      '{{.Names}}',
+    );
+    if (stopped.success) {
+      const legacyPattern =
+        /^tale(-(dev|blue|green))?-(platform|db|rag|crawler|proxy)(-(blue|green))?$/;
+      const names = stopped.stdout
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((n) => n && legacyPattern.test(n));
+      if (names.length > 0) {
+        logger.info('Legacy containers remain (stopped). Remove with:');
+        logger.info(`  docker rm ${names.join(' ')}`);
+      }
+    }
   }
 
   return result;

--- a/tools/cli/src/lib/docker/migrate-volumes.ts
+++ b/tools/cli/src/lib/docker/migrate-volumes.ts
@@ -120,7 +120,7 @@ async function detectRunningLegacyContainers(): Promise<RunningContainersResult>
   return { containers, hasLegacy: containers.length > 0 };
 }
 
-export interface MigrationResult {
+interface MigrationResult {
   migrated: string[];
   failed: string[];
   skipped: string[];
@@ -131,7 +131,7 @@ function markerPath(projectDir: string): string {
   return join(projectDir, '.tale', 'migration-pending');
 }
 
-export async function writeMigrationPending(projectDir: string): Promise<void> {
+async function writeMigrationPending(projectDir: string): Promise<void> {
   const path = markerPath(projectDir);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, new Date().toISOString() + '\n');

--- a/tools/cli/src/lib/docker/migrate-volumes.ts
+++ b/tools/cli/src/lib/docker/migrate-volumes.ts
@@ -1,0 +1,263 @@
+import { existsSync } from 'node:fs';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import * as logger from '../../utils/logger';
+import { docker } from './docker';
+
+const LEGACY_PROJECT_NAME = 'tale';
+
+// Volume mappings for migration. Keys are the new volume name (under the new
+// project ID); values are the old volume name (under the hardcoded 'tale' /
+// 'tale-dev' prefix).
+function buildVolumeMapping(
+  projectId: string,
+): Array<{ oldName: string; newName: string }> {
+  const devVolumes = [
+    'platform-data',
+    'db-data',
+    'db-backup',
+    'rag-data',
+    'crawler-data',
+    'caddy-data',
+    'caddy-config',
+  ];
+  const prodVolumes = [
+    'platform-data',
+    'caddy-data',
+    'rag-data',
+    'crawler-data',
+    'db-data',
+    'db-backup',
+  ];
+  const pairs: Array<{ oldName: string; newName: string }> = [];
+  for (const v of devVolumes) {
+    pairs.push({
+      oldName: `${LEGACY_PROJECT_NAME}-dev_${v}`,
+      newName: `${projectId}-dev_${v}`,
+    });
+  }
+  for (const v of prodVolumes) {
+    pairs.push({
+      oldName: `${LEGACY_PROJECT_NAME}_${v}`,
+      newName: `${projectId}_${v}`,
+    });
+  }
+  return pairs;
+}
+
+async function volumeExists(name: string): Promise<boolean> {
+  const result = await docker('volume', 'inspect', name);
+  return result.success;
+}
+
+async function volumeHasData(name: string): Promise<boolean> {
+  // Use a minimal image to list contents. Caller guarantees volume exists.
+  const result = await docker(
+    'run',
+    '--rm',
+    '-v',
+    `${name}:/vol:ro`,
+    'alpine',
+    'sh',
+    '-c',
+    'ls -A /vol | head -1',
+  );
+  return result.success && result.stdout.trim().length > 0;
+}
+
+/** Find a locally-available image suitable for volume copying. */
+async function resolveMigrationImage(): Promise<string> {
+  // Prefer images that are guaranteed present after any prior Tale run.
+  // Caveat: `docker image inspect <tag>` works for any image with that tag,
+  // regardless of registry.
+  const candidates = ['tale-platform', 'tale-proxy', 'alpine'];
+  for (const candidate of candidates) {
+    // Try exact match first
+    const exact = await docker('image', 'inspect', candidate);
+    if (exact.success) return candidate;
+    // Try any tag with this repo substring
+    const lookup = await docker(
+      'images',
+      '--format',
+      '{{.Repository}}:{{.Tag}}',
+    );
+    if (lookup.success) {
+      const match = lookup.stdout
+        .split('\n')
+        .find((line) => line.includes(candidate) && !line.includes('<none>'));
+      if (match) return match.trim();
+    }
+  }
+  // Final fallback: alpine — may trigger a pull.
+  return 'alpine';
+}
+
+interface RunningContainersResult {
+  containers: string[];
+  hasLegacy: boolean;
+}
+
+/** Detect running containers with the legacy 'tale-*' naming convention. */
+async function detectRunningLegacyContainers(): Promise<RunningContainersResult> {
+  const result = await docker(
+    'ps',
+    '--filter',
+    'name=tale-',
+    '--format',
+    '{{.Names}}',
+  );
+  if (!result.success) return { containers: [], hasLegacy: false };
+
+  // Only match exact legacy container names (not the new project-ID containers
+  // that might coincidentally start with "tale-").
+  const legacyPattern =
+    /^tale(-(dev|blue|green))?-(platform|db|rag|crawler|proxy)(-(blue|green))?$/;
+  const containers = result.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((name) => name && legacyPattern.test(name));
+  return { containers, hasLegacy: containers.length > 0 };
+}
+
+export interface MigrationResult {
+  migrated: string[];
+  failed: string[];
+  skipped: string[];
+  deferred: boolean;
+}
+
+function markerPath(projectDir: string): string {
+  return join(projectDir, '.tale', 'migration-pending');
+}
+
+export async function writeMigrationPending(projectDir: string): Promise<void> {
+  const path = markerPath(projectDir);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, new Date().toISOString() + '\n');
+}
+
+export function hasPendingMigration(projectDir: string): boolean {
+  return existsSync(markerPath(projectDir));
+}
+
+export async function clearMigrationPending(projectDir: string): Promise<void> {
+  await unlink(markerPath(projectDir)).catch(() => {});
+}
+
+/**
+ * Migrate legacy 'tale_*' and 'tale-dev_*' volumes to the new project-scoped
+ * names. Never stops running containers — if legacy containers are live
+ * (especially production), defers via a marker file.
+ */
+export async function migrateOldVolumes(
+  projectId: string,
+  projectDir: string,
+): Promise<MigrationResult> {
+  const result: MigrationResult = {
+    migrated: [],
+    failed: [],
+    skipped: [],
+    deferred: false,
+  };
+
+  // Safety check 1: Docker must be running
+  const ping = await docker('info');
+  if (!ping.success) {
+    logger.warn(
+      'Docker is not available. Volume migration deferred until next "tale start" or "tale deploy".',
+    );
+    await writeMigrationPending(projectDir);
+    result.deferred = true;
+    return result;
+  }
+
+  // Safety check 2: never disturb running containers
+  const running = await detectRunningLegacyContainers();
+  if (running.hasLegacy) {
+    logger.warn(
+      'Legacy Tale containers are running — volume migration deferred.',
+    );
+    for (const name of running.containers) {
+      logger.info(`  - ${name}`);
+    }
+    logger.info(
+      'Migration will run automatically during next "tale start", or with "tale deploy --migrate-volumes".',
+    );
+    await writeMigrationPending(projectDir);
+    result.deferred = true;
+    return result;
+  }
+
+  // Check whether any legacy volumes exist at all
+  const mapping = buildVolumeMapping(projectId);
+  const candidates: Array<{ oldName: string; newName: string }> = [];
+  for (const pair of mapping) {
+    if (await volumeExists(pair.oldName)) {
+      candidates.push(pair);
+    }
+  }
+
+  if (candidates.length === 0) {
+    logger.debug('No legacy volumes found, nothing to migrate.');
+    return result;
+  }
+
+  logger.step(`Migrating ${candidates.length} legacy volume(s)...`);
+  const image = await resolveMigrationImage();
+
+  for (const { oldName, newName } of candidates) {
+    // Idempotency: if destination already has data, skip.
+    if ((await volumeExists(newName)) && (await volumeHasData(newName))) {
+      logger.info(
+        `  ⏭  ${oldName} → ${newName} (destination has data, skipping)`,
+      );
+      result.skipped.push(newName);
+      continue;
+    }
+
+    // Create destination volume if absent
+    if (!(await volumeExists(newName))) {
+      const created = await docker('volume', 'create', newName);
+      if (!created.success) {
+        logger.warn(
+          `  ✗ Failed to create volume ${newName}: ${created.stderr}`,
+        );
+        result.failed.push(newName);
+        continue;
+      }
+    }
+
+    // Copy data via a throwaway container. Mount old read-only as safety.
+    const copy = await docker(
+      'run',
+      '--rm',
+      '-v',
+      `${oldName}:/old:ro`,
+      '-v',
+      `${newName}:/new`,
+      '--entrypoint',
+      'sh',
+      image,
+      '-c',
+      'cp -a /old/. /new/',
+    );
+
+    if (copy.success) {
+      logger.info(`  ✓ ${oldName} → ${newName}`);
+      result.migrated.push(newName);
+    } else {
+      logger.warn(`  ✗ ${oldName} → ${newName}: ${copy.stderr}`);
+      result.failed.push(newName);
+    }
+  }
+
+  if (result.migrated.length > 0) {
+    logger.blank();
+    logger.info('Old volumes preserved. After verifying, reclaim disk with:');
+    const oldNames = candidates.map((p) => p.oldName).join(' ');
+    logger.info(`  docker volume rm ${oldNames}`);
+  }
+
+  return result;
+}

--- a/tools/cli/src/lib/docker/wait-for-healthy.ts
+++ b/tools/cli/src/lib/docker/wait-for-healthy.ts
@@ -1,3 +1,4 @@
+import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { pipeLines } from './docker-compose';
 import { getContainerHealth } from './get-container-health';
@@ -11,9 +12,14 @@ interface HealthCheckOptions {
 }
 
 function extractServiceName(containerName: string): string {
-  // "tale-platform-blue" → "platform-blue", "tale-db" → "db"
-  const parts = containerName.split('-');
-  return parts.length > 1 ? parts.slice(1).join('-') : containerName;
+  // Strip the project ID prefix to get the service name.
+  // e.g. "my-app-a3f1b2-platform-blue" → "platform-blue" (project ID = "my-app-a3f1b2").
+  // Splitting on '-' is wrong because project IDs contain hyphens.
+  const projectId = getProjectId();
+  const prefix = `${projectId}-`;
+  return containerName.startsWith(prefix)
+    ? containerName.slice(prefix.length)
+    : containerName;
 }
 
 function startLogTail(containerName: string): {

--- a/tools/cli/src/lib/project/generate-project-id.ts
+++ b/tools/cli/src/lib/project/generate-project-id.ts
@@ -1,0 +1,50 @@
+import { randomBytes } from 'node:crypto';
+
+const MAX_PREFIX_LENGTH = 33;
+const HEX_SUFFIX_LENGTH = 6;
+const FALLBACK_PREFIX = 'tale';
+
+const VALID_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Sanitize a directory basename into a Docker-safe prefix.
+ * Applied rules: lowercase, replace non-[a-z0-9] with `-`, collapse
+ * consecutive `-`, strip leading/trailing `-`, truncate to 33 chars, then
+ * re-strip trailing `-`. If the result is empty (e.g., CJK/emoji directory),
+ * fall back to 'tale'.
+ */
+export function sanitizePrefix(dirBasename: string): string {
+  let name = dirBasename.toLowerCase().replace(/[^a-z0-9]/g, '-');
+  name = name.replace(/-{2,}/g, '-');
+  name = name.replace(/^-+|-+$/g, '');
+  if (name.length > MAX_PREFIX_LENGTH) {
+    name = name.slice(0, MAX_PREFIX_LENGTH).replace(/-+$/, '');
+  }
+  return name.length === 0 ? FALLBACK_PREFIX : name;
+}
+
+/**
+ * Generate a project ID of the form `{sanitized-name}-{6-hex}`.
+ * The hex suffix provides collision resistance when two directories share
+ * the same sanitized basename on the same machine.
+ */
+export function generateProjectId(dirBasename: string): string {
+  const prefix = sanitizePrefix(dirBasename);
+  const hex = randomBytes(Math.ceil(HEX_SUFFIX_LENGTH / 2))
+    .toString('hex')
+    .slice(0, HEX_SUFFIX_LENGTH);
+  const id = `${prefix}-${hex}`;
+  if (!VALID_ID_PATTERN.test(id)) {
+    // This should be unreachable given the sanitization rules, but validate
+    // defensively — Docker would otherwise reject the name with a cryptic error.
+    throw new Error(
+      `Generated project ID "${id}" is invalid. Expected pattern ${VALID_ID_PATTERN}.`,
+    );
+  }
+  return id;
+}
+
+/** Validate that an ID string conforms to Docker naming rules. */
+export function isValidProjectId(id: string): boolean {
+  return VALID_ID_PATTERN.test(id) && id.length > 0 && id.length <= 40;
+}

--- a/tools/cli/src/lib/project/generate-project-id.ts
+++ b/tools/cli/src/lib/project/generate-project-id.ts
@@ -13,7 +13,7 @@ const VALID_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
  * re-strip trailing `-`. If the result is empty (e.g., CJK/emoji directory),
  * fall back to 'tale'.
  */
-export function sanitizePrefix(dirBasename: string): string {
+function sanitizePrefix(dirBasename: string): string {
   let name = dirBasename.toLowerCase().replace(/[^a-z0-9]/g, '-');
   name = name.replace(/-{2,}/g, '-');
   name = name.replace(/^-+|-+$/g, '');

--- a/tools/cli/src/lib/project/project-context.ts
+++ b/tools/cli/src/lib/project/project-context.ts
@@ -1,5 +1,9 @@
-import { isValidProjectId } from './generate-project-id';
+import { basename, join } from 'node:path';
+
+import * as logger from '../../utils/logger';
+import { generateProjectId, isValidProjectId } from './generate-project-id';
 import { readProject } from './read-project';
+import { writeProject } from './write-project';
 
 let _projectId: string | null = null;
 
@@ -48,4 +52,35 @@ export async function resolveProjectContext(projectDir: string): Promise<void> {
     );
   }
   setProjectId(id);
+}
+
+/**
+ * Like `resolveProjectContext`, but if the project has no `id` yet (legacy
+ * project pre-dating per-project isolation) auto-assigns one, persists it
+ * atomically, and proceeds. This is a UX smoothing for `tale start` /
+ * `tale deploy` so users don't have to run `tale upgrade` as a separate step.
+ *
+ * An invalid (non-empty but malformed) ID still throws — it signals
+ * tampering or corruption that the user should resolve explicitly.
+ */
+export async function resolveOrAssignProjectContext(
+  projectDir: string,
+): Promise<void> {
+  const project = await readProject(projectDir);
+  const id = project.id;
+  if (typeof id === 'string' && id.trim() !== '') {
+    if (!isValidProjectId(id)) {
+      throw new Error(
+        `Project ID "${id}" in tale.json is invalid. Expected [a-z0-9][a-z0-9-]* and max 40 chars.`,
+      );
+    }
+    setProjectId(id);
+    return;
+  }
+
+  const assigned = generateProjectId(basename(projectDir));
+  project.id = assigned;
+  await writeProject(join(projectDir, 'tale.json'), project);
+  setProjectId(assigned);
+  logger.info(`Assigned project ID: ${assigned}`);
 }

--- a/tools/cli/src/lib/project/project-context.ts
+++ b/tools/cli/src/lib/project/project-context.ts
@@ -1,0 +1,56 @@
+import { isValidProjectId } from './generate-project-id';
+import { readProject } from './read-project';
+
+let _projectId: string | null = null;
+
+/**
+ * Explicitly set the project ID. Called once per command after reading tale.json.
+ * Exported primarily for tests and for init.ts, which sets the ID during
+ * project creation before tale.json exists on disk.
+ */
+export function setProjectId(id: string): void {
+  _projectId = id;
+}
+
+/**
+ * Returns the resolved project ID. Throws if `resolveProjectContext()` has
+ * not been called first — this indicates a missing bootstrap call in a
+ * command entry point and is a bug, not a user error.
+ */
+export function getProjectId(): string {
+  if (_projectId === null) {
+    throw new Error(
+      'Project context not initialized. This is a bug — resolveProjectContext() must be called before getProjectId().',
+    );
+  }
+  return _projectId;
+}
+
+/** For tests. */
+export function resetProjectContext(): void {
+  _projectId = null;
+}
+
+/**
+ * Read tale.json from the project directory, validate the `id` field, and
+ * cache it in the module-level singleton. Must be called by every command
+ * that uses Docker before any Docker operation runs.
+ *
+ * Throws with an actionable message if the project has no valid ID,
+ * directing the user to `tale upgrade` (which auto-assigns IDs to legacy projects).
+ */
+export async function resolveProjectContext(projectDir: string): Promise<void> {
+  const project = await readProject(projectDir);
+  const id = project.id;
+  if (typeof id !== 'string' || id.trim() === '') {
+    throw new Error(
+      'Project has no valid ID. Run "tale upgrade" to assign one.',
+    );
+  }
+  if (!isValidProjectId(id)) {
+    throw new Error(
+      `Project ID "${id}" in tale.json is invalid. Expected [a-z0-9][a-z0-9-]* and max 40 chars.`,
+    );
+  }
+  setProjectId(id);
+}

--- a/tools/cli/src/lib/project/project-context.ts
+++ b/tools/cli/src/lib/project/project-context.ts
@@ -26,11 +26,6 @@ export function getProjectId(): string {
   return _projectId;
 }
 
-/** For tests. */
-export function resetProjectContext(): void {
-  _projectId = null;
-}
-
 /**
  * Read tale.json from the project directory, validate the `id` field, and
  * cache it in the module-level singleton. Must be called by every command

--- a/tools/cli/src/lib/project/types.ts
+++ b/tools/cli/src/lib/project/types.ts
@@ -3,6 +3,13 @@ export interface TaleProject {
   cliVersion: string;
   createdAt: string;
   name?: string;
+  /**
+   * Unique project ID used to namespace Docker resources (containers, volumes,
+   * networks). Format: `{sanitized-name}-{6-hex}` (e.g. `my-app-a3f1b2`).
+   * Optional for backwards compatibility with pre-ID projects; `tale upgrade`
+   * auto-assigns one to legacy projects.
+   */
+  id?: string;
 }
 
 export interface Checksums {

--- a/tools/cli/src/lib/project/write-project.ts
+++ b/tools/cli/src/lib/project/write-project.ts
@@ -1,0 +1,38 @@
+import { open, rename, unlink } from 'node:fs/promises';
+
+import * as logger from '../../utils/logger';
+import type { TaleProject } from './types';
+
+/**
+ * Atomically write tale.json (or any JSON project file).
+ *
+ * Pattern: write to a sibling temp file, fsync, rename. POSIX rename is
+ * atomic on the same filesystem, so a crash mid-write leaves the original
+ * file intact rather than producing a truncated tale.json that would brick
+ * every subsequent `tale` command.
+ */
+export async function writeProject(
+  path: string,
+  project: TaleProject,
+): Promise<void> {
+  const tmp = `${path}.tmp`;
+  const content = JSON.stringify(project, null, 2) + '\n';
+  let handle;
+  try {
+    handle = await open(tmp, 'w');
+    await handle.writeFile(content);
+    await handle.sync();
+  } finally {
+    await handle?.close();
+  }
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch((cleanupErr: NodeJS.ErrnoException) => {
+      if (cleanupErr.code !== 'ENOENT') {
+        logger.debug(`Failed to clean up ${tmp}: ${cleanupErr.message}`);
+      }
+    });
+    throw err;
+  }
+}

--- a/tools/cli/src/utils/load-env.ts
+++ b/tools/cli/src/utils/load-env.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 import * as logger from './logger';
 
-export const PROJECT_NAME = 'tale';
+export { getProjectId } from '../lib/project/project-context';
 
 export interface DeploymentEnv {
   GHCR_REGISTRY: string;


### PR DESCRIPTION
Closes #1471

## Summary

Three related improvements to the Tale CLI Docker infrastructure:

### Part A — Project ID isolation
Running multiple Tale projects on one machine previously collided on Docker volume, container, and network names because `PROJECT_NAME` was hardcoded to `'tale'`. Each project now gets a unique id stored in `tale.json` (format: `{sanitized-dir-name}-{6-hex}`) and used to namespace all Docker resources.

- `tale init` generates an id; reinit preserves the existing id and `createdAt`
- `tale upgrade` auto-assigns an id to legacy projects and attempts migration
- **Safety guarantee:** `tale upgrade` **never** stops running containers. If legacy containers are live (dev or prod), migration is deferred via `.tale/migration-pending` marker. Production deployments are completely untouched by `tale upgrade` alone.
- **Dev:** deferred migration runs automatically on next `tale start` (convenience)
- **Prod:** `tale deploy` requires explicit `--migrate-volumes` flag to migrate (safety against accidental downtime)
- Volume copy uses a locally-available image (`tale-platform` → `tale-proxy` → `alpine` fallback) — no network needed in typical offline upgrade scenarios
- Sanitization handles edge cases: CJK/emoji dirs fall back to `tale-*`, leading/trailing hyphens stripped, truncation at 33 chars prevents overruns of the 63-char Docker name limit
- Also fixed `wait-for-healthy.ts` which previously assumed single-segment project names; now correctly strips multi-segment project-id prefixes

### Part B — Docker host access (#1427)
Containers can now reach host services (e.g. Ollama on `localhost:11434`) via `host.docker.internal`. Added `extra_hosts: ['host.docker.internal:host-gateway']` to platform, rag, crawler, and proxy. `db` is excluded — PostgreSQL does not initiate outbound host connections.

### Part C — compose.override.yml support
Users can drop `compose.override.yml` (or `.yaml`) in the project root to customize compose config. Dev-only for this iteration — rotatable service names differ between dev (`platform`) and prod (`platform-blue`), so prod override support is deferred to a follow-up. Added both extensions to the init gitignore template.

## Known limitations (documented, not addressed here)
- Running two dev projects simultaneously still collides on host port 443 unless `--port` is passed manually
- Copying a project directory (`cp -r`) produces two copies with the same id; a future `tale init --new-id` would address this

## Test plan
- [ ] `tale init /tmp/test-a` → verify `tale.json` has `"id": "test-a-xxxxxx"`
- [ ] `tale init /tmp/test-b` → different id; `docker ps` / `docker volume ls` show isolated resources
- [ ] Reinit preservation: `tale init --force` on existing project → same id preserved
- [ ] Sanitization: init in dir `我的项目/` → falls back to `tale-xxxxxx`
- [ ] **Safety test:** legacy `tale.json` (no id) with running `tale-platform-blue` → `tale upgrade` → assigns id, writes marker, `docker ps` shows production unchanged
- [ ] Deferred dev: after upgrade with marker, `tale start` → stops legacy containers, migrates volumes, starts new
- [ ] Deferred prod: `tale deploy` aborts with clear message; `tale deploy --migrate-volumes` succeeds
- [ ] Migration idempotency: re-run migration → skips volumes that already have data
- [ ] `docker compose config` on dev output shows `extra_hosts: ["host.docker.internal:host-gateway"]` on platform/rag/crawler/proxy (not db)
- [ ] Create `compose.override.yml` with extra env var on `platform` → `tale start` logs detection; env visible in container
- [ ] Service name parsing: `docker logs` output during deploy shows correct service names like `platform-blue` (not `app-a3f1b2-platform-blue`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--migrate-volumes` flag to the deploy command for handling legacy volume migrations.
  * Added support for `compose.override.yml` and `compose.override.yaml` files.

* **Improvements**
  * Projects now use unique, stable identifiers instead of a shared hardcoded name for better multi-project support.
  * Enhanced Docker networking with extra hosts configuration.
  * Improved legacy volume migration handling during initialization and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->