### PR TITLE
fix(platform): handle string metadata parsing, deduplicate citation indices, add locale description

### DIFF
--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -52,9 +52,18 @@ function parseMetadata(metadata: unknown): {
   defaultLocale?: string;
   [key: string]: unknown;
 } {
-  if (!metadata || typeof metadata !== 'object') return {};
+  let parsed = metadata;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch (e) {
+      console.warn('Failed to parse organization metadata', e);
+      return {};
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return {};
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- metadata is validated above
-  return metadata as { defaultLocale?: string; [key: string]: unknown };
+  return parsed as { defaultLocale?: string; [key: string]: unknown };
 }
 
 export function OrganizationSettings({
@@ -171,6 +180,7 @@ export function OrganizationSettings({
           <Select
             id="default-locale"
             label={tSettings('organization.defaultLocale')}
+            description={tSettings('organization.defaultLocaleDescription')}
             value={defaultLocale}
             onValueChange={(value) =>
               setValue('defaultLocale', value, { shouldDirty: true })

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -2035,6 +2035,10 @@ function extractToolCallsFromSteps(steps: unknown[]): {
     page?: number;
     relevance?: number;
   }> = [];
+  // Track running offset so citations from different tool calls get unique indices.
+  // Without this, both rag_search and web tools start at index 1, and the frontend
+  // Map<number, CitationInfo> keyed by index would let later tools overwrite earlier ones.
+  let citationIndexOffset = 0;
 
   for (const rawStep of steps) {
     if (!isRecord(rawStep)) continue;
@@ -2084,6 +2088,7 @@ function extractToolCallsFromSteps(steps: unknown[]): {
             ? rawOutput.value.citations
             : undefined;
       if (Array.isArray(citationSource)) {
+        let maxIndexThisToolCall = 0;
         for (const c of citationSource) {
           if (
             isRecord(c) &&
@@ -2092,9 +2097,11 @@ function extractToolCallsFromSteps(steps: unknown[]): {
             (c.type === 'rag' || c.type === 'web')
           ) {
             const citationType: 'rag' | 'web' = c.type;
+            const adjustedIndex =
+              (typeof c.index === 'number' ? c.index : 0) + citationIndexOffset;
             // Convex validators reject explicit `undefined` — omit undefined fields
             const entry: (typeof allCitations)[number] = {
-              index: typeof c.index === 'number' ? c.index : 0,
+              index: adjustedIndex,
               type: citationType,
               source: typeof c.source === 'string' ? c.source : 'Unknown',
             };
@@ -2103,7 +2110,14 @@ function extractToolCallsFromSteps(steps: unknown[]): {
             if (typeof c.page === 'number') entry.page = c.page;
             if (typeof c.relevance === 'number') entry.relevance = c.relevance;
             allCitations.push(entry);
+            if (adjustedIndex > maxIndexThisToolCall) {
+              maxIndexThisToolCall = adjustedIndex;
+            }
           }
+        }
+        // Advance offset so the next tool call's citations don't collide
+        if (maxIndexThisToolCall > 0) {
+          citationIndexOffset = maxIndexThisToolCall;
         }
       }
 

--- a/services/platform/lib/shared/utils/get-organization-default-locale.ts
+++ b/services/platform/lib/shared/utils/get-organization-default-locale.ts
@@ -6,8 +6,17 @@ import { defaultLocale } from '../../i18n/config';
  * is missing or does not contain a valid defaultLocale string.
  */
 export function getOrganizationDefaultLocale(metadata: unknown): string {
-  if (metadata && typeof metadata === 'object' && 'defaultLocale' in metadata) {
-    const value = (metadata as { defaultLocale: unknown }).defaultLocale; // oxlint-disable-line typescript/no-unsafe-type-assertion
+  let parsed = metadata;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch (e) {
+      console.warn('Failed to parse organization metadata', e);
+      return defaultLocale;
+    }
+  }
+  if (parsed && typeof parsed === 'object' && 'defaultLocale' in parsed) {
+    const value = (parsed as { defaultLocale: unknown }).defaultLocale; // oxlint-disable-line typescript/no-unsafe-type-assertion
     if (typeof value === 'string') return value;
   }
   return defaultLocale;

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -595,6 +595,7 @@
       "membersEntityLabel": "Mitglieder",
       "manageAccess": "Zugriff auf die Organisation verwalten",
       "defaultLocale": "Standardsprache",
+      "defaultLocaleDescription": "Die Basissprache für Agentennamen, Beschreibungen und Gesprächseinstiege.",
       "searchMember": "Mitglied suchen",
       "addMember": "Mitglied hinzufügen",
       "members": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -598,6 +598,7 @@
       "membersEntityLabel": "members",
       "manageAccess": "Manage access to the organization",
       "defaultLocale": "Default language",
+      "defaultLocaleDescription": "The base language for agent names, descriptions, and conversation starters.",
       "searchMember": "Search member",
       "addMember": "Add member",
       "members": {


### PR DESCRIPTION
## Summary
- **Metadata parsing**: Organization metadata can arrive as a JSON string (not just an object). Both `organization-settings.tsx` and `get-organization-default-locale.ts` now detect and parse stringified metadata gracefully.
- **Citation index deduplication**: `generate_response.ts` now tracks a running offset across tool calls so citation indices don't collide in the frontend Map when multiple tools (rag_search, web) return citations starting at index 1.
- **Locale description label**: Added `defaultLocaleDescription` i18n string (en + de) and wired it to the default language Select in organization settings.

## Test plan
- [ ] Verify organization settings page loads correctly with both object and JSON-string metadata
- [ ] Verify changing default locale persists and reflects correctly
- [ ] Trigger a chat response that uses both RAG and web citations — confirm citation numbers are unique and don't overwrite each other
- [ ] Check the organization settings locale dropdown shows the new description text in both English and German

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive help text for the default locale setting in organization settings.

* **Bug Fixes**
  * Fixed citation indices to prevent overlapping between separate tool calls.

* **Documentation**
  * Added English and German localization strings for default locale setting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->