### PR TITLE
fix(platform): prevent feedback comment box from pushing fork button

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -418,56 +418,103 @@ function MessageBubbleComponent({
             })}
           </div>
         )}
-        {!isUser && !isAssistantStreaming && !!displayContent && (
-          <div className="flex items-start gap-1 pt-2">
-            <Tooltip
-              content={isCopied ? t('actions.copied') : t('actions.copy')}
-              side="bottom"
-            >
-              <Button
-                variant="ghost"
-                size="icon"
-                className="p-1"
-                onClick={handleCopy}
+        {!isUser &&
+          !isAssistantStreaming &&
+          !!displayContent &&
+          (!hideFeedback && organizationId && message.threadId ? (
+            <MessageFeedback
+              messageId={message.id}
+              threadId={message.threadId}
+              organizationId={organizationId}
+              before={
+                <>
+                  <Tooltip
+                    content={isCopied ? t('actions.copied') : t('actions.copy')}
+                    side="bottom"
+                  >
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="p-1"
+                      onClick={handleCopy}
+                    >
+                      {isCopied ? (
+                        <CheckIcon className="text-success size-4" />
+                      ) : (
+                        <CopyIcon className="size-4" />
+                      )}
+                    </Button>
+                  </Tooltip>
+                  <Tooltip content={t('actions.showInfo')} side="bottom">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="p-1"
+                      onClick={handleInfoClick}
+                    >
+                      <Info className="size-4" />
+                    </Button>
+                  </Tooltip>
+                </>
+              }
+              after={
+                onFork ? (
+                  <Tooltip content={tChat('forkChat')} side="bottom">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="p-1"
+                      onClick={handleForkClick}
+                    >
+                      <GitFork className="size-4" />
+                    </Button>
+                  </Tooltip>
+                ) : undefined
+              }
+            />
+          ) : (
+            <div className="flex items-start gap-1 pt-2">
+              <Tooltip
+                content={isCopied ? t('actions.copied') : t('actions.copy')}
+                side="bottom"
               >
-                {isCopied ? (
-                  <CheckIcon className="text-success size-4" />
-                ) : (
-                  <CopyIcon className="size-4" />
-                )}
-              </Button>
-            </Tooltip>
-            <Tooltip content={t('actions.showInfo')} side="bottom">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="p-1"
-                onClick={handleInfoClick}
-              >
-                <Info className="size-4" />
-              </Button>
-            </Tooltip>
-            {!hideFeedback && organizationId && message.threadId && (
-              <MessageFeedback
-                messageId={message.id}
-                threadId={message.threadId}
-                organizationId={organizationId}
-              />
-            )}
-            {onFork && (
-              <Tooltip content={tChat('forkChat')} side="bottom">
                 <Button
                   variant="ghost"
                   size="icon"
                   className="p-1"
-                  onClick={handleForkClick}
+                  onClick={handleCopy}
                 >
-                  <GitFork className="size-4" />
+                  {isCopied ? (
+                    <CheckIcon className="text-success size-4" />
+                  ) : (
+                    <CopyIcon className="size-4" />
+                  )}
                 </Button>
               </Tooltip>
-            )}
-          </div>
-        )}
+              <Tooltip content={t('actions.showInfo')} side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="p-1"
+                  onClick={handleInfoClick}
+                >
+                  <Info className="size-4" />
+                </Button>
+              </Tooltip>
+              {onFork && (
+                <Tooltip content={tChat('forkChat')} side="bottom">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="p-1"
+                    onClick={handleForkClick}
+                  >
+                    <GitFork className="size-4" />
+                  </Button>
+                </Tooltip>
+              )}
+            </div>
+          ))}
 
         {galleryImages.length > 0 && (
           <ImagePreviewDialog

--- a/services/platform/app/features/chat/components/message-feedback.tsx
+++ b/services/platform/app/features/chat/components/message-feedback.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
-import { useState, useCallback } from 'react';
+import { ReactNode, useState, useCallback } from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { Button } from '@/app/components/ui/primitives/button';
@@ -14,12 +14,16 @@ interface MessageFeedbackProps {
   messageId: string;
   threadId: string;
   organizationId: string;
+  before?: ReactNode;
+  after?: ReactNode;
 }
 
 export function MessageFeedback({
   messageId,
   threadId,
   organizationId,
+  before,
+  after,
 }: MessageFeedbackProps) {
   const { t } = useT('chat');
   const { feedback, submitFeedback, removeFeedback } = useMessageFeedback({
@@ -106,8 +110,9 @@ export function MessageFeedback({
   );
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col pt-2">
       <div className="flex items-center gap-1">
+        {before}
         <Tooltip content={t('feedback.thumbsUp')} side="bottom">
           <Button
             variant="ghost"
@@ -146,16 +151,17 @@ export function MessageFeedback({
             />
           </Button>
         </Tooltip>
+        {after}
       </div>
 
       {showCommentBox && currentRating === 'negative' && (
-        <div className="mt-2 flex flex-col gap-2">
+        <div className="mt-2 flex max-w-sm flex-col gap-2">
           <textarea
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             onKeyDown={handleCommentKeyDown}
             placeholder={t('feedback.commentPlaceholder')}
-            className="border-border bg-muted text-foreground placeholder:text-muted-foreground min-h-[60px] w-full max-w-sm resize-none rounded-lg border px-3 py-2 text-sm focus:ring-1 focus:ring-offset-0 focus:outline-none"
+            className="border-border bg-muted text-foreground placeholder:text-muted-foreground min-h-[60px] w-full resize-none rounded-lg border px-3 py-2 text-sm focus:ring-1 focus:ring-offset-0 focus:outline-none"
             aria-label={t('feedback.commentPlaceholder')}
           />
           <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- When clicking thumbs-down on a chat message, the feedback comment box ("What could be improved?") was expanding the `MessageFeedback` flex child in the action bar, pushing the fork button far to the right
- Refactored `MessageFeedback` to own the full action bar layout via `before`/`after` slot props, so the comment box renders below the entire button row in normal document flow instead of inside the horizontal flex row
- The fork button now stays in place when the comment box appears, and the comment box naturally pushes content down (scrollable)

## Test plan
- [ ] Open a chat thread with assistant messages
- [ ] Click thumbs-down — comment box appears below the action bar buttons
- [ ] Verify the fork (clone) button stays in its normal position
- [ ] Submit a comment and verify it works
- [ ] Click Cancel and verify the comment box closes
- [ ] Click thumbs-up and verify it still works (no comment box)
- [ ] When feedback is hidden (`hideFeedback`), verify the fallback action bar renders correctly without feedback buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized message action toolbar to consolidate copy, feedback, and fork button controls with improved layout composition.
  * Adjusted spacing and container constraints in message feedback for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->