### PR TITLE
feat(platform): sticky save bars and conditional save buttons in settings

### DIFF
--- a/services/platform/app/components/ui/dialog/form-dialog.tsx
+++ b/services/platform/app/components/ui/dialog/form-dialog.tsx
@@ -143,7 +143,7 @@ export function FormDialog({
         ) : (
           <Stack>{children}</Stack>
         )}
-        <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           {footer}
         </div>
       </form>

--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -153,7 +153,7 @@ function BlankTabContent({
           rows={3}
         />
       </Stack>
-      <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
         <Button
           type="button"
           variant="secondary"

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -131,10 +131,7 @@ function ProfileSection() {
             {...register('name')}
           />
           {isDirty && (
-            <Button
-              type="submit"
-              disabled={isSubmitting || !isDirty || !isValid}
-            >
+            <Button type="submit" disabled={isSubmitting || !isValid}>
               {isSubmitting
                 ? tCommon('actions.saving')
                 : tCommon('actions.saveChanges')}

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -115,7 +115,12 @@ function ProfileSection() {
   return (
     <>
       <Form onSubmit={handleSubmit(onSubmit)} className="space-y-0">
-        <HStack gap={3} align="end" justify="between">
+        <HStack
+          gap={3}
+          align="end"
+          justify="between"
+          className="sticky bottom-0 z-40"
+        >
           <Input
             id="display-name"
             label={tSettings('account.profile.name')}
@@ -125,11 +130,16 @@ function ProfileSection() {
             wrapperClassName="max-w-sm flex-1"
             {...register('name')}
           />
-          <Button type="submit" disabled={isSubmitting || !isDirty || !isValid}>
-            {isSubmitting
-              ? tCommon('actions.saving')
-              : tCommon('actions.saveChanges')}
-          </Button>
+          {isDirty && (
+            <Button
+              type="submit"
+              disabled={isSubmitting || !isDirty || !isValid}
+            >
+              {isSubmitting
+                ? tCommon('actions.saving')
+                : tCommon('actions.saveChanges')}
+            </Button>
+          )}
         </HStack>
       </Form>
 

--- a/services/platform/app/features/settings/branding/components/__tests__/branding-form.test.tsx
+++ b/services/platform/app/features/settings/branding/components/__tests__/branding-form.test.tsx
@@ -77,23 +77,24 @@ describe('BrandingForm', () => {
     expect(screen.getByText('branding.accentColor')).toBeInTheDocument();
   });
 
-  it('renders save button', () => {
+  it('hides save button when form is clean', () => {
     render(<BrandingForm {...defaultProps} />);
 
-    const button = screen.getByRole('button', { name: 'actions.saveChanges' });
-    expect(button).toBeInTheDocument();
-    expect(button).toBeDisabled();
+    expect(
+      screen.queryByRole('button', { name: 'actions.saveChanges' }),
+    ).not.toBeInTheDocument();
   });
 
-  it('enables save button when form is dirty', async () => {
+  it('shows save button when form is dirty', async () => {
     render(<BrandingForm {...defaultProps} />);
 
     const input = screen.getByLabelText('branding.appName', { exact: false });
     fireEvent.change(input, { target: { value: 'Acme Corp' } });
 
-    const button = screen.getByRole('button', { name: 'actions.saveChanges' });
     await waitFor(() => {
-      expect(button).not.toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'actions.saveChanges' }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/services/platform/app/features/settings/branding/components/branding-form.tsx
+++ b/services/platform/app/features/settings/branding/components/branding-form.tsx
@@ -320,24 +320,35 @@ export function BrandingForm({
           />
         </FormSection>
 
-        <HStack justify="between" className="pt-6">
-          {hasAnyBranding && (
-            <Button type="button" variant="secondary" onClick={handleReset}>
-              {tCommon('actions.reset')}
-            </Button>
-          )}
-          <div className="ml-auto">
-            <Button
-              type="submit"
-              disabled={isSubmitting || !isDirty || !isValid}
-              className="bg-foreground text-background hover:bg-foreground/90"
-            >
-              {isSubmitting
-                ? tCommon('actions.saving')
-                : tCommon('actions.saveChanges')}
-            </Button>
-          </div>
-        </HStack>
+        {isDirty && (
+          <HStack
+            justify="between"
+            className="bg-background/80 sticky bottom-0 z-40 -mx-4 mt-4 px-4 py-3 backdrop-blur-md"
+          >
+            {hasAnyBranding && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={handleReset}
+              >
+                {tCommon('actions.reset')}
+              </Button>
+            )}
+            <div className="ml-auto">
+              <Button
+                type="submit"
+                size="sm"
+                isLoading={isSubmitting}
+                disabled={!isValid}
+              >
+                {isSubmitting
+                  ? tCommon('actions.saving')
+                  : tCommon('actions.saveChanges')}
+              </Button>
+            </div>
+          </HStack>
+        )}
       </div>
     </Form>
   );

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -256,16 +256,18 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
             </Text>
           </Stack>
 
-          <Button
-            onClick={handleSave}
-            disabled={cannotManage || upsertMutation.isPending || !isDirty}
-            size="sm"
-            className="self-start"
-          >
-            {upsertMutation.isPending
-              ? t('systemPrompt.saving')
-              : t('systemPrompt.save')}
-          </Button>
+          {isDirty && (
+            <Button
+              onClick={handleSave}
+              disabled={cannotManage || upsertMutation.isPending}
+              size="sm"
+              className="self-start"
+            >
+              {upsertMutation.isPending
+                ? t('systemPrompt.saving')
+                : t('systemPrompt.save')}
+            </Button>
+          )}
         </div>
       </Stack>
     </PageSection>

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
@@ -106,11 +106,13 @@ export function SystemPromptEditor({
       title={t('systemPrompt.title')}
       description={t('systemPrompt.description')}
       action={
-        <Button onClick={handleSave} disabled={!canSave} size="sm">
-          {upsertMutation.isPending
-            ? t('systemPrompt.saving')
-            : t('systemPrompt.save')}
-        </Button>
+        hasChanges ? (
+          <Button onClick={handleSave} disabled={!canSave} size="sm">
+            {upsertMutation.isPending
+              ? t('systemPrompt.saving')
+              : t('systemPrompt.save')}
+          </Button>
+        ) : undefined
       }
     >
       <Stack gap={6} className="max-w-2xl">

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -175,7 +175,7 @@ export function OrganizationSettings({
             wrapperClassName="max-w-sm flex-1"
           />
           {isDirty && (
-            <Button type="submit" disabled={isSubmitting || !isDirty}>
+            <Button type="submit" disabled={isSubmitting}>
               {isSubmitting
                 ? tCommon('actions.saving')
                 : tCommon('actions.saveChanges')}

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -162,25 +162,31 @@ export function OrganizationSettings({
   return (
     <Stack>
       <Form onSubmit={handleSubmit(onSubmit)} className="space-y-0">
-        <HStack gap={3} align="end" justify="between">
+        <HStack
+          gap={3}
+          align="end"
+          justify="between"
+          className="sticky bottom-0 z-40"
+        >
           <Input
             id="org-name"
             label={tSettings('organization.title')}
             {...register('name')}
             wrapperClassName="max-w-sm flex-1"
           />
-          <Button type="submit" disabled={isSubmitting || !isDirty}>
-            {isSubmitting
-              ? tCommon('actions.saving')
-              : tCommon('actions.saveChanges')}
-          </Button>
+          {isDirty && (
+            <Button type="submit" disabled={isSubmitting || !isDirty}>
+              {isSubmitting
+                ? tCommon('actions.saving')
+                : tCommon('actions.saveChanges')}
+            </Button>
+          )}
         </HStack>
 
         <div className="mt-4 max-w-sm">
           <Select
             id="default-locale"
             label={tSettings('organization.defaultLocale')}
-            description={tSettings('organization.defaultLocaleDescription')}
             value={defaultLocale}
             onValueChange={(value) =>
               setValue('defaultLocale', value, { shouldDirty: true })

--- a/services/platform/app/routes/dashboard/$id/settings/organization.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/organization.tsx
@@ -6,6 +6,7 @@ import { DataTableSkeleton } from '@/app/components/ui/data-table/data-table-ske
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { HStack, Stack } from '@/app/components/ui/layout/layout';
 import { PageSection } from '@/app/components/ui/layout/page-section';
+import { Separator } from '@/app/components/ui/layout/separator';
 import { useOrganization } from '@/app/features/organization/hooks/queries';
 import { OrganizationSettings } from '@/app/features/settings/organization/components/organization-settings';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
@@ -33,24 +34,42 @@ function OrganizationSettingsSkeleton() {
 
   return (
     <Stack gap={6}>
-      <HStack gap={3} align="end" justify="between">
-        <Stack gap={1} className="max-w-sm flex-1">
-          <Skeleton className="h-4 w-32" />
+      <PageSection
+        title={<Skeleton className="h-5 w-40" />}
+        description={<Skeleton className="h-4 w-64" />}
+        gap={5}
+      >
+        <Separator />
+        <HStack gap={3} align="end" justify="between">
+          <Stack gap={1} className="max-w-sm flex-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-9 w-full" />
+          </Stack>
+          <Skeleton className="h-9 w-28 shrink-0" />
+        </HStack>
+
+        <Stack gap={1} className="max-w-sm">
+          <Skeleton className="h-4 w-48" />
           <Skeleton className="h-9 w-full" />
         </Stack>
-        <Skeleton className="h-9 w-28 shrink-0" />
-      </HStack>
 
-      <HStack gap={2} align="center">
-        <Skeleton className="h-4 w-24 shrink-0" />
-        <Skeleton className="h-4 w-48" />
-      </HStack>
+        <div className="max-w-sm space-y-2">
+          <div className="flex flex-col gap-0.5">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-36" />
+          </div>
+          <div className="bg-muted/50 flex items-center gap-2 rounded-lg border px-4 py-3">
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="size-4 shrink-0" />
+          </div>
+        </div>
+      </PageSection>
 
       <PageSection
         title={<Skeleton className="h-5 w-24" />}
         description={<Skeleton className="h-4 w-52" />}
-        className="pt-4"
       >
+        <Separator />
         <HStack justify="between">
           <Skeleton className="h-8 max-w-sm flex-1" />
         </HStack>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -600,12 +600,14 @@
     },
     "organization": {
       "title": "Organisation (optional)",
+      "detailsTitle": "Organisationsdetails",
+      "detailsDescription": "Grundlegende Informationen über deine Organisation.",
       "organizationId": "Organisations-ID",
+      "organizationIdHint": "Für API-Integrationen verwendet",
       "membersTitle": "Organisationsmitglieder",
       "membersEntityLabel": "Mitglieder",
       "manageAccess": "Zugriff auf die Organisation verwalten",
-      "defaultLocale": "Standardsprache",
-      "defaultLocaleDescription": "Die Basissprache für Agentennamen, Beschreibungen und Gesprächseinstiege.",
+      "defaultLocale": "Welche Sprache sollen deine Agenten verwenden?",
       "searchMember": "Mitglied suchen",
       "addMember": "Mitglied hinzufügen",
       "members": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -603,12 +603,14 @@
     },
     "organization": {
       "title": "Organization (optional)",
+      "detailsTitle": "Organization details",
+      "detailsDescription": "Basic information about your organization.",
       "organizationId": "Organization ID",
+      "organizationIdHint": "Used for API integrations",
       "membersTitle": "Organization members",
       "membersEntityLabel": "members",
       "manageAccess": "Manage access to the organization",
-      "defaultLocale": "Default language",
-      "defaultLocaleDescription": "The base language for agent names, descriptions, and conversation starters.",
+      "defaultLocale": "What language should your agents use?",
       "searchMember": "Search member",
       "addMember": "Add member",
       "members": {


### PR DESCRIPTION
## Summary
- Show save/submit buttons only when forms are dirty, reducing visual clutter across all settings pages (account, branding, organization, governance)
- Add sticky bottom positioning to save bars in account, branding, and org settings so they remain visible while scrolling long forms
- Remove redundant `pt-2` padding from dialog footers (form-dialog, automation-create)
- Improve organization settings skeleton to match the new PageSection-based layout with separators
- Update i18n: friendlier locale label, add `detailsTitle`, `detailsDescription`, `organizationIdHint` keys (en + de)

## Test plan
- [ ] Verify save buttons appear only after editing a field in account, branding, org, and governance settings
- [ ] Scroll long forms (branding) and confirm the save bar stays visible at bottom
- [ ] Check dialog footers in form-dialog and automation-create for correct spacing
- [ ] Verify organization settings skeleton renders correctly during loading
- [ ] Confirm i18n strings render in both English and German

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Action buttons in settings forms now conditionally appear only when unsaved changes exist, with sticky bottom positioning for better accessibility.

* **Bug Fixes & Improvements**
  * Refined form layout spacing and padding across dialogs.
  * Enhanced organization settings labels and locale field messaging.
  * Improved loading state visuals in skeleton screens.
  * Simplified form submission button behavior across multiple settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->