### PR TITLE
fix(platform): eliminate arena mode white flash during thread creation

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -693,19 +693,20 @@ export function ChatInterface({
     void sendMessage(lastUserMessage.content);
   }, [messages, sendMessage]);
 
-  const showArena = arenaContext?.isArenaMode && !!arenaContext.arenaThreadIdA;
+  // Arena mode: mount ArenaSplitView as soon as we're in arena mode and
+  // either have thread IDs or are mid-send (pendingMessage set synchronously
+  // by useSendMessage). ArenaSplitView's ArenaColumnSkeleton handles the
+  // null-threadId case, eliminating the white flash during thread creation.
+  // The `messages.length === 0` guard avoids hiding existing thread messages
+  // during the "enable arena on existing thread" transition.
+  const showArena =
+    !!arenaContext?.isArenaMode &&
+    (!!arenaContext.arenaThreadIdA ||
+      (pendingMessage != null && messages.length === 0));
 
-  // In arena mode, while waiting for thread creation (pendingMessage set but
-  // no arena threads yet), keep the welcome page visible.
-  const arenaWaiting =
-    arenaContext?.isArenaMode && pendingMessage != null && !showArena;
-
-  // Show messages view when we have content or are loading (to show ThinkingAnimation)
   const showMessages =
-    dataThreadId ||
-    messages.length > 0 ||
-    pendingMessage ||
-    (isLoading && !arenaWaiting);
+    !showArena &&
+    (dataThreadId || messages.length > 0 || pendingMessage || isLoading);
   const showWelcome = !showMessages && !showArena;
 
   return (


### PR DESCRIPTION
## Summary
- When Arena Mode is enabled on a new chat and the user sends the first message, there was a brief white flash before the dual-column UI appeared. Root cause: `ArenaSplitView` only mounted after `await createThread` × 2 resolved and `setArenaThreadIdA` fired, leaving the welcome view visible against an already-cleared input during the network round-trips.
- Broadens `showArena` to mount `ArenaSplitView` as soon as `pendingMessage` is set (written synchronously in [use-send-message.ts:122-143](services/platform/app/features/chat/hooks/use-send-message.ts#L122-L143), before any `await`). The existing `ArenaColumnSkeleton` fallback then fills the transition window automatically — no new components.
- Guards the new branch with `messages.length === 0` so the "enable arena on an existing thread" flow cannot hide already-loaded messages. Removes the now-obsolete `arenaWaiting` variable and simplifies `showMessages` to explicit `!showArena` gating.

## Test plan
- [ ] `/dashboard/<org>/chat` (no thread) → enable Arena → send message: skeleton columns appear instantly, no white flash, transition smoothly to streamed messages.
- [ ] Chrome DevTools "Slow 3G": skeleton stays stable until messages arrive.
- [ ] Non-arena new chat send: welcome → messages flow unchanged.
- [ ] Enable Arena on an existing thread with messages: existing messages remain visible throughout, no skeleton flicker.
- [ ] Refresh `/chat/\$threadId` (arena and non-arena): normal `ThreadGate` skeleton path, unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved display logic for the chat interface to ensure correct visibility of the welcome page, messages, and arena mode during initialization and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->