### PR TITLE
perf(platform): optimistic send spinner + word-chunk stream reveal

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-split-view.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-split-view.tsx
@@ -24,6 +24,10 @@ import {
 import { useMergedChatItems } from '../../hooks/use-merged-chat-items';
 import type { ChatMessage } from '../../hooks/use-message-processing';
 import { useMessageProcessing } from '../../hooks/use-message-processing';
+import {
+  clearSendPending,
+  useIsSendPending,
+} from '../../hooks/use-pending-send';
 import type { FileAttachment } from '../../types';
 import { ChatMessages } from '../chat-messages';
 import { useArenaMode } from './arena-mode-context';
@@ -107,7 +111,17 @@ function ArenaColumn({
     api.threads.queries.isThreadGenerating,
     { threadId },
   );
-  const columnLoading = isGenerating ?? false;
+  // Optimistic flag — closes the Node-action cold-start window so both
+  // columns show "Thinking" immediately on send instead of ~200–550 ms
+  // later when the server subscription catches up.
+  const isSendPending = useIsSendPending(threadId);
+  const columnLoading = (isGenerating ?? false) || isSendPending;
+
+  // Hand off to the server signal as soon as it confirms, so a fast
+  // response doesn't leave the spinner stuck behind the 8 s safety timeout.
+  useEffect(() => {
+    if (isGenerating) clearSendPending(threadId);
+  }, [isGenerating, threadId]);
 
   // Approvals
   const { approvals: integrationApprovals } = useIntegrationApprovals(

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -57,6 +57,7 @@ import { useFileTranscriptionStatus } from '../hooks/use-file-transcription-stat
 import { useMergedChatItems } from '../hooks/use-merged-chat-items';
 import { useMessageProcessing } from '../hooks/use-message-processing';
 import { usePendingMessages } from '../hooks/use-pending-messages';
+import { useIsSendPending, clearSendPending } from '../hooks/use-pending-send';
 import { usePersistedAttachments } from '../hooks/use-persisted-attachments';
 import { useSendMessage } from '../hooks/use-send-message';
 import { useStopGenerating } from '../hooks/use-stop-generating';
@@ -395,10 +396,20 @@ export function ChatInterface({
     dataThreadId ? { threadId: dataThreadId } : 'skip',
   );
 
-  // Loading state: generationStatus is the single source of truth.
-  // The Convex subscription on isThreadGenerating reflects
-  // threadMetadata.generationStatus in real-time.
-  const isLoading = isGenerating ?? false;
+  // Client-side optimistic flag — set on send click, released when the
+  // server subscription confirms or the send fails. Closes the ~200–550 ms
+  // gap between click and `chatWithAgent` completing `markGenerating`
+  // (Node action cold start + round trips). VISUAL state only — the Stop
+  // button below reads real `isGenerating` via `onStopGenerating` gating.
+  const isSendPending = useIsSendPending(dataThreadId);
+  const isLoading = (isGenerating ?? false) || isSendPending;
+
+  // Hand off to the authoritative signal the moment it arrives: clear the
+  // optimistic flag once the server reports generating, so a fast response
+  // (idle < 8s safety timeout) doesn't leave the spinner stuck on.
+  useEffect(() => {
+    if (isGenerating && dataThreadId) clearSendPending(dataThreadId);
+  }, [isGenerating, dataThreadId]);
 
   // Stop generating
   const { stopGenerating, resetCancelled } = useStopGenerating({
@@ -1011,7 +1022,7 @@ export function ChatInterface({
               value={inputValue}
               onChange={setInputValue}
               onSendMessage={handleSendMessage}
-              onStopGenerating={stopGenerating}
+              onStopGenerating={isGenerating ? stopGenerating : undefined}
               isLoading={isLoading}
               disabled={hasNoAgents || hasActiveApproval}
               disabledReason={

--- a/services/platform/app/features/chat/hooks/use-pending-send.ts
+++ b/services/platform/app/features/chat/hooks/use-pending-send.ts
@@ -1,0 +1,58 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Per-thread optimistic "send in flight" flag, set the moment a user clicks
+ * send and cleared when the server confirms via `isThreadGenerating` or the
+ * send promise rejects. Exists because the round-trip through the `'use node'`
+ * `chatWithAgent` action adds ~200–550 ms before the spinner would otherwise
+ * appear, which feels laggy.
+ *
+ * Drives VISUAL state only (spinner, composer disable). The Stop button stays
+ * on the real server signal — see chat-interface.tsx.
+ */
+
+const SAFETY_TIMEOUT_MS = 8000;
+
+const pendingByThread = new Map<
+  string,
+  { timer: ReturnType<typeof setTimeout> }
+>();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function markSendPending(threadId: string): void {
+  const existing = pendingByThread.get(threadId);
+  if (existing) clearTimeout(existing.timer);
+  const timer = setTimeout(() => {
+    pendingByThread.delete(threadId);
+    emit();
+  }, SAFETY_TIMEOUT_MS);
+  pendingByThread.set(threadId, { timer });
+  emit();
+}
+
+export function clearSendPending(threadId: string): void {
+  const existing = pendingByThread.get(threadId);
+  if (!existing) return;
+  clearTimeout(existing.timer);
+  pendingByThread.delete(threadId);
+  emit();
+}
+
+export function useIsSendPending(threadId: string | undefined): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => (threadId ? pendingByThread.has(threadId) : false),
+    () => false,
+  );
+}

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -43,6 +43,7 @@ import {
   useUpdateThread,
 } from './mutations';
 import type { ChatMessage } from './use-message-processing';
+import { clearSendPending, markSendPending } from './use-pending-send';
 import { resetGlobalFreeze } from './use-stream-buffer';
 import type { UserContext } from './use-user-context';
 
@@ -220,6 +221,15 @@ export function useSendMessage({
         });
       }
 
+      // Track threads we've flagged optimistic-pending so the catch block can
+      // clear them regardless of which branch (arena / new-chat / existing)
+      // set them, and including any thread IDs created mid-try.
+      const pendingThreadIdsLocal = new Set<string>();
+      const markPending = (id: string) => {
+        pendingThreadIdsLocal.add(id);
+        markSendPending(id);
+      };
+
       try {
         if (isArena) {
           // --- Arena mode: Thread A = root, Thread B = branch ---
@@ -292,6 +302,12 @@ export function useSendMessage({
               });
             });
           }
+
+          // Flip per-thread optimistic spinner IMMEDIATELY so both columns
+          // show "Thinking" before the Node action cold-starts. Real
+          // isThreadGenerating subscriptions take over once they arrive.
+          markPending(tIdA);
+          markPending(tIdB);
 
           // Start both models generating (split view shows "Thinking")
           await arenaChatRef.current({
@@ -372,6 +388,11 @@ export function useSendMessage({
             await updateThread({ threadId: currentThreadId, title });
           }
 
+          // Flip the optimistic spinner IMMEDIATELY — the Node action cold
+          // start adds ~100–300 ms before markGenerating commits. Real
+          // isThreadGenerating takes over once it arrives.
+          markPending(currentThreadId);
+
           await chatWithAgent({
             agentSlug: selectedAgent.name,
             orgSlug: 'default',
@@ -392,6 +413,10 @@ export function useSendMessage({
         }
       } catch (error) {
         console.error('Failed to send message:', error);
+        // Clear every thread we flagged — server either never started the
+        // turn (pre-markGenerating throw) or rolled it back. Real state
+        // stays authoritative once isThreadGenerating catches up.
+        for (const id of pendingThreadIdsLocal) clearSendPending(id);
         clearChatState();
         resetGlobalFreeze();
 

--- a/services/platform/app/features/chat/hooks/use-stream-buffer.ts
+++ b/services/platform/app/features/chat/hooks/use-stream-buffer.ts
@@ -51,15 +51,29 @@ import {
 // ============================================================================
 
 const DEFAULT_CONFIG = {
-  /** Characters per second for reveal animation */
-  targetCPS: 20,
+  /** Effective characters per second. Translated internally to a word-tick
+   *  cadence via AVG_WORD_CHARS — text reveals in word/CJK-punct chunks, not
+   *  per character, so the effect feels like ChatGPT's token-by-token stream. */
+  targetCPS: 60,
   /** Characters to buffer before starting reveal */
   initialBufferChars: 30,
-  /** Interval between React state updates (ms) */
-  stateUpdateInterval: 30,
+  /** Average characters per word-tick — used to convert targetCPS to tick
+   *  interval. 5 matches average English word length including trailing space. */
+  avgWordChars: 5,
+  /** Hard cap on chars revealed in a single tick. Prevents a long code token
+   *  (e.g. a 200-char identifier) from dumping in one frame. */
+  maxChunkChars: 40,
   /** Maximum delta time (ms) to prevent jumps after tab switching */
   maxDeltaTime: 100,
 };
+
+// CJK ranges: Hiragana, Katakana, CJK Ext-A, CJK Unified, Hangul Syllables, halfwidth kana
+const CJK_RE = /[぀-ヿ㐀-䶿一-鿿가-힯ｦ-ﾟ]/;
+// CJK punctuation and fullwidth ASCII punctuation
+const CJK_PUNCT_RE = /[　-〿！-･]/;
+/** Consecutive CJK chars before we insert a soft boundary (keeps CJK text
+ *  chunking in small groups instead of appearing in one burst). */
+const CJK_SOFT_BOUNDARY_RUN = 3;
 
 // ============================================================================
 // TYPES
@@ -224,14 +238,43 @@ function isWordBoundary(char: string): boolean {
   return /[\s.,!?;:\-\n]/.test(char);
 }
 
-function findNextWordBoundary(text: string, startPos: number): number {
-  const maxLookAhead = Math.min(startPos + 15, text.length);
-  for (let i = startPos; i < maxLookAhead; i++) {
-    if (isWordBoundary(text[i])) {
-      return i + 1;
+/**
+ * Find the next "chunk end" for word/CJK-aware reveal.
+ *
+ * Returns a position > startPos where the next chunk ends:
+ * - After a Western word boundary (space/newline/punct)
+ * - After any CJK punctuation
+ * - After {CJK_SOFT_BOUNDARY_RUN} consecutive CJK characters (soft boundary)
+ * - At maxChunkChars (force chunk for long code tokens / URLs)
+ * - At text.length (reveal remaining tail chunk)
+ */
+function findNextWordBoundary(
+  text: string,
+  startPos: number,
+  maxChunkChars: number,
+): number {
+  if (startPos >= text.length) return startPos;
+  const maxEnd = Math.min(startPos + maxChunkChars, text.length);
+  let cjkRun = 0;
+  for (let i = startPos; i < maxEnd; i++) {
+    const ch = text[i];
+    if (CJK_PUNCT_RE.test(ch)) return i + 1;
+    if (CJK_RE.test(ch)) {
+      cjkRun++;
+      if (cjkRun >= CJK_SOFT_BOUNDARY_RUN) return i + 1;
+      continue;
     }
+    cjkRun = 0;
+    if (isWordBoundary(ch)) return i + 1;
   }
-  return startPos;
+  // No natural boundary within the window.
+  if (maxEnd < text.length) {
+    // Force a chunk at maxChunkChars — prevents hanging on long code tokens.
+    return maxEnd;
+  }
+  // Reached end of buffered text — reveal the remaining partial chunk.
+  // If more text arrives later, the next scan starts from text.length.
+  return text.length;
 }
 
 // ============================================================================
@@ -260,8 +303,9 @@ export function useStreamBuffer({
   const displayedLengthRef = useRef(cachedPosition);
   const targetTextRef = useRef('');
   const isStreamingRef = useRef(false);
-  const accumulatedCharsRef = useRef(0);
-  const lastStateUpdateRef = useRef(0);
+  // Accumulates elapsed ms between ticks. A tick (= one word/chunk reveal)
+  // fires when this exceeds tickInterval. Replaces the old per-char accumulator.
+  const accumulatedTimeRef = useRef(0);
 
   // Adaptive-rate specific refs
   const hasStartedRevealRef = useRef(false);
@@ -348,76 +392,96 @@ export function useStreamBuffer({
       lastFrameTimeRef.current = currentTime;
 
       const normalizedDelta = Math.min(deltaTime, DEFAULT_CONFIG.maxDeltaTime);
-      const frameRatio = normalizedDelta / 16.67;
 
+      // Convert effective CPS → tick interval (ms per word chunk).
+      // Default 60 CPS ÷ 5 chars/word = 12 WPS → ~83ms per tick.
       const safeCPS = Math.max(1, targetCPS);
       const effectiveCPS =
         drainCPSRef.current > 0 && !streaming ? drainCPSRef.current : safeCPS;
-      const charsPerFrame = effectiveCPS / 60;
+      // Upper-clamp so very low CPS still produces visible progress.
+      const tickInterval = Math.min(
+        500,
+        (DEFAULT_CONFIG.avgWordChars * 1000) / effectiveCPS,
+      );
 
-      accumulatedCharsRef.current += charsPerFrame * frameRatio;
+      accumulatedTimeRef.current += normalizedDelta;
 
-      const charsToAdd = Math.floor(accumulatedCharsRef.current);
-      if (charsToAdd > 0) {
-        accumulatedCharsRef.current -= charsToAdd;
-        let newDisplayed = Math.min(currentDisplayed + charsToAdd, textLength);
+      let newDisplayed = currentDisplayed;
+      let ticks = 0;
+      // Safety cap: in case of huge catch-up (shouldn't happen with maxDeltaTime
+      // clamp, but keeps the loop bounded).
+      const maxTicksPerFrame = 8;
+      while (
+        accumulatedTimeRef.current >= tickInterval &&
+        newDisplayed < textLength &&
+        ticks < maxTicksPerFrame
+      ) {
+        let candidate = findNextWordBoundary(
+          targetText,
+          newDisplayed,
+          DEFAULT_CONFIG.maxChunkChars,
+        );
+
+        if (candidate <= newDisplayed) break;
+        candidate = Math.min(candidate, textLength);
 
         // Avoid splitting surrogate pairs — emoji and other supplementary
         // characters use two UTF-16 code units. Slicing between them produces
         // an invalid string that causes react-markdown to misparse.
-        if (newDisplayed < textLength && newDisplayed > 0) {
-          const code = targetText.charCodeAt(newDisplayed - 1);
+        if (candidate < textLength && candidate > 0) {
+          const code = targetText.charCodeAt(candidate - 1);
           if (code >= 0xd800 && code <= 0xdbff) {
-            // Last char is a high surrogate — advance past the low surrogate
-            newDisplayed = Math.min(newDisplayed + 1, textLength);
+            candidate = Math.min(candidate + 1, textLength);
           }
-        }
-
-        // Snap to next word boundary
-        const nextBoundary = findNextWordBoundary(targetText, newDisplayed);
-        if (nextBoundary <= textLength && nextBoundary - newDisplayed <= 3) {
-          newDisplayed = nextBoundary;
         }
 
         // Skip past complete link/image/checkbox syntax so these elements
         // appear atomically instead of flickering from plain text to styled.
-        const syntaxEnd = findSyntaxSkipEnd(targetText, newDisplayed);
-        if (syntaxEnd > newDisplayed) {
-          newDisplayed = Math.min(syntaxEnd, textLength);
+        const syntaxEnd = findSyntaxSkipEnd(targetText, candidate);
+        if (syntaxEnd > candidate) {
+          candidate = Math.min(syntaxEnd, textLength);
         }
 
-        // Line buffering: hold at current position for ambiguous line starts
-        // or trailing empty formatting markers (**, *, ~~).
-        // Re-credit only the debited chars (not word-boundary snap's free chars)
-        // so the accumulator stays bounded and releases as a small burst.
-        if (
-          isAmbiguousPartialLine(targetText, newDisplayed, streaming) ||
-          isAtTrailingEmptyMarker(targetText, newDisplayed, streaming)
+        // Line buffering: if candidate lands inside an ambiguous markdown
+        // prefix (partial ---, ```, === etc.) or on a trailing empty marker
+        // (**, *, ~~), extend char-by-char (bounded by maxChunkChars) until
+        // the prefix resolves. If it won't resolve within budget, hold.
+        const extendCap = Math.min(
+          newDisplayed + DEFAULT_CONFIG.maxChunkChars,
+          textLength,
+        );
+        while (
+          candidate < extendCap &&
+          (isAmbiguousPartialLine(targetText, candidate, streaming) ||
+            isAtTrailingEmptyMarker(targetText, candidate, streaming))
         ) {
-          accumulatedCharsRef.current += charsToAdd;
-          newDisplayed = currentDisplayed;
+          candidate++;
         }
-
-        if (newDisplayed !== displayedLengthRef.current) {
-          displayedLengthRef.current = newDisplayed;
-
-          const timeSinceLastUpdate = currentTime - lastStateUpdateRef.current;
-          const atWordBoundary = isWordBoundary(
-            targetText[newDisplayed - 1] || '',
-          );
-          const caughtUp = newDisplayed === textLength;
-
-          const shouldUpdate =
-            timeSinceLastUpdate >= DEFAULT_CONFIG.stateUpdateInterval ||
-            atWordBoundary ||
-            caughtUp;
-
-          if (shouldUpdate) {
-            lastStateUpdateRef.current = currentTime;
-            setDisplayLength(newDisplayed);
-            setIsTyping(true);
+        // Re-apply surrogate pair protection after char-level extension.
+        if (candidate < textLength && candidate > 0) {
+          const code = targetText.charCodeAt(candidate - 1);
+          if (code >= 0xd800 && code <= 0xdbff) {
+            candidate = Math.min(candidate + 1, textLength);
           }
         }
+        if (
+          candidate < textLength &&
+          (isAmbiguousPartialLine(targetText, candidate, streaming) ||
+            isAtTrailingEmptyMarker(targetText, candidate, streaming))
+        ) {
+          // Still ambiguous — hold and wait for more text.
+          break;
+        }
+
+        accumulatedTimeRef.current -= tickInterval;
+        newDisplayed = candidate;
+        ticks++;
+      }
+
+      if (newDisplayed !== displayedLengthRef.current) {
+        displayedLengthRef.current = newDisplayed;
+        setDisplayLength(newDisplayed);
+        setIsTyping(true);
       }
 
       animationFrameRef.current = requestAnimationFrame(animate);
@@ -511,7 +575,7 @@ export function useStreamBuffer({
         } else {
           hasStartedRevealRef.current = false;
         }
-        accumulatedCharsRef.current = 0;
+        accumulatedTimeRef.current = 0;
         drainCPSRef.current = 0;
       }
 
@@ -531,7 +595,7 @@ export function useStreamBuffer({
         hasStartedRevealRef.current = false;
         drainCPSRef.current = 0;
         displayedLengthRef.current = text.length;
-        accumulatedCharsRef.current = 0;
+        accumulatedTimeRef.current = 0;
         setDisplayLength(text.length);
         setIsTyping(false);
       } else {
@@ -554,7 +618,7 @@ export function useStreamBuffer({
       hasStartedRevealRef.current = false;
       drainCPSRef.current = 0;
       displayedLengthRef.current = text.length;
-      accumulatedCharsRef.current = 0;
+      accumulatedTimeRef.current = 0;
       setDisplayLength(text.length);
       setIsTyping(false);
     }

--- a/services/platform/convex/agents/unified_chat.ts
+++ b/services/platform/convex/agents/unified_chat.ts
@@ -194,21 +194,29 @@ export const chatWithAgent = action({
     // Guardrails: chat_filter → PII → moderation_provider (see sanitize.ts).
     // Blocked outcomes throw ConvexError with structured `data` for the UI
     // and a legacy substring in `.message` for older client bundles.
-    const sanitized = await sanitizeMessage(
-      ctx,
-      args.message,
-      'input',
-      guardrails,
-      {
-        organizationId: args.organizationId,
-        orgSlug: args.orgSlug,
-        threadId: args.threadId,
-        agentSlug: args.agentSlug,
-        actorId: authUserId,
-        actorEmail: authUserEmail,
-        actorType: 'user',
-      },
-    );
+    // Roll back the generating flag on any throw so the spinner doesn't
+    // strand for ~35 min (the isThreadGenerating stale threshold).
+    let sanitized;
+    try {
+      sanitized = await sanitizeMessage(
+        ctx,
+        args.message,
+        'input',
+        guardrails,
+        {
+          organizationId: args.organizationId,
+          orgSlug: args.orgSlug,
+          threadId: args.threadId,
+          agentSlug: args.agentSlug,
+          actorId: authUserId,
+          actorEmail: authUserEmail,
+          actorType: 'user',
+        },
+      );
+    } catch (err) {
+      await rollbackGenerating();
+      throw err;
+    }
     const message = sanitized.text;
 
     // Model access RBAC: check if the user is allowed to use the requested model.
@@ -253,23 +261,31 @@ export const chatWithAgent = action({
     // Delegate to the internal mutation for transactional chat start.
     // Pass preAllocatedStreamId so startAgentChat reuses the stream
     // created by markGenerating (avoids redundant stream + status patch).
+    // Roll back the generating flag if startChat throws (thread not found,
+    // etc.) so the spinner doesn't strand for ~35 min.
     console.log(`[chatWithAgent] calling startChat threadId=${args.threadId}`);
-    const result = await ctx.runMutation(internal.agents.start_chat.startChat, {
-      threadId: args.threadId,
-      organizationId: args.organizationId,
-      userId: authUserId,
-      userEmail: authUserEmail,
-      userName: authUserName,
-      message,
-      maxSteps: args.maxSteps,
-      attachments: args.attachments,
-      additionalContext: args.additionalContext,
-      userContext: args.userContext,
-      agentConfig,
-      agentSlug: args.agentSlug,
-      preAllocatedStreamId,
-      capabilityBindings: args.capabilityBindings,
-    });
+    let result;
+    try {
+      result = await ctx.runMutation(internal.agents.start_chat.startChat, {
+        threadId: args.threadId,
+        organizationId: args.organizationId,
+        userId: authUserId,
+        userEmail: authUserEmail,
+        userName: authUserName,
+        message,
+        maxSteps: args.maxSteps,
+        attachments: args.attachments,
+        additionalContext: args.additionalContext,
+        userContext: args.userContext,
+        agentConfig,
+        agentSlug: args.agentSlug,
+        preAllocatedStreamId,
+        capabilityBindings: args.capabilityBindings,
+      });
+    } catch (err) {
+      await rollbackGenerating();
+      throw err;
+    }
     console.log(
       `[chatWithAgent] DONE threadId=${args.threadId} messageAlreadyExists=${result.messageAlreadyExists}`,
     );


### PR DESCRIPTION
## Summary

Two chat-UX responsiveness fixes bundled together.

### 1. Optimistic send spinner — closes the ~200-550 ms click-to-spinner gap

- New module-level store + `useSyncExternalStore` hook (`use-pending-send.ts`) with per-thread state, 8 s safety timeout, no external deps.
- `use-send-message.ts` flags the thread optimistic-pending right before `chatWithAgent`/`arenaChatAction` fires, and clears every flagged thread in the `catch` regardless of which branch set them (arena / new-chat / existing).
- `chat-interface.tsx` and `arena-split-view.tsx` compose `isLoading = isGenerating || isSendPending` and clear the optimistic flag the moment the real subscription confirms, so a fast response doesn't get stuck behind the safety timeout.
- **Stop button stays on the real server signal** via conditional `onStopGenerating={isGenerating ? stopGenerating : undefined}`. `ChatInput`'s existing `!onStopGenerating` disabled-check neutralizes the button during the optimistic window so a user click can't race `markGenerating` and strand the generation.

Also closes two pre-existing 35-min orphan-status paths in `chatWithAgent` (`sanitizeMessage` guardrails block and `startChat` failure) by wrapping them in try/catch + the existing `rollbackGenerating()` helper. The optimistic pattern made it worth fixing so the new code doesn't ride on top of the old orphan bug.

### 2. Word-chunk stream reveal animation

Switched `use-stream-buffer.ts` from per-character to per-word/chunk reveal so streamed chat text emerges the way ChatGPT does — whole words per tick at ~83 ms cadence, 40-char hard cap to prevent long code tokens dumping in one frame. Full CJK support: Hiragana/Katakana/CJK Unified/Hangul are treated as their own "words", broken on CJK punctuation or every 3rd consecutive character.

## Test plan

### Optimistic spinner
- [ ] Click send in an existing chat — spinner appears within one animation frame (~16 ms), not ~half a second later.
- [ ] Force a PII-blocked message (guardrails on + email in message) — optimistic spinner shows, block toast fires, `threadMetadata.generationStatus` goes back to `idle` immediately (regression-proves the bundled `rollbackGenerating` fix).
- [ ] Force a budget-exceeded or model-access-denied send — same behavior: spinner appears, error toast, status cleared.
- [ ] Offline-throttle in devtools after clicking send — 8 s safety timeout clears the optimistic spinner.
- [ ] 4× CPU throttle to widen the optimistic window, click send then immediately click Stop — Stop button should visibly be there but disabled, generation eventually starts cleanly, no stuck state.
- [ ] Arena mode: send with two threads — both columns show "Thinking" immediately; each clears independently as its real `isGenerating` arrives.

### Stream reveal
- [ ] Watch an English response stream — text reveals word-by-word rather than char-by-char, cadence feels like ChatGPT.
- [ ] Stream a Chinese/Japanese/Korean response — text arrives in small bursts (every 3 CJK chars or at punctuation), not all at once.
- [ ] Stream a response containing a long code block (e.g. a 100+ char identifier or URL) — it arrives in at most 40-char chunks rather than dumping in one frame.
- [ ] Stream a message with emoji / surrogate pairs — no broken glyphs.
- [ ] Stream a markdown message with `**bold**`, links, and horizontal rules — no flicker from partial markdown syntax.

### Build
- [ ] `npx tsc --noEmit` from `services/platform/` (pre-existing 12-line error count unchanged — all from unrelated recharts v3 / pdfjs v5 upgrades)
- [ ] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimistic UI feedback displays message sending state immediately rather than waiting for server confirmation
  * Enhanced message text streaming with improved character chunking and support for CJK languages

* **Bug Fixes**
  * Improved error handling ensures chat state properly recovers on message send failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->