### PR TITLE
feat(platform): add workflow usage & performance metrics dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
         "react-hook-form": "7.72.1",
         "react-i18next": "17.0.2",
         "react-markdown": "10.1.0",
+        "recharts": "2.15.4",
         "rehype-raw": "7.0.0",
         "rehype-sanitize": "6.0.0",
         "remark-gfm": "4.0.1",
@@ -1996,6 +1997,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@4.2.1", "", { "dependencies": { "mimic-response": "^2.0.0" } }, "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw=="],
@@ -2049,6 +2052,8 @@
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
@@ -2112,6 +2117,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
@@ -2131,6 +2138,8 @@
     "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -3012,17 +3021,25 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-syntax-highlighter": ["react-syntax-highlighter@16.1.1", "", { "dependencies": { "@babel/runtime": "^7.28.4", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^5.0.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA=="],
 
     "react-textarea-autosize": ["react-textarea-autosize@8.5.9", "", { "dependencies": { "@babel/runtime": "^7.20.13", "use-composed-ref": "^1.3.0", "use-latest": "^1.2.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A=="],
 
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
+
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -3396,6 +3413,8 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
     "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
@@ -3670,6 +3689,8 @@
 
     "dagre/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
+    "dom-helpers/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -3751,6 +3772,8 @@
     "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "react-i18next/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "react-transition-group/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/services/platform/app/features/automations/components/automations-table.test.tsx
+++ b/services/platform/app/features/automations/components/automations-table.test.tsx
@@ -14,12 +14,17 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({
     children,
     className,
+    to,
   }: {
     children?: React.ReactNode;
     className?: string;
     to?: string;
     params?: Record<string, string>;
-  }) => <a className={className}>{children}</a>,
+  }) => (
+    <a className={className} href={to ?? '#'}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({

--- a/services/platform/app/features/automations/components/automations-table.test.tsx
+++ b/services/platform/app/features/automations/components/automations-table.test.tsx
@@ -11,6 +11,15 @@ import { AutomationsTable } from './automations-table';
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
   useParams: () => ({ id: 'test-org-id' }),
+  Link: ({
+    children,
+    className,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+    to?: string;
+    params?: Record<string, string>;
+  }) => <a className={className}>{children}</a>,
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({

--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -2,11 +2,12 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import { type Row } from '@tanstack/react-table';
-import { Workflow } from 'lucide-react';
+import { BarChart3, Workflow } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DataTableSkeleton } from '@/app/components/ui/data-table/data-table-skeleton';
+import { LinkButton } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
 import { useT } from '@/lib/i18n/client';
 import { slugToUrlParam } from '@/lib/utils/workflow-slug';
@@ -201,7 +202,17 @@ export function AutomationsTable({
             setSearchQuery(e.target.value)
           }
         />
-        <AutomationsActionMenu organizationId={organizationId} />
+        <div className="flex items-center gap-2">
+          <LinkButton
+            href="/dashboard/$id/automations/metrics"
+            params={{ id: organizationId }}
+            variant="secondary"
+            icon={BarChart3}
+          >
+            {tAutomations('metrics.link')}
+          </LinkButton>
+          <AutomationsActionMenu organizationId={organizationId} />
+        </div>
       </div>
 
       <DataTable

--- a/services/platform/app/features/automations/metrics/execution-trend-chart.tsx
+++ b/services/platform/app/features/automations/metrics/execution-trend-chart.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+
+interface TrendPoint {
+  dateKey: string;
+  completed: number;
+  failed: number;
+}
+
+interface ExecutionTrendChartProps {
+  series: TrendPoint[];
+}
+
+function shortLabel(dateKey: string): string {
+  const [, month, day] = dateKey.split('-');
+  return `${month}-${day}`;
+}
+
+export function ExecutionTrendChart({ series }: ExecutionTrendChartProps) {
+  const { t } = useT('automations');
+  const data = series.map((p) => ({
+    ...p,
+    label: shortLabel(p.dateKey),
+  }));
+
+  return (
+    <div className="border-border flex flex-col gap-3 rounded-lg border px-5 py-4">
+      <Text variant="label" as="h3" className="text-sm">
+        {t('metrics.chart.trendTitle')}
+      </Text>
+      <div className="h-60 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data}
+            margin={{ top: 8, right: 8, bottom: 0, left: -16 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              className="stroke-border"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11 }}
+              stroke="currentColor"
+              className="text-muted-foreground"
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fontSize: 11 }}
+              stroke="currentColor"
+              className="text-muted-foreground"
+            />
+            <Tooltip
+              contentStyle={{
+                fontSize: 12,
+                borderRadius: 6,
+                border: '1px solid var(--border)',
+                background: 'var(--popover)',
+              }}
+              labelFormatter={(value, payload) => {
+                const first = payload?.[0];
+                if (
+                  first &&
+                  typeof first === 'object' &&
+                  'payload' in first &&
+                  first.payload &&
+                  typeof first.payload === 'object' &&
+                  'dateKey' in first.payload &&
+                  typeof first.payload.dateKey === 'string'
+                ) {
+                  return first.payload.dateKey;
+                }
+                return String(value);
+              }}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Bar
+              dataKey="completed"
+              stackId="runs"
+              fill="var(--color-chart-success, #16a34a)"
+              name={t('metrics.chart.completed')}
+              radius={[0, 0, 0, 0]}
+            />
+            <Bar
+              dataKey="failed"
+              stackId="runs"
+              fill="var(--color-chart-failure, #dc2626)"
+              name={t('metrics.chart.failed')}
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/automations/metrics/format-duration.ts
+++ b/services/platform/app/features/automations/metrics/format-duration.ts
@@ -1,0 +1,12 @@
+export function formatDurationSeconds(seconds: number): string {
+  if (!seconds || seconds <= 0) return '0s';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) {
+    return remainder > 0 ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes % 60;
+  return remainderMinutes > 0 ? `${hours}h ${remainderMinutes}m` : `${hours}h`;
+}

--- a/services/platform/app/features/automations/metrics/metrics-page.tsx
+++ b/services/platform/app/features/automations/metrics/metrics-page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { Select } from '@/app/components/ui/forms/select';
+import { Stack } from '@/app/components/ui/layout/layout';
+import { Text } from '@/app/components/ui/typography/text';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+import { useT } from '@/lib/i18n/client';
+
+import { ExecutionTrendChart } from './execution-trend-chart';
+import { MetricsSummaryCards } from './metrics-summary-cards';
+import { StatusBreakdown } from './status-breakdown';
+import { TopWorkflowsTable } from './top-workflows-table';
+
+export type PeriodDays = 7 | 30 | 90;
+
+interface WorkflowMetricsPageProps {
+  organizationId: string;
+  periodDays: PeriodDays;
+  onChangePeriod: (period: PeriodDays) => void;
+}
+
+export function WorkflowMetricsPage({
+  organizationId,
+  periodDays,
+  onChangePeriod,
+}: WorkflowMetricsPageProps) {
+  const { t } = useT('automations');
+
+  const { data, isLoading } = useConvexQuery(
+    api.wf_executions.queries.getOrgWorkflowMetrics,
+    { organizationId, periodDays },
+  );
+
+  const periodOptions = useMemo(
+    () => [
+      { value: '7', label: t('metrics.period.last7Days') },
+      { value: '30', label: t('metrics.period.last30Days') },
+      { value: '90', label: t('metrics.period.last90Days') },
+    ],
+    [t],
+  );
+
+  const summary = data?.summary;
+  const series = data?.series ?? [];
+  const topWorkflows = data?.topWorkflows ?? [];
+
+  return (
+    <Stack gap={4} className="p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <Text as="h3" variant="label" className="text-lg font-semibold">
+            {t('metrics.title')}
+          </Text>
+          <Text variant="caption">{t('metrics.description')}</Text>
+        </div>
+        <div className="w-44">
+          <Select
+            options={periodOptions}
+            value={String(periodDays)}
+            onValueChange={(v) => {
+              const next = Number(v);
+              if (next === 7 || next === 30 || next === 90)
+                onChangePeriod(next);
+            }}
+            size="sm"
+          />
+        </div>
+      </div>
+
+      {summary?.capped ? (
+        <div className="border-border bg-muted/40 rounded-md border px-3 py-2 text-xs">
+          {t('metrics.cappedNotice')}
+        </div>
+      ) : null}
+
+      <MetricsSummaryCards
+        total={summary?.total ?? 0}
+        successRate={summary?.successRate ?? 0}
+        avgExecutionTimeSeconds={summary?.avgExecutionTimeSeconds ?? 0}
+        failed={summary?.failed ?? 0}
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <ExecutionTrendChart series={series} />
+        </div>
+        <div>
+          <StatusBreakdown
+            completed={summary?.completed ?? 0}
+            failed={summary?.failed ?? 0}
+            running={summary?.running ?? 0}
+          />
+        </div>
+      </div>
+
+      <TopWorkflowsTable
+        organizationId={organizationId}
+        rows={topWorkflows}
+        isLoading={isLoading}
+      />
+    </Stack>
+  );
+}

--- a/services/platform/app/features/automations/metrics/metrics-summary-cards.tsx
+++ b/services/platform/app/features/automations/metrics/metrics-summary-cards.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+
+import { formatDurationSeconds } from './format-duration';
+
+interface MetricsSummaryCardsProps {
+  total: number;
+  successRate: number;
+  avgExecutionTimeSeconds: number;
+  failed: number;
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <Text className="text-muted-foreground text-xs">{label}</Text>
+      <Text className="font-mono text-lg font-semibold">{value}</Text>
+    </div>
+  );
+}
+
+export function MetricsSummaryCards({
+  total,
+  successRate,
+  avgExecutionTimeSeconds,
+  failed,
+}: MetricsSummaryCardsProps) {
+  const { t } = useT('automations');
+  const successRateDisplay = total > 0 ? `${successRate.toFixed(1)}%` : '—';
+
+  return (
+    <div className="border-border grid grid-cols-2 gap-8 rounded-lg border px-5 py-3 md:grid-cols-4">
+      <StatCard
+        label={t('metrics.cards.totalRuns')}
+        value={formatNumber(total)}
+      />
+      <StatCard
+        label={t('metrics.cards.successRate')}
+        value={successRateDisplay}
+      />
+      <StatCard
+        label={t('metrics.cards.avgDuration')}
+        value={formatDurationSeconds(avgExecutionTimeSeconds)}
+      />
+      <StatCard
+        label={t('metrics.cards.failedRuns')}
+        value={formatNumber(failed)}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/features/automations/metrics/status-breakdown.tsx
+++ b/services/platform/app/features/automations/metrics/status-breakdown.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
+
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+
+interface StatusBreakdownProps {
+  completed: number;
+  failed: number;
+  running: number;
+}
+
+export function StatusBreakdown({
+  completed,
+  failed,
+  running,
+}: StatusBreakdownProps) {
+  const { t } = useT('automations');
+  const total = completed + failed + running;
+
+  const data = [
+    {
+      name: t('metrics.chart.completed'),
+      value: completed,
+      color: 'var(--color-chart-success, #16a34a)',
+    },
+    {
+      name: t('metrics.chart.failed'),
+      value: failed,
+      color: 'var(--color-chart-failure, #dc2626)',
+    },
+    {
+      name: t('metrics.chart.running'),
+      value: running,
+      color: 'var(--color-chart-neutral, #3b82f6)',
+    },
+  ].filter((d) => d.value > 0);
+
+  return (
+    <div className="border-border flex flex-col gap-3 rounded-lg border px-5 py-4">
+      <Text variant="label" as="h3" className="text-sm">
+        {t('metrics.chart.statusTitle')}
+      </Text>
+      {total === 0 ? (
+        <div className="text-muted-foreground flex h-60 items-center justify-center text-sm">
+          {t('metrics.empty.noRuns')}
+        </div>
+      ) : (
+        <div className="h-60 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Tooltip
+                contentStyle={{
+                  fontSize: 12,
+                  borderRadius: 6,
+                  border: '1px solid var(--border)',
+                  background: 'var(--popover)',
+                }}
+                formatter={(value: number) => formatNumber(value)}
+              />
+              <Pie
+                data={data}
+                dataKey="value"
+                nameKey="name"
+                innerRadius={50}
+                outerRadius={80}
+                paddingAngle={2}
+                stroke="none"
+              >
+                {data.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {data.map((d) => (
+          <div key={d.name} className="flex items-center gap-2 text-xs">
+            <span
+              className="size-2 rounded-full"
+              style={{ background: d.color }}
+            />
+            <span className="text-muted-foreground">{d.name}</span>
+            <span className="font-mono font-semibold">
+              {formatNumber(d.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/automations/metrics/top-workflows-table.tsx
+++ b/services/platform/app/features/automations/metrics/top-workflows-table.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useNavigate } from '@tanstack/react-router';
+import type { ColumnDef, Row } from '@tanstack/react-table';
+import { formatDistanceToNow } from 'date-fns';
+import { BarChart3 } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+import { slugToUrlParam } from '@/lib/utils/workflow-slug';
+
+import { formatDurationSeconds } from './format-duration';
+
+export interface TopWorkflowRow {
+  wfDefinitionId: string | null;
+  workflowSlug: string | null;
+  total: number;
+  completed: number;
+  failed: number;
+  successRate: number;
+  avgExecutionTimeSeconds: number;
+  lastExecution: number | null;
+}
+
+interface TopWorkflowsTableProps {
+  organizationId: string;
+  rows: TopWorkflowRow[];
+  isLoading: boolean;
+}
+
+function displayName(row: TopWorkflowRow): string {
+  if (row.workflowSlug) return row.workflowSlug;
+  if (row.wfDefinitionId) return row.wfDefinitionId;
+  return '—';
+}
+
+export function TopWorkflowsTable({
+  organizationId,
+  rows,
+  isLoading,
+}: TopWorkflowsTableProps) {
+  const navigate = useNavigate();
+  const { t } = useT('automations');
+
+  const handleRowClick = useCallback(
+    (row: Row<TopWorkflowRow>) => {
+      const slug = row.original.workflowSlug;
+      if (!slug) return;
+      void navigate({
+        to: '/dashboard/$id/automations/$amId/executions',
+        params: { id: organizationId, amId: slugToUrlParam(slug) },
+      });
+    },
+    [navigate, organizationId],
+  );
+
+  const columns = useMemo<ColumnDef<TopWorkflowRow>[]>(
+    () => [
+      {
+        id: 'workflow',
+        header: t('metrics.table.workflow'),
+        cell: ({ row }) => (
+          <Text
+            as="span"
+            variant="label"
+            className="block max-w-[320px] truncate text-sm"
+          >
+            {displayName(row.original)}
+          </Text>
+        ),
+        size: 320,
+      },
+      {
+        id: 'runs',
+        header: () => (
+          <div className="text-right">{t('metrics.table.runs')}</div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.total)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'successRate',
+        header: () => (
+          <div className="text-right">{t('metrics.table.successRate')}</div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {row.original.total > 0
+              ? `${row.original.successRate.toFixed(1)}%`
+              : '—'}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'avgDuration',
+        header: () => (
+          <div className="text-right">{t('metrics.table.avgDuration')}</div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatDurationSeconds(row.original.avgExecutionTimeSeconds)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'failed',
+        header: () => (
+          <div className="text-right">{t('metrics.table.failed')}</div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.failed)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'lastRun',
+        header: t('metrics.table.lastRun'),
+        cell: ({ row }) => (
+          <Text as="span" variant="caption">
+            {row.original.lastExecution
+              ? formatDistanceToNow(new Date(row.original.lastExecution), {
+                  addSuffix: true,
+                })
+              : '—'}
+          </Text>
+        ),
+        size: 160,
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <div className="border-border flex flex-col gap-3 rounded-lg border px-5 py-4">
+      <Text variant="label" as="h3" className="text-sm">
+        {t('metrics.table.title')}
+      </Text>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowId={(row) =>
+          row.wfDefinitionId ?? row.workflowSlug ?? Math.random().toString()
+        }
+        isLoading={isLoading}
+        approxRowCount={isLoading ? 5 : rows.length}
+        onRowClick={handleRowClick}
+        emptyState={{
+          icon: BarChart3,
+          title: t('metrics.empty.title'),
+          description: t('metrics.empty.description'),
+        }}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -48,6 +48,7 @@ import { Route as DashboardIdSettingsAgentsRouteImport } from './routes/dashboar
 import { Route as DashboardIdSettingsAccountRouteImport } from './routes/dashboard/$id/settings/account'
 import { Route as DashboardIdConversationsStatusRouteImport } from './routes/dashboard/$id/conversations/$status'
 import { Route as DashboardIdChatThreadIdRouteImport } from './routes/dashboard/$id/chat/$threadId'
+import { Route as DashboardIdAutomationsMetricsRouteImport } from './routes/dashboard/$id/automations/metrics'
 import { Route as DashboardIdAutomationsAmIdRouteImport } from './routes/dashboard/$id/automations/$amId'
 import { Route as DashboardIdAgentsAgentIdRouteImport } from './routes/dashboard/$id/agents/$agentId'
 import { Route as DashboardIdKnowledgeWebsitesRouteImport } from './routes/dashboard/$id/_knowledge/websites'
@@ -277,6 +278,12 @@ const DashboardIdChatThreadIdRoute = DashboardIdChatThreadIdRouteImport.update({
   path: '/$threadId',
   getParentRoute: () => DashboardIdChatRoute,
 } as any)
+const DashboardIdAutomationsMetricsRoute =
+  DashboardIdAutomationsMetricsRouteImport.update({
+    id: '/metrics',
+    path: '/metrics',
+    getParentRoute: () => DashboardIdAutomationsRoute,
+  } as any)
 const DashboardIdAutomationsAmIdRoute =
   DashboardIdAutomationsAmIdRouteImport.update({
     id: '/$amId',
@@ -426,6 +433,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/$id/websites': typeof DashboardIdKnowledgeWebsitesRoute
   '/dashboard/$id/agents/$agentId': typeof DashboardIdAgentsAgentIdRouteWithChildren
   '/dashboard/$id/automations/$amId': typeof DashboardIdAutomationsAmIdRouteWithChildren
+  '/dashboard/$id/automations/metrics': typeof DashboardIdAutomationsMetricsRoute
   '/dashboard/$id/chat/$threadId': typeof DashboardIdChatThreadIdRoute
   '/dashboard/$id/conversations/$status': typeof DashboardIdConversationsStatusRoute
   '/dashboard/$id/settings/account': typeof DashboardIdSettingsAccountRoute
@@ -478,6 +486,7 @@ export interface FileRoutesByTo {
   '/dashboard/$id/vendors': typeof DashboardIdKnowledgeVendorsRoute
   '/dashboard/$id/websites': typeof DashboardIdKnowledgeWebsitesRoute
   '/dashboard/$id/automations/$amId': typeof DashboardIdAutomationsAmIdRouteWithChildren
+  '/dashboard/$id/automations/metrics': typeof DashboardIdAutomationsMetricsRoute
   '/dashboard/$id/chat/$threadId': typeof DashboardIdChatThreadIdRoute
   '/dashboard/$id/conversations/$status': typeof DashboardIdConversationsStatusRoute
   '/dashboard/$id/settings/account': typeof DashboardIdSettingsAccountRoute
@@ -539,6 +548,7 @@ export interface FileRoutesById {
   '/dashboard/$id/_knowledge/websites': typeof DashboardIdKnowledgeWebsitesRoute
   '/dashboard/$id/agents/$agentId': typeof DashboardIdAgentsAgentIdRouteWithChildren
   '/dashboard/$id/automations/$amId': typeof DashboardIdAutomationsAmIdRouteWithChildren
+  '/dashboard/$id/automations/metrics': typeof DashboardIdAutomationsMetricsRoute
   '/dashboard/$id/chat/$threadId': typeof DashboardIdChatThreadIdRoute
   '/dashboard/$id/conversations/$status': typeof DashboardIdConversationsStatusRoute
   '/dashboard/$id/settings/account': typeof DashboardIdSettingsAccountRoute
@@ -600,6 +610,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/websites'
     | '/dashboard/$id/agents/$agentId'
     | '/dashboard/$id/automations/$amId'
+    | '/dashboard/$id/automations/metrics'
     | '/dashboard/$id/chat/$threadId'
     | '/dashboard/$id/conversations/$status'
     | '/dashboard/$id/settings/account'
@@ -652,6 +663,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/vendors'
     | '/dashboard/$id/websites'
     | '/dashboard/$id/automations/$amId'
+    | '/dashboard/$id/automations/metrics'
     | '/dashboard/$id/chat/$threadId'
     | '/dashboard/$id/conversations/$status'
     | '/dashboard/$id/settings/account'
@@ -712,6 +724,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/_knowledge/websites'
     | '/dashboard/$id/agents/$agentId'
     | '/dashboard/$id/automations/$amId'
+    | '/dashboard/$id/automations/metrics'
     | '/dashboard/$id/chat/$threadId'
     | '/dashboard/$id/conversations/$status'
     | '/dashboard/$id/settings/account'
@@ -1029,6 +1042,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIdChatThreadIdRouteImport
       parentRoute: typeof DashboardIdChatRoute
     }
+    '/dashboard/$id/automations/metrics': {
+      id: '/dashboard/$id/automations/metrics'
+      path: '/metrics'
+      fullPath: '/dashboard/$id/automations/metrics'
+      preLoaderRoute: typeof DashboardIdAutomationsMetricsRouteImport
+      parentRoute: typeof DashboardIdAutomationsRoute
+    }
     '/dashboard/$id/automations/$amId': {
       id: '/dashboard/$id/automations/$amId'
       path: '/$amId'
@@ -1271,6 +1291,7 @@ const DashboardIdAutomationsAmIdRouteWithChildren =
 
 interface DashboardIdAutomationsRouteChildren {
   DashboardIdAutomationsAmIdRoute: typeof DashboardIdAutomationsAmIdRouteWithChildren
+  DashboardIdAutomationsMetricsRoute: typeof DashboardIdAutomationsMetricsRoute
   DashboardIdAutomationsIndexRoute: typeof DashboardIdAutomationsIndexRoute
 }
 
@@ -1278,6 +1299,7 @@ const DashboardIdAutomationsRouteChildren: DashboardIdAutomationsRouteChildren =
   {
     DashboardIdAutomationsAmIdRoute:
       DashboardIdAutomationsAmIdRouteWithChildren,
+    DashboardIdAutomationsMetricsRoute: DashboardIdAutomationsMetricsRoute,
     DashboardIdAutomationsIndexRoute: DashboardIdAutomationsIndexRoute,
   }
 

--- a/services/platform/app/routes/dashboard/$id/automations/metrics.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/metrics.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useCallback } from 'react';
+import { z } from 'zod';
+
+import { AccessDenied } from '@/app/components/layout/access-denied';
+import {
+  WorkflowMetricsPage,
+  type PeriodDays,
+} from '@/app/features/automations/metrics/metrics-page';
+import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+import { seo } from '@/lib/utils/seo';
+
+const searchSchema = z.object({
+  period: z.enum(['7', '30', '90']).optional(),
+});
+
+export const Route = createFileRoute('/dashboard/$id/automations/metrics')({
+  head: () => ({
+    meta: seo('automations'),
+  }),
+  validateSearch: searchSchema,
+  component: AutomationsMetricsPage,
+});
+
+function AutomationsMetricsPage() {
+  const { id: organizationId } = Route.useParams();
+  const { period } = Route.useSearch();
+  const navigate = useNavigate();
+  const { t } = useT('accessDenied');
+
+  const ability = useAbility();
+  const abilityLoading = useAbilityLoading();
+
+  const periodDays: PeriodDays = period === '7' ? 7 : period === '90' ? 90 : 30;
+
+  const handleChangePeriod = useCallback(
+    (next: PeriodDays) => {
+      const periodParam: '7' | '30' | '90' =
+        next === 7 ? '7' : next === 90 ? '90' : '30';
+      void navigate({
+        to: '/dashboard/$id/automations/metrics',
+        params: { id: organizationId },
+        search: { period: periodParam },
+        replace: true,
+      });
+    },
+    [navigate, organizationId],
+  );
+
+  if (abilityLoading) {
+    return <div className="p-4" />;
+  }
+
+  if (ability.cannot('write', 'wfDefinitions')) {
+    return <AccessDenied message={t('automations')} />;
+  }
+
+  return (
+    <WorkflowMetricsPage
+      organizationId={organizationId}
+      periodDays={periodDays}
+      onChangePeriod={handleChangePeriod}
+    />
+  );
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -898,6 +898,7 @@ import type * as workflows_executions_delete_storage_blob from "../workflows/exe
 import type * as workflows_executions_fail_execution from "../workflows/executions/fail_execution.js";
 import type * as workflows_executions_get_execution from "../workflows/executions/get_execution.js";
 import type * as workflows_executions_get_execution_step_journal from "../workflows/executions/get_execution_step_journal.js";
+import type * as workflows_executions_get_org_workflow_metrics from "../workflows/executions/get_org_workflow_metrics.js";
 import type * as workflows_executions_get_raw_execution from "../workflows/executions/get_raw_execution.js";
 import type * as workflows_executions_get_workflow_execution_stats from "../workflows/executions/get_workflow_execution_stats.js";
 import type * as workflows_executions_helpers from "../workflows/executions/helpers.js";
@@ -1861,6 +1862,7 @@ declare const fullApi: ApiFromModules<{
   "workflows/executions/fail_execution": typeof workflows_executions_fail_execution;
   "workflows/executions/get_execution": typeof workflows_executions_get_execution;
   "workflows/executions/get_execution_step_journal": typeof workflows_executions_get_execution_step_journal;
+  "workflows/executions/get_org_workflow_metrics": typeof workflows_executions_get_org_workflow_metrics;
   "workflows/executions/get_raw_execution": typeof workflows_executions_get_raw_execution;
   "workflows/executions/get_workflow_execution_stats": typeof workflows_executions_get_workflow_execution_stats;
   "workflows/executions/helpers": typeof workflows_executions_helpers;

--- a/services/platform/convex/wf_executions/queries.ts
+++ b/services/platform/convex/wf_executions/queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 
 import { queryWithRLS } from '../lib/rls';
 import { getExecutionStepJournal as getExecutionStepJournalHelper } from '../workflows/executions/get_execution_step_journal';
+import { getOrgWorkflowMetrics as getOrgWorkflowMetricsHelper } from '../workflows/executions/get_org_workflow_metrics';
 import { getRawExecution as getRawExecutionHelper } from '../workflows/executions/get_raw_execution';
 import { listExecutionsCursor as listExecutionsCursorHelper } from '../workflows/executions/list_executions_cursor';
 import { listExecutionsPaginatedNative } from '../workflows/executions/list_executions_paginated_native';
@@ -76,6 +77,16 @@ export const getExecutionStatus = queryWithRLS({
       completedAt: exec.completedAt,
       output: exec.output,
     };
+  },
+});
+
+export const getOrgWorkflowMetrics = queryWithRLS({
+  args: {
+    organizationId: v.string(),
+    periodDays: v.union(v.literal(7), v.literal(30), v.literal(90)),
+  },
+  handler: async (ctx, args) => {
+    return await getOrgWorkflowMetricsHelper(ctx, args);
   },
 });
 

--- a/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
+++ b/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
@@ -1,0 +1,203 @@
+import type { QueryCtx } from '../../_generated/server';
+
+export type PeriodDays = 7 | 30 | 90;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_SCAN = 5000;
+
+export type GetOrgWorkflowMetricsArgs = {
+  organizationId: string;
+  periodDays: PeriodDays;
+};
+
+export type OrgWorkflowSummary = {
+  total: number;
+  completed: number;
+  failed: number;
+  running: number;
+  successRate: number;
+  avgExecutionTimeSeconds: number;
+  lastExecution: number | null;
+  capped: boolean;
+};
+
+export type OrgWorkflowSeriesPoint = {
+  dateKey: string;
+  completed: number;
+  failed: number;
+  running: number;
+};
+
+export type OrgWorkflowTopItem = {
+  wfDefinitionId: string | null;
+  workflowSlug: string | null;
+  total: number;
+  completed: number;
+  failed: number;
+  successRate: number;
+  avgExecutionTimeSeconds: number;
+  lastExecution: number | null;
+};
+
+export type OrgWorkflowMetrics = {
+  summary: OrgWorkflowSummary;
+  series: OrgWorkflowSeriesPoint[];
+  topWorkflows: OrgWorkflowTopItem[];
+};
+
+interface WorkflowBucket {
+  wfDefinitionId: string | null;
+  workflowSlug: string | null;
+  total: number;
+  completed: number;
+  failed: number;
+  durationSumMs: number;
+  durationCount: number;
+  lastExecution: number;
+}
+
+function utcDateKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function utcDayStart(ts: number): number {
+  const d = new Date(ts);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+export async function getOrgWorkflowMetrics(
+  ctx: QueryCtx,
+  args: GetOrgWorkflowMetricsArgs,
+): Promise<OrgWorkflowMetrics> {
+  const now = Date.now();
+  const windowStart = now - args.periodDays * DAY_MS;
+
+  let total = 0;
+  let completed = 0;
+  let failed = 0;
+  let running = 0;
+  let durationSumMs = 0;
+  let durationCount = 0;
+  let lastExecution: number | null = null;
+
+  const seriesMap = new Map<string, OrgWorkflowSeriesPoint>();
+  const todayStart = utcDayStart(now);
+  for (let i = args.periodDays - 1; i >= 0; i--) {
+    const dayTs = todayStart - i * DAY_MS;
+    const key = utcDateKey(dayTs);
+    seriesMap.set(key, { dateKey: key, completed: 0, failed: 0, running: 0 });
+  }
+
+  const buckets = new Map<string, WorkflowBucket>();
+
+  let scanned = 0;
+  let capped = false;
+  for await (const e of ctx.db
+    .query('wfExecutions')
+    .withIndex('by_org', (q) => q.eq('organizationId', args.organizationId))
+    .order('desc')) {
+    scanned++;
+    if (scanned > MAX_SCAN) {
+      capped = true;
+      break;
+    }
+    if (e.startedAt < windowStart) continue;
+
+    total++;
+    if (lastExecution === null || e.startedAt > lastExecution) {
+      lastExecution = e.startedAt;
+    }
+
+    const dayKey = utcDateKey(e.startedAt);
+    const seriesPoint = seriesMap.get(dayKey);
+
+    const bucketKey =
+      (typeof e.wfDefinitionId === 'string' ? e.wfDefinitionId : null) ??
+      e.workflowSlug ??
+      'unknown';
+    let bucket = buckets.get(bucketKey);
+    if (!bucket) {
+      bucket = {
+        wfDefinitionId:
+          typeof e.wfDefinitionId === 'string' ? e.wfDefinitionId : null,
+        workflowSlug: e.workflowSlug ?? null,
+        total: 0,
+        completed: 0,
+        failed: 0,
+        durationSumMs: 0,
+        durationCount: 0,
+        lastExecution: 0,
+      };
+      buckets.set(bucketKey, bucket);
+    }
+    bucket.total++;
+    if (e.startedAt > bucket.lastExecution) {
+      bucket.lastExecution = e.startedAt;
+    }
+
+    switch (e.status) {
+      case 'completed': {
+        completed++;
+        bucket.completed++;
+        if (seriesPoint) seriesPoint.completed++;
+        if (e.completedAt) {
+          const durMs = e.completedAt - e.startedAt;
+          durationSumMs += durMs;
+          durationCount++;
+          bucket.durationSumMs += durMs;
+          bucket.durationCount++;
+        }
+        break;
+      }
+      case 'failed':
+        failed++;
+        bucket.failed++;
+        if (seriesPoint) seriesPoint.failed++;
+        break;
+      case 'running':
+        running++;
+        if (seriesPoint) seriesPoint.running++;
+        break;
+    }
+  }
+
+  const avgExecutionTimeSeconds =
+    durationCount > 0 ? Math.round(durationSumMs / durationCount / 1000) : 0;
+  const successRate = total > 0 ? (completed / total) * 100 : 0;
+
+  const topWorkflows: OrgWorkflowTopItem[] = [...buckets.values()]
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10)
+    .map((b) => ({
+      wfDefinitionId: b.wfDefinitionId,
+      workflowSlug: b.workflowSlug,
+      total: b.total,
+      completed: b.completed,
+      failed: b.failed,
+      successRate: b.total > 0 ? (b.completed / b.total) * 100 : 0,
+      avgExecutionTimeSeconds:
+        b.durationCount > 0
+          ? Math.round(b.durationSumMs / b.durationCount / 1000)
+          : 0,
+      lastExecution: b.lastExecution || null,
+    }));
+
+  return {
+    summary: {
+      total,
+      completed,
+      failed,
+      running,
+      successRate,
+      avgExecutionTimeSeconds,
+      lastExecution,
+      capped,
+    },
+    series: [...seriesMap.values()],
+    topWorkflows,
+  };
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1800,6 +1800,44 @@
       "openNamed": "{name} öffnen",
       "openLoop": "Schleife öffnen"
     },
+    "metrics": {
+      "link": "Metriken anzeigen",
+      "title": "Workflow-Metriken",
+      "description": "Nutzungs- und Leistungskennzahlen über alle Automatisierungen.",
+      "cappedNotice": "Es werden die letzten 5.000 Ausführungen in diesem Zeitraum angezeigt. Ältere Ausführungen sind nicht in diesen Summen enthalten.",
+      "period": {
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "last90Days": "Letzte 90 Tage"
+      },
+      "cards": {
+        "totalRuns": "Ausführungen gesamt",
+        "successRate": "Erfolgsquote",
+        "avgDuration": "Ø Dauer",
+        "failedRuns": "Fehlgeschlagen"
+      },
+      "chart": {
+        "trendTitle": "Ausführungen im Zeitverlauf",
+        "statusTitle": "Statusverteilung",
+        "completed": "Abgeschlossen",
+        "failed": "Fehlgeschlagen",
+        "running": "Läuft"
+      },
+      "table": {
+        "title": "Top-Workflows",
+        "workflow": "Workflow",
+        "runs": "Ausführungen",
+        "successRate": "Erfolgsquote",
+        "avgDuration": "Ø Dauer",
+        "failed": "Fehlgeschlagen",
+        "lastRun": "Letzte Ausführung"
+      },
+      "empty": {
+        "title": "Keine Workflow-Ausführungen",
+        "description": "Im gewählten Zeitraum wurden keine Workflows ausgeführt.",
+        "noRuns": "Keine Ausführungen in diesem Zeitraum"
+      }
+    },
     "createButton": "Automatisierung erstellen",
     "emptyState": {
       "noSteps": "Keine Automatisierungsschritte vorhanden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1800,6 +1800,44 @@
       "openNamed": "Open {name}",
       "openLoop": "Open loop"
     },
+    "metrics": {
+      "link": "View metrics",
+      "title": "Workflow metrics",
+      "description": "Usage and performance KPIs across your automations.",
+      "cappedNotice": "Showing the most recent 5,000 runs in this window. Older runs in this period are not included in these totals.",
+      "period": {
+        "last7Days": "Last 7 days",
+        "last30Days": "Last 30 days",
+        "last90Days": "Last 90 days"
+      },
+      "cards": {
+        "totalRuns": "Total runs",
+        "successRate": "Success rate",
+        "avgDuration": "Avg duration",
+        "failedRuns": "Failed runs"
+      },
+      "chart": {
+        "trendTitle": "Runs over time",
+        "statusTitle": "Status breakdown",
+        "completed": "Completed",
+        "failed": "Failed",
+        "running": "Running"
+      },
+      "table": {
+        "title": "Top workflows",
+        "workflow": "Workflow",
+        "runs": "Runs",
+        "successRate": "Success rate",
+        "avgDuration": "Avg duration",
+        "failed": "Failed",
+        "lastRun": "Last run"
+      },
+      "empty": {
+        "title": "No workflow runs",
+        "description": "No workflows have run in the selected period.",
+        "noRuns": "No runs in this period"
+      }
+    },
     "createButton": "Create automation",
     "emptyState": {
       "noSteps": "No automation steps to display",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1798,6 +1798,44 @@
       "openNamed": "Ouvrir {name}",
       "openLoop": "Ouvrir la boucle"
     },
+    "metrics": {
+      "link": "Voir les métriques",
+      "title": "Métriques des workflows",
+      "description": "Indicateurs d'utilisation et de performance de vos automatisations.",
+      "cappedNotice": "Affichage des 5 000 exécutions les plus récentes sur cette période. Les exécutions plus anciennes ne sont pas incluses dans ces totaux.",
+      "period": {
+        "last7Days": "7 derniers jours",
+        "last30Days": "30 derniers jours",
+        "last90Days": "90 derniers jours"
+      },
+      "cards": {
+        "totalRuns": "Exécutions totales",
+        "successRate": "Taux de réussite",
+        "avgDuration": "Durée moyenne",
+        "failedRuns": "Échecs"
+      },
+      "chart": {
+        "trendTitle": "Exécutions dans le temps",
+        "statusTitle": "Répartition par statut",
+        "completed": "Terminées",
+        "failed": "Échouées",
+        "running": "En cours"
+      },
+      "table": {
+        "title": "Top workflows",
+        "workflow": "Workflow",
+        "runs": "Exécutions",
+        "successRate": "Taux de réussite",
+        "avgDuration": "Durée moyenne",
+        "failed": "Échecs",
+        "lastRun": "Dernière exécution"
+      },
+      "empty": {
+        "title": "Aucune exécution",
+        "description": "Aucun workflow n'a été exécuté sur la période sélectionnée.",
+        "noRuns": "Aucune exécution sur cette période"
+      }
+    },
     "createButton": "Créer une automatisation",
     "emptyState": {
       "noSteps": "Aucune étape d'automatisation à afficher",

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -123,6 +123,7 @@
     "react-hook-form": "7.72.1",
     "react-i18next": "17.0.2",
     "react-markdown": "10.1.0",
+    "recharts": "2.15.4",
     "rehype-raw": "7.0.0",
     "rehype-sanitize": "6.0.0",
     "remark-gfm": "4.0.1",


### PR DESCRIPTION
## Summary

- New `/dashboard/:id/automations/metrics` page with org-wide KPIs (total runs, success rate, avg duration, failed runs), a daily runs-over-time bar chart, a status donut, and a top-workflows table whose rows link to the existing per-workflow executions view.
- 7 / 30 / 90-day period selector, URL-persistent via `?period=`. Gated by the same ability check used for the automations list.
- Backend: `getOrgWorkflowMetrics` RPC aggregates `wfExecutions` with a 5,000-row scan cap, pre-seeds daily series buckets so empty days render as zero, and groups per-workflow stats. Adds `recharts` for the charts.

## Test plan

- [ ] Run `bunx tsc --noEmit` and `bunx oxlint --type-aware` from `services/platform/` — both clean
- [ ] Open `/dashboard/:id/automations`, click **View metrics** — page renders with 4 stat cards, trend chart, status donut, and top-workflows table
- [ ] Change period selector (7 / 30 / 90) — data refetches and `?period=` updates in URL
- [ ] Click a row in top-workflows — navigates to that workflow's existing executions tab
- [ ] Verify org with zero runs in window shows clean empty states (no chart noise, empty table with CTA)
- [ ] Switch locale to `de` / `fr` — all labels translated, no raw i18n keys leak
- [ ] As a user without `write` on `wfDefinitions`, visit `/automations/metrics` — `<AccessDenied />` renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Automation Metrics dashboard displaying execution trends, status breakdown, and top workflows overview
  * Added selectable reporting periods (7, 30, and 90 days) for flexible metric analysis
  * Added quick access link in automations table to view detailed metrics

* **Chores**
  * Added charting library for metrics visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->