### PR TITLE
fix(platform): seed start step on blank workflow creation

### DIFF
--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -103,7 +103,13 @@ function BlankTabContent({
             description: data.description ?? '',
             installed: true,
             enabled: false,
-            steps: [],
+            steps: [
+              {
+                stepSlug: 'start',
+                name: 'Start',
+                stepType: 'start',
+              },
+            ],
           },
         });
 

--- a/services/platform/lib/shared/schemas/__tests__/workflows.test.ts
+++ b/services/platform/lib/shared/schemas/__tests__/workflows.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+import { workflowJsonSchema } from '../workflows';
+
+describe('workflowJsonSchema', () => {
+  it('parses a config without a steps key, defaulting steps to []', () => {
+    const result = workflowJsonSchema.safeParse({
+      name: 'Blank',
+      description: '',
+      installed: true,
+      enabled: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.steps).toEqual([]);
+    }
+  });
+
+  it('parses a config with explicit empty steps', () => {
+    const result = workflowJsonSchema.safeParse({
+      name: 'Blank',
+      installed: true,
+      enabled: false,
+      steps: [],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.steps).toEqual([]);
+    }
+  });
+
+  it('parses a config with one step', () => {
+    const result = workflowJsonSchema.safeParse({
+      name: 'One step',
+      installed: true,
+      enabled: false,
+      steps: [
+        {
+          stepSlug: 'start',
+          name: 'Start',
+          stepType: 'start',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.steps).toHaveLength(1);
+      expect(result.data.steps[0]?.config).toEqual({});
+      expect(result.data.steps[0]?.nextSteps).toEqual({});
+    }
+  });
+});

--- a/services/platform/lib/shared/schemas/workflows.ts
+++ b/services/platform/lib/shared/schemas/workflows.ts
@@ -56,7 +56,7 @@ export const workflowJsonSchema = z.object({
   enabled: z.boolean().default(false),
   config: workflowConfigSchema.optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
-  steps: z.array(workflowStepSchema),
+  steps: z.array(workflowStepSchema).default([]),
 });
 
 export type WorkflowJsonConfig = z.infer<typeof workflowJsonSchema>;


### PR DESCRIPTION
Closes #1617.

## Summary

- Seed a `start` step (`stepSlug: 'start'`, `name: 'Start'`, `stepType: 'start'`) when creating a blank workflow, so the canvas opens with a usable anchor instead of an empty "No automation steps to display" state.
- Default `steps` to `[]` on `workflowJsonSchema` so the round-trip through `serializeJson` (which strips top-level empty arrays for branding/agents/providers/integrations/workflows) is non-destructive — a workflow whose user has deleted every step still parses on next read.

## Why

Before, blank create wrote `steps: []` → `serializeJson` stripped the empty array → the saved file had no `steps` key → the schema's required `steps` field failed validation on read → `readJsonFile` returned `corrupted` → the detail page rendered "Workflow not found" and the list filtered the entry out. The toast still fired because save validates the *input* config (where `steps: []` is valid), masking the corruption.

Seeding a step fixes the user-facing UX. Defaulting `steps` to `[]` is a defensive backstop for any other code path that produces an empty steps array.

## Test plan

- [x] `npx vitest run lib/shared/schemas/__tests__/workflows.test.ts` (3 new tests: parses without `steps`, parses with explicit `[]`, parses with one step + default config/nextSteps)
- [x] `npx vitest run convex/agent_tools/workflows convex/workflows` — 154 existing tests still pass
- [x] `npx tsc --noEmit` from `services/platform/`
- [x] `npm run lint --workspace=@tale/platform`
- [ ] Manual: Automations → Create Workflow → enter name → Submit; detail page renders with a single Start step (not "Workflow not found"); list page shows the new workflow on return.
- [ ] Manual: Install an existing template (e.g. `general/conversation-sync`) — still works as before.

## Out of scope

- Other schemas that share `serializeJson` (agents, providers, integrations, branding) might have the same latent bug shape if they have a top-level required array — worth a follow-up audit.
- The read-retry loop in `routes/dashboard/$id/automations/$amId.tsx` (added in #1088) was a band-aid for this exact bug class. Left in place since it remains useful for genuine FS-propagation races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blank automations now include a default initial step to streamline workflow creation.

* **Tests**
  * Added validation tests for workflow configuration parsing and step defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->