### PR TITLE
feat(platform): add joined_organization audit + rename entered_organization

### DIFF
--- a/services/platform/convex/audit_logs/helpers.test.ts
+++ b/services/platform/convex/audit_logs/helpers.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MutationCtx } from '../_generated/server';
+
+vi.mock('../lib/helpers/audit_hash', () => ({
+  computeAuditHash: vi.fn().mockResolvedValue('hash_stub'),
+}));
+
+import { logJoinedOrganization } from './helpers';
+
+type AuditEntry = {
+  actorId: string;
+  action: string;
+  organizationId: string;
+};
+
+function createMockCtx(byActorEntries: AuditEntry[] = []) {
+  const insert = vi.fn().mockResolvedValue('audit_log_1');
+
+  // Query #1 — `by_organizationId_and_actorId` for dedup. Returns the
+  // entries the caller pre-seeded.
+  const dedupIterable = {
+    [Symbol.asyncIterator]: async function* () {
+      for (const entry of byActorEntries) {
+        yield entry;
+      }
+    },
+  };
+  const dedupWithIndex = vi.fn().mockReturnValue(dedupIterable);
+
+  // Query #2 — `by_organizationId_and_timestamp` for previousHash lookup
+  // inside createAuditLog. Returns no prior entry → empty hash chain.
+  const orderResult = { first: vi.fn().mockResolvedValue(null) };
+  const chainWithIndex = vi.fn().mockReturnValue({
+    order: vi.fn().mockReturnValue(orderResult),
+  });
+
+  const query = vi.fn().mockImplementation(() => ({
+    withIndex: vi.fn().mockImplementation((indexName: string) => {
+      if (indexName === 'by_organizationId_and_actorId') {
+        return dedupIterable;
+      }
+      if (indexName === 'by_organizationId_and_timestamp') {
+        return { order: () => orderResult };
+      }
+      throw new Error(`unexpected index: ${indexName}`);
+    }),
+  }));
+
+  const ctx = {
+    db: {
+      query,
+      insert,
+    },
+  } as unknown as MutationCtx;
+
+  return { ctx, insert, dedupWithIndex, chainWithIndex };
+}
+
+describe('logJoinedOrganization', () => {
+  const opts = {
+    organizationId: 'org_1',
+    userId: 'user_1',
+    userEmail: 'user@example.com',
+    userRole: 'member',
+  };
+
+  it('writes a joined_organization row when no prior entry exists', async () => {
+    const { ctx, insert } = createMockCtx([]);
+
+    const result = await logJoinedOrganization(ctx, opts);
+
+    expect(result).toBe('audit_log_1');
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(insert).toHaveBeenCalledWith(
+      'auditLogs',
+      expect.objectContaining({
+        organizationId: 'org_1',
+        actorId: 'user_1',
+        actorEmail: 'user@example.com',
+        actorRole: 'member',
+        actorType: 'user',
+        action: 'joined_organization',
+        category: 'member',
+        resourceType: 'organization',
+        resourceId: 'org_1',
+        status: 'success',
+      }),
+    );
+  });
+
+  it('skips the write when a prior joined_organization row exists', async () => {
+    const { ctx, insert } = createMockCtx([
+      {
+        actorId: 'user_1',
+        action: 'joined_organization',
+        organizationId: 'org_1',
+      },
+    ]);
+
+    const result = await logJoinedOrganization(ctx, opts);
+
+    expect(result).toBeNull();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('does not skip when prior rows are for unrelated actions only', async () => {
+    const { ctx, insert } = createMockCtx([
+      {
+        actorId: 'user_1',
+        action: 'signed_in_to_organization',
+        organizationId: 'org_1',
+      },
+      {
+        actorId: 'user_1',
+        action: 'add_member',
+        organizationId: 'org_1',
+      },
+    ]);
+
+    await logJoinedOrganization(ctx, opts);
+
+    expect(insert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/convex/audit_logs/helpers.ts
+++ b/services/platform/convex/audit_logs/helpers.ts
@@ -256,6 +256,55 @@ export async function logSuccess(
   });
 }
 
+interface LogJoinedOrganizationOptions {
+  organizationId: string;
+  userId: string;
+  userEmail: string;
+  userRole: string;
+}
+
+/**
+ * Log a `joined_organization` audit row for the given user.
+ *
+ * Lifecycle event — should fire exactly once per (org, user) pair.
+ * Skips the write (returns null) if an entry already exists for this
+ * actor/org pair, regardless of how long ago. Uses the
+ * `by_organizationId_and_actorId` index for the existence check; a typical
+ * actor has only tens of rows, so the in-memory action filter is cheap.
+ */
+export async function logJoinedOrganization(
+  ctx: MutationCtx,
+  options: LogJoinedOrganizationOptions,
+): Promise<Id<'auditLogs'> | null> {
+  for await (const entry of ctx.db
+    .query('auditLogs')
+    .withIndex('by_organizationId_and_actorId', (q) =>
+      q
+        .eq('organizationId', options.organizationId)
+        .eq('actorId', options.userId),
+    )) {
+    if (entry.action === 'joined_organization') {
+      return null;
+    }
+  }
+
+  return logSuccess(ctx, {
+    auditCtx: {
+      organizationId: options.organizationId,
+      actor: {
+        id: options.userId,
+        email: options.userEmail,
+        role: options.userRole,
+        type: 'user',
+      },
+    },
+    action: 'joined_organization',
+    category: 'member',
+    resourceType: 'organization',
+    resourceId: options.organizationId,
+  });
+}
+
 interface LogFailureOptions {
   auditCtx: AuditContext;
   action: string;

--- a/services/platform/convex/audit_logs/internal_mutations.ts
+++ b/services/platform/convex/audit_logs/internal_mutations.ts
@@ -37,6 +37,23 @@ export const createAuditLog = internalMutation({
   },
 });
 
+/**
+ * Internal mutation wrapper around `logJoinedOrganization` so Better Auth
+ * hooks (which run in an HTTP ActionCtx, not a MutationCtx) can write the
+ * audit row via `ctx.runMutation`.
+ */
+export const logJoinedOrganization = internalMutation({
+  args: {
+    organizationId: v.string(),
+    userId: v.string(),
+    userEmail: v.string(),
+    userRole: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await AuditLogHelpers.logJoinedOrganization(ctx, args);
+  },
+});
+
 export const archiveOldLogs = internalMutation({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -327,9 +327,10 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
           required: false,
           input: false,
         } as const,
-        // Last organization the user entered — persists across logout/login,
-        // unlike session.activeOrganizationId which dies with the session.
-        // Written by recordOrgSwitch whenever the user enters an org.
+        // Last organization the user signed in to — persists across
+        // logout/login, unlike session.activeOrganizationId which dies with
+        // the session. Written by recordOrgSwitch whenever the user signs
+        // in to an org.
         lastActiveOrganizationId: {
           type: 'string',
           required: false,
@@ -519,20 +520,67 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
           },
           afterCreateOrganization: async (data) => {
             const slug = data.organization.slug;
-            if (!slug) return;
-            // Scaffolding is filesystem work, so defer to an action via
-            // the scheduler. Failures here should NOT block org creation —
-            // the scaffolder logs and continues per-domain.
+            if (slug) {
+              // Scaffolding is filesystem work, so defer to an action via
+              // the scheduler. Failures here should NOT block org creation —
+              // the scaffolder logs and continues per-domain.
+              try {
+                const runCtx = requireRunMutationCtx(ctx);
+                await runCtx.scheduler.runAfter(
+                  0,
+                  internal.organizations.scaffold.scaffoldNewOrganization,
+                  { orgSlug: slug },
+                );
+              } catch (err) {
+                console.error(
+                  '[afterCreateOrganization] failed to schedule scaffold',
+                  err instanceof Error ? err.message : err,
+                );
+              }
+            }
+
+            // Member-POV audit row: the creator just joined the org as
+            // owner. Better Auth has already persisted the member record
+            // with role='owner' before invoking this hook. Wrap defensively
+            // so audit failures don't bubble to the client as a 500.
             try {
               const runCtx = requireRunMutationCtx(ctx);
-              await runCtx.scheduler.runAfter(
-                0,
-                internal.organizations.scaffold.scaffoldNewOrganization,
-                { orgSlug: slug },
+              await runCtx.runMutation(
+                internal.audit_logs.internal_mutations.logJoinedOrganization,
+                {
+                  organizationId: data.organization.id,
+                  userId: data.user.id,
+                  userEmail: data.user.email,
+                  userRole: data.member.role,
+                },
               );
             } catch (err) {
               console.error(
-                '[afterCreateOrganization] failed to schedule scaffold',
+                '[afterCreateOrganization] failed to write joined_organization audit',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          },
+          afterAcceptInvitation: async (data) => {
+            // Member-POV audit row: the invitee just joined the org with
+            // the role granted by the invitation. Better Auth persists the
+            // member record before invoking this hook, so `data.member.role`
+            // is authoritative. Wrapped defensively per the same rationale
+            // as afterCreateOrganization.
+            try {
+              const runCtx = requireRunMutationCtx(ctx);
+              await runCtx.runMutation(
+                internal.audit_logs.internal_mutations.logJoinedOrganization,
+                {
+                  organizationId: data.organization.id,
+                  userId: data.user.id,
+                  userEmail: data.user.email,
+                  userRole: data.member.role,
+                },
+              );
+            } catch (err) {
+              console.error(
+                '[afterAcceptInvitation] failed to write joined_organization audit',
                 err instanceof Error ? err.message : err,
               );
             }

--- a/services/platform/convex/betterAuth/trusted_headers/find_or_create_user_from_headers.test.ts
+++ b/services/platform/convex/betterAuth/trusted_headers/find_or_create_user_from_headers.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+        create: 'betterAuth:adapter:create',
+        updateOne: 'betterAuth:adapter:updateOne',
+      },
+    },
+  },
+}));
+
+const mockLogJoinedOrganization = vi.fn();
+vi.mock('../../audit_logs/helpers', () => ({
+  logJoinedOrganization: (...args: unknown[]) =>
+    mockLogJoinedOrganization(...args),
+}));
+
+import { findOrCreateUserFromHeaders } from './find_or_create_user_from_headers';
+
+type RunMutationFn = ReturnType<typeof vi.fn>;
+type RunQueryFn = ReturnType<typeof vi.fn>;
+
+interface QueueDriver {
+  runQuery: RunQueryFn;
+  runMutation: RunMutationFn;
+}
+
+function makeCtx({
+  existingUserPage,
+  existingMemberPage,
+  existingAdminPage,
+  createdUserId = 'user_new',
+  createdOrgId = 'org_new',
+}: {
+  existingUserPage: unknown[];
+  existingMemberPage?: unknown[];
+  existingAdminPage?: unknown[];
+  createdUserId?: string;
+  createdOrgId?: string;
+}): QueueDriver {
+  // Order of runQuery calls inside findOrCreateUserFromHeaders:
+  //   1. find user by email
+  //   2a. (if user exists) find member by userId
+  //   2b. (if user does not exist) find admin member to attach to existing org
+  const runQuery = vi.fn();
+  runQuery.mockResolvedValueOnce({ page: existingUserPage });
+  if (existingUserPage.length > 0) {
+    runQuery.mockResolvedValueOnce({ page: existingMemberPage ?? [] });
+  } else {
+    runQuery.mockResolvedValueOnce({ page: existingAdminPage ?? [] });
+  }
+
+  // runMutation calls (in order, depending on branch):
+  //   - updateOne (only when existing user has a stale name)
+  //   - create user
+  //   - create member (existing-org branch) OR create org + create member (new-org branch)
+  const runMutation = vi.fn();
+  runMutation.mockImplementation(async (ref: string, args: unknown) => {
+    const a = args as { input?: { model?: string } };
+    if (ref === 'betterAuth:adapter:create') {
+      if (a.input?.model === 'user') return { _id: createdUserId };
+      if (a.input?.model === 'organization') return { _id: createdOrgId };
+      if (a.input?.model === 'member') return { _id: 'member_new' };
+    }
+    return undefined;
+  });
+
+  return { runQuery, runMutation };
+}
+
+const ARGS = {
+  email: 'new@example.com',
+  name: 'New User',
+  role: 'member',
+};
+
+describe('findOrCreateUserFromHeaders — joined_organization audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips logJoinedOrganization when the user already exists', async () => {
+    const ctx = makeCtx({
+      existingUserPage: [
+        { _id: 'user_existing', email: ARGS.email, name: ARGS.name },
+      ],
+      existingMemberPage: [
+        {
+          _id: 'member_existing',
+          userId: 'user_existing',
+          organizationId: 'org_existing',
+        },
+      ],
+    });
+
+    await findOrCreateUserFromHeaders(
+      ctx as unknown as Parameters<typeof findOrCreateUserFromHeaders>[0],
+      ARGS,
+    );
+
+    expect(mockLogJoinedOrganization).not.toHaveBeenCalled();
+  });
+
+  it('logs joined_organization with role=member when attaching new user to existing org', async () => {
+    const ctx = makeCtx({
+      existingUserPage: [],
+      existingAdminPage: [
+        {
+          _id: 'admin_member',
+          userId: 'user_other',
+          organizationId: 'org_existing',
+        },
+      ],
+      createdUserId: 'user_new',
+    });
+
+    await findOrCreateUserFromHeaders(
+      ctx as unknown as Parameters<typeof findOrCreateUserFromHeaders>[0],
+      ARGS,
+    );
+
+    expect(mockLogJoinedOrganization).toHaveBeenCalledTimes(1);
+    expect(mockLogJoinedOrganization).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        organizationId: 'org_existing',
+        userId: 'user_new',
+        userEmail: ARGS.email,
+        userRole: 'member',
+      }),
+    );
+  });
+
+  it('logs joined_organization with role=admin when creating the first org for the first user', async () => {
+    const ctx = makeCtx({
+      existingUserPage: [],
+      existingAdminPage: [],
+      createdUserId: 'user_first',
+      createdOrgId: 'org_first',
+    });
+
+    await findOrCreateUserFromHeaders(
+      ctx as unknown as Parameters<typeof findOrCreateUserFromHeaders>[0],
+      ARGS,
+    );
+
+    expect(mockLogJoinedOrganization).toHaveBeenCalledTimes(1);
+    expect(mockLogJoinedOrganization).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        organizationId: 'org_first',
+        userId: 'user_first',
+        userEmail: ARGS.email,
+        userRole: 'admin',
+      }),
+    );
+  });
+
+  it('does not propagate audit failures back to the caller', async () => {
+    mockLogJoinedOrganization.mockRejectedValueOnce(
+      new Error('audit table down'),
+    );
+
+    const ctx = makeCtx({
+      existingUserPage: [],
+      existingAdminPage: [],
+      createdUserId: 'user_first',
+      createdOrgId: 'org_first',
+    });
+
+    await expect(
+      findOrCreateUserFromHeaders(
+        ctx as unknown as Parameters<typeof findOrCreateUserFromHeaders>[0],
+        ARGS,
+      ),
+    ).resolves.toEqual({
+      userId: 'user_first',
+      organizationId: 'org_first',
+    });
+  });
+});

--- a/services/platform/convex/betterAuth/trusted_headers/find_or_create_user_from_headers.ts
+++ b/services/platform/convex/betterAuth/trusted_headers/find_or_create_user_from_headers.ts
@@ -12,6 +12,7 @@
 
 import { components } from '../../_generated/api';
 import type { MutationCtx } from '../../_generated/server';
+import { logJoinedOrganization } from '../../audit_logs/helpers';
 import type {
   BetterAuthCreateResult,
   BetterAuthFindManyResult,
@@ -169,6 +170,20 @@ export async function findOrCreateUserFromHeaders(
           },
         },
       });
+
+      try {
+        await logJoinedOrganization(ctx, {
+          organizationId: existingOrgId,
+          userId,
+          userEmail: email,
+          userRole: 'member',
+        });
+      } catch (err) {
+        console.error(
+          '[trusted_headers] failed to write joined_organization audit',
+          err instanceof Error ? err.message : err,
+        );
+      }
     } else {
       // No existing organization yet (first trusted-headers user) - create
       // a default organization for them and make them admin.
@@ -200,6 +215,20 @@ export async function findOrCreateUserFromHeaders(
           },
         },
       });
+
+      try {
+        await logJoinedOrganization(ctx, {
+          organizationId: newOrgId,
+          userId,
+          userEmail: email,
+          userRole: 'admin',
+        });
+      } catch (err) {
+        console.error(
+          '[trusted_headers] failed to write joined_organization audit',
+          err instanceof Error ? err.message : err,
+        );
+      }
     }
   }
 

--- a/services/platform/convex/organizations/record_org_switch.test.ts
+++ b/services/platform/convex/organizations/record_org_switch.test.ts
@@ -114,7 +114,7 @@ describe('recordOrgSwitch', () => {
     expect(mockLogSuccess).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
-        action: 'entered_organization',
+        action: 'signed_in_to_organization',
         category: 'auth',
         resourceType: 'organization',
         resourceId: 'org_1',
@@ -135,6 +135,26 @@ describe('recordOrgSwitch', () => {
     const ctx = createMockCtx([
       {
         actorId: 'user_1',
+        action: 'signed_in_to_organization',
+        organizationId: 'org_1',
+        category: 'auth',
+        timestamp: Date.now() - 5 * 60 * 1000,
+      },
+    ]);
+    const handler = await getHandler();
+
+    await handler(ctx, { organizationId: 'org_1' });
+
+    expect(mockLogSuccess).not.toHaveBeenCalled();
+  });
+
+  it('skips audit log when legacy entered_organization entry exists within window', async () => {
+    // Transitional dedup: until demo data is purged, the dedup query must
+    // also recognize the old action name so back-to-back sign-ins straddling
+    // the rename deploy don't double-log.
+    const ctx = createMockCtx([
+      {
+        actorId: 'user_1',
         action: 'entered_organization',
         organizationId: 'org_1',
         category: 'auth',
@@ -152,7 +172,7 @@ describe('recordOrgSwitch', () => {
     const ctx = createMockCtx([
       {
         actorId: 'user_2',
-        action: 'entered_organization',
+        action: 'signed_in_to_organization',
         organizationId: 'org_1',
         category: 'auth',
         timestamp: Date.now() - 5 * 60 * 1000,
@@ -165,7 +185,7 @@ describe('recordOrgSwitch', () => {
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('writes audit log when only non-entered_organization entries exist for user', async () => {
+  it('writes audit log when only unrelated auth entries exist for user', async () => {
     const ctx = createMockCtx([
       {
         actorId: 'user_1',
@@ -215,7 +235,7 @@ describe('recordOrgSwitch', () => {
     const ctx = createMockCtx([
       {
         actorId: 'user_1',
-        action: 'entered_organization',
+        action: 'signed_in_to_organization',
         organizationId: 'org_1',
         category: 'auth',
         timestamp: Date.now() - 5 * 60 * 1000,

--- a/services/platform/convex/organizations/record_org_switch.ts
+++ b/services/platform/convex/organizations/record_org_switch.ts
@@ -1,21 +1,27 @@
 /**
- * Record that a user entered (selected) an organization.
+ * Record that a user signed in to (activated) an organization for the
+ * current session.
  *
  * Invoked by the client right after `authClient.organization.setActive()`
  * succeeds. Does two things:
- *   1. Writes an auditable `entered_organization` log entry — the compliance
- *      "moment of tenant selection".
+ *   1. Writes an auditable `signed_in_to_organization` log entry — the
+ *      compliance "moment of tenant access".
  *   2. Persists `user.lastActiveOrganizationId` on the user record so the
  *      preference survives logout/login. Better Auth's
  *      `session.activeOrganizationId` only lives for the current session and
  *      gets reset to null when the session is destroyed on logout.
  *
- * The mutation is invoked from several client paths (initial dashboard load,
- * deep-link route guard, explicit switcher, org creation), so without dedup
- * the same user re-entering the same org during a session would spam the
- * audit log. We skip the audit write if the same user already has an
- * `entered_organization` entry for the same org within DEDUP_WINDOW_MS.
- * Cross-org switches and "user came back later" still record.
+ * Mutation name reflects the historical "switch" origin; the four invocation
+ * paths it actually serves are: initial dashboard load (auto-select after
+ * login), explicit org switcher, deep-link route guard, and post-org-creation.
+ * The audit action name (`signed_in_to_organization`) describes the
+ * user-facing semantic; the mutation name describes the state-machine call.
+ *
+ * Without dedup the same user re-activating the same org during a session
+ * would spam the audit log. We skip the audit write if the same user already
+ * has an entry for the same org within DEDUP_WINDOW_MS. The check OR-matches
+ * the legacy `entered_organization` action name so dedup keeps working
+ * across the rename for any old rows in the window.
  */
 
 import { v } from 'convex/values';
@@ -58,7 +64,9 @@ export const recordOrgSwitch = mutation({
       .order('desc')) {
       if (
         entry.actorId === actorId &&
-        entry.action === 'entered_organization'
+        // TODO: drop `entered_organization` branch after demo data purge.
+        (entry.action === 'signed_in_to_organization' ||
+          entry.action === 'entered_organization')
       ) {
         hasRecentEntry = true;
         break;
@@ -76,7 +84,7 @@ export const recordOrgSwitch = mutation({
             type: 'user',
           },
         },
-        action: 'entered_organization',
+        action: 'signed_in_to_organization',
         category: 'auth',
         resourceType: 'organization',
         resourceId: args.organizationId,

--- a/services/platform/convex/users/get_last_active_org.ts
+++ b/services/platform/convex/users/get_last_active_org.ts
@@ -1,6 +1,6 @@
 /**
  * Read the current user's `lastActiveOrganizationId` — the persistent
- * preference set by `recordOrgSwitch` whenever the user enters an org.
+ * preference set by `recordOrgSwitch` whenever the user signs in to an org.
  *
  * Unlike Better Auth's `session.activeOrganizationId` (which is wiped on
  * logout), this value lives on the user record and survives logout/login,


### PR DESCRIPTION
## Summary

- Rename audit action `entered_organization` → `signed_in_to_organization` (auth category) so the UI label reads correctly. Reviewer (Yannick) read "entered" as "joining"; actual semantic is "user activated this org as session context". Dedup query OR-matches the legacy name during transition so back-to-back sign-ins straddling the rename don't double-log.
- Add new `joined_organization` audit action (member category, actor = the new member) to fill the membership-lifecycle gap. Emits exactly once per (org, user) pair via a deduped helper, from three points: `afterCreateOrganization` hook (self org create incl. signup-time), `afterAcceptInvitation` hook, and trusted-headers first-time user (both attach-to-existing-org and create-new-org branches).
- Coexists with admin-initiated `add_member`; that one keeps capturing the admin-side trail unchanged.

Hook calls go through an internal mutation because Better Auth runs hooks in ActionCtx, not MutationCtx. All hook writes wrapped in try/catch so audit failures don't bubble to the client as 500s.

Existing `entered_organization` rows left as-is (demo stage — no backfill).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors
- [x] `npx vitest run convex/` — 178 files / 2194 tests pass
- [ ] Manual: sign in fresh → expect `signed in to organization` row (auth)
- [ ] Manual: switch org via switcher → new `signed in to organization` row for destination
- [ ] Manual: switch back within 30 min → no duplicate (legacy + new dedup honored)
- [ ] Manual: create a new org → expect both `joined organization` (member) and `signed in to organization` (auth) rows
- [ ] Manual: accept invitation via `authClient.organization.acceptInvitation` → expect `joined organization` row, single, no duplicate on retry
- [ ] Manual: trusted-headers first-time login → expect `joined organization` row
- [ ] Manual: confirm legacy `entered_organization` rows still display unchanged ("entered organization")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit logging to track when users join organizations through creation, invitation acceptance, or authentication.

* **Improvements**
  * Enhanced audit log deduplication for organization sign-in events with clearer action naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->