### PR TITLE
fix(platform): detect non–US-style addresses in PII filter

### DIFF
--- a/services/platform/convex/governance/pii/__tests__/pii_patterns.test.ts
+++ b/services/platform/convex/governance/pii/__tests__/pii_patterns.test.ts
@@ -177,6 +177,91 @@ describe('scrubPii with new patterns', () => {
   });
 });
 
+describe('address pattern', () => {
+  const addressPatterns = getEnabledPatterns(['address']);
+
+  it('detects US-style "123 Main Street"', () => {
+    const matches = detectPii('123 Main Street', addressPatterns);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('123 Main Street');
+  });
+
+  it('detects "1234 5th Ave"', () => {
+    const matches = detectPii('1234 5th Ave', addressPatterns);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('1234 5th Ave');
+  });
+
+  it('detects address embedded in prose', () => {
+    const matches = detectPii(
+      'My address is 42 Oak Lane, Apt 5',
+      addressPatterns,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('42 Oak Lane');
+  });
+
+  it('detects Indonesian-style "street X no 02G" (regression for #1473)', () => {
+    const matches = detectPii(
+      'i live in street dieng atas no 02G malang jawa timur indonesia',
+      addressPatterns,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText.toLowerCase()).toBe(
+      'street dieng atas no 02g',
+    );
+  });
+
+  it('detects "Jalan Sudirman No 15"', () => {
+    const matches = detectPii('Jalan Sudirman No 15', addressPatterns);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('Jalan Sudirman No 15');
+  });
+
+  it('detects German compound "Hauptstrasse 12"', () => {
+    const matches = detectPii('Hauptstrasse 12', addressPatterns);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('Hauptstrasse 12');
+  });
+
+  it('detects abbreviated German "Bahnhofstr. 5"', () => {
+    const matches = detectPii('Bahnhofstr. 5', addressPatterns);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe('Bahnhofstr. 5');
+  });
+
+  it('does not match plain digits with no street keyword', () => {
+    const matches = detectPii('I had 5 cookies', addressPatterns);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not match "street" without a number marker', () => {
+    const matches = detectPii('street art is cool', addressPatterns);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not match "street X 5 days" (no no/nr marker)', () => {
+    // The keyword-first form requires an explicit no/nr/number/# marker to
+    // avoid grabbing unrelated digits in the same sentence.
+    const matches = detectPii('street art is cool 5 days', addressPatterns);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('masks address with [ADDRESS] placeholder via scrubPii', () => {
+    const config = {
+      enabled: true,
+      mode: 'mask',
+      enabledPatterns: ['address'],
+      customPatterns: [],
+    } satisfies PiiConfig;
+    const result = scrubPii('Mail to 123 Main Street please', config);
+    expect(result.kind).toBe('modified');
+    if (result.kind !== 'modified') return;
+    expect(result.text).toBe('Mail to [ADDRESS] please');
+    expect(result.categoryIds).toContain('address');
+  });
+});
+
 describe('overlap dedup (regression for #1618)', () => {
   // Before the dedup fix, the phone regex matched a 14-char prefix of a
   // creditCard match; both ranges shared a start, and maskPii spliced the

--- a/services/platform/convex/governance/pii/pii_patterns.ts
+++ b/services/platform/convex/governance/pii/pii_patterns.ts
@@ -50,8 +50,20 @@ export const BUILT_IN_PII_PATTERNS: PiiPattern[] = [
   },
   {
     name: 'address',
-    regex:
-      /\b\d{1,5}\s+[\w\s]{1,30}(?:street|st|avenue|ave|road|rd|drive|dr|lane|ln|boulevard|blvd|court|ct|way|place|pl)\b/gi,
+    // Three common shapes (#1473):
+    //  1. US/UK style    "123 Main Street"          NUMBER NAME KEYWORD
+    //  2. Keyword-first  "Jalan Dieng Atas no 02G"  KEYWORD NAME no/nr/# NUMBER
+    //                    requires an explicit "no/nr/number/#" marker to
+    //                    avoid false positives like "street art is cool 5".
+    //  3. German cmpd.   "Hauptstrasse 12"          <name>strasse [Nr.] NUMBER
+    regex: new RegExp(
+      [
+        String.raw`\b\d{1,5}[a-z]?\s+[\w\s]{1,30}(?:street|st\.?|avenue|ave\.?|road|rd\.?|drive|dr\.?|lane|ln\.?|boulevard|blvd\.?|court|ct\.?|way|place|pl\.?|highway|hwy\.?)\b`,
+        String.raw`\b(?:street|jalan|jl\.?|rue|calle|avenida|carrera|via)\s+[\w\s]{1,30}?\s+(?:no\.?|nr\.?|number|#)\s*\d{1,5}[a-z]?\b`,
+        String.raw`\b\w+(?:strasse|straße|str\.?|weg|allee|platz|gasse)\s+(?:nr\.?\s*)?\d{1,5}[a-z]?\b`,
+      ].join('|'),
+      'gi',
+    ),
     replacement: '[ADDRESS]',
   },
   {


### PR DESCRIPTION
## Summary

- The address regex in [pii_patterns.ts](services/platform/convex/governance/pii/pii_patterns.ts) only matched US/UK ordering (`NUMBER NAME KEYWORD`), so inputs like `street dieng atas no 02G` or `Hauptstrasse 12` reported "No PII detected".
- Extended the pattern with two more shapes: **keyword-first international** (`Jalan/street/Rue … no/nr/# NUMBER`) and **German compound** (`Hauptstrasse 12`, `Bahnhofstr. 5`). Allowed alphanumeric house numbers (`02G`, `12B`).
- Keyword-first variant **requires** an explicit `no/nr/number/#` marker to avoid false-positives like `street art is cool 5`.
- Added 11 unit tests including the exact #1473 input as a regression case and negative tests.

## Why not a library

Investigated `libpostal`, Microsoft Presidio, `redact-pii`, `openredaction`, Transformers.js — none fit our constraints (browser + Convex Node, offline, small footprint). libpostal needs a ~4 GB data file and has no WASM port; Presidio is Python-only; the JS PII libs all use the same US-English-only address regex we already had. Full plan / alternatives matrix in [.claude/plans/stateless-wobbling-steele.md](https://github.com/tale-project/tale/pull/new/fix/pii-address-multilingual) (local).

If higher-accuracy multilingual address detection becomes a real product need, the architectural answer is a server-side libpostal Convex action — out of scope here.

## Known limitation

The regex matches the structurally-anchored part of an address (street + house number). Trailing geographic context like `malang jawa timur indonesia` (city/province/country) is **not** masked, because regex can't tell those words apart from ordinary nouns without semantic understanding. Industry tools (Presidio, Google DLP) use NER for that.

Closes #1473

## Test plan

- [x] `bunx vitest --run --project server pii_patterns` — 44/44 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --workspace=@tale/platform` clean
- [ ] Manual UI repro per #1473 steps: paste `i live in street dieng atas no 02G malang jawa timur indonesia` into Settings → Governance → PII Protection → Test detection; expect `[ADDRESS]` badge for `street dieng atas no 02G`.
- [ ] Manual: paste `123 Main Street`, `Hauptstrasse 12`, `Jalan Sudirman No 15` — each should detect.
- [ ] Manual: paste `street art is cool 5 days` — should NOT detect (false-positive guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced address detection pattern to recognize additional address formats with improved accuracy
  * Added support for international address variants, multiple street type keywords, and alternative number markers
  * Reduced false positives in address pattern matching

* **Tests**
  * Added comprehensive test coverage for address detection across multiple formats, locales, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->