### PR TITLE
fix(platform): install integration before saving OAuth2 credentials

### DIFF
--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
@@ -746,13 +746,25 @@ export function useIntegrationManage(
 
     setIsSavingOAuth2(true);
     try {
+      // If no credential record exists yet (uninstalled integration), install first
+      let credentialId = integration._id;
+      const slug = integration.name ?? '';
+      if (credentialId === slug && slug && integration.organizationId) {
+        const installResult = await installFn({
+          orgSlug: 'default',
+          slug,
+          organizationId: integration.organizationId,
+        });
+        credentialId = installResult.credentialId;
+      }
+
       const parsedScopes = oauth2Fields.scopes
         .split(/[,\s]+/)
         .map((s) => s.trim())
         .filter(Boolean);
 
       await saveOAuth2Credentials({
-        credentialId: toId<'integrationCredentials'>(integration._id),
+        credentialId: toId<'integrationCredentials'>(credentialId),
         authorizationUrl: oauth2Fields.authorizationUrl.trim(),
         tokenUrl: oauth2Fields.tokenUrl.trim(),
         scopes: parsedScopes.length > 0 ? parsedScopes : undefined,
@@ -777,13 +789,33 @@ export function useIntegrationManage(
     } finally {
       setIsSavingOAuth2(false);
     }
-  }, [oauth2Fields, integration._id, saveOAuth2Credentials, t]);
+  }, [
+    oauth2Fields,
+    integration._id,
+    integration.name,
+    integration.organizationId,
+    saveOAuth2Credentials,
+    installFn,
+    t,
+  ]);
 
   const handleReauthorize = useCallback(async () => {
     setIsSavingOAuth2(true);
     try {
+      // If no credential record exists yet (uninstalled integration), install first
+      let credentialId = integration._id;
+      const slug = integration.name ?? '';
+      if (credentialId === slug && slug && integration.organizationId) {
+        const installResult = await installFn({
+          orgSlug: 'default',
+          slug,
+          organizationId: integration.organizationId,
+        });
+        credentialId = installResult.credentialId;
+      }
+
       const authUrl = await generateOAuth2Url({
-        credentialId: toId<'integrationCredentials'>(integration._id),
+        credentialId: toId<'integrationCredentials'>(credentialId),
         organizationId: integration.organizationId ?? '',
       });
       window.location.href = authUrl;
@@ -795,7 +827,14 @@ export function useIntegrationManage(
       });
       setIsSavingOAuth2(false);
     }
-  }, [integration._id, integration.organizationId, generateOAuth2Url, t]);
+  }, [
+    integration._id,
+    integration.name,
+    integration.organizationId,
+    generateOAuth2Url,
+    installFn,
+    t,
+  ]);
 
   const oauth2FieldsComplete =
     oauth2Fields.clientId.trim().length > 0 &&


### PR DESCRIPTION
## Summary
- Fixes #1510 — saving OAuth2 credentials for uninstalled (file-based) integrations failed with `ArgumentValidationError` because the slug string was passed as `credentialId` instead of a valid Convex document ID
- Applies the same install-first pattern from `handleTestConnection` to `handleSaveOAuth2Only` and `handleReauthorize` — if the credential record doesn't exist yet, install the integration first to obtain a real document ID

## Test plan
- [ ] Open Integrations settings, select an uninstalled OAuth2 integration (e.g. Slack)
- [ ] Enter OAuth2 credentials and click Save — should succeed without `ArgumentValidationError`
- [ ] Click Reauthorize on an uninstalled integration — should redirect to OAuth flow without error
- [ ] Verify previously installed integrations still work normally (credential ID is already valid, install step is skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced OAuth2 integration re-authorization workflow to better handle missing or invalid credentials by automatically attempting installation when needed and using the updated credential identifier for subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->