### PR TITLE
fix(platform): eliminate arena mode delays for instant optimistic UX

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-split-view.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-split-view.tsx
@@ -6,6 +6,7 @@ import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 
+import { useChatLayout } from '../../context/chat-layout-context';
 import {
   useDocumentWriteApprovals,
   useHumanInputRequests,
@@ -51,12 +52,22 @@ function ArenaColumn({
     realMessages: rawMessages,
   });
 
-  // Per-column loading: check if THIS thread is generating
+  // Per-column loading: combine client-side isPending (instant) with
+  // server-side isGenerating (reactive subscription) — mirrors single-chat's
+  // useChatLoadingState pattern so "Thinking" appears immediately on send.
   const { data: isGenerating } = useConvexQuery(
     api.threads.queries.isThreadGenerating,
     resolvedThreadId ? { threadId: resolvedThreadId } : 'skip',
   );
-  const columnLoading = isGenerating ?? false;
+  const { isPending, pendingMessage } = useChatLayout();
+  const columnPending =
+    isPending &&
+    pendingMessage != null &&
+    (pendingMessage.threadId === resolvedThreadId ||
+      pendingMessage.arenaThreadIdB === resolvedThreadId ||
+      (resolvedThreadId === undefined &&
+        pendingMessage.threadId === 'pending'));
+  const columnLoading = columnPending || (isGenerating ?? false);
 
   // Approvals
   const { approvals: integrationApprovals } = useIntegrationApprovals(

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -96,20 +96,40 @@ export function ChatInterface({
 
   // Restore arena thread pair when re-enabling arena mode on an existing arena thread
   const isArenaMode = arenaContext?.isArenaMode ?? false;
+
+  // Track which threadId we've started restoration for to avoid re-querying
+  // after the eager setArenaThreadIdA below makes the original condition false.
+  const arenaRestoreThreadRef = useRef<string | null>(null);
   const needsArenaRestore =
-    isArenaMode && threadId && !arenaContext?.arenaThreadIdA;
+    isArenaMode && !!threadId && arenaRestoreThreadRef.current !== threadId;
   const { data: arenaPair } = useConvexQuery(
     api.threads.queries.getArenaThreadPair,
     needsArenaRestore ? { threadId } : 'skip',
   );
+
+  // Eagerly set arenaThreadIdA so the split view renders immediately
+  // instead of flashing the single-chat view while the query loads.
   useEffect(() => {
-    if (!arenaContext || arenaContext.arenaThreadIdA) return;
+    if (
+      !arenaContext ||
+      arenaContext.arenaThreadIdA ||
+      !isArenaMode ||
+      !threadId
+    )
+      return;
+    arenaContext.setArenaThreadIdA(threadId);
+  }, [arenaContext, isArenaMode, threadId]);
+
+  // Once the query resolves, correct both IDs with the real pair.
+  useEffect(() => {
+    if (!arenaContext || !threadId || !isArenaMode) return;
     if (arenaPair) {
-      // Existing arena thread — restore both IDs
+      arenaRestoreThreadRef.current = threadId;
       arenaContext.setArenaThreadIdA(arenaPair.threadIdA);
       arenaContext.setArenaThreadIdB(arenaPair.threadIdB);
-    } else if (isArenaMode && threadId && arenaPair === null) {
-      // Non-arena thread — use current thread as A, B will be created on send
+    } else if (arenaPair === null) {
+      arenaRestoreThreadRef.current = threadId;
+      // Non-arena thread — A stays as threadId, B will be created on send
       arenaContext.setArenaThreadIdA(threadId);
     }
   }, [arenaPair, arenaContext, isArenaMode, threadId]);

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -127,11 +127,12 @@ export function useSendMessage({
             lastMessageKey,
           });
         } else {
-          // Threads need to be created — use 'pending' so both columns
-          // (threadId=undefined) display the user message immediately.
+          // Thread A may exist (arenaThreadIdA set) but B needs creation,
+          // or neither exists yet (new chat). Use the known A ID so
+          // ArenaColumn A can match and display the optimistic message.
           setPendingMessage({
             content: message,
-            threadId: 'pending',
+            threadId: currentArena.arenaThreadIdA ?? 'pending',
             attachments: mutationAttachments,
             timestamp: pendingTimestamp,
             lastMessageKey,
@@ -210,7 +211,8 @@ export function useSendMessage({
               lastMessageKey,
             });
           } else {
-            // New chat — create both threads
+            // New chat — create threads progressively.
+            // Navigate after Thread A so split view renders while B is created.
             const newA = await createThread({
               organizationId,
               title,
@@ -219,6 +221,24 @@ export function useSendMessage({
               arenaModelId: modelA,
               teamId,
             });
+
+            tIdA = newA;
+            currentArena.setArenaThreadIdA(newA);
+            setPendingThreadId(tIdA);
+            setPendingMessage({
+              content: message,
+              threadId: tIdA,
+              attachments: mutationAttachments,
+              timestamp: pendingTimestamp,
+              lastMessageKey,
+            });
+            startTransition(() => {
+              void navigate({
+                to: '/dashboard/$id/chat/$threadId',
+                params: { id: organizationId, threadId: tIdA },
+              });
+            });
+
             const newB = await createThread({
               organizationId,
               title,
@@ -230,12 +250,10 @@ export function useSendMessage({
               teamId,
             });
 
-            tIdA = newA;
             tIdB = newB;
-            currentArena.setArenaThreadIdA(newA);
             currentArena.setArenaThreadIdB(newB);
 
-            // Update pending message with real thread IDs
+            // Update pending message with both thread IDs
             setPendingMessage({
               content: message,
               threadId: tIdA,
@@ -246,13 +264,16 @@ export function useSendMessage({
             });
           }
 
-          setPendingThreadId(tIdA);
-          startTransition(() => {
-            void navigate({
-              to: '/dashboard/$id/chat/$threadId',
-              params: { id: organizationId, threadId: tIdA },
+          // Navigate for existing-thread branches (new-chat navigated above)
+          if (currentArena.arenaThreadIdA) {
+            setPendingThreadId(tIdA);
+            startTransition(() => {
+              void navigate({
+                to: '/dashboard/$id/chat/$threadId',
+                params: { id: organizationId, threadId: tIdA },
+              });
             });
-          });
+          }
 
           // Start both models generating (split view shows "Thinking")
           await arenaChatRef.current({


### PR DESCRIPTION
## Summary
- **Fix pending message matching bug**: when enabling arena on an existing thread, the optimistic user message used `threadId: 'pending'` which failed to match ArenaColumn's real thread ID — neither column displayed the user message until Thread B was created (~800ms delay)
- **Eliminate flash of single-chat view**: eagerly set `arenaThreadIdA` from the URL thread ID so the split view renders immediately instead of waiting for the async `getArenaThreadPair` query
- **Instant "Thinking" indicator**: add client-side `isPending` to ArenaColumn loading state (matching single-chat's `isPending || isGenerating` pattern) so the loading animation appears on send, not after the server subscription fires (~1-2s delay)
- **Progressive thread creation**: navigate after Thread A creation in new arena chats so the split view renders while Thread B is still being created (~300-800ms saved)

## Test plan
- [ ] Enable arena on a non-arena thread, send message → user message appears instantly in both columns with "Thinking"
- [ ] In existing arena thread, send follow-up → user message + "Thinking" appear instantly
- [ ] Start new arena chat, send first message → split view renders after Thread A (not both threads)
- [ ] Navigate away from arena thread and back → split view appears immediately (no flash of single-chat)
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint --workspace=@tale/platform`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state display in arena split-view chat; "Thinking" indicator now appears immediately upon message send.
  * Enhanced arena mode initialization and thread restoration for smoother state management.
  * Refined message sending behavior in multi-thread arena mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->