### PR TITLE
fix(platform): clear isDirty after save when normalized shape differs

### DIFF
--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -46,15 +46,8 @@ export function AgentNavigation({
 }: AgentNavigationProps) {
   const { t } = useT('settings');
   const { t: tCommon } = useT('common');
-  const {
-    config,
-    isDirty,
-    isSaving,
-    resetConfig,
-    markSaving,
-    markSaved,
-    overrideConfig,
-  } = useAgentConfig();
+  const { config, isDirty, isSaving, resetConfig, markSaving, overrideConfig } =
+    useAgentConfig();
   const { formatDate } = useFormatDate();
   const { data: organization } = useOrganization(organizationId);
   const orgDefaultLocale = getOrganizationDefaultLocale(organization?.metadata);
@@ -148,7 +141,7 @@ export function AgentNavigation({
         organizationId,
       });
 
-      markSaved(normalized);
+      overrideConfig(normalized);
       setHistoryEntries([]);
       toast({
         title: t('agents.agentSaved'),
@@ -169,10 +162,10 @@ export function AgentNavigation({
     agentId,
     config,
     markSaving,
-    markSaved,
     onSaved,
     orgDefaultLocale,
     organizationId,
+    overrideConfig,
     saveAction,
     snapshotAction,
     t,

--- a/services/platform/app/features/agents/hooks/use-agent-config-context.test.tsx
+++ b/services/platform/app/features/agents/hooks/use-agent-config-context.test.tsx
@@ -160,6 +160,36 @@ describe('useAgentConfig', () => {
     expect(result.current.config.delegates).toEqual(['web-assistant']);
   });
 
+  it('overrideConfig clears isDirty even when persisted shape differs from working config', () => {
+    // Regression: handleSave normalizes the config (stripping empty i18n
+    // placeholders, retiring top-level translatables, etc.) and must end up
+    // with isDirty=false. Calling markSaved alone leaves `config` un-synced,
+    // so a JSON-shape divergence keeps isDirty=true forever.
+    const { result } = renderHook(() => useAgentConfig(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.updateConfig({
+        i18n: { en: { displayName: 'Assistant', description: '' } },
+      });
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    // Simulated normalized shape: empty `description` stripped.
+    const persisted: AgentJsonConfig = {
+      ...result.current.config,
+      i18n: { en: { displayName: 'Assistant' } },
+    };
+
+    act(() => {
+      result.current.overrideConfig(persisted);
+    });
+
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.config.i18n?.en?.description).toBeUndefined();
+  });
+
   it('resetConfig reverts to initial config', () => {
     const { result } = renderHook(() => useAgentConfig(), {
       wrapper: createWrapper(),


### PR DESCRIPTION
## Summary
- Agent save normalizes the config (e.g. stripping empty i18n placeholders), so the persisted shape can diverge from the working config. `markSaved` only updated the baseline, leaving `isDirty=true` forever.
- Switch to `overrideConfig(normalized)` after a successful save so config and baseline stay in sync.
- Add a regression test for the divergent-shape case.

## Test plan
- [ ] `npm run lint --workspace=@tale/platform`
- [ ] `npx tsc --noEmit` in `services/platform/`
- [ ] Run the new `use-agent-config-context` test suite
- [ ] Manual: edit an agent so a save normalizes the i18n payload, confirm the dirty indicator clears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agent configuration state management handling during save operations.

* **Tests**
  * Added test coverage for configuration override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->