### PR TITLE
fix(cli): sync project files to convex container instead of platform

### DIFF
--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -517,13 +517,6 @@ export async function deploy(options: DeployOptions): Promise<void> {
         }
       }
 
-      // Determine the active platform container for project sync
-      const activeColor = inPlaceUpdate
-        ? currentColor
-        : isFirstDeploy
-          ? getNextColor(null)
-          : getNextColor(currentColor);
-
       if (dryRun) {
         logger.success(
           `${prefix}Dry-run complete! Would deploy version ${version}`,

--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -532,15 +532,13 @@ export async function deploy(options: DeployOptions): Promise<void> {
         logger.success(`Deployment complete! Version ${version} is now live`);
       }
 
-      // Sync project files to the active container
-      if (activeColor) {
-        await syncProjectFiles(
-          `${getProjectId()}-platform-${activeColor}`,
-          env.DEPLOY_DIR,
-          dryRun,
-          prefix,
-        );
-      }
+      // Sync project files to the convex container (owns convex-data volume rw)
+      await syncProjectFiles(
+        `${getProjectId()}-convex`,
+        env.DEPLOY_DIR,
+        dryRun,
+        prefix,
+      );
     });
   } finally {
     process.removeListener('SIGINT', onInterrupt);
@@ -570,6 +568,16 @@ async function syncProjectFiles(
     return;
   }
 
+  if (!dryRun) {
+    const running = await isContainerRunning(containerName);
+    if (!running) {
+      logger.warn(
+        `${prefix}Container ${containerName} is not running, skipping file sync`,
+      );
+      return;
+    }
+  }
+
   logger.blank();
   logger.step(`${prefix}Syncing project files to ${containerName}...`);
 
@@ -592,7 +600,7 @@ async function syncProjectFiles(
 
     if (result.success) {
       // docker cp copies files as root — fix ownership so the app user can write
-      await exec('docker', [
+      const chownResult = await exec('docker', [
         'exec',
         containerName,
         'chown',
@@ -600,6 +608,11 @@ async function syncProjectFiles(
         'app:app',
         `/app/data/${dir}/`,
       ]);
+      if (!chownResult.success) {
+        logger.warn(
+          `Failed to fix ownership for ${dir}/: ${chownResult.stderr}`,
+        );
+      }
       logger.info(`Synced ${dir}/`);
     } else {
       logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);


### PR DESCRIPTION
## Summary
- **Sync target**: `platform-${color}` → `convex`. Platform mounts `convex-data` volume as `:ro`, so `docker cp` into it fails for all sync dirs. Convex owns the volume read-write — it's the correct target.
- **Pre-flight check**: Verifies convex container is running before syncing, giving one clear warning instead of N per-directory failures.
- **Chown error handling**: Warns on `chown` failure instead of silently ignoring it.

## Test plan
- [ ] `tale deploy` completes without read-only volume warnings
- [ ] `docker exec <convex-container> ls /app/data/agents/` shows synced files
- [ ] Platform SSE watcher picks up config changes through the shared volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Streamlined deployment process with consistent container targeting across all deployment modes.
* Improved error diagnostics with enhanced logging when containers are unavailable or permission issues occur during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->