### PR TITLE
fix(platform): add proper arena exit cleanup with branch merging

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-mode-context.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-mode-context.tsx
@@ -9,6 +9,9 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
+import { api } from '@/convex/_generated/api';
+
 type Verdict = 'a_better' | 'b_better' | 'tie' | 'both_bad';
 
 interface ArenaModeContextType {
@@ -19,6 +22,7 @@ interface ArenaModeContextType {
   setModelB: (modelId: string | null) => void;
   enableArenaMode: () => void;
   disableArenaMode: () => void;
+  exitArenaMode: () => void;
   arenaThreadIdA: string | null;
   arenaThreadIdB: string | null;
   setArenaThreadIdA: (threadId: string | null) => void;
@@ -57,6 +61,10 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
     setIsArenaMode(true);
   }, []);
 
+  const { mutateAsync: cleanupArenaBranch } = useConvexMutation(
+    api.threads.mutations.cleanupArenaBranch,
+  );
+
   const disableArenaMode = useCallback(() => {
     setIsArenaMode(false);
     setModelA(null);
@@ -65,6 +73,33 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
     setArenaThreadIdB(null);
     setVerdict(null);
   }, []);
+
+  const exitArenaMode = useCallback(() => {
+    // Capture values before clearing state
+    const tidA = arenaThreadIdA;
+    const tidB = arenaThreadIdB;
+    const currentVerdict = verdict;
+
+    // Reset UI state immediately for snappy UX
+    disableArenaMode();
+
+    // Fire-and-forget backend cleanup
+    if (tidA && tidB) {
+      void cleanupArenaBranch({
+        threadIdA: tidA,
+        threadIdB: tidB,
+        verdict: currentVerdict ?? undefined,
+      }).catch((err: unknown) => {
+        console.error('[arena] cleanup failed:', err);
+      });
+    }
+  }, [
+    arenaThreadIdA,
+    arenaThreadIdB,
+    verdict,
+    disableArenaMode,
+    cleanupArenaBranch,
+  ]);
 
   const value = useMemo(
     () => ({
@@ -75,6 +110,7 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
       setModelB,
       enableArenaMode,
       disableArenaMode,
+      exitArenaMode,
       arenaThreadIdA,
       arenaThreadIdB,
       setArenaThreadIdA,
@@ -88,6 +124,7 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
       modelB,
       enableArenaMode,
       disableArenaMode,
+      exitArenaMode,
       arenaThreadIdA,
       arenaThreadIdB,
       verdict,

--- a/services/platform/app/features/chat/components/arena/arena-mode-toggle.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-mode-toggle.tsx
@@ -15,11 +15,11 @@ export function ArenaModeToggle({ disabled }: { disabled?: boolean }) {
 
   if (!arenaContext) return null;
 
-  const { isArenaMode, enableArenaMode, disableArenaMode } = arenaContext;
+  const { isArenaMode, enableArenaMode, exitArenaMode } = arenaContext;
 
   const handleToggle = () => {
     if (isArenaMode) {
-      disableArenaMode();
+      exitArenaMode();
     } else {
       enableArenaMode();
     }

--- a/services/platform/app/features/chat/components/arena/arena-verdict-bar.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-verdict-bar.tsx
@@ -36,9 +36,6 @@ export function ArenaVerdictBar({
   const { mutateAsync: submitFeedback } = useConvexMutation(
     api.feedback.mutations.submitFeedback,
   );
-  const { mutateAsync: updateBranchSelections } = useConvexMutation(
-    api.threads.mutations.updateBranchSelections,
-  );
 
   const handleVerdict = useCallback(
     async (verdict: Verdict) => {
@@ -60,14 +57,6 @@ export function ArenaVerdictBar({
           },
         });
 
-        // If B is better, switch the branch selection so Thread B becomes active
-        if (verdict === 'b_better') {
-          await updateBranchSelections({
-            threadId: threadIdA,
-            branchSelections: JSON.stringify({ '0': threadIdB }),
-          });
-        }
-
         setVerdict(verdict);
 
         toast({
@@ -85,7 +74,6 @@ export function ArenaVerdictBar({
     [
       isSubmitting,
       submitFeedback,
-      updateBranchSelections,
       setVerdict,
       organizationId,
       threadIdA,

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -104,6 +104,13 @@ export function ChatInterface({
   const creatingThreadBRef = useRef(false);
   const arenaSetupThreadRef = useRef<string | null>(null);
 
+  // Reset setup ref when arena mode is turned off, so re-enabling triggers setup again
+  useEffect(() => {
+    if (!isArenaMode) {
+      arenaSetupThreadRef.current = null;
+    }
+  }, [isArenaMode]);
+
   // When arena mode is enabled on an existing thread, eagerly set Thread A
   // and create a fresh Thread B with the current message history snapshot.
   useEffect(() => {
@@ -152,7 +159,7 @@ export function ChatInterface({
     const hadThread = prevThreadIdRef.current;
     prevThreadIdRef.current = threadId;
     if (hadThread && !threadId && arenaContext?.isArenaMode) {
-      arenaContext.disableArenaMode();
+      arenaContext.exitArenaMode();
     }
   }, [threadId, arenaContext]);
 

--- a/services/platform/convex/threads/mutations.ts
+++ b/services/platform/convex/threads/mutations.ts
@@ -1,4 +1,4 @@
-import { saveMessage } from '@convex-dev/agent';
+import { listMessages, saveMessage, type MessageDoc } from '@convex-dev/agent';
 import { v } from 'convex/values';
 
 import { components } from '../_generated/api';
@@ -13,6 +13,34 @@ import { createChatThread as createChatThreadHelper } from './create_chat_thread
 import { deleteChatThread as deleteChatThreadHelper } from './delete_chat_thread';
 import { getThreadMessages } from './get_thread_messages';
 import { updateChatThread as updateChatThreadHelper } from './update_chat_thread';
+
+/**
+ * List ALL messages (including tool, system, etc.) from a thread in chronological order.
+ * Unlike getThreadMessages which filters to user/assistant only, this preserves everything.
+ */
+async function listAllMessages(
+  ctx: Parameters<typeof listMessages>[0],
+  threadId: string,
+): Promise<MessageDoc[]> {
+  const allMessages: MessageDoc[] = [];
+  let cursor: string | null = null;
+  let isDone = false;
+
+  while (!isDone) {
+    const result = await listMessages(ctx, components.agent, {
+      threadId,
+      paginationOpts: { cursor, numItems: 100 },
+      excludeToolMessages: false,
+    });
+    allMessages.push(...result.page);
+    cursor = result.continueCursor;
+    isDone = result.isDone;
+  }
+
+  // listMessages returns newest-first, reverse for chronological order
+  allMessages.reverse();
+  return allMessages;
+}
 
 export const createChatThread = mutation({
   args: {
@@ -108,13 +136,14 @@ export const createArenaThreadB = mutation({
       args.organizationId,
     );
 
-    // Copy current conversation history from Thread A → Thread B
-    const { messages } = await getThreadMessages(ctx, args.threadIdA);
-    for (const msg of messages) {
+    // Copy current conversation history from Thread A → Thread B (all message types)
+    const allMessages = await listAllMessages(ctx, args.threadIdA);
+    for (const msg of allMessages) {
+      if (!msg.message) continue;
       await saveMessage(ctx, components.agent, {
         threadId: threadIdB,
         userId: authUser._id,
-        message: { role: msg.role, content: msg.content },
+        message: msg.message,
       });
     }
 
@@ -234,7 +263,7 @@ export const updateBranchSelections = mutation({
 });
 
 /**
- * Copies all messages from one thread to another.
+ * Copies all messages from one thread to another (including tool, system, etc.).
  * Used when enabling arena mode on an existing thread — Thread B needs
  * the same conversation history as Thread A.
  */
@@ -246,16 +275,14 @@ export const copyThreadMessages = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const { messages } = await getThreadMessages(ctx, args.sourceThreadId);
+    const allMessages = await listAllMessages(ctx, args.sourceThreadId);
 
-    for (const msg of messages) {
+    for (const msg of allMessages) {
+      if (!msg.message) continue;
       await saveMessage(ctx, components.agent, {
         threadId: args.targetThreadId,
         userId: args.userId,
-        message: {
-          role: msg.role,
-          content: msg.content,
-        },
+        message: msg.message,
       });
     }
 
@@ -323,6 +350,80 @@ export const updateMessageContent = mutation({
         message: { role: 'assistant', content: args.content },
       },
     });
+    return null;
+  },
+});
+
+/**
+ * Clean up arena branch when exiting arena mode.
+ * If verdict is 'b_better', wipes Thread A and copies all of Thread B's messages into it.
+ * Then deletes Thread B, the branch link, and arena metadata.
+ */
+export const cleanupArenaBranch = mutation({
+  args: {
+    threadIdA: v.string(),
+    threadIdB: v.string(),
+    verdict: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    // Verify ownership of Thread A
+    const metaA = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadIdA))
+      .first();
+    if (!metaA || metaA.userId !== authUser._id) {
+      throw new Error('Thread not found');
+    }
+
+    // If B won, wipe Thread A and copy all of B's messages into it
+    if (args.verdict === 'b_better') {
+      // Get all messages from both threads
+      const messagesA = await listAllMessages(ctx, args.threadIdA);
+      const messagesB = await listAllMessages(ctx, args.threadIdB);
+
+      // Delete all of A's messages
+      const messageIdsA = messagesA.map((m) => m._id);
+      if (messageIdsA.length > 0) {
+        await ctx.runMutation(components.agent.messages.deleteByIds, {
+          messageIds: messageIdsA,
+        });
+      }
+
+      // Copy all of B's messages into A
+      for (const msg of messagesB) {
+        if (!msg.message) continue;
+        await saveMessage(ctx, components.agent, {
+          threadId: args.threadIdA,
+          userId: authUser._id,
+          message: msg.message,
+        });
+      }
+    }
+
+    // Delete Thread B
+    await deleteChatThreadHelper(ctx, args.threadIdB);
+
+    // Remove the branch link
+    const branchRecord = await ctx.db
+      .query('threadBranches')
+      .withIndex('by_branchThreadId', (q) =>
+        q.eq('branchThreadId', args.threadIdB),
+      )
+      .first();
+    if (branchRecord) {
+      await ctx.db.delete(branchRecord._id);
+    }
+
+    // Clean up arena metadata on Thread A
+    await ctx.db.patch(metaA._id, {
+      arenaGroupId: undefined,
+      branchSelections: undefined,
+    });
+
     return null;
   },
 });


### PR DESCRIPTION
## Summary
- Add `exitArenaMode` that resets UI instantly and fires backend cleanup via new `cleanupArenaBranch` mutation
- When verdict is "B better", wipe Thread A and copy Thread B's messages into it before deleting the branch
- Copy all message types (tool, system, etc.) instead of only user/assistant messages during arena thread creation
- Reset arena setup ref when mode is disabled so re-enabling works correctly

## Test plan
- [ ] Enable arena mode on an existing thread, verify both threads get full message history (including tool calls)
- [ ] Submit verdict "B is better", exit arena — verify Thread A now contains Thread B's messages
- [ ] Submit verdict "A is better", exit arena — verify Thread A is unchanged and Thread B is deleted
- [ ] Toggle arena mode off via the toggle button — verify cleanup runs and branch metadata is removed
- [ ] Navigate away from thread while in arena mode — verify cleanup runs
- [ ] Re-enable arena mode after exiting — verify a new Thread B is created correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arena Mode exit handling with proper cleanup when leaving comparison mode. When exiting Arena Mode after selecting a preferred response, the system now correctly manages threads and ensures the selected response persists while the comparison thread is cleaned up appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->