### PR TITLE
fix(platform): allow microphone access in permissions policy

### DIFF
--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -191,7 +191,7 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
       referrerPolicy: 'strict-origin-when-cross-origin',
       permissionsPolicy: {
         camera: [],
-        microphone: [],
+        microphone: ['self'],
         // Active features: location-request approval card uses geolocation;
         // copy-to-clipboard hook is wired into many UI surfaces.
         geolocation: ['self'],


### PR DESCRIPTION
## Summary
- The `Permissions-Policy` header had `microphone` set to an empty allowlist (`()`), which blocked the browser from granting mic access even when the user approved the permission prompt.
- Changed to `microphone=(self)` so the dictation button can request microphone permission from the same origin.

## Test plan
- [ ] Open the chat page and click the microphone/dictation button
- [ ] Verify the browser shows a permission prompt instead of immediately denying
- [ ] After granting permission, verify speech-to-text works correctly
- [ ] Verify the `Permissions-Policy` response header includes `microphone=(self)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated microphone permission settings in security configuration to enable microphone functionality from the application's own origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->