### PR TITLE
fix(platform): dedupe overlapping PII matches and add CVC pattern

### DIFF
--- a/services/platform/convex/governance/pii/__tests__/pii_patterns.test.ts
+++ b/services/platform/convex/governance/pii/__tests__/pii_patterns.test.ts
@@ -176,3 +176,127 @@ describe('scrubPii with new patterns', () => {
     expect(result.kind).toBe('pass');
   });
 });
+
+describe('overlap dedup (regression for #1618)', () => {
+  // Before the dedup fix, the phone regex matched a 14-char prefix of a
+  // creditCard match; both ranges shared a start, and maskPii spliced the
+  // shorter replacement first using original indices into a mutated string,
+  // eating adjacent characters — sometimes the next [EMAIL] token entirely.
+  const config = {
+    enabled: true,
+    mode: 'mask',
+    enabledPatterns: ['email', 'phone', 'creditCard'],
+    customPatterns: [],
+  } satisfies PiiConfig;
+
+  it('does not eat the [EMAIL] token when CC + email are adjacent', () => {
+    // The original repro from the issue: prior to the fix, the email part
+    // disappeared completely from the output.
+    const result = scrubPii('4532123456789010 test@example.com 123', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CREDIT_CARD] [EMAIL] 123');
+  });
+
+  it('keeps creditCard, drops the overlapping phone match', () => {
+    const result = scrubPii('4532-1234-5678-9010', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CREDIT_CARD]');
+    expect(result.text).not.toContain('[PHONE]');
+    expect(result.categoryIds).toEqual(['creditCard']);
+  });
+
+  it('does not corrupt surrounding text when CC + email co-occur with prose', () => {
+    const result = scrubPii(
+      'My credit card is 4532-1234-5678-9010, my email is alice@example.com.',
+      config,
+    );
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe(
+      'My credit card is [CREDIT_CARD], my email is [EMAIL].',
+    );
+  });
+
+  it('masks all three independent items when patterns do not overlap', () => {
+    const result = scrubPii(
+      'call 555-867-5309 mail a@b.com card 4532-1234-5678-9010',
+      config,
+    );
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toContain('[PHONE]');
+    expect(result.text).toContain('[EMAIL]');
+    expect(result.text).toContain('[CREDIT_CARD]');
+    expect(result.text).not.toMatch(/\d{3}-\d{3}-\d{4}/);
+    expect(result.text).not.toMatch(/4532/);
+  });
+
+  it('handles email and creditCard separated only by a non-word char', () => {
+    // The creditCard regex requires \b on both sides, so a letter-adjacent
+    // CC (e.g. ".com4532...") won't match — that's an intentional limit of
+    // the existing pattern. A non-word separator (here a comma) is enough.
+    const result = scrubPii('test@example.com,4532-1234-5678-9010', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[EMAIL],[CREDIT_CARD]');
+  });
+});
+
+describe('CVC pattern (context-anchored)', () => {
+  const config = {
+    enabled: true,
+    mode: 'mask',
+    enabledPatterns: ['cvc'],
+    customPatterns: [],
+  } satisfies PiiConfig;
+
+  it('masks "my CVC is 123"', () => {
+    const result = scrubPii('my CVC is 123', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('my [CVC]');
+  });
+
+  it('masks "cvv: 4567"', () => {
+    const result = scrubPii('cvv: 4567', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CVC]');
+  });
+
+  it('masks "card security code 890"', () => {
+    const result = scrubPii('card security code 890', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CVC]');
+  });
+
+  it('masks "card-security-code 100"', () => {
+    const result = scrubPii('card-security-code 100', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CVC]');
+  });
+
+  it('masks "CV2=999" (mixed case via i flag)', () => {
+    const result = scrubPii('CV2=999', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('[CVC]');
+  });
+
+  it('does NOT detect bare 3-digit numbers without context', () => {
+    // Intentional: bare digits would false-positive on ages, room numbers,
+    // error codes, etc. Industry-standard tools (Presidio, Comprehend, CF
+    // WAF) skip CVV for the same reason.
+    const result = scrubPii('My room is 123 and my age is 45.', config);
+    expect(result.kind).toBe('pass');
+  });
+
+  it('does NOT match the literal word "cid" without a number', () => {
+    const result = scrubPii('citric acid is sour', config);
+    expect(result.kind).toBe('pass');
+  });
+});

--- a/services/platform/convex/governance/pii/pii_detector.ts
+++ b/services/platform/convex/governance/pii/pii_detector.ts
@@ -26,6 +26,25 @@ export function detectPii(text: string, patterns: PiiPattern[]): PiiMatch[] {
     }
   }
 
-  matches.sort((a, b) => a.start - b.start);
-  return matches;
+  // Merge overlapping matches so the masker (which splices using original
+  // indices into a mutating string) never sees two ranges sharing a span.
+  // Without this, e.g. `phone` matching a 14-char prefix of a 19-char
+  // creditCard match leaves both in the list, the second splice's `match.end`
+  // points past where the string has shifted, and adjacent text — sometimes
+  // the next replacement token entirely — gets eaten. Policy: longest match
+  // wins; on equal length, earlier insertion (i.e. earlier pattern in
+  // BUILT_IN_PII_PATTERNS) wins.
+  matches.sort(
+    (a, b) => a.start - b.start || b.end - b.start - (a.end - a.start),
+  );
+  const kept: PiiMatch[] = [];
+  for (const m of matches) {
+    const last = kept[kept.length - 1];
+    if (!last || m.start >= last.end) {
+      kept.push(m);
+    } else if (m.end - m.start > last.end - last.start) {
+      kept[kept.length - 1] = m;
+    }
+  }
+  return kept;
 }

--- a/services/platform/convex/governance/pii/pii_patterns.ts
+++ b/services/platform/convex/governance/pii/pii_patterns.ts
@@ -29,6 +29,16 @@ export const BUILT_IN_PII_PATTERNS: PiiPattern[] = [
     replacement: '[CREDIT_CARD]',
   },
   {
+    // Context-anchored: bare 3-4 digit numbers are intentionally NOT detected
+    // (would false-positive on ages, room numbers, error codes). Microsoft
+    // Presidio, AWS Comprehend, and Cloudflare WAF all skip CVV detection
+    // for the same reason. This catches the labeled cases only.
+    name: 'cvc',
+    regex:
+      /\b(?:cvc|cvv|cv2|card[\s-]?security[\s-]?code)\b(?:\s+is)?\s*[:=]?\s*\d{3,4}\b/gi,
+    replacement: '[CVC]',
+  },
+  {
     name: 'ipAddress',
     regex: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g,
     replacement: '[IP_ADDRESS]',

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4260,7 +4260,8 @@
         "dateOfBirth": "Geburtsdaten",
         "address": "Straßenadressen",
         "iban": "IBAN-Nummern",
-        "germanId": "Personalausweisnummern"
+        "germanId": "Personalausweisnummern",
+        "cvc": "Kartenprüfziffern (CVC/CVV)"
       },
       "customPatternsTitle": "Benutzerdefinierte Regex-Regeln",
       "customPatternsDescription": "Füge benutzerdefinierte Regex-Muster hinzu, um weitere Arten personenbezogener Daten zu erkennen.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4260,7 +4260,8 @@
         "dateOfBirth": "Dates of birth",
         "address": "Street addresses",
         "iban": "IBAN numbers",
-        "germanId": "German ID numbers"
+        "germanId": "German ID numbers",
+        "cvc": "Card security codes (CVC/CVV)"
       },
       "customPatternsTitle": "Custom regex rules",
       "customPatternsDescription": "Add custom regex patterns to detect additional types of personal data.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4169,7 +4169,8 @@
         "dateOfBirth": "Dates de naissance",
         "address": "Adresses postales",
         "iban": "Numéros IBAN",
-        "germanId": "Numéros d'identité allemands"
+        "germanId": "Numéros d'identité allemands",
+        "cvc": "Codes de sécurité des cartes (CVC/CVV)"
       },
       "customPatternsTitle": "Règles regex personnalisées",
       "customPatternsDescription": "Ajoute des expressions régulières personnalisées pour détecter des types supplémentaires de données personnelles.",


### PR DESCRIPTION
Closes #1618.

## Summary

- Sweep overlapping PII matches in `detectPii` so the masker never sees two ranges sharing a span (longer match wins; on tie, earlier built-in wins).
- Add a context-anchored `cvc` pattern: matches `CVC: 123`, `my cvv is 4567`, `card security code 890`, etc. Bare 3-digit numbers are intentionally not detected.
- 13 new tests, including the exact repro from the issue.

## Why the bug looks like "email wasn't masked"

The reporter said only the credit card got masked and email/CVC came through. Tracing it on real inputs revealed two distinct issues:

1. **The masker was eating the `[EMAIL]` token.** The built-in `phone` regex matches a 14-char prefix of any credit-card number (e.g. `4532-1234-5678` inside `4532-1234-5678-9010`). `detectPii` returned both ranges; `maskPii` sorted DESC by start and spliced each replacement using **original-text indices** into a string already mutated by earlier splices. Once two matches shared a start, the later splice's `result.slice(match.end)` landed at the wrong offset and consumed adjacent characters — sometimes the `[EMAIL]` placeholder entirely.

   Concrete repro (verified against the unfixed code):

   | Input | Output |
   | - | - |
   | `4532123456789010 test@example.com 123` | `[CREDIT_CARD] 123` (**email vanishes**) |
   | `cc 4111-1111-1111-1111 mail user@foo.org cvv 999` | `cc [CREDIT_CARD]EMAIL] cvv 999` (`[` of `[EMAIL]` eaten) |
   | `My credit card is 4532-1234-5678-9010, my email is alice@example.com.` | `My credit card is [CREDIT_CARD]ail is [EMAIL].` (`, my em` eaten) |

   Fix: dedupe overlaps in `detectPii` via a sort-and-sweep. Once the input has no overlaps, the existing end-to-start splice in `maskPii` is correct, so `maskPii` itself is unchanged.

2. **CVC was never detected.** `BUILT_IN_PII_PATTERNS` had no CVC entry. Adding one is non-trivial because bare 3-digit numbers can't be reliably distinguished from ages, room numbers, error codes, etc. — Microsoft Presidio, AWS Comprehend, and Cloudflare WAF all skip CVV detection for the same reason. We add a context-anchored pattern that requires a label keyword (`cvc`/`cvv`/`cv2`/`card security code`) near the digits. Bare `123` is **intentionally** not detected.

## Out of scope (called out for the reviewer)

- The issue mentions "no per-issue error toast shown". Once the overlap bug is fixed, masking is deterministic and complete, so the silent-failure problem the reporter saw goes away. Adding a positive "Masked N items" notice is a separate UX decision and not in this PR.
- Bare CVV digits without a label keyword are intentionally not detected (industry-standard tools skip these).

## Behavior change for existing orgs

Existing orgs' saved `enabledPatterns` arrays don't list `cvc`, so it's off-by-default for them — admins toggle the new "Card security codes (CVC/CVV)" switch on in Settings → Guardrails. New orgs pick it up via the `PATTERN_NAMES` default in `pii-config.tsx`. No DB migration; the schema stores `enabledPatterns` as `z.array(z.string())` (no enum).

## Test plan

- [x] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors
- [x] `npx tsc --noEmit` from `services/platform/` — clean
- [x] `npx vitest run convex/governance/pii` — 33/33 (12 new + 21 existing)
- [x] `npx vitest run convex/agents/__tests__/unified_chat_ttft.test.ts` — 3/3
- [x] `npx vitest run app/features/settings/governance/components/pii-config.test.tsx` — 1/1
- [x] Manual e2e: enable PII masking, enable cvc toggle, send `My card is 4532-1234-5678-9010, email user@example.com, CVC: 987` → all three masked, no eaten text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for card security codes (CVC/CVV).
  * Extended multi-language support for PII pattern labels.

* **Bug Fixes**
  * Enhanced PII detection to better handle overlapping matches, preventing duplicate masking.

* **Tests**
  * Added comprehensive regression tests covering PII deduplication, overlapping patterns, and security code detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->