### PR TITLE
feat(platform): add member count and created date to teams table

### DIFF
--- a/services/platform/app/features/settings/teams/components/team-delete-dialog.test.tsx
+++ b/services/platform/app/features/settings/teams/components/team-delete-dialog.test.tsx
@@ -22,7 +22,8 @@ function makeTeam(overrides: Partial<Team> = {}): Team {
   return {
     id: 'team-1',
     name: 'Engineering',
-    createdAt: new Date(),
+    memberCount: 5,
+    createdAt: Date.now(),
     ...overrides,
   } as Team;
 }

--- a/services/platform/app/features/settings/teams/components/team-row-actions.test.tsx
+++ b/services/platform/app/features/settings/teams/components/team-row-actions.test.tsx
@@ -38,7 +38,8 @@ function makeTeam(overrides: Partial<Team> = {}): Team {
   return {
     id: 'team-1',
     name: 'Engineering',
-    createdAt: new Date(),
+    memberCount: 5,
+    createdAt: Date.now(),
     ...overrides,
   } as Team;
 }

--- a/services/platform/app/features/settings/teams/components/teams-table.test.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-table.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'test-org-id',
 }));
 
+vi.mock('../hooks/queries', () => ({
+  useTeamMembers: () => ({ data: [], isLoading: false }),
+}));
+
 vi.mock('../hooks/use-teams-table-config', () => ({
   useTeamsTableConfig: () => ({
     columns: [

--- a/services/platform/app/features/settings/teams/components/teams-table.test.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-table.test.tsx
@@ -32,7 +32,8 @@ function makeTeam(overrides: Partial<Team> = {}): Team {
   return {
     id: 'team-1',
     name: 'Engineering',
-    createdAt: new Date(),
+    memberCount: 5,
+    createdAt: Date.now(),
     ...overrides,
   } as Team;
 }

--- a/services/platform/app/features/settings/teams/components/teams-table.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-table.tsx
@@ -4,10 +4,12 @@ import { Users } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { PageSection } from '@/app/components/ui/layout/page-section';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
 import type { Team } from '../hooks/queries';
+import { useTeamMembers } from '../hooks/queries';
 import { useTeamsTableConfig } from '../hooks/use-teams-table-config';
 import { TeamDetailDialog } from './team-detail-dialog';
 import { TeamsActionMenu } from './teams-action-menu';
@@ -15,6 +17,25 @@ import { TeamsActionMenu } from './teams-action-menu';
 interface TeamsTableProps {
   teams: Team[] | undefined;
   organizationId: string;
+}
+
+/**
+ * Eagerly subscribes to team members for all visible teams so the data
+ * is already cached when detail/edit/delete dialogs open.
+ */
+function TeamMembersPreloader({ teamIds }: { teamIds: string[] }) {
+  return (
+    <>
+      {teamIds.map((id) => (
+        <TeamMemberSubscription key={id} teamId={id} />
+      ))}
+    </>
+  );
+}
+
+function TeamMemberSubscription({ teamId }: { teamId: string }) {
+  useTeamMembers(teamId);
+  return null;
 }
 
 export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
@@ -37,16 +58,16 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
     entityLabel: tSettings('teams.entityLabel'),
   });
 
+  const teamIds = teams?.map((t) => t.id) ?? [];
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1">
-        <h2 className="text-foreground text-base font-semibold">
-          {tSettings('teams.title')}
-        </h2>
-        <p className="text-muted-foreground text-sm">
-          {tSettings('teams.sectionDescription')}
-        </p>
-      </div>
+    <PageSection
+      title={tSettings('teams.title')}
+      description={tSettings('teams.sectionDescription')}
+      gap={3}
+    >
+      {teamIds.length > 0 && <TeamMembersPreloader teamIds={teamIds} />}
+
       <DataTable
         columns={columns}
         stickyLayout={stickyLayout}
@@ -71,6 +92,6 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
           }}
         />
       )}
-    </div>
+    </PageSection>
   );
 }

--- a/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
+++ b/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
@@ -3,6 +3,7 @@
 import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
+import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
 import { Text } from '@/app/components/ui/typography/text';
 import { useT } from '@/lib/i18n/client';
 
@@ -32,6 +33,33 @@ export function useTeamsTableConfig(
           <Text as="span" variant="label">
             {row.original.name}
           </Text>
+        ),
+      },
+      {
+        accessorKey: 'memberCount',
+        header: tSettings('teams.columns.members'),
+        cell: ({ row }) => (
+          <Text as="span" variant="caption">
+            {tSettings('teams.memberCount', {
+              count: row.original.memberCount,
+            })}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: 'createdAt',
+        header: () => (
+          <span className="block w-full text-right">
+            {tSettings('teams.columns.created')}
+          </span>
+        ),
+        size: 140,
+        cell: ({ row }) => (
+          <TableDateCell
+            date={row.original.createdAt}
+            preset="relative"
+            alignRight
+          />
         ),
       },
       {

--- a/services/platform/convex/members/__tests__/queries.test.ts
+++ b/services/platform/convex/members/__tests__/queries.test.ts
@@ -262,15 +262,18 @@ describe('getMyTeamsHandler', () => {
       })
       .mockResolvedValueOnce({
         page: [{ _id: 'team_2', name: 'Beta', organizationId: 'org_1' }],
-      });
+      })
+      // member count queries
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_1' }, { _id: 'tm_3' }] })
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_2' }] });
 
     const result = await getMyTeamsHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',
     });
 
     expect(result).toEqual([
-      { id: 'team_1', name: 'Alpha' },
-      { id: 'team_2', name: 'Beta' },
+      { id: 'team_1', name: 'Alpha', memberCount: 2, createdAt: null },
+      { id: 'team_2', name: 'Beta', memberCount: 1, createdAt: null },
     ]);
   });
 
@@ -293,15 +296,18 @@ describe('getMyTeamsHandler', () => {
       .mockRejectedValueOnce(new Error('DB connection lost'))
       .mockResolvedValueOnce({
         page: [{ _id: 'team_3', name: 'Gamma', organizationId: 'org_1' }],
-      });
+      })
+      // member count queries
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_1' }] })
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_4' }, { _id: 'tm_5' }] });
 
     const result = await getMyTeamsHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',
     });
 
     expect(result).toEqual([
-      { id: 'team_1', name: 'Alpha' },
-      { id: 'team_3', name: 'Gamma' },
+      { id: 'team_1', name: 'Alpha', memberCount: 1, createdAt: null },
+      { id: 'team_3', name: 'Gamma', memberCount: 2, createdAt: null },
     ]);
   });
 
@@ -566,20 +572,36 @@ describe('listOrgTeamsHandler', () => {
 
     ctx.runQuery.mockResolvedValueOnce({
       page: [
-        { _id: 'team_1', name: 'Alpha', organizationId: 'org_1' },
-        { _id: 'team_2', name: 'Beta', organizationId: 'org_1' },
+        {
+          _id: 'team_1',
+          name: 'Alpha',
+          organizationId: 'org_1',
+          createdAt: 1000,
+        },
+        {
+          _id: 'team_2',
+          name: 'Beta',
+          organizationId: 'org_1',
+          createdAt: 2000,
+        },
         { _id: 'team_3', name: 'Gamma', organizationId: 'org_1' },
       ],
     });
+
+    // member count queries
+    ctx.runQuery
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_1' }, { _id: 'tm_2' }] })
+      .mockResolvedValueOnce({ page: [{ _id: 'tm_3' }] })
+      .mockResolvedValueOnce({ page: [] });
 
     const result = await listOrgTeamsHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',
     });
 
     expect(result).toEqual([
-      { id: 'team_1', name: 'Alpha' },
-      { id: 'team_2', name: 'Beta' },
-      { id: 'team_3', name: 'Gamma' },
+      { id: 'team_1', name: 'Alpha', memberCount: 2, createdAt: 1000 },
+      { id: 'team_2', name: 'Beta', memberCount: 1, createdAt: 2000 },
+      { id: 'team_3', name: 'Gamma', memberCount: 0, createdAt: null },
     ]);
   });
 
@@ -595,14 +617,28 @@ describe('listOrgTeamsHandler', () => {
     const ctx = createMockCtx();
 
     ctx.runQuery.mockResolvedValueOnce({
-      page: [{ _id: 'team_1', name: 'Alpha', organizationId: 'org_1' }],
+      page: [
+        {
+          _id: 'team_1',
+          name: 'Alpha',
+          organizationId: 'org_1',
+          createdAt: 5000,
+        },
+      ],
+    });
+
+    // member count query
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'tm_1' }, { _id: 'tm_2' }, { _id: 'tm_3' }],
     });
 
     const result = await listOrgTeamsHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',
     });
 
-    expect(result).toEqual([{ id: 'team_1', name: 'Alpha' }]);
+    expect(result).toEqual([
+      { id: 'team_1', name: 'Alpha', memberCount: 3, createdAt: 5000 },
+    ]);
   });
 
   it('falls back to getMyTeamsHandler for non-admin roles', async () => {
@@ -624,12 +660,18 @@ describe('listOrgTeamsHandler', () => {
     ctx.runQuery.mockResolvedValueOnce({
       page: [{ _id: 'team_1', name: 'Alpha', organizationId: 'org_1' }],
     });
+    // member count query
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'tm_1' }],
+    });
 
     const result = await listOrgTeamsHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',
     });
 
-    expect(result).toEqual([{ id: 'team_1', name: 'Alpha' }]);
+    expect(result).toEqual([
+      { id: 'team_1', name: 'Alpha', memberCount: 1, createdAt: null },
+    ]);
   });
 
   it('returns empty array when unauthorized', async () => {

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -341,23 +341,48 @@ export async function getMyTeamsHandler(
       }),
     );
 
-  const teams: Array<{ id: string; name: string }> = [];
+  const validTeams: BetterAuthTeam[] = [];
   for (const teamResult of teamResults) {
     if (teamResult && teamResult.page.length > 0) {
-      const team = teamResult.page[0];
-      teams.push({
-        id: team._id,
-        name: team.name,
-      });
+      validTeams.push(teamResult.page[0]);
     }
   }
 
-  return teams;
+  const memberCounts = await Promise.all(
+    validTeams.map(async (team) => {
+      try {
+        const membersResult: BetterAuthFindManyResult<BetterAuthTeamMember> =
+          await ctx.runQuery(components.betterAuth.adapter.findMany, {
+            model: 'teamMember',
+            paginationOpts: { cursor: null, numItems: 100 },
+            where: [{ field: 'teamId', operator: 'eq', value: team._id }],
+          });
+        return membersResult?.page.length ?? 0;
+      } catch (error) {
+        console.warn('[Members] Failed to count team members', team._id, error);
+        return 0;
+      }
+    }),
+  );
+
+  return validTeams.map((team, i) => ({
+    id: team._id,
+    name: team.name,
+    memberCount: memberCounts[i],
+    createdAt: team.createdAt ?? null,
+  }));
 }
 
 export const getMyTeams = query({
   args: { organizationId: v.string() },
-  returns: v.array(v.object({ id: v.string(), name: v.string() })),
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      memberCount: v.number(),
+      createdAt: v.union(v.number(), v.null()),
+    }),
+  ),
   handler: getMyTeamsHandler,
 });
 
@@ -401,14 +426,40 @@ export async function listOrgTeamsHandler(
     return [];
   }
 
-  return teamsResult.page.map((team) => ({
+  const memberCounts = await Promise.all(
+    teamsResult.page.map(async (team) => {
+      try {
+        const membersResult: BetterAuthFindManyResult<BetterAuthTeamMember> =
+          await ctx.runQuery(components.betterAuth.adapter.findMany, {
+            model: 'teamMember',
+            paginationOpts: { cursor: null, numItems: 100 },
+            where: [{ field: 'teamId', operator: 'eq', value: team._id }],
+          });
+        return membersResult?.page.length ?? 0;
+      } catch (error) {
+        console.warn('[Members] Failed to count team members', team._id, error);
+        return 0;
+      }
+    }),
+  );
+
+  return teamsResult.page.map((team, i) => ({
     id: team._id,
     name: team.name,
+    memberCount: memberCounts[i],
+    createdAt: team.createdAt ?? null,
   }));
 }
 
 export const listOrgTeams = query({
   args: { organizationId: v.string() },
-  returns: v.array(v.object({ id: v.string(), name: v.string() })),
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      memberCount: v.number(),
+      createdAt: v.union(v.number(), v.null()),
+    }),
+  ),
   handler: listOrgTeamsHandler,
 });


### PR DESCRIPTION
## Summary
- Extend `getMyTeams` and `listOrgTeams` Convex queries to return `memberCount` and `createdAt` for each team
- Add member count and relative created date columns to the teams settings table
- Add `TeamMembersPreloader` component to eagerly subscribe to team member data, so detail/edit/delete dialogs open instantly
- Wrap teams table in `PageSection` for consistent settings page layout
- Update all test fixtures and mocks to include the new fields

## Test plan
- [ ] Verify teams table shows member count and relative created date columns
- [ ] Open team detail/edit/delete dialogs and confirm data loads instantly (no spinner)
- [ ] Run `convex/members/__tests__/queries.test.ts` — all tests pass
- [ ] Run teams table component tests — all pass
- [ ] Verify layout matches other settings page sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams table now displays member count for each team
  * Teams table now shows team creation date with relative time formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->