### PR TITLE
fix(platform): allow inline scripts in Canvas HTML preview iframe

### DIFF
--- a/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
@@ -20,6 +20,7 @@ function CanvasHtmlRendererComponent({
       `<!DOCTYPE html>
 <html>
 <head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; img-src * data: blob:; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src *;" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>


### PR DESCRIPTION
## Summary

- Canvas HTML preview iframe (`srcDoc=…`) was inheriting the parent page's strict-nonce CSP, which blocked every inline `<script>` and `onclick=` handler in LLM-generated HTML — buttons, sliders, autoplay timers all failed silently.
- Inject a permissive `<meta http-equiv="Content-Security-Policy">` inside the srcdoc to override the inherited policy. The iframe still uses `sandbox="allow-scripts"` (no `allow-same-origin`), so it remains an opaque origin with no access to parent cookies, storage, or same-origin APIs — same security model as a CodePen-style preview.

## Test plan

- [ ] Generate an HTML demo with `<button onclick="alert(1)">click</button>` and `<script>console.log('hi')</script>`, open in Canvas, confirm the alert fires and no `about:srcdoc` CSP errors appear in DevTools.
- [ ] Re-run the original Fibonacci demo: "逐步演示" / "自动播放" / speed slider should be interactive.
- [ ] `bun run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security protections for canvas rendering by implementing stricter content policies to limit allowed sources for resources and network connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->