### PR TITLE
feat(platform): apply tabs pattern to all governance settings groups

### DIFF
--- a/services/platform/app/routes/dashboard/$id/settings/governance.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance.tsx
@@ -76,17 +76,26 @@ function GovernanceSettingsPage() {
         key: 'content-models',
         label: t('groups.contentAndModels'),
         sections: [
-          <SystemPromptEditor
-            key="system-prompt"
-            organizationId={organizationId}
-          />,
-          <DefaultModelEditor
-            key="default-models"
-            organizationId={organizationId}
-          />,
-          <ModelAccessEditor
-            key="model-access"
-            organizationId={organizationId}
+          <Tabs
+            key="content-tabs"
+            defaultValue="system-prompt"
+            items={[
+              {
+                value: 'system-prompt',
+                label: t('groups.subtabs.systemPrompt'),
+                content: <SystemPromptEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'default-models',
+                label: t('groups.subtabs.defaultModels'),
+                content: <DefaultModelEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'model-access',
+                label: t('groups.subtabs.modelAccess'),
+                content: <ModelAccessEditor organizationId={organizationId} />,
+              },
+            ]}
           />,
         ],
       },
@@ -94,15 +103,31 @@ function GovernanceSettingsPage() {
         key: 'policies-limits',
         label: t('groups.policiesAndLimits'),
         sections: [
-          <BudgetEditor key="budgets" organizationId={organizationId} />,
-          <UploadPolicyEditor
-            key="upload-policy"
-            organizationId={organizationId}
-          />,
-          <RetentionEditor key="retention" organizationId={organizationId} />,
-          <FeatureFlagsEditor
-            key="feature-controls"
-            organizationId={organizationId}
+          <Tabs
+            key="policies-tabs"
+            defaultValue="budgets"
+            items={[
+              {
+                value: 'budgets',
+                label: t('groups.subtabs.budgets'),
+                content: <BudgetEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'upload-policy',
+                label: t('groups.subtabs.uploadPolicy'),
+                content: <UploadPolicyEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'retention',
+                label: t('groups.subtabs.retention'),
+                content: <RetentionEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'feature-controls',
+                label: t('groups.subtabs.featureControls'),
+                content: <FeatureFlagsEditor organizationId={organizationId} />,
+              },
+            ]}
           />,
         ],
       },

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3756,7 +3756,14 @@
       "subtabs": {
         "login": "Anmeldung & Authentifizierung",
         "pii": "PII-Schutz",
-        "usage": "Nutzung"
+        "usage": "Nutzung",
+        "systemPrompt": "System-Prompt",
+        "defaultModels": "Standardmodelle",
+        "modelAccess": "Modellzugriff",
+        "budgets": "Budgets",
+        "uploadPolicy": "Upload-Richtlinie",
+        "retention": "Aufbewahrung",
+        "featureControls": "Funktionssteuerung"
       }
     },
     "featureFlags": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4010,7 +4010,14 @@
       "subtabs": {
         "login": "Login & authentication",
         "pii": "PII protection",
-        "usage": "Usage"
+        "usage": "Usage",
+        "systemPrompt": "System prompt",
+        "defaultModels": "Default models",
+        "modelAccess": "Model access",
+        "budgets": "Budgets",
+        "uploadPolicy": "Upload policy",
+        "retention": "Retention",
+        "featureControls": "Feature controls"
       }
     },
     "modelAccess": {


### PR DESCRIPTION
## Summary
- Content & Models and Policies & Limits now use sub-tabs, matching the existing Security & Monitoring pattern
- Each group's sections stay within one viewport instead of scrolling a long stack
- Added 7 new subtab labels under `governance.groups.subtabs` in both `en.json` and `de.json`

## Test plan
- [ ] `/dashboard/<id>/settings/governance` → Content & Models shows 3 tabs (System prompt / Default models / Model access)
- [ ] Policies & Limits shows 4 tabs (Budgets / Upload policy / Retention / Feature controls)
- [ ] Security & Monitoring behaves exactly as before
- [ ] Switch UI language to German; verify translated tab labels
- [ ] Deep-link `?group=content-models` still selects the correct sidebar group