### PR TITLE
chore: add dev setup docs to CLAUDE.md and gitignore provider files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,6 +5,11 @@ Follow the coding standards defined in `/AGENTS.md` at the project root.
 - DO NOT include "Co-Authored-By" in commit messages.
 - DO NOT include "Generated with Claude Code" or any similar attribution in PR descriptions.
 
+## Development Setup
+
+- After cloning, run `git update-index --skip-worktree examples/branding/branding.json` to prevent local branding edits from showing in git status.
+- The `examples/` directory is the live config directory during development. New provider files created via the UI are gitignored, but modifications to tracked seed files need skip-worktree.
+
 ## Code Style
 
 - NEVER use empty catch blocks. Always log the error (e.g. `console.warn` / `console.error`) or re-throw. Silent swallowing hides bugs.

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ build/
 # Local ARM64 Dockerfile for operator
 services/operator/Dockerfile.arm64
 
-# Examples
+# Examples – seed configs are tracked; runtime additions are ignored
 examples/**/.history/
+examples/providers/*
+!examples/providers/openrouter.json
+!examples/providers/openrouter.secrets.json
 delivery_report.html


### PR DESCRIPTION
## Summary
- Add development setup section to `.claude/CLAUDE.md` documenting the `skip-worktree` workflow for `examples/branding/branding.json` and explaining the `examples/` directory role
- Update `.gitignore` to ignore runtime-created provider files in `examples/providers/` while preserving tracked seed configs (`openrouter.json`, `openrouter.secrets.json`)

## Test plan
- [ ] Verify `git status` no longer shows new provider files created via the UI in `examples/providers/`
- [ ] Confirm tracked seed files (`openrouter.json`, `openrouter.secrets.json`) are still tracked
- [ ] Check CLAUDE.md renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development setup instructions for local development workflows and configuration management.

* **Chores**
  * Updated configuration file patterns to better manage development-time generated files and seed configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->