### PR TITLE
fix(platform): derive Sentry CSP origin from SENTRY_DSN

### DIFF
--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -62,14 +62,24 @@ describe('security headers', () => {
     expect(csp).toContain('https://mcp.figma.com');
   });
 
-  test('CSP includes Sentry origin when SENTRY_DSN is set', async () => {
+  test('CSP includes Sentry origin parsed from SENTRY_DSN', async () => {
     const app = createApp({
       ...baseEnv,
-      SENTRY_DSN: 'https://abc@sentry.io/123',
+      SENTRY_DSN: 'https://abc@o1.ingest.us.sentry.io/123',
     });
     const res = await app.fetch(new Request('http://localhost/api/health'));
     const csp = res.headers.get('content-security-policy') ?? '';
-    expect(csp).toContain('https://*.ingest.sentry.io');
+    expect(csp).toContain('https://o1.ingest.us.sentry.io');
+  });
+
+  test('CSP supports self-hosted Sentry on a custom domain', async () => {
+    const app = createApp({
+      ...baseEnv,
+      SENTRY_DSN: 'https://abc@sentry.elintrio.com/123',
+    });
+    const res = await app.fetch(new Request('http://localhost/api/health'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).toContain('https://sentry.elintrio.com');
   });
 });
 

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -107,7 +107,8 @@ function getEnvConfig(): EnvConfig {
 // dropped for this reason.
 //
 // Current exceptions are gated by explicit operator opt-in:
-//   - Sentry (`*.ingest.sentry.io`): only when SENTRY_DSN is set.
+//   - Sentry: origin is parsed from SENTRY_DSN (supports SaaS ingest and
+//     self-hosted Sentry on custom domains). Only emitted when DSN is set.
 //   - Figma MCP (`mcp.figma.com`): only when SITE_URL is a loopback host
 //     (dev-only; production policy never includes it).
 //
@@ -118,8 +119,20 @@ function getEnvConfig(): EnvConfig {
 // whether HSTS is emitted (only when the deployment is HTTPS).
 // ---------------------------------------------------------------------------
 
+function sentryOriginFromDsn(dsn: string | undefined): string | null {
+  if (!dsn) return null;
+  try {
+    const url = new URL(dsn);
+    return `${url.protocol}//${url.host}`;
+  } catch (err) {
+    console.warn('Invalid SENTRY_DSN, skipping CSP allow-list entry:', err);
+    return null;
+  }
+}
+
 function buildContentSecurityPolicy(env: EnvConfig) {
-  const sentry = env.SENTRY_DSN ? ['https://*.ingest.sentry.io'] : [];
+  const sentryOrigin = sentryOriginFromDsn(env.SENTRY_DSN);
+  const sentry = sentryOrigin ? [sentryOrigin] : [];
   const figmaMcp = isLoopbackSite(env) ? ['https://mcp.figma.com'] : [];
   return {
     defaultSrc: ["'self'"],


### PR DESCRIPTION
## Summary
- Hardcoded `https://*.ingest.sentry.io` in `connect-src` blocked self-hosted Sentry and custom ingest domains (e.g. `sentry.elintrio.com`) — browser refused the envelope POST with a CSP violation.
- Parse the origin from `SENTRY_DSN` instead, so any DSN host is allow-listed automatically. When `SENTRY_DSN` is unset, no Sentry entry is emitted at all.
- Invalid DSNs log a warning and fall back to no allow-list entry rather than crashing.

## Test plan
- [x] `npx vitest run server.test.ts` — added cases for SaaS ingest host + self-hosted custom domain; existing "no Sentry when DSN unset" case still passes
- [ ] Deploy to demo with a self-hosted `SENTRY_DSN` and confirm the browser no longer blocks `…/envelope/…` requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Sentry error tracking integration in Content Security Policy by replacing broad wildcard patterns with precise, DSN-based origin parsing.
  * Added support for self-hosted Sentry instances through intelligent Sentry DSN configuration parsing and validation.

* **Tests**  
  * Expanded Content Security Policy validation test coverage to verify correct handling of both cloud-hosted and self-hosted Sentry instance configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->