### PR TITLE
feat(platform): split save prompt menu and swap history toggle to clock icon

### DIFF
--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DataTableSkeleton } from '@/app/components/ui/data-table/data-table-skeleton';
+import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { LinkButton } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
 import { useT } from '@/lib/i18n/client';
@@ -192,15 +193,12 @@ export function AutomationsTable({
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="flex items-center justify-between gap-4">
-        <input
-          type="text"
-          className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full max-w-sm rounded-md border px-3 py-1 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        <SearchInput
+          wrapperClassName="w-full max-w-sm"
           placeholder={tAutomations('search.placeholder')}
           aria-label={tAutomations('search.placeholder')}
           value={searchQuery}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setSearchQuery(e.target.value)
-          }
+          onChange={(e) => setSearchQuery(e.target.value)}
         />
         <div className="flex items-center gap-2">
           <LinkButton

--- a/services/platform/app/features/automations/metrics/metrics-page.tsx
+++ b/services/platform/app/features/automations/metrics/metrics-page.tsx
@@ -49,13 +49,8 @@ export function WorkflowMetricsPage({
 
   return (
     <Stack gap={4} className="p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <Text as="h3" variant="label" className="text-lg font-semibold">
-            {t('metrics.title')}
-          </Text>
-          <Text variant="caption">{t('metrics.description')}</Text>
-        </div>
+      <div className="flex items-center justify-between gap-4">
+        <Text variant="caption">{t('metrics.description')}</Text>
         <div className="w-44">
           <Select
             options={periodOptions}

--- a/services/platform/app/features/chat/components/chat-header.tsx
+++ b/services/platform/app/features/chat/components/chat-header.tsx
@@ -2,10 +2,9 @@
 
 import { useNavigate } from '@tanstack/react-router';
 import {
+  Clock,
   Download,
   Ellipsis,
-  PanelLeftClose,
-  PanelLeftOpen,
   Search,
   Share,
   Plus,
@@ -32,14 +31,9 @@ import { ShareChatDialog } from './share-chat-dialog';
 interface ChatHeaderProps {
   organizationId: string;
   threadId?: string;
-  onSelectPrompt?: (content: string) => void;
 }
 
-export function ChatHeader({
-  organizationId,
-  threadId,
-  onSelectPrompt,
-}: ChatHeaderProps) {
+export function ChatHeader({ organizationId, threadId }: ChatHeaderProps) {
   const navigate = useNavigate();
   const { isHistoryOpen, setIsHistoryOpen, clearChatState } = useChatLayout();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -143,7 +137,6 @@ export function ChatHeader({
         <ChatHistorySidebar
           organizationId={organizationId}
           onChatSelect={handleChatSelect}
-          onSelectPrompt={onSelectPrompt}
           className="h-full"
         />
       </Sheet>
@@ -152,7 +145,7 @@ export function ChatHeader({
         <Tooltip
           content={
             <>
-              {isHistoryOpen ? tChat('closeSidebar') : tChat('openSidebar')}
+              {isHistoryOpen ? tChat('hideHistory') : tChat('showHistory')}
               <span className="text-muted bg-muted-foreground/60 ml-3 rounded-sm px-1 py-0.5 text-xs">
                 {historyShortcut}
               </span>
@@ -166,17 +159,16 @@ export function ChatHeader({
             variant="ghost"
             onClick={handleToggleHistory}
             aria-label={
-              isHistoryOpen ? tChat('closeSidebar') : tChat('openSidebar')
+              isHistoryOpen ? tChat('hideHistory') : tChat('showHistory')
             }
             className={cn(isHistoryOpen && 'bg-accent text-accent-foreground')}
           >
-            {isHistoryOpen ? (
-              <PanelLeftClose
-                className={cn(baseIconClasses, 'text-accent-foreground')}
-              />
-            ) : (
-              <PanelLeftOpen className={baseIconClasses} />
-            )}
+            <Clock
+              className={cn(
+                baseIconClasses,
+                isHistoryOpen && 'text-accent-foreground',
+              )}
+            />
           </Button>
         </Tooltip>
 
@@ -261,14 +253,15 @@ export function ChatHeader({
             variant="ghost"
             onClick={handleToggleHistory}
             aria-label={
-              isMobileHistoryOpen ? tChat('closeSidebar') : tChat('openSidebar')
+              isMobileHistoryOpen ? tChat('hideHistory') : tChat('showHistory')
             }
           >
-            {isMobileHistoryOpen ? (
-              <PanelLeftClose className={baseIconClasses} />
-            ) : (
-              <PanelLeftOpen className={baseIconClasses} />
-            )}
+            <Clock
+              className={cn(
+                baseIconClasses,
+                isMobileHistoryOpen && 'text-accent-foreground',
+              )}
+            />
           </Button>
           <Button
             size="icon"

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from '@tanstack/react-router';
 import {
   CircleDotIcon,
   Share2Icon,
-  BookOpen,
+  ChevronDown,
   MessageSquareDashedIcon,
 } from 'lucide-react';
 import {
@@ -17,15 +17,12 @@ import {
 } from 'react';
 
 import { Stack } from '@/app/components/ui/layout/layout';
-import { Tabs } from '@/app/components/ui/navigation/tabs';
-import { Tooltip } from '@/app/components/ui/overlays/tooltip';
-import { Button } from '@/app/components/ui/primitives/button';
 import { Text } from '@/app/components/ui/typography/text';
+import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
-import { lazyComponent } from '@/lib/utils/lazy-component';
 
 import { useUpdateThread } from '../hooks/mutations';
 import {
@@ -34,14 +31,6 @@ import {
   useThreads,
 } from '../hooks/queries';
 import { ChatActions } from './chat-actions';
-
-const PromptLibraryDialog = lazyComponent<
-  import('@/app/features/prompts/components/prompt-library-dialog').PromptLibraryDialogProps
->(() =>
-  import('@/app/features/prompts/components/prompt-library-dialog').then(
-    (m) => ({ default: m.PromptLibraryDialog }),
-  ),
-);
 
 const emptySubscribe = () => () => {};
 
@@ -58,7 +47,6 @@ interface ChatHistorySidebarProps extends ComponentPropsWithoutRef<'div'> {
   onSearchOpen?: () => void;
   onNewChat?: () => void;
   onChatSelect?: () => void;
-  onSelectPrompt?: (content: string) => void;
 }
 
 export function ChatHistorySidebar({
@@ -66,7 +54,6 @@ export function ChatHistorySidebar({
   onSearchOpen,
   onNewChat,
   onChatSelect,
-  onSelectPrompt,
   className,
   ...restProps
 }: ChatHistorySidebarProps) {
@@ -78,8 +65,10 @@ export function ChatHistorySidebar({
   const [isMac, setIsMac] = useState(false);
   const [editingChatId, setEditingChatId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
-  const [activeTab, setActiveTab] = useState<'history' | 'archived'>('history');
-  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
+  const [archivedExpanded, setArchivedExpanded] = usePersistedState(
+    'chat-sidebar-archived-expanded',
+    false,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const clickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useIsMounted();
@@ -277,259 +266,220 @@ export function ChatHistorySidebar({
       )}
       {...restProps}
     >
-      <Tabs
-        value={activeTab}
-        onValueChange={(v) => {
-          if (v === 'history' || v === 'archived') setActiveTab(v);
-        }}
-        triggerClassName="flex-1"
-        className="flex min-h-0 flex-1 flex-col"
-        listClassName="w-full"
-        items={[
-          {
-            value: 'history',
-            label: t('chatHistory'),
-            content: (
-              <Stack gap={1} className="min-h-0 flex-1 overflow-y-auto pb-2">
-                {!isMounted || !chats ? (
-                  <Text as="div" variant="muted" className="px-2 text-nowrap">
-                    {t('history.loading')}
-                  </Text>
-                ) : chats.length === 0 ? (
-                  <div className="flex flex-1 flex-col items-center justify-center gap-1 px-6 pt-40 text-center">
-                    <MessageSquareDashedIcon
-                      className="text-muted-foreground/60 mb-1 size-8"
-                      aria-hidden
-                    />
-                    <Text
-                      as="div"
-                      variant="muted"
-                      className="text-foreground font-medium"
-                    >
-                      {t('history.empty')}
-                    </Text>
-                    <Text as="div" variant="caption">
-                      {t('history.emptySubtitle')}
-                    </Text>
-                  </div>
-                ) : (
-                  <>
-                    {chats.map((chat) => {
-                      const isEditing = editingChatId === chat._id;
-                      const isGenerating =
-                        !pendingThreadIds.has(chat._id) &&
-                        (chat.generationStatus === 'generating' ||
-                          executingThreadIds.has(chat._id));
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <section className="flex flex-col">
+          <Text
+            as="div"
+            variant="caption"
+            className="text-muted-foreground px-2 pt-1 pb-2 text-xs font-medium tracking-wide uppercase"
+          >
+            {t('chatHistory')}
+          </Text>
+          <Stack gap={1} className="pb-2">
+            {!isMounted || !chats ? (
+              <Text as="div" variant="muted" className="px-2 text-nowrap">
+                {t('history.loading')}
+              </Text>
+            ) : chats.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-1 px-6 py-10 text-center">
+                <MessageSquareDashedIcon
+                  className="text-muted-foreground/60 mb-1 size-8"
+                  aria-hidden
+                />
+                <Text
+                  as="div"
+                  variant="muted"
+                  className="text-foreground font-medium"
+                >
+                  {t('history.empty')}
+                </Text>
+                <Text as="div" variant="caption">
+                  {t('history.emptySubtitle')}
+                </Text>
+              </div>
+            ) : (
+              <>
+                {chats.map((chat) => {
+                  const isEditing = editingChatId === chat._id;
+                  const isGenerating =
+                    !pendingThreadIds.has(chat._id) &&
+                    (chat.generationStatus === 'generating' ||
+                      executingThreadIds.has(chat._id));
 
-                      return (
-                        <div
-                          key={chat._id}
-                          className={cn(
-                            'group relative flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors',
-                            !isEditing &&
-                              'cursor-pointer hover:bg-accent hover:text-accent-foreground',
-                            currentThreadId === chat._id &&
-                              !isEditing &&
-                              'bg-accent text-accent-foreground',
-                            isGenerating && 'animate-pulse',
-                          )}
-                        >
-                          {isEditing ? (
-                            <input
-                              ref={inputRef}
-                              value={editValue}
-                              onChange={(e) => setEditValue(e.target.value)}
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                  e.preventDefault();
-                                  void handleSaveRename(chat._id);
-                                } else if (e.key === 'Escape') {
-                                  e.preventDefault();
-                                  handleCancelRename();
-                                }
-                              }}
-                              onBlur={() => handleInputBlur(chat._id)}
-                              aria-label={t('history.renameChat')}
-                              className="ring-primary focus-visible:ring-primary min-h-[1.5rem] min-w-0 flex-1 rounded-sm bg-transparent px-1 text-sm leading-snug ring-1 outline-none focus-visible:ring-2"
-                            />
-                          ) : (
-                            <>
-                              <button
-                                type="button"
-                                aria-label={chat.title}
-                                onClick={() => {
-                                  if (clickTimeoutRef.current) {
-                                    clearTimeout(clickTimeoutRef.current);
-                                    clickTimeoutRef.current = null;
-                                    handleStartRename(chat._id, chat.title);
-                                  } else {
-                                    clickTimeoutRef.current = setTimeout(() => {
-                                      clickTimeoutRef.current = null;
-                                      handleChatClick(chat._id);
-                                    }, 250);
-                                  }
-                                }}
-                                className="absolute inset-0 cursor-pointer rounded-md"
-                              />
-                              <span className="pointer-events-none relative z-10 flex min-h-[1.5rem] flex-1 items-center gap-1.5 truncate text-left text-sm leading-snug">
-                                {pendingThreadIds.has(chat._id) && (
-                                  <CircleDotIcon
-                                    className="text-warning size-3.5 shrink-0"
-                                    aria-label={t('history.awaitingInput')}
-                                  />
-                                )}
-                                <span
-                                  className="truncate"
-                                  aria-label={
-                                    isGenerating
-                                      ? t('history.generating')
-                                      : undefined
-                                  }
-                                >
-                                  {chat.title}
-                                </span>
-                              </span>
-                              {chat.isShared && (
-                                <Share2Icon
-                                  className="text-muted-foreground pointer-events-none relative z-10 size-3 shrink-0"
-                                  aria-label={t('share.sharedIndicator')}
-                                />
-                              )}
-                              <div className="relative z-10 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
-                                <ChatActions
-                                  chat={{ id: chat._id, title: chat.title }}
-                                  currentChatId={currentThreadId}
-                                  organizationId={organizationId}
-                                  onRename={() =>
-                                    handleStartRename(chat._id, chat.title)
-                                  }
-                                />
-                              </div>
-                            </>
-                          )}
-                        </div>
-                      );
-                    })}
-                    {canLoadMore && (
-                      <button
-                        type="button"
-                        onClick={loadMore}
-                        disabled={isLoadingMore}
-                        className="text-muted-foreground hover:text-foreground px-2 py-1.5 text-sm transition-colors disabled:opacity-50"
-                      >
-                        {isLoadingMore
-                          ? t('history.loadingMore')
-                          : t('history.loadMore')}
-                      </button>
-                    )}
-                  </>
-                )}
-              </Stack>
-            ),
-          },
-          {
-            value: 'archived',
-            label: (
-              <span className="flex items-center gap-1.5">
-                {t('archived.title')}
-                {archivedChats && archivedChats.length > 0 && (
-                  <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs leading-none font-medium">
-                    {archivedChats.length}
-                  </span>
-                )}
-              </span>
-            ),
-            content: (
-              <Stack gap={1} className="min-h-0 flex-1 overflow-y-auto pb-2">
-                {!archivedChats ? (
-                  <Text as="div" variant="muted" className="px-2 text-nowrap">
-                    {t('history.loading')}
-                  </Text>
-                ) : archivedChats.length === 0 ? (
-                  <div className="flex flex-1 flex-col items-center justify-center gap-1 px-6 pt-40 text-center">
-                    <MessageSquareDashedIcon
-                      className="text-muted-foreground/60 mb-1 size-8"
-                      aria-hidden
-                    />
-                    <Text
-                      as="div"
-                      variant="muted"
-                      className="text-foreground font-medium"
+                  return (
+                    <div
+                      key={chat._id}
+                      className={cn(
+                        'group relative flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors',
+                        !isEditing &&
+                          'cursor-pointer hover:bg-accent hover:text-accent-foreground',
+                        currentThreadId === chat._id &&
+                          !isEditing &&
+                          'bg-accent text-accent-foreground',
+                        isGenerating && 'animate-pulse',
+                      )}
                     >
-                      {t('archived.empty')}
-                    </Text>
-                  </div>
-                ) : (
-                  <>
-                    {archivedChats.map((chat) => (
-                      <div
-                        key={chat._id}
-                        className="group hover:bg-accent hover:text-accent-foreground relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors"
-                      >
-                        <button
-                          type="button"
-                          aria-label={chat.title}
-                          onClick={() => handleChatClick(chat._id)}
-                          className="absolute inset-0 cursor-pointer rounded-md"
+                      {isEditing ? (
+                        <input
+                          ref={inputRef}
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              void handleSaveRename(chat._id);
+                            } else if (e.key === 'Escape') {
+                              e.preventDefault();
+                              handleCancelRename();
+                            }
+                          }}
+                          onBlur={() => handleInputBlur(chat._id)}
+                          aria-label={t('history.renameChat')}
+                          className="ring-primary focus-visible:ring-primary min-h-[1.5rem] min-w-0 flex-1 rounded-sm bg-transparent px-1 text-sm leading-snug ring-1 outline-none focus-visible:ring-2"
                         />
-                        <span className="text-muted-foreground pointer-events-none relative z-10 flex min-h-[1.5rem] flex-1 items-center truncate text-left text-sm leading-snug">
-                          <span className="truncate">{chat.title}</span>
-                        </span>
-                        <div className="relative z-10 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
-                          <ChatActions
-                            chat={{ id: chat._id, title: chat.title }}
-                            currentChatId={currentThreadId}
-                            organizationId={organizationId}
-                            isArchived
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            aria-label={chat.title}
+                            onClick={() => {
+                              if (clickTimeoutRef.current) {
+                                clearTimeout(clickTimeoutRef.current);
+                                clickTimeoutRef.current = null;
+                                handleStartRename(chat._id, chat.title);
+                              } else {
+                                clickTimeoutRef.current = setTimeout(() => {
+                                  clickTimeoutRef.current = null;
+                                  handleChatClick(chat._id);
+                                }, 250);
+                              }
+                            }}
+                            className="absolute inset-0 cursor-pointer rounded-md"
                           />
-                        </div>
-                      </div>
-                    ))}
-                    {canLoadMoreArchived && (
-                      <button
-                        type="button"
-                        onClick={loadMoreArchived}
-                        disabled={isLoadingMoreArchived}
-                        className="text-muted-foreground hover:text-foreground px-2 py-1.5 text-sm transition-colors disabled:opacity-50"
-                      >
-                        {isLoadingMoreArchived
-                          ? t('history.loadingMore')
-                          : t('history.loadMore')}
-                      </button>
-                    )}
-                  </>
+                          <span className="pointer-events-none relative z-10 flex min-h-[1.5rem] flex-1 items-center gap-1.5 truncate text-left text-sm leading-snug">
+                            {pendingThreadIds.has(chat._id) && (
+                              <CircleDotIcon
+                                className="text-warning size-3.5 shrink-0"
+                                aria-label={t('history.awaitingInput')}
+                              />
+                            )}
+                            <span
+                              className="truncate"
+                              aria-label={
+                                isGenerating
+                                  ? t('history.generating')
+                                  : undefined
+                              }
+                            >
+                              {chat.title}
+                            </span>
+                          </span>
+                          {chat.isShared && (
+                            <Share2Icon
+                              className="text-muted-foreground pointer-events-none relative z-10 size-3 shrink-0"
+                              aria-label={t('share.sharedIndicator')}
+                            />
+                          )}
+                          <div className="relative z-10 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+                            <ChatActions
+                              chat={{ id: chat._id, title: chat.title }}
+                              currentChatId={currentThreadId}
+                              organizationId={organizationId}
+                              onRename={() =>
+                                handleStartRename(chat._id, chat.title)
+                              }
+                            />
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+                {canLoadMore && (
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={isLoadingMore}
+                    className="text-muted-foreground hover:text-foreground px-2 py-1.5 text-left text-sm transition-colors disabled:opacity-50"
+                  >
+                    {isLoadingMore
+                      ? t('history.loadingMore')
+                      : t('history.loadMore')}
+                  </button>
                 )}
-              </Stack>
-            ),
-          },
-        ]}
-      />
-
-      {/* Footer — pinned to bottom */}
-      <div className="border-border mt-4 shrink-0 space-y-2 pt-2">
-        {onSelectPrompt && (
-          <Tooltip content={t('promptLibrary')} side="right">
-            <Button
-              variant="secondary"
-              onClick={() => setPromptLibraryOpen(true)}
-              className="text-muted-foreground hover:text-foreground w-full justify-start gap-2"
-            >
-              <BookOpen className="size-4" />
-              {t('promptLibrary')}
-            </Button>
-          </Tooltip>
-        )}
+              </>
+            )}
+          </Stack>
+        </section>
       </div>
 
-      {onSelectPrompt && (
-        <PromptLibraryDialog
-          open={promptLibraryOpen}
-          onOpenChange={setPromptLibraryOpen}
-          onSelectPrompt={(content) => {
-            onSelectPrompt(content);
-            onChatSelect?.();
-          }}
-        />
+      {archivedChats && archivedChats.length > 0 && (
+        <section className="border-border mt-2 shrink-0 border-t pt-2">
+          <button
+            type="button"
+            onClick={() => setArchivedExpanded(!archivedExpanded)}
+            aria-expanded={archivedExpanded}
+            className="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors"
+          >
+            <ChevronDown
+              className={cn(
+                'size-3.5 shrink-0 transition-transform',
+                !archivedExpanded && '-rotate-90',
+              )}
+              aria-hidden
+            />
+            <Text
+              as="span"
+              variant="caption"
+              className="text-muted-foreground flex flex-1 items-center gap-1.5 text-xs font-medium tracking-wide uppercase"
+            >
+              {t('archived.title')}
+              <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs leading-none font-medium normal-case">
+                {archivedChats.length}
+              </span>
+            </Text>
+          </button>
+          {archivedExpanded && (
+            <Stack gap={1} className="max-h-64 overflow-y-auto pt-1 pb-2">
+              {archivedChats.map((chat) => (
+                <div
+                  key={chat._id}
+                  className="group hover:bg-accent hover:text-accent-foreground relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors"
+                >
+                  <button
+                    type="button"
+                    aria-label={chat.title}
+                    onClick={() => handleChatClick(chat._id)}
+                    className="absolute inset-0 cursor-pointer rounded-md"
+                  />
+                  <span className="text-muted-foreground pointer-events-none relative z-10 flex min-h-[1.5rem] flex-1 items-center truncate text-left text-sm leading-snug">
+                    <span className="truncate">{chat.title}</span>
+                  </span>
+                  <div className="relative z-10 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+                    <ChatActions
+                      chat={{ id: chat._id, title: chat.title }}
+                      currentChatId={currentThreadId}
+                      organizationId={organizationId}
+                      isArchived
+                    />
+                  </div>
+                </div>
+              ))}
+              {canLoadMoreArchived && (
+                <button
+                  type="button"
+                  onClick={loadMoreArchived}
+                  disabled={isLoadingMoreArchived}
+                  className="text-muted-foreground hover:text-foreground px-2 py-1.5 text-left text-sm transition-colors disabled:opacity-50"
+                >
+                  {isLoadingMoreArchived
+                    ? t('history.loadingMore')
+                    : t('history.loadMore')}
+                </button>
+              )}
+            </Stack>
+          )}
+        </section>
       )}
     </div>
   );

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -424,13 +424,11 @@ export function ChatInput({
                 fileUploadDisabled={fileUploadDisabled}
                 disabled={inputDisabled}
               />
-              {(onSavePrompt || onOpenPromptLibrary) && (
+              {onSavePrompt && onOpenPromptLibrary && (
                 <SavePromptMenu
-                  onSavePromptDraft={() => onSavePrompt?.(value)}
-                  onOpenPromptLibrary={() => onOpenPromptLibrary?.()}
-                  canSavePromptDraft={
-                    !!onSavePrompt && !inputDisabled && value.trim().length > 0
-                  }
+                  onSavePromptDraft={() => onSavePrompt(value)}
+                  onOpenPromptLibrary={onOpenPromptLibrary}
+                  canSavePromptDraft={!inputDisabled && value.trim().length > 0}
                   disabled={inputDisabled}
                 />
               )}

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -34,6 +34,7 @@ import { ComposerModeMenu } from './composer-mode-menu';
 import { DictationButton } from './dictation-button';
 import { ImagePreviewDialog } from './message-bubble';
 import { ModelSelector } from './model-selector';
+import { SavePromptMenu } from './save-prompt-menu';
 
 const LOCALE_TO_BCP47: Record<string, string> = {
   en: 'en-US',
@@ -67,6 +68,7 @@ interface ChatInputProps extends Omit<
     { status?: string; error?: string; progress?: string }
   >;
   onSavePrompt?: (content: string) => void;
+  onOpenPromptLibrary?: () => void;
   /**
    * When true, the send button is disabled. Unlike `disabled`, the input
    * itself stays editable so the user can still revise their message — they
@@ -98,6 +100,7 @@ export function ChatInput({
   isIndexing = false,
   indexingStatuses,
   onSavePrompt,
+  onOpenPromptLibrary,
   sendBlocked = false,
   sendBlockedReason,
   ...restProps
@@ -419,12 +422,18 @@ export function ChatInput({
                 organizationId={organizationId}
                 onAttachFile={() => fileInputRef.current?.click()}
                 fileUploadDisabled={fileUploadDisabled}
-                onSavePrompt={
-                  onSavePrompt ? () => onSavePrompt(value) : undefined
-                }
-                canSavePrompt={!inputDisabled && value.trim().length > 0}
                 disabled={inputDisabled}
               />
+              {(onSavePrompt || onOpenPromptLibrary) && (
+                <SavePromptMenu
+                  onSavePromptDraft={() => onSavePrompt?.(value)}
+                  onOpenPromptLibrary={() => onOpenPromptLibrary?.()}
+                  canSavePromptDraft={
+                    !!onSavePrompt && !inputDisabled && value.trim().length > 0
+                  }
+                  disabled={inputDisabled}
+                />
+              )}
               {isArenaMode ? (
                 <ArenaModelSelector organizationId={organizationId} />
               ) : (

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -79,6 +79,14 @@ const SavePromptDialog = lazyComponent<
   ),
 );
 
+const PromptLibraryDialog = lazyComponent<
+  import('@/app/features/prompts/components/prompt-library-dialog').PromptLibraryDialogProps
+>(() =>
+  import('@/app/features/prompts/components/prompt-library-dialog').then(
+    (mod) => ({ default: mod.PromptLibraryDialog }),
+  ),
+);
+
 function chatDraftKey(
   userId: string | undefined,
   organizationId: string,
@@ -205,6 +213,7 @@ export function ChatInterface({
     messageId: string;
     content: string;
   } | null>(null);
+  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
 
   // Build a lookup of messageId → promptId for saved prompts
   const { prompts } = usePrompts(organizationId);
@@ -1029,6 +1038,7 @@ export function ChatInterface({
               onSavePrompt={(content) =>
                 setSavePromptData({ messageId: '', content })
               }
+              onOpenPromptLibrary={() => setPromptLibraryOpen(true)}
             />
           </FileUpload.Root>
         )}
@@ -1041,6 +1051,14 @@ export function ChatInterface({
         }}
         initialContent={savePromptData?.content ?? ''}
         sourceMessageId={savePromptData?.messageId}
+      />
+
+      <PromptLibraryDialog
+        open={promptLibraryOpen}
+        onOpenChange={setPromptLibraryOpen}
+        onSelectPrompt={(content) => {
+          setInsertedPrompt(content);
+        }}
       />
     </div>
   );

--- a/services/platform/app/features/chat/components/composer-mode-menu.tsx
+++ b/services/platform/app/features/chat/components/composer-mode-menu.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  Bookmark,
   Bot,
   Check,
   Circle,
@@ -35,8 +34,6 @@ interface ComposerModeMenuProps {
   organizationId: string;
   onAttachFile?: () => void;
   fileUploadDisabled?: boolean;
-  onSavePrompt?: () => void;
-  canSavePrompt?: boolean;
   disabled?: boolean;
 }
 
@@ -78,8 +75,6 @@ export function ComposerModeMenu({
   organizationId,
   onAttachFile,
   fileUploadDisabled = false,
-  onSavePrompt,
-  canSavePrompt = false,
   disabled = false,
 }: ComposerModeMenuProps) {
   const { t } = useT('composer');
@@ -234,18 +229,6 @@ export function ComposerModeMenu({
       groups.push(capabilityGroup);
     }
 
-    if (onSavePrompt) {
-      groups.push([
-        {
-          type: 'item',
-          label: tChat('savePrompt'),
-          icon: Bookmark,
-          onClick: onSavePrompt,
-          disabled: !canSavePrompt,
-        },
-      ]);
-    }
-
     return groups;
   }, [
     fileUploadDisabled,
@@ -258,8 +241,6 @@ export function ComposerModeMenu({
     setCapabilityEnabled,
     switchTo,
     arenaContext,
-    onSavePrompt,
-    canSavePrompt,
     t,
     tChat,
   ]);

--- a/services/platform/app/features/chat/components/save-prompt-menu.tsx
+++ b/services/platform/app/features/chat/components/save-prompt-menu.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { BookOpen, Bookmark } from 'lucide-react';
+
+import {
+  DropdownMenu,
+  type DropdownMenuGroup,
+} from '@/app/components/ui/overlays/dropdown-menu';
+import { Button } from '@/app/components/ui/primitives/button';
+import { useT } from '@/lib/i18n/client';
+
+interface SavePromptMenuProps {
+  onSavePromptDraft: () => void;
+  onOpenPromptLibrary: () => void;
+  canSavePromptDraft: boolean;
+  disabled?: boolean;
+}
+
+export function SavePromptMenu({
+  onSavePromptDraft,
+  onOpenPromptLibrary,
+  canSavePromptDraft,
+  disabled = false,
+}: SavePromptMenuProps) {
+  const { t: tChat } = useT('chat');
+
+  const items: DropdownMenuGroup[] = [
+    [
+      {
+        type: 'item',
+        label: tChat('savePromptDraft'),
+        icon: Bookmark,
+        onClick: onSavePromptDraft,
+        disabled: !canSavePromptDraft,
+      },
+      {
+        type: 'item',
+        label: tChat('promptLibrary'),
+        icon: BookOpen,
+        onClick: onOpenPromptLibrary,
+      },
+    ],
+  ];
+
+  return (
+    <DropdownMenu
+      trigger={
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={tChat('savePromptMenu')}
+          aria-haspopup="menu"
+          disabled={disabled}
+        >
+          <Bookmark className="size-4" aria-hidden="true" />
+        </Button>
+      }
+      items={items}
+      align="start"
+    />
+  );
+}

--- a/services/platform/app/routes/dashboard/$id/automations.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations.tsx
@@ -38,6 +38,16 @@ function AutomationsLayout() {
   });
   const currentFolder = indexMatch?.search?.folder;
 
+  const isMetrics = useMatch({
+    from: '/dashboard/$id/automations/metrics',
+    shouldThrow: false,
+  });
+  const breadcrumbLeaf = currentFolder
+    ? currentFolder
+    : isMetrics
+      ? t('metrics.title')
+      : null;
+
   return (
     <PageLayout
       organizationId={organizationId}
@@ -46,7 +56,7 @@ function AutomationsLayout() {
           <>
             <AdaptiveHeaderRoot standalone={false}>
               <AdaptiveHeaderTitle>
-                {currentFolder ? (
+                {breadcrumbLeaf ? (
                   <span className="flex items-center gap-1">
                     <button
                       type="button"
@@ -61,7 +71,7 @@ function AutomationsLayout() {
                       {t('title')}
                     </button>
                     <ChevronRight className="text-muted-foreground size-4 shrink-0" />
-                    <span>{currentFolder}</span>
+                    <span>{breadcrumbLeaf}</span>
                   </span>
                 ) : (
                   t('title')

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -174,7 +174,7 @@ function ThreadGate({
 }
 
 function ChatLayoutContent({ organizationId }: { organizationId: string }) {
-  const { isHistoryOpen, clearChatState, setInsertedPrompt } = useChatLayout();
+  const { isHistoryOpen, clearChatState } = useChatLayout();
 
   // Read threadId from URL — ChatInterface stays mounted across route changes.
   const threadMatch = useMatch({
@@ -234,11 +234,7 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
   return (
     <PageLayout className="bg-background h-full overflow-hidden">
       <LayoutErrorBoundary organizationId={organizationId}>
-        <ChatHeader
-          organizationId={organizationId}
-          threadId={threadId}
-          onSelectPrompt={setInsertedPrompt}
-        />
+        <ChatHeader organizationId={organizationId} threadId={threadId} />
       </LayoutErrorBoundary>
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -253,10 +249,7 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
             >
               <div className="border-border bg-background flex h-full flex-col overflow-hidden border-r">
                 <LayoutErrorBoundary organizationId={organizationId}>
-                  <ChatHistorySidebar
-                    organizationId={organizationId}
-                    onSelectPrompt={setInsertedPrompt}
-                  />
+                  <ChatHistorySidebar organizationId={organizationId} />
                 </LayoutErrorBoundary>
               </div>
             </m.div>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2823,8 +2823,6 @@
     "hideSearch": "Suche ausblenden",
     "showHistory": "Verlauf anzeigen",
     "hideHistory": "Verlauf ausblenden",
-    "openSidebar": "Seitenleiste öffnen",
-    "closeSidebar": "Seitenleiste schließen",
     "chatHistory": "Chatverlauf",
     "searchPlaceholder": "Chats suchen",
     "messagePlaceholder": "Nachricht eingeben...",
@@ -3084,6 +3082,8 @@
     },
     "promptLibrary": "Prompt-Bibliothek",
     "savePrompt": "Prompt speichern",
+    "savePromptDraft": "Prompt-Entwurf speichern",
+    "savePromptMenu": "Speicheroptionen",
     "unsavePrompt": "Prompt entfernen",
     "unsavePromptConfirm": "Der gespeicherte Prompt wird entfernt. Du kannst ihn jederzeit erneut speichern.",
     "unsavePromptAction": "Entfernen"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1812,8 +1812,8 @@
       "openLoop": "Open loop"
     },
     "metrics": {
-      "link": "View metrics",
-      "title": "Workflow metrics",
+      "link": "Metrics",
+      "title": "Automation metrics",
       "description": "Usage and performance KPIs across your automations.",
       "cappedNotice": "Showing the most recent 5,000 runs in this window. Older runs in this period are not included in these totals.",
       "period": {
@@ -2823,8 +2823,6 @@
     "hideSearch": "Hide search",
     "showHistory": "Show history",
     "hideHistory": "Hide history",
-    "openSidebar": "Open sidebar",
-    "closeSidebar": "Close sidebar",
     "chatHistory": "History",
     "searchPlaceholder": "Search chats",
     "messagePlaceholder": "Type a message...",
@@ -3084,6 +3082,8 @@
     },
     "promptLibrary": "Prompt library",
     "savePrompt": "Save prompt",
+    "savePromptDraft": "Save prompt draft",
+    "savePromptMenu": "Save options",
     "unsavePrompt": "Unsave prompt",
     "unsavePromptConfirm": "This will remove the saved prompt. You can always save it again later.",
     "unsavePromptAction": "Unsave"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2819,8 +2819,6 @@
     "hideSearch": "Masquer la recherche",
     "showHistory": "Afficher l'historique",
     "hideHistory": "Masquer l'historique",
-    "openSidebar": "Ouvrir la barre latérale",
-    "closeSidebar": "Fermer la barre latérale",
     "chatHistory": "Historique",
     "searchPlaceholder": "Rechercher dans les chats",
     "messagePlaceholder": "Saisis un message...",
@@ -3080,6 +3078,8 @@
     },
     "promptLibrary": "Bibliothèque de prompts",
     "savePrompt": "Enregistrer le prompt",
+    "savePromptDraft": "Enregistrer le brouillon de prompt",
+    "savePromptMenu": "Options d'enregistrement",
     "unsavePrompt": "Retirer le prompt",
     "unsavePromptConfirm": "Le prompt enregistré sera supprimé. Tu pourras toujours le sauvegarder à nouveau plus tard.",
     "unsavePromptAction": "Retirer"


### PR DESCRIPTION
## Summary

- Extract save prompt + prompt library actions into a dedicated `SavePromptMenu` sitting next to the composer mode menu, cleaning them out of the mode menu's flow.
- Swap the history sidebar toggle to a `Clock` icon and standardize on `showHistory` / `hideHistory` strings (drop the unused `openSidebar` / `closeSidebar` keys).
- Rewrite the history sidebar as a single scroll column with a persisted, collapsible "Archived" section (replaces the tabs-based layout).
- Add a metrics breadcrumb on the automations layout and use the shared `SearchInput` in the automations table.

## Test plan

- [ ] Open a chat — verify the new bookmark menu appears beside the composer, saving a prompt draft still works, and "Prompt library" opens the dialog.
- [ ] Toggle the history sidebar from the header — icon shows Clock, tooltip reads "Show/Hide history", keyboard shortcut still works.
- [ ] Open the history sidebar — confirm the single scroll column, expand/collapse "Archived", refresh to verify the expanded state persists.
- [ ] Visit `/dashboard/:id/automations/metrics` — breadcrumb shows `Automations › Metrics`; folder breadcrumbs still work elsewhere.
- [ ] Search within the automations table — styling matches other `SearchInput` instances.
- [ ] Quick pass across `en` / `de` / `fr` to confirm no missing strings in these surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated prompt library access in chat interface
  * Added capability to save prompt drafts
  * Collapsible archived section in chat history sidebar

* **Refactor**
  * Improved search input component in automations table
  * Simplified metrics page header layout
  * Updated chat history toggle icon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->