### PR TITLE
feat(platform): in-product changelog notification for non-admin users

### DIFF
--- a/docs/release-notes-format.md
+++ b/docs/release-notes-format.md
@@ -1,0 +1,89 @@
+# Release Notes Format
+
+Authoritative format for GitHub Release notes on `tale-project/tale`. The `/release` slash command drafts notes against this spec, and the in-product "What's new" link takes users directly to these releases.
+
+## Why this spec exists
+
+Operators and end-users rely on release notes to know:
+- Whether a security fix affects them.
+- Whether a model or provider change will shift their workflow outputs.
+- Whether an upgrade requires manual steps.
+
+Consistent sectioning — in a consistent order — makes it easy to scan a release for the three things above without reading every bullet.
+
+## Required sections
+
+Include only the sections that have content. Always use this order:
+
+| Order | Section header | Scope |
+|-------|----------------|-------|
+| 1 | `## 🔒 Security` | CVE fixes, dependency patches, auth/session/crypto hardening, secret handling |
+| 2 | `## 🤖 Model & Provider` | LLM model swap/upgrade/deprecation, provider config changes that alter output |
+| 3 | `## 💥 Breaking Changes` | API removal/renaming, schema changes requiring manual migration, removed features |
+| 4 | `## 🚀 Features` | New user-visible functionality |
+| 5 | `## ⚡ Performance` | Measurable performance wins worth calling out |
+| 6 | `## 🛠 Improvements` | Non-breaking enhancements, UX polish |
+| 7 | `## 🐛 Fixes` | Bug fixes (non-security) |
+| 8 | `## 📝 Other` | Docs, refactors, chores — include sparingly |
+
+## Required framing
+
+Every release must include, at minimum:
+
+1. **Title**: `v{version} — {short tagline}`, e.g. `v1.6.0 — Usage analytics & multi-tenancy`.
+2. **Summary**: 2–3 sentences at the top describing what changed and why. No emoji.
+3. **Upgrade instructions**:
+   ```markdown
+   ## Upgrade
+
+   Run `tale upgrade` to update the CLI, then `tale deploy` to apply the new version.
+   ```
+   Both steps are required — `tale upgrade` fetches the new CLI, `tale deploy` applies it. Omitting either leaves the deployment on the old version.
+4. **Manual migration notes** (only when relevant): if any breaking change requires operator action beyond `tale deploy`, include a `## Migration Guide` section with numbered steps.
+5. **Full Changelog link** at the bottom:
+   ```markdown
+   **Full Changelog**: https://github.com/tale-project/tale/compare/v{previous}...v{new}
+   ```
+
+## Classification rules
+
+- **Security**: anything touching authentication, session, secrets storage, crypto, or reachable dependency CVEs. When in doubt, classify as security AND file a [Security Advisory](./security-advisories.md).
+- **Model & Provider**: any change that could alter LLM output for the same user input — model bumps, provider swaps, prompt/template changes in default agents.
+- **Breaking Changes**: users or operators must do something to keep working after upgrade. If upgrade "just works," it is not breaking.
+- **Other**: only for changes worth mentioning that fit nowhere else. Trivial chores (typo fixes, internal refactors, test-only changes) should be omitted.
+
+## Example
+
+```markdown
+# v1.6.0 — Usage analytics & multi-tenancy
+
+This release adds time-based usage analytics, hardens multi-tenant org isolation,
+and bumps the default reasoning model. No breaking changes.
+
+## 🔒 Security
+- Tighten org-scoping on governance policy queries (#1573)
+
+## 🤖 Model & Provider
+- Default reasoning model bumped from Opus 4.6 → Opus 4.7 (#1590)
+
+## 🚀 Features
+- Time-based usage analytics dashboard under `/metrics/usage` (#1574)
+- Multi-org support: users can belong to multiple organizations (#1573)
+
+## 🛠 Improvements
+- Tabs underline variant adopted across settings surfaces (#1571)
+
+## 🐛 Fixes
+- Fix prompt library sidebar scroll on short viewports (#1572)
+
+## Upgrade
+
+Run `tale upgrade` to update the CLI, then `tale deploy` to apply the new version.
+
+**Full Changelog**: https://github.com/tale-project/tale/compare/v1.5.2...v1.6.0
+```
+
+## Related
+
+- [`/release` slash command](../.claude/commands/release.md) — drafts notes following this spec.
+- [Security advisory process](./security-advisories.md) — when to also file a GitHub Security Advisory.

--- a/docs/security-advisories.md
+++ b/docs/security-advisories.md
@@ -1,0 +1,60 @@
+# Security Advisory Process
+
+How Tale coordinates, files, and publishes security-relevant fixes.
+
+## Channels
+
+- **Primary**: [GitHub Security Advisories](https://github.com/tale-project/tale/security/advisories) on `tale-project/tale`. Advisories are drafted privately, linked to CVE when applicable, then published after a patched release is available.
+- **Secondary**: every advisory is cross-referenced in the corresponding GitHub Release notes under the `## 🔒 Security` section (see [release-notes-format.md](./release-notes-format.md)).
+- **Direct notification** (manual, for now): critical advisories are emailed to known deployment operators. There is no automated operator email list yet — this is a future work item.
+
+## When to file an advisory
+
+File a GitHub Security Advisory when any of the following applies:
+
+- CVSS v3.1 score ≥ 4.0 (Medium or higher).
+- Any bug that could leak secrets across tenants, leak session tokens, or escalate privileges.
+- Any fix in authentication, session, organization-scoping, crypto, or secrets storage — even if no external report triggered it.
+- Any reachable dependency CVE (the vulnerable code path is exercised by Tale).
+
+**Do not** file an advisory for dependency CVEs whose code paths are demonstrably unreachable by Tale — document those in the normal `## 🔒 Security` release notes section instead, with a note on why they are not exploitable here.
+
+## Severity → escalation matrix
+
+| CVSS | Advisory | Release notes | Direct email to operators |
+|------|----------|---------------|---------------------------|
+| Critical (9.0+) | Required | Required, prominent summary | Yes — before public disclosure if coordinated, otherwise at publish |
+| High (7.0–8.9) | Required | Required | Only if exploitation requires no user action |
+| Medium (4.0–6.9) | Required | Required | No |
+| Low (<4.0) | Optional | Required | No |
+
+## Timeline
+
+1. **Private draft** in GitHub Security Advisory. Include affected versions, description, severity estimate.
+2. **Request CVE** via GitHub's advisory UI if severity ≥ Medium.
+3. **Prepare patched release** on a private fork/branch. Do not push patches to `main` before the advisory is ready to publish.
+4. **Coordinated disclosure** with the reporter if externally reported — typically 90 days max embargo, shorter for actively exploited issues.
+5. **Publish advisory** simultaneously with the patched `tale upgrade` availability. Reference the CVE and the release tag.
+6. **Cross-link** in the release notes for the patched version.
+
+## What to include in an advisory
+
+- Affected versions (range or list).
+- Patched version (exact tag, e.g. `v1.6.1`).
+- Summary of impact — what an attacker could do.
+- Prerequisites — network position, auth state, feature flags required to exploit.
+- Workarounds for operators who cannot upgrade immediately.
+- Credits to the reporter (with permission).
+
+## Operator action
+
+Operators should:
+
+- Watch `tale-project/tale` releases (`GitHub → Watch → Custom → Security advisories` is free, no platform work needed).
+- Treat `## 🔒 Security` entries in release notes as an upgrade prompt.
+- Subscribe to the direct notification list (once it exists) for critical-only alerts.
+
+## Related
+
+- [Release notes format](./release-notes-format.md) — where Security entries live in notes.
+- [`/release` slash command](../.claude/commands/release.md) — drafts the Security section.

--- a/services/platform/app/components/__tests__/user-button.test.tsx
+++ b/services/platform/app/components/__tests__/user-button.test.tsx
@@ -29,6 +29,17 @@ vi.mock('@/app/hooks/use-toast', () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
+vi.mock('@/app/hooks/use-changelog-notification', () => ({
+  useChangelogNotification: () => ({
+    currentVersion: undefined,
+    hasUnseenVersion: false,
+    shouldShowToast: false,
+    releaseUrl: null,
+    markSeen: vi.fn(),
+    markToasted: vi.fn(),
+  }),
+}));
+
 // Mock theme
 const mockSetTheme = vi.fn();
 vi.mock('@/app/components/theme/theme-provider', () => ({

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -32,6 +32,7 @@ import {
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { Text } from '@/app/components/ui/typography/text';
 import { useUserOrganizationsWithDetails } from '@/app/features/organization/hooks/queries';
+import { useChangelogNotification } from '@/app/hooks/use-changelog-notification';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { useLocale } from '@/app/hooks/use-locale';
@@ -73,6 +74,13 @@ export function UserButton({
 
   const { organizations: userOrgs } = useUserOrganizationsWithDetails();
   const availableOrgs = useMemo(() => userOrgs ?? [], [userOrgs]);
+
+  const {
+    currentVersion,
+    hasUnseenVersion,
+    releaseUrl,
+    markSeen: markChangelogSeen,
+  } = useChangelogNotification();
 
   const location = useLocation();
   const switchOrganization = useCallback(
@@ -156,6 +164,23 @@ export function UserButton({
                   <Text className="font-semibold">{displayName}</Text>
                   {displayName !== user.email && (
                     <Text variant="muted">{user.email}</Text>
+                  )}
+                  {currentVersion && releaseUrl && (
+                    <Text variant="muted" className="text-xs">
+                      {t('userButton.currentVersion', {
+                        version: currentVersion,
+                      })}
+                      {' · '}
+                      <a
+                        href={releaseUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={markChangelogSeen}
+                        className="text-foreground cursor-pointer underline underline-offset-2 hover:opacity-80"
+                      >
+                        {t('userButton.whatsNew')}
+                      </a>
+                    </Text>
                   )}
                 </>
               )}
@@ -344,6 +369,9 @@ export function UserButton({
     handleSignOutClick,
     availableOrgs,
     switchOrganization,
+    currentVersion,
+    releaseUrl,
+    markChangelogSeen,
   ]);
 
   const triggerContent = (
@@ -353,7 +381,15 @@ export function UserButton({
         label ? 'gap-3 px-3 py-2 w-full' : 'justify-center p-2',
       )}
     >
-      <UserCircle className="text-muted-foreground size-5 shrink-0" />
+      <div className="relative">
+        <UserCircle className="text-muted-foreground size-5 shrink-0" />
+        {hasUnseenVersion && (
+          <span
+            className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-red-500"
+            aria-hidden="true"
+          />
+        )}
+      </div>
       {label && (
         <Text as="span" variant="label">
           {label}

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -176,9 +176,15 @@ export function UserButton({
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={markChangelogSeen}
-                        className="text-foreground cursor-pointer underline underline-offset-2 hover:opacity-80"
+                        className="text-foreground relative inline-flex cursor-pointer items-center underline underline-offset-2 hover:opacity-80"
                       >
                         {t('userButton.whatsNew')}
+                        {hasUnseenVersion && (
+                          <span
+                            className="ml-1.5 size-1.5 rounded-full bg-red-500"
+                            aria-hidden="true"
+                          />
+                        )}
                       </a>
                     </Text>
                   )}
@@ -372,6 +378,7 @@ export function UserButton({
     currentVersion,
     releaseUrl,
     markChangelogSeen,
+    hasUnseenVersion,
   ]);
 
   const triggerContent = (

--- a/services/platform/app/features/changelog/components/changelog-toast-trigger.tsx
+++ b/services/platform/app/features/changelog/components/changelog-toast-trigger.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { useEffect, useRef } from 'react';
+
+import { useChangelogNotification } from '@/app/hooks/use-changelog-notification';
+import { toast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * Fires a one-shot toast when the user's last-toasted version is older
+ * than the current deployment version. After the toast dispatches the
+ * client records `markToasted`, so the same version never re-toasts —
+ * even across sessions. The red dot on UserButton persists separately
+ * (governed by `markSeen`) until the user actually views the release
+ * notes.
+ */
+export function ChangelogToastTrigger() {
+  const { t } = useT('changelog');
+  const { shouldShowToast, currentVersion, releaseUrl, markSeen, markToasted } =
+    useChangelogNotification();
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (!shouldShowToast || !currentVersion || !releaseUrl) return;
+    if (firedRef.current) return;
+    firedRef.current = true;
+
+    toast({
+      duration: 15_000,
+      title: t('toast.title', { version: currentVersion }),
+      description: t('toast.description'),
+      action: (
+        <ToastPrimitives.Action altText={t('toast.action')} asChild>
+          <a
+            href={releaseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => {
+              markSeen();
+            }}
+            className="bg-foreground text-background inline-flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-medium transition-colors hover:opacity-90"
+          >
+            {t('toast.action')}
+          </a>
+        </ToastPrimitives.Action>
+      ),
+    });
+    markToasted();
+  }, [shouldShowToast, currentVersion, releaseUrl, markSeen, markToasted, t]);
+
+  return null;
+}

--- a/services/platform/app/hooks/use-changelog-notification.ts
+++ b/services/platform/app/hooks/use-changelog-notification.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useMutation, useQuery } from 'convex/react';
+
+import { api } from '@/convex/_generated/api';
+import { getEnv } from '@/lib/env';
+
+const GITHUB_RELEASES_BASE =
+  'https://github.com/tale-project/tale/releases/tag';
+
+// True when `candidate` is strictly newer than `baseline` using
+// dot-separated integer comparison (e.g. "1.10.0" > "1.9.9"). Missing
+// baseline means "never acknowledged" → treat anything as newer.
+export function isNewer(
+  candidate: string,
+  baseline: string | undefined | null,
+): boolean {
+  if (!baseline) return true;
+  const parse = (v: string) =>
+    v.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const a = parse(candidate);
+  const b = parse(baseline);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai !== bi) return ai > bi;
+  }
+  return false;
+}
+
+interface ChangelogNotification {
+  currentVersion: string | undefined;
+  hasUnseenVersion: boolean;
+  shouldShowToast: boolean;
+  releaseUrl: string | null;
+  markSeen: () => void;
+  markToasted: () => void;
+}
+
+export function useChangelogNotification(): ChangelogNotification {
+  const currentVersion = getEnv('TALE_VERSION');
+  const state = useQuery(
+    api.users.notification_state.getUserNotificationState,
+    currentVersion ? {} : 'skip',
+  );
+  const markSeenMutation = useMutation(
+    api.users.notification_state.markChangelogSeen,
+  );
+  const markToastedMutation = useMutation(
+    api.users.notification_state.markToastShown,
+  );
+
+  // `state === undefined` means the query is still loading; we hold back
+  // toast/dot until we know whether the user has acknowledged the version
+  // to avoid a spurious flash.
+  const stateLoaded = state !== undefined;
+
+  const hasUnseenVersion =
+    !!currentVersion &&
+    stateLoaded &&
+    isNewer(currentVersion, state?.lastSeenChangelogVersion ?? null);
+
+  const shouldShowToast =
+    !!currentVersion &&
+    stateLoaded &&
+    isNewer(currentVersion, state?.lastToastedVersion ?? null);
+
+  const releaseUrl = currentVersion
+    ? `${GITHUB_RELEASES_BASE}/v${currentVersion}`
+    : null;
+
+  return {
+    currentVersion,
+    hasUnseenVersion,
+    shouldShowToast,
+    releaseUrl,
+    markSeen: () => {
+      if (!currentVersion) return;
+      void markSeenMutation({ version: currentVersion });
+    },
+    markToasted: () => {
+      if (!currentVersion) return;
+      void markToastedMutation({ version: currentVersion });
+    },
+  };
+}

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -21,6 +21,7 @@ import {
 import { TwoFactorGraceBanner } from '@/app/features/auth/components/two-factor-grace-banner';
 import { TwoFactorLowBackupCodesBanner } from '@/app/features/auth/components/two-factor-low-backup-codes-banner';
 import { usePasswordExpiryGate } from '@/app/features/auth/hooks/use-password-expiry-gate';
+import { ChangelogToastTrigger } from '@/app/features/changelog/components/changelog-toast-trigger';
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { TeamFilterProvider } from '@/app/hooks/use-team-filter';
@@ -152,6 +153,7 @@ function DashboardLayout() {
                     organizationId={organizationId}
                   />
                 )}
+                {hasRole && <ChangelogToastTrigger />}
                 {isSwitching ? (
                   <FullPageCenter>
                     <VStack gap={3} align="center">

--- a/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
@@ -87,6 +87,10 @@ vi.mock(
   }),
 );
 
+vi.mock('@/app/features/changelog/components/changelog-toast-trigger', () => ({
+  ChangelogToastTrigger: () => null,
+}));
+
 vi.mock('@convex-dev/react-query', () => ({
   convexQuery: vi.fn(),
 }));

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -696,6 +696,7 @@ import type * as users_has_any_users from "../users/has_any_users.js";
 import type * as users_helpers from "../users/helpers.js";
 import type * as users_internal_mutations from "../users/internal_mutations.js";
 import type * as users_mutations from "../users/mutations.js";
+import type * as users_notification_state from "../users/notification_state.js";
 import type * as users_password_metadata from "../users/password_metadata.js";
 import type * as users_queries from "../users/queries.js";
 import type * as users_reset_owner from "../users/reset_owner.js";
@@ -1662,6 +1663,7 @@ declare const fullApi: ApiFromModules<{
   "users/helpers": typeof users_helpers;
   "users/internal_mutations": typeof users_internal_mutations;
   "users/mutations": typeof users_mutations;
+  "users/notification_state": typeof users_notification_state;
   "users/password_metadata": typeof users_password_metadata;
   "users/queries": typeof users_queries;
   "users/reset_owner": typeof users_reset_owner;

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -39,7 +39,10 @@ import { messageMetadataTable } from './streaming/schema';
 import { threadBranchesTable } from './threads/branch_schema';
 import { threadMetadataTable } from './threads/schema';
 import { twoFactorAttemptsTable } from './two_factor/schema';
-import { userPasswordMetadataTable } from './users/schema';
+import {
+  userNotificationStateTable,
+  userPasswordMetadataTable,
+} from './users/schema';
 import { vendorsTable } from './vendors/schema';
 import { websitesTable } from './websites/schema';
 import {
@@ -93,6 +96,7 @@ export default defineSchema({
   threadMetadata: threadMetadataTable,
   twoFactorAttempts: twoFactorAttemptsTable,
   userPasswordMetadata: userPasswordMetadataTable,
+  userNotificationState: userNotificationStateTable,
   products: productsTable,
   ssoProviders: ssoProvidersTable,
   vendors: vendorsTable,

--- a/services/platform/convex/users/notification_state.ts
+++ b/services/platform/convex/users/notification_state.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-user notification acknowledgment state.
+ *
+ * Tracks which changelog version the user has explicitly seen (clicked
+ * "What's new") and which version has already triggered the upgrade
+ * toast. Keeping these separate lets the toast fire exactly once per
+ * version while the red-dot indicator persists until the user actually
+ * views the release notes.
+ */
+
+import { v } from 'convex/values';
+
+import { mutation, query } from '../_generated/server';
+import { getAuthUserIdentity } from '../lib/rls';
+
+const notificationStateShape = v.object({
+  userId: v.string(),
+  lastSeenChangelogVersion: v.optional(v.string()),
+  lastToastedVersion: v.optional(v.string()),
+  updatedAt: v.number(),
+});
+
+export const getUserNotificationState = query({
+  args: {},
+  returns: v.union(notificationStateShape, v.null()),
+  handler: async (ctx) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return null;
+
+    const row = await ctx.db
+      .query('userNotificationState')
+      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
+      .first();
+
+    if (!row) return null;
+    return {
+      userId: row.userId,
+      lastSeenChangelogVersion: row.lastSeenChangelogVersion,
+      lastToastedVersion: row.lastToastedVersion,
+      updatedAt: row.updatedAt,
+    };
+  },
+});
+
+export const markToastShown = mutation({
+  args: { version: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { version }) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const existing = await ctx.db
+      .query('userNotificationState')
+      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
+      .first();
+
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        lastToastedVersion: version,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert('userNotificationState', {
+        userId: authUser.userId,
+        lastToastedVersion: version,
+        updatedAt: now,
+      });
+    }
+    return null;
+  },
+});
+
+export const markChangelogSeen = mutation({
+  args: { version: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { version }) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const existing = await ctx.db
+      .query('userNotificationState')
+      .withIndex('by_userId', (q) => q.eq('userId', authUser.userId))
+      .first();
+
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        lastSeenChangelogVersion: version,
+        lastToastedVersion: version,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert('userNotificationState', {
+        userId: authUser.userId,
+        lastSeenChangelogVersion: version,
+        lastToastedVersion: version,
+        updatedAt: now,
+      });
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/users/schema.ts
+++ b/services/platform/convex/users/schema.ts
@@ -12,3 +12,16 @@ export const userPasswordMetadataTable = defineTable({
   passwordChangedAt: v.number(),
   forceChangeOnNextLogin: v.optional(v.boolean()),
 }).index('by_userId', ['userId']);
+
+// Per-user notification acknowledgment state.
+// `lastSeenChangelogVersion` is set when the user explicitly views the
+// release notes (clicks "What's new"); the red dot stays until then.
+// `lastToastedVersion` advances whenever the toast is displayed, so the
+// toast never fires twice for the same version even if the user closes
+// it without viewing.
+export const userNotificationStateTable = defineTable({
+  userId: v.string(),
+  lastSeenChangelogVersion: v.optional(v.string()),
+  lastToastedVersion: v.optional(v.string()),
+  updatedAt: v.number(),
+}).index('by_userId', ['userId']);

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -515,6 +515,8 @@
       "manageAccount": "Konto verwalten",
       "settings": "Einstellungen",
       "helpFeedback": "Hilfe & Feedback",
+      "currentVersion": "Aktuelle Version: v{version}",
+      "whatsNew": "Neuigkeiten",
       "themeSystem": "Systemdesign",
       "themeLight": "Helles Design",
       "themeDark": "Dunkles Design",
@@ -4491,6 +4493,13 @@
         "title": "Noch keine Nutzung",
         "description": "Für den ausgewählten Zeitraum wurde keine KI-Nutzung erfasst."
       }
+    }
+  },
+  "changelog": {
+    "toast": {
+      "title": "Aktualisiert auf v{version}",
+      "description": "Sehen Sie sich die Änderungen in dieser Version an.",
+      "action": "Anzeigen"
     }
   }
 }

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -515,6 +515,8 @@
       "manageAccount": "Manage account",
       "settings": "Settings",
       "helpFeedback": "Help & feedback",
+      "currentVersion": "Current version: v{version}",
+      "whatsNew": "What's new",
       "themeSystem": "System theme",
       "themeLight": "Light theme",
       "themeDark": "Dark theme",
@@ -4498,6 +4500,13 @@
         "title": "No usage yet",
         "description": "No AI usage has been recorded for the selected period."
       }
+    }
+  },
+  "changelog": {
+    "toast": {
+      "title": "Upgraded to v{version}",
+      "description": "See what changed in this release.",
+      "action": "View"
     }
   }
 }

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -515,6 +515,8 @@
       "manageAccount": "Gérer le compte",
       "settings": "Paramètres",
       "helpFeedback": "Aide et retours",
+      "currentVersion": "Version actuelle : v{version}",
+      "whatsNew": "Nouveautés",
       "themeSystem": "Thème système",
       "themeLight": "Thème clair",
       "themeDark": "Thème sombre",
@@ -4320,5 +4322,12 @@
       "similarityScore": "Similarité : {score} %"
     },
     "noResults": "Aucun résultat de comparaison pour le moment."
+  },
+  "changelog": {
+    "toast": {
+      "title": "Mis à jour vers v{version}",
+      "description": "Découvrez les changements de cette version.",
+      "action": "Voir"
+    }
   }
 }

--- a/services/platform/vite-plugins/inject-env.ts
+++ b/services/platform/vite-plugins/inject-env.ts
@@ -7,6 +7,7 @@ interface EnvConfig {
   FILE_EVENTS_ENABLED: boolean;
   SENTRY_DSN?: string;
   SENTRY_TRACES_SAMPLE_RATE: number;
+  TALE_VERSION?: string;
 }
 
 function getEnvConfig(): EnvConfig {
@@ -22,6 +23,7 @@ function getEnvConfig(): EnvConfig {
     SENTRY_TRACES_SAMPLE_RATE: parseFloat(
       process.env.SENTRY_TRACES_SAMPLE_RATE || '1.0',
     ),
+    TALE_VERSION: process.env.TALE_VERSION,
   };
 }
 


### PR DESCRIPTION
## Summary

- Close the gap for operators and end users who don't watch GitHub releases — surface upgrade notices inside the product via a one-shot toast, a red-dot indicator on the UserButton, and a "Current version · What's new" link in the user dropdown that opens the matching GitHub release.
- Add a per-user `userNotificationState` table (independent of Better Auth's auto-generated schema, following the `userPasswordMetadata` precedent) that tracks `lastToastedVersion` and `lastSeenChangelogVersion` separately — the toast never repeats for a version, while the red dot persists until the user explicitly views the release.
- Introduce companion process docs: `docs/release-notes-format.md` defines an 8-section classification spec (adding 🔒 Security and 🤖 Model & Provider categories) that backs the release notes the "What's new" link points to; `docs/security-advisories.md` documents the severity matrix and timeline for GitHub Security Advisories.
- Dev-mode vite plugin now injects `TALE_VERSION` so the client can read `window.__ENV__.TALE_VERSION` (production server path already did this).

### Design notes

- **Entry point is in the user dropdown**, not a standalone page. Version is deployment-wide so rendering changelog content inside the platform would just duplicate GitHub. The UserButton header shows "Current version: v{version} · What's new" where the version tells users which version they're on and the link is the action.
- **No role filtering** — all logged-in users see the same indicator. Platform changes affect everyone, not just admins.
- **Per-user, not per-org** — switching orgs does not re-trigger the toast. Version state lives on the user, tracked via `userId`.
- **No one-shot migration**: existing users will see the toast exactly once on the release that ships this feature. That is accurate — the feature itself is what is new.

### Out of scope

- In-product changelog rendering page, email notifications, NotificationBell integration, role-based filtering. All deferred until there's concrete demand.

## Test plan

- [ ] `TALE_VERSION=1.5.0 npm run dev --workspace=@tale/platform` and log in as an existing user → toast "Upgraded to v1.5.0" fires, red dot appears on avatar and beside "What's new" in dropdown, Convex `userNotificationState` row gets `lastToastedVersion: "1.5.0"`, `lastSeenChangelogVersion` empty
- [ ] Refresh → toast does NOT re-fire, red dot persists
- [ ] Click "What's new" link in dropdown → new tab opens `github.com/tale-project/tale/releases/tag/v1.5.0`, both red dots disappear, row gets `lastSeenChangelogVersion: "1.5.0"`
- [ ] Bump to `TALE_VERSION=1.6.0`, restart dev, refresh → toast fires for v1.6.0, red dots return
- [ ] Close toast (×) without clicking View → red dots remain, toast does not re-fire on refresh
- [ ] Switch between orgs (A has multiple memberships) → no re-trigger; state is per-user
- [ ] Unset `TALE_VERSION` → no toast, no red dot, no "What's new" line in dropdown (graceful degradation)
- [ ] Downgrade (set `TALE_VERSION` to older) → no toast, no red dot (`isNewer` returns false)
- [ ] Mobile navigation → UserButton with `label` prop shows red dot on avatar and same dropdown content
- [ ] `npm run typecheck --workspace=@tale/platform` passes
- [ ] `npm run lint --workspace=@tale/platform` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Version information is now displayed in the user menu with a "What's new" link for quick access to release notes
  * Visual notification badges indicate when new versions are available
  * Toast notifications automatically prompt users to review changes in newly released versions with direct access to release notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->