### PR TITLE
fix(platform): chat file attachment flicker on stream completion

### DIFF
--- a/services/platform/app/features/chat/hooks/__tests__/use-message-processing.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-message-processing.test.ts
@@ -4,6 +4,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockLoadMore = vi.fn();
 
+// The Convex `api` proxy returns a NEW object on every property access, so
+// identity-based lookup doesn't work. Key by the function path string the
+// proxy exposes under Symbol.for("functionName") (e.g.
+// "threads/queries:isThreadGenerating").
+const FUNCTION_NAME = Symbol.for('functionName');
+const queryResults = new Map<string, unknown>();
+
+function functionPath(queryRef: unknown): string {
+  if (typeof queryRef === 'object' && queryRef !== null) {
+    const name = (queryRef as Record<symbol, unknown>)[FUNCTION_NAME];
+    if (typeof name === 'string') return name;
+  }
+  return String(queryRef);
+}
+
+function setQueryResult(queryRef: unknown, value: unknown) {
+  queryResults.set(functionPath(queryRef), value);
+}
+
 vi.mock('@convex-dev/agent/react', () => ({
   useUIMessages: vi.fn(() => ({
     results: undefined,
@@ -15,10 +34,14 @@ vi.mock('@convex-dev/agent/react', () => ({
 vi.mock('../use-stream-buffer', () => ({}));
 
 vi.mock('convex/react', () => ({
-  useQuery: vi.fn(() => undefined),
+  useQuery: vi.fn((queryRef: unknown) =>
+    queryResults.get(functionPath(queryRef)),
+  ),
 }));
 
 import { useUIMessages } from '@convex-dev/agent/react';
+
+import { api } from '@/convex/_generated/api';
 
 import {
   useMessageProcessing,
@@ -46,6 +69,7 @@ function createUIMessage(
 describe('useMessageProcessing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    queryResults.clear();
   });
 
   describe('streamingMessage', () => {
@@ -1072,7 +1096,8 @@ describe('useMessageProcessing', () => {
       url: 'https://example.com/generated.png',
     };
 
-    it('hides file-only message when its turn has an active streaming assistant', () => {
+    it('hides file-only message while the thread is generating', () => {
+      setQueryResult(api.threads.queries.isThreadGenerating, true);
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({
@@ -1107,7 +1132,47 @@ describe('useMessageProcessing', () => {
       ).toBeUndefined();
     });
 
+    it('hides file-only during the between-step gap (pre-tool success, no streaming yet, isGenerating=true)', () => {
+      // Regression case: shipped guard looked for streaming/pending assistant
+      // status, which is undefined in the window between pre-tool `success`
+      // and post-tool creation. The isGenerating-based guard covers it.
+      setQueryResult(api.threads.queries.isThreadGenerating, true);
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate a PDF',
+          }),
+          createUIMessage({
+            id: 'msg-pre-tool',
+            order: 1,
+            role: 'assistant',
+            text: 'Let me generate that PDF.',
+            status: 'success',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      expect(
+        result.current.messages.find((m) => m.key === 'file-1'),
+      ).toBeUndefined();
+    });
+
     it('merges file-only parts into a text-bearing assistant in the same turn', () => {
+      setQueryResult(api.threads.queries.isThreadGenerating, true);
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({
@@ -1259,6 +1324,7 @@ describe('useMessageProcessing', () => {
     });
 
     it('does not let a later-turn streaming message hide a prior-turn file-only', () => {
+      setQueryResult(api.threads.queries.isThreadGenerating, true);
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({

--- a/services/platform/app/features/chat/hooks/__tests__/use-message-processing.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-message-processing.test.ts
@@ -1051,4 +1051,259 @@ describe('useMessageProcessing', () => {
       expect(extractFileAttachments(input)).toEqual([]);
     });
   });
+
+  describe('file-only message merging', () => {
+    const pdfPart = {
+      type: 'file' as const,
+      mediaType: 'application/pdf',
+      filename: 'report.pdf',
+      url: 'https://example.com/report.pdf',
+    };
+    const pdfPart2 = {
+      type: 'file' as const,
+      mediaType: 'application/pdf',
+      filename: 'appendix.pdf',
+      url: 'https://example.com/appendix.pdf',
+    };
+    const imagePart = {
+      type: 'file' as const,
+      mediaType: 'image/png',
+      filename: 'generated.png',
+      url: 'https://example.com/generated.png',
+    };
+
+    it('hides file-only message when its turn has an active streaming assistant', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate a PDF',
+          }),
+          createUIMessage({
+            id: 'msg-streaming',
+            order: 1,
+            role: 'assistant',
+            text: 'Working on it…',
+            status: 'streaming',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      expect(
+        result.current.messages.find((m) => m.key === 'file-1'),
+      ).toBeUndefined();
+    });
+
+    it('merges file-only parts into a text-bearing assistant in the same turn', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate a PDF',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+          createUIMessage({
+            id: 'msg-text',
+            order: 1,
+            role: 'assistant',
+            text: 'Done. PDF below.',
+            status: 'streaming',
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      expect(
+        result.current.messages.find((m) => m.key === 'file-1'),
+      ).toBeUndefined();
+      const textMsg = result.current.messages.find((m) => m.key === 'msg-text');
+      expect(textMsg?.fileParts?.map((p) => p.url)).toEqual([pdfPart.url]);
+    });
+
+    it('renders file-only message standalone when its turn has no active streaming', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate an image',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [imagePart],
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      const fileMsg = result.current.messages.find((m) => m.key === 'file-1');
+      expect(fileMsg).toBeDefined();
+      expect(fileMsg?.fileParts?.map((p) => p.url)).toEqual([imagePart.url]);
+    });
+
+    it('renders file-only standalone when the turn ended in failure (no active streaming)', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate a PDF',
+          }),
+          createUIMessage({
+            id: 'msg-failed',
+            order: 1,
+            role: 'assistant',
+            text: 'Partial text before failure',
+            status: 'failed',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      const fileMsg = result.current.messages.find((m) => m.key === 'file-1');
+      expect(fileMsg).toBeDefined();
+      expect(fileMsg?.fileParts?.map((p) => p.url)).toEqual([pdfPart.url]);
+    });
+
+    it('merges two file-only messages into the same text-bearing assistant', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user',
+            order: 0,
+            role: 'user',
+            text: 'Generate two PDFs',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+          createUIMessage({
+            id: 'file-2',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart2],
+          }),
+          createUIMessage({
+            id: 'msg-text',
+            order: 1,
+            role: 'assistant',
+            text: 'Both ready.',
+            status: 'success',
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      expect(
+        result.current.messages.find((m) => m.key === 'file-1'),
+      ).toBeUndefined();
+      expect(
+        result.current.messages.find((m) => m.key === 'file-2'),
+      ).toBeUndefined();
+      const textMsg = result.current.messages.find((m) => m.key === 'msg-text');
+      expect(textMsg?.fileParts?.map((p) => p.url)).toEqual([
+        pdfPart.url,
+        pdfPart2.url,
+      ]);
+    });
+
+    it('does not let a later-turn streaming message hide a prior-turn file-only', () => {
+      mockUseUIMessages.mockReturnValue({
+        results: [
+          createUIMessage({
+            id: 'msg-user-1',
+            order: 0,
+            role: 'user',
+            text: 'First',
+          }),
+          createUIMessage({
+            id: 'msg-done',
+            order: 1,
+            role: 'assistant',
+            text: 'Here is your file.',
+            status: 'success',
+          }),
+          createUIMessage({
+            id: 'file-1',
+            order: 1,
+            role: 'assistant',
+            text: '',
+            status: 'success',
+            parts: [pdfPart],
+          }),
+          createUIMessage({
+            id: 'msg-user-2',
+            order: 2,
+            role: 'user',
+            text: 'Second',
+          }),
+          createUIMessage({
+            id: 'msg-streaming-next',
+            order: 3,
+            role: 'assistant',
+            text: 'Working…',
+            status: 'streaming',
+          }),
+        ],
+        loadMore: mockLoadMore,
+        status: 'Exhausted',
+      } as unknown as ReturnType<typeof useUIMessages>);
+
+      const { result } = renderHook(() => useMessageProcessing('thread-1'));
+      const fileMsg = result.current.messages.find((m) => m.key === 'file-1');
+      expect(fileMsg).toBeDefined();
+      expect(fileMsg?.fileParts?.map((p) => p.url)).toEqual([pdfPart.url]);
+    });
+  });
 });

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -186,6 +186,21 @@ export function useMessageProcessing(
         ? Math.min(...userMessages.map((m) => m.order))
         : 0;
 
+    // When a tool writes a file-only assistant message (via appendFilePart)
+    // mid-stream, its row lands before the post-tool text message does.
+    // If we render it standalone in that window, the bubble unmounts and the
+    // post-tool message's TypewriterText mounts fresh once the merge catches up
+    // — visible as a flicker. Hide file-only messages while their turn still
+    // has an active streaming/pending assistant message; the forward merge
+    // will attach them once that message gains content. Read the order from
+    // the same uiMessages snapshot the merge iterates to keep the pass
+    // consistent.
+    const activeTurnOrder = uiMessages.find(
+      (m) =>
+        m.role === 'assistant' &&
+        (m.status === 'streaming' || m.status === 'pending'),
+    )?.order;
+
     const currentKeys = new Set<string>();
 
     const result = uiMessages
@@ -347,10 +362,27 @@ export function useMessageProcessing(
       }
     }
 
-    // Pass 2: rebuild without file-only messages, merging extra parts immutably
+    // Pass 2: rebuild without file-only messages, merging extra parts immutably.
+    // Also hide any file-only message that did not find a merge target but
+    // shares its order with an in-flight streaming/pending assistant message
+    // — the forward merge will pick it up as soon as that message streams
+    // text, so deferring is preferable to a transient standalone bubble.
     return (
       result
-        .filter((msg) => !fileOnlyKeys.has(msg.key))
+        .filter((msg) => {
+          if (fileOnlyKeys.has(msg.key)) return false;
+          if (
+            activeTurnOrder != null &&
+            msg.role === 'assistant' &&
+            !msg.content &&
+            !msg.isAborted &&
+            msg.fileParts?.length &&
+            msg.order === activeTurnOrder
+          ) {
+            return false;
+          }
+          return true;
+        })
         // oxlint-disable-next-line oxc/no-map-spread -- immutable update required
         .map((msg) => {
           const extra = extraFileParts.get(msg.key);

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -116,6 +116,17 @@ export function useMessageProcessing(
     threadId ? { threadId } : 'skip',
   );
 
+  // Thread-level generation status. Held true across an entire multi-step
+  // turn (set by markGenerating, cleared by clearGenerationStatus) including
+  // the gap between pre-tool message success and post-tool message creation
+  // — exactly when an orphan file-only message must stay hidden. Prefer this
+  // over scanning uiMessages for a streaming/pending status, which is
+  // undefined during that gap.
+  const isGenerating = useQuery(
+    api.threads.queries.isThreadGenerating,
+    threadId ? { threadId } : 'skip',
+  );
+
   const isLoadingMore = paginationStatus === 'LoadingMore';
 
   // Check if we've loaded the first message (order: 0)
@@ -189,17 +200,25 @@ export function useMessageProcessing(
     // When a tool writes a file-only assistant message (via appendFilePart)
     // mid-stream, its row lands before the post-tool text message does.
     // If we render it standalone in that window, the bubble unmounts and the
-    // post-tool message's TypewriterText mounts fresh once the merge catches up
-    // — visible as a flicker. Hide file-only messages while their turn still
-    // has an active streaming/pending assistant message; the forward merge
-    // will attach them once that message gains content. Read the order from
-    // the same uiMessages snapshot the merge iterates to keep the pass
-    // consistent.
-    const activeTurnOrder = uiMessages.find(
-      (m) =>
-        m.role === 'assistant' &&
-        (m.status === 'streaming' || m.status === 'pending'),
-    )?.order;
+    // post-tool message's TypewriterText mounts fresh once the merge catches
+    // up — visible as a flicker. Hide file-only messages while the turn is
+    // still generating; the forward merge attaches them once the post-tool
+    // message gains content. Use threadMetadata.generationStatus (via
+    // isThreadGenerating) rather than a streaming/pending status scan —
+    // those statuses are undefined during the gap between pre-tool `success`
+    // and post-tool creation, but generationStatus stays true across that
+    // gap. Scope to the current turn by taking the max assistant order in
+    // the same uiMessages snapshot the merge iterates, so a completed
+    // earlier turn's file-only (if any) is not hidden by a later turn's
+    // generation.
+    let activeTurnOrder: number | undefined;
+    if (isGenerating) {
+      let maxOrder = -Infinity;
+      for (const m of uiMessages) {
+        if (m.role === 'assistant' && m.order > maxOrder) maxOrder = m.order;
+      }
+      if (Number.isFinite(maxOrder)) activeTurnOrder = maxOrder;
+    }
 
     const currentKeys = new Set<string>();
 
@@ -390,7 +409,7 @@ export function useMessageProcessing(
           return { ...msg, fileParts: [...(msg.fileParts ?? []), ...extra] };
         })
     );
-  }, [uiMessages, messageErrors]);
+  }, [uiMessages, messageErrors, isGenerating]);
 
   // Find active assistant message (streaming or pending tool execution).
   // Unified lookup ensures ThinkingAnimation receives tool parts during both phases.


### PR DESCRIPTION
## Summary

- When an assistant turn generates a file mid-stream (e.g. `panda-research-report.pdf`), the PDF card briefly appeared in a standalone bubble, then disappeared as the post-tool text message mounted fresh and re-animated its content.
- Root cause: `appendGeneratedFilePart` writes a separate file-only assistant message (F) via its own mutation; F lands in the subscription result before the post-tool text message (M2) does. With the previous forward-only merge, F rendered standalone during that window, then was filtered and reattached to M2 once M2 gained content — a visible mount/unmount plus fresh `TypewriterText` animation.
- Fix: in [use-message-processing.ts](services/platform/app/features/chat/hooks/use-message-processing.ts), compute `activeTurnOrder` from the same `uiMessages` snapshot the merge pass iterates, and hide file-only messages whose order matches it. The existing forward merge attaches F as soon as M2 gains content, so the PDF appears once, inside M2's bubble, without the intermediate bubble.
- Image-gen agents (FLUX/Gemini) are unaffected: they save via `saveMessage` without `promptMessageId`, so their file-only message sits at a different `order` than any active streaming message. Failed turns also fall back to standalone rendering (no active streaming → guard inert).

## Test plan

- [x] Unit: 6 new cases in [use-message-processing.test.ts](services/platform/app/features/chat/hooks/__tests__/use-message-processing.test.ts) — active-turn hiding, merge on M2 arrival, image-gen standalone, failed-turn fallback, double-file merge, cross-turn guard. All 48 tests pass.
- [x] `npx tsc --noEmit` from `services/platform/` — clean.
- [x] `npm run lint --workspace=@tale/platform` — clean.
- [ ] Manual: run the panda research agent on `dji.tale.dev` — PDF card should appear only once, inside the post-tool bubble, no standalone flicker.
- [ ] Manual: image-generation agent (FLUX/Gemini) still renders the generated image as a standalone bubble at turn end.
- [ ] Manual: arena dual-column — both columns render consistently.
- [ ] Manual: retry after a failed tool turn — old file-only hides once the retry starts streaming; new file lands on the new post-tool message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite covering file-only message handling, merging behavior, and visibility rules in conversations.

* **Improvements**
  * Enhanced handling of file-only assistant messages, including improved merging into text-bearing messages and visibility management during active conversation streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->