### PR TITLE
fix(platform): reorder fork button after feedback and space message actions

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -419,7 +419,7 @@ function MessageBubbleComponent({
           </div>
         )}
         {!isUser && !isAssistantStreaming && !!displayContent && (
-          <div className="flex items-start pt-2">
+          <div className="flex items-start gap-1 pt-2">
             <Tooltip
               content={isCopied ? t('actions.copied') : t('actions.copy')}
               side="bottom"
@@ -447,6 +447,13 @@ function MessageBubbleComponent({
                 <Info className="size-4" />
               </Button>
             </Tooltip>
+            {!hideFeedback && organizationId && message.threadId && (
+              <MessageFeedback
+                messageId={message.id}
+                threadId={message.threadId}
+                organizationId={organizationId}
+              />
+            )}
             {onFork && (
               <Tooltip content={tChat('forkChat')} side="bottom">
                 <Button
@@ -458,13 +465,6 @@ function MessageBubbleComponent({
                   <GitFork className="size-4" />
                 </Button>
               </Tooltip>
-            )}
-            {!hideFeedback && organizationId && message.threadId && (
-              <MessageFeedback
-                messageId={message.id}
-                threadId={message.threadId}
-                organizationId={organizationId}
-              />
             )}
           </div>
         )}

--- a/services/platform/app/features/chat/components/message-feedback.tsx
+++ b/services/platform/app/features/chat/components/message-feedback.tsx
@@ -107,7 +107,7 @@ export function MessageFeedback({
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center">
+      <div className="flex items-center gap-1">
         <Tooltip content={t('feedback.thumbsUp')} side="bottom">
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
- Move the fork button to the end of the assistant message action row (after thumbs up/down) so destructive/branching actions sit after the lightweight feedback controls.
- Add `gap-1` between action buttons in [message-bubble.tsx](services/platform/app/features/chat/components/message-bubble.tsx) and between the thumbs-up/down buttons in [message-feedback.tsx](services/platform/app/features/chat/components/message-feedback.tsx) so the icons aren't visually crammed.

## Test plan
- [ ] Open any assistant message: buttons appear in order copy, info, 👍, 👎, fork, with visible spacing between each.
- [ ] Click fork still forks the chat.
- [ ] Thumbs up/down feedback flow still works.
- [ ] Shared chat view unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in the message toolbar layout to improve visual clarity and alignment of message action controls.
  * Adjusted spacing between message feedback buttons (thumbs up and thumbs down) for improved visual consistency and better visual separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->