### PR TITLE
fix(platform): disable SSE file events by default, fix cancel bug

### DIFF
--- a/services/platform/app/hooks/use-file-events.ts
+++ b/services/platform/app/hooks/use-file-events.ts
@@ -33,7 +33,8 @@ export function useFileEvents() {
       let data: { type: string; orgSlug?: string };
       try {
         data = JSON.parse(e.data);
-      } catch {
+      } catch (err) {
+        console.warn('[useFileEvents] Failed to parse SSE message:', err);
         return;
       }
 

--- a/services/platform/app/hooks/use-file-events.ts
+++ b/services/platform/app/hooks/use-file-events.ts
@@ -1,20 +1,33 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
+import { getEnv } from '@/lib/env';
+
 import { configKeys } from './config-query-keys';
 
 /**
- * Connects to the /api/file-events SSE endpoint and invalidates TanStack
- * Query caches when config files change on disk (external edits, git pull,
- * other users, etc.).
+ * Connects to the /events/file SSE endpoint and invalidates TanStack Query
+ * caches when config files change on disk (external edits, git pull, other
+ * users, etc.).
+ *
+ * Requires `TALE_FILE_EVENTS=true` on the server. When the feature is
+ * disabled the hook is a no-op — no EventSource is created.
  *
  * Mount once near the app root.
  */
 export function useFileEvents() {
   const queryClient = useQueryClient();
 
+  const enabled = getEnv('FILE_EVENTS_ENABLED');
+
   useEffect(() => {
+    if (!enabled) return undefined;
+
     const es = new EventSource('/events/file');
+
+    es.addEventListener('error', () => {
+      es.close();
+    });
 
     es.addEventListener('message', (e) => {
       let data: { type: string; orgSlug?: string };
@@ -36,5 +49,5 @@ export function useFileEvents() {
     });
 
     return () => es.close();
-  }, [queryClient]);
+  }, [queryClient, enabled]);
 }

--- a/services/platform/lib/env.ts
+++ b/services/platform/lib/env.ts
@@ -5,6 +5,7 @@ declare global {
       BASE_PATH?: string;
       MICROSOFT_AUTH_ENABLED?: boolean;
       TRUSTED_HEADERS_ENABLED?: boolean;
+      FILE_EVENTS_ENABLED?: boolean;
       SENTRY_DSN?: string;
       SENTRY_TRACES_SAMPLE_RATE?: number;
       TALE_VERSION?: string;
@@ -17,6 +18,7 @@ export function getEnv(key: 'SITE_URL'): string;
 export function getEnv(key: 'BASE_PATH'): string;
 export function getEnv(key: 'MICROSOFT_AUTH_ENABLED'): boolean;
 export function getEnv(key: 'TRUSTED_HEADERS_ENABLED'): boolean;
+export function getEnv(key: 'FILE_EVENTS_ENABLED'): boolean;
 export function getEnv(key: 'SENTRY_DSN'): string | undefined;
 export function getEnv(key: 'SENTRY_TRACES_SAMPLE_RATE'): number;
 export function getEnv(key: 'TALE_VERSION'): string | undefined;
@@ -26,6 +28,7 @@ export function getEnv(
     | 'BASE_PATH'
     | 'MICROSOFT_AUTH_ENABLED'
     | 'TRUSTED_HEADERS_ENABLED'
+    | 'FILE_EVENTS_ENABLED'
     | 'SENTRY_DSN'
     | 'SENTRY_TRACES_SAMPLE_RATE'
     | 'TALE_VERSION',
@@ -35,7 +38,11 @@ export function getEnv(
     if (key === 'BASE_PATH') {
       return '';
     }
-    if (key === 'MICROSOFT_AUTH_ENABLED' || key === 'TRUSTED_HEADERS_ENABLED') {
+    if (
+      key === 'MICROSOFT_AUTH_ENABLED' ||
+      key === 'TRUSTED_HEADERS_ENABLED' ||
+      key === 'FILE_EVENTS_ENABLED'
+    ) {
       return false;
     }
     if (key === 'SENTRY_DSN' || key === 'TALE_VERSION') {

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -7,6 +7,7 @@ const baseEnv = {
   BASE_PATH: '',
   MICROSOFT_AUTH_ENABLED: false,
   TRUSTED_HEADERS_ENABLED: false,
+  FILE_EVENTS_ENABLED: true,
   SENTRY_DSN: undefined,
   SENTRY_TRACES_SAMPLE_RATE: 1,
   TALE_VERSION: undefined,
@@ -92,5 +93,11 @@ describe('SSE /events/file', () => {
     expect(res.body).toBeInstanceOf(ReadableStream);
     // Cancel to drop the SSE client and avoid leaking the controller.
     await res.body?.cancel();
+  });
+
+  test('returns 404 when FILE_EVENTS_ENABLED is false', async () => {
+    const app = createApp({ ...baseEnv, FILE_EVENTS_ENABLED: false });
+    const res = await app.fetch(new Request('http://localhost/events/file'));
+    expect(res.status).toBe(404);
   });
 });

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -24,11 +24,12 @@ const SHUTDOWN_MARKER = '/tmp/platform-shutting-down';
 
 const sseClients = new Set<ReadableStreamDefaultController>();
 
+const fileEventsEnabled = process.env.TALE_FILE_EVENTS === 'true';
 const configDir = process.env.TALE_CONFIG_DIR;
 // Post-split (Phase 2): TALE_CONFIG_DIR points at the convex-data volume
 // mounted read-only on the platform container (for config-file SSE + branding
 // image serving). Skip watcher setup gracefully if the directory is absent.
-if (configDir && existsSync(configDir)) {
+if (fileEventsEnabled && configDir && existsSync(configDir)) {
   const watcher = createConfigWatcher(configDir);
   watcher.onChange((event) => {
     const payload = `data: ${JSON.stringify(event)}\n\n`;
@@ -60,6 +61,7 @@ interface EnvConfig {
   BASE_PATH: string;
   MICROSOFT_AUTH_ENABLED: boolean;
   TRUSTED_HEADERS_ENABLED: boolean;
+  FILE_EVENTS_ENABLED: boolean;
   SENTRY_DSN: string | undefined;
   SENTRY_TRACES_SAMPLE_RATE: number;
   TALE_VERSION: string | undefined;
@@ -85,6 +87,7 @@ function getEnvConfig(): EnvConfig {
     BASE_PATH: getBasePath(),
     MICROSOFT_AUTH_ENABLED: !!process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
     TRUSTED_HEADERS_ENABLED: process.env.TRUSTED_HEADERS_ENABLED === 'true',
+    FILE_EVENTS_ENABLED: fileEventsEnabled,
     SENTRY_DSN: process.env.SENTRY_DSN,
     SENTRY_TRACES_SAMPLE_RATE: parseFloat(
       process.env.SENTRY_TRACES_SAMPLE_RATE || '1.0',
@@ -220,14 +223,18 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
     return c.json({ status: 'ok' });
   });
 
-  app.get('/events/file', () => {
+  app.get('/events/file', (c) => {
+    if (!env.FILE_EVENTS_ENABLED) return c.notFound();
+
+    let ctrl: ReadableStreamDefaultController;
     const stream = new ReadableStream({
       start(controller) {
-        sseClients.add(controller);
-        controller.enqueue('data: {"type":"connected"}\n\n');
+        ctrl = controller;
+        sseClients.add(ctrl);
+        ctrl.enqueue('data: {"type":"connected"}\n\n');
       },
-      cancel(controller) {
-        sseClients.delete(controller);
+      cancel() {
+        sseClients.delete(ctrl);
       },
     });
     return new Response(stream, {

--- a/services/platform/vite-plugins/inject-env.ts
+++ b/services/platform/vite-plugins/inject-env.ts
@@ -4,6 +4,7 @@ interface EnvConfig {
   SITE_URL: string;
   BASE_PATH: string;
   MICROSOFT_AUTH_ENABLED: boolean;
+  FILE_EVENTS_ENABLED: boolean;
   SENTRY_DSN?: string;
   SENTRY_TRACES_SAMPLE_RATE: number;
 }
@@ -16,6 +17,7 @@ function getEnvConfig(): EnvConfig {
     SITE_URL: process.env.SITE_URL,
     BASE_PATH: (process.env.BASE_PATH ?? '').replace(/\/$/, ''),
     MICROSOFT_AUTH_ENABLED: process.env.MICROSOFT_AUTH_ENABLED === 'true',
+    FILE_EVENTS_ENABLED: process.env.TALE_FILE_EVENTS === 'true',
     SENTRY_DSN: process.env.SENTRY_DSN,
     SENTRY_TRACES_SAMPLE_RATE: parseFloat(
       process.env.SENTRY_TRACES_SAMPLE_RATE || '1.0',

--- a/services/platform/vite-plugins/inject-env.ts
+++ b/services/platform/vite-plugins/inject-env.ts
@@ -16,7 +16,7 @@ function getEnvConfig(): EnvConfig {
   return {
     SITE_URL: process.env.SITE_URL,
     BASE_PATH: (process.env.BASE_PATH ?? '').replace(/\/$/, ''),
-    MICROSOFT_AUTH_ENABLED: process.env.MICROSOFT_AUTH_ENABLED === 'true',
+    MICROSOFT_AUTH_ENABLED: !!process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
     FILE_EVENTS_ENABLED: process.env.TALE_FILE_EVENTS === 'true',
     SENTRY_DSN: process.env.SENTRY_DSN,
     SENTRY_TRACES_SAMPLE_RATE: parseFloat(

--- a/services/platform/vite-plugins/watch-examples.ts
+++ b/services/platform/vite-plugins/watch-examples.ts
@@ -27,7 +27,8 @@ export function watchExamples(): Plugin {
         for (const client of clients) {
           try {
             client.write(payload);
-          } catch {
+          } catch (err) {
+            console.warn('SSE write failed; dropping client', err);
             clients.delete(client);
           }
         }

--- a/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
@@ -100,6 +100,7 @@ export function generateDevCompose(
   // needs it locally for server.ts (chokidar root + branding image dir).
   platform.environment = {
     TALE_CONFIG_DIR: '/app/data',
+    TALE_FILE_EVENTS: 'true',
     CONVEX_URL: 'http://convex:3210',
   };
   platform.depends_on = {


### PR DESCRIPTION
## Summary

- **Fix cancel bug**: `ReadableStream.cancel(reason)` was shadowing the controller — disconnected SSE clients were never removed from the set, causing continuous `Controller is already closed` errors on every config file change
- **Make SSE opt-in**: Gate `/events/file` behind `TALE_FILE_EVENTS=true` env var — disabled by default in production, auto-enabled by `tale start` for development
- **Frontend guard**: `useFileEvents` hook checks `FILE_EVENTS_ENABLED` before creating an EventSource, with an `error` listener as safety net

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint --workspace=@tale/platform`)
- [x] All 7 server tests pass, including new "returns 404 when disabled" test
- [ ] Deploy without `TALE_FILE_EVENTS` — verify no SSE errors in logs
- [ ] Run `tale start` — verify file change events still work in dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File events feature is now configurable and can be disabled via server-side environment settings.

* **Tests**
  * Added test coverage for file events endpoint behavior when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->