### PR TITLE
fix(platform): default structuredResponsesEnabled to false

### DIFF
--- a/examples/agents/researcher.json
+++ b/examples/agents/researcher.json
@@ -10,7 +10,6 @@
     "openrouter:openai/gpt-5.2-pro",
     "openrouter:google/gemini-3.1-pro-preview"
   ],
-  "structuredResponsesEnabled": true,
   "maxSteps": 40,
   "timeoutMs": 1500000,
   "outputReserve": 4096,

--- a/examples/agents/translator.json
+++ b/examples/agents/translator.json
@@ -22,7 +22,6 @@
     "openrouter:google/gemini-3.1-pro-preview",
     "openrouter:qwen/qwen3-next-80b-a3b-instruct"
   ],
-  "structuredResponsesEnabled": true,
   "maxSteps": 20,
   "timeoutMs": 1200000,
   "outputReserve": 8192,

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -47,7 +47,7 @@ function InstructionsTab() {
   const { providers } = useListProviders('default');
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
 
-  const structuredResponsesEnabled = config.structuredResponsesEnabled ?? true;
+  const structuredResponsesEnabled = config.structuredResponsesEnabled ?? false;
   const selectedModels = config.supportedModels;
 
   const modelDisplayNames = useMemo(() => {

--- a/services/platform/convex/agent_tools/approval_shared.ts
+++ b/services/platform/convex/agent_tools/approval_shared.ts
@@ -18,7 +18,7 @@ export const DEFAULT_AGENT_CONFIG: SerializableAgentConfig = {
   includeTeamKnowledge: false,
   includeOrgKnowledge: false,
   knowledgeFileIds: [],
-  structuredResponsesEnabled: true,
+  structuredResponsesEnabled: false,
   timeoutMs: 1_200_000,
 };
 

--- a/services/platform/convex/agents/config.ts
+++ b/services/platform/convex/agents/config.ts
@@ -52,7 +52,7 @@ export function toSerializableConfig(
       .filter((f) => f.ragStatus === 'completed')
       .map((f) => String(f.fileId)),
     delegateSlugs: config.delegates,
-    structuredResponsesEnabled: config.structuredResponsesEnabled ?? true,
+    structuredResponsesEnabled: config.structuredResponsesEnabled ?? false,
     timeoutMs: config.timeoutMs,
     outputReserve: config.outputReserve,
     responseCacheEnabled: config.responseCacheEnabled,

--- a/services/platform/convex/lib/agent_chat/types.ts
+++ b/services/platform/convex/lib/agent_chat/types.ts
@@ -52,7 +52,7 @@ export interface SerializableAgentConfig {
   knowledgeFileIds?: string[];
   /** Agent slugs of delegate agents (file-based agent names) */
   delegateSlugs?: string[];
-  /** Whether to inject structured response markers into the system prompt (default true) */
+  /** Whether to inject structured response markers into the system prompt (default false) */
   structuredResponsesEnabled?: boolean;
   /** Per-agent timeout in milliseconds */
   timeoutMs?: number;

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -638,7 +638,7 @@ export async function generateAgentResponse(
     agentInstructions =
       enableStreaming &&
       resolvedInstructions &&
-      structuredResponsesEnabled !== false
+      structuredResponsesEnabled === true
         ? `${resolvedInstructions}\n\n${STRUCTURED_RESPONSE_INSTRUCTIONS}`
         : resolvedInstructions;
     const systemPrompt = agentInstructions

--- a/services/platform/convex/lib/agent_response/types.ts
+++ b/services/platform/convex/lib/agent_response/types.ts
@@ -37,7 +37,7 @@ export interface GenerateResponseConfig {
   agentTeamIds?: string[];
   /** Pre-resolved completed file IDs from agent-specific knowledge files */
   knowledgeFileIds?: string[];
-  /** Whether to inject structured response markers into the system prompt (default true) */
+  /** Whether to inject structured response markers into the system prompt (default false) */
   structuredResponsesEnabled?: boolean;
   /** Agent instructions for context window display (not sent to LLM, already in agent config) */
   instructions?: string;


### PR DESCRIPTION
## Summary

- Flips the `structuredResponsesEnabled` default from `true` to `false`. Agents that don't explicitly opt in no longer get the generic `[[CONCLUSION]]` / `[[KEY_POINTS]]` / `[[DETAILS]]` / `[[NEXT_STEPS]]` marker instructions injected into their system prompt.
- Drops the now-redundant explicit `true` from `translator` (its prompt doesn't use any markers) and `researcher` (its prompt uses only `[[CONCLUSION]]`, which the frontend parses unconditionally). Also flips the approval-flow `DEFAULT_AGENT_CONFIG` fallback to `false` for consistency.
- `chat-agent` keeps its explicit `true` — it remains the canonical long-form agent that benefits from the marker menu.

## Why

The flag was defaulting to `true` in three fallback spots (`config.ts`, `generate_response.ts`, `instructions.tsx`), so any agent that didn't set the field — e.g. `image-creator` — showed the UI switch as "on" despite the injection being irrelevant or misleading for its use case. Flipping to "opt-in" makes the default semantically honest and avoids injecting chat-format guidance into agents whose own prompts already define their output shape.

## Behavioral impact

- `image-creator` and any custom agent without the field: Switch now reads off; no effect on image generation itself (that path bypasses `generate_response` entirely).
- `translator` / `researcher`: no generic marker instructions injected. Researcher's own `[[CONCLUSION]]` continues to work via unconditional frontend parsing in `marker-parser.ts`.
- `chat-agent`: unchanged.
- Existing custom agents in DB without the field: treated as off under the new default. Users who relied on "unset = on" will need to toggle it on explicitly.

## Test plan

- [ ] `cd services/platform && npx tsc --noEmit` — clean
- [ ] `npm run lint --workspace=@tale/platform` — 0 errors
- [ ] Open `image-creator` agent instructions page — Switch shows off
- [ ] Open `translator` / `researcher` agent instructions pages — Switch shows off
- [ ] Open `chat-agent` agent instructions page — Switch shows on
- [ ] Run a research query on `researcher`; confirm the closing `[[CONCLUSION]]` line is rendered (stripped by frontend, not shown raw)
- [ ] Send a substantial question to `chat-agent`; confirm marker-based sections still render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Changed the default configuration for structured responses to be disabled. Agents will now have this feature off by default, requiring explicit enablement if desired. Documentation and example configurations updated to reflect the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->