### PR TITLE
fix(platform): enforce 2FA policy when admin tightens grace period

### DIFF
--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -125,10 +125,10 @@ function TwoFactorEnrollPage() {
       align="stretch"
       className="bg-background text-foreground min-h-screen"
     >
-      <div className="px-4 pt-8 pb-16 sm:px-8 md:pb-32">
+      <div className="px-4 pt-8 pb-8 sm:px-8">
         <LogoLink href="/" />
       </div>
-      <main className="mx-auto w-full max-w-[24.875rem] px-4">
+      <main className="mx-auto w-full max-w-[24.875rem] px-4 pb-12">
         <Stack gap={6}>
           <Stack gap={2} className="text-center">
             <Heading level={1} size="xl">

--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -9,9 +9,15 @@
  * `forced-change-password.$id.tsx` does: the `_auth` layout rejects
  * authenticated users, but this page requires an active session.
  */
-import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
+import {
+  createFileRoute,
+  redirect,
+  useNavigate,
+  useSearch,
+} from '@tanstack/react-router';
 import { QRCodeSVG } from 'qrcode.react';
 import { useState } from 'react';
+import { z } from 'zod';
 
 import { Input } from '@/app/components/ui/forms/input';
 import { Stack, VStack } from '@/app/components/ui/layout/layout';
@@ -25,7 +31,12 @@ import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 import { extractSecret, normalizeOtpauthURI } from '@/lib/utils/totp';
 
+const searchSchema = z.object({
+  redirectTo: z.string().optional(),
+});
+
 export const Route = createFileRoute('/2fa-enroll')({
+  validateSearch: searchSchema,
   beforeLoad: async () => {
     const session = await authClient.getSession();
     if (!session?.data?.user) {
@@ -62,6 +73,7 @@ function TwoFactorEnrollPage() {
   const { t } = useT('twoFactor');
   const navigate = useNavigate();
   const queryClient = useReactQueryClient();
+  const { redirectTo } = useSearch({ from: '/2fa-enroll' });
 
   const [step, setStep] = useState<Step>({ kind: 'password' });
   const [password, setPassword] = useState('');
@@ -116,7 +128,7 @@ function TwoFactorEnrollPage() {
     await queryClient
       .invalidateQueries({ queryKey: ['auth', 'session'] })
       .catch(() => undefined);
-    void navigate({ to: '/dashboard' });
+    void navigate({ to: redirectTo || '/dashboard' });
   }
 
   return (

--- a/services/platform/app/routes/dashboard.tsx
+++ b/services/platform/app/routes/dashboard.tsx
@@ -1,7 +1,14 @@
-import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
+import {
+  Outlet,
+  createFileRoute,
+  redirect,
+  useNavigate,
+} from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { getEnv } from '@/lib/env';
 
@@ -24,9 +31,33 @@ export const Route = createFileRoute('/dashboard')({
 });
 
 function DashboardRedirect() {
+  const navigate = useNavigate();
   const { isAuthenticated, isLoading } = useConvexAuth();
   const [sessionVerified, setSessionVerified] = useState(false);
   const [hasValidSession, setHasValidSession] = useState(true);
+
+  // Hard 2FA enforcement: when the org policy requires 2FA and the user is
+  // past their (effective) grace deadline, hold them at /2fa-enroll until
+  // they complete enrolment. This catches all entry paths into the
+  // dashboard — fresh login, existing session restore, SSO callback,
+  // direct-URL navigation — without needing per-path patches.
+  //
+  // Uses client-side navigation (not window.location) so the browser's
+  // `beforeunload` handlers in nested editors don't fire a "leave site?"
+  // confirm dialog when redirecting an unenrolled user.
+  const { data: twoFactorStatus } = useConvexQuery(
+    api.two_factor.queries.getStatus,
+    {},
+    { enabled: isAuthenticated },
+  );
+  useEffect(() => {
+    if (
+      twoFactorStatus?.authenticated &&
+      twoFactorStatus.decision === 'blocked'
+    ) {
+      void navigate({ to: '/2fa-enroll', replace: true });
+    }
+  }, [twoFactorStatus, navigate]);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -62,6 +93,13 @@ function DashboardRedirect() {
   }
 
   if (sessionVerified && !hasValidSession) {
+    return null;
+  }
+
+  if (
+    twoFactorStatus?.authenticated &&
+    twoFactorStatus.decision === 'blocked'
+  ) {
     return null;
   }
 

--- a/services/platform/app/routes/dashboard.tsx
+++ b/services/platform/app/routes/dashboard.tsx
@@ -36,11 +36,12 @@ function DashboardRedirect() {
   const [sessionVerified, setSessionVerified] = useState(false);
   const [hasValidSession, setHasValidSession] = useState(true);
 
-  // Hard 2FA enforcement: when the org policy requires 2FA and the user is
-  // past their (effective) grace deadline, hold them at /2fa-enroll until
-  // they complete enrolment. This catches all entry paths into the
-  // dashboard — fresh login, existing session restore, SSO callback,
-  // direct-URL navigation — without needing per-path patches.
+  // Client-side 2FA enforcement: when the org policy requires 2FA and the
+  // user is past their (effective) grace deadline, route them to
+  // /2fa-enroll. Catches normal entry paths (fresh login, existing
+  // session restore, SSO callback, direct-URL navigation). A determined
+  // client could still call Convex directly — server-side enforcement
+  // is tracked separately.
   //
   // Uses client-side navigation (not window.location) so the browser's
   // `beforeunload` handlers in nested editors don't fire a "leave site?"
@@ -55,7 +56,17 @@ function DashboardRedirect() {
       twoFactorStatus?.authenticated &&
       twoFactorStatus.decision === 'blocked'
     ) {
-      void navigate({ to: '/2fa-enroll', replace: true });
+      const basePath = getEnv('BASE_PATH');
+      const pathname = window.location.pathname;
+      const routePath = basePath
+        ? pathname.replace(new RegExp(`^${basePath}`), '')
+        : pathname;
+      const redirectTo = routePath + window.location.search;
+      void navigate({
+        to: '/2fa-enroll',
+        search: { redirectTo },
+        replace: true,
+      });
     }
   }, [twoFactorStatus, navigate]);
 
@@ -93,6 +104,13 @@ function DashboardRedirect() {
   }
 
   if (sessionVerified && !hasValidSession) {
+    return null;
+  }
+
+  // Fail-closed: while authenticated but `getStatus` has not yet resolved
+  // (or errored), hold the dashboard. Otherwise a transient query failure
+  // would silently let a `'blocked'` user through.
+  if (isAuthenticated && twoFactorStatus === undefined) {
     return null;
   }
 

--- a/services/platform/convex/two_factor/__tests__/helpers.test.ts
+++ b/services/platform/convex/two_factor/__tests__/helpers.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+      },
+    },
+  },
+}));
+
+const mockGetTwoFactorPolicy = vi.fn();
+vi.mock('../../governance/helpers', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    getTwoFactorPolicy: (...args: unknown[]) => mockGetTwoFactorPolicy(...args),
+  };
+});
+
+import { evaluateTwoFactorEnforcement } from '../helpers';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface MockCtx {
+  runQuery: ReturnType<typeof vi.fn>;
+}
+
+function createCtx(opts: {
+  orgs?: string[];
+  accountProviders?: string[];
+}): MockCtx {
+  const { orgs = ['org_1'], accountProviders = ['credential'] } = opts;
+  const ctx = {
+    runQuery: vi.fn(async (model: string, args: { model: string }) => {
+      if (args.model === 'member') {
+        return {
+          page: orgs.map((organizationId) => ({ organizationId })),
+        };
+      }
+      if (args.model === 'account') {
+        return {
+          page: accountProviders.map((providerId) => ({ providerId })),
+        };
+      }
+      return { page: [] };
+    }),
+  };
+  return ctx;
+}
+
+beforeEach(() => {
+  mockGetTwoFactorPolicy.mockReset();
+});
+
+describe('evaluateTwoFactorEnforcement', () => {
+  it("returns 'ok' when policy is not enforced", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: false,
+      gracePeriodDays: 7,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: null,
+      now: 1_000_000,
+    });
+    expect(result.decision).toBe('ok');
+    expect(result.graceDeadline).toBeNull();
+    expect(result.graceUntilToSet).toBeNull();
+  });
+
+  it("returns 'ok' when user already has 2FA enabled", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 0,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: true,
+      twoFactorGraceUntil: null,
+      now: 1_000_000,
+    });
+    expect(result.decision).toBe('ok');
+  });
+
+  it("returns 'ok' for SSO-only users when policy exempts them", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 0,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({ accountProviders: ['microsoft'] });
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: null,
+      now: 1_000_000,
+    });
+    expect(result.decision).toBe('ok');
+  });
+
+  it("returns 'blocked' for credential user when grace=0 and no anchor", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 0,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: null,
+      now: 1_000_000,
+    });
+    expect(result.decision).toBe('blocked');
+    expect(result.graceUntilToSet).toBeNull();
+  });
+
+  it('regression #1616: existing anchor + tightened policy → blocked immediately', async () => {
+    // User signed in once under grace=7 → anchor was set to now+7d.
+    // Admin then changes the policy to grace=0. The user's next sign-in
+    // (or next dashboard navigation) must report 'blocked', not 'grace'.
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 0,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const now = 1_000_000;
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: now + 6 * DAY_MS,
+      now,
+    });
+    expect(result.decision).toBe('blocked');
+  });
+
+  it('returns capped deadline when stored anchor > current policy window', async () => {
+    // Stored anchor = now+7d, policy now = 1d → effective deadline = now+1d.
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 1,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const now = 1_000_000;
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: now + 7 * DAY_MS,
+      now,
+    });
+    expect(result.decision).toBe('grace');
+    expect(result.graceDeadline).toBe(now + 1 * DAY_MS);
+    // Don't overwrite the stored anchor when capping — it stays as-is.
+    expect(result.graceUntilToSet).toBeNull();
+  });
+
+  it('preserves shorter stored anchor when admin loosens policy', async () => {
+    // Stored anchor = now+1d, policy now = 30d → keep the shorter deadline.
+    // Loosening must not extend a user's window.
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 30,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const now = 1_000_000;
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: now + 1 * DAY_MS,
+      now,
+    });
+    expect(result.decision).toBe('grace');
+    expect(result.graceDeadline).toBe(now + 1 * DAY_MS);
+  });
+
+  it("returns 'grace' with anchor proposal on first encounter under enforcement", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 7,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const now = 1_000_000;
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: null,
+      now,
+    });
+    expect(result.decision).toBe('grace');
+    expect(result.graceUntilToSet).toBe(now + 7 * DAY_MS);
+    expect(result.graceDeadline).toBe(now + 7 * DAY_MS);
+  });
+
+  it("returns 'blocked' when stored anchor has elapsed", async () => {
+    mockGetTwoFactorPolicy.mockResolvedValue({
+      enforced: true,
+      gracePeriodDays: 7,
+      exemptSsoUsers: true,
+    });
+    const ctx = createCtx({});
+    const now = 10_000_000;
+    const result = await evaluateTwoFactorEnforcement(ctx as never, {
+      userId: 'u1',
+      twoFactorEnabled: false,
+      twoFactorGraceUntil: now - 1, // anchor already in the past
+      now,
+    });
+    expect(result.decision).toBe('blocked');
+  });
+});

--- a/services/platform/convex/two_factor/auth_hooks.ts
+++ b/services/platform/convex/two_factor/auth_hooks.ts
@@ -347,9 +347,10 @@ async function signInEnforcementAfterHook(
   // session but returning `enrollRequired: true` lets the client route
   // to the wall while preserving access to the 2FA plugin endpoints.
   //
-  // Security note: a user who manually bypasses the client-side redirect
-  // could still reach the dashboard. Full enforcement requires a server-
-  // side RLS check on every authenticated request — tracked separately.
-  // For this ticket we ship soft enforcement + audit visibility.
+  // The hard gate lives in the `/dashboard` route guard (see
+  // `app/routes/dashboard.tsx`), which calls `getStatus` and redirects
+  // any 'blocked' user to `/2fa-enroll`. That covers fresh login,
+  // existing-session restore, SSO callback, and direct-URL navigation —
+  // including users who try to bypass this client-side redirect.
   return mw.json({ twoFactorRedirect: true, enrollRequired: true });
 }

--- a/services/platform/convex/two_factor/auth_hooks.ts
+++ b/services/platform/convex/two_factor/auth_hooks.ts
@@ -347,10 +347,12 @@ async function signInEnforcementAfterHook(
   // session but returning `enrollRequired: true` lets the client route
   // to the wall while preserving access to the 2FA plugin endpoints.
   //
-  // The hard gate lives in the `/dashboard` route guard (see
-  // `app/routes/dashboard.tsx`), which calls `getStatus` and redirects
-  // any 'blocked' user to `/2fa-enroll`. That covers fresh login,
-  // existing-session restore, SSO callback, and direct-URL navigation —
-  // including users who try to bypass this client-side redirect.
+  // A client-side redirect in the `/dashboard` route guard (see
+  // `app/routes/dashboard.tsx`) calls `getStatus` and routes any
+  // 'blocked' user to `/2fa-enroll`. That covers normal entry paths
+  // (fresh login, existing-session restore, SSO callback, direct-URL
+  // navigation). Server-side enforcement on subsequent queries and
+  // mutations is still pending — a determined client could call Convex
+  // directly and bypass the redirect. Tracked separately.
   return mw.json({ twoFactorRedirect: true, enrollRequired: true });
 }

--- a/services/platform/convex/two_factor/helpers.ts
+++ b/services/platform/convex/two_factor/helpers.ts
@@ -33,6 +33,14 @@ export interface TwoFactorEnforcementResult {
    */
   graceUntilToSet: number | null;
   /**
+   * Effective deadline (ms epoch) by which the user must enrol to keep
+   * access — `min(user.twoFactorGraceUntil, now + policy.gracePeriodDays)`.
+   * Lets admin tightening take effect immediately while preserving the
+   * "no extension on policy loosening" guarantee. Null when decision is
+   * 'ok' or 'blocked'.
+   */
+  graceDeadline: number | null;
+  /**
    * Strictest two-factor policy across the user's orgs. Exposed for UI
    * banners that want to render remaining grace days.
    */
@@ -130,7 +138,12 @@ export async function evaluateTwoFactorEnforcement(
       : mergeStrictestTwoFactorPolicy(policies);
 
   if (!policy.enforced || args.twoFactorEnabled) {
-    return { decision: 'ok', graceUntilToSet: null, policy };
+    return {
+      decision: 'ok',
+      graceUntilToSet: null,
+      graceDeadline: null,
+      policy,
+    };
   }
 
   // SSO-only users are exempt when policy permits. A user with BOTH a
@@ -139,24 +152,49 @@ export async function evaluateTwoFactorEnforcement(
   if (policy.exemptSsoUsers) {
     const accounts = await findUserAccounts(ctx, args.userId);
     if (!hasCredentialProvider(accounts)) {
-      return { decision: 'ok', graceUntilToSet: null, policy };
+      return {
+        decision: 'ok',
+        graceUntilToSet: null,
+        graceDeadline: null,
+        policy,
+      };
     }
   }
 
-  const graceUntil = args.twoFactorGraceUntil ?? null;
-  if (graceUntil === null) {
-    // Policy enforcement first applies to this user right now — propose a
-    // grace window. Caller writes idempotently.
-    const toSet = now + policy.gracePeriodDays * 24 * 60 * 60 * 1000;
-    // Fail-closed when grace is zero (immediate enforcement).
-    if (policy.gracePeriodDays === 0) {
-      return { decision: 'blocked', graceUntilToSet: null, policy };
-    }
-    return { decision: 'grace', graceUntilToSet: toSet, policy };
+  // Fail-closed when grace is zero — no anchor can save the user.
+  if (policy.gracePeriodDays === 0) {
+    return {
+      decision: 'blocked',
+      graceUntilToSet: null,
+      graceDeadline: null,
+      policy,
+    };
   }
 
-  if (now >= graceUntil) {
-    return { decision: 'blocked', graceUntilToSet: null, policy };
+  // Cap the stored anchor by `now + current policy gracePeriodDays`.
+  // This lets admin tightening apply immediately to users with an existing
+  // (longer) anchor — without that cap, tightening was a no-op for anyone
+  // who had already signed in under the old policy. Loosening still cannot
+  // extend a user's window because we keep the original anchor in storage
+  // and never write a later one.
+  const policyGraceMs = policy.gracePeriodDays * 24 * 60 * 60 * 1000;
+  const storedAnchor = args.twoFactorGraceUntil ?? null;
+  const policyAnchor = now + policyGraceMs;
+  const effectiveDeadline =
+    storedAnchor === null ? policyAnchor : Math.min(storedAnchor, policyAnchor);
+
+  if (now >= effectiveDeadline) {
+    return {
+      decision: 'blocked',
+      graceUntilToSet: null,
+      graceDeadline: null,
+      policy,
+    };
   }
-  return { decision: 'grace', graceUntilToSet: null, policy };
+  return {
+    decision: 'grace',
+    graceUntilToSet: storedAnchor === null ? policyAnchor : null,
+    graceDeadline: effectiveDeadline,
+    policy,
+  };
 }

--- a/services/platform/convex/two_factor/internal_queries.ts
+++ b/services/platform/convex/two_factor/internal_queries.ts
@@ -39,12 +39,14 @@ export const evaluateEnforcement = internalQuery({
       v.literal('blocked'),
     ),
     graceUntilToSet: v.union(v.number(), v.null()),
+    graceDeadline: v.union(v.number(), v.null()),
   }),
   handler: async (ctx, args) => {
     const result = await evaluateTwoFactorEnforcement(ctx, args);
     return {
       decision: result.decision,
       graceUntilToSet: result.graceUntilToSet,
+      graceDeadline: result.graceDeadline,
     };
   },
 });

--- a/services/platform/convex/two_factor/queries.ts
+++ b/services/platform/convex/two_factor/queries.ts
@@ -126,7 +126,11 @@ export const getStatus = query({
       twoFactorEnabled,
       enforced: result.policy.enforced,
       decision: result.decision,
-      graceUntil: twoFactorGraceUntil ?? result.graceUntilToSet,
+      // Surface the *effective* deadline (capped by current policy), not the
+      // raw stored anchor — admin tightening must take effect immediately
+      // for the UI countdown too, otherwise the banner contradicts the
+      // enforcement decision.
+      graceUntil: result.graceDeadline,
       hasCredential,
       exemptSsoUsers: result.policy.exemptSsoUsers,
       backupCodesRemaining,


### PR DESCRIPTION
## Summary

- Cap stored `twoFactorGraceUntil` against the current policy on read so admin tightening (e.g. 7d → 0) takes effect immediately. Loosening still cannot extend an existing anchor.
- Add a `/dashboard` route guard that redirects `decision === 'blocked'` users to `/2fa-enroll`, closing the soft-enforcement gap acknowledged in the original code comment (existing sessions, SSO callback, direct-URL navigation now all funnel through enrolment).
- Surface the *effective* (capped) deadline through `getStatus` so the grace banner countdown agrees with the enforcement decision.
- Tighten the `/2fa-enroll` layout so the QR + verify input no longer overflow under the viewport.

Closes #1616

## Root cause

`twoFactorGraceUntil` was a write-once per-user anchor. Once a user signed in under enforcement with a 7-day grace, their anchor was set to `now + 7d` and never revisited. Subsequent admin changes to `gracePeriodDays` only affected *new* anchor writes, so tightening the policy was silently a no-op for any user who had already touched the system. Reproduces the exact screenshot in the issue ("required in 6 days" with grace set to 0).

## Test plan

- [x] New unit tests in `services/platform/convex/two_factor/__tests__/helpers.test.ts` (9 cases incl. direct regression for #1616)
- [x] `npx vitest run convex/two_factor` — 9/9 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --workspace=@tale/platform` clean
- [ ] Manual end-to-end (recommended on review):
  - [ ] Set policy `enforced=true, gracePeriodDays=7`, log in as non-admin once, then tighten to `gracePeriodDays=0` — non-admin's next dashboard navigation redirects to `/2fa-enroll`, banner no longer reads "in N days"
  - [ ] Existing logged-in user (session restored from cookie) lands on dashboard, gets redirected to `/2fa-enroll`
  - [ ] Complete TOTP enrolment → land on `/dashboard`
  - [ ] User with anchor `now+1d` + admin loosens to grace=30 → effective deadline still `now+1d` (no extension)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard now enforces 2FA requirement, automatically redirecting unenrolled users to complete enrollment.

* **Bug Fixes**
  * Grace period deadline now properly updates when 2FA policies are tightened.

* **Style**
  * Improved layout spacing on the 2FA enrollment page.

* **Tests**
  * Added test coverage for 2FA enforcement scenarios including policy changes and grace periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->