### PR TITLE
fix(platform): clean up residual arena branches on exit and smooth transition

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-mode-context.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-mode-context.tsx
@@ -16,6 +16,7 @@ type Verdict = 'a_better' | 'b_better' | 'tie' | 'both_bad';
 
 interface ArenaModeContextType {
   isArenaMode: boolean;
+  isExitingArena: boolean;
   modelA: string | null;
   modelB: string | null;
   setModelA: (modelId: string | null) => void;
@@ -51,6 +52,7 @@ interface ArenaModeProviderProps {
 
 export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
   const [isArenaMode, setIsArenaMode] = useState(false);
+  const [isExitingArena, setIsExitingArena] = useState(false);
   const [modelA, setModelA] = useState<string | null>(null);
   const [modelB, setModelB] = useState<string | null>(null);
   const [arenaThreadIdA, setArenaThreadIdA] = useState<string | null>(null);
@@ -80,19 +82,28 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
     const tidB = arenaThreadIdB;
     const currentVerdict = verdict;
 
-    // Reset UI state immediately for snappy UX
-    disableArenaMode();
-
-    // Fire-and-forget backend cleanup
-    if (tidA && tidB) {
-      void cleanupArenaBranch({
-        threadIdA: tidA,
-        threadIdB: tidB,
-        verdict: currentVerdict ?? undefined,
-      }).catch((err: unknown) => {
-        console.error('[arena] cleanup failed:', err);
-      });
+    // No backend state to clean up; exit immediately.
+    if (!tidA || !tidB) {
+      disableArenaMode();
+      return;
     }
+
+    // Show skeleton while the backend migrates messages and branch records.
+    // Only flip arena off after the mutation settles so the UI doesn't flash
+    // Thread A's pre-cleanup messages (especially under verdict='b_better').
+    setIsExitingArena(true);
+    void cleanupArenaBranch({
+      threadIdA: tidA,
+      threadIdB: tidB,
+      verdict: currentVerdict ?? undefined,
+    })
+      .catch((err: unknown) => {
+        console.error('[arena] cleanup failed:', err);
+      })
+      .finally(() => {
+        disableArenaMode();
+        setIsExitingArena(false);
+      });
   }, [
     arenaThreadIdA,
     arenaThreadIdB,
@@ -104,6 +115,7 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
   const value = useMemo(
     () => ({
       isArenaMode,
+      isExitingArena,
       modelA,
       modelB,
       setModelA,
@@ -120,6 +132,7 @@ export function ArenaModeProvider({ children }: ArenaModeProviderProps) {
     }),
     [
       isArenaMode,
+      isExitingArena,
       modelA,
       modelB,
       enableArenaMode,

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -54,6 +54,7 @@ import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaSplitView } from './arena/arena-split-view';
 import { ChatInput } from './chat-input';
 import { ChatMessages } from './chat-messages';
+import { MessagesSkeleton } from './messages-skeleton';
 import { WelcomeView } from './welcome-view';
 
 function chatDraftKey(
@@ -704,10 +705,18 @@ export function ChatInterface({
     (!!arenaContext.arenaThreadIdA ||
       (pendingMessage != null && messages.length === 0));
 
+  // While cleanupArenaBranch is running the underlying messages are being
+  // rewritten (verdict='b_better' wipes Thread A and copies B's messages in).
+  // Render a skeleton in this window so the user doesn't see the pre-cleanup
+  // Thread A content flash before the new messages arrive.
+  const showExitingSkeleton =
+    !showArena && !!arenaContext?.isExitingArena && !!dataThreadId;
+
   const showMessages =
     !showArena &&
+    !showExitingSkeleton &&
     (dataThreadId || messages.length > 0 || pendingMessage || isLoading);
-  const showWelcome = !showMessages && !showArena;
+  const showWelcome = !showMessages && !showArena && !showExitingSkeleton;
 
   return (
     <div
@@ -740,6 +749,8 @@ export function ChatInterface({
               onSuggestionClick={setInputValue}
             />
           )}
+
+          {showExitingSkeleton && <MessagesSkeleton />}
 
           {showMessages && (
             <ChatMessages

--- a/services/platform/app/features/chat/components/messages-skeleton.tsx
+++ b/services/platform/app/features/chat/components/messages-skeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
+import { cn } from '@/lib/utils/cn';
+
+const rows: Array<{ role: 'user' | 'assistant'; widths: string[] }> = [
+  { role: 'user', widths: ['w-40'] },
+  { role: 'assistant', widths: ['w-full', 'w-5/6', 'w-2/3'] },
+  { role: 'user', widths: ['w-56'] },
+  { role: 'assistant', widths: ['w-full', 'w-4/5'] },
+];
+
+export function MessagesSkeleton() {
+  return (
+    <div className="flex w-full max-w-(--chat-max-width) flex-col gap-6 self-center">
+      {rows.map((row, rowIdx) => (
+        <div
+          key={rowIdx}
+          className={cn(
+            'flex flex-col gap-2',
+            row.role === 'user' ? 'items-end' : 'items-start',
+          )}
+        >
+          {row.widths.map((w, i) => (
+            <Skeleton
+              key={i}
+              className={cn('h-4', w)}
+              label="Loading message"
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/services/platform/convex/threads/mutations.ts
+++ b/services/platform/convex/threads/mutations.ts
@@ -301,7 +301,15 @@ export const createArenaBranchLink = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    // Find the last user message in the root thread to use as fork point
+    // Idempotent: one arena session ↔ one branch link, regardless of round count.
+    const existing = await ctx.db
+      .query('threadBranches')
+      .withIndex('by_branchThreadId', (q) =>
+        q.eq('branchThreadId', args.branchThreadId),
+      )
+      .first();
+    if (existing) return null;
+
     const { messages } = await getThreadMessages(ctx, args.rootThreadId);
 
     const userMessages = messages.filter((m) => m.role === 'user');
@@ -379,6 +387,20 @@ export const cleanupArenaBranch = mutation({
       throw new Error('Thread not found');
     }
 
+    // Defense-in-depth: also verify Thread B ownership and arena pairing.
+    const metaB = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadIdB))
+      .first();
+    if (
+      !metaB ||
+      metaB.userId !== authUser._id ||
+      !metaA.arenaGroupId ||
+      metaB.arenaGroupId !== metaA.arenaGroupId
+    ) {
+      throw new Error('Thread not found');
+    }
+
     // If B won, wipe Thread A and copy all of B's messages into it
     if (args.verdict === 'b_better') {
       // Get all messages from both threads
@@ -393,13 +415,30 @@ export const cleanupArenaBranch = mutation({
         });
       }
 
-      // Copy all of B's messages into A
+      // Copy all of B's messages into A, preserving metadata that saveMessage
+      // accepts. _creationTime is system-assigned on insert and cannot be
+      // overridden, so copied messages will have new timestamps; order is
+      // preserved by sequential iteration.
       for (const msg of messagesB) {
         if (!msg.message) continue;
         await saveMessage(ctx, components.agent, {
           threadId: args.threadIdA,
           userId: authUser._id,
+          agentName: msg.agentName,
           message: msg.message,
+          metadata: {
+            fileIds: msg.fileIds,
+            finishReason: msg.finishReason,
+            model: msg.model,
+            provider: msg.provider,
+            providerMetadata: msg.providerMetadata,
+            sources: msg.sources,
+            reasoning: msg.reasoning,
+            reasoningDetails: msg.reasoningDetails,
+            usage: msg.usage,
+            warnings: msg.warnings,
+            error: msg.error,
+          },
         });
       }
     }
@@ -407,15 +446,14 @@ export const cleanupArenaBranch = mutation({
     // Delete Thread B
     await deleteChatThreadHelper(ctx, args.threadIdB);
 
-    // Remove the branch link
-    const branchRecord = await ctx.db
+    // Remove all branch links for Thread B (there may be multiple from old
+    // data written before createArenaBranchLink was made idempotent).
+    for await (const record of ctx.db
       .query('threadBranches')
       .withIndex('by_branchThreadId', (q) =>
         q.eq('branchThreadId', args.threadIdB),
-      )
-      .first();
-    if (branchRecord) {
-      await ctx.db.delete(branchRecord._id);
+      )) {
+      await ctx.db.delete(record._id);
     }
 
     // Clean up arena metadata on Thread A


### PR DESCRIPTION
## Summary
- Fix orphaned `threadBranches` records after exiting Arena Mode with multiple rounds — root cause was non-idempotent `createArenaBranchLink` (one insert per arena message) combined with cleanup that only removed `.first()` match.
- Preserve message metadata (fileIds/usage/provider/providerMetadata/sources/reasoning/finishReason/warnings/error/agentName) when verdict=`b_better` copies Thread B's messages into Thread A. Note: `_creationTime` is a Convex system field and cannot be overridden, so copied messages get new timestamps — ordering is preserved.
- Add defense-in-depth ownership + `arenaGroupId` pairing check on Thread B in `cleanupArenaBranch`.
- Fix UI jump on exit by awaiting the cleanup mutation before collapsing the split view and rendering a `MessagesSkeleton` during the migration window.

## Repro (before)
1. Chat → enable Arena Mode → send 3–4 messages → exit.
2. Branch navigator (`1/2`, `2/2`) remained visible because N−1 orphan branch records survived cleanup.
3. With verdict=`b_better`, the user briefly saw Thread A's old messages before they were replaced by Thread B's.

## Test plan
- [ ] Typecheck: `cd services/platform && npx tsc --noEmit`
- [ ] Lint: `npm run lint --workspace=@tale/platform`
- [ ] Repro case: enter arena, send 4 messages, exit — confirm no branch nav appears and `threadBranches` has 0 rows for the thread.
- [ ] Verdict=`b_better` with attachments on Thread B: exit → confirm attachments preserved in Thread A.
- [ ] Exit UX: skeleton should display smoothly; no flash of pre-cleanup messages.
- [ ] Auth regression: construct a call with a foreign `threadIdB` — should be rejected.