### PR TITLE
fix(cli): always run migration detect() to catch end-state drift

### DIFF
--- a/tools/cli/src/lib/upgrade/runner.test.ts
+++ b/tools/cli/src/lib/upgrade/runner.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { ApplyOutcome, Migration, MigrationContext } from './types';
+
+// --- Mocks ---
+
+const recordAppliedMock = mock();
+
+mock.module('./state', () => ({
+  recordApplied: recordAppliedMock,
+}));
+
+mock.module('../../utils/logger', () => ({
+  blank: mock(),
+  header: mock(),
+  info: mock(),
+  notice: mock(),
+  step: mock(),
+  success: mock(),
+  warn: mock(),
+  debug: mock(),
+  error: mock(),
+}));
+
+mock.module('../../utils/confirm', () => ({
+  confirm: mock(() => Promise.resolve(true)),
+}));
+
+// --- Helpers ---
+
+const CTX: MigrationContext = {
+  projectId: 'test-project',
+  projectDir: '/tmp/test-project',
+};
+
+function makeMigration(
+  id: string,
+  opts: {
+    detect?: boolean;
+    apply?: ApplyOutcome;
+    stops?: string[];
+    detectFn?: () => Promise<boolean>;
+  } = {},
+): Migration {
+  return {
+    id,
+    introducedIn: '0.0.1',
+    description: `Migration ${id}`,
+    detect: opts.detectFn ?? mock(() => Promise.resolve(opts.detect ?? false)),
+    requiredStops: mock(() => Promise.resolve(opts.stops ?? [])),
+    apply: mock(() => Promise.resolve(opts.apply ?? 'applied')),
+  };
+}
+
+// --- Import after mocks ---
+
+const { runPendingMigrations, planPendingMigrations } =
+  await import('./runner');
+
+afterEach(() => {
+  recordAppliedMock.mockReset();
+});
+
+// --- Tests ---
+
+describe('runPendingMigrations', () => {
+  test('returns proceed=true with no applied when nothing is pending', async () => {
+    const m = makeMigration('a', { detect: false });
+    const result = await runPendingMigrations([m], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result).toEqual({ proceed: true, applied: [], declined: false });
+    expect(m.detect).toHaveBeenCalledWith(CTX);
+    expect(m.apply).not.toHaveBeenCalled();
+  });
+
+  test('applies a new pending migration', async () => {
+    const m = makeMigration('a', { detect: true, apply: 'applied' });
+    const result = await runPendingMigrations([m], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result.proceed).toBe(true);
+    expect(result.applied).toEqual(['a']);
+    expect(m.apply).toHaveBeenCalledWith(CTX, { dryRun: false });
+    expect(recordAppliedMock).toHaveBeenCalledTimes(1);
+    expect(recordAppliedMock.mock.calls[0][1]).toMatchObject({ id: 'a' });
+  });
+
+  test('re-detects and re-applies a drifted migration (detect returns true even if previously recorded)', async () => {
+    // Simulate a migration whose end-state has drifted: detect() returns true
+    // even though recordApplied would be a no-op (already recorded).
+    // The key assertion: detect() IS called, apply() IS called.
+    const m = makeMigration('split-convex', {
+      detect: true,
+      apply: 'applied',
+    });
+
+    const result = await runPendingMigrations([m], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result.proceed).toBe(true);
+    expect(result.applied).toEqual(['split-convex']);
+    expect(m.detect).toHaveBeenCalledTimes(1);
+    expect(m.apply).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips migrations whose detect() returns false', async () => {
+    const satisfied = makeMigration('done', { detect: false });
+    const pending = makeMigration('todo', { detect: true, apply: 'applied' });
+
+    const result = await runPendingMigrations([satisfied, pending], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result.applied).toEqual(['todo']);
+    expect(satisfied.detect).toHaveBeenCalled();
+    expect(satisfied.apply).not.toHaveBeenCalled();
+  });
+
+  test('preserves registry order for mixed pending migrations', async () => {
+    const a = makeMigration('a', { detect: true, apply: 'applied' });
+    const b = makeMigration('b', { detect: false });
+    const c = makeMigration('c', { detect: true, apply: 'applied' });
+
+    const result = await runPendingMigrations([a, b, c], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result.applied).toEqual(['a', 'c']);
+    // Verify order: a applied before c
+    const aCallOrder = (a.apply as ReturnType<typeof mock>).mock
+      .invocationCallOrder[0];
+    const cCallOrder = (c.apply as ReturnType<typeof mock>).mock
+      .invocationCallOrder[0];
+    expect(aCallOrder).toBeLessThan(cCallOrder);
+  });
+
+  test('propagates detect() errors with context', async () => {
+    const m = makeMigration('bad', {
+      detectFn: () => Promise.reject(new Error('docker not found')),
+    });
+
+    await expect(
+      runPendingMigrations([m], CTX, {
+        context: 'deploy',
+        assumeYes: true,
+      }),
+    ).rejects.toThrow('migration bad: detect() failed: docker not found');
+  });
+
+  test('collects requiredStops from all pending migrations', async () => {
+    const a = makeMigration('a', {
+      detect: true,
+      apply: 'applied',
+      stops: ['container-1'],
+    });
+    const b = makeMigration('b', {
+      detect: true,
+      apply: 'applied',
+      stops: ['container-2', 'container-1'],
+    });
+
+    const stopsReceived: string[][] = [];
+    const performStops = mock((s: string[]) => {
+      stopsReceived.push(s);
+      return Promise.resolve();
+    });
+
+    await runPendingMigrations([a, b], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+      performStops,
+    });
+
+    expect(performStops).toHaveBeenCalledTimes(1);
+    expect(stopsReceived[0]).toContain('container-1');
+    expect(stopsReceived[0]).toContain('container-2');
+    expect(stopsReceived[0]).toHaveLength(2); // deduplicated
+  });
+
+  test('handles noop outcome from apply()', async () => {
+    const m = makeMigration('already-ok', { detect: true, apply: 'noop' });
+
+    const result = await runPendingMigrations([m], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+    });
+
+    expect(result.applied).toEqual(['already-ok']);
+    expect(recordAppliedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('dry-run prints plan but does not apply', async () => {
+    const m = makeMigration('a', { detect: true });
+
+    const result = await runPendingMigrations([m], CTX, {
+      context: 'deploy',
+      assumeYes: true,
+      dryRun: true,
+    });
+
+    expect(result.applied).toEqual([]);
+    expect(m.apply).not.toHaveBeenCalled();
+    expect(recordAppliedMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('planPendingMigrations', () => {
+  test('returns empty array when nothing is pending', async () => {
+    const m = makeMigration('a', { detect: false });
+    const result = await planPendingMigrations([m], CTX);
+    expect(result).toEqual([]);
+  });
+
+  test('returns pending migrations without applying', async () => {
+    const m = makeMigration('a', { detect: true });
+    const result = await planPendingMigrations([m], CTX);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+    expect(m.apply).not.toHaveBeenCalled();
+  });
+});

--- a/tools/cli/src/lib/upgrade/runner.ts
+++ b/tools/cli/src/lib/upgrade/runner.ts
@@ -1,13 +1,17 @@
 import pkg from '../../../package.json';
 import { confirm } from '../../utils/confirm';
 import * as logger from '../../utils/logger';
-import { readMigrationsState, recordApplied, appliedIds } from './state';
+import { recordApplied } from './state';
 import type { Migration, MigrationContext } from './types';
 
 /**
- * Compute the pending subset of migrations: those whose `id` is not already
- * recorded in `.tale/migrations.json` and whose `detect()` returns true for
- * the current state.
+ * Compute the pending subset of migrations: those whose `detect()` returns
+ * true for the current observable state.
+ *
+ * Per the contract in types.ts, `detect()` is the sole source of truth —
+ * `migrations.json` is a log, not a gate. A migration whose end-state has
+ * drifted (e.g. a volume was deleted after the migration was recorded) will
+ * be re-detected and re-applied automatically.
  *
  * Order is preserved from the registry — callers must not reorder.
  */
@@ -15,11 +19,8 @@ async function computePending(
   registry: readonly Migration[],
   ctx: MigrationContext,
 ): Promise<Migration[]> {
-  const state = await readMigrationsState(ctx.projectDir);
-  const already = appliedIds(state);
   const pending: Migration[] = [];
   for (const m of registry) {
-    if (already.has(m.id)) continue;
     try {
       if (await m.detect(ctx)) pending.push(m);
     } catch (err) {

--- a/tools/cli/src/lib/upgrade/state.ts
+++ b/tools/cli/src/lib/upgrade/state.ts
@@ -24,7 +24,7 @@ function legacyMarkerPath(projectDir: string): string {
  * per-migration identity, so we must let each registered migration's detect()
  * re-discover any real pending work) and delete the legacy marker.
  */
-export async function readMigrationsState(
+async function readMigrationsState(
   projectDir: string,
 ): Promise<MigrationsState> {
   const path = statePath(projectDir);
@@ -91,8 +91,4 @@ export async function recordApplied(
   }
   state.applied.push(entry);
   await writeMigrationsState(projectDir, state);
-}
-
-export function appliedIds(state: MigrationsState): Set<string> {
-  return new Set(state.applied.map((a) => a.id));
 }


### PR DESCRIPTION
## Summary

- Remove the `already.has(m.id)` gate in `computePending()` that skipped `detect()` for migrations already recorded in `migrations.json`
- `detect()` now runs unconditionally for every registered migration, honoring the contract in `types.ts` that observable state is the source of truth
- Add 11 unit tests for the migration runner covering drift re-detection, registry ordering, error propagation, and dry-run

## Context

Production incident: after `tale deploy`, the `split-convex` migration was recorded as applied but its end-state (populated `convex-data` volume) was later invalidated. The runner skipped re-detection because `migrations.json` said "done", `ensureVolumes` created an empty volume, and Convex started with a fresh empty database.

The root cause was `runner.ts:22`:
```typescript
if (already.has(m.id)) continue; // never calls detect() again
```

This violated `types.ts:26-28`:
> `detect` and `apply` must NOT consult `migrations.json`, CLI versions, or any other external history. Those are caches/logs, not sources of truth — the filesystem/volume/container state is.

## Test plan

- [x] `npx tsc --noEmit` — typecheck clean
- [x] `bun test` — 51/51 pass (11 new + 40 existing)
- [ ] Manual: deploy, then `docker volume rm <project>_convex-data`, re-deploy → migration re-detects and re-copies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the migration runner, including scenarios for pending migrations, drift detection, and error handling.

* **Refactor**
  * Updated migration pending detection to rely on dynamic detection rather than stored state records.
  * Simplified internal migration state APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->