### PR TITLE
fix(platform): dedupe entered_organization audit entries within 30min

### DIFF
--- a/services/platform/convex/organizations/record_org_switch.test.ts
+++ b/services/platform/convex/organizations/record_org_switch.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        updateMany: 'betterAuth:adapter:updateMany',
+      },
+    },
+  },
+}));
+
+const mockGetAuthUser = vi.fn();
+vi.mock('../auth', () => ({
+  authComponent: {
+    getAuthUser: (...args: unknown[]) => mockGetAuthUser(...args),
+  },
+}));
+
+const mockLogSuccess = vi.fn();
+vi.mock('../audit_logs/helpers', () => ({
+  logSuccess: (...args: unknown[]) => mockLogSuccess(...args),
+}));
+
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      null: stub,
+    },
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    mutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+type AuditEntry = {
+  actorId: string;
+  action: string;
+  organizationId: string;
+  category: string;
+  timestamp: number;
+};
+
+function createMockCtx(recentEntries: AuditEntry[] = []) {
+  const order = vi.fn().mockImplementation(() => ({
+    [Symbol.asyncIterator]: async function* () {
+      for (const entry of recentEntries) {
+        yield entry;
+      }
+    },
+  }));
+  const withIndex = vi.fn().mockReturnValue({ order });
+  const query = vi.fn().mockReturnValue({ withIndex });
+
+  return {
+    db: { query },
+    runMutation: vi.fn().mockResolvedValue(undefined),
+    auth: {},
+    _builders: { query, withIndex, order },
+  };
+}
+
+const AUTH_USER = {
+  _id: 'user_1',
+  email: 'user@example.com',
+};
+
+const MEMBER = { role: 'admin' };
+
+describe('recordOrgSwitch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    mockGetOrganizationMember.mockResolvedValue(MEMBER);
+    mockLogSuccess.mockResolvedValue('audit_log_1');
+  });
+
+  async function getHandler() {
+    const { recordOrgSwitch } = await import('./record_org_switch');
+    return (recordOrgSwitch as unknown as { handler: Function }).handler;
+  }
+
+  it('throws when unauthenticated', async () => {
+    mockGetAuthUser.mockResolvedValue(null);
+    const ctx = createMockCtx();
+    const handler = await getHandler();
+
+    await expect(handler(ctx, { organizationId: 'org_1' })).rejects.toThrow(
+      'Unauthenticated',
+    );
+    expect(mockLogSuccess).not.toHaveBeenCalled();
+  });
+
+  it('writes audit log on first entry for this (user, org)', async () => {
+    const ctx = createMockCtx([]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).toHaveBeenCalledTimes(1);
+    expect(mockLogSuccess).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        action: 'entered_organization',
+        category: 'auth',
+        resourceType: 'organization',
+        resourceId: 'org_1',
+        auditCtx: expect.objectContaining({
+          organizationId: 'org_1',
+          actor: expect.objectContaining({
+            id: 'user_1',
+            email: 'user@example.com',
+            role: 'admin',
+            type: 'user',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('skips audit log when same (user, org) entry exists within window', async () => {
+    const ctx = createMockCtx([
+      {
+        actorId: 'user_1',
+        action: 'entered_organization',
+        organizationId: 'org_1',
+        category: 'auth',
+        timestamp: Date.now() - 5 * 60 * 1000,
+      },
+    ]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).not.toHaveBeenCalled();
+  });
+
+  it('writes audit log when previous same-org entry is from a different user', async () => {
+    const ctx = createMockCtx([
+      {
+        actorId: 'user_2',
+        action: 'entered_organization',
+        organizationId: 'org_1',
+        category: 'auth',
+        timestamp: Date.now() - 5 * 60 * 1000,
+      },
+    ]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes audit log when only non-entered_organization entries exist for user', async () => {
+    const ctx = createMockCtx([
+      {
+        actorId: 'user_1',
+        action: 'login',
+        organizationId: 'org_1',
+        category: 'auth',
+        timestamp: Date.now() - 5 * 60 * 1000,
+      },
+    ]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('queries by_org_category_timestamp scoped to last 30 minutes', async () => {
+    const ctx = createMockCtx([]);
+    const handler = await getHandler();
+    const before = Date.now();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(ctx._builders.query).toHaveBeenCalledWith('auditLogs');
+    expect(ctx._builders.withIndex).toHaveBeenCalledWith(
+      'by_org_category_timestamp',
+      expect.any(Function),
+    );
+    expect(ctx._builders.order).toHaveBeenCalledWith('desc');
+
+    const indexFn = ctx._builders.withIndex.mock.calls[0][1] as (
+      q: Record<string, ReturnType<typeof vi.fn>>,
+    ) => unknown;
+    const eq = vi.fn().mockReturnThis();
+    const gte = vi.fn().mockReturnThis();
+    indexFn({ eq, gte });
+
+    expect(eq).toHaveBeenNthCalledWith(1, 'organizationId', 'org_1');
+    expect(eq).toHaveBeenNthCalledWith(2, 'category', 'auth');
+    expect(gte).toHaveBeenCalledTimes(1);
+    const cutoff = gte.mock.calls[0][1] as number;
+    expect(cutoff).toBeGreaterThanOrEqual(before - 30 * 60 * 1000);
+    expect(cutoff).toBeLessThanOrEqual(Date.now() - 30 * 60 * 1000 + 1000);
+  });
+
+  it('always updates lastActiveOrganizationId, even when audit log is deduped', async () => {
+    const ctx = createMockCtx([
+      {
+        actorId: 'user_1',
+        action: 'entered_organization',
+        organizationId: 'org_1',
+        category: 'auth',
+        timestamp: Date.now() - 5 * 60 * 1000,
+      },
+    ]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'betterAuth:adapter:updateMany',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          model: 'user',
+          where: [{ field: '_id', value: 'user_1', operator: 'eq' }],
+          update: { lastActiveOrganizationId: 'org_1' },
+        }),
+      }),
+    );
+  });
+
+  it('updates lastActiveOrganizationId on first entry too', async () => {
+    const ctx = createMockCtx([]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'betterAuth:adapter:updateMany',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          update: { lastActiveOrganizationId: 'org_1' },
+        }),
+      }),
+    );
+  });
+
+  it('returns null', async () => {
+    const ctx = createMockCtx();
+    const handler = await getHandler();
+
+    const result = await handler(ctx, { organizationId: 'org_1' });
+
+    expect(result).toBeNull();
+  });
+});

--- a/services/platform/convex/organizations/record_org_switch.ts
+++ b/services/platform/convex/organizations/record_org_switch.ts
@@ -9,6 +9,13 @@
  *      preference survives logout/login. Better Auth's
  *      `session.activeOrganizationId` only lives for the current session and
  *      gets reset to null when the session is destroyed on logout.
+ *
+ * The mutation is invoked from several client paths (initial dashboard load,
+ * deep-link route guard, explicit switcher, org creation), so without dedup
+ * the same user re-entering the same org during a session would spam the
+ * audit log. We skip the audit write if the same user already has an
+ * `entered_organization` entry for the same org within DEDUP_WINDOW_MS.
+ * Cross-org switches and "user came back later" still record.
  */
 
 import { v } from 'convex/values';
@@ -18,6 +25,8 @@ import { mutation } from '../_generated/server';
 import { logSuccess } from '../audit_logs/helpers';
 import { authComponent } from '../auth';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+
+const DEDUP_WINDOW_MS = 30 * 60 * 1000;
 
 export const recordOrgSwitch = mutation({
   args: {
@@ -35,21 +44,44 @@ export const recordOrgSwitch = mutation({
     // client cannot spam audit logs for tenants they don't belong to.
     const member = await getOrganizationMember(ctx, args.organizationId);
 
-    await logSuccess(ctx, {
-      auditCtx: {
-        organizationId: args.organizationId,
-        actor: {
-          id: String(authUser._id),
-          email: authUser.email,
-          role: member.role,
-          type: 'user',
+    const actorId = String(authUser._id);
+    const cutoff = Date.now() - DEDUP_WINDOW_MS;
+    let hasRecentEntry = false;
+    for await (const entry of ctx.db
+      .query('auditLogs')
+      .withIndex('by_org_category_timestamp', (q) =>
+        q
+          .eq('organizationId', args.organizationId)
+          .eq('category', 'auth')
+          .gte('timestamp', cutoff),
+      )
+      .order('desc')) {
+      if (
+        entry.actorId === actorId &&
+        entry.action === 'entered_organization'
+      ) {
+        hasRecentEntry = true;
+        break;
+      }
+    }
+
+    if (!hasRecentEntry) {
+      await logSuccess(ctx, {
+        auditCtx: {
+          organizationId: args.organizationId,
+          actor: {
+            id: actorId,
+            email: authUser.email,
+            role: member.role,
+            type: 'user',
+          },
         },
-      },
-      action: 'entered_organization',
-      category: 'auth',
-      resourceType: 'organization',
-      resourceId: args.organizationId,
-    });
+        action: 'entered_organization',
+        category: 'auth',
+        resourceType: 'organization',
+        resourceId: args.organizationId,
+      });
+    }
 
     // Persist the preference so next login lands here again.
     await ctx.runMutation(components.betterAuth.adapter.updateMany, {


### PR DESCRIPTION
## Summary

- The `recordOrgSwitch` mutation is invoked from four client paths (initial dashboard load, deep-link `$id` route guard, explicit switcher, org creation), and `audit_logs/helpers.ts` has no rate-limiting — so the same user re-entering the same org during a session spammed the audit log (e.g., `ym@tale.dev` × 3 in 2 days from normal tab opens / reloads).
- Skip the `entered_organization` audit write when the same user already has an `entered_organization` entry for the same org within the last 30 minutes, using the existing `by_org_category_timestamp` index. Cross-org switches and "user came back later" still record.
- The `lastActiveOrganizationId` update still always runs (cheap and idempotent).
- Adds `record_org_switch.test.ts` (9 tests) covering: unauth rejection, first-entry write, dedup hit, different-user, different-action, index/window correctness, lastActive update on both paths, null return.

## Test plan

- [x] `npx vitest run convex/organizations/record_org_switch.test.ts` — 9/9 passing
- [x] `npx tsc --noEmit` from `services/platform/` — 0 errors
- [x] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors
- [ ] Manual smoke on local dev:
  - Log in → land on dashboard → reload twice → audit log shows a single `entered_organization` entry
  - Switch to a different org via the switcher → new entry recorded
  - Wait >30 min, reload → new entry recorded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization switch audit logs are no longer duplicated when users switch to the same organization within a 30-minute window.

* **Tests**
  * Added comprehensive test coverage for organization switch functionality, including deduplication scenarios and audit logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->