### PR TITLE
fix(platform): resolve governance default × model_access mismatch

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -51,7 +51,6 @@ import {
   useWorkflowUpdateApprovals,
 } from '../hooks/queries';
 import { useConvexFileUpload } from '../hooks/use-convex-file-upload';
-import { useDefaultModel } from '../hooks/use-default-model';
 import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { useFileIndexingStatus } from '../hooks/use-file-indexing-status';
 import { useMergedChatItems } from '../hooks/use-merged-chat-items';
@@ -196,7 +195,6 @@ export function ChatInterface({
 
   const { agent: effectiveAgent, isLoading: isAgentLoading } =
     useEffectiveAgent(organizationId);
-  const { data: governanceDefault } = useDefaultModel(organizationId);
 
   const [inputValue, setInputValue, clearInputValue] = usePersistedState(
     chatDraftKey(user?.userId, organizationId, threadId),
@@ -636,8 +634,7 @@ export function ChatInterface({
     },
     selectedAgent: effectiveAgent,
     modelId: effectiveAgent?.name
-      ? (selectedModelOverrides[effectiveAgent.name] ??
-        governanceDefault?.modelId)
+      ? selectedModelOverrides[effectiveAgent.name]
       : undefined,
     enabledCapabilities,
     userContext,
@@ -717,8 +714,7 @@ export function ChatInterface({
     async (newContent: string) => {
       if (!editingMessage || !dataThreadId || !effectiveAgent) return;
       const modelId = effectiveAgent.name
-        ? (selectedModelOverrides[effectiveAgent.name] ??
-          governanceDefault?.modelId)
+        ? selectedModelOverrides[effectiveAgent.name]
         : undefined;
 
       // Optimistic: show edited content immediately, truncate messages after it.
@@ -755,7 +751,6 @@ export function ChatInterface({
       rootThreadId,
       effectiveAgent,
       selectedModelOverrides,
-      governanceDefault,
       organizationId,
       userContext,
       editAndBranchAction,

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -352,13 +352,29 @@ export function useSendMessage({
         clearChatState();
         resetGlobalFreeze();
 
-        const errorMessage =
+        const rawMessage =
           error instanceof Error ? error.message : String(error);
-        const isPiiBlocked = errorMessage.includes('Message blocked: PII');
+        // First-line truncation defends against multi-line stack-like payloads
+        // from upstream LLM providers leaking into the toast.
+        const errorMessage = rawMessage.split('\n')[0] ?? rawMessage;
+        const lower = errorMessage.toLowerCase();
+
+        let title = t('toast.sendFailed');
+        if (errorMessage.includes('Message blocked: PII')) {
+          title = t('toast.piiBlocked');
+        } else if (
+          lower.includes('not available for your account') ||
+          lower.includes('model access policy') ||
+          lower.includes('do not have access to the selected model')
+        ) {
+          title = t('toast.modelAccessDenied');
+        } else if (lower.includes('usage limit') || lower.includes('budget')) {
+          title = t('toast.budgetExceeded');
+        }
 
         toast({
-          title: isPiiBlocked ? t('toast.piiBlocked') : t('toast.sendFailed'),
-          description: isPiiBlocked ? errorMessage : undefined,
+          title,
+          description: errorMessage,
           variant: 'destructive',
         });
       } finally {

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { AlertCircle, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Alert } from '@/app/components/ui/feedback/alert';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
@@ -19,8 +20,10 @@ import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import {
   defaultModelsConfigSchema,
+  modelAccessConfigSchema,
   type DefaultModelsConfig,
   type DefaultModelRule,
+  type ModelAccessConfig,
 } from '@/lib/shared/schemas/governance';
 import { cn } from '@/lib/utils/cn';
 import { isRecord } from '@/lib/utils/type-guards';
@@ -28,6 +31,59 @@ import { isRecord } from '@/lib/utils/type-guards';
 import { useUpsertGovernancePolicy } from '../hooks/mutations';
 import { useGovernancePolicy } from '../hooks/queries';
 import { SelectTriggerButton } from './select-trigger-button';
+
+function stripQualifier(s: string): string {
+  const idx = s.indexOf(':');
+  return idx === -1 ? s : s.slice(idx + 1);
+}
+
+/**
+ * Simulate which model_access rule applies to a user who matches the given
+ * default-model rule's scope, and decide whether the chosen model would be
+ * denied. Mirrors the backend priority: team > role > default (user scope is
+ * not a valid default-model scope).
+ */
+function computeAccessConflict(
+  accessConfig: ModelAccessConfig | null,
+  rule: DefaultModelRule,
+): 'allowlist' | 'blocklist' | null {
+  if (!rule.modelId) return null;
+  if (!accessConfig || !accessConfig.enabled || accessConfig.rules.length === 0)
+    return null;
+
+  let matched = undefined as (typeof accessConfig.rules)[number] | undefined;
+  if (rule.scope === 'team' && rule.scopeId) {
+    matched = accessConfig.rules.find(
+      (r) => r.scope === 'team' && r.scopeId === rule.scopeId,
+    );
+  }
+  if (!matched && rule.scope === 'role' && rule.scopeId) {
+    matched = accessConfig.rules.find(
+      (r) => r.scope === 'role' && r.scopeId === rule.scopeId,
+    );
+  }
+  if (!matched) {
+    matched = accessConfig.rules.find((r) => r.scope === 'default');
+  }
+  if (!matched) return null;
+
+  const target = stripQualifier(rule.modelId);
+  const blocked = (matched.blockedModels ?? []).map(stripQualifier);
+  if (blocked.includes(target)) return 'blocklist';
+
+  const allowed = matched.allowedModels.map(stripQualifier);
+  if (accessConfig.mode === 'allowlist' && !allowed.includes(target))
+    return 'allowlist';
+
+  return null;
+}
+
+function parseModelAccessConfig(policy: unknown): ModelAccessConfig | null {
+  const config = isRecord(policy) ? policy : null;
+  if (!config) return null;
+  const result = modelAccessConfigSchema.safeParse(config);
+  return result.success ? result.data : null;
+}
 
 interface DefaultModelEditorProps {
   organizationId: string;
@@ -88,6 +144,7 @@ interface RuleDialogProps {
   cannotManage: boolean;
   teamOptions: { value: string; label: string }[];
   providerList: ProviderInfo[];
+  accessConfig: ModelAccessConfig | null;
 }
 
 function RuleDialog({
@@ -99,6 +156,7 @@ function RuleDialog({
   cannotManage,
   teamOptions,
   providerList,
+  accessConfig,
 }: RuleDialogProps) {
   const { t } = useT('governance');
   const [draft, setDraft] = useState(initialRule);
@@ -156,6 +214,11 @@ function RuleDialog({
         label: m.displayName || m.id,
       }));
   }, [providerList, draft.providerName]);
+
+  const conflict = useMemo(
+    () => computeAccessConflict(accessConfig, draft),
+    [accessConfig, draft],
+  );
 
   return (
     <FormDialog
@@ -272,6 +335,23 @@ function RuleDialog({
             }
           />
         </div>
+
+        {conflict && (
+          <Alert
+            variant="warning"
+            icon={AlertCircle}
+            title={t(
+              conflict === 'allowlist'
+                ? 'defaultModels.allowlistConflictWarningTitle'
+                : 'defaultModels.blocklistConflictWarningTitle',
+            )}
+            description={t(
+              conflict === 'allowlist'
+                ? 'defaultModels.allowlistConflictWarning'
+                : 'defaultModels.blocklistConflictWarning',
+            )}
+          />
+        )}
       </Stack>
     </FormDialog>
   );
@@ -288,9 +368,18 @@ export function DefaultModelEditor({
     organizationId,
     'default_models',
   );
+  const { data: accessPolicy } = useGovernancePolicy(
+    organizationId,
+    'model_access',
+  );
   const upsertMutation = useUpsertGovernancePolicy();
   const { teams } = useOrgTeams();
   const { providers } = useListProviders('default');
+
+  const accessConfig = useMemo(
+    () => parseModelAccessConfig(accessPolicy?.config),
+    [accessPolicy],
+  );
 
   const teamOptions = useMemo(
     () =>
@@ -605,6 +694,7 @@ export function DefaultModelEditor({
         cannotManage={cannotManage}
         teamOptions={teamOptions}
         providerList={providerList}
+        accessConfig={accessConfig}
       />
     </PageSection>
   );

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -3,6 +3,7 @@
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Skeleton } from '@/app/components/ui/feedback/skeleton';
 import { CheckboxGroup } from '@/app/components/ui/forms/checkbox-group';
@@ -20,7 +21,10 @@ import { useAbility } from '@/app/hooks/use-ability';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import {
+  defaultModelsConfigSchema,
   modelAccessConfigSchema,
+  type DefaultModelRule,
+  type DefaultModelsConfig,
   type ModelAccessConfig,
   type ModelAccessRule,
 } from '@/lib/shared/schemas/governance';
@@ -30,6 +34,61 @@ import { isRecord } from '@/lib/utils/type-guards';
 import { useUpsertGovernancePolicy } from '../hooks/mutations';
 import { useGovernancePolicy } from '../hooks/queries';
 import { SelectTriggerButton } from './select-trigger-button';
+
+function stripQualifier(s: string): string {
+  const idx = s.indexOf(':');
+  return idx === -1 ? s : s.slice(idx + 1);
+}
+
+function parseDefaultModelsConfig(policy: unknown): DefaultModelsConfig | null {
+  const config = isRecord(policy) ? policy : null;
+  if (!config) return null;
+  const result = defaultModelsConfigSchema.safeParse(config);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Given a proposed model_access configuration, return the default-model rules
+ * whose modelId would be denied. Mirrors backend `checkModelAccess` priority:
+ * team > role > default (default_models has no user scope).
+ */
+function findDefaultRulesDeniedBy(
+  nextAccess: ModelAccessConfig,
+  defaultRules: DefaultModelRule[],
+): DefaultModelRule[] {
+  if (!nextAccess.enabled || nextAccess.rules.length === 0) return [];
+
+  const denied: DefaultModelRule[] = [];
+  for (const d of defaultRules) {
+    let matched: ModelAccessRule | undefined;
+    if (d.scope === 'team' && d.scopeId) {
+      matched = nextAccess.rules.find(
+        (r) => r.scope === 'team' && r.scopeId === d.scopeId,
+      );
+    }
+    if (!matched && d.scope === 'role' && d.scopeId) {
+      matched = nextAccess.rules.find(
+        (r) => r.scope === 'role' && r.scopeId === d.scopeId,
+      );
+    }
+    if (!matched) {
+      matched = nextAccess.rules.find((r) => r.scope === 'default');
+    }
+    if (!matched) continue;
+
+    const target = stripQualifier(d.modelId);
+    const blocked = (matched.blockedModels ?? []).map(stripQualifier);
+    const allowed = matched.allowedModels.map(stripQualifier);
+    if (blocked.includes(target)) {
+      denied.push(d);
+      continue;
+    }
+    if (nextAccess.mode === 'allowlist' && !allowed.includes(target)) {
+      denied.push(d);
+    }
+  }
+  return denied;
+}
 
 interface ModelAccessEditorProps {
   organizationId: string;
@@ -261,6 +320,14 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     organizationId,
     'model_access',
   );
+  const { data: defaultPolicy } = useGovernancePolicy(
+    organizationId,
+    'default_models',
+  );
+  const defaultRules = useMemo<DefaultModelRule[]>(() => {
+    const parsed = parseDefaultModelsConfig(defaultPolicy?.config);
+    return parsed?.enabled ? parsed.rules : [];
+  }, [defaultPolicy]);
   const upsertMutation = useUpsertGovernancePolicy();
   const { members } = useMembers(organizationId);
   const { teams } = useOrgTeams();
@@ -318,6 +385,13 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [dialogRule, setDialogRule] = useState(emptyRule());
 
+  // Pending save + affected-defaults confirmation state.
+  const [pendingSave, setPendingSave] = useState<{
+    next: ModelAccessConfig;
+    affected: DefaultModelRule[];
+    revert: () => void;
+  } | null>(null);
+
   if (!isLoading && !initializedRef.current) {
     initializedRef.current = true;
     setEnabled(savedConfig.enabled);
@@ -345,30 +419,54 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     [organizationId, upsertMutation, toast, t],
   );
 
+  /**
+   * Attempt to save; if the proposed config would deny any current
+   * default-model rule, open a confirm dialog. `revert` restores local state
+   * if the admin cancels.
+   */
+  const attemptSaveConfig = useCallback(
+    (next: ModelAccessConfig, revert: () => void) => {
+      const affected = findDefaultRulesDeniedBy(next, defaultRules);
+      if (affected.length === 0) {
+        void saveConfig(next);
+        return;
+      }
+      setPendingSave({ next, affected, revert });
+    },
+    [defaultRules, saveConfig],
+  );
+
   const handleToggleEnabled = useCallback(
     (checked: boolean) => {
+      const prev = enabled;
       setEnabled(checked);
-      void saveConfig({ enabled: checked, mode, rules });
+      attemptSaveConfig({ enabled: checked, mode, rules }, () =>
+        setEnabled(prev),
+      );
     },
-    [saveConfig, mode, rules],
+    [attemptSaveConfig, enabled, mode, rules],
   );
 
   const handleModeChange = useCallback(
     (value: string) => {
       if (!isModeValue(value)) return;
+      const prev = mode;
       setMode(value);
-      void saveConfig({ enabled, mode: value, rules });
+      attemptSaveConfig({ enabled, mode: value, rules }, () => setMode(prev));
     },
-    [saveConfig, enabled, rules],
+    [attemptSaveConfig, enabled, mode, rules],
   );
 
   const removeRule = useCallback(
     (index: number) => {
+      const prev = rules;
       const newRules = rules.filter((_, i) => i !== index);
       setRules(newRules);
-      void saveConfig({ enabled, mode, rules: newRules });
+      attemptSaveConfig({ enabled, mode, rules: newRules }, () =>
+        setRules(prev),
+      );
     },
-    [rules, enabled, mode, saveConfig],
+    [rules, enabled, mode, attemptSaveConfig],
   );
 
   const openAddDialog = useCallback(() => {
@@ -388,6 +486,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
 
   const handleDialogSave = useCallback(
     (rule: ModelAccessRule) => {
+      const prev = rules;
       let newRules: ModelAccessRule[];
       if (editingIndex === null) {
         newRules = [...rules, rule];
@@ -395,9 +494,11 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
         newRules = rules.map((r, i) => (i === editingIndex ? rule : r));
       }
       setRules(newRules);
-      void saveConfig({ enabled, mode, rules: newRules });
+      attemptSaveConfig({ enabled, mode, rules: newRules }, () =>
+        setRules(prev),
+      );
     },
-    [editingIndex, rules, enabled, mode, saveConfig],
+    [editingIndex, rules, enabled, mode, attemptSaveConfig],
   );
 
   const resolveTarget = useCallback(
@@ -598,6 +699,37 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
           mode={mode}
         />
       )}
+
+      <ConfirmDialog
+        open={pendingSave !== null}
+        onOpenChange={(open) => {
+          if (!open && pendingSave) {
+            pendingSave.revert();
+            setPendingSave(null);
+          }
+        }}
+        title={t('modelAccess.removeDefaultConfirmTitle')}
+        description={t('modelAccess.removeDefaultConfirmBody', {
+          rules:
+            pendingSave?.affected
+              .map((r) => {
+                const target =
+                  r.scope === 'default'
+                    ? t('modelAccess.allUsers')
+                    : (r.scopeId ?? r.scope);
+                return `${r.modelId} (${target})`;
+              })
+              .join(', ') ?? '',
+        })}
+        confirmText={t('modelAccess.removeDefaultConfirmAction')}
+        variant="destructive"
+        onConfirm={() => {
+          if (pendingSave) {
+            void saveConfig(pendingSave.next);
+            setPendingSave(null);
+          }
+        }}
+      />
     </PageSection>
   );
 }

--- a/services/platform/convex/agents/unified_chat.ts
+++ b/services/platform/convex/agents/unified_chat.ts
@@ -126,9 +126,16 @@ export const chatWithAgent = action({
     // Same supportedModels gate as the explicit modelId path — silently
     // ignored if the governance model isn't in the agent's supported list.
     if (!args.modelId && governanceDefault?.modelId) {
+      // Reconstruct a qualified ref so the governance-specified provider flows
+      // through to parseModelRef downstream. applyModelOverride's matching is
+      // qualifier-insensitive, so matching against supportedModels still works
+      // whether entries are qualified or plain.
+      const qualifiedRef = governanceDefault.providerName
+        ? `${governanceDefault.providerName}:${governanceDefault.modelId}`
+        : governanceDefault.modelId;
       applyModelOverride(
         agentConfig,
-        governanceDefault.modelId,
+        qualifiedRef,
         configResult.supportedModels,
       );
     }
@@ -233,6 +240,25 @@ export const chatWithAgent = action({
         },
       );
       if (!accessCheck.allowed) {
+        await ctx.runMutation(
+          internal.audit_logs.internal_mutations.createAuditLog,
+          {
+            organizationId: args.organizationId,
+            actorId: authUserId,
+            actorEmail: authUserEmail,
+            actorType: 'user',
+            action: 'model_access.denied',
+            category: 'ai',
+            resourceType: 'chat_message',
+            resourceId: args.threadId,
+            status: 'denied',
+            metadata: {
+              requestedModelId: args.modelId,
+              reason: accessCheck.reason ?? null,
+              agentSlug: args.agentSlug,
+            },
+          },
+        );
         await rollbackGenerating();
         throw new Error(
           accessCheck.reason ?? 'You do not have access to the selected model.',

--- a/services/platform/convex/governance/__tests__/resolve_default_model.test.ts
+++ b/services/platform/convex/governance/__tests__/resolve_default_model.test.ts
@@ -5,9 +5,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const mockReadPolicyConfig = vi.fn();
+const mockCheckModelAccess = vi.fn();
 
 vi.mock('../helpers', () => ({
   readPolicyConfig: (...args: unknown[]) => mockReadPolicyConfig(...args),
+}));
+
+vi.mock('../model_access_enforcement', () => ({
+  checkModelAccess: (...args: unknown[]) => mockCheckModelAccess(...args),
 }));
 
 // Import after mocks
@@ -23,6 +28,9 @@ const ctx = {} as Parameters<typeof resolveDefaultModel>[0];
 describe('resolveDefaultModel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: allow every model so existing scope-priority tests stay focused
+    // on scope behavior. Access-check cases override this per test.
+    mockCheckModelAccess.mockResolvedValue({ allowed: true });
   });
 
   it('returns null when no default_models policy exists', async () => {
@@ -31,6 +39,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-1'],
       'member',
     );
@@ -58,6 +67,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-1'],
       'member',
     );
@@ -74,6 +84,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-1'],
       'member',
     );
@@ -102,6 +113,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-engineering'],
       'member',
     );
@@ -133,7 +145,13 @@ describe('resolveDefaultModel', () => {
       ],
     });
 
-    const result = await resolveDefaultModel(ctx, 'org-1', ['team-1'], 'admin');
+    const result = await resolveDefaultModel(
+      ctx,
+      'org-1',
+      'user-1',
+      ['team-1'],
+      'admin',
+    );
 
     expect(result).toEqual({ providerName: 'openai', modelId: 'gpt-4o' });
   });
@@ -159,6 +177,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-unrelated'],
       'developer',
     );
@@ -196,6 +215,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-marketing'],
       'member',
     );
@@ -225,6 +245,7 @@ describe('resolveDefaultModel', () => {
     const result = await resolveDefaultModel(
       ctx,
       'org-1',
+      'user-1',
       ['team-a', 'team-b'],
       'member',
     );
@@ -248,8 +269,105 @@ describe('resolveDefaultModel', () => {
       ],
     });
 
-    const result = await resolveDefaultModel(ctx, 'org-1', [], undefined);
+    const result = await resolveDefaultModel(
+      ctx,
+      'org-1',
+      'user-1',
+      [],
+      undefined,
+    );
 
     expect(result).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Model-access cross-check (Layer 1)
+  // -------------------------------------------------------------------------
+
+  it('returns null when the resolved default is denied by model_access', async () => {
+    mockReadPolicyConfig.mockResolvedValue({
+      enabled: true,
+      rules: [
+        {
+          scope: 'default',
+          providerName: 'openrouter',
+          modelId: 'qwen/qwen3-vl-32b-instruct',
+        },
+      ],
+    });
+    mockCheckModelAccess.mockResolvedValue({
+      allowed: false,
+      reason: 'Model not in allowlist',
+    });
+
+    const result = await resolveDefaultModel(
+      ctx,
+      'org-1',
+      'user-1',
+      ['team-1'],
+      'member',
+    );
+
+    expect(result).toBeNull();
+    expect(mockCheckModelAccess).toHaveBeenCalledWith(
+      ctx,
+      'org-1',
+      'user-1',
+      ['team-1'],
+      'member',
+      'qwen/qwen3-vl-32b-instruct',
+    );
+  });
+
+  it('returns the rule when the resolved default is allowed by model_access', async () => {
+    mockReadPolicyConfig.mockResolvedValue({
+      enabled: true,
+      rules: [
+        {
+          scope: 'default',
+          providerName: 'openrouter',
+          modelId: 'kimi-k2.5',
+        },
+      ],
+    });
+    mockCheckModelAccess.mockResolvedValue({ allowed: true });
+
+    const result = await resolveDefaultModel(
+      ctx,
+      'org-1',
+      'user-1',
+      [],
+      'member',
+    );
+
+    expect(result).toEqual({
+      providerName: 'openrouter',
+      modelId: 'kimi-k2.5',
+    });
+  });
+
+  it('does not call checkModelAccess when no rule applies', async () => {
+    mockReadPolicyConfig.mockResolvedValue({
+      enabled: true,
+      rules: [
+        {
+          scope: 'role',
+          scopeId: 'admin',
+          providerName: 'openai',
+          modelId: 'gpt-4o',
+        },
+      ],
+    });
+
+    const result = await resolveDefaultModel(
+      ctx,
+      'org-1',
+      'user-1',
+      [],
+      'member',
+    );
+
+    expect(result).toBeNull();
+    expect(mockCheckModelAccess).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/governance/default_model_query.ts
+++ b/services/platform/convex/governance/default_model_query.ts
@@ -51,6 +51,12 @@ export const getMyDefaultModel = query({
 
     const teamIds = membershipsResult?.page.map((m) => m.teamId) ?? [];
 
-    return resolveDefaultModel(ctx, args.organizationId, teamIds, member.role);
+    return resolveDefaultModel(
+      ctx,
+      args.organizationId,
+      member.userId,
+      teamIds,
+      member.role,
+    );
   },
 });

--- a/services/platform/convex/governance/internal_queries.ts
+++ b/services/platform/convex/governance/internal_queries.ts
@@ -333,7 +333,13 @@ export const resolveDefaultModelInternal = internalQuery({
 
     const teamIds = membershipsResult?.page.map((m) => m.teamId) ?? [];
 
-    return resolveDefaultModel(ctx, args.organizationId, teamIds, member.role);
+    return resolveDefaultModel(
+      ctx,
+      args.organizationId,
+      args.userId,
+      teamIds,
+      member.role,
+    );
   },
 });
 

--- a/services/platform/convex/governance/model_access_enforcement.ts
+++ b/services/platform/convex/governance/model_access_enforcement.ts
@@ -1,6 +1,7 @@
 import type { GenericQueryCtx } from 'convex/server';
 
 import type { ModelAccessConfig } from '../../lib/shared/schemas/governance';
+import { stripModelRefQualifier } from '../../lib/shared/utils/model-ref';
 import type { DataModel } from '../_generated/dataModel';
 import { readPolicyConfig } from './helpers';
 
@@ -98,12 +99,15 @@ function isModelPermitted(
   blockedModels: string[],
   modelId: string,
 ): boolean {
-  if (blockedModels.includes(modelId)) {
+  const plainId = stripModelRefQualifier(modelId);
+  const plainBlocked = blockedModels.map(stripModelRefQualifier);
+  if (plainBlocked.includes(plainId)) {
     return false;
   }
 
   if (mode === 'allowlist') {
-    return allowedModels.includes(modelId);
+    const plainAllowed = allowedModels.map(stripModelRefQualifier);
+    return plainAllowed.includes(plainId);
   }
 
   // blocklist mode: everything allowed except blocked

--- a/services/platform/convex/governance/resolve_default_model.ts
+++ b/services/platform/convex/governance/resolve_default_model.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../lib/shared/schemas/governance';
 import type { DataModel } from '../_generated/dataModel';
 import { readPolicyConfig } from './helpers';
+import { checkModelAccess } from './model_access_enforcement';
 
 interface DefaultModelOverride {
   providerName: string;
@@ -39,11 +40,15 @@ function findApplicableModelRule(
 /**
  * Resolve the default model override for a user based on governance policies.
  *
- * Returns the provider/model override or null if no governance override exists.
+ * Returns the provider/model override or null if no governance override exists,
+ * or if the resolved model is denied by the org's model_access policy (so that
+ * callers fall through to an access-safe auto-pick rather than propagating a
+ * model that will be rejected downstream).
  */
 export async function resolveDefaultModel(
   ctx: GenericQueryCtx<DataModel>,
   organizationId: string,
+  userId: string,
   teamIds: string[],
   userRole?: string,
 ): Promise<DefaultModelOverride | null> {
@@ -59,6 +64,18 @@ export async function resolveDefaultModel(
 
   const rule = findApplicableModelRule(config.rules, teamIds, userRole);
   if (!rule) {
+    return null;
+  }
+
+  const accessCheck = await checkModelAccess(
+    ctx,
+    organizationId,
+    userId,
+    teamIds,
+    userRole,
+    rule.modelId,
+  );
+  if (!accessCheck.allowed) {
     return null;
   }
 

--- a/services/platform/convex/openai_compat/internal_actions.ts
+++ b/services/platform/convex/openai_compat/internal_actions.ts
@@ -10,6 +10,7 @@
 import { streamText, type ModelMessage } from 'ai';
 import { v } from 'convex/values';
 
+import { stripModelRefQualifier } from '../../lib/shared/utils/model-ref';
 import { isRecord } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
@@ -157,6 +158,39 @@ export const chatDirectModel = internalAction({
       throw new Error(
         budgetResult.reason ??
           'Usage limit reached for this period. Contact your administrator.',
+      );
+    }
+
+    // Model access RBAC. Strip provider qualifier so governance policies
+    // (which store plain model ids) match regardless of routing.
+    const accessCheck = await ctx.runQuery(
+      internal.governance.internal_queries.checkModelAccessInternal,
+      {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        modelId: stripModelRefQualifier(args.modelId),
+      },
+    );
+    if (!accessCheck.allowed) {
+      await ctx.runMutation(
+        internal.audit_logs.internal_mutations.createAuditLog,
+        {
+          organizationId: args.organizationId,
+          actorId: args.userId,
+          actorEmail: args.userEmail,
+          actorType: 'api',
+          action: 'model_access.denied',
+          category: 'ai',
+          resourceType: 'openai_compat_request',
+          status: 'denied',
+          metadata: {
+            requestedModelId: args.modelId,
+            reason: accessCheck.reason ?? null,
+          },
+        },
+      );
+      throw new Error(
+        accessCheck.reason ?? 'You do not have access to the selected model.',
       );
     }
 

--- a/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_agent_with_tools.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_agent_with_tools.ts
@@ -13,6 +13,7 @@ import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { Agent } from '@convex-dev/agent';
 import { z } from 'zod/v4';
 
+import { stripModelRefQualifier } from '../../../../../lib/shared/utils/model-ref';
 import { isRecord } from '../../../../../lib/utils/type-guards';
 import { components, internal } from '../../../../_generated/api';
 import type { ActionCtx } from '../../../../_generated/server';
@@ -147,6 +148,7 @@ export async function executeAgentWithTools(
     stepSlug?: string;
     knowledgeFileIds?: string[];
     languageModel: LanguageModelV3;
+    resolvedModelId?: string;
   },
 ): Promise<LLMExecutionResult> {
   if (config.outputFormat === 'json' && !config.outputSchema) {
@@ -171,6 +173,45 @@ export async function executeAgentWithTools(
         budgetResult.reason ??
           'Workflow LLM step blocked: usage limit reached for this period.',
       );
+    }
+
+    // Model access RBAC for the resolved chat model. Skipped when no user
+    // identity is attached (e.g. system-triggered executions), matching the
+    // conditional above.
+    if (_args.resolvedModelId) {
+      const accessCheck = await ctx.runQuery(
+        internal.governance.internal_queries.checkModelAccessInternal,
+        {
+          organizationId: _args.organizationId,
+          userId: _args.userId,
+          modelId: stripModelRefQualifier(_args.resolvedModelId),
+        },
+      );
+      if (!accessCheck.allowed) {
+        await ctx.runMutation(
+          internal.audit_logs.internal_mutations.createAuditLog,
+          {
+            organizationId: _args.organizationId,
+            actorId: _args.userId,
+            actorType: 'workflow',
+            action: 'model_access.denied',
+            category: 'ai',
+            resourceType: 'workflow_llm_step',
+            ...(_args.stepSlug ? { resourceId: _args.stepSlug } : {}),
+            status: 'denied',
+            metadata: {
+              requestedModelId: _args.resolvedModelId,
+              reason: accessCheck.reason ?? null,
+              executionId: _args.executionId,
+              stepSlug: _args.stepSlug ?? null,
+            },
+          },
+        );
+        throw new Error(
+          accessCheck.reason ??
+            'Workflow LLM step blocked: model not permitted by model access policy.',
+        );
+      }
     }
   }
 

--- a/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_llm_node.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_llm_node.ts
@@ -75,6 +75,7 @@ export async function executeLLMNode(
       knowledgeFileIds,
       userId,
       languageModel,
+      resolvedModelId: chatModelData.modelId,
     },
   );
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2737,7 +2737,9 @@
     "toast": {
       "generateFailed": "Antwort konnte nicht generiert werden",
       "sendFailed": "Nachricht konnte nicht gesendet werden",
-      "piiBlocked": "Nachricht durch PII-Richtlinie blockiert"
+      "piiBlocked": "Nachricht durch PII-Richtlinie blockiert",
+      "modelAccessDenied": "Modell nicht verfügbar",
+      "budgetExceeded": "Nutzungslimit erreicht"
     },
     "thinking": {
       "default": "Denkt nach",
@@ -4077,7 +4079,11 @@
       "noModelsFound": "Keine Modelle gefunden",
       "noTeamsFound": "Keine Teams gefunden",
       "enabled": "Aktiviert",
-      "confirm": "Bestätigen"
+      "confirm": "Bestätigen",
+      "allowlistConflictWarningTitle": "Modell nicht in Allowlist",
+      "allowlistConflictWarning": "Dieses Modell ist derzeit nicht durch die Allowlist der Modellzugriffsrichtlinie für diesen Geltungsbereich zugelassen. Betroffene Benutzer weichen auf ein erlaubtes Modell aus.",
+      "blocklistConflictWarningTitle": "Modell ist blockiert",
+      "blocklistConflictWarning": "Dieses Modell ist derzeit durch die Modellzugriffsrichtlinie für diesen Geltungsbereich blockiert. Betroffene Benutzer weichen auf ein erlaubtes Modell aus."
     },
     "uploadPolicy": {
       "title": "Upload-Richtlinie",
@@ -4295,7 +4301,10 @@
       "preview": "Vorschau",
       "saved": "Modellzugriffsrichtlinie gespeichert",
       "saveFailed": "Modellzugriffsrichtlinie konnte nicht gespeichert werden",
-      "denied": "Modell für dein Konto nicht verfügbar. Wende dich an deinen Administrator, um Zugriff zu beantragen."
+      "denied": "Modell für dein Konto nicht verfügbar. Wende dich an deinen Administrator, um Zugriff zu beantragen.",
+      "removeDefaultConfirmTitle": "Berechtigung für aktives Standardmodell entfernen?",
+      "removeDefaultConfirmBody": "Folgende Standardmodell-Regel(n) verwenden Modelle, die nicht mehr erlaubt wären: {rules}. Betroffene Benutzer weichen auf ein anderes erlaubtes Modell aus.",
+      "removeDefaultConfirmAction": "Trotzdem speichern"
     }
   },
   "prompts": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2737,7 +2737,9 @@
     "toast": {
       "generateFailed": "Failed to generate response",
       "sendFailed": "Failed to send message",
-      "piiBlocked": "Message blocked by PII policy"
+      "piiBlocked": "Message blocked by PII policy",
+      "modelAccessDenied": "Model not available",
+      "budgetExceeded": "Usage limit reached"
     },
     "thinking": {
       "default": "Thinking",
@@ -4077,7 +4079,11 @@
       "noModelsFound": "No models found",
       "noTeamsFound": "No teams found",
       "enabled": "Enabled",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "allowlistConflictWarningTitle": "Model not in allowlist",
+      "allowlistConflictWarning": "This model isn't currently permitted by the Model access allowlist for this scope. Users receiving this default will fall back to an allowlist-permitted model.",
+      "blocklistConflictWarningTitle": "Model is blocked",
+      "blocklistConflictWarning": "This model is currently blocked by the Model access policy for this scope. Users receiving this default will fall back to a permitted model."
     },
     "uploadPolicy": {
       "title": "Upload policy",
@@ -4302,7 +4308,10 @@
       "preview": "Preview",
       "saved": "Model access policy saved",
       "saveFailed": "Failed to save model access policy",
-      "denied": "Model not available for your account. Contact your administrator to request access."
+      "denied": "Model not available for your account. Contact your administrator to request access.",
+      "removeDefaultConfirmTitle": "Remove permission for active default model?",
+      "removeDefaultConfirmBody": "The following default model rule(s) currently assign models that would no longer be permitted: {rules}. Affected users will fall back to another permitted model.",
+      "removeDefaultConfirmAction": "Save anyway"
     }
   },
   "prompts": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2733,7 +2733,9 @@
     "toast": {
       "generateFailed": "Échec de la génération de la réponse",
       "sendFailed": "Échec de l'envoi du message",
-      "piiBlocked": "Message bloqué par la politique de protection des données personnelles"
+      "piiBlocked": "Message bloqué par la politique de protection des données personnelles",
+      "modelAccessDenied": "Modèle non disponible",
+      "budgetExceeded": "Limite d'utilisation atteinte"
     },
     "thinking": {
       "default": "Réflexion",
@@ -3995,7 +3997,11 @@
       "noModelsFound": "Aucun modèle trouvé",
       "noTeamsFound": "Aucune équipe trouvée",
       "enabled": "Activé",
-      "confirm": "Confirmer"
+      "confirm": "Confirmer",
+      "allowlistConflictWarningTitle": "Modèle absent de la liste d'autorisation",
+      "allowlistConflictWarning": "Ce modèle n'est actuellement pas autorisé par la politique d'accès aux modèles pour cette portée. Les utilisateurs concernés basculeront vers un modèle autorisé.",
+      "blocklistConflictWarningTitle": "Modèle bloqué",
+      "blocklistConflictWarning": "Ce modèle est actuellement bloqué par la politique d'accès aux modèles pour cette portée. Les utilisateurs concernés basculeront vers un modèle autorisé."
     },
     "uploadPolicy": {
       "title": "Politique de téléversement",
@@ -4199,7 +4205,10 @@
       "preview": "Aperçu",
       "saved": "Politique d'accès aux modèles enregistrée",
       "saveFailed": "Échec de l'enregistrement de la politique d'accès aux modèles",
-      "denied": "Modèle non disponible pour ton compte. Contacte ton administrateur pour demander l'accès."
+      "denied": "Modèle non disponible pour ton compte. Contacte ton administrateur pour demander l'accès.",
+      "removeDefaultConfirmTitle": "Révoquer l'accès à un modèle par défaut actif ?",
+      "removeDefaultConfirmBody": "Les règles de modèle par défaut suivantes utilisent des modèles qui ne seraient plus autorisés : {rules}. Les utilisateurs concernés basculeront vers un autre modèle autorisé.",
+      "removeDefaultConfirmAction": "Enregistrer quand même"
     }
   },
   "prompts": {


### PR DESCRIPTION
## Summary

- End users hit an opaque "Failed to send message" toast when an admin combined three settings: `default_models` rule pointing to model X, `model_access` enabled in allowlist mode, X not in the allowlist. The frontend pre-resolved the governance default via `getMyDefaultModel` and sent it as an explicit `modelId`, bypassing the backend auto-path's allowlist filtering.
- Fix is layered: backend sanitizes the governance default against `model_access`; frontend stops pre-resolving; error UX surfaces the real backend reason; admin UI warns on conflicting policy combinations.
- Also closes pre-existing gaps: the OpenAI-compat `chatDirectModel` endpoint and workflow LLM steps now enforce `model_access` alongside their existing budget check (they were only running the budget gate before).

## Changes

**Backend**
- `resolveDefaultModel` cross-checks against `checkModelAccess` and returns `null` if denied, so callers fall through to the auto-pick path. Signature adds a `userId` parameter; both call sites already had it in scope.
- `isModelPermitted` normalizes both the input id and stored `allowedModels`/`blockedModels` via `stripModelRefQualifier`, so `provider:id` and plain `id` forms compare correctly.
- `unified_chat` reconstructs a qualified `provider:model` ref before calling `applyModelOverride`, so the governance-specified provider flows through to `parseModelRef` downstream (the ref was being flattened to plain id, letting the agent's declared provider win).
- `unified_chat`, `openai_compat/chatDirectModel`, and workflow `executeAgentWithTools` emit audit logs on denial (`action: 'model_access.denied'`, matching the PII audit pattern).
- `openai_compat/chatDirectModel` and workflow LLM steps now call `checkModelAccessInternal` right after `checkBudgetForRequest`. The workflow check is skipped when no user identity is attached, preserving the budget-check symmetry for system-triggered executions.

**Frontend**
- `chat-interface` drops the `?? governanceDefault?.modelId` fallback on both the send path and the edit-and-branch path; only user-selected overrides are sent as `modelId`. The backend auto-path (now allowlist-aware via Layer 1) picks the default.
- `use-send-message` stops discarding non-PII error messages. Title routes by keyword match (model access / budget / PII / generic `sendFailed`); description shows the first line of the backend reason (truncated to defend against multi-line provider payloads).
- `default-model-editor`: inline warning in the rule dialog when the selected model isn't permitted by the current `model_access` policy for the chosen scope (non-blocking).
- `model-access-editor`: before saving any change that would deny a currently-referenced default-model rule, opens a `ConfirmDialog` listing the affected rules. Cancel restores local state.

**i18n**
- New keys in `en` / `de` / `fr`: `chat.toast.modelAccessDenied`, `chat.toast.budgetExceeded`, `settings.governance.defaultModels.allowlistConflictWarning(Title)`, `settings.governance.defaultModels.blocklistConflictWarning(Title)`, `settings.governance.modelAccess.removeDefaultConfirm(Title|Body|Action)`.

**Tests**
- `resolve_default_model.test.ts` updated for the new `userId` param and extended with three access-check cases (default allowed, default denied, no rule → no access-check call).

## Test plan

- [ ] Reproduce the original bug: set `default_models` = Qwen3 VL 32B (OpenRouter) for all users, set `model_access` allowlist = [Kimi K2.5, Qwen3 Next 80B], send a chat message in Auto mode → message should send successfully using an allowlisted model (no toast error).
- [ ] Manually pick a model that gets added to blocklist mid-session → next send shows specific "Model ... is not available for your account" in toast description under the Model-not-available title.
- [ ] Allowlist excludes every model in the agent's supportedModels → toast shows "No model in this agent is permitted by your organization's model access policy." as description.
- [ ] Admin saves a Default Models rule whose model is outside the allowlist → yellow inline warning appears in the rule dialog; save still works.
- [ ] Admin removes Kimi K2.5 from allowlist while Kimi K2.5 is the active default → confirm dialog lists the affected default rule; cancel restores state, confirm proceeds.
- [ ] Call `/api/v1/chat/completions` with a model that's outside the org's allowlist → HTTP error body contains the access-denied reason; audit log recorded.
- [ ] Run a workflow with an LLM step whose resolved org chat model is excluded by allowlist → step fails with access-denied reason captured against the step; audit log recorded.
- [ ] System-triggered workflow (no `userId`) → access check is skipped; step runs normally.
- [ ] Automated: `npx vitest run convex/governance/__tests__/resolve_default_model.test.ts convex/agents/__tests__/unified_chat_ttft.test.ts` — 15/15 pass locally. `npx tsc --noEmit` and `npm run lint --workspace=@tale/platform` both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conflict warnings when setting default models that violate access policies.
  * Introduced confirmation dialogs for changes affecting active policy rules.

* **Bug Fixes**
  * Improved error messages for model access denials and usage limit violations.
  * Fixed model identifier matching in access control to handle qualified references consistently.

* **Localization**
  * Added new error and warning messages in English, German, and French for model access and budget-related notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->