### PR TITLE
fix(db): gate healthcheck on init-scripts completion to unblock startup

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -73,17 +73,20 @@ services:
     restart: unless-stopped
 
     # Health check
-    # Docker will check if the database is ready
+    # Gates dependent services on BOTH PostgreSQL accepting connections AND
+    # the post-start init scripts having finished (they create `tale_knowledge`
+    # + extensions in the background, so `pg_isready` alone races with rag's
+    # dbmate startup on slow CI runners).
     healthcheck:
       test:
         [
           'CMD-SHELL',
-          'pg_isready -U ${POSTGRES_USER:-tale} -d ${POSTGRES_DB:-tale}',
+          'pg_isready -U ${POSTGRES_USER:-tale} -d ${POSTGRES_DB:-tale} && [ -f /tmp/.db_ready ]',
         ]
-      interval: 30s
+      interval: 5s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 120s
 
     # Resource limits (optional, adjust based on your needs)
     # deploy:


### PR DESCRIPTION
Smoke tests intermittently failed with "container tale-rag is unhealthy" ~60s after rag starts. Root cause: db healthcheck only ran pg_isready, so dependent services saw db as Healthy before the background init scripts finished creating tale_knowledge + extensions. RAG's dbmate retry budget (30 attempts × 2s = 60s) could be exhausted on slow CI runners before the database existed, causing the entrypoint to exit.

Gate the healthcheck on /tmp/.db_ready (touched after init scripts run) and bump start_period to 120s. Also protects crawler from the same race.

## Summary

<!-- 1–3 sentences. What changed and why. Link issues / discussions. -->

## Pre-merge checklist

Tick each box or mark **N/A** with a short reason. Empty boxes are a blocker.

- [ ] Ran `bun run check` (format, lint, typecheck, all tests).
- [ ] Updated `services/platform/messages/{en,de,fr}.json` for any new/renamed/removed keys — or N/A.
- [ ] Updated `docs/`, `docs/de/`, and `docs/fr/` for every user-visible change — or N/A.
- [ ] Ran `bun run --filter @tale/docs lint` (broken links + oxlint) — or N/A.
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` if the change affects what they document — or N/A.

<details>
<summary><strong>Does this change need docs and translations?</strong> (decision tree)</summary>

Walk top-down. First **yes** wins.

- Did you add, rename, or remove a key in `services/platform/messages/`? → **Yes.**
- Did you add, change, or remove a UI element a user can click, see, or read? → **Yes.**
- Did you add, rename, remove, or change the default of an env var, CLI flag, config file key, or API field? → **Yes.**
- Did you change error wording, validation rules, or rate limits a user can hit? → **Yes.**
- Pure refactor, internal type, test, build script, or comment? → **No.** Note the scope in the commit body.

If unsure, default to **yes**. Reviewer time is cheaper than stale docs.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database service reliability monitoring with more frequent health checks and extended initialization grace period to better handle varying deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->