### PR TITLE
fix(platform): show user emails in usage table and add skeleton loading to governance tabs

### DIFF
--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -4,6 +4,7 @@ import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
@@ -482,7 +483,13 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
   );
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -4,6 +4,7 @@ import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
 import { Switch } from '@/app/components/ui/forms/switch';
@@ -461,7 +462,13 @@ export function DefaultModelEditor({
   );
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
@@ -83,25 +83,19 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
 
   const savedConfig = useMemo(() => parseConfig(policy?.config), [policy]);
 
-  const [hydrated, setHydrated] = useState(false);
-  const [enabled, setEnabled] = useState(true);
-  const [maxAttempts, setMaxAttempts] = useState(
-    String(DEFAULT_LOGIN_MAX_ATTEMPTS),
-  );
-  const [scheduleSeconds, setScheduleSeconds] = useState(
-    scheduleToString(DEFAULT_LOGIN_BACKOFF_MS),
-  );
-  const [trustedProxies, setTrustedProxies] = useState(
-    DEFAULT_TRUSTED_PROXIES.join(', '),
-  );
+  const initializedRef = useRef(false);
+  const [enabled, setEnabled] = useState(false);
+  const [maxAttempts, setMaxAttempts] = useState('');
+  const [scheduleSeconds, setScheduleSeconds] = useState('');
+  const [trustedProxies, setTrustedProxies] = useState('');
 
-  useEffect(() => {
+  if (!isLoading && !initializedRef.current) {
+    initializedRef.current = true;
     setEnabled(savedConfig.enabled);
     setMaxAttempts(String(savedConfig.maxAttemptsBeforeLockout));
     setScheduleSeconds(scheduleToString(savedConfig.backoffSchedule));
     setTrustedProxies(savedConfig.trustedProxies.join(', '));
-    setHydrated(true);
-  }, [savedConfig]);
+  }
 
   const cannotManage = ability.cannot('write', 'orgSettings');
 
@@ -185,7 +179,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
     t,
   ]);
 
-  if (isLoading || !hydrated) {
+  if (isLoading || !initializedRef.current) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -83,6 +83,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
 
   const savedConfig = useMemo(() => parseConfig(policy?.config), [policy]);
 
+  const [hydrated, setHydrated] = useState(false);
   const [enabled, setEnabled] = useState(true);
   const [maxAttempts, setMaxAttempts] = useState(
     String(DEFAULT_LOGIN_MAX_ATTEMPTS),
@@ -99,6 +100,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
     setMaxAttempts(String(savedConfig.maxAttemptsBeforeLockout));
     setScheduleSeconds(scheduleToString(savedConfig.backoffSchedule));
     setTrustedProxies(savedConfig.trustedProxies.join(', '));
+    setHydrated(true);
   }, [savedConfig]);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
@@ -183,7 +185,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
     t,
   ]);
 
-  if (isLoading) {
+  if (isLoading || !hydrated) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { Stack } from '@/app/components/ui/layout/layout';
@@ -182,7 +183,15 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
     t,
   ]);
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
 
   return (
     <PageSection

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -309,6 +309,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     [policy],
   );
 
+  const [hydrated, setHydrated] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [mode, setMode] = useState<ModelAccessConfig['mode']>('blocklist');
   const [rules, setRules] = useState<ModelAccessRule[]>([]);
@@ -321,6 +322,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     setEnabled(savedConfig.enabled);
     setMode(savedConfig.mode);
     setRules(savedConfig.rules);
+    setHydrated(true);
   }, [savedConfig]);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
@@ -439,7 +441,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     [allModelOptions],
   );
 
-  if (isLoading) {
+  if (isLoading || !hydrated) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Pencil, Plus, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
@@ -309,7 +309,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     [policy],
   );
 
-  const [hydrated, setHydrated] = useState(false);
+  const initializedRef = useRef(false);
   const [enabled, setEnabled] = useState(false);
   const [mode, setMode] = useState<ModelAccessConfig['mode']>('blocklist');
   const [rules, setRules] = useState<ModelAccessRule[]>([]);
@@ -318,12 +318,12 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [dialogRule, setDialogRule] = useState(emptyRule());
 
-  useEffect(() => {
+  if (!isLoading && !initializedRef.current) {
+    initializedRef.current = true;
     setEnabled(savedConfig.enabled);
     setMode(savedConfig.mode);
     setRules(savedConfig.rules);
-    setHydrated(true);
-  }, [savedConfig]);
+  }
 
   const cannotManage = ability.cannot('write', 'orgSettings');
 
@@ -441,7 +441,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     [allModelOptions],
   );
 
-  if (isLoading || !hydrated) {
+  if (isLoading || !initializedRef.current) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -4,6 +4,7 @@ import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { CheckboxGroup } from '@/app/components/ui/forms/checkbox-group';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
@@ -439,7 +440,13 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
   );
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
@@ -49,26 +49,17 @@ export function PasswordPolicyEditor({
 
   const savedConfig = useMemo(() => parseConfig(policy?.config), [policy]);
 
-  const [hydrated, setHydrated] = useState(false);
-  const [minLength, setMinLength] = useState(
-    String(DEFAULT_PASSWORD_POLICY.minLength),
-  );
-  const [requireUpper, setRequireUpper] = useState(
-    DEFAULT_PASSWORD_POLICY.requireUpper,
-  );
-  const [requireLower, setRequireLower] = useState(
-    DEFAULT_PASSWORD_POLICY.requireLower,
-  );
-  const [requireDigit, setRequireDigit] = useState(
-    DEFAULT_PASSWORD_POLICY.requireDigit,
-  );
-  const [requireSpecial, setRequireSpecial] = useState(
-    DEFAULT_PASSWORD_POLICY.requireSpecial,
-  );
+  const initializedRef = useRef(false);
+  const [minLength, setMinLength] = useState('');
+  const [requireUpper, setRequireUpper] = useState(false);
+  const [requireLower, setRequireLower] = useState(false);
+  const [requireDigit, setRequireDigit] = useState(false);
+  const [requireSpecial, setRequireSpecial] = useState(false);
   const [rotationEnabled, setRotationEnabled] = useState(false);
   const [rotationDays, setRotationDays] = useState('90');
 
-  useEffect(() => {
+  if (!isLoading && !initializedRef.current) {
+    initializedRef.current = true;
     setMinLength(String(savedConfig.minLength));
     setRequireUpper(savedConfig.requireUpper);
     setRequireLower(savedConfig.requireLower);
@@ -78,8 +69,7 @@ export function PasswordPolicyEditor({
     setRotationDays(
       savedConfig.rotationDays > 0 ? String(savedConfig.rotationDays) : '90',
     );
-    setHydrated(true);
-  }, [savedConfig]);
+  }
 
   const cannotManage = ability.cannot('write', 'orgSettings');
 
@@ -157,7 +147,7 @@ export function PasswordPolicyEditor({
     t,
   ]);
 
-  if (isLoading || !hydrated) {
+  if (isLoading || !initializedRef.current) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -49,6 +49,7 @@ export function PasswordPolicyEditor({
 
   const savedConfig = useMemo(() => parseConfig(policy?.config), [policy]);
 
+  const [hydrated, setHydrated] = useState(false);
   const [minLength, setMinLength] = useState(
     String(DEFAULT_PASSWORD_POLICY.minLength),
   );
@@ -77,6 +78,7 @@ export function PasswordPolicyEditor({
     setRotationDays(
       savedConfig.rotationDays > 0 ? String(savedConfig.rotationDays) : '90',
     );
+    setHydrated(true);
   }, [savedConfig]);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
@@ -155,7 +157,7 @@ export function PasswordPolicyEditor({
     t,
   ]);
 
-  if (isLoading) {
+  if (isLoading || !hydrated) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
@@ -154,7 +155,15 @@ export function PasswordPolicyEditor({
     t,
   ]);
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
 
   return (
     <PageSection

--- a/services/platform/app/features/settings/governance/components/pii-config.tsx
+++ b/services/platform/app/features/settings/governance/components/pii-config.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ShieldCheck } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { Alert } from '@/app/components/ui/feedback/alert';
 import { Badge } from '@/app/components/ui/feedback/badge';
@@ -61,20 +61,20 @@ export function PiiConfig({ organizationId }: PiiConfigProps) {
   > | null>(null);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
-  const [hydrated, setHydrated] = useState(false);
+  const initializedRef = useRef(false);
 
-  // Sync from server data once loaded
-  useEffect(() => {
-    if (policy && !hydrated) {
+  // Sync from server data once loaded (render-time to avoid flicker)
+  if (!isLoading && !initializedRef.current) {
+    initializedRef.current = true;
+    if (policy) {
       setEnabled(policy.enabled ?? false);
       setMode(policy.config?.mode ?? 'mask');
       setEnabledPatterns(
         new Set<string>(policy.config?.enabledPatterns ?? PATTERN_NAMES),
       );
       setCustomPatterns(policy.config?.customPatterns ?? []);
-      setHydrated(true);
     }
-  }, [policy, hydrated]);
+  }
 
   const saveConfig = useCallback(
     async (overrides: {
@@ -205,7 +205,7 @@ export function PiiConfig({ organizationId }: PiiConfigProps) {
     setTestResults(detectPii(testText, allPatterns));
   }, [testText, enabledPatterns, customPatterns]);
 
-  if (isLoading || !hydrated) {
+  if (isLoading || !initializedRef.current) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/pii-config.tsx
+++ b/services/platform/app/features/settings/governance/components/pii-config.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Alert } from '@/app/components/ui/feedback/alert';
 import { Badge } from '@/app/components/ui/feedback/badge';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
@@ -205,7 +206,13 @@ export function PiiConfig({ organizationId }: PiiConfigProps) {
   }, [testText, enabledPatterns, customPatterns]);
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   const modeOptions = [

--- a/services/platform/app/features/settings/governance/components/pii-config.tsx
+++ b/services/platform/app/features/settings/governance/components/pii-config.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ShieldCheck } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Alert } from '@/app/components/ui/feedback/alert';
 import { Badge } from '@/app/components/ui/feedback/badge';
@@ -61,20 +61,20 @@ export function PiiConfig({ organizationId }: PiiConfigProps) {
   > | null>(null);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
-  const initialized = useRef(false);
+  const [hydrated, setHydrated] = useState(false);
 
   // Sync from server data once loaded
   useEffect(() => {
-    if (policy && !initialized.current) {
-      initialized.current = true;
+    if (policy && !hydrated) {
       setEnabled(policy.enabled ?? false);
       setMode(policy.config?.mode ?? 'mask');
       setEnabledPatterns(
         new Set<string>(policy.config?.enabledPatterns ?? PATTERN_NAMES),
       );
       setCustomPatterns(policy.config?.customPatterns ?? []);
+      setHydrated(true);
     }
-  }, [policy]);
+  }, [policy, hydrated]);
 
   const saveConfig = useCallback(
     async (overrides: {
@@ -205,7 +205,7 @@ export function PiiConfig({ organizationId }: PiiConfigProps) {
     setTestResults(detectPii(testText, allPatterns));
   }, [testText, enabledPatterns, customPatterns]);
 
-  if (isLoading) {
+  if (isLoading || !hydrated) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/retention-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/retention-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
@@ -50,23 +50,23 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
     [policy],
   );
 
-  const [hydrated, setHydrated] = useState(false);
+  const initializedRef = useRef(false);
   const [enabled, setEnabled] = useState(false);
-  const [retentionDays, setRetentionDays] = useState(90);
+  const [retentionDays, setRetentionDays] = useState(0);
   const [userTempEnabled, setUserTempEnabled] = useState(false);
-  const [userTempRetentionHours, setUserTempRetentionHours] = useState(24);
+  const [userTempRetentionHours, setUserTempRetentionHours] = useState(0);
   const [agentTempEnabled, setAgentTempEnabled] = useState(false);
-  const [agentTempRetentionHours, setAgentTempRetentionHours] = useState(24);
+  const [agentTempRetentionHours, setAgentTempRetentionHours] = useState(0);
 
-  useEffect(() => {
+  if (!isLoading && !initializedRef.current) {
+    initializedRef.current = true;
     setEnabled(savedConfig.enabled);
     setRetentionDays(savedConfig.retentionDays);
     setUserTempEnabled(savedConfig.userTempEnabled ?? false);
     setUserTempRetentionHours(savedConfig.userTempRetentionHours ?? 24);
     setAgentTempEnabled(savedConfig.agentTempEnabled ?? false);
     setAgentTempRetentionHours(savedConfig.agentTempRetentionHours ?? 24);
-    setHydrated(true);
-  }, [savedConfig]);
+  }
 
   const cannotManage = ability.cannot('write', 'orgSettings');
 
@@ -108,7 +108,7 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
     ],
   );
 
-  if (isLoading || !hydrated) {
+  if (isLoading || !initializedRef.current) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/retention-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/retention-editor.tsx
@@ -50,6 +50,7 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
     [policy],
   );
 
+  const [hydrated, setHydrated] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [retentionDays, setRetentionDays] = useState(90);
   const [userTempEnabled, setUserTempEnabled] = useState(false);
@@ -64,6 +65,7 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
     setUserTempRetentionHours(savedConfig.userTempRetentionHours ?? 24);
     setAgentTempEnabled(savedConfig.agentTempEnabled ?? false);
     setAgentTempRetentionHours(savedConfig.agentTempRetentionHours ?? 24);
+    setHydrated(true);
   }, [savedConfig]);
 
   const cannotManage = ability.cannot('write', 'orgSettings');
@@ -106,7 +108,7 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
     ],
   );
 
-  if (isLoading) {
+  if (isLoading || !hydrated) {
     return (
       <div aria-busy="true" className="space-y-3 py-4">
         <Skeleton className="h-6 w-48" />

--- a/services/platform/app/features/settings/governance/components/retention-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/retention-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { Stack } from '@/app/components/ui/layout/layout';
@@ -106,7 +107,13 @@ export function RetentionEditor({ organizationId }: RetentionEditorProps) {
   );
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Stack } from '@/app/components/ui/layout/layout';
@@ -91,7 +92,13 @@ export function SystemPromptEditor({
   }, [organizationId, prefix, suffix, upsertMutation, toast, t]);
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { Stack } from '@/app/components/ui/layout/layout';
@@ -142,7 +143,13 @@ export function UploadPolicyEditor({
   }, []);
 
   if (isLoading) {
-    return null;
+    return (
+      <div aria-busy="true" className="space-y-3 py-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
   }
 
   return (

--- a/services/platform/app/features/settings/governance/components/usage-dashboard.tsx
+++ b/services/platform/app/features/settings/governance/components/usage-dashboard.tsx
@@ -28,6 +28,7 @@ interface UsageDashboardProps {
 
 type UsageEntry = {
   userId: string;
+  displayName: string;
   teamId?: string;
   inputTokens: number;
   outputTokens: number;
@@ -83,8 +84,8 @@ export function UsageDashboard({ organizationId }: UsageDashboardProps) {
         id: 'user',
         header: 'User',
         cell: ({ row }) => (
-          <Text as="span" variant="label" className="font-mono text-xs">
-            {row.original.userId}
+          <Text as="span" variant="label" className="text-sm">
+            {row.original.displayName}
           </Text>
         ),
         size: 220,

--- a/services/platform/app/features/settings/governance/components/usage-dashboard.tsx
+++ b/services/platform/app/features/settings/governance/components/usage-dashboard.tsx
@@ -84,7 +84,11 @@ export function UsageDashboard({ organizationId }: UsageDashboardProps) {
         id: 'user',
         header: 'User',
         cell: ({ row }) => (
-          <Text as="span" variant="label" className="text-sm">
+          <Text
+            as="span"
+            variant="label"
+            className="block max-w-[220px] truncate text-sm"
+          >
             {row.original.displayName}
           </Text>
         ),

--- a/services/platform/app/routes/dashboard/$id/settings/governance.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useMemo } from 'react';
 import { z } from 'zod';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { Tabs } from '@/app/components/ui/navigation/tabs';
 import { BudgetEditor } from '@/app/features/settings/governance/components/budget-editor';
 import { FeatureFlagsEditor } from '@/app/features/settings/governance/components/feature-flags-editor';
@@ -187,7 +188,20 @@ function GovernanceSettingsPage() {
   };
 
   if (abilityLoading) {
-    return null;
+    return (
+      <div className="flex gap-6">
+        <div className="w-[16rem] shrink-0 space-y-2">
+          <Skeleton className="h-9 w-full rounded-md" />
+          <Skeleton className="h-9 w-full rounded-md" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    );
   }
 
   if (ability.cannot('read', 'orgSettings')) {

--- a/services/platform/app/routes/dashboard/$id/settings/governance.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance.tsx
@@ -189,7 +189,7 @@ function GovernanceSettingsPage() {
 
   if (abilityLoading) {
     return (
-      <div className="flex gap-6">
+      <div aria-busy="true" className="flex gap-6">
         <div className="w-[16rem] shrink-0 space-y-2">
           <Skeleton className="h-9 w-full rounded-md" />
           <Skeleton className="h-9 w-full rounded-md" />

--- a/services/platform/convex/documents/get_user_names_batch.ts
+++ b/services/platform/convex/documents/get_user_names_batch.ts
@@ -45,7 +45,7 @@ export async function getUserNamesBatch(
     const user = isRecord(userRaw) ? userRaw : undefined;
 
     if (user) {
-      const displayName = getString(user, 'name') ?? getString(user, 'email');
+      const displayName = getString(user, 'name') || getString(user, 'email');
       if (displayName) {
         return { userId, displayName };
       }

--- a/services/platform/convex/governance/queries.ts
+++ b/services/platform/convex/governance/queries.ts
@@ -139,7 +139,9 @@ export const getUsageSummary = query({
     const userNameMap = await getUserNamesBatch(ctx, userIds);
 
     const entries = rawEntries.map((e) =>
-      Object.assign(e, { displayName: userNameMap.get(e.userId) ?? e.userId }),
+      Object.assign({}, e, {
+        displayName: userNameMap.get(e.userId) ?? e.userId,
+      }),
     );
 
     return {

--- a/services/platform/convex/governance/queries.ts
+++ b/services/platform/convex/governance/queries.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import { authComponent } from '../auth';
+import { getUserNamesBatch } from '../documents/get_user_names_batch';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getOrganizationMember } from '../lib/rls';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
@@ -108,7 +109,7 @@ export const getUsageSummary = query({
     const defaultPeriodKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
     const periodKey = args.periodKey ?? defaultPeriodKey;
 
-    const entries: Array<{
+    const rawEntries: Array<{
       userId: string;
       teamId?: string;
       inputTokens: number;
@@ -123,7 +124,7 @@ export const getUsageSummary = query({
       .withIndex('by_org_period', (q) =>
         q.eq('organizationId', args.organizationId).eq('periodKey', periodKey),
       )) {
-      entries.push({
+      rawEntries.push({
         userId: entry.userId,
         teamId: entry.teamId,
         inputTokens: entry.inputTokens,
@@ -133,6 +134,13 @@ export const getUsageSummary = query({
         requestCount: entry.requestCount,
       });
     }
+
+    const userIds = rawEntries.map((e) => e.userId);
+    const userNameMap = await getUserNamesBatch(ctx, userIds);
+
+    const entries = rawEntries.map((e) =>
+      Object.assign(e, { displayName: userNameMap.get(e.userId) ?? e.userId }),
+    );
 
     return {
       periodKey,


### PR DESCRIPTION
## Summary
- **Usage table**: Resolve user IDs to display names (name/email) using the existing `getUserNamesBatch` helper in the `getUsageSummary` query, so the User column shows readable emails instead of raw Convex IDs
- **Skeleton loading**: Replace `return null` loading guards with `Skeleton` placeholders across all 9 governance editor components and the route-level ability check, matching the existing pattern in `feature-flags-editor.tsx`

## Test plan
- [ ] Open Governance > Security & Monitoring > Usage — verify User column shows emails/names instead of IDs
- [ ] Navigate between all governance tabs and confirm skeleton placeholders appear during initial data load (throttle network in DevTools to observe)
- [ ] Verify no regressions in existing governance tab functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Governance settings editors (budget, policies, model access, PII configuration, and retention) now display loading placeholders instead of blank screens while data loads.
  * Governance settings page now shows loading indicators during initialization.

* **Improvements**
  * Usage dashboard now displays user display names for better readability instead of user IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->