### PR TITLE
refactor(platform): derive integration install state from credentials

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,11 +5,6 @@ Follow the coding standards defined in `/AGENTS.md` at the project root.
 - DO NOT include "Co-Authored-By" in commit messages.
 - DO NOT include "Generated with Claude Code" or any similar attribution in PR descriptions.
 
-## Development Setup
-
-- After cloning, run `git update-index --skip-worktree examples/branding/branding.json` to prevent local branding edits from showing in git status.
-- The `examples/` directory is the live config directory during development. New provider files created via the UI are gitignored, but modifications to tracked seed files need skip-worktree.
-
 ## Code Style
 
 - NEVER use empty catch blocks. Always log the error (e.g. `console.warn` / `console.error`) or re-throw. Silent swallowing hides bugs.

--- a/examples/integrations/ai-image/config.json
+++ b/examples/integrations/ai-image/config.json
@@ -2,7 +2,6 @@
   "title": "AI Image",
   "description": "Create and edit images with AI. Supports OpenAI (GPT Image, DALL-E), Together AI, and other compatible providers.",
   "version": 1,
-  "installed": true,
   "type": "rest_api",
   "authMethod": "bearer_token",
   "supportedAuthMethods": ["bearer_token"],

--- a/examples/integrations/circuly/config.json
+++ b/examples/integrations/circuly/config.json
@@ -2,7 +2,6 @@
   "title": "Circuly",
   "description": "Circuly API integration for products, customers, and subscriptions",
   "version": 1,
-  "installed": true,
   "authMethod": "basic_auth",
   "secretBindings": ["username", "password"],
   "allowedHosts": ["circuly.io"],

--- a/examples/integrations/discord/config.json
+++ b/examples/integrations/discord/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Discord",
-  "installed": false,
   "description": "Discord Bot API integration for guilds, channels, and messages",
   "version": 1,
   "authMethod": "bearer_token",

--- a/examples/integrations/github/config.json
+++ b/examples/integrations/github/config.json
@@ -1,6 +1,5 @@
 {
   "title": "GitHub",
-  "installed": false,
   "description": "GitHub REST API integration for repositories, issues, pull requests, and code search",
   "version": 1,
   "authMethod": "bearer_token",

--- a/examples/integrations/gmail/config.json
+++ b/examples/integrations/gmail/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Gmail",
-  "installed": false,
   "description": "Google Gmail API integration for email, labels, threads, and drafts",
   "version": 2,
   "authMethod": "oauth2",

--- a/examples/integrations/outlook/config.json
+++ b/examples/integrations/outlook/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Microsoft Outlook",
-  "installed": false,
   "description": "Microsoft Graph API integration for Outlook mail, calendar, and contacts",
   "version": 2,
   "authMethod": "oauth2",

--- a/examples/integrations/protel/config.json
+++ b/examples/integrations/protel/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Protel PMS",
-  "installed": false,
   "description": "Hotel Property Management System - Direct SQL Access for reservations, guest profiles, rooms, and postings",
   "version": 1,
   "type": "sql",

--- a/examples/integrations/shopify/config.json
+++ b/examples/integrations/shopify/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Shopify",
-  "installed": false,
   "description": "Shopify Admin API integration for products, customers, and orders",
   "version": 1,
   "authMethod": "api_key",

--- a/examples/integrations/slack/config.json
+++ b/examples/integrations/slack/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Slack",
-  "installed": false,
   "description": "Slack API integration for channels, messages, and users",
   "version": 1,
   "authMethod": "oauth2",

--- a/examples/integrations/tavily/config.json
+++ b/examples/integrations/tavily/config.json
@@ -2,14 +2,7 @@
   "title": "Tavily",
   "description": "Open-web search and page extraction optimised for LLM agents. Use with the Researcher agent for real-time research with cited sources.",
   "version": 1,
-  "installed": false,
   "type": "rest_api",
-  "exposeAsCapability": {
-    "label": "Web search",
-    "icon": "globe",
-    "tooltip": "Search the open web for current information via Tavily",
-    "order": 10
-  },
   "authMethod": "api_key",
   "supportedAuthMethods": ["api_key"],
   "secretBindings": ["apiKey"],

--- a/examples/integrations/teams/config.json
+++ b/examples/integrations/teams/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Microsoft Teams",
-  "installed": false,
   "description": "Microsoft Graph API integration for Teams channels, messages, and chats",
   "version": 1,
   "authMethod": "oauth2",

--- a/examples/integrations/twilio/config.json
+++ b/examples/integrations/twilio/config.json
@@ -1,6 +1,5 @@
 {
   "title": "Twilio",
-  "installed": false,
   "description": "Twilio API integration for SMS messaging, voice calls, and phone number management",
   "version": 1,
   "authMethod": "basic_auth",

--- a/services/platform/app/features/chat/hooks/use-composer-capabilities.ts
+++ b/services/platform/app/features/chat/hooks/use-composer-capabilities.ts
@@ -35,13 +35,12 @@ export interface CapabilityEntry {
   tooltip?: string;
   icon: LucideIcon;
   order: number;
-  installed: boolean;
-  /** installed AND the credential row for this slug is active. */
+  /** The credential row for this slug exists and is active. */
   ready: boolean;
 }
 
 export interface IntegrationReadiness {
-  /** slug → ready (file `installed` AND credential `isActive`). */
+  /** slug → ready (an active credential row exists for this slug). */
   readyBySlug: Map<string, boolean>;
   /** slug → human-readable title from the integration's config.json. */
   titleBySlug: Map<string, string>;
@@ -89,9 +88,7 @@ export function useIntegrationReadiness(
       const slug =
         typeof integration.slug === 'string' ? integration.slug : undefined;
       if (!slug) continue;
-      const installed = integration.installed === true;
-      const isActive = activeBySlug.get(slug) === true;
-      readyBySlug.set(slug, installed && isActive);
+      readyBySlug.set(slug, activeBySlug.get(slug) === true);
       if (typeof integration.title === 'string' && integration.title) {
         titleBySlug.set(slug, integration.title);
       }
@@ -132,14 +129,12 @@ export function useComposerCapabilities(
         ? integration.exposeAsCapability
         : null;
       if (!exposure) continue;
-      const installed = integration.installed === true;
       entries.push({
         slug,
         label: exposure.label,
         tooltip: exposure.tooltip,
         icon: resolveCapabilityIcon(exposure.icon),
         order: typeof exposure.order === 'number' ? exposure.order : 100,
-        installed,
         ready: readiness.readyBySlug.get(slug) === true,
       });
     }

--- a/services/platform/app/features/settings/integrations/components/__tests__/integrations.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/__tests__/integrations.test.tsx
@@ -42,7 +42,6 @@ function makeIntegration(
     slug: 'test-slug',
     title: 'Test Integration',
     description: 'A test integration',
-    installed: true,
     authMethod: 'bearer_token',
     operationCount: 5,
     hash: 'abc123',

--- a/services/platform/app/features/settings/integrations/components/integrations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.tsx
@@ -23,7 +23,6 @@ export interface IntegrationListItem {
   slug: string;
   title: string;
   description?: string;
-  installed: boolean;
   type?: 'rest_api' | 'sql';
   authMethod: string;
   operationCount: number;

--- a/services/platform/app/features/settings/integrations/hooks/actions.ts
+++ b/services/platform/app/features/settings/integrations/hooks/actions.ts
@@ -36,9 +36,6 @@ export function useTestIntegration() {
   const mutateAsync: typeof base.mutateAsync = useCallback(
     async (...args) => {
       const result = await base.mutateAsync(...args);
-      // A successful test flips the credential to isActive and self-heals
-      // config.installed on disk, so the cached file-based integrations list
-      // must be refetched to pick up the new `installed` value.
       void queryClient.invalidateQueries({
         queryKey: ['config', 'integrations'],
       });

--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
@@ -845,7 +845,11 @@ export function useIntegrationManage(
 
   const handleUninstall = useCallback(async () => {
     try {
-      await uninstallFn({ orgSlug: 'default', slug: integration.name ?? '' });
+      await uninstallFn({
+        orgSlug: 'default',
+        slug: integration.name ?? '',
+        organizationId: integration.organizationId ?? '',
+      });
       void queryClient.invalidateQueries({
         queryKey: ['config', 'integrations'],
       });

--- a/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
@@ -1,7 +1,6 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useAction } from 'convex/react';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
@@ -113,25 +112,6 @@ function IntegrationsPage() {
     useIntegrations(orgSlug);
   const { data: credentials } = useIntegrationCredentials(organizationId);
   const { data: ssoProvider, isLoading: isSsoLoading } = useSsoProvider();
-
-  // Auto-create missing credential records for installed integrations
-  const installFn = useAction(api.integrations.file_actions.installIntegration);
-  const ensuredRef = useRef(new Set<string>());
-  useEffect(() => {
-    if (!orgSlug || !credentials || !fileIntegrations.length) return;
-    const credSlugs = new Set(
-      (credentials ?? []).map((c: { slug: string }) => c.slug),
-    );
-    for (const item of fileIntegrations) {
-      if (!item || !('slug' in item) || !('installed' in item)) continue;
-      if (!item.installed) continue;
-      const slug = String(item.slug);
-      if (!credSlugs.has(slug) && !ensuredRef.current.has(slug)) {
-        ensuredRef.current.add(slug);
-        void installFn({ orgSlug, slug, organizationId });
-      }
-    }
-  }, [fileIntegrations, credentials, installFn, organizationId, orgSlug]);
 
   // Handle OAuth2 redirect query params
   useEffect(() => {

--- a/services/platform/convex/agent_tools/integrations/create_bound_integration_tool.ts
+++ b/services/platform/convex/agent_tools/integrations/create_bound_integration_tool.ts
@@ -61,6 +61,12 @@ function jsonTypeToZod(
     case 'boolean':
       schema = z.boolean();
       break;
+    case 'array':
+      schema = z.array(z.unknown());
+      break;
+    case 'object':
+      schema = z.record(z.string(), z.unknown());
+      break;
     default:
       schema = z.string();
   }
@@ -192,11 +198,7 @@ export function createBoundIntegrationTool(
             organizationId,
             integrationName,
             operation: args.operation,
-            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Zod-validated params is Record<string, unknown>; narrowing to primitive values for Convex serialization
-            params: (args.params || {}) as Record<
-              string,
-              string | number | boolean | null
-            >,
+            params: args.params || {},
             threadId,
             messageId,
           },

--- a/services/platform/convex/integrations/file_actions.ts
+++ b/services/platform/convex/integrations/file_actions.ts
@@ -95,6 +95,7 @@ export const readIntegration = action({
 export const listIntegrations = action({
   args: {
     orgSlug: v.string(),
+    organizationId: v.optional(v.string()),
     filter: v.optional(
       v.union(v.literal('installed'), v.literal('templates'), v.literal('all')),
     ),
@@ -125,11 +126,25 @@ export const listIntegrations = action({
       (e) => !e.startsWith('.') && validateIntegrationSlug(e),
     );
 
+    // `installed` is derived from the DB: an integration is installed iff a
+    // credential row exists for its slug in this organization. Fetching the
+    // credential set once avoids N queries inside the dir.map loop.
+    const installedSlugs = new Set<string>();
+    if (args.organizationId) {
+      const credentials = await ctx.runQuery(
+        internal.integrations.credential_queries.listInternal,
+        { organizationId: args.organizationId },
+      );
+      for (const cred of credentials as Array<{ slug: string }>) {
+        installedSlugs.add(cred.slug);
+      }
+    }
+
     const results = await Promise.all(
       dirs.map(async (slug) => {
         const result = await readIntegrationConfigFile(args.orgSlug, slug);
         if (result.ok) {
-          const installed = result.config.installed ?? false;
+          const installed = installedSlugs.has(slug);
           if (filterMode === 'installed' && !installed) return null;
           if (filterMode === 'templates' && installed) return null;
 
@@ -147,7 +162,6 @@ export const listIntegrations = action({
             slug,
             title: result.config.title,
             description: result.config.description,
-            installed,
             type: result.config.type,
             authMethod: result.config.authMethod,
             supportedAuthMethods: result.config.supportedAuthMethods,
@@ -275,70 +289,7 @@ export const installIntegration = action({
       credentialId = existing._id;
     }
 
-    const { hash } = await writeInstalledFlag(args.orgSlug, args.slug, result);
-    return { hash, credentialId };
-  },
-});
-
-async function writeInstalledFlag(
-  orgSlug: string,
-  slug: string,
-  result: Extract<IntegrationReadResult, { ok: true }>,
-): Promise<{ hash: string; changed: boolean }> {
-  if (result.config.installed) {
-    return { hash: result.hash, changed: false };
-  }
-  const updatedConfig: IntegrationJsonConfig = {
-    ...result.config,
-    installed: true,
-  };
-  const newContent = serializeIntegrationJson(updatedConfig);
-  const filePath = resolveConfigPath(orgSlug, slug);
-  await atomicWrite(filePath, newContent);
-  return { hash: sha256(newContent), changed: true };
-}
-
-/**
- * Internal: flip `installed: true` on the config file if needed.
- * Idempotent — a no-op when the file is already marked installed or missing.
- * Used to self-heal when a credential becomes active but the on-disk config
- * was reverted (e.g. by a git checkout of a tracked seed file).
- */
-export const ensureInstalledInternal = internalAction({
-  args: {
-    orgSlug: v.string(),
-    slug: v.string(),
-  },
-  returns: v.object({ changed: v.boolean() }),
-  handler: async (_ctx, args): Promise<{ changed: boolean }> => {
-    console.log(
-      `[Integrations] ensureInstalledInternal: orgSlug=${args.orgSlug} slug=${args.slug} configPath=${resolveConfigPath(args.orgSlug, args.slug)}`,
-    );
-    if (!validateIntegrationSlug(args.slug)) {
-      console.warn(
-        `[Integrations] ensureInstalledInternal: invalid slug, skipping (slug=${args.slug})`,
-      );
-      return { changed: false };
-    }
-    const result = await readIntegrationConfigFile(args.orgSlug, args.slug);
-    if (!result.ok) {
-      console.warn(
-        `[Integrations] ensureInstalledInternal: cannot read config, skipping (slug=${args.slug} error=${result.error} message=${result.message})`,
-      );
-      return { changed: false };
-    }
-    console.log(
-      `[Integrations] ensureInstalledInternal: read ok (slug=${args.slug} installed=${result.config.installed ?? false})`,
-    );
-    const { changed } = await writeInstalledFlag(
-      args.orgSlug,
-      args.slug,
-      result,
-    );
-    console.log(
-      `[Integrations] ensureInstalledInternal: done (slug=${args.slug} changed=${changed})`,
-    );
-    return { changed };
+    return { hash: result.hash, credentialId };
   },
 });
 
@@ -346,9 +297,10 @@ export const uninstallIntegration = action({
   args: {
     orgSlug: v.string(),
     slug: v.string(),
+    organizationId: v.string(),
   },
-  returns: v.object({ hash: v.string() }),
-  handler: async (ctx, args): Promise<{ hash: string }> => {
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, args): Promise<{ deleted: boolean }> => {
     const authUser = await authComponent.getAuthUser(ctx);
     if (!authUser) throw new Error('Unauthenticated');
 
@@ -356,25 +308,21 @@ export const uninstallIntegration = action({
       throw new Error(`Invalid integration slug: ${args.slug}`);
     }
 
-    const result = await readIntegrationConfigFile(args.orgSlug, args.slug);
-    if (!result.ok) {
-      throw new Error(`Cannot uninstall integration: ${result.message}`);
+    const existing = await ctx.runQuery(
+      internal.integrations.credential_queries.getBySlugInternal,
+      { organizationId: args.organizationId, slug: args.slug },
+    );
+
+    if (!existing) {
+      return { deleted: false };
     }
 
-    if (!result.config.installed) {
-      return { hash: result.hash };
-    }
+    await ctx.runMutation(
+      internal.integrations.credential_mutations.deleteCredentialsInternal,
+      { credentialId: existing._id },
+    );
 
-    const updatedConfig: IntegrationJsonConfig = {
-      ...result.config,
-      installed: false,
-    };
-
-    const newContent = serializeIntegrationJson(updatedConfig);
-    const filePath = resolveConfigPath(args.orgSlug, args.slug);
-    await atomicWrite(filePath, newContent);
-
-    return { hash: sha256(newContent) };
+    return { deleted: true };
   },
 });
 
@@ -448,43 +396,5 @@ export const readIntegrationForExecution = internalAction({
       connectorCode,
       hash: configResult.hash,
     };
-  },
-});
-
-export const listIntegrationsForAgent = internalAction({
-  args: {
-    orgSlug: v.string(),
-  },
-  returns: v.any(),
-  handler: async (_ctx, args) => {
-    const dir = resolveIntegrationsDir(args.orgSlug);
-    let entries: string[];
-    try {
-      entries = await readdir(dir);
-    } catch {
-      return [];
-    }
-
-    const dirs = entries.filter(
-      (e) => !e.startsWith('.') && validateIntegrationSlug(e),
-    );
-
-    const results = await Promise.all(
-      dirs.map(async (slug) => {
-        const result = await readIntegrationConfigFile(args.orgSlug, slug);
-        if (result.ok && result.config.installed) {
-          return {
-            slug,
-            title: result.config.title,
-            description: result.config.description,
-            type: result.config.type,
-            operationCount: result.config.operations?.length ?? 0,
-          };
-        }
-        return null;
-      }),
-    );
-
-    return results.filter(Boolean);
   },
 });

--- a/services/platform/convex/integrations/load_integration.ts
+++ b/services/platform/convex/integrations/load_integration.ts
@@ -151,7 +151,6 @@ export const loadIntegration = internalAction({
       title: string;
       description?: string;
       version?: number;
-      installed?: boolean;
       type?: 'rest_api' | 'sql';
       authMethod: string;
       supportedAuthMethods?: string[];

--- a/services/platform/convex/integrations/oauth2_token_exchange.ts
+++ b/services/platform/convex/integrations/oauth2_token_exchange.ts
@@ -127,20 +127,6 @@ export const handleOAuth2Callback = internalAction({
       },
     );
 
-    // Self-heal: keep config.installed in sync with credential activation so
-    // the composer/engine readiness gates agree with the DB, even if a git
-    // checkout reset the tracked seed file back to installed:false.
-    console.log(
-      `[Integrations] oauth2_token_exchange: running ensureInstalled (orgSlug=${orgSlug} slug=${credential.slug})`,
-    );
-    const ensureResult = await ctx.runAction(
-      internal.integrations.file_actions.ensureInstalledInternal,
-      { orgSlug, slug: credential.slug },
-    );
-    console.log(
-      `[Integrations] oauth2_token_exchange: ensureInstalled result changed=${ensureResult.changed}`,
-    );
-
     debugLog(
       `OAuth2 token exchange successful for credential ${args.credentialId}`,
     );

--- a/services/platform/convex/integrations/test_connection.ts
+++ b/services/platform/convex/integrations/test_connection.ts
@@ -320,19 +320,6 @@ export async function testConnection(
           errorMessage: undefined,
         },
       );
-      // Self-heal: tracked seed configs can be reset to installed:false by
-      // git checkouts while the credential row stays active. Re-align the
-      // file so the composer/engine readiness gates agree with the DB.
-      console.log(
-        `[Integrations] test_connection: running ensureInstalled (orgSlug=${orgSlug} slug=${credential.slug})`,
-      );
-      const ensureResult = await ctx.runAction(
-        internal.integrations.file_actions.ensureInstalledInternal,
-        { orgSlug, slug: credential.slug },
-      );
-      console.log(
-        `[Integrations] test_connection: ensureInstalled result changed=${ensureResult.changed}`,
-      );
     }
 
     debugLog(

--- a/services/platform/lib/shared/schemas/integrations.ts
+++ b/services/platform/lib/shared/schemas/integrations.ts
@@ -83,7 +83,6 @@ export const integrationJsonSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   version: z.number().int().optional(),
-  installed: z.boolean().default(false),
   type: z.enum(['rest_api', 'sql']).optional(),
   exposeAsCapability: exposeAsCapabilitySchema.optional(),
   authMethod: z.enum(['api_key', 'bearer_token', 'basic_auth', 'oauth2']),


### PR DESCRIPTION
## Summary

- Remove the `installed` field from integration config JSON files; install state is now derived from the presence of a credential row in `integrationCredentials`.
- Eliminates the dual source of truth that required `ensureInstalledInternal` self-heal calls and caused the "Requires X" regression after every `tale deploy --fresh` (the seed re-wrote `installed: false`, masking active credentials until the next Test click flipped it back).
- As part of the cleanup, tavily seed drops `exposeAsCapability` (a local override that was stuck on skip-worktree and never reached main), and `.claude/CLAUDE.md` drops the skip-worktree recommendation that enabled the drift in the first place.

## What changed

**Backend**
- `integrationJsonSchema` drops `installed`
- `listIntegrations` derives `installed` from `integrationCredentials` (single query, O(1) lookup)
- `installIntegration` no longer writes to disk; `uninstallIntegration` now deletes the credential row (gains `organizationId` arg)
- Removed `writeInstalledFlag`, `ensureInstalledInternal`, and the unused `listIntegrationsForAgent`
- `test_connection` / `oauth2_token_exchange` drop the self-heal calls

**Frontend**
- `useIntegrationReadiness`: `ready = isActive` (credential row existence ≡ installed)
- `IntegrationListItem` interface drops `installed`; test mocks updated
- Removed the "auto-create missing credential" effect in the settings route (no longer possible to have `installed && !credential`)
- `handleUninstall` now passes `organizationId`

**Seed**
- 12 `examples/integrations/*/config.json` stripped of `"installed"`
- `tavily/config.json` additionally drops `exposeAsCapability`

**Docs**
- `.claude/CLAUDE.md` removes the `## Development Setup` section recommending `git update-index --skip-worktree` (root cause of the exposeAsCapability regression that surfaced this design flaw)

## Why

Putting `installed` in the JSON config mixed two lifecycles:
- **Definition** (versioned with code) — operations, authMethod, allowedHosts, etc.
- **Runtime per-deployment state** — "has this org's admin completed setup?"

Symptoms that it was misplaced:
1. `ensureInstalledInternal` existed purely to self-heal the field from overwrites — a cycle the primary source of truth should never need.
2. The readiness check `ready = installed && isActive` was redundant: an active credential row already implies `installed`.
3. Every `tale deploy --fresh` wiped `installed: true` back to `installed: false`, forcing the user to click Test before the UI recognized a still-valid credential.
4. Developers had to `skip-worktree` the seed JSON so local runtime edits wouldn't pollute git — but that same mechanism silently swallowed real config changes (exactly what happened to tavily's `exposeAsCapability`).

## Migration

- **No DB migration.** `integrationCredentials` already has everything needed; `isActive` is the ready signal.
- **No data migration.** Existing `/app/data/integrations/<slug>/config.json` files carrying `installed` will still parse — Zod drops unknown fields. On next write, the field disappears.
- **`_generated/api.d.ts`** will regenerate on next `convex dev`/deploy and must be included in the follow-up commit when it does.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint --workspace=@tale/platform` — 0 warnings / 0 errors
- [x] `integrations.test.tsx` — 10/10 passed
- [ ] Deploy to staging with `tale deploy --fresh` and confirm the Researcher agent's Tavily tool stays "ready" without clicking Test
- [ ] Install a new integration from scratch (no prior credential) and confirm the card flips to "Connected" after a successful Test
- [ ] Uninstall an integration and confirm the credential row is deleted (DB check) and the card reverts to "Not connected"
- [ ] Confirm the composer "+" menu no longer shows "Web search (Requires Tavily)" once Tavily no longer declares `exposeAsCapability`

## Follow-ups (not in this PR)

- `services/platform/convex/workflows/file_actions.ts` + `lib/shared/schemas/workflows.ts` have the **same design flaw** (workflows also carry `installed` on disk). Mirror fix to be opened as a separate PR once this one lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved integration status tracking to be more reliable and database-driven, removing dependency on configuration file flags.
  * Updated integration readiness logic to determine activation based on active credentials rather than installation flags.
  * Streamlined integration management workflows by removing automatic synchronization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->