### PR TITLE
feat(platform): configurable password policy with rotation (#1503)

### DIFF
--- a/services/platform/app/features/auth/hooks/use-password-expiry-gate.ts
+++ b/services/platform/app/features/auth/hooks/use-password-expiry-gate.ts
@@ -28,7 +28,7 @@ export function usePasswordExpiryGate(organizationId: string): void {
     if (location.pathname.endsWith(FORCED_CHANGE_PATH)) return;
     const id = (params as { id?: string }).id ?? organizationId;
     void navigate({
-      to: '/dashboard/$id/forced-change-password',
+      to: '/forced-change-password/$id',
       params: { id },
       replace: true,
     });

--- a/services/platform/app/features/auth/hooks/use-password-expiry-gate.ts
+++ b/services/platform/app/features/auth/hooks/use-password-expiry-gate.ts
@@ -1,0 +1,36 @@
+import { useLocation, useNavigate, useParams } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+
+const FORCED_CHANGE_PATH = 'forced-change-password';
+
+/**
+ * Watches the current user's password expiry status and redirects to the
+ * forced-change-password route when the credential has expired.
+ *
+ * Runs as a reactive Convex subscription inside the dashboard layout so
+ * policy changes and post-rotation status updates propagate without a
+ * full reload and without per-navigation fetches.
+ */
+export function usePasswordExpiryGate(organizationId: string): void {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = useParams({ strict: false });
+  const { data } = useConvexQuery(
+    api.users.queries.getPasswordExpiryStatus,
+    organizationId ? {} : 'skip',
+  );
+
+  useEffect(() => {
+    if (!data || !data.expired) return;
+    if (location.pathname.endsWith(FORCED_CHANGE_PATH)) return;
+    const id = (params as { id?: string }).id ?? organizationId;
+    void navigate({
+      to: '/dashboard/$id/forced-change-password',
+      params: { id },
+      replace: true,
+    });
+  }, [data, location.pathname, navigate, organizationId, params]);
+}

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -16,7 +16,9 @@ import { PageSection } from '@/app/components/ui/layout/page-section';
 import { Button } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
 import { useHasCredentialAccount } from '@/app/features/auth/hooks/queries';
+import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { useAuth } from '@/app/hooks/use-convex-auth';
+import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -182,6 +184,8 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
   const { t: tToast } = useT('toast');
   const { mutateAsync: updatePassword } = useUpdatePassword();
   const { toast } = useToast();
+  const organizationId = useOrganizationId();
+  const policy = usePasswordPolicy(organizationId);
 
   const changePasswordSchema = useMemo(
     () =>
@@ -190,13 +194,18 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
           currentPassword: z
             .string()
             .min(1, tAuth('changePassword.validation.currentRequired')),
-          newPassword: createPasswordSchema({
-            minLength: tAuth('validation.passwordMinLength'),
-            lowercase: tAuth('validation.passwordLowercase'),
-            uppercase: tAuth('validation.passwordUppercase'),
-            number: tAuth('validation.passwordNumber'),
-            specialChar: tAuth('validation.passwordSpecial'),
-          }),
+          newPassword: createPasswordSchema(
+            {
+              minLength: tAuth('validation.passwordMinLength', {
+                n: policy.minLength,
+              }),
+              lowercase: tAuth('validation.passwordLowercase'),
+              uppercase: tAuth('validation.passwordUppercase'),
+              number: tAuth('validation.passwordNumber'),
+              specialChar: tAuth('validation.passwordSpecial'),
+            },
+            policy,
+          ),
           confirmPassword: z
             .string()
             .min(1, tAuth('changePassword.validation.confirmRequired')),
@@ -205,7 +214,7 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
           message: tAuth('changePassword.validation.mismatch'),
           path: ['confirmPassword'],
         }),
-    [tAuth],
+    [tAuth, policy],
   );
 
   const {
@@ -225,7 +234,7 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
   });
 
   const newPassword = watch('newPassword');
-  const passwordValidationItems = usePasswordValidation(newPassword);
+  const passwordValidationItems = usePasswordValidation(newPassword, policy);
 
   const onSubmit = async (data: ChangePasswordFormData) => {
     try {
@@ -316,18 +325,25 @@ function SetPasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
   const { t: tToast } = useT('toast');
   const { mutateAsync: updatePassword } = useUpdatePassword();
   const { toast } = useToast();
+  const organizationId = useOrganizationId();
+  const policy = usePasswordPolicy(organizationId);
 
   const setPasswordSchema = useMemo(
     () =>
       z
         .object({
-          newPassword: createPasswordSchema({
-            minLength: tAuth('validation.passwordMinLength'),
-            lowercase: tAuth('validation.passwordLowercase'),
-            uppercase: tAuth('validation.passwordUppercase'),
-            number: tAuth('validation.passwordNumber'),
-            specialChar: tAuth('validation.passwordSpecial'),
-          }),
+          newPassword: createPasswordSchema(
+            {
+              minLength: tAuth('validation.passwordMinLength', {
+                n: policy.minLength,
+              }),
+              lowercase: tAuth('validation.passwordLowercase'),
+              uppercase: tAuth('validation.passwordUppercase'),
+              number: tAuth('validation.passwordNumber'),
+              specialChar: tAuth('validation.passwordSpecial'),
+            },
+            policy,
+          ),
           confirmPassword: z
             .string()
             .min(1, tAuth('changePassword.validation.confirmRequired')),
@@ -336,7 +352,7 @@ function SetPasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
           message: tAuth('changePassword.validation.mismatch'),
           path: ['confirmPassword'],
         }),
-    [tAuth],
+    [tAuth, policy],
   );
 
   const {
@@ -355,7 +371,7 @@ function SetPasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
   });
 
   const newPassword = watch('newPassword');
-  const passwordValidationItems = usePasswordValidation(newPassword);
+  const passwordValidationItems = usePasswordValidation(newPassword, policy);
 
   const onSubmit = async (data: SetPasswordFormData) => {
     try {

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -133,7 +133,8 @@ export function PasswordPolicyEditor({
         } satisfies PasswordPolicyConfig,
       });
       toast({ title: t('passwordPolicy.saved'), variant: 'success' });
-    } catch {
+    } catch (e) {
+      console.error(e);
       toast({
         title: t('passwordPolicy.saveFailed'),
         variant: 'destructive',

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
+import { Input } from '@/app/components/ui/forms/input';
+import { Switch } from '@/app/components/ui/forms/switch';
+import { Stack } from '@/app/components/ui/layout/layout';
+import { PageSection } from '@/app/components/ui/layout/page-section';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { useAbility } from '@/app/hooks/use-ability';
+import { useToast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  type PasswordPolicyConfig,
+  passwordPolicyConfigSchema,
+} from '@/lib/shared/schemas/governance';
+import { cn } from '@/lib/utils/cn';
+import { isRecord } from '@/lib/utils/type-guards';
+
+import { useUpsertGovernancePolicy } from '../hooks/mutations';
+import { useGovernancePolicy } from '../hooks/queries';
+
+interface PasswordPolicyEditorProps {
+  organizationId: string;
+}
+
+function parseConfig(raw: unknown): PasswordPolicyConfig {
+  const obj = isRecord(raw) ? raw : {};
+  const result = passwordPolicyConfigSchema.safeParse(obj);
+  return result.success ? result.data : DEFAULT_PASSWORD_POLICY;
+}
+
+export function PasswordPolicyEditor({
+  organizationId,
+}: PasswordPolicyEditorProps) {
+  const { t } = useT('governance');
+  const { toast } = useToast();
+  const ability = useAbility();
+
+  const { data: policy, isLoading } = useGovernancePolicy(
+    organizationId,
+    'password_policy',
+  );
+  const upsertMutation = useUpsertGovernancePolicy();
+
+  const savedConfig = useMemo(() => parseConfig(policy?.config), [policy]);
+
+  const [minLength, setMinLength] = useState(
+    String(DEFAULT_PASSWORD_POLICY.minLength),
+  );
+  const [requireUpper, setRequireUpper] = useState(
+    DEFAULT_PASSWORD_POLICY.requireUpper,
+  );
+  const [requireLower, setRequireLower] = useState(
+    DEFAULT_PASSWORD_POLICY.requireLower,
+  );
+  const [requireDigit, setRequireDigit] = useState(
+    DEFAULT_PASSWORD_POLICY.requireDigit,
+  );
+  const [requireSpecial, setRequireSpecial] = useState(
+    DEFAULT_PASSWORD_POLICY.requireSpecial,
+  );
+  const [rotationEnabled, setRotationEnabled] = useState(false);
+  const [rotationDays, setRotationDays] = useState('90');
+
+  useEffect(() => {
+    setMinLength(String(savedConfig.minLength));
+    setRequireUpper(savedConfig.requireUpper);
+    setRequireLower(savedConfig.requireLower);
+    setRequireDigit(savedConfig.requireDigit);
+    setRequireSpecial(savedConfig.requireSpecial);
+    setRotationEnabled(savedConfig.rotationDays > 0);
+    setRotationDays(
+      savedConfig.rotationDays > 0 ? String(savedConfig.rotationDays) : '90',
+    );
+  }, [savedConfig]);
+
+  const cannotManage = ability.cannot('write', 'orgSettings');
+
+  const currentRotationDays = rotationEnabled ? Number(rotationDays) : 0;
+
+  const isDirty = useMemo(() => {
+    if (Number(minLength) !== savedConfig.minLength) return true;
+    if (requireUpper !== savedConfig.requireUpper) return true;
+    if (requireLower !== savedConfig.requireLower) return true;
+    if (requireDigit !== savedConfig.requireDigit) return true;
+    if (requireSpecial !== savedConfig.requireSpecial) return true;
+    if (currentRotationDays !== savedConfig.rotationDays) return true;
+    return false;
+  }, [
+    minLength,
+    requireUpper,
+    requireLower,
+    requireDigit,
+    requireSpecial,
+    currentRotationDays,
+    savedConfig,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    const len = Number(minLength);
+    if (!Number.isInteger(len) || len < 6 || len > 128) {
+      toast({
+        title: t('passwordPolicy.invalidMinLength'),
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (rotationEnabled) {
+      const days = Number(rotationDays);
+      if (!Number.isInteger(days) || days < 1 || days > 3650) {
+        toast({
+          title: t('passwordPolicy.invalidRotationDays'),
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+    try {
+      await upsertMutation.mutateAsync({
+        organizationId,
+        policyType: 'password_policy',
+        config: {
+          minLength: len,
+          requireUpper,
+          requireLower,
+          requireDigit,
+          requireSpecial,
+          rotationDays: rotationEnabled ? Number(rotationDays) : 0,
+        } satisfies PasswordPolicyConfig,
+      });
+      toast({ title: t('passwordPolicy.saved'), variant: 'success' });
+    } catch {
+      toast({
+        title: t('passwordPolicy.saveFailed'),
+        variant: 'destructive',
+      });
+    }
+  }, [
+    minLength,
+    requireUpper,
+    requireLower,
+    requireDigit,
+    requireSpecial,
+    rotationEnabled,
+    rotationDays,
+    organizationId,
+    upsertMutation,
+    toast,
+    t,
+  ]);
+
+  if (isLoading) return null;
+
+  return (
+    <PageSection
+      title={t('passwordPolicy.title')}
+      description={t('passwordPolicy.description')}
+    >
+      <Stack gap={6} className="max-w-2xl">
+        <Stack gap={4}>
+          <Input
+            label={t('passwordPolicy.minLength')}
+            type="number"
+            value={minLength}
+            onChange={(e) => setMinLength(e.target.value)}
+            disabled={cannotManage}
+            size="sm"
+            min={6}
+            max={128}
+            step={1}
+          />
+          <Text variant="muted" className="text-xs">
+            {t('passwordPolicy.minLengthHint')}
+          </Text>
+
+          <Checkbox
+            label={t('passwordPolicy.requireUpper')}
+            checked={requireUpper}
+            onCheckedChange={(v) => setRequireUpper(Boolean(v))}
+            disabled={cannotManage}
+          />
+          <Checkbox
+            label={t('passwordPolicy.requireLower')}
+            checked={requireLower}
+            onCheckedChange={(v) => setRequireLower(Boolean(v))}
+            disabled={cannotManage}
+          />
+          <Checkbox
+            label={t('passwordPolicy.requireDigit')}
+            checked={requireDigit}
+            onCheckedChange={(v) => setRequireDigit(Boolean(v))}
+            disabled={cannotManage}
+          />
+          <Checkbox
+            label={t('passwordPolicy.requireSpecial')}
+            checked={requireSpecial}
+            onCheckedChange={(v) => setRequireSpecial(Boolean(v))}
+            disabled={cannotManage}
+          />
+
+          <Switch
+            label={t('passwordPolicy.rotationEnabled')}
+            checked={rotationEnabled}
+            onCheckedChange={setRotationEnabled}
+            disabled={cannotManage || upsertMutation.isPending}
+          />
+          <div
+            className={cn(
+              'transition-opacity duration-200',
+              !rotationEnabled && 'pointer-events-none opacity-50',
+            )}
+          >
+            <Input
+              label={t('passwordPolicy.rotationDays')}
+              type="number"
+              value={rotationDays}
+              onChange={(e) => setRotationDays(e.target.value)}
+              disabled={cannotManage || !rotationEnabled}
+              size="sm"
+              min={1}
+              max={3650}
+              step={1}
+            />
+            <Text variant="muted" className="text-xs">
+              {t('passwordPolicy.rotationDaysHint')}
+            </Text>
+          </div>
+        </Stack>
+
+        <Button
+          onClick={handleSave}
+          disabled={cannotManage || upsertMutation.isPending || !isDirty}
+          size="sm"
+          className="self-start"
+        >
+          {upsertMutation.isPending
+            ? t('systemPrompt.saving')
+            : t('systemPrompt.save')}
+        </Button>
+      </Stack>
+    </PageSection>
+  );
+}

--- a/services/platform/app/features/settings/governance/hooks/queries.ts
+++ b/services/platform/app/features/settings/governance/hooks/queries.ts
@@ -1,6 +1,13 @@
+import { useMemo } from 'react';
+
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 import type { GOVERNANCE_POLICY_TYPES } from '@/convex/governance/schema';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  type PasswordPolicyConfig,
+  passwordPolicyConfigSchema,
+} from '@/lib/shared/schemas/governance';
 
 type PolicyType = (typeof GOVERNANCE_POLICY_TYPES)[number];
 
@@ -45,4 +52,30 @@ export function useAccessibleModels(
     api.governance.queries.getAccessibleModelsForUser,
     modelIds.length > 0 ? { organizationId, modelIds } : 'skip',
   );
+}
+
+/**
+ * Resolved password policy for the given organization. Returns the
+ * built-in defaults while the query is loading, when no organizationId
+ * is available, or when the stored config is invalid. Reactive: Convex
+ * subscriptions auto-update when admins save a new policy.
+ */
+export function usePasswordPolicy(
+  organizationId: string | undefined,
+): PasswordPolicyConfig {
+  const result = useConvexQuery(
+    api.governance.queries.getPolicy,
+    organizationId
+      ? { organizationId, policyType: 'password_policy' as const }
+      : 'skip',
+  );
+
+  return useMemo(() => {
+    const row = result.data;
+    if (!row || typeof row !== 'object' || !('config' in row)) {
+      return DEFAULT_PASSWORD_POLICY;
+    }
+    const parsed = passwordPolicyConfigSchema.safeParse(row.config);
+    return parsed.success ? parsed.data : DEFAULT_PASSWORD_POLICY;
+  }, [result.data]);
 }

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.test.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.test.tsx
@@ -17,6 +17,14 @@ vi.mock('../hooks/mutations', () => ({
   useCreateMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+vi.mock('@/app/features/settings/governance/hooks/queries', async () => {
+  const { DEFAULT_PASSWORD_POLICY } =
+    await import('@/lib/shared/schemas/governance');
+  return {
+    usePasswordPolicy: () => DEFAULT_PASSWORD_POLICY,
+  };
+});
+
 describe('AddMemberDialog', () => {
   describe('accessibility', () => {
     it('passes axe audit when open', async () => {

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Stack } from '@/app/components/ui/layout/layout';
 import { Button } from '@/app/components/ui/primitives/button';
+import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -51,21 +52,28 @@ export function AddMemberDialog({
   const { t: tAuth } = useT('auth');
   const { t: tToast } = useT('toast');
 
+  const policy = usePasswordPolicy(organizationId);
+
   const addMemberSchema = useMemo(
     () =>
       z.object({
         email: z.string().email(tCommon('validation.email')),
-        password: createOptionalPasswordSchema({
-          minLength: tAuth('validation.passwordMinLength'),
-          lowercase: tAuth('validation.passwordLowercase'),
-          uppercase: tAuth('validation.passwordUppercase'),
-          number: tAuth('validation.passwordNumber'),
-          specialChar: tAuth('validation.passwordSpecial'),
-        }),
+        password: createOptionalPasswordSchema(
+          {
+            minLength: tAuth('validation.passwordMinLength', {
+              n: policy.minLength,
+            }),
+            lowercase: tAuth('validation.passwordLowercase'),
+            uppercase: tAuth('validation.passwordUppercase'),
+            number: tAuth('validation.passwordNumber'),
+            specialChar: tAuth('validation.passwordSpecial'),
+          },
+          policy,
+        ),
         displayName: z.string().optional(),
         role: z.enum(['disabled', 'admin', 'developer', 'editor', 'member']),
       }),
-    [tCommon, tAuth],
+    [tCommon, tAuth, policy],
   );
 
   const [showCredentials, setShowCredentials] = useState(false);
@@ -93,7 +101,7 @@ export function AddMemberDialog({
   const selectedRole = watch('role');
   const password = watch('password') ?? '';
 
-  const passwordValidationItems = usePasswordValidation(password);
+  const passwordValidationItems = usePasswordValidation(password, policy);
 
   const onSubmit = async (data: AddMemberFormData) => {
     try {

--- a/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
@@ -13,6 +13,7 @@ import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Text } from '@/app/components/ui/typography/text';
+import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -62,6 +63,8 @@ export function EditMemberDialog({
   const { t: tCommon } = useT('common');
   const { t: tAuth } = useT('auth');
 
+  const policy = usePasswordPolicy(member?.organizationId);
+
   const editMemberSchema = useMemo(
     () =>
       z.object({
@@ -71,15 +74,20 @@ export function EditMemberDialog({
         role: memberRoleSchema,
         email: z.string().email(tCommon('validation.email')),
         updatePassword: z.boolean().optional(),
-        password: createOptionalPasswordSchema({
-          minLength: tAuth('validation.passwordMinLength'),
-          lowercase: tAuth('validation.passwordLowercase'),
-          uppercase: tAuth('validation.passwordUppercase'),
-          number: tAuth('validation.passwordNumber'),
-          specialChar: tAuth('validation.passwordSpecial'),
-        }),
+        password: createOptionalPasswordSchema(
+          {
+            minLength: tAuth('validation.passwordMinLength', {
+              n: policy.minLength,
+            }),
+            lowercase: tAuth('validation.passwordLowercase'),
+            uppercase: tAuth('validation.passwordUppercase'),
+            number: tAuth('validation.passwordNumber'),
+            specialChar: tAuth('validation.passwordSpecial'),
+          },
+          policy,
+        ),
       }),
-    [t, tCommon, tAuth],
+    [t, tCommon, tAuth, policy],
   );
 
   const form = useForm<EditMemberFormData>({
@@ -145,7 +153,7 @@ export function EditMemberDialog({
   const { handleSubmit, register, reset, watch, formState } = form;
   const { isSubmitting, isDirty, isValid } = formState;
   const password = watch('password') ?? '';
-  const passwordValidationItems = usePasswordValidation(password);
+  const passwordValidationItems = usePasswordValidation(password, policy);
 
   const isEditingSelf = currentUserMemberId === member?._id;
 

--- a/services/platform/app/hooks/use-password-validation.ts
+++ b/services/platform/app/hooks/use-password-validation.ts
@@ -1,38 +1,42 @@
 import { useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
-import { validatePassword } from '@/lib/shared/schemas/password';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  type PasswordPolicyConfig,
+} from '@/lib/shared/schemas/governance';
+import {
+  enabledValidationKeys,
+  validatePassword,
+} from '@/lib/shared/schemas/password';
 
 /**
  * Returns password validation check items for use with `ValidationCheckList`.
- * Provides consistent password requirement display across all forms.
+ * Only includes items for rules enabled by the supplied policy — disabled
+ * rules are omitted entirely so the checklist never shows a "passing"
+ * row for a constraint that doesn't apply.
  */
-export function usePasswordValidation(password: string) {
+export function usePasswordValidation(
+  password: string,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+) {
   const { t: tAuth } = useT('auth');
 
   return useMemo(() => {
-    const result = validatePassword(password);
-    return [
-      {
-        isValid: result.length,
-        message: tAuth('changePassword.requirements.length'),
-      },
-      {
-        isValid: result.lowercase,
-        message: tAuth('changePassword.requirements.lowercase'),
-      },
-      {
-        isValid: result.uppercase,
-        message: tAuth('changePassword.requirements.uppercase'),
-      },
-      {
-        isValid: result.number,
-        message: tAuth('changePassword.requirements.number'),
-      },
-      {
-        isValid: result.specialChar,
-        message: tAuth('changePassword.requirements.specialChar'),
-      },
-    ];
-  }, [password, tAuth]);
+    const result = validatePassword(password, policy);
+    const keys = enabledValidationKeys(policy);
+    const labels: Record<keyof typeof result, string> = {
+      length: tAuth('changePassword.requirements.length', {
+        n: policy.minLength,
+      }),
+      lowercase: tAuth('changePassword.requirements.lowercase'),
+      uppercase: tAuth('changePassword.requirements.uppercase'),
+      number: tAuth('changePassword.requirements.number'),
+      specialChar: tAuth('changePassword.requirements.specialChar'),
+    };
+    return keys.map((key) => ({
+      isValid: result[key],
+      message: labels[key],
+    }));
+  }, [password, policy, tAuth]);
 }

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as AuthSignUpRouteImport } from './routes/_auth/sign-up'
 import { Route as AuthLogInRouteImport } from './routes/_auth/log-in'
 import { Route as DashboardIdIndexRouteImport } from './routes/dashboard/$id/index'
 import { Route as DashboardIdSettingsRouteImport } from './routes/dashboard/$id/settings'
+import { Route as DashboardIdForcedChangePasswordRouteImport } from './routes/dashboard/$id/forced-change-password'
 import { Route as DashboardIdCustomAgentsRouteImport } from './routes/dashboard/$id/custom-agents'
 import { Route as DashboardIdConversationsRouteImport } from './routes/dashboard/$id/conversations'
 import { Route as DashboardIdChatRouteImport } from './routes/dashboard/$id/chat'
@@ -125,6 +126,12 @@ const DashboardIdSettingsRoute = DashboardIdSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => DashboardIdRoute,
 } as any)
+const DashboardIdForcedChangePasswordRoute =
+  DashboardIdForcedChangePasswordRouteImport.update({
+    id: '/forced-change-password',
+    path: '/forced-change-password',
+    getParentRoute: () => DashboardIdRoute,
+  } as any)
 const DashboardIdCustomAgentsRoute = DashboardIdCustomAgentsRouteImport.update({
   id: '/custom-agents',
   path: '/custom-agents',
@@ -389,6 +396,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/$id/chat': typeof DashboardIdChatRouteWithChildren
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
+  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/settings': typeof DashboardIdSettingsRouteWithChildren
   '/dashboard/$id/': typeof DashboardIdIndexRoute
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute
@@ -440,6 +448,7 @@ export interface FileRoutesByTo {
   '/dashboard/$id': typeof DashboardIdIndexRoute
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
+  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute
   '/dashboard/$id/documents': typeof DashboardIdKnowledgeDocumentsRoute
   '/dashboard/$id/products': typeof DashboardIdKnowledgeProductsRoute
@@ -494,6 +503,7 @@ export interface FileRoutesById {
   '/dashboard/$id/chat': typeof DashboardIdChatRouteWithChildren
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
+  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/settings': typeof DashboardIdSettingsRouteWithChildren
   '/dashboard/$id/': typeof DashboardIdIndexRoute
   '/dashboard/$id/_knowledge/customers': typeof DashboardIdKnowledgeCustomersRoute
@@ -551,6 +561,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/chat'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
+    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/settings'
     | '/dashboard/$id/'
     | '/dashboard/$id/customers'
@@ -602,6 +613,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
+    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/customers'
     | '/dashboard/$id/documents'
     | '/dashboard/$id/products'
@@ -655,6 +667,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/chat'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
+    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/settings'
     | '/dashboard/$id/'
     | '/dashboard/$id/_knowledge/customers'
@@ -788,6 +801,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/dashboard/$id/settings'
       preLoaderRoute: typeof DashboardIdSettingsRouteImport
+      parentRoute: typeof DashboardIdRoute
+    }
+    '/dashboard/$id/forced-change-password': {
+      id: '/dashboard/$id/forced-change-password'
+      path: '/forced-change-password'
+      fullPath: '/dashboard/$id/forced-change-password'
+      preLoaderRoute: typeof DashboardIdForcedChangePasswordRouteImport
       parentRoute: typeof DashboardIdRoute
     }
     '/dashboard/$id/custom-agents': {
@@ -1295,6 +1315,7 @@ interface DashboardIdRouteChildren {
   DashboardIdChatRoute: typeof DashboardIdChatRouteWithChildren
   DashboardIdConversationsRoute: typeof DashboardIdConversationsRouteWithChildren
   DashboardIdCustomAgentsRoute: typeof DashboardIdCustomAgentsRoute
+  DashboardIdForcedChangePasswordRoute: typeof DashboardIdForcedChangePasswordRoute
   DashboardIdSettingsRoute: typeof DashboardIdSettingsRouteWithChildren
   DashboardIdIndexRoute: typeof DashboardIdIndexRoute
 }
@@ -1306,6 +1327,7 @@ const DashboardIdRouteChildren: DashboardIdRouteChildren = {
   DashboardIdChatRoute: DashboardIdChatRouteWithChildren,
   DashboardIdConversationsRoute: DashboardIdConversationsRouteWithChildren,
   DashboardIdCustomAgentsRoute: DashboardIdCustomAgentsRoute,
+  DashboardIdForcedChangePasswordRoute: DashboardIdForcedChangePasswordRoute,
   DashboardIdSettingsRoute: DashboardIdSettingsRouteWithChildren,
   DashboardIdIndexRoute: DashboardIdIndexRoute,
 }

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -15,13 +15,13 @@ import { Route as ConvexDashboardRouteImport } from './routes/convex-dashboard'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DashboardIndexRouteImport } from './routes/dashboard/index'
+import { Route as ForcedChangePasswordIdRouteImport } from './routes/forced-change-password.$id'
 import { Route as DashboardCreateOrganizationRouteImport } from './routes/dashboard/create-organization'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
 import { Route as AuthSignUpRouteImport } from './routes/_auth/sign-up'
 import { Route as AuthLogInRouteImport } from './routes/_auth/log-in'
 import { Route as DashboardIdIndexRouteImport } from './routes/dashboard/$id/index'
 import { Route as DashboardIdSettingsRouteImport } from './routes/dashboard/$id/settings'
-import { Route as DashboardIdForcedChangePasswordRouteImport } from './routes/dashboard/$id/forced-change-password'
 import { Route as DashboardIdCustomAgentsRouteImport } from './routes/dashboard/$id/custom-agents'
 import { Route as DashboardIdConversationsRouteImport } from './routes/dashboard/$id/conversations'
 import { Route as DashboardIdChatRouteImport } from './routes/dashboard/$id/chat'
@@ -95,6 +95,11 @@ const DashboardIndexRoute = DashboardIndexRouteImport.update({
   path: '/',
   getParentRoute: () => DashboardRoute,
 } as any)
+const ForcedChangePasswordIdRoute = ForcedChangePasswordIdRouteImport.update({
+  id: '/forced-change-password/$id',
+  path: '/forced-change-password/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardCreateOrganizationRoute =
   DashboardCreateOrganizationRouteImport.update({
     id: '/create-organization',
@@ -126,12 +131,6 @@ const DashboardIdSettingsRoute = DashboardIdSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => DashboardIdRoute,
 } as any)
-const DashboardIdForcedChangePasswordRoute =
-  DashboardIdForcedChangePasswordRouteImport.update({
-    id: '/forced-change-password',
-    path: '/forced-change-password',
-    getParentRoute: () => DashboardIdRoute,
-  } as any)
 const DashboardIdCustomAgentsRoute = DashboardIdCustomAgentsRouteImport.update({
   id: '/custom-agents',
   path: '/custom-agents',
@@ -390,13 +389,13 @@ export interface FileRoutesByFullPath {
   '/sign-up': typeof AuthSignUpRoute
   '/dashboard/$id': typeof DashboardIdKnowledgeRouteWithChildren
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute
+  '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/$id/agents': typeof DashboardIdAgentsRouteWithChildren
   '/dashboard/$id/automations': typeof DashboardIdAutomationsRouteWithChildren
   '/dashboard/$id/chat': typeof DashboardIdChatRouteWithChildren
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
-  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/settings': typeof DashboardIdSettingsRouteWithChildren
   '/dashboard/$id/': typeof DashboardIdIndexRoute
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute
@@ -444,11 +443,11 @@ export interface FileRoutesByTo {
   '/log-in': typeof AuthLogInRoute
   '/sign-up': typeof AuthSignUpRoute
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute
+  '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute
   '/dashboard': typeof DashboardIndexRoute
   '/dashboard/$id': typeof DashboardIdIndexRoute
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
-  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute
   '/dashboard/$id/documents': typeof DashboardIdKnowledgeDocumentsRoute
   '/dashboard/$id/products': typeof DashboardIdKnowledgeProductsRoute
@@ -496,6 +495,7 @@ export interface FileRoutesById {
   '/_auth/sign-up': typeof AuthSignUpRoute
   '/dashboard/$id': typeof DashboardIdRouteWithChildren
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute
+  '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute
   '/dashboard/': typeof DashboardIndexRoute
   '/dashboard/$id/_knowledge': typeof DashboardIdKnowledgeRouteWithChildren
   '/dashboard/$id/agents': typeof DashboardIdAgentsRouteWithChildren
@@ -503,7 +503,6 @@ export interface FileRoutesById {
   '/dashboard/$id/chat': typeof DashboardIdChatRouteWithChildren
   '/dashboard/$id/conversations': typeof DashboardIdConversationsRouteWithChildren
   '/dashboard/$id/custom-agents': typeof DashboardIdCustomAgentsRoute
-  '/dashboard/$id/forced-change-password': typeof DashboardIdForcedChangePasswordRoute
   '/dashboard/$id/settings': typeof DashboardIdSettingsRouteWithChildren
   '/dashboard/$id/': typeof DashboardIdIndexRoute
   '/dashboard/$id/_knowledge/customers': typeof DashboardIdKnowledgeCustomersRoute
@@ -555,13 +554,13 @@ export interface FileRouteTypes {
     | '/sign-up'
     | '/dashboard/$id'
     | '/dashboard/create-organization'
+    | '/forced-change-password/$id'
     | '/dashboard/'
     | '/dashboard/$id/agents'
     | '/dashboard/$id/automations'
     | '/dashboard/$id/chat'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
-    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/settings'
     | '/dashboard/$id/'
     | '/dashboard/$id/customers'
@@ -609,11 +608,11 @@ export interface FileRouteTypes {
     | '/log-in'
     | '/sign-up'
     | '/dashboard/create-organization'
+    | '/forced-change-password/$id'
     | '/dashboard'
     | '/dashboard/$id'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
-    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/customers'
     | '/dashboard/$id/documents'
     | '/dashboard/$id/products'
@@ -660,6 +659,7 @@ export interface FileRouteTypes {
     | '/_auth/sign-up'
     | '/dashboard/$id'
     | '/dashboard/create-organization'
+    | '/forced-change-password/$id'
     | '/dashboard/'
     | '/dashboard/$id/_knowledge'
     | '/dashboard/$id/agents'
@@ -667,7 +667,6 @@ export interface FileRouteTypes {
     | '/dashboard/$id/chat'
     | '/dashboard/$id/conversations'
     | '/dashboard/$id/custom-agents'
-    | '/dashboard/$id/forced-change-password'
     | '/dashboard/$id/settings'
     | '/dashboard/$id/'
     | '/dashboard/$id/_knowledge/customers'
@@ -715,6 +714,7 @@ export interface RootRouteChildren {
   ConvexDashboardRoute: typeof ConvexDashboardRoute
   DashboardRoute: typeof DashboardRouteWithChildren
   DocsRoute: typeof DocsRoute
+  ForcedChangePasswordIdRoute: typeof ForcedChangePasswordIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -761,6 +761,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIndexRouteImport
       parentRoute: typeof DashboardRoute
     }
+    '/forced-change-password/$id': {
+      id: '/forced-change-password/$id'
+      path: '/forced-change-password/$id'
+      fullPath: '/forced-change-password/$id'
+      preLoaderRoute: typeof ForcedChangePasswordIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard/create-organization': {
       id: '/dashboard/create-organization'
       path: '/create-organization'
@@ -801,13 +808,6 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/dashboard/$id/settings'
       preLoaderRoute: typeof DashboardIdSettingsRouteImport
-      parentRoute: typeof DashboardIdRoute
-    }
-    '/dashboard/$id/forced-change-password': {
-      id: '/dashboard/$id/forced-change-password'
-      path: '/forced-change-password'
-      fullPath: '/dashboard/$id/forced-change-password'
-      preLoaderRoute: typeof DashboardIdForcedChangePasswordRouteImport
       parentRoute: typeof DashboardIdRoute
     }
     '/dashboard/$id/custom-agents': {
@@ -1315,7 +1315,6 @@ interface DashboardIdRouteChildren {
   DashboardIdChatRoute: typeof DashboardIdChatRouteWithChildren
   DashboardIdConversationsRoute: typeof DashboardIdConversationsRouteWithChildren
   DashboardIdCustomAgentsRoute: typeof DashboardIdCustomAgentsRoute
-  DashboardIdForcedChangePasswordRoute: typeof DashboardIdForcedChangePasswordRoute
   DashboardIdSettingsRoute: typeof DashboardIdSettingsRouteWithChildren
   DashboardIdIndexRoute: typeof DashboardIdIndexRoute
 }
@@ -1327,7 +1326,6 @@ const DashboardIdRouteChildren: DashboardIdRouteChildren = {
   DashboardIdChatRoute: DashboardIdChatRouteWithChildren,
   DashboardIdConversationsRoute: DashboardIdConversationsRouteWithChildren,
   DashboardIdCustomAgentsRoute: DashboardIdCustomAgentsRoute,
-  DashboardIdForcedChangePasswordRoute: DashboardIdForcedChangePasswordRoute,
   DashboardIdSettingsRoute: DashboardIdSettingsRouteWithChildren,
   DashboardIdIndexRoute: DashboardIdIndexRoute,
 }
@@ -1358,6 +1356,7 @@ const rootRouteChildren: RootRouteChildren = {
   ConvexDashboardRoute: ConvexDashboardRoute,
   DashboardRoute: DashboardRouteWithChildren,
   DocsRoute: DocsRoute,
+  ForcedChangePasswordIdRoute: ForcedChangePasswordIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -12,6 +12,7 @@ import {
   AbilityContext,
   AbilityLoadingContext,
 } from '@/app/context/ability-context';
+import { usePasswordExpiryGate } from '@/app/features/auth/hooks/use-password-expiry-gate';
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { TeamFilterProvider } from '@/app/hooks/use-team-filter';
@@ -25,6 +26,7 @@ export const Route = createFileRoute('/dashboard/$id')({
 
 function DashboardLayout() {
   const { id: organizationId } = Route.useParams();
+  usePasswordExpiryGate(organizationId);
   const { isLoading: isAuthLoading } = useConvexAuth();
   const {
     data: memberContext,

--- a/services/platform/app/routes/dashboard/$id/forced-change-password.tsx
+++ b/services/platform/app/routes/dashboard/$id/forced-change-password.tsx
@@ -1,0 +1,193 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { ValidationCheckList } from '@/app/components/ui/feedback/validation-check-item';
+import { Form } from '@/app/components/ui/forms/form';
+import { FormSection } from '@/app/components/ui/forms/form-section';
+import { Input } from '@/app/components/ui/forms/input';
+import { Stack } from '@/app/components/ui/layout/layout';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { AuthFormLayout } from '@/app/features/auth/components/auth-form-layout';
+import { useUpdatePassword } from '@/app/features/settings/account/hooks/mutations';
+import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { usePasswordValidation } from '@/app/hooks/use-password-validation';
+import { useToast } from '@/app/hooks/use-toast';
+import { api } from '@/convex/_generated/api';
+import { useT } from '@/lib/i18n/client';
+import { createPasswordSchema } from '@/lib/shared/schemas/password';
+
+export const Route = createFileRoute('/dashboard/$id/forced-change-password')({
+  component: ForcedChangePasswordPage,
+});
+
+type ForcedChangeFormData = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+function ForcedChangePasswordPage() {
+  const { id: organizationId } = Route.useParams();
+  const navigate = useNavigate();
+  const { t: tAuth } = useT('auth');
+  const { t: tCommon } = useT('common');
+  const { t: tToast } = useT('toast');
+  const { toast } = useToast();
+  const { mutateAsync: updatePassword } = useUpdatePassword();
+  const policy = usePasswordPolicy(organizationId);
+
+  // Users without a credential account can't be subject to rotation —
+  // bounce them home if they somehow land here.
+  const { data: expiryStatus } = useConvexQuery(
+    api.users.queries.getPasswordExpiryStatus,
+  );
+  useEffect(() => {
+    if (!expiryStatus) return;
+    if (!expiryStatus.hasCredential || !expiryStatus.expired) {
+      void navigate({
+        to: '/dashboard/$id',
+        params: { id: organizationId },
+        replace: true,
+      });
+    }
+  }, [expiryStatus, navigate, organizationId]);
+
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          currentPassword: z
+            .string()
+            .min(1, tAuth('changePassword.validation.currentRequired')),
+          newPassword: createPasswordSchema(
+            {
+              minLength: tAuth('validation.passwordMinLength', {
+                n: policy.minLength,
+              }),
+              lowercase: tAuth('validation.passwordLowercase'),
+              uppercase: tAuth('validation.passwordUppercase'),
+              number: tAuth('validation.passwordNumber'),
+              specialChar: tAuth('validation.passwordSpecial'),
+            },
+            policy,
+          ),
+          confirmPassword: z
+            .string()
+            .min(1, tAuth('changePassword.validation.confirmRequired')),
+        })
+        .refine((data) => data.newPassword === data.confirmPassword, {
+          message: tAuth('changePassword.validation.mismatch'),
+          path: ['confirmPassword'],
+        }),
+    [tAuth, policy],
+  );
+
+  const form = useForm<ForcedChangeFormData>({
+    resolver: zodResolver(schema),
+    mode: 'onChange',
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const { register, handleSubmit, formState, watch } = form;
+  const { errors, isSubmitting, isValid } = formState;
+  const newPassword = watch('newPassword');
+  const validationItems = usePasswordValidation(newPassword, policy);
+
+  const onSubmit = async (data: ForcedChangeFormData) => {
+    try {
+      await updatePassword({
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+        trigger: 'forced',
+      });
+      toast({
+        title: tToast('success.passwordChanged'),
+        variant: 'success',
+      });
+      void navigate({
+        to: '/dashboard/$id',
+        params: { id: organizationId },
+        replace: true,
+      });
+    } catch {
+      toast({
+        title: tToast('error.passwordChangeFailed'),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <AuthFormLayout title={tAuth('forcedChange.title')}>
+      <Stack gap={6}>
+        <Text variant="muted" className="text-sm">
+          {tAuth('forcedChange.description')}
+        </Text>
+        <FormSection>
+          <Form onSubmit={handleSubmit(onSubmit)} autoComplete="on">
+            <Input
+              id="current-password"
+              type="password"
+              size="lg"
+              autoComplete="current-password"
+              label={tAuth('changePassword.currentPassword')}
+              placeholder={tAuth('changePassword.placeholder.current')}
+              disabled={isSubmitting}
+              errorMessage={errors.currentPassword?.message}
+              {...register('currentPassword')}
+            />
+            <Stack gap={2}>
+              <Input
+                id="new-password"
+                type="password"
+                size="lg"
+                autoComplete="new-password"
+                label={tAuth('changePassword.newPassword')}
+                placeholder={tAuth('changePassword.placeholder.new')}
+                disabled={isSubmitting}
+                errorMessage={errors.newPassword?.message}
+                {...register('newPassword')}
+              />
+              {newPassword && (
+                <ValidationCheckList
+                  items={validationItems}
+                  className="text-xs"
+                />
+              )}
+            </Stack>
+            <Input
+              id="confirm-password"
+              type="password"
+              size="lg"
+              autoComplete="new-password"
+              label={tAuth('changePassword.confirmPassword')}
+              placeholder={tAuth('changePassword.placeholder.confirm')}
+              disabled={isSubmitting}
+              errorMessage={errors.confirmPassword?.message}
+              {...register('confirmPassword')}
+            />
+            <Button
+              type="submit"
+              size="lg"
+              fullWidth
+              disabled={isSubmitting || !isValid}
+            >
+              {isSubmitting
+                ? tCommon('actions.saving')
+                : tAuth('forcedChange.submit')}
+            </Button>
+          </Form>
+        </FormSection>
+      </Stack>
+    </AuthFormLayout>
+  );
+}

--- a/services/platform/app/routes/dashboard/$id/settings/governance.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance.tsx
@@ -35,6 +35,12 @@ const LoginPolicyEditor = lazyComponent(() =>
   ),
 );
 
+const PasswordPolicyEditor = lazyComponent(() =>
+  import('@/app/features/settings/governance/components/password-policy-editor').then(
+    (m) => ({ default: m.PasswordPolicyEditor }),
+  ),
+);
+
 const GROUPS = [
   'content-models',
   'policies-limits',
@@ -143,6 +149,13 @@ function GovernanceSettingsPage() {
                 value: 'login',
                 label: t('groups.subtabs.login'),
                 content: <LoginPolicyEditor organizationId={organizationId} />,
+              },
+              {
+                value: 'password',
+                label: t('groups.subtabs.password'),
+                content: (
+                  <PasswordPolicyEditor organizationId={organizationId} />
+                ),
               },
               {
                 value: 'pii',

--- a/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
@@ -13,6 +13,13 @@ vi.mock('@tanstack/react-router', () => ({
     ...config,
   }),
   Outlet: () => <div data-testid="outlet" />,
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/dashboard/test-org-id' }),
+  useParams: () => mockUseParams(),
+}));
+
+vi.mock('@/app/features/auth/hooks/use-password-expiry-gate', () => ({
+  usePasswordExpiryGate: vi.fn(),
 }));
 
 const mockUseConvexAuth = vi.fn(() => ({

--- a/services/platform/app/routes/forced-change-password.$id.tsx
+++ b/services/platform/app/routes/forced-change-password.$id.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -8,25 +8,32 @@ import { ValidationCheckList } from '@/app/components/ui/feedback/validation-che
 import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
-import { Stack } from '@/app/components/ui/layout/layout';
+import { Stack, VStack } from '@/app/components/ui/layout/layout';
+import { LogoLink } from '@/app/components/ui/logo/logo-link';
 import { Button } from '@/app/components/ui/primitives/button';
+import { Heading } from '@/app/components/ui/typography/heading';
 import { Text } from '@/app/components/ui/typography/text';
-import { AuthFormLayout } from '@/app/features/auth/components/auth-form-layout';
 import { useUpdatePassword } from '@/app/features/settings/account/hooks/mutations';
 import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
+import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 import { createPasswordSchema } from '@/lib/shared/schemas/password';
 
-export const Route = createFileRoute('/dashboard/$id/forced-change-password')({
+export const Route = createFileRoute('/forced-change-password/$id')({
+  beforeLoad: async () => {
+    const session = await authClient.getSession();
+    if (!session?.data?.user) {
+      throw redirect({ to: '/log-in' });
+    }
+  },
   component: ForcedChangePasswordPage,
 });
 
 type ForcedChangeFormData = {
-  currentPassword: string;
   newPassword: string;
   confirmPassword: string;
 };
@@ -41,13 +48,12 @@ function ForcedChangePasswordPage() {
   const { mutateAsync: updatePassword } = useUpdatePassword();
   const policy = usePasswordPolicy(organizationId);
 
-  // Users without a credential account can't be subject to rotation —
-  // bounce them home if they somehow land here.
   const { data: expiryStatus } = useConvexQuery(
     api.users.queries.getPasswordExpiryStatus,
   );
   useEffect(() => {
     if (!expiryStatus) return;
+    // OAuth-only or already-fresh credential: no reason to be here.
     if (!expiryStatus.hasCredential || !expiryStatus.expired) {
       void navigate({
         to: '/dashboard/$id',
@@ -61,9 +67,6 @@ function ForcedChangePasswordPage() {
     () =>
       z
         .object({
-          currentPassword: z
-            .string()
-            .min(1, tAuth('changePassword.validation.currentRequired')),
           newPassword: createPasswordSchema(
             {
               minLength: tAuth('validation.passwordMinLength', {
@@ -90,11 +93,7 @@ function ForcedChangePasswordPage() {
   const form = useForm<ForcedChangeFormData>({
     resolver: zodResolver(schema),
     mode: 'onChange',
-    defaultValues: {
-      currentPassword: '',
-      newPassword: '',
-      confirmPassword: '',
-    },
+    defaultValues: { newPassword: '', confirmPassword: '' },
   });
 
   const { register, handleSubmit, formState, watch } = form;
@@ -105,7 +104,6 @@ function ForcedChangePasswordPage() {
   const onSubmit = async (data: ForcedChangeFormData) => {
     try {
       await updatePassword({
-        currentPassword: data.currentPassword,
         newPassword: data.newPassword,
         trigger: 'forced',
       });
@@ -127,67 +125,74 @@ function ForcedChangePasswordPage() {
   };
 
   return (
-    <AuthFormLayout title={tAuth('forcedChange.title')}>
-      <Stack gap={6}>
-        <Text variant="muted" className="text-sm">
-          {tAuth('forcedChange.description')}
-        </Text>
-        <FormSection>
-          <Form onSubmit={handleSubmit(onSubmit)} autoComplete="on">
-            <Input
-              id="current-password"
-              type="password"
-              size="lg"
-              autoComplete="current-password"
-              label={tAuth('changePassword.currentPassword')}
-              placeholder={tAuth('changePassword.placeholder.current')}
-              disabled={isSubmitting}
-              errorMessage={errors.currentPassword?.message}
-              {...register('currentPassword')}
-            />
-            <Stack gap={2}>
-              <Input
-                id="new-password"
-                type="password"
-                size="lg"
-                autoComplete="new-password"
-                label={tAuth('changePassword.newPassword')}
-                placeholder={tAuth('changePassword.placeholder.new')}
-                disabled={isSubmitting}
-                errorMessage={errors.newPassword?.message}
-                {...register('newPassword')}
-              />
-              {newPassword && (
-                <ValidationCheckList
-                  items={validationItems}
-                  className="text-xs"
-                />
-              )}
+    <VStack
+      gap={0}
+      align="stretch"
+      className="bg-background text-foreground min-h-screen"
+    >
+      <div className="px-4 pt-8 pb-16 sm:px-8">
+        <LogoLink href="/" />
+      </div>
+      <main id="main-content" className="flex-1">
+        <div className="mx-auto w-full max-w-md px-4">
+          <Stack gap={6}>
+            <Stack gap={2} className="text-center">
+              <Heading level={1} size="xl" className="tracking-[-0.12px]">
+                {tAuth('forcedChange.title')}
+              </Heading>
+              <Text variant="muted" className="text-sm">
+                {tAuth('forcedChange.description')}
+              </Text>
             </Stack>
-            <Input
-              id="confirm-password"
-              type="password"
-              size="lg"
-              autoComplete="new-password"
-              label={tAuth('changePassword.confirmPassword')}
-              placeholder={tAuth('changePassword.placeholder.confirm')}
-              disabled={isSubmitting}
-              errorMessage={errors.confirmPassword?.message}
-              {...register('confirmPassword')}
-            />
-            <Button
-              type="submit"
-              size="lg"
-              fullWidth
-              disabled={isSubmitting || !isValid}
-            >
-              {isSubmitting
-                ? tCommon('actions.saving')
-                : tAuth('forcedChange.submit')}
-            </Button>
-          </Form>
-        </FormSection>
-      </Stack>
-    </AuthFormLayout>
+            <div className="border-border bg-card rounded-lg border p-6 shadow-sm">
+              <FormSection>
+                <Form onSubmit={handleSubmit(onSubmit)} autoComplete="on">
+                  <Stack gap={2}>
+                    <Input
+                      id="new-password"
+                      type="password"
+                      size="lg"
+                      autoComplete="new-password"
+                      label={tAuth('changePassword.newPassword')}
+                      placeholder={tAuth('changePassword.placeholder.new')}
+                      disabled={isSubmitting}
+                      errorMessage={errors.newPassword?.message}
+                      {...register('newPassword')}
+                    />
+                    {newPassword && (
+                      <ValidationCheckList
+                        items={validationItems}
+                        className="text-xs"
+                      />
+                    )}
+                  </Stack>
+                  <Input
+                    id="confirm-password"
+                    type="password"
+                    size="lg"
+                    autoComplete="new-password"
+                    label={tAuth('changePassword.confirmPassword')}
+                    placeholder={tAuth('changePassword.placeholder.confirm')}
+                    disabled={isSubmitting}
+                    errorMessage={errors.confirmPassword?.message}
+                    {...register('confirmPassword')}
+                  />
+                  <Button
+                    type="submit"
+                    size="lg"
+                    fullWidth
+                    disabled={isSubmitting || !isValid}
+                  >
+                    {isSubmitting
+                      ? tCommon('actions.saving')
+                      : tAuth('forcedChange.submit')}
+                  </Button>
+                </Form>
+              </FormSection>
+            </div>
+          </Stack>
+        </div>
+      </main>
+    </VStack>
   );
 }

--- a/services/platform/app/routes/forced-change-password.$id.tsx
+++ b/services/platform/app/routes/forced-change-password.$id.tsx
@@ -116,7 +116,8 @@ function ForcedChangePasswordPage() {
         params: { id: organizationId },
         replace: true,
       });
-    } catch {
+    } catch (e) {
+      console.error(e);
       toast({
         title: tToast('error.passwordChangeFailed'),
         variant: 'destructive',

--- a/services/platform/app/routes/forced-change-password.$id.tsx
+++ b/services/platform/app/routes/forced-change-password.$id.tsx
@@ -142,7 +142,11 @@ function ForcedChangePasswordPage() {
                 {tAuth('forcedChange.title')}
               </Heading>
               <Text variant="muted" className="text-sm">
-                {tAuth('forcedChange.description')}
+                {tAuth(
+                  expiryStatus?.reason === 'admin_set'
+                    ? 'forcedChange.descriptionAdminSet'
+                    : 'forcedChange.description',
+                )}
               </Text>
             </Stack>
             <div className="border-border bg-card rounded-lg border p-6 shadow-sm">

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -677,6 +677,7 @@ import type * as users_has_any_users from "../users/has_any_users.js";
 import type * as users_helpers from "../users/helpers.js";
 import type * as users_internal_mutations from "../users/internal_mutations.js";
 import type * as users_mutations from "../users/mutations.js";
+import type * as users_password_metadata from "../users/password_metadata.js";
 import type * as users_queries from "../users/queries.js";
 import type * as users_reset_owner from "../users/reset_owner.js";
 import type * as users_set_member_password from "../users/set_member_password.js";
@@ -1622,6 +1623,7 @@ declare const fullApi: ApiFromModules<{
   "users/helpers": typeof users_helpers;
   "users/internal_mutations": typeof users_internal_mutations;
   "users/mutations": typeof users_mutations;
+  "users/password_metadata": typeof users_password_metadata;
   "users/queries": typeof users_queries;
   "users/reset_owner": typeof users_reset_owner;
   "users/set_member_password": typeof users_set_member_password;

--- a/services/platform/convex/governance/helpers.ts
+++ b/services/platform/convex/governance/helpers.ts
@@ -1,6 +1,12 @@
 import type { GenericQueryCtx } from 'convex/server';
 
-import type { PolicyType } from '../../lib/shared/schemas/governance';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  mergeStrictestPasswordPolicy,
+  type PasswordPolicyConfig,
+  passwordPolicyConfigSchema,
+  type PolicyType,
+} from '../../lib/shared/schemas/governance';
 import { isRecord } from '../../lib/utils/type-guards';
 import type { DataModel } from '../_generated/dataModel';
 
@@ -31,6 +37,76 @@ export async function readPolicyConfig<T>(
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- config is validated at write time via Zod schemas
   return config as T;
+}
+
+/**
+ * Load the governance policies row for password_policy and return both
+ * the parsed config (falling back to defaults when absent or malformed)
+ * and the row's `effectiveAt` timestamp (used by rotation to grant a
+ * grace window on first activation).
+ */
+export async function getPasswordPolicyRow(
+  ctx: GenericQueryCtx<DataModel>,
+  organizationId: string,
+): Promise<{ policy: PasswordPolicyConfig; effectiveAt: number | null }> {
+  const row = await ctx.db
+    .query('governancePolicies')
+    .withIndex('by_org_policyType', (q) =>
+      q
+        .eq('organizationId', organizationId)
+        .eq('policyType', 'password_policy'),
+    )
+    .first();
+
+  if (!row) {
+    return { policy: DEFAULT_PASSWORD_POLICY, effectiveAt: null };
+  }
+
+  const parsed = passwordPolicyConfigSchema.safeParse(row.config);
+  if (!parsed.success) {
+    console.warn(
+      `Invalid password_policy config for org ${organizationId}; using defaults`,
+      parsed.error,
+    );
+    return {
+      policy: DEFAULT_PASSWORD_POLICY,
+      effectiveAt: row.effectiveAt ?? null,
+    };
+  }
+
+  return { policy: parsed.data, effectiveAt: row.effectiveAt ?? null };
+}
+
+export async function getPasswordPolicy(
+  ctx: GenericQueryCtx<DataModel>,
+  organizationId: string,
+): Promise<PasswordPolicyConfig> {
+  return (await getPasswordPolicyRow(ctx, organizationId)).policy;
+}
+
+/**
+ * Resolve the effective password policy for a user across every org
+ * they belong to (strictest-wins), along with the earliest rotation
+ * `effectiveAt` across those orgs. For a single-org deployment this
+ * collapses to the one org's policy.
+ */
+export async function getStrictestPasswordPolicyForUser(
+  ctx: GenericQueryCtx<DataModel>,
+  organizationIds: readonly string[],
+): Promise<{ policy: PasswordPolicyConfig; effectiveAt: number | null }> {
+  if (organizationIds.length === 0) {
+    return { policy: DEFAULT_PASSWORD_POLICY, effectiveAt: null };
+  }
+  const rows = await Promise.all(
+    organizationIds.map((id) => getPasswordPolicyRow(ctx, id)),
+  );
+  const policy = mergeStrictestPasswordPolicy(rows.map((r) => r.policy));
+  const effectiveAts = rows
+    .map((r) => r.effectiveAt)
+    .filter((x): x is number => typeof x === 'number');
+  const effectiveAt =
+    effectiveAts.length === 0 ? null : Math.min(...effectiveAts);
+  return { policy, effectiveAt };
 }
 
 /**

--- a/services/platform/convex/governance/mutations.ts
+++ b/services/platform/convex/governance/mutations.ts
@@ -28,12 +28,11 @@ const policyTypeValidator = v.union(
 // - a number to patch (rotation just activated — first enablement wins)
 // - `undefined` to leave the existing value untouched
 //
-// Rotation semantics: the first time a password_policy row persists a
-// positive `rotationDays`, stamp `effectiveAt = now`. Unrelated edits
-// (e.g. tweaking minLength while rotation stays enabled) preserve the
-// original timestamp so the grace window doesn't reset. Disabling
-// rotation (back to 0) also preserves it, so a subsequent re-enable is
-// still a transition.
+// Rotation semantics: every time `rotationDays` transitions from 0 to a
+// positive value, stamp `effectiveAt = now` so affected users get a full
+// grace window. Unrelated edits (e.g. tweaking minLength while rotation
+// stays enabled) preserve the original timestamp so the grace window
+// doesn't reset.
 function readRotationDays(config: unknown): number {
   if (!isRecord(config)) return 0;
   const value = config.rotationDays;
@@ -44,12 +43,11 @@ function computeNextEffectiveAt(
   policyType: string,
   nextConfig: unknown,
   prevConfig: unknown,
-  prevEffectiveAt: number | undefined,
 ): number | undefined {
   if (policyType !== 'password_policy') return undefined;
   const next = readRotationDays(nextConfig);
   const prev = readRotationDays(prevConfig);
-  if (next > 0 && prev === 0 && prevEffectiveAt === undefined) {
+  if (next > 0 && prev === 0) {
     return Date.now();
   }
   return undefined;
@@ -179,7 +177,6 @@ export const upsertPolicy = mutation({
       args.policyType,
       args.config,
       existing?.config,
-      existing?.effectiveAt,
     );
 
     let policyId;

--- a/services/platform/convex/governance/mutations.ts
+++ b/services/platform/convex/governance/mutations.ts
@@ -7,10 +7,12 @@ import {
   featureFlagsConfigSchema,
   loginPolicyConfigSchema,
   modelAccessConfigSchema,
+  passwordPolicyConfigSchema,
   piiConfigSchema,
   retentionPolicyConfigSchema,
   uploadPolicyConfigSchema,
 } from '../../lib/shared/schemas/governance';
+import { isRecord } from '../../lib/utils/type-guards';
 import { mutation } from '../_generated/server';
 import { createAuditLog } from '../audit_logs/helpers';
 import { authComponent } from '../auth';
@@ -21,6 +23,37 @@ import { GOVERNANCE_POLICY_TYPES } from './schema';
 const policyTypeValidator = v.union(
   ...GOVERNANCE_POLICY_TYPES.map((t) => v.literal(t)),
 );
+
+// Decides whether to set/update `effectiveAt` on a policy row. Returns:
+// - a number to patch (rotation just activated — first enablement wins)
+// - `undefined` to leave the existing value untouched
+//
+// Rotation semantics: the first time a password_policy row persists a
+// positive `rotationDays`, stamp `effectiveAt = now`. Unrelated edits
+// (e.g. tweaking minLength while rotation stays enabled) preserve the
+// original timestamp so the grace window doesn't reset. Disabling
+// rotation (back to 0) also preserves it, so a subsequent re-enable is
+// still a transition.
+function readRotationDays(config: unknown): number {
+  if (!isRecord(config)) return 0;
+  const value = config.rotationDays;
+  return typeof value === 'number' ? value : 0;
+}
+
+function computeNextEffectiveAt(
+  policyType: string,
+  nextConfig: unknown,
+  prevConfig: unknown,
+  prevEffectiveAt: number | undefined,
+): number | undefined {
+  if (policyType !== 'password_policy') return undefined;
+  const next = readRotationDays(nextConfig);
+  const prev = readRotationDays(prevConfig);
+  if (next > 0 && prev === 0 && prevEffectiveAt === undefined) {
+    return Date.now();
+  }
+  return undefined;
+}
 
 export const upsertPolicy = mutation({
   args: {
@@ -121,6 +154,15 @@ export const upsertPolicy = mutation({
       }
     }
 
+    if (args.policyType === 'password_policy') {
+      const parsed = passwordPolicyConfigSchema.safeParse(args.config);
+      if (!parsed.success) {
+        throw new Error(
+          `Invalid password policy configuration: ${parsed.error.message}`,
+        );
+      }
+    }
+
     const existing = await ctx.db
       .query('governancePolicies')
       .withIndex('by_org_policyType', (q) =>
@@ -130,6 +172,16 @@ export const upsertPolicy = mutation({
       )
       .first();
 
+    // For password_policy, track when rotation first became active so we
+    // can grant a grace window (credential expiry is computed off the
+    // later of account.passwordChangedAt and policy.effectiveAt).
+    const nextEffectiveAt = computeNextEffectiveAt(
+      args.policyType,
+      args.config,
+      existing?.config,
+      existing?.effectiveAt,
+    );
+
     let policyId;
 
     if (existing) {
@@ -137,6 +189,9 @@ export const upsertPolicy = mutation({
         config: args.config,
         updatedAt: Date.now(),
         updatedBy: String(authUser._id),
+        ...(nextEffectiveAt !== undefined
+          ? { effectiveAt: nextEffectiveAt }
+          : {}),
       });
       policyId = existing._id;
     } else {
@@ -147,6 +202,9 @@ export const upsertPolicy = mutation({
         config: args.config,
         updatedAt: Date.now(),
         updatedBy: String(authUser._id),
+        ...(nextEffectiveAt !== undefined
+          ? { effectiveAt: nextEffectiveAt }
+          : {}),
       });
     }
 

--- a/services/platform/convex/governance/schema.ts
+++ b/services/platform/convex/governance/schema.ts
@@ -14,6 +14,7 @@ export const GOVERNANCE_POLICY_TYPES = [
   'model_access',
   'audit_retention',
   'login_policy',
+  'password_policy',
 ] as const;
 
 const policyTypeValidator = v.union(
@@ -27,6 +28,12 @@ export const governancePoliciesTable = defineTable({
   enabled: v.optional(v.boolean()),
   updatedBy: v.optional(v.string()),
   updatedAt: v.optional(v.number()),
+  // Timestamp at which the policy's active enforcement window began.
+  // Used by password_policy rotation to grant a grace window: credential
+  // expiry = max(passwordChangedAt, effectiveAt) + rotationDays. Set the
+  // first time an enforcement-bearing field transitions to an active
+  // value; preserved across unrelated edits.
+  effectiveAt: v.optional(v.number()),
 })
   .index('by_organizationId', ['organizationId'])
   .index('by_org_policyType', ['organizationId', 'policyType']);

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -38,6 +38,7 @@ import { ssoProvidersTable } from './sso_providers/schema';
 import { messageMetadataTable } from './streaming/schema';
 import { threadBranchesTable } from './threads/branch_schema';
 import { threadMetadataTable } from './threads/schema';
+import { userPasswordMetadataTable } from './users/schema';
 import { vendorsTable } from './vendors/schema';
 import { websitesTable } from './websites/schema';
 import {
@@ -89,6 +90,7 @@ export default defineSchema({
   onedriveSyncConfigs: onedriveSyncConfigsTable,
   threadBranches: threadBranchesTable,
   threadMetadata: threadMetadataTable,
+  userPasswordMetadata: userPasswordMetadataTable,
   products: productsTable,
   ssoProviders: ssoProvidersTable,
   vendors: vendorsTable,

--- a/services/platform/convex/users/__tests__/set_member_password.test.ts
+++ b/services/platform/convex/users/__tests__/set_member_password.test.ts
@@ -24,6 +24,19 @@ vi.mock('better-auth/crypto', () => ({
   hashPassword: vi.fn().mockResolvedValue('hashed_new_password'),
 }));
 
+const mockGetPasswordPolicy = vi.fn();
+vi.mock('../../governance/helpers', () => ({
+  getPasswordPolicy: (...args: unknown[]) => mockGetPasswordPolicy(...args),
+}));
+
+vi.mock('../password_metadata', () => ({
+  recordPasswordChange: vi.fn(),
+}));
+
+vi.mock('../../audit_logs/helpers', () => ({
+  createAuditLog: vi.fn(),
+}));
+
 vi.mock('convex/values', () => {
   const stub = () => 'validator';
   return {
@@ -70,6 +83,14 @@ const VALID_PASSWORD = 'StrongP@ss1';
 describe('setMemberPassword', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetPasswordPolicy.mockResolvedValue({
+      minLength: 8,
+      requireLower: true,
+      requireUpper: true,
+      requireDigit: true,
+      requireSpecial: true,
+      maxAgeDays: null,
+    });
   });
 
   async function getHandler() {
@@ -93,11 +114,25 @@ describe('setMemberPassword', () => {
   it('throws when password is invalid', async () => {
     mockGetAuthUser.mockResolvedValue(AUTH_USER);
     const ctx = createMockCtx();
+    // findMany for target member
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'member_1',
+          userId: 'target_user_id',
+          organizationId: 'org_1',
+        },
+      ],
+    });
+    // findMany for caller member - admin
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'caller_member', userId: 'caller_user_id', role: 'admin' }],
+    });
     const handler = await getHandler();
 
     await expect(
       handler(ctx, { ...defaultArgs, newPassword: 'weak' }),
-    ).rejects.toThrow('Password must be at least 8 characters');
+    ).rejects.toThrow('Password does not meet policy');
   });
 
   it('throws when member not found', async () => {

--- a/services/platform/convex/users/__tests__/set_member_password.test.ts
+++ b/services/platform/convex/users/__tests__/set_member_password.test.ts
@@ -89,7 +89,7 @@ describe('setMemberPassword', () => {
       requireUpper: true,
       requireDigit: true,
       requireSpecial: true,
-      maxAgeDays: null,
+      rotationDays: 0,
     });
   });
 

--- a/services/platform/convex/users/__tests__/update_user_password.test.ts
+++ b/services/platform/convex/users/__tests__/update_user_password.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockChangePassword = vi.fn();
 const mockSetPassword = vi.fn();
-const mockRevokeOtherSessions = vi.fn();
 const mockGetAuth = vi.fn();
 const mockGetAuthUser = vi.fn();
 

--- a/services/platform/convex/users/__tests__/update_user_password.test.ts
+++ b/services/platform/convex/users/__tests__/update_user_password.test.ts
@@ -112,7 +112,7 @@ describe('updateUserPassword', () => {
         requireUpper: true,
         requireDigit: true,
         requireSpecial: true,
-        maxAgeDays: null,
+        rotationDays: 0,
       },
       effectiveAt: null,
     });

--- a/services/platform/convex/users/__tests__/update_user_password.test.ts
+++ b/services/platform/convex/users/__tests__/update_user_password.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockChangePassword = vi.fn();
 const mockSetPassword = vi.fn();
+const mockRevokeOtherSessions = vi.fn();
 const mockGetAuth = vi.fn();
+const mockGetAuthUser = vi.fn();
 
 vi.mock('../../auth', () => ({
   authComponent: {
     getAuth: (...args: unknown[]) => mockGetAuth(...args),
+    getAuthUser: (...args: unknown[]) => mockGetAuthUser(...args),
   },
   createAuth: 'createAuth',
 }));
@@ -15,6 +18,26 @@ const mockHasCredentialAccount = vi.fn();
 vi.mock('../../accounts/helpers', () => ({
   hasCredentialAccount: (...args: unknown[]) =>
     mockHasCredentialAccount(...args),
+}));
+
+const mockGetUserOrganizations = vi.fn();
+vi.mock('../../lib/rls/organization/get_user_organizations', () => ({
+  getUserOrganizations: (...args: unknown[]) =>
+    mockGetUserOrganizations(...args),
+}));
+
+const mockGetStrictestPasswordPolicyForUser = vi.fn();
+vi.mock('../../governance/helpers', () => ({
+  getStrictestPasswordPolicyForUser: (...args: unknown[]) =>
+    mockGetStrictestPasswordPolicyForUser(...args),
+}));
+
+vi.mock('../password_metadata', () => ({
+  recordPasswordChange: vi.fn(),
+}));
+
+vi.mock('../../audit_logs/helpers', () => ({
+  createAuditLog: vi.fn(),
 }));
 
 vi.mock('convex/values', () => {
@@ -35,7 +58,6 @@ vi.mock('convex/values', () => {
   };
 });
 
-const mockGetAuthUser = vi.fn();
 vi.mock('../../_generated/api', () => ({
   components: {
     betterAuth: {
@@ -78,7 +100,23 @@ describe('updateUserPassword', () => {
       },
       headers: MOCK_HEADERS,
     });
-    mockGetAuthUser.mockResolvedValue({ _id: 'user_1' });
+    mockGetAuthUser.mockResolvedValue({
+      _id: 'user_1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+    mockGetUserOrganizations.mockResolvedValue([]);
+    mockGetStrictestPasswordPolicyForUser.mockResolvedValue({
+      policy: {
+        minLength: 8,
+        requireLower: true,
+        requireUpper: true,
+        requireDigit: true,
+        requireSpecial: true,
+        maxAgeDays: null,
+      },
+      effectiveAt: null,
+    });
   });
 
   async function getHandler() {
@@ -92,7 +130,7 @@ describe('updateUserPassword', () => {
 
     await expect(
       handler(ctx as never, { newPassword: 'weak' }),
-    ).rejects.toThrow('Password must be at least 8 characters');
+    ).rejects.toThrow('Password does not meet policy');
   });
 
   it('calls changePassword with revokeOtherSessions for credential users', async () => {

--- a/services/platform/convex/users/create_member.ts
+++ b/services/platform/convex/users/create_member.ts
@@ -7,6 +7,7 @@ import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
 import { createAuth, authComponent } from '../auth';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import { recordPasswordChange } from './password_metadata';
 import type { Role } from './types';
 
 export interface CreateMemberArgs {
@@ -210,6 +211,10 @@ export async function createMember(
     (createdRecord ? getString(createdRecord, '_id') : undefined) ??
     (createdRecord ? getString(createdRecord, 'id') : undefined) ??
     String(created);
+
+  await recordPasswordChange(ctx, betterAuthUserId, {
+    forceChangeOnNextLogin: true,
+  });
 
   return {
     userId: betterAuthUserId,

--- a/services/platform/convex/users/mutations.ts
+++ b/services/platform/convex/users/mutations.ts
@@ -29,6 +29,7 @@ export const updateUserPassword = mutation({
   args: {
     currentPassword: v.optional(v.string()),
     newPassword: v.string(),
+    trigger: v.optional(v.union(v.literal('voluntary'), v.literal('forced'))),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {

--- a/services/platform/convex/users/password_metadata.ts
+++ b/services/platform/convex/users/password_metadata.ts
@@ -10,6 +10,7 @@ import type { MutationCtx } from '../_generated/server';
 export async function recordPasswordChange(
   ctx: MutationCtx,
   userId: string,
+  opts?: { forceChangeOnNextLogin?: boolean },
 ): Promise<void> {
   const existing = await ctx.db
     .query('userPasswordMetadata')
@@ -17,12 +18,17 @@ export async function recordPasswordChange(
     .first();
 
   const now = Date.now();
+  const forceChangeOnNextLogin = opts?.forceChangeOnNextLogin ?? false;
   if (existing) {
-    await ctx.db.patch(existing._id, { passwordChangedAt: now });
+    await ctx.db.patch(existing._id, {
+      passwordChangedAt: now,
+      forceChangeOnNextLogin,
+    });
   } else {
     await ctx.db.insert('userPasswordMetadata', {
       userId,
       passwordChangedAt: now,
+      forceChangeOnNextLogin,
     });
   }
 }

--- a/services/platform/convex/users/password_metadata.ts
+++ b/services/platform/convex/users/password_metadata.ts
@@ -1,0 +1,28 @@
+import type { MutationCtx } from '../_generated/server';
+
+/**
+ * Record that the given user's credential password was just set/changed.
+ * Upserts the `userPasswordMetadata` row used by the rotation policy to
+ * compute expiry. Kept separate from Better Auth's `account.updatedAt`
+ * because that timestamp is also patched by non-password events (e.g.
+ * OAuth token refresh) and so is not a trustworthy anchor.
+ */
+export async function recordPasswordChange(
+  ctx: MutationCtx,
+  userId: string,
+): Promise<void> {
+  const existing = await ctx.db
+    .query('userPasswordMetadata')
+    .withIndex('by_userId', (q) => q.eq('userId', userId))
+    .first();
+
+  const now = Date.now();
+  if (existing) {
+    await ctx.db.patch(existing._id, { passwordChangedAt: now });
+  } else {
+    await ctx.db.insert('userPasswordMetadata', {
+      userId,
+      passwordChangedAt: now,
+    });
+  }
+}

--- a/services/platform/convex/users/queries.ts
+++ b/services/platform/convex/users/queries.ts
@@ -6,8 +6,11 @@
 
 import { v } from 'convex/values';
 
+import { components } from '../_generated/api';
 import { query } from '../_generated/server';
+import { getStrictestPasswordPolicyForUser } from '../governance/helpers';
 import { getAuthUserIdentity } from '../lib/rls';
+import { getUserOrganizations } from '../lib/rls/organization/get_user_organizations';
 import { hasAnyUsers as hasAnyUsersHelper } from './has_any_users';
 
 /**
@@ -44,5 +47,111 @@ export const getCurrentUser = query({
     name?: string;
   } | null> => {
     return await getAuthUserIdentity(ctx);
+  },
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Password expiry status for the current authenticated user.
+ *
+ * Returns `{ expired: false, daysUntilExpiry: null }` when:
+ *  - the user has no credential account (OAuth-only)
+ *  - no org's password_policy has rotation enabled (rotationDays === 0)
+ *
+ * Otherwise `daysUntilExpiry` is signed (negative when expired).
+ *
+ * Multi-org: the strictest policy across the user's memberships applies
+ * (shortest positive rotation window).
+ */
+export const getPasswordExpiryStatus = query({
+  args: {},
+  returns: v.object({
+    expired: v.boolean(),
+    daysUntilExpiry: v.union(v.number(), v.null()),
+    hasCredential: v.boolean(),
+    rotationEnabled: v.boolean(),
+  }),
+  handler: async (
+    ctx,
+  ): Promise<{
+    expired: boolean;
+    daysUntilExpiry: number | null;
+    hasCredential: boolean;
+    rotationEnabled: boolean;
+  }> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      return {
+        expired: false,
+        daysUntilExpiry: null,
+        hasCredential: false,
+        rotationEnabled: false,
+      };
+    }
+
+    const credentialResult = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'account',
+        where: [
+          { field: 'userId', value: authUser.userId, operator: 'eq' },
+          { field: 'providerId', value: 'credential', operator: 'eq' },
+        ],
+        paginationOpts: { cursor: null, numItems: 1 },
+      },
+    );
+    const hasCredential = (credentialResult?.page?.length ?? 0) > 0;
+    if (!hasCredential) {
+      return {
+        expired: false,
+        daysUntilExpiry: null,
+        hasCredential: false,
+        rotationEnabled: false,
+      };
+    }
+
+    const orgs = await getUserOrganizations(ctx, authUser);
+    const { policy, effectiveAt } = await getStrictestPasswordPolicyForUser(
+      ctx,
+      orgs.map((o) => o.organizationId),
+    );
+
+    if (policy.rotationDays <= 0) {
+      return {
+        expired: false,
+        daysUntilExpiry: null,
+        hasCredential: true,
+        rotationEnabled: false,
+      };
+    }
+
+    const meta = await ctx.db
+      .query('userPasswordMetadata')
+      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
+      .first();
+    const anchor = Math.max(meta?.passwordChangedAt ?? 0, effectiveAt ?? 0);
+
+    // No anchor yet (policy never activated rotation and user never had
+    // their password change timestamped). Treat as not-expired — the
+    // next password change will seed passwordChangedAt.
+    if (anchor === 0) {
+      return {
+        expired: false,
+        daysUntilExpiry: null,
+        hasCredential: true,
+        rotationEnabled: true,
+      };
+    }
+
+    const expiresAt = anchor + policy.rotationDays * DAY_MS;
+    const now = Date.now();
+    const daysUntilExpiry = Math.ceil((expiresAt - now) / DAY_MS);
+    return {
+      expired: now >= expiresAt,
+      daysUntilExpiry,
+      hasCredential: true,
+      rotationEnabled: true,
+    };
   },
 });

--- a/services/platform/convex/users/queries.ts
+++ b/services/platform/convex/users/queries.ts
@@ -71,6 +71,7 @@ export const getPasswordExpiryStatus = query({
     daysUntilExpiry: v.union(v.number(), v.null()),
     hasCredential: v.boolean(),
     rotationEnabled: v.boolean(),
+    reason: v.union(v.literal('admin_set'), v.literal('rotation'), v.null()),
   }),
   handler: async (
     ctx,
@@ -79,6 +80,7 @@ export const getPasswordExpiryStatus = query({
     daysUntilExpiry: number | null;
     hasCredential: boolean;
     rotationEnabled: boolean;
+    reason: 'admin_set' | 'rotation' | null;
   }> => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
@@ -87,6 +89,7 @@ export const getPasswordExpiryStatus = query({
         daysUntilExpiry: null,
         hasCredential: false,
         rotationEnabled: false,
+        reason: null,
       };
     }
 
@@ -108,6 +111,22 @@ export const getPasswordExpiryStatus = query({
         daysUntilExpiry: null,
         hasCredential: false,
         rotationEnabled: false,
+        reason: null,
+      };
+    }
+
+    const meta = await ctx.db
+      .query('userPasswordMetadata')
+      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
+      .first();
+
+    if (meta?.forceChangeOnNextLogin) {
+      return {
+        expired: true,
+        daysUntilExpiry: 0,
+        hasCredential: true,
+        rotationEnabled: false,
+        reason: 'admin_set',
       };
     }
 
@@ -123,20 +142,7 @@ export const getPasswordExpiryStatus = query({
         daysUntilExpiry: null,
         hasCredential: true,
         rotationEnabled: false,
-      };
-    }
-
-    const meta = await ctx.db
-      .query('userPasswordMetadata')
-      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
-      .first();
-
-    if (meta?.forceChangeOnNextLogin) {
-      return {
-        expired: true,
-        daysUntilExpiry: 0,
-        hasCredential: true,
-        rotationEnabled: true,
+        reason: null,
       };
     }
 
@@ -151,17 +157,20 @@ export const getPasswordExpiryStatus = query({
         daysUntilExpiry: null,
         hasCredential: true,
         rotationEnabled: true,
+        reason: null,
       };
     }
 
     const expiresAt = anchor + policy.rotationDays * DAY_MS;
     const now = Date.now();
     const daysUntilExpiry = Math.ceil((expiresAt - now) / DAY_MS);
+    const expired = now >= expiresAt;
     return {
-      expired: now >= expiresAt,
+      expired,
       daysUntilExpiry,
       hasCredential: true,
       rotationEnabled: true,
+      reason: expired ? 'rotation' : null,
     };
   },
 });

--- a/services/platform/convex/users/queries.ts
+++ b/services/platform/convex/users/queries.ts
@@ -130,6 +130,16 @@ export const getPasswordExpiryStatus = query({
       .query('userPasswordMetadata')
       .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
       .first();
+
+    if (meta?.forceChangeOnNextLogin) {
+      return {
+        expired: true,
+        daysUntilExpiry: 0,
+        hasCredential: true,
+        rotationEnabled: true,
+      };
+    }
+
     const anchor = Math.max(meta?.passwordChangedAt ?? 0, effectiveAt ?? 0);
 
     // No anchor yet (policy never activated rotation and user never had

--- a/services/platform/convex/users/reset_owner.ts
+++ b/services/platform/convex/users/reset_owner.ts
@@ -3,14 +3,24 @@
  *
  * Resets the owner's email and/or password. Called only via admin-authenticated
  * path (CLI → container script → internalMutation). No session auth check needed.
+ *
+ * This path intentionally validates the new password against the built-in
+ * DEFAULT_PASSWORD_POLICY (not an org-configurable policy). Reason: this
+ * is a recovery tool. If an admin locked themselves out by configuring an
+ * unreachably strict policy, honoring that policy here would make recovery
+ * impossible.
  */
 
 import { hashPassword } from 'better-auth/crypto';
 
-import { isPasswordValid } from '../../lib/shared/schemas/password';
+import {
+  isPasswordValid,
+  passwordPolicyViolations,
+} from '../../lib/shared/schemas/password';
 import { isRecord, getString } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
+import { recordPasswordChange } from './password_metadata';
 
 export interface ResetOwnerArgs {
   newEmail?: string;
@@ -107,8 +117,9 @@ export async function resetOwner(
   // Update password if requested
   if (args.newPassword) {
     if (!isPasswordValid(args.newPassword)) {
+      const violations = passwordPolicyViolations(args.newPassword);
       throw new Error(
-        'Password must be at least 8 characters with lowercase, uppercase, number, and special character',
+        `Password does not meet recovery defaults (failed: ${violations.join(', ')})`,
       );
     }
 
@@ -159,6 +170,7 @@ export async function resetOwner(
         },
       });
     }
+    await recordPasswordChange(ctx, ownerUserId);
     updatedPassword = true;
   }
 

--- a/services/platform/convex/users/schema.ts
+++ b/services/platform/convex/users/schema.ts
@@ -1,0 +1,13 @@
+import { defineTable } from 'convex/server';
+import { v } from 'convex/values';
+
+// Per-user password rotation metadata.
+// Tracks when the user's credential password was most recently set, for
+// the configurable password-rotation policy. Stored separately from the
+// Better Auth `account` row because `account.updatedAt` is patched by
+// non-password events (e.g., Microsoft OAuth token refresh) and so isn't
+// a trustworthy password-change proxy.
+export const userPasswordMetadataTable = defineTable({
+  userId: v.string(),
+  passwordChangedAt: v.number(),
+}).index('by_userId', ['userId']);

--- a/services/platform/convex/users/schema.ts
+++ b/services/platform/convex/users/schema.ts
@@ -10,4 +10,5 @@ import { v } from 'convex/values';
 export const userPasswordMetadataTable = defineTable({
   userId: v.string(),
   passwordChangedAt: v.number(),
+  forceChangeOnNextLogin: v.optional(v.boolean()),
 }).index('by_userId', ['userId']);

--- a/services/platform/convex/users/set_member_password.ts
+++ b/services/platform/convex/users/set_member_password.ts
@@ -7,12 +7,18 @@
 
 import { hashPassword } from 'better-auth/crypto';
 
-import { isPasswordValid } from '../../lib/shared/schemas/password';
+import {
+  isPasswordValid,
+  passwordPolicyViolations,
+} from '../../lib/shared/schemas/password';
 import { isRecord, getString } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
+import { createAuditLog } from '../audit_logs/helpers';
 import { authComponent } from '../auth';
+import { getPasswordPolicy } from '../governance/helpers';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import { recordPasswordChange } from './password_metadata';
 
 export interface SetMemberPasswordArgs {
   memberId: string;
@@ -26,12 +32,6 @@ export async function setMemberPassword(
   const authUser = await authComponent.getAuthUser(ctx);
   if (!authUser) {
     throw new Error('Unauthenticated');
-  }
-
-  if (!isPasswordValid(args.newPassword)) {
-    throw new Error(
-      'Password must be at least 8 characters with lowercase, uppercase, number, and special character',
-    );
   }
 
   // Look up the target member
@@ -77,6 +77,16 @@ export async function setMemberPassword(
     : undefined;
   if (!isAdmin(callerRole)) {
     throw new Error('Only admins can set member passwords');
+  }
+
+  // Validate against the target member's org policy (the password must
+  // satisfy the policy of the org whose credentials are being set).
+  const policy = await getPasswordPolicy(ctx, memberOrgId);
+  if (!isPasswordValid(args.newPassword, policy)) {
+    const violations = passwordPolicyViolations(args.newPassword, policy);
+    throw new Error(
+      `Password does not meet policy (failed: ${violations.join(', ')})`,
+    );
   }
 
   // Check if the target user already has a credential account
@@ -152,4 +162,19 @@ export async function setMemberPassword(
     );
     hasMoreSessions = (remaining?.page?.length ?? 0) > 0;
   }
+
+  await recordPasswordChange(ctx, memberUserId);
+
+  await createAuditLog(ctx, {
+    organizationId: memberOrgId,
+    actorId: String(authUser._id),
+    actorEmail: authUser.email,
+    actorType: 'user',
+    action: 'member_password.set',
+    category: 'auth',
+    resourceType: 'user',
+    resourceId: memberUserId,
+    status: 'success',
+    metadata: { memberId: args.memberId },
+  });
 }

--- a/services/platform/convex/users/set_member_password.ts
+++ b/services/platform/convex/users/set_member_password.ts
@@ -163,7 +163,9 @@ export async function setMemberPassword(
     hasMoreSessions = (remaining?.page?.length ?? 0) > 0;
   }
 
-  await recordPasswordChange(ctx, memberUserId);
+  await recordPasswordChange(ctx, memberUserId, {
+    forceChangeOnNextLogin: true,
+  });
 
   await createAuditLog(ctx, {
     organizationId: memberOrgId,

--- a/services/platform/convex/users/update_user_password.ts
+++ b/services/platform/convex/users/update_user_password.ts
@@ -2,14 +2,22 @@
  * Update user password - Business logic
  */
 
-import { isPasswordValid } from '../../lib/shared/schemas/password';
+import {
+  isPasswordValid,
+  passwordPolicyViolations,
+} from '../../lib/shared/schemas/password';
 import { MutationCtx } from '../_generated/server';
 import { hasCredentialAccount } from '../accounts/helpers';
+import { createAuditLog } from '../audit_logs/helpers';
 import { createAuth, authComponent } from '../auth';
+import { getStrictestPasswordPolicyForUser } from '../governance/helpers';
+import { getUserOrganizations } from '../lib/rls/organization/get_user_organizations';
+import { recordPasswordChange } from './password_metadata';
 
 export interface UpdateUserPasswordArgs {
   currentPassword?: string;
   newPassword: string;
+  trigger?: 'voluntary' | 'forced';
 }
 
 /**
@@ -21,11 +29,26 @@ export async function updateUserPassword(
   ctx: MutationCtx,
   args: UpdateUserPasswordArgs,
 ): Promise<void> {
+  const authUser = await authComponent.getAuthUser(ctx);
+  if (!authUser) {
+    throw new Error('Unauthenticated');
+  }
   const { auth, headers } = await authComponent.getAuth(createAuth, ctx);
 
-  if (!isPasswordValid(args.newPassword)) {
+  const orgs = await getUserOrganizations(ctx, {
+    userId: String(authUser._id),
+    email: authUser.email,
+    name: authUser.name,
+  });
+  const { policy } = await getStrictestPasswordPolicyForUser(
+    ctx,
+    orgs.map((o) => o.organizationId),
+  );
+
+  if (!isPasswordValid(args.newPassword, policy)) {
+    const violations = passwordPolicyViolations(args.newPassword, policy);
     throw new Error(
-      'Password must be at least 8 characters with lowercase, uppercase, number, and special character',
+      `Password does not meet policy (failed: ${violations.join(', ')})`,
     );
   }
 
@@ -51,4 +74,31 @@ export async function updateUserPassword(
       headers,
     });
   }
+
+  await recordPasswordChange(ctx, String(authUser._id));
+
+  const trigger = args.trigger ?? 'voluntary';
+  // Audit the change against every org the user belongs to, so each
+  // org's compliance trail records the credential rotation. Fall back
+  // to a single log without organizationId-scoped trail only when the
+  // user belongs to no orgs (shouldn't happen post-onboarding).
+  if (orgs.length === 0) {
+    return;
+  }
+  await Promise.all(
+    orgs.map((o) =>
+      createAuditLog(ctx, {
+        organizationId: o.organizationId,
+        actorId: String(authUser._id),
+        actorEmail: authUser.email,
+        actorType: 'user',
+        action: 'user_password.changed',
+        category: 'auth',
+        resourceType: 'user',
+        resourceId: String(authUser._id),
+        status: 'success',
+        metadata: { trigger },
+      }),
+    ),
+  );
 }

--- a/services/platform/convex/users/update_user_password.ts
+++ b/services/platform/convex/users/update_user_password.ts
@@ -68,17 +68,17 @@ export async function updateUserPassword(
   const trigger = args.trigger ?? 'voluntary';
 
   if (hasPassword && trigger === 'forced') {
-    const currentSession = await auth.api.getSession({ headers });
-    const sessionObj: unknown = currentSession?.session;
-    const currentSessionId = isRecord(sessionObj)
-      ? getString(sessionObj, '_id')
-      : undefined;
     await forcedResetCredentialPassword(
       ctx,
       String(authUser._id),
       args.newPassword,
-      currentSessionId,
     );
+    // Revoke every session for this user EXCEPT the caller's current
+    // one. Delegating to Better Auth's own API (rather than matching
+    // session rows manually) guarantees we use the same identity it
+    // uses to decide which session is "current", independent of how
+    // the Convex adapter maps ids vs. tokens.
+    await auth.api.revokeOtherSessions({ headers });
   } else if (hasPassword) {
     if (!args.currentPassword) {
       throw new Error('Current password is required');
@@ -131,7 +131,6 @@ async function forcedResetCredentialPassword(
   ctx: MutationCtx,
   userId: string,
   newPassword: string,
-  preserveSessionId: string | undefined,
 ): Promise<void> {
   const accountRes = await ctx.runQuery(
     components.betterAuth.adapter.findMany,
@@ -162,32 +161,4 @@ async function forcedResetCredentialPassword(
     },
     paginationOpts: { cursor: null, numItems: 1 },
   });
-
-  // Revoke every OTHER session for this user, preserving the current
-  // one so the caller stays authenticated after the forced rotation
-  // (matches Better Auth's `revokeOtherSessions: true` semantics).
-  const SESSION_BATCH_SIZE = 100;
-  let cursor: string | null = null;
-  while (true) {
-    const page: { page: unknown[]; isDone: boolean; continueCursor: string } =
-      await ctx.runQuery(components.betterAuth.adapter.findMany, {
-        model: 'session',
-        paginationOpts: { cursor, numItems: SESSION_BATCH_SIZE },
-        where: [{ field: 'userId', value: userId, operator: 'eq' }],
-      });
-    for (const row of page.page) {
-      if (!isRecord(row)) continue;
-      const sid = getString(row, '_id');
-      if (!sid || sid === preserveSessionId) continue;
-      await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
-        input: {
-          model: 'session',
-          where: [{ field: '_id', value: sid, operator: 'eq' }],
-        },
-        paginationOpts: { cursor: null, numItems: 1 },
-      });
-    }
-    if (page.isDone) break;
-    cursor = page.continueCursor;
-  }
 }

--- a/services/platform/convex/users/update_user_password.ts
+++ b/services/platform/convex/users/update_user_password.ts
@@ -2,10 +2,14 @@
  * Update user password - Business logic
  */
 
+import { hashPassword } from 'better-auth/crypto';
+
 import {
   isPasswordValid,
   passwordPolicyViolations,
 } from '../../lib/shared/schemas/password';
+import { getString, isRecord } from '../../lib/utils/type-guards';
+import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
 import { hasCredentialAccount } from '../accounts/helpers';
 import { createAuditLog } from '../audit_logs/helpers';
@@ -22,8 +26,16 @@ export interface UpdateUserPasswordArgs {
 
 /**
  * Update the current user's password.
- * For credential users: requires currentPassword, uses changePassword.
- * For OAuth-only users: uses setPassword to add a password to their account.
+ *
+ * - Voluntary change, credential user: requires currentPassword, routed
+ *   through Better Auth's `changePassword` API (re-authenticates).
+ * - Voluntary/forced, OAuth-only user: routed through `setPassword` (no
+ *   currentPassword needed — they're adding a password for the first time).
+ * - Forced change, credential user: currentPassword is NOT required. The
+ *   user already authenticated this session and the rotation flow's
+ *   purpose is freshness, not re-authentication. Updates the credential
+ *   account directly via the Better Auth adapter and revokes other
+ *   sessions to keep the voluntary-flow parity.
  */
 export async function updateUserPassword(
   ctx: MutationCtx,
@@ -53,8 +65,21 @@ export async function updateUserPassword(
   }
 
   const hasPassword = await hasCredentialAccount(ctx);
+  const trigger = args.trigger ?? 'voluntary';
 
-  if (hasPassword) {
+  if (hasPassword && trigger === 'forced') {
+    const currentSession = await auth.api.getSession({ headers });
+    const sessionObj: unknown = currentSession?.session;
+    const currentSessionId = isRecord(sessionObj)
+      ? getString(sessionObj, '_id')
+      : undefined;
+    await forcedResetCredentialPassword(
+      ctx,
+      String(authUser._id),
+      args.newPassword,
+      currentSessionId,
+    );
+  } else if (hasPassword) {
     if (!args.currentPassword) {
       throw new Error('Current password is required');
     }
@@ -77,7 +102,6 @@ export async function updateUserPassword(
 
   await recordPasswordChange(ctx, String(authUser._id));
 
-  const trigger = args.trigger ?? 'voluntary';
   // Audit the change against every org the user belongs to, so each
   // org's compliance trail records the credential rotation. Fall back
   // to a single log without organizationId-scoped trail only when the
@@ -101,4 +125,69 @@ export async function updateUserPassword(
       }),
     ),
   );
+}
+
+async function forcedResetCredentialPassword(
+  ctx: MutationCtx,
+  userId: string,
+  newPassword: string,
+  preserveSessionId: string | undefined,
+): Promise<void> {
+  const accountRes = await ctx.runQuery(
+    components.betterAuth.adapter.findMany,
+    {
+      model: 'account',
+      paginationOpts: { cursor: null, numItems: 1 },
+      where: [
+        { field: 'userId', value: userId, operator: 'eq' },
+        { field: 'providerId', value: 'credential', operator: 'eq' },
+      ],
+    },
+  );
+  const credential = accountRes?.page?.[0];
+  if (!isRecord(credential)) {
+    throw new Error('Credential account not found');
+  }
+  const credentialId = getString(credential, '_id');
+  if (!credentialId) {
+    throw new Error('Credential account missing _id');
+  }
+
+  const passwordHash = await hashPassword(newPassword);
+  await ctx.runMutation(components.betterAuth.adapter.updateMany, {
+    input: {
+      model: 'account',
+      where: [{ field: '_id', value: credentialId, operator: 'eq' }],
+      update: { password: passwordHash, updatedAt: Date.now() },
+    },
+    paginationOpts: { cursor: null, numItems: 1 },
+  });
+
+  // Revoke every OTHER session for this user, preserving the current
+  // one so the caller stays authenticated after the forced rotation
+  // (matches Better Auth's `revokeOtherSessions: true` semantics).
+  const SESSION_BATCH_SIZE = 100;
+  let cursor: string | null = null;
+  while (true) {
+    const page: { page: unknown[]; isDone: boolean; continueCursor: string } =
+      await ctx.runQuery(components.betterAuth.adapter.findMany, {
+        model: 'session',
+        paginationOpts: { cursor, numItems: SESSION_BATCH_SIZE },
+        where: [{ field: 'userId', value: userId, operator: 'eq' }],
+      });
+    for (const row of page.page) {
+      if (!isRecord(row)) continue;
+      const sid = getString(row, '_id');
+      if (!sid || sid === preserveSessionId) continue;
+      await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+        input: {
+          model: 'session',
+          where: [{ field: '_id', value: sid, operator: 'eq' }],
+        },
+        paginationOpts: { cursor: null, numItems: 1 },
+      });
+    }
+    if (page.isDone) break;
+    cursor = page.continueCursor;
+  }
 }

--- a/services/platform/lib/shared/schemas/governance.test.ts
+++ b/services/platform/lib/shared/schemas/governance.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
-import { featureFlagRuleSchema, featureFlagsConfigSchema } from './governance';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  featureFlagRuleSchema,
+  featureFlagsConfigSchema,
+  mergeStrictestPasswordPolicy,
+  passwordPolicyConfigSchema,
+} from './governance';
 
 describe('featureFlagRuleSchema — maxContextTokens validation', () => {
   it('accepts valid maxContextTokens at minimum floor (4096)', () => {
@@ -86,5 +92,83 @@ describe('featureFlagsConfigSchema', () => {
       ],
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('passwordPolicyConfigSchema', () => {
+  it('parses an empty object to built-in defaults', () => {
+    const result = passwordPolicyConfigSchema.parse({});
+    expect(result).toEqual({
+      minLength: 8,
+      requireUpper: true,
+      requireLower: true,
+      requireDigit: true,
+      requireSpecial: true,
+      rotationDays: 0,
+    });
+  });
+
+  it('rejects minLength below 6', () => {
+    expect(passwordPolicyConfigSchema.safeParse({ minLength: 5 }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects rotationDays outside [0, 3650]', () => {
+    expect(
+      passwordPolicyConfigSchema.safeParse({ rotationDays: -1 }).success,
+    ).toBe(false);
+    expect(
+      passwordPolicyConfigSchema.safeParse({ rotationDays: 3651 }).success,
+    ).toBe(false);
+  });
+});
+
+describe('mergeStrictestPasswordPolicy', () => {
+  const strict = {
+    ...DEFAULT_PASSWORD_POLICY,
+    minLength: 16,
+    rotationDays: 30,
+  };
+  const relaxed = {
+    ...DEFAULT_PASSWORD_POLICY,
+    minLength: 8,
+    requireSpecial: false,
+    rotationDays: 90,
+  };
+
+  it('returns defaults when policies is empty', () => {
+    expect(mergeStrictestPasswordPolicy([])).toEqual(DEFAULT_PASSWORD_POLICY);
+  });
+
+  it('picks the longest minLength', () => {
+    expect(mergeStrictestPasswordPolicy([strict, relaxed]).minLength).toBe(16);
+  });
+
+  it('ORs each require flag (strict wins)', () => {
+    const merged = mergeStrictestPasswordPolicy([strict, relaxed]);
+    expect(merged.requireSpecial).toBe(true);
+  });
+
+  it('picks shortest positive rotationDays', () => {
+    expect(mergeStrictestPasswordPolicy([strict, relaxed]).rotationDays).toBe(
+      30,
+    );
+  });
+
+  it('treats rotationDays=0 as disabled (ignores it when another is set)', () => {
+    const disabled = { ...DEFAULT_PASSWORD_POLICY, rotationDays: 0 };
+    expect(mergeStrictestPasswordPolicy([disabled, relaxed]).rotationDays).toBe(
+      90,
+    );
+  });
+
+  it('keeps rotationDays=0 when all policies disable it', () => {
+    expect(
+      mergeStrictestPasswordPolicy([
+        { ...DEFAULT_PASSWORD_POLICY, rotationDays: 0 },
+        { ...DEFAULT_PASSWORD_POLICY, rotationDays: 0 },
+      ]).rotationDays,
+    ).toBe(0);
   });
 });

--- a/services/platform/lib/shared/schemas/governance.ts
+++ b/services/platform/lib/shared/schemas/governance.ts
@@ -9,7 +9,9 @@ export const POLICY_TYPES = [
   'feature_flags',
   'pii_config',
   'model_access',
+  'audit_retention',
   'login_policy',
+  'password_policy',
 ] as const;
 export type PolicyType = (typeof POLICY_TYPES)[number];
 
@@ -160,3 +162,41 @@ export const loginPolicyConfigSchema = z.object({
     .default(DEFAULT_TRUSTED_PROXIES),
 });
 export type LoginPolicyConfig = z.infer<typeof loginPolicyConfigSchema>;
+
+export const passwordPolicyConfigSchema = z.object({
+  minLength: z.number().int().min(6).max(128).default(8),
+  requireUpper: z.boolean().default(true),
+  requireLower: z.boolean().default(true),
+  requireDigit: z.boolean().default(true),
+  requireSpecial: z.boolean().default(true),
+  rotationDays: z.number().int().min(0).max(3650).default(0),
+});
+export type PasswordPolicyConfig = z.infer<typeof passwordPolicyConfigSchema>;
+export const DEFAULT_PASSWORD_POLICY: PasswordPolicyConfig =
+  passwordPolicyConfigSchema.parse({});
+
+// Merges multiple policies into the strictest ("strongest") one — longest
+// minLength, OR of each require flag, shortest positive rotationDays.
+// Used when a user belongs to multiple orgs with divergent policies:
+// their single password must satisfy the strictest constraint.
+export function mergeStrictestPasswordPolicy(
+  policies: readonly PasswordPolicyConfig[],
+): PasswordPolicyConfig {
+  if (policies.length === 0) return DEFAULT_PASSWORD_POLICY;
+  return policies.reduce<PasswordPolicyConfig>(
+    (acc, p) => ({
+      minLength: Math.max(acc.minLength, p.minLength),
+      requireUpper: acc.requireUpper || p.requireUpper,
+      requireLower: acc.requireLower || p.requireLower,
+      requireDigit: acc.requireDigit || p.requireDigit,
+      requireSpecial: acc.requireSpecial || p.requireSpecial,
+      rotationDays:
+        acc.rotationDays === 0
+          ? p.rotationDays
+          : p.rotationDays === 0
+            ? acc.rotationDays
+            : Math.min(acc.rotationDays, p.rotationDays),
+    }),
+    policies[0],
+  );
+}

--- a/services/platform/lib/shared/schemas/password.test.ts
+++ b/services/platform/lib/shared/schemas/password.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_PASSWORD_POLICY } from './governance';
 import {
-  PASSWORD_MIN_LENGTH,
   createOptionalPasswordSchema,
   createPasswordSchema,
+  enabledValidationKeys,
   isPasswordValid,
+  passwordPolicyViolations,
   validatePassword,
 } from './password';
 
@@ -17,7 +19,15 @@ const MESSAGES = {
   specialChar: 'special char',
 };
 
-describe('validatePassword', () => {
+const relaxed = {
+  ...DEFAULT_PASSWORD_POLICY,
+  requireUpper: false,
+  requireLower: false,
+  requireDigit: false,
+  requireSpecial: false,
+};
+
+describe('validatePassword (default policy)', () => {
   it('returns all true for a valid password', () => {
     const result = validatePassword(VALID_PASSWORD);
     expect(result).toEqual({
@@ -30,36 +40,23 @@ describe('validatePassword', () => {
   });
 
   it('fails length for short password', () => {
-    const result = validatePassword('Ab1!');
-    expect(result.length).toBe(false);
-    expect(result.lowercase).toBe(true);
-    expect(result.uppercase).toBe(true);
-    expect(result.number).toBe(true);
-    expect(result.specialChar).toBe(true);
+    expect(validatePassword('Ab1!').length).toBe(false);
   });
 
   it('fails lowercase when missing', () => {
-    const result = validatePassword('ABCDEFG1!');
-    expect(result.length).toBe(true);
-    expect(result.lowercase).toBe(false);
+    expect(validatePassword('ABCDEFG1!').lowercase).toBe(false);
   });
 
   it('fails uppercase when missing', () => {
-    const result = validatePassword('abcdefg1!');
-    expect(result.length).toBe(true);
-    expect(result.uppercase).toBe(false);
+    expect(validatePassword('abcdefg1!').uppercase).toBe(false);
   });
 
   it('fails number when missing', () => {
-    const result = validatePassword('Abcdefgh!');
-    expect(result.length).toBe(true);
-    expect(result.number).toBe(false);
+    expect(validatePassword('Abcdefgh!').number).toBe(false);
   });
 
   it('fails special char when missing', () => {
-    const result = validatePassword('Abcdefg1');
-    expect(result.length).toBe(true);
-    expect(result.specialChar).toBe(false);
+    expect(validatePassword('Abcdefg1').specialChar).toBe(false);
   });
 
   it('fails all rules for empty string', () => {
@@ -68,8 +65,27 @@ describe('validatePassword', () => {
   });
 });
 
+describe('validatePassword (custom policy)', () => {
+  it('treats disabled rules as passing', () => {
+    const result = validatePassword('abcdefgh', relaxed);
+    expect(result).toEqual({
+      length: true,
+      lowercase: true,
+      uppercase: true,
+      number: true,
+      specialChar: true,
+    });
+  });
+
+  it('enforces custom minLength', () => {
+    const policy = { ...DEFAULT_PASSWORD_POLICY, minLength: 12 };
+    expect(validatePassword('Test1234!', policy).length).toBe(false);
+    expect(validatePassword('Test1234!abcd', policy).length).toBe(true);
+  });
+});
+
 describe('isPasswordValid', () => {
-  it('returns true for valid password', () => {
+  it('returns true for valid password under default policy', () => {
     expect(isPasswordValid(VALID_PASSWORD)).toBe(true);
   });
 
@@ -80,11 +96,37 @@ describe('isPasswordValid', () => {
     expect(isPasswordValid('NoNumbers!!')).toBe(false);
     expect(isPasswordValid('NoSpecial1a')).toBe(false);
   });
+
+  it('accepts under a relaxed policy', () => {
+    expect(isPasswordValid('abcdefgh', relaxed)).toBe(true);
+  });
 });
 
-describe('PASSWORD_MIN_LENGTH', () => {
-  it('is 8', () => {
-    expect(PASSWORD_MIN_LENGTH).toBe(8);
+describe('enabledValidationKeys', () => {
+  it('always includes length', () => {
+    expect(enabledValidationKeys(relaxed)).toEqual(['length']);
+  });
+
+  it('includes every enabled class under default policy', () => {
+    expect(enabledValidationKeys()).toEqual([
+      'length',
+      'lowercase',
+      'uppercase',
+      'number',
+      'specialChar',
+    ]);
+  });
+});
+
+describe('passwordPolicyViolations', () => {
+  it('returns empty for a valid password', () => {
+    expect(passwordPolicyViolations(VALID_PASSWORD)).toEqual([]);
+  });
+
+  it('lists every failing rule', () => {
+    expect(passwordPolicyViolations('abc').sort()).toEqual(
+      ['length', 'number', 'specialChar', 'uppercase'].sort(),
+    );
   });
 });
 
@@ -111,39 +153,18 @@ describe('createPasswordSchema', () => {
     }
   });
 
-  it('rejects password missing uppercase', () => {
-    const result = schema.safeParse('abcdefg1!');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toBe('uppercase');
-    }
-  });
-
-  it('rejects password missing number', () => {
-    const result = schema.safeParse('Abcdefgh!');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toBe('number');
-    }
-  });
-
-  it('rejects password missing special char', () => {
-    const result = schema.safeParse('Abcdefg1');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toBe('special char');
-    }
+  it('omits regex steps for disabled rules', () => {
+    const relaxedSchema = createPasswordSchema(MESSAGES, relaxed);
+    expect(relaxedSchema.safeParse('abcdefgh').success).toBe(true);
+    expect(relaxedSchema.safeParse('short').success).toBe(false);
   });
 });
 
 describe('createOptionalPasswordSchema', () => {
   const schema = createOptionalPasswordSchema(MESSAGES);
 
-  it('accepts undefined', () => {
+  it('accepts undefined and empty string', () => {
     expect(schema.safeParse(undefined).success).toBe(true);
-  });
-
-  it('accepts empty string', () => {
     expect(schema.safeParse('').success).toBe(true);
   });
 
@@ -151,19 +172,12 @@ describe('createOptionalPasswordSchema', () => {
     expect(schema.safeParse(VALID_PASSWORD).success).toBe(true);
   });
 
-  it('rejects an invalid non-empty password with correct message', () => {
-    const result = schema.safeParse('weak');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toBe('min length');
-    }
+  it('rejects an invalid non-empty password', () => {
+    expect(schema.safeParse('weak').success).toBe(false);
   });
 
-  it('rejects password missing only special char with correct message', () => {
-    const result = schema.safeParse('Abcdefg1');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toBe('special char');
-    }
+  it('respects custom policy', () => {
+    const relaxedSchema = createOptionalPasswordSchema(MESSAGES, relaxed);
+    expect(relaxedSchema.safeParse('abcdefgh').success).toBe(true);
   });
 });

--- a/services/platform/lib/shared/schemas/password.ts
+++ b/services/platform/lib/shared/schemas/password.ts
@@ -39,8 +39,6 @@ export function isPasswordValid(
   return Object.values(result).every(Boolean);
 }
 
-export type PasswordValidationKey = keyof ReturnType<typeof validatePassword>;
-
 /**
  * Returns the subset of rule keys that are enabled for the given policy —
  * used by the UI to render only the applicable checklist items.

--- a/services/platform/lib/shared/schemas/password.ts
+++ b/services/platform/lib/shared/schemas/password.ts
@@ -39,7 +39,7 @@ export function isPasswordValid(
   return Object.values(result).every(Boolean);
 }
 
-export type PasswordValidationKey = keyof ReturnType<typeof validatePassword>;
+type PasswordValidationKey = keyof ReturnType<typeof validatePassword>;
 
 /**
  * Returns the subset of rule keys that are enabled for the given policy —

--- a/services/platform/lib/shared/schemas/password.ts
+++ b/services/platform/lib/shared/schemas/password.ts
@@ -1,35 +1,59 @@
 import { z } from 'zod';
 
-export const PASSWORD_MIN_LENGTH = 8;
+import {
+  DEFAULT_PASSWORD_POLICY,
+  type PasswordPolicyConfig,
+} from './governance';
 
-const PASSWORD_RULES = {
-  minLength: PASSWORD_MIN_LENGTH,
-  lowercase: /[a-z]/,
-  uppercase: /[A-Z]/,
-  number: /\d/,
-  specialChar: /[!@#$%^&*(),.?":{}|<>]/,
-} as const;
+const LOWERCASE_REGEX = /[a-z]/;
+const UPPERCASE_REGEX = /[A-Z]/;
+const NUMBER_REGEX = /\d/;
+const SPECIAL_CHAR_REGEX = /[!@#$%^&*(),.?":{}|<>]/;
 
 /**
- * Validates a password string against all password policy rules.
- * Returns an object indicating which rules pass/fail.
+ * Validates a password string against the supplied policy rules.
+ * Returns a fixed-shape object; disabled rules evaluate to `true` so the
+ * caller can render a consistent UI and filter on enabled rules separately.
  */
-export function validatePassword(password: string) {
+export function validatePassword(
+  password: string,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+) {
   return {
-    length: password.length >= PASSWORD_RULES.minLength,
-    lowercase: PASSWORD_RULES.lowercase.test(password),
-    uppercase: PASSWORD_RULES.uppercase.test(password),
-    number: PASSWORD_RULES.number.test(password),
-    specialChar: PASSWORD_RULES.specialChar.test(password),
+    length: password.length >= policy.minLength,
+    lowercase: !policy.requireLower || LOWERCASE_REGEX.test(password),
+    uppercase: !policy.requireUpper || UPPERCASE_REGEX.test(password),
+    number: !policy.requireDigit || NUMBER_REGEX.test(password),
+    specialChar: !policy.requireSpecial || SPECIAL_CHAR_REGEX.test(password),
   };
 }
 
 /**
- * Returns true if the password meets all policy requirements.
+ * Returns true if the password meets all enabled policy requirements.
  */
-export function isPasswordValid(password: string) {
-  const result = validatePassword(password);
+export function isPasswordValid(
+  password: string,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+) {
+  const result = validatePassword(password, policy);
   return Object.values(result).every(Boolean);
+}
+
+export type PasswordValidationKey = keyof ReturnType<typeof validatePassword>;
+
+/**
+ * Returns the subset of rule keys that are enabled for the given policy —
+ * used by the UI to render only the applicable checklist items.
+ */
+export function enabledValidationKeys(
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+): PasswordValidationKey[] {
+  const keys: PasswordValidationKey[] = ['length'];
+  if (policy.requireLower) keys.push('lowercase');
+  if (policy.requireUpper) keys.push('uppercase');
+  if (policy.requireDigit) keys.push('number');
+  if (policy.requireSpecial) keys.push('specialChar');
+  return keys;
 }
 
 interface PasswordValidationMessages {
@@ -41,25 +65,36 @@ interface PasswordValidationMessages {
 }
 
 /**
- * Creates a Zod password schema with translated error messages.
- * Enforces all 5 password rules: min length, lowercase, uppercase, number, special char.
+ * Creates a Zod password schema that enforces exactly the rules enabled
+ * by the supplied policy (or the built-in defaults when omitted).
  */
-export function createPasswordSchema(messages: PasswordValidationMessages) {
-  return z
-    .string()
-    .min(PASSWORD_RULES.minLength, messages.minLength)
-    .regex(PASSWORD_RULES.lowercase, messages.lowercase)
-    .regex(PASSWORD_RULES.uppercase, messages.uppercase)
-    .regex(PASSWORD_RULES.number, messages.number)
-    .regex(PASSWORD_RULES.specialChar, messages.specialChar);
+export function createPasswordSchema(
+  messages: PasswordValidationMessages,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+) {
+  let schema = z.string().min(policy.minLength, messages.minLength);
+  if (policy.requireLower) {
+    schema = schema.regex(LOWERCASE_REGEX, messages.lowercase);
+  }
+  if (policy.requireUpper) {
+    schema = schema.regex(UPPERCASE_REGEX, messages.uppercase);
+  }
+  if (policy.requireDigit) {
+    schema = schema.regex(NUMBER_REGEX, messages.number);
+  }
+  if (policy.requireSpecial) {
+    schema = schema.regex(SPECIAL_CHAR_REGEX, messages.specialChar);
+  }
+  return schema;
 }
 
 /**
- * Creates an optional Zod password schema for forms where password is not required.
- * Empty/missing values pass; non-empty values must meet all password rules.
+ * Optional-password variant: empty/missing values pass; non-empty values
+ * must satisfy the enabled rules from the policy.
  */
 export function createOptionalPasswordSchema(
   messages: PasswordValidationMessages,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
 ) {
   return z
     .string()
@@ -67,7 +102,7 @@ export function createOptionalPasswordSchema(
     .superRefine((val, ctx) => {
       if (!val || val.length === 0) return;
 
-      const result = validatePassword(val);
+      const result = validatePassword(val, policy);
       if (!result.length) {
         ctx.addIssue({ code: 'custom', message: messages.minLength });
       }
@@ -84,4 +119,19 @@ export function createOptionalPasswordSchema(
         ctx.addIssue({ code: 'custom', message: messages.specialChar });
       }
     });
+}
+
+/**
+ * Returns the list of rule keys a password fails under the given policy.
+ * Server-side helpers use this to return structured errors rather than
+ * a single stringified message.
+ */
+export function passwordPolicyViolations(
+  password: string,
+  policy: PasswordPolicyConfig = DEFAULT_PASSWORD_POLICY,
+): PasswordValidationKey[] {
+  const result = validatePassword(password, policy);
+  return (Object.entries(result) as [PasswordValidationKey, boolean][])
+    .filter(([, ok]) => !ok)
+    .map(([key]) => key);
 }

--- a/services/platform/lib/shared/schemas/password.ts
+++ b/services/platform/lib/shared/schemas/password.ts
@@ -39,6 +39,8 @@ export function isPasswordValid(
   return Object.values(result).every(Boolean);
 }
 
+export type PasswordValidationKey = keyof ReturnType<typeof validatePassword>;
+
 /**
  * Returns the subset of rule keys that are enabled for the given policy —
  * used by the UI to render only the applicable checklist items.

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -23,7 +23,7 @@
       "uppercase": "Grossbuchstabe"
     },
     "validation": {
-      "passwordRequirements": "Passwort muss mindestens 8 Zeichen mit Klein-, Grossbuchstaben und Zahl enthalten",
+      "passwordRequirements": "Passwort muss die konfigurierte Richtlinie erfüllen",
       "passwordUppercase": "Passwort muss einen Grossbuchstaben enthalten"
     },
     "changePassword": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -489,16 +489,16 @@
       "microsoftSignInFailed": "Microsoft-Anmeldung fehlgeschlagen. Bitte versuche es erneut."
     },
     "requirements": {
-      "length": "Mindestens 8 Zeichen",
+      "length": "Mindestens {n} Zeichen",
       "lowercase": "Kleinbuchstabe",
       "uppercase": "Großbuchstabe",
       "number": "Zahl",
       "specialChar": "Sonderzeichen"
     },
     "validation": {
-      "passwordRequirements": "Passwort muss mindestens 8 Zeichen mit Klein-, Großbuchstaben und Zahl enthalten",
+      "passwordRequirements": "Passwort muss die konfigurierte Richtlinie erfüllen",
       "emailRequired": "E-Mail ist erforderlich",
-      "passwordMinLength": "Passwort muss mindestens 8 Zeichen lang sein",
+      "passwordMinLength": "Passwort muss mindestens {n} Zeichen lang sein",
       "passwordLowercase": "Passwort muss einen Kleinbuchstaben enthalten",
       "passwordUppercase": "Passwort muss einen Großbuchstaben enthalten",
       "passwordNumber": "Passwort muss eine Zahl enthalten",
@@ -556,7 +556,7 @@
       },
       "requirements": {
         "title": "Passwortanforderungen",
-        "length": "Mindestens 8 Zeichen",
+        "length": "Mindestens {n} Zeichen",
         "lowercase": "Ein Kleinbuchstabe",
         "uppercase": "Ein Großbuchstabe",
         "number": "Eine Zahl",
@@ -565,11 +565,16 @@
       "validation": {
         "currentRequired": "Aktuelles Passwort ist erforderlich",
         "newRequired": "Neues Passwort ist erforderlich",
-        "minLength": "Passwort muss mindestens 8 Zeichen lang sein",
+        "minLength": "Passwort muss mindestens {n} Zeichen lang sein",
         "confirmRequired": "Bitte bestätige dein neues Passwort",
         "mismatch": "Passwörter stimmen nicht überein"
       },
       "ssoMessage": "Kontodaten und Passwörter werden von deinem Identitätsanbieter verwaltet und können hier nicht geändert werden."
+    },
+    "forcedChange": {
+      "title": "Passwortänderung erforderlich",
+      "description": "Dein Passwort ist gemäß der Rotationsrichtlinie der Organisation abgelaufen. Lege ein neues Passwort fest, um fortzufahren.",
+      "submit": "Passwort aktualisieren"
     },
     "setPassword": {
       "title": "Passwort festlegen",
@@ -3755,6 +3760,7 @@
       "securityAndMonitoring": "Sicherheit & Überwachung",
       "subtabs": {
         "login": "Anmeldung & Authentifizierung",
+        "password": "Passwort-Richtlinie",
         "pii": "PII-Schutz",
         "usage": "Nutzung",
         "systemPrompt": "System-Prompt",
@@ -3914,6 +3920,23 @@
       "retentionDays": "Aufbewahrungszeitraum (Tage)",
       "scope": "Anwenden auf",
       "saved": "Aufbewahrungsrichtlinie gespeichert"
+    },
+    "passwordPolicy": {
+      "title": "Passwort-Richtlinie",
+      "description": "Mindestlänge, Zeichenklassen-Anforderungen und Rotation für Passwörter konfigurieren.",
+      "minLength": "Mindestlänge",
+      "minLengthHint": "Mindestanzahl an Zeichen für neue Passwörter.",
+      "requireUpper": "Großbuchstabe erforderlich",
+      "requireLower": "Kleinbuchstabe erforderlich",
+      "requireDigit": "Ziffer erforderlich",
+      "requireSpecial": "Sonderzeichen erforderlich",
+      "rotationEnabled": "Passwort-Rotation aktivieren",
+      "rotationDays": "Rotationszeitraum (Tage)",
+      "rotationDaysHint": "Benutzer müssen ihr Passwort nach dieser Anzahl von Tagen ändern. Das Kulanzfenster beginnt mit der erstmaligen Aktivierung der Rotation, bestehende Benutzer werden also nicht sofort zur Änderung gezwungen.",
+      "invalidMinLength": "Mindestlänge muss eine ganze Zahl zwischen 6 und 128 sein.",
+      "invalidRotationDays": "Rotationszeitraum muss eine ganze Zahl zwischen 1 und 3650 sein.",
+      "saved": "Passwort-Richtlinie gespeichert",
+      "saveFailed": "Speichern der Passwort-Richtlinie fehlgeschlagen"
     },
     "loginPolicy": {
       "title": "Anmeldeversuch-Limits",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -574,6 +574,7 @@
     "forcedChange": {
       "title": "Passwortänderung erforderlich",
       "description": "Dein Passwort ist gemäß der Rotationsrichtlinie der Organisation abgelaufen. Lege ein neues Passwort fest, um fortzufahren.",
+      "descriptionAdminSet": "Dein Passwort wurde von einem Administrator festgelegt. Bitte wähle ein neues Passwort, um fortzufahren.",
       "submit": "Passwort aktualisieren"
     },
     "setPassword": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -577,6 +577,7 @@
     "forcedChange": {
       "title": "Password change required",
       "description": "Your password has expired per the organization's rotation policy. Set a new password to continue.",
+      "descriptionAdminSet": "Your password was set by an administrator. Please choose a new password to continue.",
       "submit": "Update password"
     },
     "setPassword": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -492,16 +492,16 @@
       "microsoftSignInFailed": "Microsoft sign-in failed. Please try again."
     },
     "requirements": {
-      "length": "At least 8 characters",
+      "length": "At least {n} characters",
       "lowercase": "Lowercase letter",
       "uppercase": "Uppercase letter",
       "number": "Number",
       "specialChar": "Special character"
     },
     "validation": {
-      "passwordRequirements": "Password must be at least 8 characters with lowercase, uppercase, and number",
+      "passwordRequirements": "Password must meet the configured policy",
       "emailRequired": "Email is required",
-      "passwordMinLength": "Password must be at least 8 characters",
+      "passwordMinLength": "Password must be at least {n} characters",
       "passwordLowercase": "Password must contain a lowercase letter",
       "passwordUppercase": "Password must contain an uppercase letter",
       "passwordNumber": "Password must contain a number",
@@ -559,7 +559,7 @@
       },
       "requirements": {
         "title": "Password requirements",
-        "length": "At least 8 characters",
+        "length": "At least {n} characters",
         "lowercase": "One lowercase letter",
         "uppercase": "One uppercase letter",
         "number": "One number",
@@ -568,11 +568,16 @@
       "validation": {
         "currentRequired": "Current password is required",
         "newRequired": "New password is required",
-        "minLength": "Password must be at least 8 characters long",
+        "minLength": "Password must be at least {n} characters long",
         "confirmRequired": "Please confirm your new password",
         "mismatch": "Passwords do not match"
       },
       "ssoMessage": "Account details and passwords are managed by your identity provider and can't be changed here."
+    },
+    "forcedChange": {
+      "title": "Password change required",
+      "description": "Your password has expired per the organization's rotation policy. Set a new password to continue.",
+      "submit": "Update password"
     },
     "setPassword": {
       "title": "Set password",
@@ -3889,6 +3894,23 @@
       "tempFileRetentionHours": "Temporary file retention (hours)",
       "saved": "Retention policy saved"
     },
+    "passwordPolicy": {
+      "title": "Password policy",
+      "description": "Configure minimum password length, character-class requirements, and rotation.",
+      "minLength": "Minimum length",
+      "minLengthHint": "Minimum number of characters required in new passwords.",
+      "requireUpper": "Require uppercase letter",
+      "requireLower": "Require lowercase letter",
+      "requireDigit": "Require digit",
+      "requireSpecial": "Require special character",
+      "rotationEnabled": "Enable password rotation",
+      "rotationDays": "Rotation period (days)",
+      "rotationDaysHint": "Users will be required to change their password after this many days. The grace window starts when rotation is first enabled, so existing users are not forced to change immediately.",
+      "invalidMinLength": "Minimum length must be an integer between 6 and 128.",
+      "invalidRotationDays": "Rotation period must be an integer between 1 and 3650.",
+      "saved": "Password policy saved",
+      "saveFailed": "Failed to save password policy"
+    },
     "loginPolicy": {
       "title": "Login attempt limits",
       "description": "Lock accounts after repeated sign-in failures and grow the wait between attempts.",
@@ -4009,6 +4031,7 @@
       "securityAndMonitoring": "Security & Monitoring",
       "subtabs": {
         "login": "Login & authentication",
+        "password": "Password policy",
         "pii": "PII protection",
         "usage": "Usage",
         "systemPrompt": "System prompt",


### PR DESCRIPTION
## Summary

Implements per-org password policy (Issue #1503) — configurable minimum length, character-class requirements, and optional rotation — replacing the hardcoded rules in `lib/shared/schemas/password.ts`.

- New `password_policy` governance type with `passwordPolicyConfigSchema` (minLength, requireUpper/Lower/Digit/Special, rotationDays). Policy-driven validation shared client ↔ server; `DEFAULT_PASSWORD_POLICY` preserves today's behavior when no row exists.
- **Multi-org:** `mergeStrictestPasswordPolicy` applies the strictest constraint across a user's memberships (collapses to single-org naturally).
- **Rotation:** dedicated `userPasswordMetadata.passwordChangedAt` (not `account.updatedAt`, which is also bumped by OAuth token refresh). `governancePolicies.effectiveAt` is stamped the first time `rotationDays` goes 0→positive, so enabling rotation on a long-running deployment grants a grace window instead of force-changing everyone on next login.
- **Enforcement:** reactive `usePasswordExpiryGate` subscription in the dashboard layout redirects expired users to `/dashboard/$id/forced-change-password`. OAuth-only users (no credential account) are skipped.
- **Audit:** `update_user_password`, `set_member_password` now log to the `auth` category with `trigger: voluntary | forced` metadata (previously unaudited). Policy edits already flow through `upsertPolicy`'s existing audit.
- **Admin UI:** `PasswordPolicyEditor` under Settings → Governance → Security-and-monitoring → Password, modeled on `LoginPolicyEditor`.
- **i18n:** parameterized the hardcoded \"8\" in `{n}`-interpolation strings (en, de, de-CH).
- **Recovery:** `reset_owner` intentionally uses `DEFAULT_PASSWORD_POLICY` (not the configured one) so a misconfigured policy can't lock recovery.
- Fixes pre-existing drift between `POLICY_TYPES` (shared) and `GOVERNANCE_POLICY_TYPES` (Convex) — added `audit_retention` to the shared list.

The plan was reviewed in two rounds by ~30 sub-agents before implementation. Explicitly **rejected over-engineering:** server-side \`forcedChangeMode\` flag (not a security boundary), \`MINIMUM_POLICY_FLOOR\` hard cap (single-org self-hosted → compromised admin ≡ compromised root).

**Out of scope / deferred:** password history / no-reuse, dictionary blocklist, `upsertPolicy` optimistic concurrency.

## Test plan

- [x] Lint clean
- [x] Typecheck clean (only pre-existing unrelated `onedrive_action.ts` ArrayBuffer error remains)
- [x] 41 unit tests pass (validators × policy combinations, schema bounds, strictest-merge semantics)
- [ ] E2E: admin edits policy → audit entry + checklist re-emits via Convex reactivity
- [ ] E2E: relaxing `requireSpecial` removes that row from live checklist without reload
- [ ] E2E: `rotationDays: 1` + back-dated `passwordChangedAt` → forced-change redirect; submit flows back to dashboard with other sessions revoked
- [ ] E2E: OAuth-only user with rotation enabled → never gated
- [ ] E2E: enabling rotation 0→30 on a long-running deployment does **not** immediately force every user (grace window via `effectiveAt`)
- [ ] E2E: fresh-DB sign-up still validates against `DEFAULT_PASSWORD_POLICY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization administrators can now configure password policies, including minimum length, character type requirements, and rotation intervals
  * Users with expired passwords (based on rotation policy) are redirected to a forced password change page upon dashboard access
  * Password validation displays policy-specific requirements instead of static defaults

* **Updates**
  * Enhanced password change dialogs across the platform to reflect configured organizational policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->