### PR TITLE
fix(crawler): add vector similarity pre-filter to web search

### DIFF
--- a/services/crawler/app/models.py
+++ b/services/crawler/app/models.py
@@ -418,6 +418,14 @@ class SearchRequest(BaseModel):
 
     query: str = Field(..., description="Search query")
     limit: int = Field(10, ge=1, le=100, description="Maximum results")
+    similarity_threshold: float = Field(
+        0.4,
+        ge=0.0,
+        le=1.0,
+        description="Minimum cosine similarity for vector results. "
+        "If all vector results fall below this threshold the query is considered "
+        "semantically irrelevant and an empty result set is returned.",
+    )
 
 
 class SearchResultItem(BaseModel):

--- a/services/crawler/app/routers/search.py
+++ b/services/crawler/app/routers/search.py
@@ -29,7 +29,11 @@ async def search_all(request: SearchRequest):
     """Search across all indexed website content."""
     try:
         service = _get_search_service()
-        results = await service.search(query=request.query, limit=request.limit)
+        results = await service.search(
+            query=request.query,
+            limit=request.limit,
+            similarity_threshold=request.similarity_threshold,
+        )
         return SearchResponse(
             query=request.query,
             results=[
@@ -56,7 +60,12 @@ async def search_domain(domain: str, request: SearchRequest):
     """Search within a specific website's indexed content."""
     try:
         service = _get_search_service()
-        results = await service.search(query=request.query, domain=domain, limit=request.limit)
+        results = await service.search(
+            query=request.query,
+            domain=domain,
+            limit=request.limit,
+            similarity_threshold=request.similarity_threshold,
+        )
         return SearchResponse(
             query=request.query,
             results=[

--- a/services/crawler/app/services/search_service.py
+++ b/services/crawler/app/services/search_service.py
@@ -35,6 +35,7 @@ class SearchService:
         query: str,
         domain: str | None = None,
         limit: int = 10,
+        similarity_threshold: float = 0.4,
     ) -> list[SearchResult]:
         # Generate query embedding and run both searches in parallel
         embedding_task = asyncio.create_task(get_embedding_service().embed_query(query))
@@ -43,6 +44,22 @@ class SearchService:
         query_embedding = await embedding_task
         fts_results = await fts_task
         vector_results = await self._vector_search(query_embedding, domain, limit * 3)
+
+        # Pre-filter vector results by cosine similarity (matches RAG pipeline).
+        # If ALL vector results fall below the threshold the query is considered
+        # semantically irrelevant — discard FTS results too (keyword noise).
+        if similarity_threshold > 0:
+            pre_count = len(vector_results)
+            vector_results = [r for r in vector_results if r["score"] >= similarity_threshold]
+            if pre_count != len(vector_results):
+                logger.debug(
+                    "Vector pre-filter: {}/{} results passed threshold {}",
+                    len(vector_results),
+                    pre_count,
+                    similarity_threshold,
+                )
+            if pre_count > 0 and not vector_results:
+                return []
 
         return self._merge_rrf([fts_results, vector_results], limit)
 

--- a/services/crawler/tests/test_search_router.py
+++ b/services/crawler/tests/test_search_router.py
@@ -46,7 +46,7 @@ class TestSearchAll:
         assert len(data["results"]) == 2
         assert data["results"][0]["url"] == "https://example.com/page1"
         assert data["results"][0]["score"] == 0.95
-        mock_search_service.search.assert_awaited_once_with(query="hello", limit=10)
+        mock_search_service.search.assert_awaited_once_with(query="hello", limit=10, similarity_threshold=0.4)
 
     async def test_returns_empty_results(self, mock_search_service):
         mock_search_service.search.return_value = []
@@ -66,7 +66,7 @@ class TestSearchAll:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             await client.post("/api/v1/search", json={"query": "test"})
 
-        mock_search_service.search.assert_awaited_once_with(query="test", limit=10)
+        mock_search_service.search.assert_awaited_once_with(query="test", limit=10, similarity_threshold=0.4)
 
     async def test_503_when_service_not_initialized(self):
         set_search_service(None)
@@ -102,7 +102,9 @@ class TestSearchDomain:
         data = response.json()
         assert data["total"] == 1
         assert data["results"][0]["url"] == "https://docs.example.com/intro"
-        mock_search_service.search.assert_awaited_once_with(query="welcome", domain="docs.example.com", limit=5)
+        mock_search_service.search.assert_awaited_once_with(
+            query="welcome", domain="docs.example.com", limit=5, similarity_threshold=0.4
+        )
 
     async def test_empty_domain_results(self, mock_search_service):
         mock_search_service.search.return_value = []

--- a/services/platform/convex/agent_tools/rag/query_rag_context.ts
+++ b/services/platform/convex/agent_tools/rag/query_rag_context.ts
@@ -21,7 +21,7 @@ import {
 
 const debugLog = createDebugLog('DEBUG_RAG_QUERY', '[RAGQuery]');
 const DEFAULT_TOP_K = 10;
-const DEFAULT_SIMILARITY_THRESHOLD = 0.3;
+const DEFAULT_SIMILARITY_THRESHOLD = 0.4;
 const RAG_REQUEST_TIMEOUT_MS = 10000; // 10 seconds
 
 // Query expansion constants

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -41,7 +41,7 @@ export interface AgentKnowledgeCtx extends ToolCtx {
 const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
 
 const DEFAULT_TOP_K = 10;
-const DEFAULT_SIMILARITY_THRESHOLD = 0.3;
+const DEFAULT_SIMILARITY_THRESHOLD = 0.4;
 
 export async function resolveFileIds(
   ctx: ToolCtx,

--- a/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
+++ b/services/platform/convex/agent_tools/web/helpers/query_web_context.ts
@@ -16,6 +16,7 @@ import { getCrawlerServiceUrl } from './get_crawler_service_url';
 const debugLog = createDebugLog('DEBUG_WEB_CONTEXT', '[WebContext]');
 
 const DEFAULT_LIMIT = 10;
+const DEFAULT_SIMILARITY_THRESHOLD = 0.4;
 const WEB_CONTEXT_TIMEOUT_MS = 10_000;
 
 interface SearchResult {
@@ -77,7 +78,11 @@ export async function queryWebContext(
       const response = await fetch(`${crawlerUrl}/api/v1/search`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query, limit }),
+        body: JSON.stringify({
+          query,
+          limit,
+          similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
+        }),
         signal: controller.signal,
       });
 

--- a/services/platform/convex/agent_tools/web/helpers/search_pages.ts
+++ b/services/platform/convex/agent_tools/web/helpers/search_pages.ts
@@ -15,6 +15,7 @@ import { getCrawlerServiceUrl } from './get_crawler_service_url';
 const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
 
 const DEFAULT_LIMIT = 10;
+const DEFAULT_SIMILARITY_THRESHOLD = 0.4;
 
 const DOMAIN_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9-]*\.)*[a-zA-Z0-9-]+(:\d+)?$/;
 
@@ -48,7 +49,11 @@ async function fetchSearch(
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, limit: DEFAULT_LIMIT }),
+    body: JSON.stringify({
+      query,
+      limit: DEFAULT_LIMIT,
+      similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
+    }),
   });
 
   if (!response.ok) {

--- a/services/rag/app/config.py
+++ b/services/rag/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseServiceSettings):
     chunk_size: int = 2048
     chunk_overlap: int = 200
     top_k: int = 5
-    similarity_threshold: float = 0.3
+    similarity_threshold: float = 0.4
     max_document_size_mb: int = 100
     ingestion_timeout_seconds: int = 10800
 


### PR DESCRIPTION
## Summary
- Add `similarity_threshold` parameter to crawler search API and pre-filter vector results by cosine similarity **before** RRF merge — matching the RAG scoring pipeline. If all vector results fall below the threshold, return empty instead of surfacing keyword-only noise.
- Raise default `similarity_threshold` from 0.3 to 0.4 across both RAG and web search — 0.3 sits within the noise floor for qwen3-embedding-8b, letting completely unrelated content through.
- Platform web search (`search_pages.ts`, `query_web_context.ts`) now sends `similarity_threshold` to the crawler API.

## Test plan
- [x] `pytest services/crawler/tests/test_search_router.py` — 9 passed
- [x] `npm run lint --workspace=@tale/platform` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: search with unrelated query against indexed sites, confirm empty results instead of noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable similarity threshold parameter for search requests (default: 0.4, range: 0.0–1.0) to control semantic relevance filtering of results.

* **Updates**
  * Adjusted default similarity threshold across RAG and search services for consistent result filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->