### PR TITLE
fix(platform): add optimistic message display for arena mode

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -172,11 +172,15 @@ export function ChatInterface({
     terminalAssistantCount,
   } = useMessageProcessing(dataThreadId);
 
-  // Merge with pending messages from context for optimistic UI
-  const messages = usePendingMessages({
+  // Merge with pending messages from context for optimistic UI.
+  // In arena mode, ArenaColumns handle their own pending messages —
+  // use rawMessages to keep a stable reference and avoid triggering
+  // useMergedChatItems recalculation for components that won't render.
+  const pendingMergedMessages = usePendingMessages({
     threadId: dataThreadId,
     realMessages: rawMessages,
   });
+  const messages = isArenaMode ? rawMessages : pendingMergedMessages;
 
   // Agent availability — disable input when no agents exist
   const { agents } = useChatAgents(organizationId);

--- a/services/platform/app/features/chat/context/chat-layout-context.tsx
+++ b/services/platform/app/features/chat/context/chat-layout-context.tsx
@@ -31,6 +31,11 @@ export interface PendingMessage {
    * Cleared when dataThreadId changes (branch subscription caught up).
    */
   editedMessageId?: string;
+  /**
+   * Secondary thread ID for arena mode. When set, pending message matches
+   * both `threadId` (column A) and `arenaThreadIdB` (column B).
+   */
+  arenaThreadIdB?: string;
 }
 
 export interface SelectedAgent {

--- a/services/platform/app/features/chat/hooks/use-pending-messages.ts
+++ b/services/platform/app/features/chat/hooks/use-pending-messages.ts
@@ -113,7 +113,9 @@ export function usePendingMessages({
         pendingThreadId !== null &&
         pendingMessage.threadId === pendingThreadId);
     const isSecondaryArenaThread =
-      pendingMessage.arenaThreadIdB === threadId && !isPrimaryThread;
+      pendingMessage.arenaThreadIdB != null &&
+      pendingMessage.arenaThreadIdB === threadId &&
+      !isPrimaryThread;
 
     if (!isPrimaryThread && !isSecondaryArenaThread) return realMessages;
 

--- a/services/platform/app/features/chat/hooks/use-pending-messages.ts
+++ b/services/platform/app/features/chat/hooks/use-pending-messages.ts
@@ -51,14 +51,16 @@ export function usePendingMessages({
       return;
     }
 
-    // Only clear for matching thread
-    const isMatchingThread =
+    // Only clear for the primary thread — the secondary arena column must NOT
+    // clear the shared pending message because its lastMessageKey comes from a
+    // different thread and would never match the baseline.
+    const isPrimaryThread =
       pendingMessage.threadId === threadId ||
       (threadId === undefined && pendingMessage.threadId === 'pending') ||
       (threadId === undefined &&
         pendingThreadId !== null &&
         pendingMessage.threadId === pendingThreadId);
-    if (!isMatchingThread) return;
+    if (!isPrimaryThread) return;
 
     // For new threads: clear when any real message arrives
     if (hasMessages && pendingMessage.lastMessageKey === undefined) {
@@ -104,14 +106,16 @@ export function usePendingMessages({
       return [...before, edited];
     }
 
-    const isMatchingThread =
+    const isPrimaryThread =
       pendingMessage.threadId === threadId ||
       (threadId === undefined && pendingMessage.threadId === 'pending') ||
       (threadId === undefined &&
         pendingThreadId !== null &&
         pendingMessage.threadId === pendingThreadId);
+    const isSecondaryArenaThread =
+      pendingMessage.arenaThreadIdB === threadId && !isPrimaryThread;
 
-    if (!isMatchingThread) return realMessages;
+    if (!isPrimaryThread && !isSecondaryArenaThread) return realMessages;
 
     const attachments: FileAttachment[] | undefined =
       pendingMessage.attachments?.map((a) => ({
@@ -135,6 +139,12 @@ export function usePendingMessages({
     // New thread (no real messages yet): show only optimistic
     if (realMessages.length === 0) {
       return [optimisticMessage];
+    }
+
+    // Secondary arena thread: always show optimistic until primary clears it.
+    // Its lastMessageKey comes from a different thread so cannot be compared.
+    if (isSecondaryArenaThread) {
+      return [...realMessages, optimisticMessage];
     }
 
     // Existing thread: append optimistic until real message arrives at the end

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -94,6 +94,51 @@ export function useSendMessage({
         return;
       }
 
+      // Convert attachments format (synchronous — needed for optimistic message)
+      const mutationAttachments = attachments?.map((a) => ({
+        fileId: a.fileId,
+        fileName: a.fileName,
+        fileType: a.fileType,
+        fileSize: a.fileSize,
+      }));
+
+      const currentArena = arenaRef.current;
+      const modelA = currentArena?.modelA;
+      const modelB = currentArena?.modelB;
+      const isArena = currentArena?.isArenaMode && modelA && modelB;
+
+      // Set pending state scoped to this thread (null for new-chat page)
+      setPendingThreadId(threadId ?? null);
+      setIsPending(true);
+      onBeforeSend?.();
+
+      // For arena mode, show optimistic message SYNCHRONOUSLY before any
+      // network calls (PII check, thread creation) so the UI updates instantly.
+      const lastMessageKey = messages[messages.length - 1]?.key;
+      const pendingTimestamp = new Date();
+      if (isArena) {
+        if (currentArena.arenaThreadIdA && currentArena.arenaThreadIdB) {
+          setPendingMessage({
+            content: message,
+            threadId: currentArena.arenaThreadIdA,
+            arenaThreadIdB: currentArena.arenaThreadIdB,
+            attachments: mutationAttachments,
+            timestamp: pendingTimestamp,
+            lastMessageKey,
+          });
+        } else {
+          // Threads need to be created — use 'pending' so both columns
+          // (threadId=undefined) display the user message immediately.
+          setPendingMessage({
+            content: message,
+            threadId: 'pending',
+            attachments: mutationAttachments,
+            timestamp: pendingTimestamp,
+            lastMessageKey,
+          });
+        }
+      }
+
       // Pre-check PII policy before creating thread
       try {
         const piiPolicy = await convexClient.query(
@@ -113,6 +158,7 @@ export function useSendMessage({
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         if (errorMessage.includes('Message blocked: PII')) {
+          clearChatState();
           toast({
             title: t('toast.piiBlocked'),
             description: errorMessage,
@@ -122,25 +168,7 @@ export function useSendMessage({
         }
       }
 
-      // Set pending state scoped to this thread (null for new-chat page)
-      setPendingThreadId(threadId ?? null);
-      setIsPending(true);
-      onBeforeSend?.();
-
       try {
-        // Convert attachments format
-        const mutationAttachments = attachments?.map((a) => ({
-          fileId: a.fileId,
-          fileName: a.fileName,
-          fileType: a.fileType,
-          fileSize: a.fileSize,
-        }));
-
-        const currentArena = arenaRef.current;
-        const modelA = currentArena?.modelA;
-        const modelB = currentArena?.modelB;
-        const isArena = currentArena?.isArenaMode && modelA && modelB;
-
         if (isArena) {
           // --- Arena mode: Thread A = root, Thread B = branch ---
           const title =
@@ -171,6 +199,16 @@ export function useSendMessage({
             });
             tIdB = newB;
             currentArena.setArenaThreadIdB(newB);
+
+            // Update pending message with real thread IDs
+            setPendingMessage({
+              content: message,
+              threadId: tIdA,
+              arenaThreadIdB: tIdB,
+              attachments: mutationAttachments,
+              timestamp: pendingTimestamp,
+              lastMessageKey,
+            });
           } else {
             // New chat — create both threads
             const newA = await createThread({
@@ -196,7 +234,25 @@ export function useSendMessage({
             tIdB = newB;
             currentArena.setArenaThreadIdA(newA);
             currentArena.setArenaThreadIdB(newB);
+
+            // Update pending message with real thread IDs
+            setPendingMessage({
+              content: message,
+              threadId: tIdA,
+              arenaThreadIdB: tIdB,
+              attachments: mutationAttachments,
+              timestamp: pendingTimestamp,
+              lastMessageKey,
+            });
           }
+
+          setPendingThreadId(tIdA);
+          startTransition(() => {
+            void navigate({
+              to: '/dashboard/$id/chat/$threadId',
+              params: { id: organizationId, threadId: tIdA },
+            });
+          });
 
           // Start both models generating (split view shows "Thinking")
           await arenaChatRef.current({
@@ -217,32 +273,12 @@ export function useSendMessage({
               : undefined,
             copyHistoryToB: needsCopyHistory || undefined,
           });
-
-          // Navigate AFTER arena chat completes — split view is already
-          // showing, so this just updates the URL without visual change.
-          setPendingMessage({
-            content: message,
-            threadId: tIdA,
-            attachments: mutationAttachments,
-            timestamp: new Date(),
-            lastMessageKey: messages[messages.length - 1]?.key,
-          });
-          setPendingThreadId(tIdA);
-          startTransition(() => {
-            void navigate({
-              to: '/dashboard/$id/chat/$threadId',
-              params: { id: organizationId, threadId: tIdA },
-            });
-          });
         } else {
           // --- Standard mode: send to one model ---
           let currentThreadId = threadId;
           let isFirstMessage = false;
 
-          const lastMessageKey = messages[messages.length - 1]?.key;
-
           if (!currentThreadId) {
-            const pendingTimestamp = new Date();
             setPendingMessage({
               content: message,
               threadId: 'pending',


### PR DESCRIPTION
## Summary
- Set optimistic (pending) message **synchronously before any network calls** (PII check, thread creation, arena chat mutation) so the user's message appears instantly in both arena columns
- Add `arenaThreadIdB` to `PendingMessage` so a single pending message can match both arena columns
- Fix race condition where Column B's `usePendingMessages` cleanup effect would immediately clear the shared pending message because its `lastMessageKey` baseline comes from a different thread
- Skip `usePendingMessages` result in `chat-interface.tsx` during arena mode to avoid triggering unnecessary `useMergedChatItems` recalculation

## Test plan
- [ ] Send a message in Arena Mode (existing thread with both threads) — user message should appear instantly in both columns
- [ ] Send a first message in Arena Mode (new chat, no threads yet) — message appears with 'pending' state before thread creation
- [ ] Send a message in standard (non-arena) mode — behavior unchanged, message appears instantly
- [ ] Edit-and-branch in standard mode — still works correctly
- [ ] PII block scenario — optimistic message is cleared and toast shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced arena mode to properly display pending messages across both comparison columns
  * Improved message sending responsiveness with earlier UI feedback during composition
  * Optimized message rendering to prevent unnecessary recalculations in specialized chat views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->