### PR TITLE
fix(platform): self-heal integration installed flag on credential activation

### DIFF
--- a/services/platform/app/features/settings/integrations/hooks/actions.ts
+++ b/services/platform/app/features/settings/integrations/hooks/actions.ts
@@ -30,7 +30,24 @@ export function useInstallIntegration() {
 }
 
 export function useTestIntegration() {
-  return useConvexAction(api.integrations.actions.testConnection);
+  const base = useConvexAction(api.integrations.actions.testConnection);
+  const queryClient = useQueryClient();
+
+  const mutateAsync: typeof base.mutateAsync = useCallback(
+    async (...args) => {
+      const result = await base.mutateAsync(...args);
+      // A successful test flips the credential to isActive and self-heals
+      // config.installed on disk, so the cached file-based integrations list
+      // must be refetched to pick up the new `installed` value.
+      void queryClient.invalidateQueries({
+        queryKey: ['config', 'integrations'],
+      });
+      return result;
+    },
+    [base, queryClient],
+  );
+
+  return { ...base, mutateAsync };
 }
 
 export function useTestSsoConfig() {

--- a/services/platform/convex/integrations/file_actions.ts
+++ b/services/platform/convex/integrations/file_actions.ts
@@ -275,21 +275,70 @@ export const installIntegration = action({
       credentialId = existing._id;
     }
 
-    if (result.config.installed) {
-      return { hash: result.hash, credentialId };
+    const { hash } = await writeInstalledFlag(args.orgSlug, args.slug, result);
+    return { hash, credentialId };
+  },
+});
+
+async function writeInstalledFlag(
+  orgSlug: string,
+  slug: string,
+  result: Extract<IntegrationReadResult, { ok: true }>,
+): Promise<{ hash: string; changed: boolean }> {
+  if (result.config.installed) {
+    return { hash: result.hash, changed: false };
+  }
+  const updatedConfig: IntegrationJsonConfig = {
+    ...result.config,
+    installed: true,
+  };
+  const newContent = serializeIntegrationJson(updatedConfig);
+  const filePath = resolveConfigPath(orgSlug, slug);
+  await atomicWrite(filePath, newContent);
+  return { hash: sha256(newContent), changed: true };
+}
+
+/**
+ * Internal: flip `installed: true` on the config file if needed.
+ * Idempotent — a no-op when the file is already marked installed or missing.
+ * Used to self-heal when a credential becomes active but the on-disk config
+ * was reverted (e.g. by a git checkout of a tracked seed file).
+ */
+export const ensureInstalledInternal = internalAction({
+  args: {
+    orgSlug: v.string(),
+    slug: v.string(),
+  },
+  returns: v.object({ changed: v.boolean() }),
+  handler: async (_ctx, args): Promise<{ changed: boolean }> => {
+    console.log(
+      `[Integrations] ensureInstalledInternal: orgSlug=${args.orgSlug} slug=${args.slug} configPath=${resolveConfigPath(args.orgSlug, args.slug)}`,
+    );
+    if (!validateIntegrationSlug(args.slug)) {
+      console.warn(
+        `[Integrations] ensureInstalledInternal: invalid slug, skipping (slug=${args.slug})`,
+      );
+      return { changed: false };
     }
-
-    // Set installed: true in config.json
-    const updatedConfig: IntegrationJsonConfig = {
-      ...result.config,
-      installed: true,
-    };
-
-    const newContent = serializeIntegrationJson(updatedConfig);
-    const filePath = resolveConfigPath(args.orgSlug, args.slug);
-    await atomicWrite(filePath, newContent);
-
-    return { hash: sha256(newContent), credentialId };
+    const result = await readIntegrationConfigFile(args.orgSlug, args.slug);
+    if (!result.ok) {
+      console.warn(
+        `[Integrations] ensureInstalledInternal: cannot read config, skipping (slug=${args.slug} error=${result.error} message=${result.message})`,
+      );
+      return { changed: false };
+    }
+    console.log(
+      `[Integrations] ensureInstalledInternal: read ok (slug=${args.slug} installed=${result.config.installed ?? false})`,
+    );
+    const { changed } = await writeInstalledFlag(
+      args.orgSlug,
+      args.slug,
+      result,
+    );
+    console.log(
+      `[Integrations] ensureInstalledInternal: done (slug=${args.slug} changed=${changed})`,
+    );
+    return { changed };
   },
 });
 

--- a/services/platform/convex/integrations/oauth2_token_exchange.ts
+++ b/services/platform/convex/integrations/oauth2_token_exchange.ts
@@ -127,6 +127,20 @@ export const handleOAuth2Callback = internalAction({
       },
     );
 
+    // Self-heal: keep config.installed in sync with credential activation so
+    // the composer/engine readiness gates agree with the DB, even if a git
+    // checkout reset the tracked seed file back to installed:false.
+    console.log(
+      `[Integrations] oauth2_token_exchange: running ensureInstalled (orgSlug=${orgSlug} slug=${credential.slug})`,
+    );
+    const ensureResult = await ctx.runAction(
+      internal.integrations.file_actions.ensureInstalledInternal,
+      { orgSlug, slug: credential.slug },
+    );
+    console.log(
+      `[Integrations] oauth2_token_exchange: ensureInstalled result changed=${ensureResult.changed}`,
+    );
+
     debugLog(
       `OAuth2 token exchange successful for credential ${args.credentialId}`,
     );

--- a/services/platform/convex/integrations/test_connection.ts
+++ b/services/platform/convex/integrations/test_connection.ts
@@ -320,6 +320,19 @@ export async function testConnection(
           errorMessage: undefined,
         },
       );
+      // Self-heal: tracked seed configs can be reset to installed:false by
+      // git checkouts while the credential row stays active. Re-align the
+      // file so the composer/engine readiness gates agree with the DB.
+      console.log(
+        `[Integrations] test_connection: running ensureInstalled (orgSlug=${orgSlug} slug=${credential.slug})`,
+      );
+      const ensureResult = await ctx.runAction(
+        internal.integrations.file_actions.ensureInstalledInternal,
+        { orgSlug, slug: credential.slug },
+      );
+      console.log(
+        `[Integrations] test_connection: ensureInstalled result changed=${ensureResult.changed}`,
+      );
     }
 
     debugLog(


### PR DESCRIPTION
## Summary

- `Settings → Integrations` shows Tavily as **Connected** (green badge driven by `cred.isActive`), but the chat composer `+` menu gates *Deep research* and *Web search* on `installed && isActive`, so they show *Requires Tavily*. The two surfaces can disagree when the tracked seed file (`examples/integrations/tavily/config.json`) gets reverted to `installed: false` by a `git checkout` while the DB credential row stays active. Once in that state, the UI has no path to re-run `installIntegration` (the save/test flow only installs when *no* credential row exists yet).
- Self-heal at the two write sites that flip `isActive: true` — [test_connection.ts](services/platform/convex/integrations/test_connection.ts) and [oauth2_token_exchange.ts](services/platform/convex/integrations/oauth2_token_exchange.ts) — by calling a new idempotent internal action `ensureInstalledInternal` in [file_actions.ts](services/platform/convex/integrations/file_actions.ts) that rewrites `config.json` with `installed: true` when it's missing.
- Invalidate the `['config', 'integrations']` TanStack cache after a successful test in [useTestIntegration](services/platform/app/features/settings/integrations/hooks/actions.ts#L32-L51), so the composer picks up the healed flag without a page refresh.
- Debug `console.log` on the self-heal path for log-based verification (can swap to `createDebugLog('DEBUG_INTEGRATIONS', ...)` later if noise is a concern).

## Why not the alternatives

- **Tighten the "Connected" badge to `installed && isActive`** — regresses the user's current UX (they already see Tavily as Connected), and doesn't actually unblock them.
- **Relax the composer to `isActive` only** — the engine/runtime (`listForExecution`, `start_workflow_from_file`) still filters by `installed: true`, so the capability would fail silently at execution time.
- **One-off migration** — heavier than a demo-stage fix, and the write-site heal covers all affected users on their next save.

## Test plan

- [ ] Reproduce the bug: with Tavily already connected, `git checkout -- examples/integrations/tavily/config.json` to flip the seed back to `installed: false`; confirm composer shows *Requires Tavily* on Web search / Deep research while Settings → Integrations still shows **Connected**.
- [ ] With this PR, open Settings → Integrations → Tavily → click **Test connection**.
- [ ] `examples/integrations/tavily/config.json` on disk now has `"installed": true`.
- [ ] Composer `+` menu shows *Web search* and *Deep research* without the *Requires Tavily* hint (no page refresh needed).
- [ ] Confirm Convex logs show `[Integrations] ensureInstalledInternal: done (slug=tavily changed=true)` on the first heal and `changed=false` on a subsequent test.
- [ ] Repeat with an OAuth2 integration (e.g. Gmail) to cover `oauth2_token_exchange.ts`.
- [ ] Regression: with `installed: true` already on disk, Test connection is a no-op for the file — no spurious `git status` churn.
- [ ] `npx tsc --noEmit` from `services/platform/` and `npm run lint --workspace=@tale/platform` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration installation state synchronization following OAuth activation and connection testing.
  * Added automatic verification to ensure integration configuration consistency after credential updates.

* **Refactor**
  * Optimized integration configuration and credential management workflows for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->