### PR TITLE
fix(cli): preserve container provider secrets on tale deploy

### DIFF
--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -1,4 +1,6 @@
 import { existsSync } from 'node:fs';
+import { cp, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
@@ -77,6 +79,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
   // Track containers started during this deploy for cleanup on interrupt
   const startedContainers: string[] = [];
+  // Track tmp staging dirs created by syncProjectFiles so interrupts don't leak /tmp/tale-sync-*
+  const tempStageDirs = new Set<string>();
   let interrupted = false;
 
   const onInterrupt = () => {
@@ -93,6 +97,15 @@ export async function deploy(options: DeployOptions): Promise<void> {
         // Best-effort cleanup: log so an operator can follow up manually.
         logger.warn(
           `Failed to clean up ${name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    for (const stageDir of tempStageDirs) {
+      try {
+        Bun.spawnSync(['rm', '-rf', stageDir]);
+      } catch (err) {
+        logger.warn(
+          `Failed to clean up stage dir ${stageDir}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
@@ -531,6 +544,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         env.DEPLOY_DIR,
         dryRun,
         prefix,
+        tempStageDirs,
       );
     });
   } finally {
@@ -552,6 +566,7 @@ async function syncProjectFiles(
   projectDir: string,
   dryRun: boolean,
   prefix: string,
+  tempStageDirs: Set<string>,
 ): Promise<void> {
   const dirsToSync = SYNC_DIRS.filter((dir) =>
     existsSync(join(projectDir, dir)),
@@ -581,38 +596,146 @@ async function syncProjectFiles(
       logger.info(
         `${prefix}Would sync ${dir}/ → ${containerName}:/app/data/${dir}/`,
       );
+      if (dir === 'providers') {
+        logger.info(
+          `${prefix}  (any existing container *.secrets.json will be preserved)`,
+        );
+      }
       continue;
     }
 
-    const dockerSrcPath = srcPath.replaceAll('\\', '/');
-    const result = await exec('docker', [
-      'cp',
-      `${dockerSrcPath}/.`,
-      `${containerName}:/app/data/${dir}/`,
-    ]);
+    // INVARIANT: when dir === 'providers', `dockerSrcDir` must come from
+    // stageProvidersWithoutConflictingSecrets() so that *.secrets.json files
+    // written via the admin UI (SOPS-encrypted API keys, etc.) are not
+    // clobbered by host copies. Do not remove this branch without also
+    // moving the protection elsewhere.
+    let dockerSrcDir = srcPath;
+    let tempStageDir: string | null = null;
+    let preserved: string[] = [];
 
-    if (result.success) {
-      // docker cp copies files as root — fix ownership so the app user can write
-      const chownResult = await exec('docker', [
-        'exec',
-        containerName,
-        'chown',
-        '-R',
-        'app:app',
-        `/app/data/${dir}/`,
-      ]);
-      if (!chownResult.success) {
-        logger.warn(
-          `Failed to fix ownership for ${dir}/: ${chownResult.stderr}`,
+    if (dir === 'providers') {
+      const containerSecrets = await listContainerSecrets(containerName);
+      if (containerSecrets.size > 0) {
+        const staged = await stageProvidersWithoutConflictingSecrets(
+          srcPath,
+          containerSecrets,
         );
+        tempStageDir = staged.stageDir;
+        tempStageDirs.add(staged.stageDir);
+        preserved = staged.skipped;
+        dockerSrcDir = staged.stageDir;
       }
-      logger.info(`Synced ${dir}/`);
-    } else {
-      logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);
+    }
+
+    try {
+      const dockerSrcPath = dockerSrcDir.replaceAll('\\', '/');
+      const result = await exec('docker', [
+        'cp',
+        `${dockerSrcPath}/.`,
+        `${containerName}:/app/data/${dir}/`,
+      ]);
+
+      if (result.success) {
+        // docker cp copies files as root — fix ownership so the app user can write
+        const chownResult = await exec('docker', [
+          'exec',
+          containerName,
+          'chown',
+          '-R',
+          'app:app',
+          `/app/data/${dir}/`,
+        ]);
+        if (!chownResult.success) {
+          logger.warn(
+            `Failed to fix ownership for ${dir}/: ${chownResult.stderr}`,
+          );
+        }
+        logger.info(`Synced ${dir}/`);
+        if (preserved.length > 0) {
+          logger.info(
+            `Preserved ${preserved.length} existing container secret(s) (host copy skipped to avoid overwriting UI edits):`,
+          );
+          for (const p of preserved) {
+            logger.info(`  - providers/${p}`);
+          }
+          logger.info(
+            `  To push host values instead: docker exec ${containerName} rm /app/data/providers/<file>, then redeploy.`,
+          );
+        }
+      } else {
+        logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);
+      }
+    } finally {
+      if (tempStageDir) {
+        tempStageDirs.delete(tempStageDir);
+        await rm(tempStageDir, { recursive: true, force: true });
+      }
     }
   }
 
   if (!dryRun) {
     logger.success('Project files synced');
   }
+}
+
+// Enumerate *.secrets.json files already in the convex container so the
+// subsequent docker cp can skip host copies that would overwrite them.
+// Distinguishes benign "directory missing" (first deploy, empty volume) from
+// hard failures (container unreachable, permission denied, etc.) — the latter
+// aborts the deploy rather than silently reverting to the old overwrite
+// behavior.
+async function listContainerSecrets(
+  containerName: string,
+): Promise<Set<string>> {
+  const result = await exec('docker', [
+    'exec',
+    containerName,
+    'find',
+    '/app/data/providers',
+    '-type',
+    'f',
+    '-name',
+    '*.secrets.json',
+    '-printf',
+    '%P\n',
+  ]);
+  if (result.success) {
+    return new Set(
+      result.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  }
+  if (/No such file or directory/.test(result.stderr)) {
+    // Providers directory not yet created — nothing to protect.
+    return new Set();
+  }
+  throw new Error(
+    `Failed to enumerate container provider secrets on ${containerName}: ${result.stderr || 'unknown error'}`,
+  );
+}
+
+// Copy host `providers/` into a fresh tmp dir and delete any *.secrets.json
+// whose relative path also exists in the container. The resulting stage dir
+// is what `docker cp` will ship — so conflicting secrets are preserved on the
+// container side, non-conflicting files sync as before. fs.cp defaults to
+// dereference=false, which keeps symlinks intact.
+async function stageProvidersWithoutConflictingSecrets(
+  srcDir: string,
+  protectedRelPaths: Set<string>,
+): Promise<{ stageDir: string; skipped: string[] }> {
+  const stageDir = await mkdtemp(join(tmpdir(), 'tale-sync-'));
+  await cp(srcDir, stageDir, { recursive: true });
+  const skipped: string[] = [];
+  for (const rel of protectedRelPaths) {
+    // `rel` comes from the Linux container's find, so it uses '/'. Split
+    // and re-join so Windows host paths resolve correctly against stageDir.
+    const candidate = join(stageDir, ...rel.split('/'));
+    if (existsSync(candidate)) {
+      await rm(candidate);
+      skipped.push(rel);
+    }
+  }
+  return { stageDir, skipped };
 }


### PR DESCRIPTION
## Summary

- `tale deploy` ran `docker cp host/providers/. container:/app/data/providers/`, which clobbered SOPS-encrypted `*.secrets.json` files that users had saved via the admin UI. Next deploy silently reverted those keys to the host copy.
- For the `providers/` directory only, stage host files into a tmp dir, delete any `*.secrets.json` whose relative path also exists in the container, then `docker cp` the stage. UI-configured secrets survive the sync; new secrets still bootstrap normally.
- `find` failures are discriminated: `No such file or directory` (fresh volume, first deploy) is benign → empty set → host secrets bootstrap as usual. Any other failure (container unreachable, permission denied, etc.) aborts the deploy rather than silently reverting to the overwrite behavior.
- Tmp stage dirs are tracked at the `deploy()` scope so the SIGINT handler cleans them up alongside started containers.

## Scope

- **Only** `providers/*.secrets.json` is protected. Non-secret provider JSON (e.g. `openrouter.json` — also UI-editable) and the other four `SYNC_DIRS` (`agents`, `workflows`, `integrations`, `branding`) keep existing host-wins behavior. Secrets are the irrecoverable case; non-secret fields can be re-entered in the UI in seconds. The staging framework is reusable if we want to extend coverage later.
- No new CLI flag. No change to `--fresh` / rollback / update / reset — verified none of them reach `syncProjectFiles` except `deploy`.
- `docker-entrypoint.sh` already skips seeding `*.secrets.json` from the builtin tree, so the two layers are aligned.

## Test plan

- [ ] Fresh volume: `tale reset --all` → `tale deploy` with host `providers/openrouter.secrets.json` (value A) → verify container has A and no "Preserved" log line.
- [ ] UI edit preserved: update OpenRouter key in admin UI (value B) → `tale deploy` → log shows `Preserved 1 existing container secret(s): - providers/openrouter.secrets.json` + rescue hint → `docker exec <convex> cat /app/data/providers/openrouter.secrets.json` still matches B.
- [ ] Non-secret JSON still overwrites: edit host `providers/openrouter.json` → `tale deploy` → container file matches host.
- [ ] New secret bootstrap: add host `providers/anthropic.secrets.json` not yet in container → `tale deploy` → container gets the new file.
- [ ] Multi-org: host `providers/acme/openai.secrets.json` + container already has same path → container version preserved.
- [ ] Dry-run: `tale deploy --dry-run` prints `Would sync providers/ …` plus the "existing container *.secrets.json will be preserved" notice, makes no `docker exec` calls.
- [ ] Hard error: stop the convex container, run `tale deploy` → `listContainerSecrets` throws, deploy aborts with a visible error (no silent overwrite).
- [ ] SIGINT: `tale deploy` then Ctrl+C during the sync step → no `/tmp/tale-sync-*` leftovers.
- [ ] `npx tsc --noEmit`, `bunx oxlint`, `bunx oxfmt --check` all pass.