### PR TITLE
feat(platform): send images natively to vision-capable chat models

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -388,6 +388,7 @@ import type * as lib_agent_response_structured_response_instructions from "../li
 import type * as lib_agent_response_types from "../lib/agent_response/types.js";
 import type * as lib_agent_response_validators from "../lib/agent_response/validators.js";
 import type * as lib_agent_response_with_timeout from "../lib/agent_response/with_timeout.js";
+import type * as lib_attachments_build_inline_multi_modal_prompt from "../lib/attachments/build_inline_multi_modal_prompt.js";
 import type * as lib_attachments_build_multi_modal_content from "../lib/attachments/build_multi_modal_content.js";
 import type * as lib_attachments_format_markdown from "../lib/attachments/format_markdown.js";
 import type * as lib_attachments_index from "../lib/attachments/index.js";
@@ -1387,6 +1388,7 @@ declare const fullApi: ApiFromModules<{
   "lib/agent_response/types": typeof lib_agent_response_types;
   "lib/agent_response/validators": typeof lib_agent_response_validators;
   "lib/agent_response/with_timeout": typeof lib_agent_response_with_timeout;
+  "lib/attachments/build_inline_multi_modal_prompt": typeof lib_attachments_build_inline_multi_modal_prompt;
   "lib/attachments/build_multi_modal_content": typeof lib_attachments_build_multi_modal_content;
   "lib/attachments/format_markdown": typeof lib_attachments_format_markdown;
   "lib/attachments/index": typeof lib_attachments_index;

--- a/services/platform/convex/lib/agent_chat/__tests__/tool_building_parallelization.test.ts
+++ b/services/platform/convex/lib/agent_chat/__tests__/tool_building_parallelization.test.ts
@@ -277,6 +277,7 @@ describe('runAgentGeneration — tool building parallelization', () => {
         modelId: 'gpt-4o',
         inputCentsPerMillion: 250,
         outputCentsPerMillion: 1000,
+        tags: ['chat'],
       },
     };
     mockResolveModelById.mockResolvedValue(modelResult);

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -6,6 +6,7 @@ import {
   saveMessage,
   type MessageDoc,
 } from '@convex-dev/agent';
+import type { ModelMessage } from 'ai';
 import type { FunctionHandle } from 'convex/server';
 import { v } from 'convex/values';
 
@@ -46,6 +47,7 @@ import type {
   BeforeContextResult,
   BeforeGenerateResult,
 } from '../agent_response/types';
+import { buildInlineMultiModalPrompt } from '../attachments/build_inline_multi_modal_prompt';
 import {
   estimateTokens,
   DEFAULT_MODEL_CONTEXT_LIMIT,
@@ -127,6 +129,13 @@ export const runAgentGeneration = internalAction({
     userId: v.optional(v.string()),
     agentSlug: v.optional(v.string()),
     promptMessage: v.string(),
+    /**
+     * Un-augmented user text (without the attachment markdown that
+     * `buildMessageWithAttachments` appends to `promptMessage`). Used as the
+     * text part when building a multimodal prompt for vision-capable models,
+     * so PDF/audio references aren't duplicated.
+     */
+    originalUserText: v.optional(v.string()),
     additionalContext: v.optional(v.record(v.string(), v.string())),
     userContext: v.optional(
       v.object({
@@ -173,6 +182,7 @@ export const runAgentGeneration = internalAction({
       organizationId,
       userId,
       promptMessage,
+      originalUserText,
       additionalContext,
       userContext,
       parentThreadId,
@@ -342,10 +352,35 @@ export const runAgentGeneration = internalAction({
           const resolvedProvider = modelData.providerName;
           const resolvedModelId = modelData.modelId;
 
+          // Vision branch: when the resolved chat model has the `vision`
+          // tag and the turn carries image attachments, inline the images
+          // as multimodal content and drop the `image` tool for this
+          // attempt. Failover to a non-vision model on the next attempt
+          // re-evaluates and reverts to the markdown + image-tool path.
+          const imageAttachments =
+            attachments?.filter((a) => a.fileType.startsWith('image/')) ?? [];
+          const isVisionCapable = modelData.tags.includes('vision');
+          const useMultiModal = isVisionCapable && imageAttachments.length > 0;
+
+          let multiModalPrompt: ModelMessage[] | undefined;
+          if (useMultiModal) {
+            const built = await buildInlineMultiModalPrompt(ctx, {
+              userText: originalUserText ?? promptMessage,
+              imageAttachments,
+            });
+            multiModalPrompt = built.prompt;
+            debugLog('MULTIMODAL_BRANCH', {
+              modelId: resolvedModelId,
+              inlinedImageCount: built.inlinedImageCount,
+              skippedImages: built.skippedImages,
+            });
+          }
+
           // Create agent factory function from serializable config
           const createAgent = () => {
             // Filter tools: exclude rag_search/web when their retrieval mode
             // is 'context' or 'off' (tool should only be available in 'tool'/'both').
+            // Drop `image` when the chat model handles images natively.
             const knowledgeMode = agentConfig.knowledgeMode ?? 'off';
             const webSearchMode = agentConfig.webSearchMode ?? 'off';
             const filteredToolNames = agentConfig.convexToolNames?.filter(
@@ -364,6 +399,7 @@ export const runAgentGeneration = internalAction({
                   webSearchMode !== 'both'
                 )
                   return false;
+                if (n === 'image' && useMultiModal) return false;
                 return true;
               },
             );
@@ -428,6 +464,7 @@ export const runAgentGeneration = internalAction({
               parentThreadId,
               agentOptions,
               attachments,
+              multiModalPrompt,
               streamId,
               promptMessageId,
               maxSteps,

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -401,6 +401,7 @@ export async function startAgentChat(
       userId: thread?.userId,
       agentSlug: args.agentSlug,
       promptMessage: messageContent,
+      originalUserText: trimmedMessage,
       attachments: actionAttachments,
       streamId: streamId || undefined,
       promptMessageId,

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -184,6 +184,69 @@ import { AgentTimeoutError, withTimeout } from './with_timeout';
 const PLATFORM_HARD_LIMIT_MS = 540_000;
 
 /**
+ * Fast non-cryptographic hash of a byte buffer (FNV-1a, double-pass for
+ * 64-bit equivalent uniqueness). Used to fingerprint inlined image bytes
+ * for cache-key derivation — collision-resistant enough for cache dedup,
+ * not for security.
+ */
+function fnv1aBytes(bytes: Uint8Array): string {
+  let h1 = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    h1 ^= bytes[i];
+    h1 = Math.imul(h1, 0x01000193);
+  }
+  let h2 = 0x6c62272e;
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    h2 ^= bytes[i];
+    h2 = Math.imul(h2, 0x01000193);
+  }
+  return (
+    (h1 >>> 0).toString(16).padStart(8, '0') +
+    (h2 >>> 0).toString(16).padStart(8, '0')
+  );
+}
+
+/**
+ * Stringify a prompt for the response-cache key. Multimodal prompts must
+ * contribute every image identity, otherwise two requests with the same
+ * text but different images would share a key.
+ */
+function fingerprintPrompt(prompt: string | ModelMessage[]): string {
+  if (typeof prompt === 'string') return prompt;
+  return JSON.stringify(
+    prompt.map((m) => {
+      const content = m.content;
+      if (typeof content === 'string') {
+        return { role: m.role, text: content };
+      }
+      const parts = (Array.isArray(content) ? content : []).map((p) => {
+        if (p.type === 'text') return { t: 'text', v: p.text };
+        if (p.type === 'image') {
+          const img = p.image;
+          if (img instanceof URL) return { t: 'image', v: img.toString() };
+          if (typeof img === 'string') return { t: 'image', v: img };
+          if (img instanceof Uint8Array) {
+            return { t: 'image', v: fnv1aBytes(img) };
+          }
+          return { t: 'image', v: 'unknown' };
+        }
+        if (p.type === 'file') {
+          const data = p.data;
+          if (data instanceof URL) return { t: 'file', v: data.toString() };
+          if (typeof data === 'string') return { t: 'file', v: data };
+          if (data instanceof Uint8Array) {
+            return { t: 'file', v: fnv1aBytes(data) };
+          }
+          return { t: 'file', v: 'unknown' };
+        }
+        return { t: p.type };
+      });
+      return { role: m.role, parts };
+    }),
+  );
+}
+
+/**
  * How often the abort watcher polls the stream status (ms).
  */
 const ABORT_POLL_INTERVAL_MS = 1500;
@@ -782,8 +845,11 @@ export async function generateAgentResponse(
       elapsedMs: Date.now() - startTime,
     });
 
-    // Hook can override prompt content (e.g., for attachments → ModelMessage[])
-    let hookPromptContent: string | ModelMessage[] | undefined;
+    // Multimodal prompt (e.g. inlined image parts for vision-capable models)
+    // is the default in-flight prompt. The beforeGenerate hook may still
+    // override it via `promptContent`.
+    let hookPromptContent: string | ModelMessage[] | undefined =
+      args.multiModalPrompt;
 
     // Call beforeGenerate hook if provided
     if (hooks?.beforeGenerate) {
@@ -867,12 +933,15 @@ export async function generateAgentResponse(
       : structuredThreadContext.threadContext;
 
     // ── Response cache lookup ──
+    // Multimodal prompts (ModelMessage[]) must contribute a stable fingerprint
+    // to the key, otherwise two requests with identical text but different
+    // images would collide on an empty-string user-message slot.
     const cacheKey = computeCacheKey({
       agentName: agentType,
       model,
       instructions: instructions ?? '',
       threadContext: structuredThreadContext.threadContext,
-      userMessage: typeof promptToSend === 'string' ? promptToSend : '',
+      userMessage: fingerprintPrompt(promptToSend),
       generationParams,
     });
 
@@ -1301,7 +1370,7 @@ export async function generateAgentResponse(
             { threadId, userId },
             {
               system: systemPrompt,
-              prompt: promptMessage,
+              prompt: promptToSend,
               abortSignal: abortController.signal,
               ...(promptMessageId ? { promptMessageId } : {}),
               ...(generationParams?.temperature != null && {

--- a/services/platform/convex/lib/agent_response/types.ts
+++ b/services/platform/convex/lib/agent_response/types.ts
@@ -136,6 +136,12 @@ export interface GenerateResponseArgs {
   parentThreadId?: string;
   agentOptions?: Record<string, unknown>;
   attachments?: FileAttachment[];
+  /**
+   * Pre-built multimodal prompt with inline image parts. When set, used as
+   * the in-flight prompt to the LLM in place of `promptMessage`. The
+   * `beforeGenerate` hook can still override it via `promptContent`.
+   */
+  multiModalPrompt?: ModelMessage[];
   streamId?: string;
   promptMessageId?: string;
   maxSteps?: number;

--- a/services/platform/convex/lib/attachments/build_inline_multi_modal_prompt.ts
+++ b/services/platform/convex/lib/attachments/build_inline_multi_modal_prompt.ts
@@ -1,0 +1,89 @@
+import type { ImagePart, ModelMessage } from 'ai';
+
+import type { ActionCtx } from '../../_generated/server';
+import type { FileAttachment } from './types';
+
+const MAX_IMAGE_BYTES = 1 * 1024 * 1024;
+
+export interface BuildInlineMultiModalPromptResult {
+  prompt: ModelMessage[];
+  inlinedImageCount: number;
+  skippedImages: Array<{ fileName: string; reason: string }>;
+}
+
+/**
+ * Build a multimodal user message with image bytes embedded as ImagePart.
+ *
+ * Reads images directly from `_storage` and inlines them. Does NOT mutate
+ * the agent component's file registry — that registration is upload-time
+ * scope, not per-turn.
+ *
+ * Pass the *un-augmented* user text. Non-image attachments (PDFs, audio)
+ * are referenced via the saved-message markdown that the model already
+ * sees through thread context, so they are not duplicated here.
+ */
+export async function buildInlineMultiModalPrompt(
+  ctx: ActionCtx,
+  params: {
+    userText: string;
+    imageAttachments: FileAttachment[];
+  },
+): Promise<BuildInlineMultiModalPromptResult> {
+  const { userText, imageAttachments } = params;
+
+  const imageParts: ImagePart[] = [];
+  const skippedImages: Array<{ fileName: string; reason: string }> = [];
+
+  for (const att of imageAttachments) {
+    try {
+      const blob = await ctx.storage.get(att.fileId);
+      if (!blob) {
+        skippedImages.push({
+          fileName: att.fileName,
+          reason: 'not found in storage',
+        });
+        continue;
+      }
+      if (blob.size > MAX_IMAGE_BYTES) {
+        const sizeMB = (blob.size / (1024 * 1024)).toFixed(2);
+        const maxMB = (MAX_IMAGE_BYTES / (1024 * 1024)).toFixed(0);
+        skippedImages.push({
+          fileName: att.fileName,
+          reason: `${sizeMB}MB exceeds ${maxMB}MB limit`,
+        });
+        continue;
+      }
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      imageParts.push({
+        type: 'image',
+        image: bytes,
+        mediaType: blob.type || att.fileType || 'image/png',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      skippedImages.push({
+        fileName: att.fileName,
+        reason: `read failed: ${message}`,
+      });
+    }
+  }
+
+  const content: Array<{ type: 'text'; text: string } | ImagePart> = [
+    { type: 'text', text: userText },
+    ...imageParts,
+  ];
+
+  if (skippedImages.length > 0) {
+    const lines = skippedImages.map((s) => `- ${s.fileName}: ${s.reason}`);
+    content.push({
+      type: 'text',
+      text: `\n\n[Some images could not be included]\n${lines.join('\n')}`,
+    });
+  }
+
+  return {
+    prompt: [{ role: 'user', content }],
+    inlinedImageCount: imageParts.length,
+    skippedImages,
+  };
+}

--- a/services/platform/convex/providers/errors.ts
+++ b/services/platform/convex/providers/errors.ts
@@ -100,6 +100,11 @@ const NO_FAILOVER_PATTERNS = [
   'context_length',
   'maximum context length',
   'context window',
+  // Image-input rejections that fail on any vision model deterministically.
+  'image format',
+  'unsupported format',
+  'unsupported image',
+  'invalid image',
 ];
 
 /**


### PR DESCRIPTION
## Summary

- When an agent's resolved chat model has the `vision` tag (e.g. Claude Opus 4.6, Qwen3-VL), inline image attachments as `ImagePart` in a multimodal `ModelMessage[]` and drop the `image` tool from the tool list for that turn — no more round-trip through a separate vision model that returns a text description.
- Non-vision models keep today's behavior (markdown reference + `image` tool fallback). The fallback chain re-evaluates per attempt, so a vision → non-vision failover automatically reverts to the tool path.
- Fixes two pre-existing bugs that the multimodal payload would expose: the non-streaming `generateText` call dropping the multimodal `promptToSend`, and the response cache key collapsing `ModelMessage[]` prompts to an empty string.

## What changed

| File | Why |
|------|-----|
| `lib/attachments/build_inline_multi_modal_prompt.ts` (new) | Reads images from `_storage` and builds `ImagePart`s inline. No DB mutation, 1MB-per-image cap, oversize/missing files surfaced as text-part warnings. |
| `lib/agent_chat/internal_actions.ts` | Adds `originalUserText` arg, the vision branch, the `image`-tool filter, and plumbs `multiModalPrompt` through. |
| `lib/agent_chat/start_agent_chat.ts` | Passes the un-augmented user text as `originalUserText` so PDF/audio markdown isn't duplicated in the multimodal prompt. |
| `lib/agent_response/types.ts` | Adds `multiModalPrompt?: ModelMessage[]` to `GenerateResponseArgs`. |
| `lib/agent_response/generate_response.ts` | (a) Initializes `hookPromptContent` from the new arg; (b) fixes line 1304 — non-streaming `generateText` now uses `promptToSend`; (c) cache key now fingerprints multimodal content via FNV-1a over image bytes. |
| `providers/errors.ts` | Adds image-format patterns to `NO_FAILOVER_PATTERNS` so deterministic format rejections fail fast. |
| `lib/agent_chat/__tests__/tool_building_parallelization.test.ts` | Adds `tags: ['chat']` to mocked `modelData` so the new vision check finds an iterable. |

## Behavior changes worth noting

- Vision-capable runs no longer emit a `tool-image` span — image processing is folded into the main LLM call. A `MULTIMODAL_BRANCH` debug log is added so support can see which path was taken.
- Image input tokens flow into the chat model's `usage.inputTokens` rather than a separate vision-model line item.
- Image-format / unsupported-image errors now abort the turn (after fallback exhaustion) instead of being contained in the tool's try/catch. The new `NO_FAILOVER_PATTERNS` entries ensure these don't churn the fallback chain.

## Out of scope (pre-existing gaps, separate tasks)

- Multi-turn image persistence — saved user message remains markdown; matches today's behavior.
- Delegation/workflow attachment forwarding — sub-agents still don't receive parent's image attachments.
- OpenAI-compat `/v1/chat/completions` shim multimodal input parsing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --workspace=@tale/platform` clean
- [x] `bunx vitest run convex/lib/agent_chat convex/lib/agent_response convex/lib/attachments convex/lib/response_cache convex/providers` — 156/156 pass
- [ ] Manual end-to-end (vision): pick an agent with `openrouter:anthropic/claude-opus-4.6` first in `supportedModels`, upload an image; verify no `tool-image` span and the answer references visual details
- [ ] Manual end-to-end (non-vision fallback): use an agent with a chat-only first model, upload an image; verify the `image` tool fires
- [ ] Manual failover: force-fail the vision model and confirm fallback reverts to the `image` tool path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native support for inline image attachments in chat conversations for vision-capable models (1MB per-image maximum).

* **Bug Fixes**
  * Improved prompt fingerprinting to prevent cache collisions when processing multimodal content.
  * Enhanced error handling for image-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->