### PR TITLE
fix: rag similarity threshold + pdf preview horizontal scroll

### DIFF
--- a/services/crawler/app/services/search_service.py
+++ b/services/crawler/app/services/search_service.py
@@ -50,13 +50,15 @@ class SearchService:
         # semantically irrelevant — discard FTS results too (keyword noise).
         if similarity_threshold > 0:
             pre_count = len(vector_results)
+            top_score = max((r["score"] for r in vector_results), default=0.0)
             vector_results = [r for r in vector_results if r["score"] >= similarity_threshold]
             if pre_count != len(vector_results):
                 logger.debug(
-                    "Vector pre-filter: {}/{} results passed threshold {}",
+                    "Vector pre-filter: {}/{} results passed threshold {} (top score {:.3f})",
                     len(vector_results),
                     pre_count,
                     similarity_threshold,
+                    top_score,
                 )
             if pre_count > 0 and not vector_results:
                 return []

--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -281,8 +281,8 @@ export function DocumentPreviewDialog({
         </div>
       )}
       {!isLoading && resolvedUrl && (
-        <div className="flex min-h-0 flex-1 gap-5 px-5 pb-5">
-          <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-full min-h-0 gap-5 px-5 pb-5">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             <DocumentPreview url={resolvedUrl} fileName={displayName} />
           </div>
           {doc && <DetailsSidebar doc={doc} />}

--- a/services/platform/app/features/documents/components/document-preview-pdf.tsx
+++ b/services/platform/app/features/documents/components/document-preview-pdf.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { ChevronUp, ChevronDown, ZoomIn, ZoomOut } from 'lucide-react';
+import {
+  ChevronUp,
+  ChevronDown,
+  GripVertical,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 // PDF.js is bundled locally (see pdfjs-dist in package.json). Loading it from
 // a CDN would break offline deployments and count as a third-party data
 // transfer for GDPR purposes. The worker URL is resolved through Vite's
@@ -13,7 +19,13 @@ import type {
   RenderTask,
 } from 'pdfjs-dist/types/src/display/api';
 import type { PageViewport } from 'pdfjs-dist/types/src/display/display_utils';
-import React, { useReducer, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useReducer,
+  useEffect,
+  useRef,
+  useCallback,
+  useState,
+} from 'react';
 
 import { HStack } from '@/app/components/ui/layout/layout';
 import { useT } from '@/lib/i18n/client';
@@ -251,8 +263,71 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
     queueRenderPage({ pageNum: bounded, scale: state.scale });
   };
 
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const dragStartRef = useRef<{
+    pointerX: number;
+    pointerY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
+  const [toolbarOffset, setToolbarOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+
+  const clampToolbarOffset = useCallback((x: number, y: number) => {
+    const container = containerRef.current;
+    const toolbar = toolbarRef.current;
+    if (!container || !toolbar) return { x, y };
+    const c = container.getBoundingClientRect();
+    const t = toolbar.getBoundingClientRect();
+    // Default position is centered horizontally with a 16px gap from the
+    // bottom. Offsets are measured from that anchor, so positive y moves the
+    // toolbar down and negative y moves it up.
+    const halfX = Math.max(0, (c.width - t.width) / 2);
+    const maxDown = 0;
+    const maxUp = -(c.height - t.height - 32);
+    return {
+      x: Math.min(halfX, Math.max(-halfX, x)),
+      y: Math.min(maxDown, Math.max(maxUp, y)),
+    };
+  }, []);
+
+  const onHandlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    dragStartRef.current = {
+      pointerX: e.clientX,
+      pointerY: e.clientY,
+      originX: toolbarOffset.x,
+      originY: toolbarOffset.y,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setIsDragging(true);
+  };
+
+  const onHandlePointerMove = (e: React.PointerEvent<HTMLButtonElement>) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    setToolbarOffset(
+      clampToolbarOffset(
+        start.originX + (e.clientX - start.pointerX),
+        start.originY + (e.clientY - start.pointerY),
+      ),
+    );
+  };
+
+  const onHandlePointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (!dragStartRef.current) return;
+    dragStartRef.current = null;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch (err) {
+      console.warn('Failed to release pointer capture:', err);
+    }
+    setIsDragging(false);
+  };
+
   return (
-    <>
+    <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
       <PreviewPane className="overflow-x-auto">
         <div className="flex min-h-full w-fit min-w-full justify-center">
           <canvas
@@ -261,66 +336,83 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
             style={{ maxWidth: `calc(48rem * ${state.scale})` }}
           />
         </div>
-        {/* Sticky center-bottom toolbar */}
-        <div className="sticky bottom-4 z-50 flex w-full justify-center">
-          <HStack
-            gap={4}
-            className="bg-background text-foreground rounded-full px-4 py-2 shadow-xl ring-1 ring-white/10"
-          >
-            <HStack gap={2}>
-              <button
-                onClick={onPrevPage}
-                disabled={state.pageNum <= 1}
-                className="grid size-8 place-items-center rounded-full transition hover:bg-white/10 disabled:opacity-35"
-                aria-label={tCommon('aria.previousPage')}
-              >
-                <ChevronUp className="size-5" />
-              </button>
-              <button
-                onClick={onNextPage}
-                disabled={state.pageNum >= state.totalPages}
-                className="grid size-8 place-items-center rounded-full transition hover:bg-white/10 disabled:opacity-35"
-                aria-label={tCommon('aria.nextPage')}
-              >
-                <ChevronDown className="size-5" />
-              </button>
-            </HStack>
-            <input
-              type="number"
-              min={1}
-              max={Math.max(1, state.totalPages)}
-              value={state.pageNum}
-              onChange={onPageInputChange}
-              className="bg-background w-10 appearance-none rounded-md py-1 text-center text-sm ring-1 ring-white/20 focus:ring-white/40 focus:outline-none"
-            />
-            <div>/</div>
-            <div className="w-4 text-center text-sm tabular-nums">
-              {state.totalPages || 0}
-            </div>
-            <HStack gap={2}>
-              <button
-                onClick={onZoomOut}
-                className="grid size-8 place-items-center rounded-full transition hover:bg-white/10"
-                aria-label={tCommon('aria.zoomOut')}
-              >
-                <ZoomOut className="size-4" />
-              </button>
-              <button
-                onClick={onZoomIn}
-                className="grid size-8 place-items-center rounded-full transition hover:bg-white/10"
-                aria-label={tCommon('aria.zoomIn')}
-              >
-                <ZoomIn className="size-4" />
-              </button>
-            </HStack>
-          </HStack>
-        </div>
         {!state.pdfDoc && (
           <div className="mt-4 text-center text-gray-500">
             {t('preview.loading')}
           </div>
         )}
       </PreviewPane>
-    </>
+      {/* Floating toolbar pinned to the bottom of the visible pane (draggable) */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 z-50 flex justify-center">
+        <HStack
+          ref={toolbarRef}
+          gap={2}
+          style={{
+            transform: `translate(${toolbarOffset.x}px, ${toolbarOffset.y}px)`,
+          }}
+          className="bg-background text-foreground pointer-events-auto rounded-full py-2 pr-4 pl-2 shadow-xl ring-1 ring-white/10"
+        >
+          <button
+            type="button"
+            onPointerDown={onHandlePointerDown}
+            onPointerMove={onHandlePointerMove}
+            onPointerUp={onHandlePointerUp}
+            onPointerCancel={onHandlePointerUp}
+            className={`text-muted-foreground grid size-8 touch-none place-items-center rounded-full transition hover:bg-white/10 ${
+              isDragging ? 'cursor-grabbing' : 'cursor-grab'
+            }`}
+            aria-label={t('preview.dragToolbar')}
+          >
+            <GripVertical className="size-4" />
+          </button>
+          <HStack gap={2}>
+            <button
+              onClick={onPrevPage}
+              disabled={state.pageNum <= 1}
+              className="grid size-8 place-items-center rounded-full transition hover:bg-white/10 disabled:opacity-35"
+              aria-label={tCommon('aria.previousPage')}
+            >
+              <ChevronUp className="size-5" />
+            </button>
+            <button
+              onClick={onNextPage}
+              disabled={state.pageNum >= state.totalPages}
+              className="grid size-8 place-items-center rounded-full transition hover:bg-white/10 disabled:opacity-35"
+              aria-label={tCommon('aria.nextPage')}
+            >
+              <ChevronDown className="size-5" />
+            </button>
+          </HStack>
+          <input
+            type="number"
+            min={1}
+            max={Math.max(1, state.totalPages)}
+            value={state.pageNum}
+            onChange={onPageInputChange}
+            className="bg-background w-10 appearance-none rounded-md py-1 text-center text-sm ring-1 ring-white/20 focus:ring-white/40 focus:outline-none"
+          />
+          <div>/</div>
+          <div className="w-4 text-center text-sm tabular-nums">
+            {state.totalPages || 0}
+          </div>
+          <HStack gap={2}>
+            <button
+              onClick={onZoomOut}
+              className="grid size-8 place-items-center rounded-full transition hover:bg-white/10"
+              aria-label={tCommon('aria.zoomOut')}
+            >
+              <ZoomOut className="size-4" />
+            </button>
+            <button
+              onClick={onZoomIn}
+              className="grid size-8 place-items-center rounded-full transition hover:bg-white/10"
+              aria-label={tCommon('aria.zoomIn')}
+            >
+              <ZoomIn className="size-4" />
+            </button>
+          </HStack>
+        </HStack>
+      </div>
+    </div>
   );
 };

--- a/services/platform/app/features/documents/components/document-preview-pdf.tsx
+++ b/services/platform/app/features/documents/components/document-preview-pdf.tsx
@@ -279,13 +279,13 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
     const toolbar = toolbarRef.current;
     if (!container || !toolbar) return { x, y };
     const c = container.getBoundingClientRect();
-    const t = toolbar.getBoundingClientRect();
+    const tb = toolbar.getBoundingClientRect();
     // Default position is centered horizontally with a 16px gap from the
     // bottom. Offsets are measured from that anchor, so positive y moves the
     // toolbar down and negative y moves it up.
-    const halfX = Math.max(0, (c.width - t.width) / 2);
+    const halfX = Math.max(0, (c.width - tb.width) / 2);
     const maxDown = 0;
-    const maxUp = -(c.height - t.height - 32);
+    const maxUp = -(c.height - tb.height - 32);
     return {
       x: Math.min(halfX, Math.max(-halfX, x)),
       y: Math.min(maxDown, Math.max(maxUp, y)),

--- a/services/platform/app/features/documents/components/document-preview-pdf.tsx
+++ b/services/platform/app/features/documents/components/document-preview-pdf.tsx
@@ -253,15 +253,16 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
 
   return (
     <>
-      <PreviewPane className="overflow-x-visible">
-        {/* Canvas */}
-        <canvas
-          ref={canvasRef}
-          className="absolute top-0 left-1/2 block -translate-x-1/2"
-          style={{ maxWidth: `calc(48rem * ${state.scale})`, height: 'auto' }}
-        />
+      <PreviewPane className="overflow-x-auto">
+        <div className="flex min-h-full w-fit min-w-full justify-center">
+          <canvas
+            ref={canvasRef}
+            className="block h-auto"
+            style={{ maxWidth: `calc(48rem * ${state.scale})` }}
+          />
+        </div>
         {/* Sticky center-bottom toolbar */}
-        <div className="sticky top-[95%] z-50 flex w-full justify-center">
+        <div className="sticky bottom-4 z-50 flex w-full justify-center">
           <HStack
             gap={4}
             className="bg-background text-foreground rounded-full px-4 py-2 shadow-xl ring-1 ring-white/10"

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -41,7 +41,7 @@ export interface AgentKnowledgeCtx extends ToolCtx {
 const debugLog = createDebugLog('DEBUG_AGENT_TOOLS', '[AgentTools]');
 
 const DEFAULT_TOP_K = 10;
-const DEFAULT_SIMILARITY_THRESHOLD = 0.51;
+const DEFAULT_SIMILARITY_THRESHOLD = 0.4;
 
 export async function resolveFileIds(
   ctx: ToolCtx,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3236,6 +3236,7 @@
       "unknownError": "Unbekannter Fehler",
       "document": "Dokument",
       "title": "Dokumentvorschau",
+      "dragToolbar": "Werkzeugleiste verschieben",
       "sidebar": {
         "document": "Dokument",
         "size": "Größe",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3236,6 +3236,7 @@
       "unknownError": "Unknown error",
       "document": "Document",
       "title": "Document preview",
+      "dragToolbar": "Drag toolbar",
       "sidebar": {
         "document": "Document",
         "size": "Size",

--- a/services/rag/app/services/search_service.py
+++ b/services/rag/app/services/search_service.py
@@ -102,13 +102,15 @@ class RagSearchService:
             # to the indexed documents — discard FTS results too (they are keyword noise).
             if similarity_threshold > 0:
                 pre_count = len(vector_results)
+                top_score = max((r["score"] for r in vector_results), default=0.0)
                 vector_results = [r for r in vector_results if r["score"] >= similarity_threshold]
                 if pre_count != len(vector_results):
                     logger.debug(
-                        "Vector pre-filter: {}/{} results passed threshold {}",
+                        "Vector pre-filter: {}/{} results passed threshold {} (top score {:.3f})",
                         len(vector_results),
                         pre_count,
                         similarity_threshold,
+                        top_score,
                     )
                 if pre_count > 0 and not vector_results:
                     return []


### PR DESCRIPTION
## Summary
- Lower agent knowledge default similarity threshold from 0.51 → 0.4 to reduce false-negative drops on marginal matches, and log the top vector score in the pre-filter debug line so tuning is observable (crawler + rag services).
- Fix PDF preview so zoomed pages can be scrolled horizontally instead of being clipped by the preview pane, and anchor the zoom toolbar to `sticky bottom-4` instead of `top-[95%]`.

## Test plan
- [ ] Run an agent knowledge search against a corpus with borderline-relevance matches; verify results that previously fell between 0.4 and 0.51 now appear.
- [ ] Check crawler/rag debug logs show the new `top score` field in the pre-filter line.
- [ ] Open a PDF in the document preview, zoom in, scroll horizontally to reach both edges of the page.
- [ ] Confirm the zoom toolbar stays visible at the bottom of the viewport while scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced PDF document preview layout with improved canvas centering and horizontal scrolling support.

* **Bug Fixes**
  * Adjusted search result filtering parameters for optimized retrieval performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->