### PR TITLE
fix(platform): render markdown inside block-level HTML wrappers in chat

### DIFF
--- a/services/platform/app/features/chat/components/incremental-markdown.tsx
+++ b/services/platform/app/features/chat/components/incremental-markdown.tsx
@@ -35,6 +35,7 @@ import type {
 
 import { findBlockSplitPoint } from '../utils/find-block-split';
 import { remarkCjkAttention } from '../utils/micromark-cjk-attention';
+import { normalizeHtmlBlocks } from '../utils/normalize-html-blocks';
 import { remendMarkdown } from '../utils/remend-markdown';
 
 const chatSanitizeSchema = {
@@ -138,7 +139,10 @@ const StreamingMarkdown = memo(
     showCursor?: boolean;
   }) {
     const rawRevealed = content ? content.slice(0, revealedLength) : '';
-    const revealedContent = remendMarkdown(rawRevealed);
+    // normalizeHtmlBlocks runs first so block-level HTML tags get the blank
+    // lines CommonMark needs to parse markdown inside them; remendMarkdown
+    // then closes any incomplete syntax for stable mid-stream rendering.
+    const revealedContent = remendMarkdown(normalizeHtmlBlocks(rawRevealed));
 
     // Refs must track the remended string because react-markdown's AST
     // node.position offsets reference positions in the string it received.
@@ -309,6 +313,9 @@ const StableMarkdown = memo(
     content: string;
     components?: MarkdownComponentMap;
   }) {
+    // Same normalization as StreamingMarkdown — block-level HTML tags need
+    // surrounding blank lines for CommonMark to parse markdown inside them.
+    const normalized = normalizeHtmlBlocks(content);
     return (
       <Markdown
         remarkPlugins={REMARK_PLUGINS}
@@ -316,7 +323,7 @@ const StableMarkdown = memo(
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- same as StreamingMarkdown
         components={components as Components}
       >
-        {content}
+        {normalized}
       </Markdown>
     );
   },

--- a/services/platform/app/features/chat/utils/__tests__/normalize-html-blocks.test.ts
+++ b/services/platform/app/features/chat/utils/__tests__/normalize-html-blocks.test.ts
@@ -1,0 +1,136 @@
+import { micromark } from 'micromark';
+import { describe, expect, it } from 'vitest';
+
+import { micromarkCjkAttention } from '../micromark-cjk-attention';
+import { normalizeHtmlBlocks } from '../normalize-html-blocks';
+
+const renderHtml = (md: string): string =>
+  micromark(md, {
+    extensions: [micromarkCjkAttention()],
+    allowDangerousHtml: true,
+  }).trim();
+
+describe('normalizeHtmlBlocks — markdown inside HTML blocks', () => {
+  it('inserts blank lines around <div align="center"> so bold renders', () => {
+    const input =
+      '<div align="center">\n⭐ **活化石** &nbsp;|&nbsp; 🌍 **世界自然基金会标志**\n</div>';
+    const out = normalizeHtmlBlocks(input);
+    expect(renderHtml(out)).toContain('<strong>活化石</strong>');
+    expect(renderHtml(out)).toContain('<strong>世界自然基金会标志</strong>');
+  });
+
+  it('is idempotent — already-spaced HTML blocks are returned unchanged', () => {
+    const already = '<div align="center">\n\n⭐ **活化石**\n\n</div>';
+    expect(normalizeHtmlBlocks(already)).toBe(already);
+  });
+
+  it('handles nested block tags (<table><tbody><tr>) by spacing each', () => {
+    const input =
+      '<table>\n<tbody>\n<tr><td>**bold**</td></tr>\n</tbody>\n</table>';
+    const out = normalizeHtmlBlocks(input);
+    // Each block tag is now on a line surrounded by blanks
+    expect(
+      out.split('\n').filter((l) => l.trim() === '').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('handles a single-line wrapped paragraph: <div>x</div>\\nmd\\n<div>y</div>', () => {
+    const input = '<div>top</div>\n# heading\n<div>bottom</div>';
+    const out = normalizeHtmlBlocks(input);
+    expect(renderHtml(out)).toContain('<h1>heading</h1>');
+  });
+});
+
+describe('normalizeHtmlBlocks — code blocks must NOT be touched', () => {
+  it('leaves <div> inside fenced ``` block verbatim', () => {
+    const input = '```html\n<div align="center">\nhello **world**\n</div>\n```';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+
+  it('leaves <div> inside fenced ~~~ block verbatim', () => {
+    const input = '~~~\n<div>\n**raw**\n</div>\n~~~';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+
+  it('only normalizes <div> outside the fence, not inside', () => {
+    const input =
+      '<div>\nbefore\n</div>\n```\n<div>\ninside fence\n</div>\n```\n<div>\nafter\n</div>';
+    const out = normalizeHtmlBlocks(input);
+    // Inside-fence <div> stays glued to its content (no blank line inserted)
+    expect(out).toContain('```\n<div>\ninside fence\n</div>\n```');
+    // Outside-fence <div> gets blank lines
+    expect(out).toMatch(/<div>\n\nbefore/);
+    expect(out).toMatch(/after\n\n<\/div>/);
+  });
+
+  it('handles a fenced block opened with extra backticks', () => {
+    const input = '````\n<div>x</div>\n````';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+});
+
+describe('normalizeHtmlBlocks — inline tags pass through untouched', () => {
+  it('does not insert blanks around inline <span>', () => {
+    const input = 'before <span>x</span> after';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+
+  it('does not match tags whose name is a prefix of a block tag', () => {
+    // <divider> shares prefix with <div> but is not a block-level tag
+    const input = '<divider>x</divider>';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+
+  it('does not insert blanks for inline <a> at line start', () => {
+    const input = '<a href="#">link</a>';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+});
+
+describe('normalizeHtmlBlocks — edge cases', () => {
+  it('returns empty string unchanged', () => {
+    expect(normalizeHtmlBlocks('')).toBe('');
+  });
+
+  it('returns text without any < unchanged (cheap pre-check)', () => {
+    const input = 'just a plain message with no html at all';
+    expect(normalizeHtmlBlocks(input)).toBe(input);
+  });
+
+  it('handles tag right at the start with no preceding line', () => {
+    const input = '<div>\nhi\n</div>';
+    const out = normalizeHtmlBlocks(input);
+    // No leading blank line should be prepended (out can start with the tag)
+    expect(out.startsWith('<div>')).toBe(true);
+  });
+
+  it('handles tag right at the end with no following line', () => {
+    const input = 'hi\n<div>';
+    const out = normalizeHtmlBlocks(input);
+    // Opening tags don't need a blank before — per CommonMark, an HTML
+    // block start interrupts the preceding paragraph. And no blank after
+    // because there are no following input lines.
+    expect(out).toBe('hi\n<div>');
+  });
+
+  it('matches tag with attributes', () => {
+    const input = '<div class="foo" id="bar">\n**x**\n</div>';
+    const out = normalizeHtmlBlocks(input);
+    expect(renderHtml(out)).toContain('<strong>x</strong>');
+  });
+
+  it('matches self-closing form like <hr/> with blank line after', () => {
+    const input = 'before\n<hr/>\nafter';
+    const out = normalizeHtmlBlocks(input);
+    // <hr/> is treated as an opening tag — blank inserted only AFTER so
+    // the next markdown content parses as its own block. The preceding
+    // paragraph terminates naturally per CommonMark's interrupt rule.
+    expect(out).toBe('before\n<hr/>\n\nafter');
+  });
+
+  it('case-insensitive tag matching', () => {
+    const input = '<DIV>\n**x**\n</DIV>';
+    const out = normalizeHtmlBlocks(input);
+    expect(renderHtml(out)).toContain('<strong>x</strong>');
+  });
+});

--- a/services/platform/app/features/chat/utils/normalize-html-blocks.ts
+++ b/services/platform/app/features/chat/utils/normalize-html-blocks.ts
@@ -1,0 +1,168 @@
+/**
+ * normalizeHtmlBlocks — auto-insert blank lines around block-level HTML tags
+ * so markdown inside is parsed.
+ *
+ * CommonMark type-6 HTML blocks (any block-level tag at the start of a line)
+ * swallow all subsequent lines as raw HTML until a blank line is reached. So
+ *
+ *   <div align="center">
+ *   ⭐ **活化石** | 🌍 **世界自然基金会标志**
+ *   </div>
+ *
+ * renders the `**` literally because the entire 3-line region is one HTML
+ * block and markdown is never parsed inside it. Inserting blank lines turns it
+ * into three separate blocks (the open tag, the markdown paragraph, the close
+ * tag) and the bold renders correctly.
+ *
+ * Skipped contexts (do NOT insert anything):
+ *   - Inside fenced code blocks (``` or ~~~) — content is raw, must stay verbatim
+ *   - Inline tags like <span>, <a> — only block-level tags trigger HTML blocks
+ *
+ * Idempotent: text that already has blank lines around its block tags is
+ * returned unchanged.
+ */
+
+// CommonMark spec § 4.6 HTML blocks, condition 6: full list of block-level
+// HTML tag names that open a type-6 HTML block.
+const BLOCK_HTML_TAGS = new Set([
+  'address',
+  'article',
+  'aside',
+  'base',
+  'basefont',
+  'blockquote',
+  'body',
+  'caption',
+  'center',
+  'col',
+  'colgroup',
+  'dd',
+  'details',
+  'dialog',
+  'dir',
+  'div',
+  'dl',
+  'dt',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'frame',
+  'frameset',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hr',
+  'html',
+  'iframe',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'menu',
+  'menuitem',
+  'nav',
+  'noframes',
+  'ol',
+  'optgroup',
+  'option',
+  'p',
+  'param',
+  'section',
+  'source',
+  'summary',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'title',
+  'tr',
+  'track',
+  'ul',
+]);
+
+// Match a tag name at the very start of a line (after up to 3 spaces of
+// indentation, per CommonMark). Captures direction (`/` for closing) and tag.
+// Trailing context must be space, `>`, `/>`, or end-of-line — matches the
+// HTML block start condition exactly so we don't mistake `<divider>` for
+// `<div>`.
+const TAG_LINE_RE = /^\s{0,3}<(\/?)([a-zA-Z][a-zA-Z0-9-]*)(\s|>|\/>|$)/;
+
+const FENCE_OPEN_RE = /^\s{0,3}(```+|~~~+)/;
+
+function isBlockTagLine(
+  line: string,
+): { tag: string; isClose: boolean } | null {
+  const m = line.match(TAG_LINE_RE);
+  if (!m) return null;
+  const tag = m[2].toLowerCase();
+  if (!BLOCK_HTML_TAGS.has(tag)) return null;
+  return { tag, isClose: m[1] === '/' };
+}
+
+export function normalizeHtmlBlocks(text: string): string {
+  // Cheap pre-check — most messages contain no HTML at all.
+  if (!text || text.indexOf('<') === -1) return text;
+
+  const lines = text.split('\n');
+  const out: string[] = [];
+  let inFence = false;
+  let fenceMarker = '';
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Fenced code blocks: pass through untouched, including the fence lines
+    // themselves. The closing fence must use the SAME marker char and at
+    // least as many of them — but matching length is tricky and rarely
+    // matters in practice; we accept any line of the same marker char as
+    // closing, which mirrors how most users write fences.
+    if (inFence) {
+      out.push(line);
+      const closeMatch = line.match(/^\s{0,3}(```+|~~~+)\s*$/);
+      if (closeMatch && closeMatch[1][0] === fenceMarker[0]) {
+        inFence = false;
+        fenceMarker = '';
+      }
+      continue;
+    }
+
+    const fenceOpen = line.match(FENCE_OPEN_RE);
+    if (fenceOpen) {
+      inFence = true;
+      fenceMarker = fenceOpen[1];
+      out.push(line);
+      continue;
+    }
+
+    const block = isBlockTagLine(line);
+    if (!block) {
+      out.push(line);
+      continue;
+    }
+
+    // For a closing tag, ensure the previous emitted line is blank so that
+    // the preceding markdown paragraph terminates before the HTML block.
+    if (block.isClose && out.length > 0 && out[out.length - 1].trim() !== '') {
+      out.push('');
+    }
+
+    out.push(line);
+
+    // For an opening tag, ensure the next input line is blank so that the
+    // markdown content following the tag is parsed as its own block.
+    if (!block.isClose && i + 1 < lines.length && lines[i + 1].trim() !== '') {
+      out.push('');
+    }
+  }
+
+  return out.join('\n');
+}


### PR DESCRIPTION
## Summary

Fixes a bug where chat content like

```
<div align="center">
⭐ **活化石** | 🌍 **世界自然基金会标志** | 🇨🇳 **中国外交使者**
</div>
```

renders the asterisks literally instead of bolding the CJK text.

**Root cause**: CommonMark §4.6 type-6 HTML blocks. Any line starting with a block-level HTML tag (`<div>`, `<table>`, `<center>`, etc.) opens an HTML block that consumes every subsequent line as raw HTML until a blank line. So markdown nested under `<div>` is never parsed — `**活化石**` is just text, no `<strong>` ever produced. Verified via standalone micromark reproducer.

**Fix**: New utility `normalize-html-blocks.ts` does a single pass over input lines, detects block-level HTML tag opens/closes, and inserts blank lines around them so the inner markdown becomes its own block per CommonMark.

- Inserts blank line **after opening** block tags (so following markdown parses)
- Inserts blank line **before closing** block tags (so preceding markdown terminates)
- **Skips fenced code blocks entirely** (` ``` ` and `~~~`) — code stays verbatim
- Inline tags (`<span>`, `<a>`) and tag-name-prefix collisions (`<divider>` ≠ `<div>`) ignored
- Idempotent on already-spaced input

Applied to **both** `StableMarkdown` (completed messages) and `StreamingMarkdown` (mid-stream reveal) so historical and in-flight messages both render correctly.

## Test plan

- [x] 18 unit tests covering: basic render, idempotency, nested tags, fenced ``` and ~~~ skip, mixed inside/outside fence, multi-backtick fences, inline tags pass-through, tag-prefix collision, attributes, self-closing, case-insensitive
- [x] Full chat/utils suite: 333 / 333 tests pass (no regressions)
- [x] `npm run lint --workspace=@tale/platform` clean
- [x] `npx tsc --noEmit` baseline unchanged (12 pre-existing errors from recharts v3 / pdfjs v5 upgrades, unrelated)
- [ ] Manual: reproduce the panda message in dev, verify `**活化石**` renders bold (no literal asterisks)
- [ ] Manual: send an HTML-in-fenced-code message (e.g. ` ```html\n<div>x</div>\n``` `), verify it stays verbatim and is NOT modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML blocks in chat messages to ensure Markdown formatting renders correctly when mixed with HTML content.

* **Tests**
  * Added comprehensive test coverage for HTML block normalization, including edge cases with nested tags, code blocks, and various tag configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->