### PR TITLE
feat(platform): notifications panel mark-all-read, filter, and pagination

### DIFF
--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Bell, ChevronDown, ChevronRight } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Popover } from '@/app/components/ui/overlays/popover';
 import { Button } from '@/app/components/ui/primitives/button';
@@ -11,10 +11,14 @@ import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { isRecord } from '@/lib/utils/type-guards';
 
-import { useMarkNotificationRead } from '../hooks/mutations';
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+} from '../hooks/mutations';
 import {
   useNotificationsList,
   useNotificationsUnreadCount,
+  type NotificationsFilter,
 } from '../hooks/queries';
 
 interface NotificationBellProps {
@@ -26,6 +30,8 @@ const SEVERITY_DOT: Record<string, string> = {
   warning: 'bg-amber-500',
   critical: 'bg-red-500',
 };
+
+const LOAD_MORE_NUM_ITEMS = 25;
 
 // Strip a leading `notifications.` namespace prefix that was accidentally
 // stored in earlier rows — we already bind the namespace with
@@ -41,12 +47,20 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
   const [expandedId, setExpandedId] = useState<Id<'notifications'> | null>(
     null,
   );
+  const [filter, setFilter] = useState<NotificationsFilter>('unread');
+  // IDs the user just marked as read — hidden instantly while the Convex
+  // subscription catches up, so the row doesn't linger in the Unread view.
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   const { t } = useT('notifications');
   const { formatRelative, formatDate } = useFormatDate();
 
-  const { data: list } = useNotificationsList(organizationId);
+  const { results, status, loadMore } = useNotificationsList(
+    organizationId,
+    filter,
+  );
   const { data: unread } = useNotificationsUnreadCount(organizationId);
   const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
 
   const handleToggleExpand = useCallback(
     (notificationId: Id<'notifications'>) => {
@@ -59,13 +73,56 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
 
   const handleMarkRead = useCallback(
     (notificationId: Id<'notifications'>) => {
+      setHiddenIds((prev) => {
+        const next = new Set(prev);
+        next.add(notificationId);
+        return next;
+      });
       void markRead.mutateAsync({ notificationId });
     },
     [markRead],
   );
 
-  const items = list?.page ?? [];
+  const handleMarkAllRead = useCallback(() => {
+    // Optimistically hide everything currently visible in the Unread view.
+    if (filter === 'unread') {
+      setHiddenIds((prev) => {
+        const next = new Set(prev);
+        for (const n of results) {
+          if (!n.read) next.add(n._id);
+        }
+        return next;
+      });
+    }
+    void markAllRead.mutateAsync({ organizationId });
+  }, [filter, markAllRead, organizationId, results]);
+
+  const handleFilterChange = useCallback((next: NotificationsFilter) => {
+    setFilter(next);
+    setExpandedId(null);
+    setHiddenIds(new Set());
+  }, []);
+
+  // Drop hidden IDs from the set once they disappear from the query results
+  // (or flip to `read`) so the set doesn't grow unbounded.
+  useEffect(() => {
+    if (hiddenIds.size === 0) return;
+    const stillPresent = new Set<string>();
+    for (const n of results) {
+      if (hiddenIds.has(n._id) && !n.read) stillPresent.add(n._id);
+    }
+    if (stillPresent.size !== hiddenIds.size) {
+      setHiddenIds(stillPresent);
+    }
+  }, [results, hiddenIds]);
+
+  const items = useMemo(
+    () => results.filter((n) => !hiddenIds.has(n._id)),
+    [results, hiddenIds],
+  );
   const unreadCount = unread ?? 0;
+  const canLoadMore = status === 'CanLoadMore';
+  const isLoadingMore = status === 'LoadingMore';
 
   return (
     <Popover
@@ -93,19 +150,46 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
         </button>
       }
     >
-      <div className="flex max-h-[32rem] flex-col">
-        <div className="border-border flex items-center justify-between border-b px-4 py-3">
-          <span className="text-sm font-semibold">{t('title')}</span>
-          {unreadCount > 0 && (
-            <span className="text-muted-foreground text-xs">
-              {t('unreadCount', { count: unreadCount })}
-            </span>
-          )}
+      <div className="flex h-[24rem] flex-col">
+        <div className="border-border flex flex-col gap-2 border-b px-4 py-3">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-semibold">{t('title')}</span>
+            {unreadCount > 0 && (
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={markAllRead.isPending}
+                onClick={handleMarkAllRead}
+              >
+                {t('markAllAsRead')}
+              </Button>
+            )}
+          </div>
+          <div
+            role="tablist"
+            aria-label={t('title')}
+            className="bg-muted flex w-fit rounded-md p-0.5"
+          >
+            <FilterPill
+              active={filter === 'unread'}
+              onClick={() => handleFilterChange('unread')}
+              label={
+                unreadCount > 0
+                  ? `${t('filterUnread')} (${unreadCount > 99 ? '99+' : unreadCount})`
+                  : t('filterUnread')
+              }
+            />
+            <FilterPill
+              active={filter === 'all'}
+              onClick={() => handleFilterChange('all')}
+              label={t('filterAll')}
+            />
+          </div>
         </div>
         <div className="flex-1 overflow-y-auto">
           {items.length === 0 ? (
             <div className="text-muted-foreground px-4 py-8 text-center text-sm">
-              {t('empty')}
+              {status === 'LoadingFirstPage' ? t('loading') : t('empty')}
             </div>
           ) : (
             <ul className="divide-border divide-y">
@@ -195,8 +279,46 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
               })}
             </ul>
           )}
+          {(canLoadMore || isLoadingMore) && (
+            <div className="border-border border-t p-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="w-full"
+                disabled={!canLoadMore}
+                onClick={() => loadMore(LOAD_MORE_NUM_ITEMS)}
+              >
+                {isLoadingMore ? t('loading') : t('loadMore')}
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </Popover>
+  );
+}
+
+interface FilterPillProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}
+
+function FilterPill({ active, onClick, label }: FilterPillProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+        active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {label}
+    </button>
   );
 }

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -50,7 +50,7 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
   const [filter, setFilter] = useState<NotificationsFilter>('unread');
   // IDs the user just marked as read — hidden instantly while the Convex
   // subscription catches up, so the row doesn't linger in the Unread view.
-  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+  const [hiddenIds, setHiddenIds] = useState(new Set<string>());
   const { t } = useT('notifications');
   const { formatRelative, formatDate } = useFormatDate();
 

--- a/services/platform/app/features/notifications/hooks/mutations.ts
+++ b/services/platform/app/features/notifications/hooks/mutations.ts
@@ -4,3 +4,7 @@ import { api } from '@/convex/_generated/api';
 export function useMarkNotificationRead() {
   return useConvexMutation(api.notifications.mutations.markRead);
 }
+
+export function useMarkAllNotificationsRead() {
+  return useConvexMutation(api.notifications.mutations.markAllRead);
+}

--- a/services/platform/app/features/notifications/hooks/queries.ts
+++ b/services/platform/app/features/notifications/hooks/queries.ts
@@ -1,11 +1,18 @@
+import { useConvexPaginatedQuery } from '@/app/hooks/use-convex-paginated-query';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 
-export function useNotificationsList(organizationId: string) {
-  return useConvexQuery(api.notifications.queries.list, {
-    organizationId,
-    paginationOpts: { cursor: null, numItems: 25 },
-  });
+export type NotificationsFilter = 'all' | 'unread';
+
+export function useNotificationsList(
+  organizationId: string,
+  filter: NotificationsFilter = 'unread',
+) {
+  return useConvexPaginatedQuery(
+    api.notifications.queries.list,
+    { organizationId, filter },
+    { initialNumItems: 25 },
+  );
 }
 
 export function useNotificationsUnreadCount(organizationId: string) {

--- a/services/platform/convex/notifications/mutations.ts
+++ b/services/platform/convex/notifications/mutations.ts
@@ -34,3 +34,30 @@ export const markRead = mutation({
     return null;
   },
 });
+
+export const markAllRead = mutation({
+  args: { organizationId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    await getOrganizationMember(ctx, args.organizationId, {
+      userId: String(authUser._id),
+      email: authUser.email,
+      name: authUser.name,
+    });
+
+    const userId = String(authUser._id);
+    for await (const n of ctx.db
+      .query('notifications')
+      .withIndex('by_org_created', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      if (!n.readBy.includes(userId)) {
+        await ctx.db.patch(n._id, { readBy: [...n.readBy, userId] });
+      }
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/notifications/queries.ts
+++ b/services/platform/convex/notifications/queries.ts
@@ -32,6 +32,7 @@ export const list = query({
   args: {
     organizationId: v.string(),
     paginationOpts: paginationOptsValidator,
+    filter: v.optional(v.union(v.literal('all'), v.literal('unread'))),
   },
   returns: v.object({
     page: v.array(notificationDocValidator),
@@ -48,6 +49,7 @@ export const list = query({
       name: authUser.name,
     });
     const userId = String(authUser._id);
+    const filter = args.filter ?? 'all';
 
     const result = await ctx.db
       .query('notifications')
@@ -57,22 +59,28 @@ export const list = query({
       .order('desc')
       .paginate(args.paginationOpts);
 
+    // When filtering to unread we drop already-read rows from the returned
+    // page. The `isDone` / `continueCursor` still reflect the underlying
+    // pagination cursor, so pages can be shorter than `numItems` but the
+    // client can keep calling `loadMore` until the index is exhausted.
+    const mapped = result.page.map((n) => ({
+      _id: n._id,
+      _creationTime: n._creationTime,
+      organizationId: n.organizationId,
+      category: n.category,
+      severity: n.severity,
+      titleKey: n.titleKey,
+      bodyKey: n.bodyKey,
+      params: n.params,
+      createdAt: n.createdAt,
+      readBy: n.readBy,
+      read: n.readBy.includes(userId),
+    }));
+
     return {
       isDone: result.isDone,
       continueCursor: result.continueCursor,
-      page: result.page.map((n) => ({
-        _id: n._id,
-        _creationTime: n._creationTime,
-        organizationId: n.organizationId,
-        category: n.category,
-        severity: n.severity,
-        titleKey: n.titleKey,
-        bodyKey: n.bodyKey,
-        params: n.params,
-        createdAt: n.createdAt,
-        readBy: n.readBy,
-        read: n.readBy.includes(userId),
-      })),
+      page: filter === 'unread' ? mapped.filter((n) => !n.read) : mapped,
     };
   },
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4151,6 +4151,11 @@
     "unreadCount": "{count, plural, one {# ungelesen} other {# ungelesen}}",
     "empty": "Keine Benachrichtigungen.",
     "markAsRead": "Als gelesen markieren",
+    "markAllAsRead": "Alle als gelesen markieren",
+    "filterUnread": "Ungelesen",
+    "filterAll": "Alle",
+    "loadMore": "Mehr laden",
+    "loading": "Lädt…",
     "accountLocked": "Konto vorübergehend gesperrt: {email}",
     "lockoutDetails": "{consecutiveFailures} fehlgeschlagene Anmeldeversuche von {ip}."
   }

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4170,6 +4170,11 @@
     "unreadCount": "{count, plural, one {# unread} other {# unread}}",
     "empty": "No notifications.",
     "markAsRead": "Mark as read",
+    "markAllAsRead": "Mark all as read",
+    "filterUnread": "Unread",
+    "filterAll": "All",
+    "loadMore": "Load more",
+    "loading": "Loading…",
     "accountLocked": "Account temporarily locked: {email}",
     "lockoutDetails": "{consecutiveFailures} failed sign-in attempts from {ip}."
   },


### PR DESCRIPTION
## Summary
- Add **Mark all as read** button to the notifications popover header, backed by a new `markAllRead` Convex mutation (auth + org RLS, idempotent).
- Add **Unread / All** segmented filter (default Unread), backed by a new `filter` arg on the `list` query that drops already-read rows server-side.
- Switch the bell list to `useConvexPaginatedQuery` with 25-item pages and a **Load more** button; optimistic hide of just-marked rows until the reactive subscription catches up.
- Fixed-height popover (`h-[24rem]`) with internal scroll so the panel is a consistent size regardless of content.
- i18n keys added to `en.json` and `de.json`.

## Test plan
- [ ] Run `convex dev` once so `_generated/api.d.ts` picks up `markAllRead`; commit the regenerated file in a follow-up.
- [ ] `cd services/platform && npx tsc --noEmit` — clean.
- [ ] `npm run lint --workspace=@tale/platform` — clean.
- [ ] Seed / trigger several unread notifications (e.g. via account-lockout path); open the bell popover.
  - [ ] Default tab is **Unread**, unread count shows on the pill and as the red bell badge.
  - [ ] Click a single **Mark as read** — row disappears instantly from Unread view; reopen / switch to **All** to confirm it's still present and marked read.
  - [ ] Click **Mark all as read** — all visible unread rows disappear instantly, badge clears.
  - [ ] With > 25 notifications, scroll list and click **Load more** to page through.
  - [ ] Switch locale to `de` — all new labels render in German.
  - [ ] Empty state and short lists render at the fixed popover height with scrollbar only when needed.