### PR TITLE
fix(platform): remove duplicate Share item from chat header dropdown

### DIFF
--- a/services/platform/app/features/chat/components/chat-header.tsx
+++ b/services/platform/app/features/chat/components/chat-header.tsx
@@ -103,16 +103,6 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
   const headerMenuItems = useMemo<DropdownMenuGroup[]>(
     () => [
       [
-        ...(threadId
-          ? [
-              {
-                type: 'item' as const,
-                label: tChat('share.button'),
-                icon: Share,
-                onClick: () => setIsShareDialogOpen(true),
-              },
-            ]
-          : []),
         {
           type: 'item' as const,
           label: tChat('export.button'),
@@ -121,7 +111,7 @@ export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
         },
       ],
     ],
-    [tChat, threadId],
+    [tChat],
   );
 
   const baseIconClasses = 'size-5 text-muted-foreground p-0.25';


### PR DESCRIPTION
## Summary
- Remove the duplicate "Share" entry from the chat header's `...` dropdown menu
- The Share button already exists as a standalone button in the header bar — the dropdown entry was accidentally added in #1397

## Test plan
- [ ] Open a chat thread on desktop — Share button visible in header, dropdown only shows Export
- [ ] Open on mobile — Share icon button in header, dropdown only shows Export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the share dropdown menu item from the chat header. The menu now contains only the export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->