### PR TITLE
feat(platform): image-generation agents with FLUX and Gemini

### DIFF
--- a/examples/agents/image-creator.json
+++ b/examples/agents/image-creator.json
@@ -1,16 +1,44 @@
 {
   "displayName": "Image Creator",
-  "description": "Generate and edit images using AI. Describe what you want, and I'll create or modify images for you.",
-  "systemInstructions": "You are a helpful assistant.",
-  "integrationBindings": ["ai-image"],
+  "description": "Generates and edits images from text prompts using FLUX, Imagen, or Nano Banana.",
+  "primaryBehavior": "image-generation",
   "supportedModels": [
-    "openrouter:moonshotai/kimi-k2.5",
-    "openrouter:anthropic/claude-sonnet-4.6"
+    "vercel-gateway:bfl/flux-2-pro",
+    "vercel-gateway:bfl/flux-pro-1.1-ultra",
+    "vercel-gateway:bfl/flux-kontext-pro",
+    "vercel-gateway:bfl/flux-kontext-max",
+    "vercel-gateway:google/imagen-4.0-generate-001",
+    "vercel-gateway:google/imagen-4.0-fast-generate-001",
+    "vercel-gateway:google/imagen-4.0-ultra-generate-001",
+    "vercel-gateway:google/gemini-2.5-flash-image",
+    "openrouter:black-forest-labs/flux.2-pro",
+    "openrouter:black-forest-labs/flux.2-max",
+    "openrouter:black-forest-labs/flux.2-flex"
   ],
+  "timeoutMs": 120000,
+  "composerMode": {
+    "label": "Image generation",
+    "icon": "image",
+    "tooltip": "Generate or edit images from a description",
+    "order": 30
+  },
   "conversationStarters": [
     "Generate a product photo for a minimalist white coffee mug",
     "Create a watercolor illustration of a sunset over the ocean",
     "Design a social media banner for a summer sale event",
     "Generate a logo concept for a tech startup called 'NovaByte'"
-  ]
+  ],
+  "visibleInChat": true,
+  "i18n": {
+    "de": {
+      "displayName": "Bildgenerator",
+      "description": "Erzeugt und bearbeitet Bilder aus Textbeschreibungen mit FLUX, Imagen oder Nano Banana.",
+      "conversationStarters": [
+        "Erzeuge ein Produktfoto einer minimalistischen weißen Kaffeetasse",
+        "Erstelle eine Aquarell-Illustration eines Sonnenuntergangs über dem Meer",
+        "Entwirf ein Social-Media-Banner für einen Sommerschlussverkauf",
+        "Erzeuge ein Logo-Konzept für ein Tech-Startup namens 'NovaByte'"
+      ]
+    }
+  }
 }

--- a/examples/providers/openrouter.json
+++ b/examples/providers/openrouter.json
@@ -191,6 +191,38 @@
         "inputCentsPerMillion": 8,
         "outputCentsPerMillion": 30
       }
+    },
+    {
+      "id": "black-forest-labs/flux.2-pro",
+      "displayName": "FLUX.2 [pro]",
+      "description": "Frontier-level image generation and editing from Black Forest Labs. Served via OpenRouter's chat/completions endpoint with multimodal output.",
+      "tags": ["image-generation", "image-edit"],
+      "imageGenerationMode": "chat-multimodal",
+      "cost": { "imageCentsPerImage": 6 }
+    },
+    {
+      "id": "black-forest-labs/flux.2-max",
+      "displayName": "FLUX.2 [max]",
+      "description": "Top-tier FLUX.2 variant; highest quality and editing consistency. Served via OpenRouter's chat/completions endpoint with multimodal output.",
+      "tags": ["image-generation", "image-edit"],
+      "imageGenerationMode": "chat-multimodal",
+      "cost": { "imageCentsPerImage": 9 }
+    },
+    {
+      "id": "black-forest-labs/flux.2-flex",
+      "displayName": "FLUX.2 [flex]",
+      "description": "FLUX.2 variant tuned for complex text, typography, and multi-reference editing. Served via OpenRouter's chat/completions endpoint with multimodal output.",
+      "tags": ["image-generation", "image-edit"],
+      "imageGenerationMode": "chat-multimodal",
+      "cost": { "imageCentsPerImage": 4 }
+    },
+    {
+      "id": "google/gemini-2.5-flash-image",
+      "displayName": "Nano Banana (Gemini 2.5 Flash Image)",
+      "description": "Gemini 2.5 multimodal image generation + editing. Supports reference images.",
+      "tags": ["image-generation", "image-edit"],
+      "imageGenerationMode": "chat-multimodal",
+      "cost": { "imageCentsPerImage": 4 }
     }
   ],
   "i18n": {

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -352,19 +352,28 @@ function SearchableSelectOptionItem({
       )}
     >
       {showRadio && (
+        // Outer wrapper matches the first label-row height (~24px, driven by
+        // the optional badge's line-height + py) and centers the 16px radio
+        // within it. Without this, `items-start` on the parent would top-align
+        // the smaller radio against a taller label+badge row, leaving the
+        // circle visibly above the badge's vertical center.
         <span
           aria-hidden="true"
-          className={cn(
-            'border-border bg-background pointer-events-none flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-150',
-            isSelected && 'border-blue-600',
-          )}
+          className="pointer-events-none flex h-6 shrink-0 items-center"
         >
-          {isSelected && (
-            <Circle
-              className="size-2.5 fill-blue-600 text-blue-600"
-              aria-hidden="true"
-            />
-          )}
+          <span
+            className={cn(
+              'border-border bg-background flex size-4 items-center justify-center rounded-full border transition-colors duration-150',
+              isSelected && 'border-blue-600',
+            )}
+          >
+            {isSelected && (
+              <Circle
+                className="size-2.5 fill-blue-600 text-blue-600"
+                aria-hidden="true"
+              />
+            )}
+          </span>
         </span>
       )}
       <div className="min-w-0 flex-1">

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -19,6 +19,11 @@ import { cn } from '@/lib/utils/cn';
 export interface SearchableSelectOption {
   value: string;
   label: string;
+  /**
+   * Optional inline badge rendered right after the label (e.g. a provider
+   * tag on a model row). Wraps onto a second line when the label is long.
+   */
+  labelBadge?: ReactNode;
   description?: string;
   disabled?: boolean;
 }
@@ -363,9 +368,12 @@ function SearchableSelectOptionItem({
         </span>
       )}
       <div className="min-w-0 flex-1">
-        <Text as="div" variant="label">
-          {option.label}
-        </Text>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Text as="span" variant="label">
+            {option.label}
+          </Text>
+          {option.labelBadge}
+        </div>
         {option.description && (
           <Text as="div" variant="caption">
             {option.description}

--- a/services/platform/app/components/ui/overlays/sheet.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.tsx
@@ -50,6 +50,13 @@ interface SheetProps extends VariantProps<typeof sheetVariants> {
   hideClose?: boolean;
   /** Width of the sheet panel */
   size?: 'sm' | 'md';
+  /**
+   * Called when focus moves into the sheet on open. Call `event.preventDefault()`
+   * to suppress Radix's default (focus first tabbable inside Content) and take
+   * over focus management — useful to avoid races with `autoFocus` + slide-in
+   * animation.
+   */
+  onOpenAutoFocus?: (event: Event) => void;
 }
 
 const SheetCloseButton = forwardRef<
@@ -79,6 +86,7 @@ export function Sheet({
   children,
   className,
   hideClose,
+  onOpenAutoFocus,
 }: SheetProps) {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -86,6 +94,7 @@ export function Sheet({
         <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80" />
         <DialogPrimitive.Content
           className={cn(sheetVariants({ side, size }), className)}
+          onOpenAutoFocus={onOpenAutoFocus}
         >
           <DialogPrimitive.Title className="sr-only">
             {title}

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -16,6 +16,7 @@ import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { HStack, VStack } from '@/app/components/ui/layout/layout';
+import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { Button } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
 import { useUploadPolicy } from '@/app/features/settings/governance/hooks/use-upload-policy';
@@ -66,6 +67,16 @@ interface ChatInputProps extends Omit<
     { status?: string; error?: string; progress?: string }
   >;
   onSavePrompt?: (content: string) => void;
+  /**
+   * When true, the send button is disabled. Unlike `disabled`, the input
+   * itself stays editable so the user can still revise their message — they
+   * just can't send it in the current state (e.g. an edit reference is
+   * attached but the selected model doesn't support editing). Pair with a
+   * visible reason (e.g. the EditingBanner) so it isn't mysterious.
+   */
+  sendBlocked?: boolean;
+  /** Tooltip shown on the send button when `sendBlocked` is true. */
+  sendBlockedReason?: string;
 }
 
 export function ChatInput({
@@ -87,6 +98,8 @@ export function ChatInput({
   isIndexing = false,
   indexingStatuses,
   onSavePrompt,
+  sendBlocked = false,
+  sendBlockedReason,
   ...restProps
 }: ChatInputProps) {
   const { t: tChat } = useT('chat');
@@ -126,7 +139,8 @@ export function ChatInput({
       isLoading ||
       disabled ||
       isUploading ||
-      isIndexing
+      isIndexing ||
+      sendBlocked
     )
       return;
 
@@ -426,27 +440,39 @@ export function ChatInput({
                 lang={speechLang}
                 onTranscript={handleTranscript}
               />
-              <Button
-                type="button"
-                onClick={isLoading ? onStopGenerating : handleSendMessage}
-                disabled={
-                  isLoading
-                    ? !onStopGenerating
-                    : (!value.trim() && attachments.length === 0) ||
-                      inputDisabled ||
-                      isUploading ||
-                      isIndexing
+              <Tooltip
+                content={
+                  sendBlocked && sendBlockedReason && !isLoading
+                    ? sendBlockedReason
+                    : ''
                 }
-                size="icon"
-                className="rounded-full"
-                aria-label={isLoading ? tChat('stopGenerating') : tChat('send')}
+                side="top"
               >
-                {isLoading ? (
-                  <CircleStop className="size-4" />
-                ) : (
-                  <ArrowUp className="size-4" />
-                )}
-              </Button>
+                <Button
+                  type="button"
+                  onClick={isLoading ? onStopGenerating : handleSendMessage}
+                  disabled={
+                    isLoading
+                      ? !onStopGenerating
+                      : (!value.trim() && attachments.length === 0) ||
+                        inputDisabled ||
+                        isUploading ||
+                        isIndexing ||
+                        sendBlocked
+                  }
+                  size="icon"
+                  className="rounded-full"
+                  aria-label={
+                    isLoading ? tChat('stopGenerating') : tChat('send')
+                  }
+                >
+                  {isLoading ? (
+                    <CircleStop className="size-4" />
+                  ) : (
+                    <ArrowUp className="size-4" />
+                  )}
+                </Button>
+              </Tooltip>
             </HStack>
           </HStack>
         </div>

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -26,9 +26,11 @@ import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 
+import { stripModelRefQualifier } from '../../../../lib/shared/utils/model-ref';
 import { useDeletePrompt } from '../../prompts/hooks/mutations';
 import { usePrompts } from '../../prompts/hooks/queries';
 import { useMyFeatureFlags } from '../../settings/governance/hooks/queries';
+import { useListProviders } from '../../settings/providers/hooks/queries';
 import { useBranchContext } from '../context/branch-context';
 import { useChatLayout } from '../context/chat-layout-context';
 import {
@@ -58,12 +60,15 @@ import { usePendingMessages } from '../hooks/use-pending-messages';
 import { usePersistedAttachments } from '../hooks/use-persisted-attachments';
 import { useSendMessage } from '../hooks/use-send-message';
 import { useStopGenerating } from '../hooks/use-stop-generating';
+import { useThreadImages } from '../hooks/use-thread-images';
 import { useUserContext } from '../hooks/use-user-context';
 import type { FileAttachment } from '../types';
 import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaSplitView } from './arena/arena-split-view';
 import { ChatInput } from './chat-input';
 import { ChatMessages } from './chat-messages';
+import { EditingBanner, imageRefToAttachment } from './editing-banner';
+import { useEffectiveEditingImage } from './editing-banner';
 import { MessagesSkeleton } from './messages-skeleton';
 import { WelcomeView } from './welcome-view';
 
@@ -278,6 +283,37 @@ export function ChatInterface({
   // Agent availability — disable input when no agents exist
   const { agents } = useChatAgents(organizationId);
   const hasNoAgents = agents !== undefined && agents.length === 0;
+
+  // Image-generation agent derivations for EditingBanner.
+  const activeAgentMeta = useMemo(
+    () => agents?.find((a) => a.name === effectiveAgent?.name),
+    [agents, effectiveAgent?.name],
+  );
+  const isImageGenAgent =
+    activeAgentMeta?.primaryBehavior === 'image-generation';
+  const threadImages = useThreadImages(isImageGenAgent ? messages : undefined);
+  const { providers: providersForEdit } = useListProviders('default');
+  const activeModelRef = effectiveAgent?.name
+    ? (selectedModelOverrides[effectiveAgent.name] ??
+      activeAgentMeta?.supportedModels?.[0])
+    : undefined;
+  const activeModelInfo = useMemo(() => {
+    if (!activeModelRef) return undefined;
+    const plain = stripModelRefQualifier(activeModelRef);
+    for (const p of providersForEdit) {
+      if (!p || !('models' in p) || !Array.isArray(p.models)) continue;
+      for (const model of p.models) {
+        if (model.id === plain) return model;
+      }
+    }
+    return undefined;
+  }, [activeModelRef, providersForEdit]);
+  const currentModelSupportsEdit = Boolean(
+    activeModelInfo?.tags?.includes('image-edit'),
+  );
+  const currentModelLabel = activeModelInfo?.displayName;
+  const { active: activeEditingImage } = useEffectiveEditingImage(threadImages);
+  const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
 
   // Thread status — disable input for archived threads
   // Always check the URL threadId (root thread), not dataThreadId (which may
@@ -617,7 +653,31 @@ export function ChatInterface({
     // during the budget-banner → thread transition). Smooth for existing threads.
     scrollingToBottomBehaviorRef.current = threadId ? 'smooth' : 'instant';
     clearInputValue();
-    await sendMessage(message, sentAttachments);
+
+    // For image-generation agents, if an editing image is active in the
+    // banner and not dismissed, prepend it as the reference attachment.
+    let finalAttachments = sentAttachments;
+    if (
+      isImageGenAgent &&
+      currentModelSupportsEdit &&
+      activeEditingImage &&
+      activeEditingImage.ref.fileId
+    ) {
+      const imageAtt = imageRefToAttachment(activeEditingImage.ref);
+      if (imageAtt) {
+        finalAttachments = [
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- FileAttachment.fileId is a branded Id<'_storage'>; runtime value is the same string the server accepts.
+          imageAtt as unknown as FileAttachment,
+          ...(sentAttachments ?? []),
+        ];
+      }
+      // Consume: clear explicit ref. dismissedImageKey reset naturally when a
+      // new image lands because its key differs.
+      setEditingImageRef(null);
+      setDismissedImageKey(null);
+    }
+
+    await sendMessage(message, finalAttachments);
   };
 
   // No client-side optimistic loading needed — server sets
@@ -919,9 +979,24 @@ export function ChatInterface({
           </div>
         ) : (
           <FileUpload.Root>
+            {isImageGenAgent && threadImages.length > 0 && (
+              <div className="mx-auto w-full max-w-(--chat-max-width)">
+                <EditingBanner
+                  threadImages={threadImages}
+                  currentModelSupportsEdit={currentModelSupportsEdit}
+                  currentModelLabel={currentModelLabel}
+                />
+              </div>
+            )}
             <ChatInput
               className="mx-auto w-full max-w-(--chat-max-width)"
-              placeholder={t('placeholder')}
+              placeholder={
+                isImageGenAgent
+                  ? activeEditingImage && currentModelSupportsEdit
+                    ? t('imageEdit.placeholder')
+                    : t('imageEdit.placeholderCreate')
+                  : t('placeholder')
+              }
               value={inputValue}
               onChange={setInputValue}
               onSendMessage={handleSendMessage}
@@ -944,6 +1019,18 @@ export function ChatInterface({
               fileUploadDisabled={fileUploadDisabled}
               isIndexing={isIndexing}
               indexingStatuses={indexingStatuses}
+              sendBlocked={
+                isImageGenAgent &&
+                !!activeEditingImage &&
+                !currentModelSupportsEdit
+              }
+              sendBlockedReason={
+                isImageGenAgent &&
+                !!activeEditingImage &&
+                !currentModelSupportsEdit
+                  ? t('imageEdit.modelCannotEdit')
+                  : undefined
+              }
               onSavePrompt={(content) =>
                 setSavePromptData({ messageId: '', content })
               }

--- a/services/platform/app/features/chat/components/editing-banner.tsx
+++ b/services/platform/app/features/chat/components/editing-banner.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { AlertTriangle, ChevronDown, Pencil, X } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+
+import { Popover } from '@/app/components/ui/overlays/popover';
+import { useT } from '@/lib/i18n/client';
+
+import {
+  useChatLayout,
+  type EditingImageRef,
+} from '../context/chat-layout-context';
+import type { ThreadImage } from '../hooks/use-thread-images';
+import { ImagePreviewDialog } from './message-bubble/image-preview-dialog';
+import { ThumbnailPicker } from './thumbnail-picker';
+
+interface EditingBannerProps {
+  /** Every image in the current thread, newest first (from useThreadImages). */
+  threadImages: ThreadImage[];
+  /** Whether the currently selected model supports reference-image edits. */
+  currentModelSupportsEdit: boolean;
+  /** Current model's display name, shown next to the thumbnail. */
+  currentModelLabel?: string;
+  /**
+   * CTA for "Switch to an edit-capable model". Wired in chat-input so the
+   * banner doesn't need to know the full picker. Omit to hide the CTA.
+   */
+  onSwitchModel?: () => void;
+}
+
+export function imageRefToAttachment(ref: EditingImageRef): {
+  fileId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+} | null {
+  if (!ref.fileId) return null;
+  return {
+    fileId: ref.fileId,
+    fileName: ref.fileName ?? 'reference-image',
+    fileType: ref.mimeType,
+    // Size isn't tracked (we reference an existing storage id rather than
+    // uploading). Server code tolerates 0 since it reads bytes from storage.
+    fileSize: 0,
+  };
+}
+
+/**
+ * Derives the image that should be the active editing target:
+ * explicit ref (from ↻ Edit / ThumbnailPicker) > latest thread image.
+ * Returns null when nothing to edit OR when user dismissed the current latest.
+ */
+export function useEffectiveEditingImage(threadImages: ThreadImage[]): {
+  active: { ref: EditingImageRef; key: string } | null;
+  isDismissed: boolean;
+} {
+  const { editingImageRef, dismissedImageKey } = useChatLayout();
+
+  return useMemo(() => {
+    if (editingImageRef) {
+      const explicitKey = `explicit:${editingImageRef.fileId || editingImageRef.url}`;
+      return {
+        active: { ref: editingImageRef, key: explicitKey },
+        isDismissed: false,
+      };
+    }
+    const latest = threadImages[0];
+    if (!latest || !latest.fileId) {
+      // Latest with no fileId (e.g., a blob preview URL) can't round-trip to
+      // the server as an edit reference. Hide the banner for those.
+      return { active: null, isDismissed: false };
+    }
+    if (dismissedImageKey === latest.key) {
+      return { active: null, isDismissed: true };
+    }
+    return {
+      active: {
+        ref: {
+          fileId: latest.fileId,
+          url: latest.url,
+          mimeType: latest.mimeType,
+          fileName: latest.fileName,
+        },
+        key: latest.key,
+      },
+      isDismissed: false,
+    };
+  }, [editingImageRef, dismissedImageKey, threadImages]);
+}
+
+export const EditingBanner = memo(function EditingBanner({
+  threadImages,
+  currentModelSupportsEdit,
+  currentModelLabel,
+  onSwitchModel,
+}: EditingBannerProps) {
+  const { t } = useT('chat');
+  const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const { active } = useEffectiveEditingImage(threadImages);
+
+  if (!active) return null;
+
+  const { ref, key: activeKey } = active;
+
+  const handleDismiss = () => {
+    setEditingImageRef(null);
+    setDismissedImageKey(activeKey);
+  };
+
+  const handlePick = (img: ThreadImage) => {
+    // Accept even when fileId is missing — the banner still updates visually
+    // so the user sees their pick take effect. The send path (chat-interface)
+    // skips pre-attach when fileId is empty, so those images just render as
+    // a reference without round-tripping to the model.
+    setEditingImageRef({
+      fileId: img.fileId ?? '',
+      url: img.url,
+      mimeType: img.mimeType,
+      fileName: img.fileName,
+    });
+    setDismissedImageKey(null);
+    setPickerOpen(false);
+  };
+
+  const refHasUsableId = Boolean(ref.fileId);
+  const disabled = !currentModelSupportsEdit || !refHasUsableId;
+  // When the selected model can't actually consume the attached image, flip
+  // the whole banner into a warning state (amber ring + tinted background)
+  // so users notice — the previous muted-grey treatment was too subtle and
+  // people sent edit prompts that silently became text-to-image regenerations.
+  const containerClass = disabled
+    ? 'bg-amber-50 ring-amber-300 text-amber-900 dark:bg-amber-950/40 dark:ring-amber-700/60 dark:text-amber-100'
+    : 'bg-muted/60 ring-border';
+  return (
+    <div
+      className={
+        'mb-2 flex items-center gap-2 rounded-xl px-2 py-1.5 ring-1 ' +
+        containerClass
+      }
+    >
+      {ref.url ? (
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          aria-label={t('imageEdit.previewReference')}
+          className="ring-border focus:ring-ring size-9 shrink-0 cursor-zoom-in overflow-hidden rounded-md border-none bg-transparent p-0 ring-1 transition-opacity hover:opacity-80 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+        >
+          <img
+            src={ref.url}
+            alt={ref.fileName ?? ''}
+            className="size-full object-cover"
+          />
+        </button>
+      ) : (
+        <div className="ring-border size-9 shrink-0 overflow-hidden rounded-md ring-1">
+          <div className="bg-muted flex size-full items-center justify-center">
+            <Pencil className="text-muted-foreground size-4" />
+          </div>
+        </div>
+      )}
+      {ref.url && (
+        <ImagePreviewDialog
+          isOpen={previewOpen}
+          onOpenChange={setPreviewOpen}
+          src={ref.url}
+          alt={ref.fileName ?? ''}
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <p
+          className={
+            'truncate text-sm font-medium ' +
+            (disabled
+              ? 'text-amber-900 dark:text-amber-100'
+              : 'text-foreground')
+          }
+        >
+          {t('imageEdit.editingLatest')}
+        </p>
+        {disabled ? (
+          <p className="flex items-start gap-1 text-xs font-medium text-amber-800 dark:text-amber-200">
+            <AlertTriangle
+              className="mt-0.5 size-3.5 shrink-0"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
+            <span>
+              {t('imageEdit.modelCannotEdit')}
+              {onSwitchModel && (
+                <button
+                  type="button"
+                  onClick={onSwitchModel}
+                  className="ml-1 underline underline-offset-2 hover:no-underline"
+                >
+                  {t('imageEdit.change')}
+                </button>
+              )}
+            </span>
+          </p>
+        ) : (
+          currentModelLabel && (
+            <p className="text-muted-foreground truncate text-xs">
+              {currentModelLabel}
+            </p>
+          )
+        )}
+      </div>
+      {threadImages.length > 1 && (
+        <Popover
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          align="end"
+          side="top"
+          trigger={
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 rounded px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:underline"
+              aria-label={t('imageEdit.change')}
+            >
+              {t('imageEdit.change')}
+              <ChevronDown className="size-3" />
+            </button>
+          }
+        >
+          <ThumbnailPicker
+            images={threadImages}
+            activeKey={activeKey}
+            onPick={handlePick}
+          />
+        </Popover>
+      )}
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label={t('imageEdit.dismiss')}
+        className="text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md transition-colors focus:outline-none focus-visible:ring-1"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+});

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -29,9 +29,15 @@ import { Button } from '@/app/components/ui/primitives/button';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
+import { useChatLayout } from '../context/chat-layout-context';
 import { CitationsContext } from '../context/citations-context';
-import { useMessageMetadata, useFileUrls } from '../hooks/queries';
+import {
+  useChatAgents,
+  useMessageMetadata,
+  useFileUrls,
+} from '../hooks/queries';
 import { useCitations } from '../hooks/use-citations';
+import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { injectCitationTags } from '../utils/inject-citation-tags';
 import { sanitizeChatError } from '../utils/sanitize-chat-error';
 import {
@@ -169,6 +175,34 @@ function MessageBubbleComponent({
 
   const { metadata } = useMessageMetadata(message.id, message.threadId);
   const { citations, hasCitations } = useCitations(metadata?.citations);
+
+  // Image-generation agents show a ↻ Edit button on assistant image parts.
+  const { agent: effectiveAgentForEdit } = useEffectiveAgent(
+    organizationId ?? '',
+  );
+  const { agents: agentsForEdit } = useChatAgents(organizationId ?? '');
+  const isImageGenAgent =
+    agentsForEdit?.find((a) => a.name === effectiveAgentForEdit?.name)
+      ?.primaryBehavior === 'image-generation';
+  const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
+  const handleEditImagePart = useCallback(
+    (part: { url: string; mediaType: string; filename?: string }) => {
+      let fileId = '';
+      try {
+        fileId = new URL(part.url).searchParams.get('id') ?? '';
+      } catch {
+        // Non-storage URL (e.g. data URL); edit reference won't resolve server-side
+      }
+      setEditingImageRef({
+        fileId,
+        url: part.url,
+        mimeType: part.mediaType,
+        fileName: part.filename,
+      });
+      setDismissedImageKey(null);
+    },
+    [setEditingImageRef, setDismissedImageKey],
+  );
   const citationNumbers = useMemo(() => new Set(citations.keys()), [citations]);
   const citationsContextValue = useMemo(() => ({ citations }), [citations]);
   const messageContentContextValue = useMemo(
@@ -413,6 +447,9 @@ function MessageBubbleComponent({
           <div className="mt-2 flex flex-col gap-2">
             {message.fileParts.map((part, i) => {
               const galleryIdx = filePartGalleryIndices[i];
+              const isAssistantImage =
+                message.role === 'assistant' &&
+                part.mediaType.startsWith('image/');
               return (
                 <FilePartDisplay
                   key={part.url}
@@ -420,6 +457,11 @@ function MessageBubbleComponent({
                   organizationId={organizationId}
                   onImageClick={
                     galleryIdx >= 0 ? () => openGallery(galleryIdx) : undefined
+                  }
+                  onEditImage={
+                    isImageGenAgent && isAssistantImage
+                      ? () => handleEditImagePart(part)
+                      : undefined
                   }
                 />
               );
@@ -445,7 +487,8 @@ function MessageBubbleComponent({
         )}
         {!isUser &&
           !isAssistantStreaming &&
-          !!displayContent &&
+          (!!displayContent ||
+            (message.fileParts && message.fileParts.length > 0)) &&
           (!hideFeedback && organizationId && message.threadId ? (
             <MessageFeedback
               messageId={message.id}

--- a/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Image,
   Paperclip,
+  Pencil,
   Presentation,
   Settings2,
 } from 'lucide-react';
@@ -239,10 +240,17 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
 export const FilePartDisplay = memo(function FilePartDisplay({
   filePart,
   onImageClick,
+  onEditImage,
   organizationId,
 }: {
   filePart: FilePart;
   onImageClick?: () => void;
+  /**
+   * Shortcut for image-generation agents: when set, renders an ↻ Edit button
+   * overlay on image thumbnails. Clicking it promotes this image to the
+   * composer's editing reference (pre-attached on next send).
+   */
+  onEditImage?: () => void;
   organizationId?: string;
 }) {
   const { t } = useT('chat');
@@ -250,19 +258,56 @@ export const FilePartDisplay = memo(function FilePartDisplay({
   const isImage = filePart.mediaType.startsWith('image/');
 
   if (isImage) {
+    // When onEditImage is provided, this is an assistant-generated image for
+    // an image-generation agent — render it full-size so the output is the
+    // focal point of the message. Otherwise keep the small 36px thumbnail
+    // used for incidental images on chat messages.
+    const isLarge = Boolean(onEditImage);
+    const containerClasses = isLarge
+      ? 'relative inline-block max-w-md overflow-hidden rounded-xl ring-1 ring-border'
+      : 'group relative inline-block';
+    const buttonClasses = isLarge
+      ? 'block w-full cursor-pointer border-none bg-transparent p-0 transition-opacity hover:opacity-95 focus:outline-none'
+      : 'ring-border focus:ring-ring size-9 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 ring-1 transition-opacity hover:opacity-80 focus:ring-2 focus:ring-offset-2 focus:outline-none';
+    const imgClasses = isLarge
+      ? 'block h-auto w-full object-contain'
+      : 'size-full object-cover';
+    const editButtonClasses = isLarge
+      ? 'bg-background/90 ring-border text-foreground hover:bg-background absolute top-2 right-2 flex size-8 items-center justify-center rounded-full shadow-sm ring-1 transition-opacity focus:outline-none'
+      : 'bg-background/95 ring-border text-foreground hover:bg-background absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full opacity-0 shadow-sm ring-1 transition-opacity group-hover:opacity-100 focus:opacity-100 focus:outline-none';
+
     return (
-      <button
-        type="button"
-        onClick={onImageClick}
-        className="ring-border focus:ring-ring size-9 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 ring-1 transition-opacity hover:opacity-80 focus:ring-2 focus:ring-offset-2 focus:outline-none"
-        aria-label={t('fallback.image')}
-      >
-        <img
-          src={filePart.url}
-          alt={filePart.filename || t('fileTypes.image')}
-          className="size-full object-cover"
-        />
-      </button>
+      <div className={containerClasses}>
+        <button
+          type="button"
+          onClick={onImageClick}
+          className={buttonClasses}
+          aria-label={t('fallback.image')}
+        >
+          <img
+            src={filePart.url}
+            alt={filePart.filename || t('fileTypes.image')}
+            className={imgClasses}
+          />
+        </button>
+        {onEditImage && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEditImage();
+            }}
+            className={editButtonClasses}
+            aria-label={t('imageEdit.editThis')}
+            title={t('imageEdit.editThis')}
+          >
+            <Pencil
+              className={isLarge ? 'size-4' : 'size-3'}
+              strokeWidth={1.75}
+            />
+          </button>
+        )}
+      </div>
     );
   }
 

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import startCase from 'lodash/startCase';
 import { ChevronDown, Cpu } from 'lucide-react';
 import {
   type ReactNode,
@@ -9,6 +10,7 @@ import {
   useState,
 } from 'react';
 
+import { Badge } from '@/app/components/ui/feedback/badge';
 import {
   SearchableSelect,
   type SearchableSelectOption,
@@ -16,7 +18,10 @@ import {
 import { useAccessibleModels } from '@/app/features/settings/governance/hooks/queries';
 import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
 import { useT } from '@/lib/i18n/client';
-import { stripModelRefQualifier } from '@/lib/shared/utils/model-ref';
+import {
+  parseModelRef,
+  stripModelRefQualifier,
+} from '@/lib/shared/utils/model-ref';
 
 import { useChatLayout } from '../context/chat-layout-context';
 import { useChatAgents } from '../hooks/queries';
@@ -42,15 +47,29 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const { selectedModelOverrides, setSelectedModelOverride } = useChatLayout();
   const [open, setOpen] = useState(false);
 
+  const activeAgent = useMemo(
+    () => agents?.find((a) => a.name === effectiveAgent?.name),
+    [agents, effectiveAgent?.name],
+  );
+
   const supportedModels = useMemo(() => {
-    const agent = agents?.find((a) => a.name === effectiveAgent?.name);
-    return agent?.supportedModels ?? [];
-  }, [agents, effectiveAgent?.name]);
+    return activeAgent?.supportedModels ?? [];
+  }, [activeAgent]);
+
+  const requiredTag =
+    activeAgent?.primaryBehavior === 'image-generation'
+      ? 'image-generation'
+      : 'chat';
 
   const modelInfoMap = useMemo(() => {
     const map = new Map<
       string,
-      { displayName: string; description?: string; tags: string[] }
+      {
+        displayName: string;
+        description?: string;
+        tags: string[];
+        providerName: string;
+      }
     >();
     for (const provider of providers) {
       if (
@@ -64,11 +83,24 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
           displayName: model.displayName,
           description: model.description || undefined,
           tags: model.tags ?? [],
+          providerName: provider.name,
         });
       }
     }
     return map;
   }, [providers]);
+
+  // Return the provider's slug (its JSON filename without extension) — this
+  // is the stable, machine-readable identifier users write in model refs,
+  // not the cosmetic `displayName` from the provider JSON.
+  const getProviderSlug = useCallback(
+    (ref: string): string | undefined => {
+      const parsed = parseModelRef(ref);
+      if (parsed.providerName) return parsed.providerName;
+      return modelInfoMap.get(parsed.modelId)?.providerName;
+    },
+    [modelInfoMap],
+  );
 
   const renderTagIcons = useCallback(
     (option: SearchableSelectOption): ReactNode => {
@@ -82,9 +114,9 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const chatModels = useMemo(() => {
     return supportedModels.filter((ref) => {
       const info = modelInfoMap.get(stripModelRefQualifier(ref));
-      return info?.tags.includes('chat');
+      return info?.tags.includes(requiredTag);
     });
-  }, [supportedModels, modelInfoMap]);
+  }, [supportedModels, modelInfoMap, requiredTag]);
 
   // Governance policies match on plain model ids; strip qualifiers before asking.
   const chatModelPlainIds = useMemo(
@@ -112,14 +144,31 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
     [modelInfoMap],
   );
 
+  // Auto mode is only meaningful for chat agents, where models are
+  // interchangeable from a capability/style standpoint. Image-gen models
+  // differ visibly per-model (style, editing ability, cost), so "Auto" would
+  // just hide a creative decision behind a vague default — we force an
+  // explicit pick instead.
+  const isImageGenAgent = requiredTag === 'image-generation';
+
   const currentModelId = useMemo(() => {
     // User's explicit override (localStorage) takes highest priority
     if (effectiveAgent?.name && selectedModelOverrides[effectiveAgent.name]) {
       return selectedModelOverrides[effectiveAgent.name];
     }
-    // No override → Auto mode
+    // No override: chat agents show Auto; image-gen agents show the first
+    // supported model (which matches what the backend resolves when no
+    // override is set — the agent JSON's `supportedModels[0]`).
+    if (isImageGenAgent) {
+      return filteredModels[0] ?? AUTO_MODEL;
+    }
     return AUTO_MODEL;
-  }, [effectiveAgent?.name, selectedModelOverrides]);
+  }, [
+    effectiveAgent?.name,
+    selectedModelOverrides,
+    isImageGenAgent,
+    filteredModels,
+  ]);
 
   // Clear stale override when agent changes
   useEffect(() => {
@@ -164,19 +213,32 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
     );
   }
 
-  const autoOption: SearchableSelectOption = {
-    value: AUTO_MODEL,
-    label: t('modelSelector.auto'),
-    description: t('modelSelector.autoDescription'),
-  };
+  const modelOptions = filteredModels.map((ref) => {
+    const info = modelInfoMap.get(stripModelRefQualifier(ref));
+    const providerSlug = getProviderSlug(ref);
+    return {
+      value: ref,
+      label: getDisplayName(ref),
+      labelBadge: providerSlug ? (
+        <Badge variant="outline" className="text-[10px] font-normal">
+          {startCase(providerSlug)}
+        </Badge>
+      ) : undefined,
+      description: info?.description,
+    };
+  });
 
-  const modelOptions = filteredModels.map((ref) => ({
-    value: ref,
-    label: getDisplayName(ref),
-    description: modelInfoMap.get(stripModelRefQualifier(ref))?.description,
-  }));
-
-  const options = [autoOption, ...modelOptions];
+  // Auto option only makes sense for chat agents (see comment on isImageGenAgent).
+  const options: SearchableSelectOption[] = isImageGenAgent
+    ? modelOptions
+    : [
+        {
+          value: AUTO_MODEL,
+          label: t('modelSelector.auto'),
+          description: t('modelSelector.autoDescription'),
+        },
+        ...modelOptions,
+      ];
 
   return (
     <SearchableSelect

--- a/services/platform/app/features/chat/components/model-tag-icons.tsx
+++ b/services/platform/app/features/chat/components/model-tag-icons.tsx
@@ -1,4 +1,11 @@
-import { Brain, Image, MessageCircle, type LucideIcon } from 'lucide-react';
+import {
+  Brain,
+  Image,
+  ImagePlus,
+  MessageCircle,
+  Pencil,
+  type LucideIcon,
+} from 'lucide-react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 
@@ -6,6 +13,14 @@ const TAG_CONFIG: Record<string, { icon: LucideIcon; labelKey: string }> = {
   chat: { icon: MessageCircle, labelKey: 'modelSelector.tags.chat' },
   vision: { icon: Image, labelKey: 'modelSelector.tags.vision' },
   embedding: { icon: Brain, labelKey: 'modelSelector.tags.embedding' },
+  'image-generation': {
+    icon: ImagePlus,
+    labelKey: 'modelSelector.tags.imageGeneration',
+  },
+  'image-edit': {
+    icon: Pencil,
+    labelKey: 'modelSelector.tags.imageEdit',
+  },
 };
 
 interface ModelTagIconsProps {

--- a/services/platform/app/features/chat/components/thumbnail-picker.tsx
+++ b/services/platform/app/features/chat/components/thumbnail-picker.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { memo } from 'react';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import { useFileUrls } from '../hooks/queries';
+import type { ThreadImage } from '../hooks/use-thread-images';
+
+interface ThumbnailPickerProps {
+  images: ThreadImage[];
+  activeKey?: string;
+  onPick: (image: ThreadImage) => void;
+}
+
+/**
+ * Grid of every image in the current thread, used inside the EditingBanner's
+ * "Change ▾" popover. User-uploaded attachments lack a URL at derive time;
+ * we resolve those here via useFileUrls and thread them back into the items.
+ */
+export const ThumbnailPicker = memo(function ThumbnailPicker({
+  images,
+  activeKey,
+  onPick,
+}: ThumbnailPickerProps) {
+  const { t } = useT('chat');
+
+  const unresolvedFileIds = images
+    .filter((img) => !img.url && img.fileId)
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex Id<'_storage'> is a branded string; runtime value is the same
+    .map((img) => img.fileId as Id<'_storage'>);
+  const { data: resolvedUrls } = useFileUrls(unresolvedFileIds);
+
+  const urlByFileId = new Map<string, string>();
+  if (resolvedUrls) {
+    for (const r of resolvedUrls) {
+      if (r.url) urlByFileId.set(r.fileId, r.url);
+    }
+  }
+
+  const displayable = images
+    .map((img) => {
+      if (img.url) return img;
+      const resolved = img.fileId ? urlByFileId.get(img.fileId) : undefined;
+      if (resolved) {
+        return { ...img, url: resolved };
+      }
+      return null;
+    })
+    .filter((img): img is ThreadImage => img !== null);
+
+  if (displayable.length === 0) {
+    return (
+      <p className="text-muted-foreground p-4 text-center text-sm">
+        {t('imageEdit.noOtherImages')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-h-64 w-64 overflow-y-auto">
+      <p className="text-muted-foreground mb-2 text-xs font-medium">
+        {t('imageEdit.pickAnImage')}
+      </p>
+      <div className="grid grid-cols-3 gap-2">
+        {displayable.map((img) => {
+          const isActive = img.key === activeKey;
+          return (
+            <button
+              key={img.key}
+              type="button"
+              onClick={() => onPick(img)}
+              className={
+                'ring-border hover:ring-primary focus:ring-primary size-16 cursor-pointer overflow-hidden rounded-md border-none bg-transparent p-0 ring-1 transition-all focus:outline-none' +
+                (isActive ? ' ring-primary ring-2' : '')
+              }
+              title={img.fileName ?? ''}
+            >
+              <img
+                src={img.url}
+                alt={img.fileName ?? ''}
+                className="size-full object-cover"
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/services/platform/app/features/chat/context/chat-layout-context.tsx
+++ b/services/platform/app/features/chat/context/chat-layout-context.tsx
@@ -43,6 +43,19 @@ export interface SelectedAgent {
   displayName: string;
 }
 
+/**
+ * Reference to an image that should be attached to the next composer
+ * submission as an edit target (for primaryBehavior='image-generation' agents).
+ * Set explicitly via the ↻ Edit button or the ThumbnailPicker popover; when
+ * null, the EditingBanner falls back to the latest image in the thread.
+ */
+export interface EditingImageRef {
+  fileId: string;
+  url: string;
+  mimeType: string;
+  fileName?: string;
+}
+
 /** Internal storage shape — includes expiry timestamp per override. */
 interface ModelOverrideEntry {
   modelId: string;
@@ -72,6 +85,19 @@ interface ChatLayoutContextType {
   /** Content inserted from the sidebar prompt section — consumed by ChatInterface */
   insertedPrompt: string | null;
   setInsertedPrompt: (content: string | null) => void;
+  /**
+   * Explicit editing target, set via ↻ Edit button or ThumbnailPicker. When
+   * non-null, overrides the "latest image" auto-pick in EditingBanner.
+   */
+  editingImageRef: EditingImageRef | null;
+  setEditingImageRef: (ref: EditingImageRef | null) => void;
+  /**
+   * Image key (from useThreadImages) the user dismissed via × on the banner.
+   * Kept in state so that when a NEW image lands, its key differs from this
+   * and the banner re-appears automatically.
+   */
+  dismissedImageKey: string | null;
+  setDismissedImageKey: (key: string | null) => void;
 }
 
 const ChatLayoutContext = createContext<ChatLayoutContextType | null>(null);
@@ -100,6 +126,11 @@ export function ChatLayoutProvider({
   );
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [insertedPrompt, setInsertedPrompt] = useState<string | null>(null);
+  const [editingImageRef, setEditingImageRef] =
+    useState<EditingImageRef | null>(null);
+  const [dismissedImageKey, setDismissedImageKey] = useState<string | null>(
+    null,
+  );
   const agentKey = user?.userId
     ? `selected-agent-${user.userId}-${organizationId}`
     : `selected-agent-${organizationId}`;
@@ -177,6 +208,8 @@ export function ChatLayoutProvider({
   const clearChatState = useCallback(() => {
     setPendingThreadId(null);
     setPendingMessage(null);
+    setEditingImageRef(null);
+    setDismissedImageKey(null);
   }, []);
 
   const value = useMemo(
@@ -196,6 +229,10 @@ export function ChatLayoutProvider({
       setCapabilityEnabled,
       insertedPrompt,
       setInsertedPrompt,
+      editingImageRef,
+      setEditingImageRef,
+      dismissedImageKey,
+      setDismissedImageKey,
     }),
     [
       pendingThreadId,
@@ -209,6 +246,8 @@ export function ChatLayoutProvider({
       enabledCapabilities,
       setCapabilityEnabled,
       insertedPrompt,
+      editingImageRef,
+      dismissedImageKey,
     ],
   );
 

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -134,6 +134,12 @@ export interface ChatAgent {
   displayName: string;
   description?: string;
   visibleInChat?: boolean;
+  /**
+   * Root behavior. Omitted = 'chat'. 'image-generation' flips the composer
+   * into direct image-gen mode (model picker filters on image tag, EditingBanner
+   * activates when the thread has images).
+   */
+  primaryBehavior?: 'chat' | 'image-generation';
   supportedModels?: string[];
   toolNames?: string[];
   roleRestriction?: string;
@@ -173,6 +179,12 @@ export function useChatAgents(_organizationId: string) {
           displayName: a.displayName,
           description: a.description,
           visibleInChat: a.visibleInChat,
+          primaryBehavior:
+            'primaryBehavior' in a &&
+            (a.primaryBehavior === 'chat' ||
+              a.primaryBehavior === 'image-generation')
+              ? a.primaryBehavior
+              : undefined,
           supportedModels: a.supportedModels,
           conversationStarters: a.conversationStarters,
           composerMode:

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -296,8 +296,18 @@ export function useMessageProcessing(
     }
 
     // Merge file-only assistant messages into the nearest following text-bearing
-    // assistant message. The file part message has an earlier _creationTime
-    // (saved during the tool call) so it sorts before the text message.
+    // assistant message in the SAME turn (matching `order`). The file part
+    // message has an earlier _creationTime (saved during the tool call) so it
+    // sorts before the text message.
+    //
+    // The `order` guard is critical: without it, a file-only assistant message
+    // whose companion text never arrives (e.g. an image-generation agent that
+    // outputs only fileParts) would steal-attach to whatever subsequent turn's
+    // assistant text happens to exist — most visibly, an error message from
+    // the NEXT user turn, making the successful image appear fused with an
+    // unrelated later error. `order` corresponds to a logical turn, so
+    // constraining the merge to a single turn prevents cross-turn bleeding
+    // while still preserving tool-call behavior (file + text share an order).
     //
     // Pass 1: build a map of key → extra fileParts to attach, O(n)
     const extraFileParts = new Map<string, FilePart[]>();
@@ -313,10 +323,20 @@ export function useMessageProcessing(
       )
         continue;
 
-      // Find the next text-bearing assistant message
+      // Find the next text-bearing assistant message in the SAME turn.
       for (let j = i + 1; j < result.length; j++) {
         const next = result[j];
-        if (next?.role === 'assistant' && next.content) {
+        if (!next) continue;
+        // Bail out once we cross into a later turn — file-only message stays
+        // standalone in its own turn.
+        if (
+          msg.order != null &&
+          next.order != null &&
+          next.order !== msg.order
+        ) {
+          break;
+        }
+        if (next.role === 'assistant' && next.content) {
           extraFileParts.set(next.key, [
             ...(extraFileParts.get(next.key) ?? []),
             ...(msg.fileParts ?? []),

--- a/services/platform/app/features/chat/hooks/use-thread-images.ts
+++ b/services/platform/app/features/chat/hooks/use-thread-images.ts
@@ -1,0 +1,105 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type {
+  FileAttachment,
+  FilePart,
+} from '../components/message-bubble/types';
+
+interface MessageLike {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  timestamp: Date;
+  attachments?: FileAttachment[];
+  fileParts?: FilePart[];
+}
+
+export interface ThreadImage {
+  /** Unique key for React lists (messageId + index). */
+  key: string;
+  /** Convex storage id extracted from the image URL, if present. */
+  fileId?: string;
+  /** Display URL for the thumbnail / preview. */
+  url: string;
+  /** IANA media type, e.g. 'image/png'. */
+  mimeType: string;
+  /** Original filename if known. */
+  fileName?: string;
+  /** Which side of the conversation this image belongs to. */
+  role: 'user' | 'assistant';
+  /** Chronological ordering. */
+  timestamp: Date;
+  /** Message this image was attached to / produced for. */
+  messageId: string;
+}
+
+function extractStorageFileId(url: string): string | undefined {
+  try {
+    return new URL(url).searchParams.get('id') ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Derives a chronological list of every image visible in the given thread —
+ * assistant-generated file parts AND user-uploaded image attachments alike.
+ *
+ * Used by EditingBanner (to pre-attach the latest image) and ThumbnailPicker
+ * (to let the user pick a specific older image to edit).
+ *
+ * No new query — pulls from the messages already loaded by useThreadMessages.
+ */
+export function useThreadImages(
+  messages: MessageLike[] | undefined,
+): ThreadImage[] {
+  return useMemo(() => {
+    if (!messages || messages.length === 0) return [];
+
+    const images: ThreadImage[] = [];
+    for (const msg of messages) {
+      if (msg.role !== 'user' && msg.role !== 'assistant') continue;
+      const role: 'user' | 'assistant' = msg.role;
+      // Assistant-generated images land on fileParts[] (image/*).
+      if (msg.fileParts) {
+        msg.fileParts.forEach((part, i) => {
+          if (!part.mediaType.startsWith('image/')) return;
+          images.push({
+            key: `${msg.id}-fp-${i}`,
+            fileId: extractStorageFileId(part.url),
+            url: part.url,
+            mimeType: part.mediaType,
+            fileName: part.filename,
+            role,
+            timestamp: msg.timestamp,
+            messageId: msg.id,
+          });
+        });
+      }
+      // User-uploaded images land on attachments[]. previewUrl is a blob: URL
+      // during upload; skip those — they aren't yet persisted.
+      if (msg.attachments) {
+        msg.attachments.forEach((att, i) => {
+          if (!att.fileType.startsWith('image/')) return;
+          if (att.previewUrl) return;
+          images.push({
+            key: `${msg.id}-att-${i}`,
+            fileId: att.fileId,
+            // attachments don't carry a URL here; component should resolve via
+            // useFileUrls. We surface the fileId as the canonical handle so
+            // pre-attach works; consumers use fileId to reupload-reference.
+            url: '',
+            mimeType: att.fileType,
+            fileName: att.fileName,
+            role,
+            timestamp: msg.timestamp,
+            messageId: msg.id,
+          });
+        });
+      }
+    }
+    // Newest first makes "latest image" a simple images[0] read.
+    return images.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  }, [messages]);
+}

--- a/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
@@ -26,6 +26,7 @@ import {
   useSaveProvider,
   useSaveProviderSecret,
 } from '../hooks/mutations';
+import { modelTagLabel } from '../utils/model-tag-label';
 
 const modelTagLiterals = ['chat', 'vision', 'embedding'] as const;
 
@@ -655,11 +656,7 @@ export function ProviderAddPanel({
                             </Text>
                             {watchedModels[index]?.tags.map((tag) => (
                               <Badge key={tag} variant="outline">
-                                {tag === 'chat'
-                                  ? t('providers.tagChat')
-                                  : tag === 'vision'
-                                    ? t('providers.tagVision')
-                                    : t('providers.tagEmbedding')}
+                                {modelTagLabel(tag, t)}
                               </Badge>
                             ))}
                           </HStack>
@@ -757,11 +754,7 @@ export function ProviderAddPanel({
                     handleDialogTagToggle(tag, checked === true)
                   }
                 />
-                {tag === 'chat'
-                  ? t('providers.tagChat')
-                  : tag === 'vision'
-                    ? t('providers.tagVision')
-                    : t('providers.tagEmbedding')}
+                {modelTagLabel(tag, t)}
               </label>
             ))}
           </HStack>

--- a/services/platform/app/features/settings/providers/components/provider-edit-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-edit-panel.tsx
@@ -16,6 +16,7 @@ import { useT } from '@/lib/i18n/client';
 
 import { useSaveProvider } from '../hooks/mutations';
 import { useReadProvider } from '../hooks/queries';
+import { modelTagLabel } from '../utils/model-tag-label';
 
 const NONE_VALUE = '__none__';
 
@@ -181,13 +182,7 @@ export function ProviderEditPanel({
                   return (
                     <Select
                       key={tag}
-                      label={
-                        tag === 'chat'
-                          ? t('providers.tagChat')
-                          : tag === 'vision'
-                            ? t('providers.tagVision')
-                            : t('providers.tagEmbedding')
-                      }
+                      label={modelTagLabel(tag, t)}
                       options={[
                         {
                           value: NONE_VALUE,

--- a/services/platform/app/features/settings/providers/utils/model-tag-label.ts
+++ b/services/platform/app/features/settings/providers/utils/model-tag-label.ts
@@ -1,0 +1,16 @@
+import type { TFunction } from 'i18next';
+
+import type { ModelTag } from '@/lib/shared/schemas/providers';
+
+const TAG_KEYS: Record<ModelTag, string> = {
+  chat: 'providers.tagChat',
+  vision: 'providers.tagVision',
+  embedding: 'providers.tagEmbedding',
+  'image-generation': 'providers.tagImageGeneration',
+  'image-edit': 'providers.tagImageEdit',
+};
+
+export function modelTagLabel(tag: string, t: TFunction): string {
+  const key = (TAG_KEYS as Record<string, string | undefined>)[tag];
+  return key ? t(key) : tag;
+}

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -270,7 +270,7 @@ function InstructionsTab() {
         open={promptLibraryOpen}
         onOpenChange={setPromptLibraryOpen}
         onSelectPrompt={(content) => {
-          const current = config.systemInstructions;
+          const current = config.systemInstructions ?? '';
           const separator = current.trim() ? '\n\n' : '';
           updateConfig({
             systemInstructions: current + separator + content,

--- a/services/platform/app/routes/dashboard/$id/settings/providers/$providerName.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/providers/$providerName.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { ChevronRight, Loader2, Pencil, Trash2, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import {
   Table,
@@ -33,6 +33,7 @@ import {
   ProviderConfigProvider,
   useProviderConfig,
 } from '@/app/features/settings/providers/hooks/use-provider-config-context';
+import { modelTagLabel } from '@/app/features/settings/providers/utils/model-tag-label';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
@@ -305,6 +306,7 @@ function ApiKeySection({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [apiKey, setApiKey] = useState('');
   const [saving, setSaving] = useState(false);
+  const apiKeyInputRef = useRef<HTMLInputElement>(null);
 
   const handleSaveKey = useCallback(
     async (e: React.FormEvent) => {
@@ -379,6 +381,10 @@ function ApiKeySection({
         size="md"
         hideClose
         className="flex flex-col gap-0 p-0"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          requestAnimationFrame(() => apiKeyInputRef.current?.focus());
+        }}
       >
         <HStack
           justify="between"
@@ -412,12 +418,12 @@ function ApiKeySection({
                 </Text>
               )}
               <Input
+                ref={apiKeyInputRef}
                 type="password"
                 label={t('providers.apiKey')}
                 placeholder={t('providers.apiKeyEnter')}
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                autoFocus
               />
             </Stack>
           </div>
@@ -453,6 +459,8 @@ interface ModelFormState {
   dimensions: string;
   inputCostPerMillion: string;
   outputCostPerMillion: string;
+  imageCostPerImage: string;
+  imageGenerationMode: '' | 'images-api' | 'chat-multimodal';
   baseUrl: string;
   apiKey: string;
 }
@@ -465,6 +473,8 @@ const EMPTY_MODEL_FORM: ModelFormState = {
   dimensions: '',
   inputCostPerMillion: '',
   outputCostPerMillion: '',
+  imageCostPerImage: '',
+  imageGenerationMode: '',
   baseUrl: '',
   apiKey: '',
 };
@@ -491,6 +501,7 @@ function ModelsSection({
   const [modelKeyAction, setModelKeyAction] = useState<
     'none' | 'remove' | 'replace'
   >('none');
+  const modelIdInputRef = useRef<HTMLInputElement>(null);
 
   const openAddDialog = useCallback(() => {
     setEditingIndex(null);
@@ -505,7 +516,7 @@ function ModelsSection({
       const model = config.models[index];
       if (!model) return;
       setEditingIndex(index);
-      const formData = {
+      const formData: ModelFormState = {
         id: model.id,
         displayName: model.displayName,
         description: model.description ?? '',
@@ -519,6 +530,11 @@ function ModelsSection({
           model.cost?.outputCentsPerMillion != null
             ? String(model.cost.outputCentsPerMillion / 100)
             : '',
+        imageCostPerImage:
+          model.cost?.imageCentsPerImage != null
+            ? String(model.cost.imageCentsPerImage / 100)
+            : '',
+        imageGenerationMode: model.imageGenerationMode ?? '',
         baseUrl: model.baseUrl ?? '',
         apiKey: '',
       };
@@ -533,24 +549,45 @@ function ModelsSection({
   const handleSubmitModel = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
+      const hasTokenCost =
+        !!form.inputCostPerMillion || !!form.outputCostPerMillion;
+      const hasImageCost = !!form.imageCostPerImage;
       const cost =
-        form.inputCostPerMillion || form.outputCostPerMillion
+        hasTokenCost || hasImageCost
           ? {
-              inputCentsPerMillion: form.inputCostPerMillion
-                ? Math.round(Number(form.inputCostPerMillion) * 100)
-                : 0,
-              outputCentsPerMillion: form.outputCostPerMillion
-                ? Math.round(Number(form.outputCostPerMillion) * 100)
-                : 0,
+              ...(hasTokenCost
+                ? {
+                    inputCentsPerMillion: form.inputCostPerMillion
+                      ? Math.round(Number(form.inputCostPerMillion) * 100)
+                      : 0,
+                    outputCentsPerMillion: form.outputCostPerMillion
+                      ? Math.round(Number(form.outputCostPerMillion) * 100)
+                      : 0,
+                  }
+                : {}),
+              ...(hasImageCost
+                ? {
+                    imageCentsPerImage: Math.round(
+                      Number(form.imageCostPerImage) * 100,
+                    ),
+                  }
+                : {}),
             }
           : undefined;
+      const isImageGen = form.tags.includes('image-generation');
       const model = {
         id: form.id,
         displayName: form.displayName,
         description: form.description || undefined,
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tags are constrained to checkbox values
-        tags: form.tags as Array<'chat' | 'vision' | 'embedding'>,
+        tags: form.tags as Array<
+          'chat' | 'vision' | 'embedding' | 'image-generation' | 'image-edit'
+        >,
         dimensions: form.dimensions ? Number(form.dimensions) : undefined,
+        imageGenerationMode:
+          isImageGen && form.imageGenerationMode
+            ? form.imageGenerationMode
+            : undefined,
         baseUrl: form.baseUrl.trim() || undefined,
         cost,
       };
@@ -690,22 +727,27 @@ function ModelsSection({
                     <HStack gap={1}>
                       {model.tags.map((tag) => (
                         <Badge key={tag} variant="outline" className="text-xs">
-                          {tag === 'chat'
-                            ? t('providers.tagChat')
-                            : tag === 'vision'
-                              ? t('providers.tagVision')
-                              : tag === 'embedding'
-                                ? t('providers.tagEmbedding')
-                                : tag}
+                          {modelTagLabel(tag, t)}
                         </Badge>
                       ))}
                     </HStack>
                   </TableCell>
                   <TableCell className="text-right">
-                    {model.cost ? (
+                    {model.cost?.imageCentsPerImage != null ? (
                       <Text className="text-muted-foreground text-xs">
-                        ${(model.cost.inputCentsPerMillion / 100).toFixed(2)} /
-                        ${(model.cost.outputCentsPerMillion / 100).toFixed(2)}
+                        ${(model.cost.imageCentsPerImage / 100).toFixed(2)}/img
+                      </Text>
+                    ) : model.cost?.inputCentsPerMillion != null ||
+                      model.cost?.outputCentsPerMillion != null ? (
+                      <Text className="text-muted-foreground text-xs">
+                        $
+                        {((model.cost.inputCentsPerMillion ?? 0) / 100).toFixed(
+                          2,
+                        )}{' '}
+                        / $
+                        {(
+                          (model.cost.outputCentsPerMillion ?? 0) / 100
+                        ).toFixed(2)}
                       </Text>
                     ) : (
                       <Text className="text-muted-foreground text-xs">—</Text>
@@ -743,6 +785,10 @@ function ModelsSection({
         size="md"
         hideClose
         className="flex flex-col gap-0 p-0"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          requestAnimationFrame(() => modelIdInputRef.current?.focus());
+        }}
       >
         <HStack
           justify="between"
@@ -772,11 +818,11 @@ function ModelsSection({
           <div className="flex-1 overflow-y-auto p-4 sm:px-6 sm:py-5">
             <Stack gap={4}>
               <Input
+                ref={modelIdInputRef}
                 label={t('providers.modelId')}
                 value={form.id}
                 onChange={(e) => setForm((f) => ({ ...f, id: e.target.value }))}
                 placeholder={t('providers.modelIdPlaceholder')}
-                autoFocus
               />
               <Input
                 label={t('providers.displayName')}
@@ -796,7 +842,15 @@ function ModelsSection({
                 rows={2}
               />
               <HStack gap={4} align="center" className="flex-wrap">
-                {(['chat', 'vision', 'embedding'] as const).map((tag) => (
+                {(
+                  [
+                    'chat',
+                    'vision',
+                    'embedding',
+                    'image-generation',
+                    'image-edit',
+                  ] as const
+                ).map((tag) => (
                   <label
                     key={tag}
                     className="flex items-center gap-1.5 text-sm"
@@ -812,13 +866,7 @@ function ModelsSection({
                         }));
                       }}
                     />
-                    {tag === 'chat'
-                      ? t('providers.tagChat')
-                      : tag === 'vision'
-                        ? t('providers.tagVision')
-                        : tag === 'embedding'
-                          ? t('providers.tagEmbedding')
-                          : tag}
+                    {modelTagLabel(tag, t)}
                   </label>
                 ))}
               </HStack>
@@ -832,6 +880,36 @@ function ModelsSection({
                   }
                   placeholder="e.g., 1536"
                 />
+              )}
+              {form.tags.includes('image-generation') && (
+                <Stack gap={3}>
+                  <div>
+                    <label className="text-foreground mb-1 block text-xs font-medium">
+                      {t('providers.imageGenerationMode')}
+                    </label>
+                    <select
+                      className="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+                      value={form.imageGenerationMode}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- select option values are constrained to the empty string or one of the two enum variants
+                          imageGenerationMode: e.target
+                            .value as ModelFormState['imageGenerationMode'],
+                        }))
+                      }
+                    >
+                      <option value="">
+                        images-api ({t('providers.default')})
+                      </option>
+                      <option value="images-api">images-api</option>
+                      <option value="chat-multimodal">chat-multimodal</option>
+                    </select>
+                    <Text className="text-muted-foreground mt-1 text-xs">
+                      {t('providers.imageGenerationModeHelp')}
+                    </Text>
+                  </div>
+                </Stack>
               )}
               <HStack gap={3}>
                 <Input
@@ -863,6 +941,22 @@ function ModelsSection({
                   step={0.01}
                 />
               </HStack>
+              {form.tags.includes('image-generation') && (
+                <Input
+                  label="Cost per image (USD)"
+                  type="number"
+                  value={form.imageCostPerImage}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      imageCostPerImage: e.target.value,
+                    }))
+                  }
+                  placeholder="e.g., 0.06"
+                  min={0}
+                  step={0.01}
+                />
+              )}
               <Text className="text-muted-foreground text-xs">
                 {t('providers.costHelp')}
               </Text>

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -127,6 +127,7 @@ import type * as agents_arena_chat from "../agents/arena_chat.js";
 import type * as agents_config from "../agents/config.js";
 import type * as agents_file_actions from "../agents/file_actions.js";
 import type * as agents_file_utils from "../agents/file_utils.js";
+import type * as agents_image_generation_run_image_generation from "../agents/image_generation/run_image_generation.js";
 import type * as agents_internal_actions from "../agents/internal_actions.js";
 import type * as agents_internal_mutations from "../agents/internal_mutations.js";
 import type * as agents_internal_queries from "../agents/internal_queries.js";
@@ -1103,6 +1104,7 @@ declare const fullApi: ApiFromModules<{
   "agents/config": typeof agents_config;
   "agents/file_actions": typeof agents_file_actions;
   "agents/file_utils": typeof agents_file_utils;
+  "agents/image_generation/run_image_generation": typeof agents_image_generation_run_image_generation;
   "agents/internal_actions": typeof agents_internal_actions;
   "agents/internal_mutations": typeof agents_internal_mutations;
   "agents/internal_queries": typeof agents_internal_queries;

--- a/services/platform/convex/agents/config.ts
+++ b/services/platform/convex/agents/config.ts
@@ -29,7 +29,8 @@ export function toSerializableConfig(
 
   return {
     name: agentName,
-    instructions: config.systemInstructions,
+    primaryBehavior: config.primaryBehavior,
+    instructions: config.systemInstructions ?? '',
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- toolNames are validated on file read; always valid ToolName values
     convexToolNames: config.toolNames as ToolName[],
     integrationBindings: config.integrationBindings,

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -108,6 +108,7 @@ export const listAgents = action({
             displayName: result.config.displayName,
             description: result.config.description,
             visibleInChat: result.config.visibleInChat,
+            primaryBehavior: result.config.primaryBehavior,
             supportedModels: result.config.supportedModels,
             toolNames: result.config.toolNames,
             roleRestriction: result.config.roleRestriction,
@@ -173,6 +174,7 @@ export const saveAgent = action({
       { orgSlug: args.orgSlug },
     );
     const byProvider = new Map<string, Set<string>>();
+    const modelTagLookup = new Map<string, string[]>();
     for (const m of allModels) {
       let set = byProvider.get(m.providerName);
       if (!set) {
@@ -180,11 +182,15 @@ export const saveAgent = action({
         byProvider.set(m.providerName, set);
       }
       set.add(m.id);
+      modelTagLookup.set(`${m.providerName}:${m.id}`, m.tags);
     }
 
+    const requireImageGenerationTag =
+      config.primaryBehavior === 'image-generation';
     const warnings: string[] = [];
     for (const ref of config.supportedModels) {
       const { providerName, modelId } = parseModelRef(ref);
+      let resolvedProviderName = providerName;
       if (providerName) {
         const set = byProvider.get(providerName);
         if (!set) {
@@ -207,6 +213,17 @@ export const saveAgent = action({
           warnings.push(
             `"${modelId}" matches ${matches.length} providers (${matches.join(', ')}); pinning to "${matches[0]}". Use "${matches[0]}:${modelId}" to pin explicitly.`,
           );
+        }
+        resolvedProviderName = matches[0];
+      }
+
+      if (requireImageGenerationTag && resolvedProviderName) {
+        const tags = modelTagLookup.get(`${resolvedProviderName}:${modelId}`);
+        if (!tags || !tags.includes('image-generation')) {
+          throw new ConvexError({
+            code: 'VALIDATION_ERROR',
+            message: `Model "${ref}" is missing the "image-generation" tag and cannot be used by an image-generation agent.`,
+          });
         }
       }
     }

--- a/services/platform/convex/agents/file_utils.ts
+++ b/services/platform/convex/agents/file_utils.ts
@@ -28,7 +28,16 @@ export interface AgentJsonConfig {
   displayName: string;
   description?: string;
   avatarUrl?: string;
-  systemInstructions: string;
+  /**
+   * Root behavior. Omitted = 'chat' (default). 'image-generation' routes the
+   * user's message straight to an image model, bypassing the tool loop.
+   */
+  primaryBehavior?: 'chat' | 'image-generation';
+  /**
+   * Required for chat agents. Optional for image-generation agents (used as a
+   * style/constraint prefix prepended to the user prompt if present).
+   */
+  systemInstructions?: string;
   toolNames?: string[];
   integrationBindings?: string[];
   delegates?: string[];

--- a/services/platform/convex/agents/image_generation/run_image_generation.ts
+++ b/services/platform/convex/agents/image_generation/run_image_generation.ts
@@ -134,6 +134,7 @@ export const runImageGeneration = internalAction({
       let usage:
         | { inputTokens: number; outputTokens: number; totalTokens: number }
         | undefined;
+      let providerCostUsd: number | undefined;
 
       if (resolved.kind === 'images-api') {
         // `prompt.images` at the AI SDK level routes to the standard OpenAI
@@ -173,16 +174,20 @@ export const runImageGeneration = internalAction({
         //
         // The wire shape is well-defined, so we issue the /chat/completions
         // call directly and parse the images out ourselves.
-        const { images: extractedImages, usage: extractedUsage } =
-          await fetchChatCompletionImages({
-            baseUrl: resolved.modelData.baseUrl,
-            apiKey: resolved.modelData.apiKey,
-            modelId: resolved.modelData.modelId,
-            textPrompt,
-            attachmentImages: attachmentBytes,
-          });
+        const {
+          images: extractedImages,
+          usage: extractedUsage,
+          providerCostUsd: extractedCostUsd,
+        } = await fetchChatCompletionImages({
+          baseUrl: resolved.modelData.baseUrl,
+          apiKey: resolved.modelData.apiKey,
+          modelId: resolved.modelData.modelId,
+          textPrompt,
+          attachmentImages: attachmentBytes,
+        });
         for (const img of extractedImages) imageBlobs.push(img);
         usage = extractedUsage;
+        providerCostUsd = extractedCostUsd;
       }
 
       if (imageBlobs.length === 0) {
@@ -232,14 +237,19 @@ export const runImageGeneration = internalAction({
 
       const durationMs = Date.now() - startedAt;
 
-      // Cost accounting. For image-only models (FLUX / Imagen) we charge per
-      // image using the model's `imageCentsPerImage`. For chat-multimodal
-      // image gen (Nano Banana / GPT-Image) we have real token usage AND
-      // typically a per-image fee — charge whichever is present (per-image
-      // dominates when both are set).
+      // Cost accounting. Prefer the gateway's billed USD amount
+      // (`usage.cost` from OpenRouter-compatible responses) — it accounts
+      // for resolution-dependent pricing that a flat per-image rate cannot
+      // express (FLUX.2 charges per megapixel). Fall back to the model's
+      // `imageCentsPerImage` when no provider cost was reported, and to
+      // token-derived math (computed in onAgentComplete) otherwise.
       const perImageCost = resolved.modelData.imageCentsPerImage;
       const imageCostCents =
-        perImageCost != null ? imageBlobs.length * perImageCost : undefined;
+        providerCostUsd != null
+          ? providerCostUsd * 100
+          : perImageCost != null
+            ? imageBlobs.length * perImageCost
+            : undefined;
 
       // Usage ledger + audit (best effort — don't fail the turn on telemetry)
       try {
@@ -327,6 +337,12 @@ export const runImageGeneration = internalAction({
 interface ChatCompletionsImageResult {
   images: Array<{ bytes: Uint8Array; mediaType: string }>;
   usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+  /**
+   * Actual cost in USD reported by the gateway (OpenRouter exposes this via
+   * `usage.cost`). Undefined when the gateway doesn't return a cost field,
+   * in which case callers fall back to the model's static per-image price.
+   */
+  providerCostUsd?: number;
 }
 
 /**
@@ -360,10 +376,14 @@ async function fetchChatCompletionImages(opts: {
 
   // Gateways that honor OpenAI's multimodal-output spec read `modalities`
   // as a top-level body field. Unknown-field tolerant gateways ignore it.
+  // `usage.include` asks OpenRouter to return the actual USD cost in
+  // `usage.cost` — megapixel-priced image models don't fit a flat per-image
+  // rate, so we prefer the gateway's billed amount over a static estimate.
   const body = {
     model: opts.modelId,
     messages: [{ role: 'user', content: userContent }],
     modalities: ['image'],
+    usage: { include: true },
   };
 
   const url = `${opts.baseUrl.replace(/\/+$/, '')}/chat/completions`;
@@ -407,6 +427,7 @@ async function fetchChatCompletionImages(opts: {
       prompt_tokens?: number;
       completion_tokens?: number;
       total_tokens?: number;
+      cost?: number;
     };
   };
 
@@ -429,6 +450,8 @@ async function fetchChatCompletionImages(opts: {
       outputTokens: body_.usage?.completion_tokens ?? 0,
       totalTokens: body_.usage?.total_tokens ?? 0,
     },
+    providerCostUsd:
+      typeof body_.usage?.cost === 'number' ? body_.usage.cost : undefined,
   };
 }
 

--- a/services/platform/convex/agents/image_generation/run_image_generation.ts
+++ b/services/platform/convex/agents/image_generation/run_image_generation.ts
@@ -1,0 +1,449 @@
+'use node';
+
+/**
+ * Direct-mode image generation runtime.
+ *
+ * Called for agents with `primaryBehavior === 'image-generation'`. Bypasses
+ * the chat-loop generate_response pipeline entirely — the user's latest
+ * message (text + any attached images) is sent straight to an image model
+ * via AI SDK, and the resulting image(s) are saved as an assistant message.
+ */
+
+import { saveMessage } from '@convex-dev/agent';
+import { generateImage } from 'ai';
+import { v } from 'convex/values';
+
+import { parseModelRef } from '../../../lib/shared/utils/model-ref';
+import { components, internal } from '../../_generated/api';
+import type { Id } from '../../_generated/dataModel';
+import { internalAction } from '../../_generated/server';
+import { onAgentComplete } from '../../lib/agent_completion';
+import { createDebugLog } from '../../lib/debug_log';
+import { buildDownloadUrl } from '../../lib/helpers/public_storage_url';
+import {
+  resolveImageModelById,
+  resolveImageModelByTag,
+  type ResolvedImageModel,
+} from '../../providers/resolve_model';
+
+const debugLog = createDebugLog(
+  'DEBUG_IMAGE_GENERATION',
+  '[runImageGeneration]',
+);
+
+/** Input: an image attachment from the user's turn. */
+const attachmentImageValidator = v.object({
+  fileId: v.string(),
+  fileName: v.string(),
+  mimeType: v.string(),
+});
+
+export const runImageGeneration = internalAction({
+  args: {
+    threadId: v.string(),
+    promptMessageId: v.string(),
+    /**
+     * Model reference in `provider:model-id` form, or bare `model-id`.
+     * Empty string falls back to the org's `image-generation` tag default.
+     */
+    modelRef: v.string(),
+    /** Raw user text prompt (without attachment markdown). */
+    rawPrompt: v.string(),
+    /** Optional style/constraint prefix from the agent config. */
+    systemInstructions: v.optional(v.string()),
+    /** Image attachments on the user message. Used for edit mode. */
+    attachmentImages: v.optional(v.array(attachmentImageValidator)),
+    /** Persistent stream id created at startAgentChat time. */
+    streamId: v.optional(v.string()),
+    /** Agent slug for telemetry/audit. */
+    agentSlug: v.optional(v.string()),
+    /** Org slug for provider resolution. */
+    orgSlug: v.optional(v.string()),
+    /** For usage ledger. */
+    organizationId: v.optional(v.string()),
+    userId: v.optional(v.string()),
+    teamIds: v.optional(v.array(v.string())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const startedAt = Date.now();
+    const agentSlug = args.agentSlug ?? 'image-creator';
+
+    try {
+      // Resolve model (by qualified ref if provided, else by image-generation tag)
+      let resolved: ResolvedImageModel;
+      if (args.modelRef && args.modelRef !== 'default') {
+        const { providerName, modelId } = parseModelRef(args.modelRef);
+        resolved = await resolveImageModelById(ctx, {
+          modelId,
+          providerName,
+          orgSlug: args.orgSlug,
+        });
+      } else {
+        resolved = await resolveImageModelByTag(ctx, {
+          orgSlug: args.orgSlug,
+        });
+      }
+
+      // Resolve bytes for any attached images (edit mode). We read the raw
+      // bytes from Convex storage and pass them as Uint8Array to the AI SDK —
+      // passing a URL would fail because the gateway cannot reach our dev
+      // localhost, and even in prod there are auth/proxy complications that
+      // sending bytes sidesteps entirely.
+      const attachmentImages = args.attachmentImages ?? [];
+      const attachmentBytes: Array<{ bytes: Uint8Array; mediaType: string }> =
+        [];
+      for (const att of attachmentImages) {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- storage ids round-trip through v.string(); Id<'_storage'> is the branded string ctx.storage.get expects.
+        const blob = await ctx.storage.get(att.fileId as Id<'_storage'>);
+        if (!blob) continue;
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        attachmentBytes.push({
+          bytes: buf,
+          mediaType: att.mimeType || blob.type || 'image/png',
+        });
+      }
+      const hasAttachments = attachmentBytes.length > 0;
+
+      // Edit-mode guard — text-only models cannot consume reference images.
+      if (hasAttachments && !resolved.modelData.tags.includes('image-edit')) {
+        throw new Error(
+          `Model "${resolved.modelData.modelId}" does not support image editing. ` +
+            'Switch to FLUX Kontext or Nano Banana to use attached images as references.',
+        );
+      }
+
+      // Build prompt: optional systemInstructions prefix + user message text
+      const textPrompt = args.systemInstructions
+        ? `${args.systemInstructions}\n\n${args.rawPrompt}`
+        : args.rawPrompt;
+
+      debugLog('generating', {
+        threadId: args.threadId,
+        modelId: resolved.modelData.modelId,
+        mode: resolved.kind,
+        hasAttachments,
+        attachmentCount: attachmentBytes.length,
+      });
+
+      // Call the appropriate AI SDK function.
+      const imageBlobs: Array<{
+        bytes: Uint8Array;
+        mediaType: string;
+      }> = [];
+      let usage:
+        | { inputTokens: number; outputTokens: number; totalTokens: number }
+        | undefined;
+
+      if (resolved.kind === 'images-api') {
+        // `prompt.images` at the AI SDK level routes to the standard OpenAI
+        // `/v1/images/edits` multipart endpoint — supported by LocalAI,
+        // LiteLLM, self-hosted gateways, and OpenAI itself. Gateways that
+        // don't expose `/v1/images/edits` (e.g. Vercel AI Gateway) will fail
+        // here; remove the `image-edit` tag from those models so the UI
+        // never sends edit requests to them.
+        const promptArg: string | { text: string; images: Uint8Array[] } =
+          hasAttachments
+            ? {
+                text: textPrompt,
+                images: attachmentBytes.map((a) => a.bytes),
+              }
+            : textPrompt;
+
+        const result = await generateImage({
+          model: resolved.imageModel,
+          prompt: promptArg,
+          n: 1,
+        });
+        for (const img of result.images) {
+          imageBlobs.push({
+            bytes: img.uint8Array,
+            mediaType: img.mediaType || 'image/png',
+          });
+        }
+      } else {
+        // chat-multimodal — Nano Banana / GPT-Image / OpenRouter FLUX / etc.
+        //
+        // We do NOT go through @ai-sdk/openai-compatible here: its chat
+        // response parser reads only `choices[0].message.content` and
+        // `.tool_calls`, silently dropping `choices[0].message.images[]`
+        // — which is exactly where gateways (OpenRouter, Vercel Gateway,
+        // plus the OpenAI gpt-image-in-chat spec) put generated images.
+        // `generateText` would therefore always see `result.files === []`.
+        //
+        // The wire shape is well-defined, so we issue the /chat/completions
+        // call directly and parse the images out ourselves.
+        const { images: extractedImages, usage: extractedUsage } =
+          await fetchChatCompletionImages({
+            baseUrl: resolved.modelData.baseUrl,
+            apiKey: resolved.modelData.apiKey,
+            modelId: resolved.modelData.modelId,
+            textPrompt,
+            attachmentImages: attachmentBytes,
+          });
+        for (const img of extractedImages) imageBlobs.push(img);
+        usage = extractedUsage;
+      }
+
+      if (imageBlobs.length === 0) {
+        throw new Error(
+          `Model "${resolved.modelData.modelId}" returned no image.`,
+        );
+      }
+
+      // Persist image blobs to Convex storage and build downloadable file parts.
+      // Use buildDownloadUrl so the URL is (a) browser-accessible via the
+      // public HTTP API proxy and (b) carries ?id=<storageId>, which the
+      // frontend's EditingBanner depends on to round-trip the image as a
+      // reference attachment for edit-mode requests.
+      const fileParts = await Promise.all(
+        imageBlobs.map(async (img, idx) => {
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Uint8Array<ArrayBufferLike> ↔ BlobPart mismatch is a TS strictness quirk; runtime is fine.
+          const blob = new Blob([img.bytes as BlobPart], {
+            type: img.mediaType,
+          });
+          const storageId = await ctx.storage.store(blob);
+          const extension = img.mediaType.split('/')[1] ?? 'png';
+          const fileName = `${agentSlug}-${Date.now()}-${idx + 1}.${extension}`;
+          const downloadUrl = buildDownloadUrl(storageId, fileName);
+          return {
+            type: 'file' as const,
+            mimeType: img.mediaType,
+            data: downloadUrl,
+            filename: fileName,
+          };
+        }),
+      );
+
+      // Save assistant message with image file parts. Do NOT pass
+      // promptMessageId: that's for attaching an extra file part to an existing
+      // assistant message at the same `order` as the prompt. For a brand-new
+      // assistant reply we let the SDK allocate the next `order` naturally —
+      // otherwise the image ends up collocated with the user turn and the
+      // next user message renders directly under it as if this one never
+      // responded.
+      const { messageId } = await saveMessage(ctx, components.agent, {
+        threadId: args.threadId,
+        message: {
+          role: 'assistant',
+          content: fileParts,
+        },
+      });
+
+      const durationMs = Date.now() - startedAt;
+
+      // Cost accounting. For image-only models (FLUX / Imagen) we charge per
+      // image using the model's `imageCentsPerImage`. For chat-multimodal
+      // image gen (Nano Banana / GPT-Image) we have real token usage AND
+      // typically a per-image fee — charge whichever is present (per-image
+      // dominates when both are set).
+      const perImageCost = resolved.modelData.imageCentsPerImage;
+      const imageCostCents =
+        perImageCost != null ? imageBlobs.length * perImageCost : undefined;
+
+      // Usage ledger + audit (best effort — don't fail the turn on telemetry)
+      try {
+        await onAgentComplete(ctx, {
+          threadId: args.threadId,
+          agentType: 'image-generation',
+          agentSlug,
+          organizationId: args.organizationId,
+          userId: args.userId,
+          teamIds: args.teamIds,
+          result: {
+            threadId: args.threadId,
+            messageId,
+            model: resolved.modelData.modelId,
+            provider: resolved.modelData.providerName,
+            usage: usage ?? {
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            durationMs,
+          },
+          providerCost:
+            resolved.modelData.inputCentsPerMillion != null
+              ? {
+                  inputCentsPerMillion: resolved.modelData.inputCentsPerMillion,
+                  outputCentsPerMillion:
+                    resolved.modelData.outputCentsPerMillion ?? 0,
+                }
+              : undefined,
+          costCentsOverride: imageCostCents,
+        });
+      } catch (telemetryErr) {
+        console.warn('[runImageGeneration] telemetry failed:', telemetryErr);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[runImageGeneration] failed:', {
+        threadId: args.threadId,
+        modelRef: args.modelRef,
+        error: message,
+      });
+
+      // Surface a failed assistant message so the UI has something to render.
+      // Same ordering rule as the success path above — no promptMessageId.
+      try {
+        await saveMessage(ctx, components.agent, {
+          threadId: args.threadId,
+          message: {
+            role: 'assistant',
+            content: `Image generation failed: ${message}`,
+          },
+          metadata: {
+            status: 'failed',
+            error: message,
+          },
+        });
+      } catch (saveErr) {
+        console.error(
+          '[runImageGeneration] also failed to save error message:',
+          saveErr,
+        );
+      }
+    } finally {
+      // Always clear the generation status so the UI stops showing "Thinking..."
+      if (args.streamId) {
+        try {
+          await ctx.runMutation(
+            internal.threads.internal_mutations.clearGenerationStatus,
+            { threadId: args.threadId, streamId: args.streamId },
+          );
+        } catch (clearErr) {
+          console.error(
+            '[runImageGeneration] failed to clear generation status:',
+            clearErr,
+          );
+        }
+      }
+    }
+
+    return null;
+  },
+});
+
+interface ChatCompletionsImageResult {
+  images: Array<{ bytes: Uint8Array; mediaType: string }>;
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+}
+
+/**
+ * Direct POST to `/chat/completions` with multimodal output, parsing image
+ * data URIs out of `choices[0].message.images[].image_url.url`.
+ *
+ * This is the documented response shape used by OpenRouter and Vercel AI
+ * Gateway for image-producing chat models, AND is what OpenAI itself
+ * emits for its multimodal GPT-image-in-chat output. `@ai-sdk/openai-
+ * compatible`'s chat response parser ignores `message.images`, so we go
+ * direct instead of chasing AI SDK abstractions that don't know about it.
+ */
+async function fetchChatCompletionImages(opts: {
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+  textPrompt: string;
+  attachmentImages: Array<{ bytes: Uint8Array; mediaType: string }>;
+}): Promise<ChatCompletionsImageResult> {
+  const userContent: Array<
+    | { type: 'text'; text: string }
+    | { type: 'image_url'; image_url: { url: string } }
+  > = [{ type: 'text', text: opts.textPrompt }];
+  for (const att of opts.attachmentImages) {
+    const b64 = Buffer.from(att.bytes).toString('base64');
+    userContent.push({
+      type: 'image_url',
+      image_url: { url: `data:${att.mediaType};base64,${b64}` },
+    });
+  }
+
+  // Gateways that honor OpenAI's multimodal-output spec read `modalities`
+  // as a top-level body field. Unknown-field tolerant gateways ignore it.
+  const body = {
+    model: opts.modelId,
+    messages: [{ role: 'user', content: userContent }],
+    modalities: ['image'],
+  };
+
+  const url = `${opts.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${opts.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(
+      `${opts.modelId} chat/completions failed (${response.status}): ${errText || response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as unknown;
+  if (
+    !json ||
+    typeof json !== 'object' ||
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed to object by the checks above
+    !Array.isArray((json as { choices?: unknown }).choices)
+  ) {
+    throw new Error('Unexpected chat/completions response shape');
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by shape check above
+  const body_ = json as {
+    choices: Array<{
+      message?: {
+        content?: string | null;
+        images?: Array<{
+          type?: string;
+          image_url?: { url?: string } | string;
+        }>;
+      };
+    }>;
+    usage?: {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+      total_tokens?: number;
+    };
+  };
+
+  const rawImages = body_.choices[0]?.message?.images ?? [];
+  const images: Array<{ bytes: Uint8Array; mediaType: string }> = [];
+  for (const entry of rawImages) {
+    const entryUrl =
+      typeof entry.image_url === 'string'
+        ? entry.image_url
+        : entry.image_url?.url;
+    if (!entryUrl) continue;
+    const parsed = parseDataUri(entryUrl);
+    if (parsed) images.push(parsed);
+  }
+
+  return {
+    images,
+    usage: {
+      inputTokens: body_.usage?.prompt_tokens ?? 0,
+      outputTokens: body_.usage?.completion_tokens ?? 0,
+      totalTokens: body_.usage?.total_tokens ?? 0,
+    },
+  };
+}
+
+function parseDataUri(
+  url: string,
+): { bytes: Uint8Array; mediaType: string } | null {
+  // data:image/png;base64,xxxx
+  const match = /^data:([^;,]+)(?:;base64)?,([\s\S]+)$/.exec(url);
+  if (!match) return null;
+  const mediaType = match[1] || 'image/png';
+  const payload = match[2];
+  try {
+    const bytes = new Uint8Array(Buffer.from(payload, 'base64'));
+    return { bytes, mediaType };
+  } catch {
+    return null;
+  }
+}

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -21,6 +21,7 @@ import { createAuditLog } from '../../audit_logs/helpers';
 import { checkBudget } from '../../governance/budget_enforcement';
 import { resolveFeatureFlags } from '../../governance/feature_enforcement';
 import { resolveBudgetContext } from '../../governance/resolve_budget_context';
+import { resolveOrgSlug } from '../../organizations/resolve_org_slug';
 import { persistentStreaming } from '../../streaming/helpers';
 import type { FileAttachment } from '../attachments';
 import type { AgentType } from '../context_management/constants';
@@ -337,6 +338,45 @@ export async function startAgentChat(
       internal.threads.generate_thread_title.generateThreadTitle,
       { threadId, firstMessage: messageContent, organizationId },
     );
+  }
+
+  // Direct-mode image-generation agents skip the tool-loop pipeline — the
+  // user's latest message is sent straight to an image model.
+  if (enforcedConfig.primaryBehavior === 'image-generation') {
+    const imageAttachments = (actionAttachments ?? []).filter((a) =>
+      a.fileType.startsWith('image/'),
+    );
+    const orgSlug = await resolveOrgSlug(ctx, organizationId);
+
+    debugLog('SCHEDULE_IMAGE_GENERATION', {
+      threadId,
+      model,
+      hasAttachments: imageAttachments.length > 0,
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.agents.image_generation.run_image_generation.runImageGeneration,
+      {
+        threadId,
+        promptMessageId,
+        modelRef: model,
+        rawPrompt: trimmedMessage,
+        systemInstructions: enforcedConfig.instructions || undefined,
+        attachmentImages: imageAttachments.map((a) => ({
+          fileId: a.fileId,
+          fileName: a.fileName,
+          mimeType: a.fileType,
+        })),
+        streamId: streamId || undefined,
+        agentSlug: args.agentSlug,
+        orgSlug,
+        organizationId,
+        userId: thread?.userId,
+      },
+    );
+
+    return { messageAlreadyExists, streamId };
   }
 
   // Schedule the generic agent action with full configuration

--- a/services/platform/convex/lib/agent_chat/types.ts
+++ b/services/platform/convex/lib/agent_chat/types.ts
@@ -15,7 +15,12 @@ import type { AgentType } from '../context_management/constants';
 export interface SerializableAgentConfig {
   /** Agent name identifier */
   name: string;
-  /** System instructions for the agent */
+  /**
+   * Root behavior. Omitted = 'chat'. When 'image-generation', the startAgentChat
+   * helper routes to the direct image-gen action instead of runAgentGeneration.
+   */
+  primaryBehavior?: 'chat' | 'image-generation';
+  /** System instructions for the agent (empty for image-generation agents with no style prefix) */
   instructions: string;
   /** List of Convex tool names to enable */
   convexToolNames?: ToolName[];

--- a/services/platform/convex/lib/agent_completion/on_agent_complete.ts
+++ b/services/platform/convex/lib/agent_completion/on_agent_complete.ts
@@ -76,6 +76,12 @@ export interface OnAgentCompleteArgs {
     inputCentsPerMillion: number;
     outputCentsPerMillion: number;
   };
+  /**
+   * When set, overrides the token-derived cost estimate and is recorded
+   * directly on message metadata and the usage ledger. Used for models
+   * priced per unit other than tokens (e.g. per-image for image gen).
+   */
+  costCentsOverride?: number;
   options?: {
     skipMetadata?: boolean;
   };
@@ -104,18 +110,22 @@ export async function onAgentComplete(
 
   const promises: Promise<unknown>[] = [];
 
-  // Compute cost estimate (used by both metadata save and ledger)
+  // Compute cost estimate (used by both metadata save and ledger). Models
+  // priced per-unit other than tokens (e.g. per-image for image gen) can
+  // pass `costCentsOverride` to bypass the token-based math entirely.
   const msgInputTokens = result.usage?.inputTokens ?? 0;
   const msgOutputTokens = result.usage?.outputTokens ?? 0;
   const costCents =
-    msgInputTokens > 0 || msgOutputTokens > 0
-      ? estimateCostCents(
-          result.model,
-          msgInputTokens,
-          msgOutputTokens,
-          args.providerCost,
-        )
-      : undefined;
+    args.costCentsOverride != null
+      ? args.costCentsOverride
+      : msgInputTokens > 0 || msgOutputTokens > 0
+        ? estimateCostCents(
+            result.model,
+            msgInputTokens,
+            msgOutputTokens,
+            args.providerCost,
+          )
+        : undefined;
 
   // Step 1: Save message metadata (unless skipped)
   if (!options?.skipMetadata) {
@@ -174,10 +184,14 @@ export async function onAgentComplete(
     }
   }
 
-  // Step 2: Increment usage ledger
+  // Step 2: Increment usage ledger.
+  // Record whenever we have ANY metered signal (tokens > 0 OR a direct cost
+  // override, e.g. per-image pricing for image-gen models). Skipping purely
+  // on tokens would cause image generations to go uncounted.
   const totalTokens = msgInputTokens + msgOutputTokens;
+  const hasMeteredSignal = totalTokens > 0 || args.costCentsOverride != null;
 
-  if (totalTokens > 0 && organizationId && userId && costCents != null) {
+  if (hasMeteredSignal && organizationId && userId && costCents != null) {
     const timestamp = Date.now();
 
     const teamId = teamIds?.[0];

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -344,11 +344,16 @@ export const resolveModelData = internalAction({
     baseUrl: v.string(),
     apiKey: v.string(),
     modelId: v.string(),
+    tags: v.array(v.string()),
     dimensions: v.optional(v.number()),
     maxOutputTokens: v.optional(v.number()),
     supportsStructuredOutputs: v.boolean(),
+    imageGenerationMode: v.optional(
+      v.union(v.literal('images-api'), v.literal('chat-multimodal')),
+    ),
     inputCentsPerMillion: v.optional(v.number()),
     outputCentsPerMillion: v.optional(v.number()),
+    imageCentsPerImage: v.optional(v.number()),
   }),
   handler: async (_ctx, args) => {
     const orgSlug = args.orgSlug ?? 'default';
@@ -401,13 +406,17 @@ export const resolveModelData = internalAction({
           provider.secrets.modelKeys?.[definition.id] ??
           provider.secrets.apiKey,
         modelId: args.modelId,
+        tags: [...definition.tags],
+        dimensions: definition.dimensions,
         maxOutputTokens: definition.maxOutputTokens,
         supportsStructuredOutputs:
           definition.supportsStructuredOutputs ??
           provider.config.supportsStructuredOutputs ??
           false,
+        imageGenerationMode: definition.imageGenerationMode,
         inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
         outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
+        imageCentsPerImage: definition.cost?.imageCentsPerImage,
       };
     }
 
@@ -435,11 +444,16 @@ export const resolveModelByTag = internalAction({
     baseUrl: v.string(),
     apiKey: v.string(),
     modelId: v.string(),
+    tags: v.array(v.string()),
     dimensions: v.optional(v.number()),
     maxOutputTokens: v.optional(v.number()),
     supportsStructuredOutputs: v.boolean(),
+    imageGenerationMode: v.optional(
+      v.union(v.literal('images-api'), v.literal('chat-multimodal')),
+    ),
     inputCentsPerMillion: v.optional(v.number()),
     outputCentsPerMillion: v.optional(v.number()),
+    imageCentsPerImage: v.optional(v.number()),
   }),
   handler: async (_ctx, args) => {
     const orgSlug = args.orgSlug ?? 'default';
@@ -475,14 +489,17 @@ export const resolveModelByTag = internalAction({
               provider.secrets.modelKeys?.[definition.id] ??
               provider.secrets.apiKey,
             modelId: definition.id,
+            tags: [...definition.tags],
             dimensions: definition.dimensions,
             maxOutputTokens: definition.maxOutputTokens,
             supportsStructuredOutputs:
               definition.supportsStructuredOutputs ??
               provider.config.supportsStructuredOutputs ??
               false,
+            imageGenerationMode: definition.imageGenerationMode,
             inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
             outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
+            imageCentsPerImage: definition.cost?.imageCentsPerImage,
           };
         }
       }
@@ -501,14 +518,17 @@ export const resolveModelByTag = internalAction({
             provider.secrets.modelKeys?.[definition.id] ??
             provider.secrets.apiKey,
           modelId: definition.id,
+          tags: [...definition.tags],
           dimensions: definition.dimensions,
           maxOutputTokens: definition.maxOutputTokens,
           supportsStructuredOutputs:
             definition.supportsStructuredOutputs ??
             provider.config.supportsStructuredOutputs ??
             false,
+          imageGenerationMode: definition.imageGenerationMode,
           inputCentsPerMillion: definition.cost?.inputCentsPerMillion,
           outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
+          imageCentsPerImage: definition.cost?.imageCentsPerImage,
         };
       }
     }

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -9,6 +9,7 @@
 
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type {
+  ImageModelV3,
   LanguageModelV3,
   LanguageModelV3Middleware,
 } from '@ai-sdk/provider';
@@ -22,17 +23,42 @@ export interface ResolvedModelData {
   baseUrl: string;
   apiKey: string;
   modelId: string;
+  tags: string[];
   dimensions?: number;
   maxOutputTokens?: number;
   supportsStructuredOutputs: boolean;
+  imageGenerationMode?: 'images-api' | 'chat-multimodal';
   inputCentsPerMillion?: number;
   outputCentsPerMillion?: number;
+  /** For per-image pricing (image-generation models). Complements the token
+   * fields above, which remain the cost source for chat/embedding models. */
+  imageCentsPerImage?: number;
 }
 
 interface ResolvedLanguageModel {
   languageModel: LanguageModelV3;
   modelData: ResolvedModelData;
 }
+
+/**
+ * Outcome of resolving an image-generation model. Branches on the model's
+ * `imageGenerationMode`:
+ * - `'images-api'`: uses `/v1/images/generations` via `generateImage()`
+ *   (FLUX, Imagen).
+ * - `'chat-multimodal'`: uses `/v1/chat/completions` with image parts,
+ *   images returned in `result.files` (Nano Banana, GPT-Image).
+ */
+export type ResolvedImageModel =
+  | {
+      kind: 'images-api';
+      imageModel: ImageModelV3;
+      modelData: ResolvedModelData;
+    }
+  | {
+      kind: 'chat-multimodal';
+      languageModel: LanguageModelV3;
+      modelData: ResolvedModelData;
+    };
 
 /**
  * Workaround: Flatten tool inputSchemas that use `oneOf`/`anyOf` at the root.
@@ -231,4 +257,81 @@ export async function resolveLanguageModelById(
     },
   )) as ResolvedModelData;
   return { languageModel: createLanguageModel(modelData), modelData };
+}
+
+// ---------------------------------------------------------------------------
+// Image model resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a bare image or language model for direct image generation.
+ * No middleware is applied — the chat-schema-fix workaround is tool-specific
+ * and irrelevant when no tools are passed.
+ */
+function buildImageResolution(
+  modelData: ResolvedModelData,
+): ResolvedImageModel {
+  const provider = createOpenAICompatible({
+    name: modelData.providerName,
+    baseURL: modelData.baseUrl,
+    apiKey: modelData.apiKey,
+  });
+  if (modelData.imageGenerationMode === 'chat-multimodal') {
+    return {
+      kind: 'chat-multimodal',
+      languageModel: provider.chatModel(modelData.modelId),
+      modelData,
+    };
+  }
+  return {
+    kind: 'images-api',
+    imageModel: provider.imageModel(modelData.modelId),
+    modelData,
+  };
+}
+
+/**
+ * Resolve an image-generation model by explicit model ID.
+ * Throws if the resolved model lacks the `'image-generation'` tag.
+ */
+export async function resolveImageModelById(
+  ctx: ActionCtx,
+  opts: { modelId: string; providerName?: string; orgSlug?: string },
+): Promise<ResolvedImageModel> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resolveModelData returns v.any() but shape is guaranteed by file_actions contract
+  const modelData = (await ctx.runAction(
+    internal.providers.file_actions.resolveModelData,
+    {
+      modelId: opts.modelId,
+      providerName: opts.providerName,
+      orgSlug: opts.orgSlug,
+    },
+  )) as ResolvedModelData;
+  if (!modelData.tags.includes('image-generation')) {
+    throw new Error(
+      `Model "${modelData.modelId}" lacks the "image-generation" tag.`,
+    );
+  }
+  return buildImageResolution(modelData);
+}
+
+/**
+ * Resolve the default image-generation model for the org (or first provider
+ * that has one). Uses the `defaults['image-generation']` field when set,
+ * otherwise falls back to the first model carrying the tag.
+ */
+export async function resolveImageModelByTag(
+  ctx: ActionCtx,
+  opts: { providerName?: string; orgSlug?: string } = {},
+): Promise<ResolvedImageModel> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resolveModelByTag returns v.any() but shape is guaranteed by file_actions contract
+  const modelData = (await ctx.runAction(
+    internal.providers.file_actions.resolveModelByTag,
+    {
+      tag: 'image-generation',
+      providerName: opts.providerName,
+      orgSlug: opts.orgSlug,
+    },
+  )) as ResolvedModelData;
+  return buildImageResolution(modelData);
 }

--- a/services/platform/lib/shared/schemas/agents.ts
+++ b/services/platform/lib/shared/schemas/agents.ts
@@ -12,7 +12,6 @@ export function isRetrievalMode(value: string): value is RetrievalMode {
 const retrievalModeSchema = z.enum(retrievalModeLiterals);
 
 const primaryBehaviorLiterals = ['chat', 'image-generation'] as const;
-export type AgentPrimaryBehavior = (typeof primaryBehaviorLiterals)[number];
 const primaryBehaviorSchema = z.enum(primaryBehaviorLiterals);
 
 const composerModeSchema = z.object({

--- a/services/platform/lib/shared/schemas/agents.ts
+++ b/services/platform/lib/shared/schemas/agents.ts
@@ -11,6 +11,10 @@ export function isRetrievalMode(value: string): value is RetrievalMode {
 
 const retrievalModeSchema = z.enum(retrievalModeLiterals);
 
+const primaryBehaviorLiterals = ['chat', 'image-generation'] as const;
+export type AgentPrimaryBehavior = (typeof primaryBehaviorLiterals)[number];
+const primaryBehaviorSchema = z.enum(primaryBehaviorLiterals);
+
 const composerModeSchema = z.object({
   label: z.string().min(1).max(80),
   icon: z.string().max(80).optional(),
@@ -31,57 +35,102 @@ const translatableFieldsSchema = z.object({
  * Schema for the agent JSON file format.
  * Matches the AgentJsonConfig type in convex/agents/file_utils.ts.
  */
-export const agentJsonSchema = z.object({
-  displayName: z.string().min(1).max(200),
-  description: z.string().max(1000).optional(),
-  avatarUrl: z.string().url().optional(),
-  systemInstructions: z.string().min(1),
-  toolNames: z.array(z.string()).optional(),
-  integrationBindings: z.array(z.string()).optional(),
-  delegates: z.array(z.string()).optional(),
-  workflows: z.array(z.string()).optional(),
-  supportedModels: z
-    .array(
-      z.string().min(1).refine(isValidModelRef, {
-        message: 'Invalid model ref (expected "[provider:]model-id")',
-      }),
-    )
-    .min(1),
-  provider: z
-    .string()
-    .min(1)
-    .max(100)
-    .regex(/^[a-z0-9][a-z0-9_-]*$/)
-    .optional(),
-  knowledgeMode: retrievalModeSchema.optional(),
-  webSearchMode: retrievalModeSchema.optional(),
-  includeOrgKnowledge: z.boolean().optional(),
-  includeTeamKnowledge: z.boolean().optional(),
-  knowledgeTopK: z.number().int().min(1).max(50).optional(),
-  structuredResponsesEnabled: z.boolean().optional(),
-  maxSteps: z.number().int().min(1).max(100).optional(),
-  timeoutMs: z.number().int().min(1000).optional(),
-  outputReserve: z.number().int().optional(),
-  /**
-   * Max number of integration tool calls allowed for a single agent run.
-   * Enforced at the integration-tool wrapper. Agents that cannot call
-   * integrations should leave this unset.
-   */
-  maxIntegrationCallsPerRun: z.number().int().min(1).max(500).optional(),
-  composerMode: composerModeSchema.optional(),
-  roleRestriction: z.literal('admin_developer').optional(),
-  conversationStarters: z.array(z.string().max(200)).max(4).optional(),
-  visibleInChat: z.boolean().optional(),
-  responseCacheEnabled: z.boolean().optional(),
-  responseCacheTtlMs: z.number().int().min(1000).max(604_800_000).optional(),
-  noCacheToolNames: z.array(z.string().min(1)).optional(),
-  i18n: z
-    .record(
-      z.string().regex(/^[a-z]{2}(-[A-Z]{2})?$/),
-      translatableFieldsSchema,
-    )
-    .optional(),
-});
+export const agentJsonSchema = z
+  .object({
+    displayName: z.string().min(1).max(200),
+    description: z.string().max(1000).optional(),
+    avatarUrl: z.string().url().optional(),
+    /**
+     * Root behavior this agent runs. Omitted = 'chat' (default tool-calling chat
+     * loop). When set to 'image-generation', the user message is routed straight
+     * to an image model; toolNames/integrationBindings/workflows are ignored.
+     */
+    primaryBehavior: primaryBehaviorSchema.optional(),
+    /**
+     * Required for chat agents (enforced by superRefine). Optional for
+     * image-generation agents, where an empty value means the user prompt goes
+     * to the image model unchanged; non-empty is prepended to the prompt as a
+     * style/constraint prefix.
+     */
+    systemInstructions: z.string().optional(),
+    toolNames: z.array(z.string()).optional(),
+    integrationBindings: z.array(z.string()).optional(),
+    delegates: z.array(z.string()).optional(),
+    workflows: z.array(z.string()).optional(),
+    supportedModels: z
+      .array(
+        z.string().min(1).refine(isValidModelRef, {
+          message: 'Invalid model ref (expected "[provider:]model-id")',
+        }),
+      )
+      .min(1),
+    provider: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-z0-9][a-z0-9_-]*$/)
+      .optional(),
+    knowledgeMode: retrievalModeSchema.optional(),
+    webSearchMode: retrievalModeSchema.optional(),
+    includeOrgKnowledge: z.boolean().optional(),
+    includeTeamKnowledge: z.boolean().optional(),
+    knowledgeTopK: z.number().int().min(1).max(50).optional(),
+    structuredResponsesEnabled: z.boolean().optional(),
+    maxSteps: z.number().int().min(1).max(100).optional(),
+    timeoutMs: z.number().int().min(1000).optional(),
+    outputReserve: z.number().int().optional(),
+    /**
+     * Max number of integration tool calls allowed for a single agent run.
+     * Enforced at the integration-tool wrapper. Agents that cannot call
+     * integrations should leave this unset.
+     */
+    maxIntegrationCallsPerRun: z.number().int().min(1).max(500).optional(),
+    composerMode: composerModeSchema.optional(),
+    roleRestriction: z.literal('admin_developer').optional(),
+    conversationStarters: z.array(z.string().max(200)).max(4).optional(),
+    visibleInChat: z.boolean().optional(),
+    responseCacheEnabled: z.boolean().optional(),
+    responseCacheTtlMs: z.number().int().min(1000).max(604_800_000).optional(),
+    noCacheToolNames: z.array(z.string().min(1)).optional(),
+    i18n: z
+      .record(
+        z.string().regex(/^[a-z]{2}(-[A-Z]{2})?$/),
+        translatableFieldsSchema,
+      )
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Chat agents require non-empty systemInstructions.
+    if (
+      (data.primaryBehavior ?? 'chat') === 'chat' &&
+      (data.systemInstructions == null || data.systemInstructions.length === 0)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['systemInstructions'],
+        message: 'systemInstructions is required for chat agents',
+      });
+    }
+    // Image-generation agents have no tool loop — these fields are meaningless.
+    if (data.primaryBehavior === 'image-generation') {
+      const disallowed: Array<keyof typeof data> = [
+        'toolNames',
+        'integrationBindings',
+        'workflows',
+        'delegates',
+      ];
+      for (const key of disallowed) {
+        const value = data[key];
+        if (Array.isArray(value) && value.length > 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [key],
+            message: `${String(key)} is not supported when primaryBehavior is "image-generation" — the agent bypasses the tool loop.`,
+          });
+        }
+      }
+    }
+  });
 type AgentJson = z.infer<typeof agentJsonSchema>;
 
 /**

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -12,7 +12,6 @@ export type ModelTag = z.infer<typeof modelTagSchema>;
 
 const imageGenerationModeLiterals = ['images-api', 'chat-multimodal'] as const;
 const imageGenerationModeSchema = z.enum(imageGenerationModeLiterals);
-export type ImageGenerationMode = z.infer<typeof imageGenerationModeSchema>;
 
 const modelDefinitionSchema = z.object({
   id: z.string().min(1).max(200),

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -1,8 +1,18 @@
 import { z } from 'zod/v4';
 
-const modelTagLiterals = ['chat', 'vision', 'embedding'] as const;
+const modelTagLiterals = [
+  'chat',
+  'vision',
+  'embedding',
+  'image-generation',
+  'image-edit',
+] as const;
 const modelTagSchema = z.enum(modelTagLiterals);
-type ModelTag = z.infer<typeof modelTagSchema>;
+export type ModelTag = z.infer<typeof modelTagSchema>;
+
+const imageGenerationModeLiterals = ['images-api', 'chat-multimodal'] as const;
+const imageGenerationModeSchema = z.enum(imageGenerationModeLiterals);
+export type ImageGenerationMode = z.infer<typeof imageGenerationModeSchema>;
 
 const modelDefinitionSchema = z.object({
   id: z.string().min(1).max(200),
@@ -14,10 +24,17 @@ const modelDefinitionSchema = z.object({
   supportsStructuredOutputs: z.boolean().optional(),
   fallbackModelId: z.string().min(1).max(200).optional(),
   baseUrl: z.string().url().optional(),
+  imageGenerationMode: imageGenerationModeSchema.optional(),
   cost: z
     .object({
-      inputCentsPerMillion: z.number(),
-      outputCentsPerMillion: z.number(),
+      inputCentsPerMillion: z.number().optional(),
+      outputCentsPerMillion: z.number().optional(),
+      /**
+       * For image-generation models that charge per image rather than per
+       * token. When set, cost tracking for this model uses
+       * `imageCount * imageCentsPerImage` directly, bypassing token math.
+       */
+      imageCentsPerImage: z.number().optional(),
     })
     .optional(),
 });
@@ -28,6 +45,7 @@ const providerDefaultsSchema = z.object({
   chat: z.string().min(1).max(200).optional(),
   vision: z.string().min(1).max(200).optional(),
   embedding: z.string().min(1).max(200).optional(),
+  'image-generation': z.string().min(1).max(200).optional(),
   fallbackProviderName: z.string().min(1).max(200).optional(),
   fallbackModelId: z.string().min(1).max(200).optional(),
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1571,6 +1571,11 @@
       "tagChat": "Chat",
       "tagVision": "Vision",
       "tagEmbedding": "Embedding",
+      "tagImageGeneration": "Bildgenerierung",
+      "tagImageEdit": "Bildbearbeitung",
+      "imageGenerationMode": "Bildgenerierungs-Modus",
+      "imageGenerationModeHelp": "Wie dieses Bildmodell aufgerufen wird. `images-api` nutzt den Standard-Endpunkt /v1/images/generations (FLUX, Imagen; Bearbeitung via /v1/images/edits). `chat-multimodal` nutzt /v1/chat/completions mit Bild-Inhaltsteilen (Nano Banana, GPT-Image; Bearbeitung via Bild-Teile in der Nutzernachricht).",
+      "default": "Standard",
       "displayNameRequired": "Anzeigename ist erforderlich",
       "invalidBaseUrl": "Basis-URL muss eine gültige URL sein",
       "modelIdRequired": "Alle Modelle müssen eine ID haben",
@@ -2804,7 +2809,9 @@
       "tags": {
         "chat": "Chat",
         "vision": "Vision",
-        "embedding": "Embedding"
+        "embedding": "Embedding",
+        "imageGeneration": "Bildgenerierung",
+        "imageEdit": "Bildbearbeitung"
       }
     },
     "searchChat": "Chat durchsuchen",
@@ -2890,6 +2897,19 @@
       "file": "Datei",
       "attachment": "Anhang",
       "imageAttachment": "Bildanhang"
+    },
+    "imageEdit": {
+      "editThis": "Dieses Bild bearbeiten",
+      "previewReference": "Referenzbild in Vollbild anzeigen",
+      "editingLatest": "Letztes Bild bearbeiten",
+      "editing": "Bearbeiten",
+      "dismiss": "Dieses Bild nicht referenzieren",
+      "change": "Ändern",
+      "placeholder": "Beschreibe die Bearbeitung…",
+      "placeholderCreate": "Beschreibe ein zu erzeugendes Bild…",
+      "modelCannotEdit": "Dieses Modell erzeugt nur neue Bilder. Wechsle zu einem Bearbeitungsmodell, um Änderungen anzuwenden.",
+      "pickAnImage": "Bild zum Bearbeiten auswählen",
+      "noOtherImages": "Keine weiteren Bilder in diesem Thread."
     },
     "downloadFile": "Datei herunterladen",
     "toolStatus": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1571,6 +1571,11 @@
       "tagChat": "Chat",
       "tagVision": "Vision",
       "tagEmbedding": "Embedding",
+      "tagImageGeneration": "Image generation",
+      "tagImageEdit": "Image edit",
+      "imageGenerationMode": "Image generation mode",
+      "imageGenerationModeHelp": "How this image model is invoked. `images-api` uses the standard /v1/images/generations endpoint (FLUX, Imagen; edit mode via /v1/images/edits). `chat-multimodal` uses /v1/chat/completions with image content parts (Nano Banana, GPT-Image; edit mode via image parts in the user message).",
+      "default": "default",
       "displayNameRequired": "Display name is required",
       "invalidBaseUrl": "Base URL must be a valid URL",
       "modelIdRequired": "All models must have an ID",
@@ -2804,7 +2809,9 @@
       "tags": {
         "chat": "Chat",
         "vision": "Vision",
-        "embedding": "Embedding"
+        "embedding": "Embedding",
+        "imageGeneration": "Image generation",
+        "imageEdit": "Image editing"
       }
     },
     "searchChat": "Search chat",
@@ -2890,6 +2897,19 @@
       "file": "File",
       "attachment": "Attachment",
       "imageAttachment": "Image attachment"
+    },
+    "imageEdit": {
+      "editThis": "Edit this image",
+      "previewReference": "Preview reference image",
+      "editingLatest": "Editing last image",
+      "editing": "Editing",
+      "dismiss": "Don't reference this image",
+      "change": "Change",
+      "placeholder": "Describe the edit…",
+      "placeholderCreate": "Describe an image to create…",
+      "modelCannotEdit": "This model creates new images only. Switch to an editing model to apply changes.",
+      "pickAnImage": "Pick an image to edit",
+      "noOtherImages": "No other images in this thread."
     },
     "downloadFile": "Download file",
     "toolStatus": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1567,6 +1567,11 @@
       "tagChat": "Chat",
       "tagVision": "Vision",
       "tagEmbedding": "Embedding",
+      "tagImageGeneration": "Génération d'images",
+      "tagImageEdit": "Édition d'images",
+      "imageGenerationMode": "Mode de génération d'images",
+      "imageGenerationModeHelp": "Comment ce modèle d'image est invoqué. `images-api` utilise le point de terminaison standard /v1/images/generations (FLUX, Imagen ; édition via /v1/images/edits). `chat-multimodal` utilise /v1/chat/completions avec des parties d'image dans le contenu (Nano Banana, GPT-Image ; édition via les parties image dans le message utilisateur).",
+      "default": "défaut",
       "displayNameRequired": "Le nom d'affichage est requis",
       "invalidBaseUrl": "L'URL de base doit être une URL valide",
       "modelIdRequired": "Tous les modèles doivent avoir un ID",
@@ -2800,7 +2805,9 @@
       "tags": {
         "chat": "Chat",
         "vision": "Vision",
-        "embedding": "Embedding"
+        "embedding": "Embedding",
+        "imageGeneration": "Génération d'images",
+        "imageEdit": "Édition d'images"
       }
     },
     "searchChat": "Rechercher dans le chat",
@@ -2886,6 +2893,19 @@
       "file": "Fichier",
       "attachment": "Pièce jointe",
       "imageAttachment": "Pièce jointe image"
+    },
+    "imageEdit": {
+      "editThis": "Modifier cette image",
+      "previewReference": "Prévisualiser l'image de référence",
+      "editingLatest": "Modifier la dernière image",
+      "editing": "Modifier",
+      "dismiss": "Ne pas référencer cette image",
+      "change": "Changer",
+      "placeholder": "Décrivez la modification…",
+      "placeholderCreate": "Décrivez une image à créer…",
+      "modelCannotEdit": "Ce modèle ne crée que de nouvelles images. Passez à un modèle d'édition pour appliquer des modifications.",
+      "pickAnImage": "Choisir une image à modifier",
+      "noOtherImages": "Aucune autre image dans ce fil."
     },
     "downloadFile": "Télécharger le fichier",
     "toolStatus": {


### PR DESCRIPTION
## Summary
- New `primaryBehavior: 'image-generation'` for agents: bypasses the tool loop and routes prompts directly to an image model via OpenRouter.
- Adds FLUX.2 (pro/max/flex) and Gemini 2.5 Flash Image to the OpenRouter provider config; extends provider/model schemas with image-generation tags, per-image cost, and `chat-multimodal` generation mode.
- Chat UI additions: thumbnail picker, editing banner, thread image gallery, and updated model selector/badges.
- Billing: `run_image_generation` reads OpenRouter `usage.cost` (via `usage.include`) and prefers it over a flat per-image rate — FLUX.2 prices per megapixel, so static rates under/over-bill at non-default resolutions.

## Test plan
- [ ] Create an agent with `primaryBehavior: 'image-generation'` bound to a FLUX.2 model; send a prompt; verify an image is generated and attached to the message.
- [ ] Same flow with Gemini 2.5 Flash Image.
- [ ] Verify billing rows use gateway-reported cost for FLUX.2 at non-default resolutions (not the flat per-image rate).
- [ ] Verify radio control in the searchable-select vertically centers against the label + badge row.
- [ ] Thumbnail picker + editing banner + thread images render correctly in chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added image-generation agent type with built-in editing support.
  * Introduced new image generation models: FLUX.2 (pro, max, flex) and Gemini 2.5 Flash Image.
  * Added image editing interface and thumbnail picker for managing generated and uploaded images.
  * Enhanced model selector with provider badges and image generation capabilities.

* **Improvements**
  * Expanded localization support to German and French for image workflows.
  * Added send-blocking UI with custom messaging for constrained operations.
  * Extended component APIs for better customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->