### PR TITLE
fix(platform): restore i18n keys lost to orphan detector false positives

### DIFF
--- a/services/platform/lib/i18n/messages-usage.test.ts
+++ b/services/platform/lib/i18n/messages-usage.test.ts
@@ -206,10 +206,20 @@ function buildUsedKeys(allFlatKeys: Set<string>): {
       // ternaries / inline expressions, e.g.
       //   t(isDisabled ? 'disabled' : 'noMembership')
       //   t(cond ? 'a.b' : 'a.c', params)
+      // The body pattern uses mutually-exclusive alternatives
+      // (`[^()]` OR a balanced `\([^()]*\)`) so the outer `*` does not
+      // overlap with the inner group — this avoids catastrophic
+      // backtracking. The `${alias}` interpolation is safe: aliases come
+      // from `T_ALIAS_HEURISTIC_RE` / `T_DESTRUCTURE_RE`, both of which
+      // capture only `\w`-character identifiers.
       const callBodyRe = new RegExp(
         `(?<![\\w$])${alias}\\(((?:[^()]|\\([^()]*\\))*)\\)`,
         'g',
       );
+      // Greedy by design: any quoted token in the captured body becomes
+      // a candidate. Spurious matches (e.g. a literal that's not a
+      // translation key) are filtered out by the `allFlatKeys.has(...)`
+      // membership check below.
       const innerLiteralRe = /['"`]([\w-]+(?:\.[\w-]+)*)['"`]/g;
 
       for (const m of content.matchAll(literalRe)) {

--- a/services/platform/lib/i18n/messages-usage.test.ts
+++ b/services/platform/lib/i18n/messages-usage.test.ts
@@ -101,6 +101,18 @@ const I18N_T_RE = /\bi18n\.t\(\s*['"`]([\w.-]+)['"`]/g;
 // `t()`. Requires at least one dot to avoid matching every short literal.
 const DOTTED_LITERAL_RE = /['"`]([\w-]+(?:\.[\w-]+)+)['"`]/g;
 
+// Heuristic: identifiers shaped `t<Capital><rest>` (e.g. `tTables`,
+// `tCustomers`, `tDocuments`) follow the codebase convention where the
+// suffix names the namespace. We use this to recover translation aliases
+// that are not destructured from `useT(...)` in the current file but
+// instead arrive via a callback parameter or function argument:
+//   ({ tTables, builders }) => [{ header: tTables('headers.product') }, ...]
+//   function createCreationTimeColumn(tTables: TranslationFn) { ... }
+// We only register the alias when the inferred namespace actually exists
+// at the top level of en.json/global.json, so identifiers like `tEntity`
+// (whose namespace is genuinely dynamic) are ignored.
+const T_ALIAS_HEURISTIC_RE = /\b(t[A-Z]\w*)\(/g;
+
 function recordAlias(
   aliases: Map<string, Set<string>>,
   alias: string,
@@ -121,10 +133,16 @@ function buildUsedKeys(allFlatKeys: Set<string>): {
   const exact = new Set<string>();
   const wildcardPrefixes = new Set<string>();
 
-  // First pass: collect every namespace ever registered anywhere. This is
-  // used in the second pass to interpret bare dotted literals like
-  // `'vendors.title'` — if `vendors` is a known namespace, the literal
-  // covers `vendors.title`.
+  // Top-level namespaces are the keys of en.json + global.json. We use
+  // this set both to validate the t-alias heuristic (`tFoo` only counts
+  // when `foo` is a real top-level namespace) and to interpret bare
+  // dotted literals like `'vendors.title'`.
+  const topLevelNamespaces = new Set<string>();
+  for (const key of allFlatKeys) {
+    const dot = key.indexOf('.');
+    topLevelNamespaces.add(dot === -1 ? key : key.slice(0, dot));
+  }
+
   const allNamespaces = new Set<string>();
   const fileScans: Array<{
     file: string;
@@ -151,6 +169,19 @@ function buildUsedKeys(allFlatKeys: Set<string>): {
       }
       for (const m of content.matchAll(I18N_T_RE)) exact.add(m[1]);
 
+      // Heuristic alias detection: any `tFoo(...)` call where `Foo`
+      // names a real top-level namespace is treated as `tFoo` aliasing
+      // that namespace, even when no `useT('foo')` appears in the file.
+      // Skips identifiers like `tEntity` whose namespace is dynamic.
+      for (const m of content.matchAll(T_ALIAS_HEURISTIC_RE)) {
+        const alias = m[1];
+        const inferredNs = alias[1].toLowerCase() + alias.slice(2);
+        if (topLevelNamespaces.has(inferredNs)) {
+          recordAlias(aliases, alias, inferredNs);
+          allNamespaces.add(inferredNs);
+        }
+      }
+
       fileScans.push({ file, content, aliases });
     }
   }
@@ -170,6 +201,16 @@ function buildUsedKeys(allFlatKeys: Set<string>): {
         `(?<![\\w$])${alias}\\(\\s*\`([\\w.-]+)\\.\\$\\{`,
         'g',
       );
+      // Capture the full argument body of `<alias>(...)` calls, supporting
+      // up to one level of nested parens. This catches keys passed via
+      // ternaries / inline expressions, e.g.
+      //   t(isDisabled ? 'disabled' : 'noMembership')
+      //   t(cond ? 'a.b' : 'a.c', params)
+      const callBodyRe = new RegExp(
+        `(?<![\\w$])${alias}\\(((?:[^()]|\\([^()]*\\))*)\\)`,
+        'g',
+      );
+      const innerLiteralRe = /['"`]([\w-]+(?:\.[\w-]+)*)['"`]/g;
 
       for (const m of content.matchAll(literalRe)) {
         const suffix = m[1];
@@ -185,17 +226,210 @@ function buildUsedKeys(allFlatKeys: Set<string>): {
           wildcardPrefixes.add(`${ns}.${prefix}.`);
         }
       }
+      for (const m of content.matchAll(callBodyRe)) {
+        const body = m[1];
+        for (const lit of body.matchAll(innerLiteralRe)) {
+          const candidate = lit[1];
+          for (const ns of namespaces) {
+            const fullKey = `${ns}.${candidate}`;
+            if (allFlatKeys.has(fullKey)) exact.add(fullKey);
+          }
+          if (candidate.includes('.') && allFlatKeys.has(candidate)) {
+            exact.add(candidate);
+          }
+        }
+      }
     }
 
-    // Indirect-string-key sweep: any dotted string literal whose first
-    // segment is a known namespace OR which matches a real flat key.
+    // Indirect-string-key sweep: dotted string literals that resolve
+    // to a real translation key. We try, in order:
+    //   1. literal matches a flat key as-is (`'tables.headers.name'`),
+    //   2. literal's first segment is a known top-level namespace
+    //      (`'vendors.title'` → `vendors` is a namespace),
+    //   3. literal is a key SUFFIX under a namespace registered in this
+    //      file (`'headers.product'` in a file where `tables` is bound,
+    //      via `useT('tables')` or the `tTables` heuristic),
+    //   4. cross-file lookup-table fallback: a dotted literal sitting in
+    //      a "translation key" position — value of a `*Key` property
+    //      (`labelKey: 'modelSelector.tags.chat'`), an `as const` cast
+    //      (`'priority.high' as const`), or argument of a bare `t(...)`
+    //      call where `t` isn't bound in this file (the t function came
+    //      in via a custom hook return). For these we search every
+    //      namespace, since the suffix's namespace is determined cross-
+    //      file and can't be inferred locally.
+    // Step 3's per-file restriction prevents accidental matches from
+    // unrelated namespaces (e.g. `'pii.blocked'` discriminator codes
+    // would otherwise resurrect `governance.pii.blocked`).
+    const fileNamespaces = new Set<string>();
+    for (const namespaces of aliases.values()) {
+      for (const ns of namespaces) fileNamespaces.add(ns);
+    }
+    // Lookup-table literals: dotted strings sitting in positions that
+    // hint at translation-key storage (a `*Key` property, an `as const`
+    // cast, or the argument of a bare `t(...)` call where `t` isn't
+    // bound here). For these we permit a global namespace search since
+    // the alias resolution happens in another file.
+    const lookupTableLiterals = new Set<string>();
+    const KEY_PROPERTY_DOT_RE =
+      /\b\w*Key\s*:\s*['"`]([\w-]+(?:\.[\w-]+)+)['"`]/g;
+    const AS_CONST_DOT_RE = /['"`]([\w-]+(?:\.[\w-]+)+)['"`]\s*as\s+const\b/g;
+    const BARE_T_CALL_DOT_RE =
+      /(?<![\w$])t\(\s*['"`]([\w-]+(?:\.[\w-]+)+)['"`]/g;
+    for (const m of content.matchAll(KEY_PROPERTY_DOT_RE)) {
+      lookupTableLiterals.add(m[1]);
+    }
+    for (const m of content.matchAll(AS_CONST_DOT_RE)) {
+      lookupTableLiterals.add(m[1]);
+    }
+    if (!aliases.has('t')) {
+      for (const m of content.matchAll(BARE_T_CALL_DOT_RE)) {
+        lookupTableLiterals.add(m[1]);
+      }
+    }
+    const consumesTranslationFn =
+      /\bTFunction\b/.test(content) ||
+      /\bt\s*:\s*\(\s*key\s*:\s*string/.test(content);
+    if (consumesTranslationFn) {
+      for (const m of content.matchAll(DOTTED_LITERAL_RE)) {
+        lookupTableLiterals.add(m[1]);
+      }
+    }
+
+    // Single-segment literal candidates: identifiers stored in property
+    // positions (`title: 'deleteCustomer'`, `i18nKey: 'errorHintAuthError'`,
+    // inside `keys: { ... }` blocks, etc.) that are passed to `t(...)`
+    // dynamically. Translation keys in this codebase are camelCase
+    // identifiers, so we collect single-word strings sitting in clear
+    // key-storage positions and try them against the file's namespaces
+    // (or globally when the file imports `TFunction` / has an unbound
+    // `t`). Membership in `allFlatKeys` is the final filter, so the
+    // false-positive rate stays low.
+    // Local single-segment candidates: literals stored in property
+    // positions inside this file. Resolved against the file's own
+    // namespaces.
+    const localSingleCandidates = new Set<string>();
+    const SINGLE_KEY_PROPERTY_RE = /\b\w*Key\s*:\s*['"`]([a-zA-Z][\w-]*)['"`]/g;
+    const SINGLE_AS_CONST_RE = /['"`]([a-zA-Z][\w-]*)['"`]\s*as\s+const\b/g;
+    // Inside a `keys: { ... }` object, every string-literal property
+    // value is a candidate translation key.
+    const KEYS_BLOCK_RE = /\bkeys\s*:\s*\{([^{}]*)\}/g;
+    const KEYS_BLOCK_VALUE_RE = /:\s*['"`]([a-zA-Z][\w-]*)['"`]/g;
+    for (const m of content.matchAll(SINGLE_KEY_PROPERTY_RE)) {
+      localSingleCandidates.add(m[1]);
+    }
+    for (const m of content.matchAll(SINGLE_AS_CONST_RE)) {
+      localSingleCandidates.add(m[1]);
+    }
+    for (const block of content.matchAll(KEYS_BLOCK_RE)) {
+      for (const m of block[1].matchAll(KEYS_BLOCK_VALUE_RE)) {
+        localSingleCandidates.add(m[1]);
+      }
+    }
+    // Strong-signal single-segment candidates: values inside a const
+    // record whose name contains `I18N`, `KEY(S)`, or `TRANSLATION(S)`
+    // (e.g. `CATEGORY_I18N_KEY`, `TAG_KEYS`). These are translation
+    // key suffixes consumed cross-file via a t-fn and so deserve a
+    // global namespace search regardless of where the t-fn is bound.
+    // The lazy `[^{]*?` lets us skip over an optional type annotation
+    // (`Record<X, string>`) before reaching the object literal.
+    const strongSingleCandidates = new Set<string>();
+    const I18N_RECORD_RE =
+      /\b\w*(?:I18N|KEY|KEYS|TRANSLATION|TRANSLATIONS)\w*\b[^{]*?=\s*\{([^{}]*)\}/g;
+    const RECORD_VALUE_RE = /:\s*['"`]([a-zA-Z][\w-]*)['"`]/g;
+    for (const block of content.matchAll(I18N_RECORD_RE)) {
+      for (const m of block[1].matchAll(RECORD_VALUE_RE)) {
+        strongSingleCandidates.add(m[1]);
+      }
+    }
+    // Functions whose name ends in `Key` / `Keys` (e.g. `statusLabelKey`,
+    // `presetLabelKey`) typically build a translation-key suffix, then
+    // get consumed via `t(<fnName>(args))` at the callsite. We collect
+    // every string literal returned by such a function and treat the
+    // values as strong candidates. Match the function header with a
+    // regex, then walk the body counting `{`/`}` to find the true
+    // closing brace — a lazy regex would stop at any inner `}` (e.g.
+    // inside an `if`/`else` block) and miss later `return` statements.
+    const KEY_FUNCTION_HEADER_RE =
+      /\bfunction\s+\w*[Kk]eys?\s*\([^)]*\)[^{]*\{/g;
+    const RETURN_LITERAL_RE = /\breturn\s+['"`]([\w-]+(?:\.[\w-]+)*)['"`]/g;
+    for (const m of content.matchAll(KEY_FUNCTION_HEADER_RE)) {
+      const bodyStart = (m.index ?? 0) + m[0].length;
+      let depth = 1;
+      let i = bodyStart;
+      while (i < content.length && depth > 0) {
+        const c = content[i];
+        if (c === '{') depth++;
+        else if (c === '}') depth--;
+        i++;
+      }
+      if (depth !== 0) continue;
+      const body = content.slice(bodyStart, i - 1);
+      for (const r of body.matchAll(RETURN_LITERAL_RE)) {
+        strongSingleCandidates.add(r[1]);
+      }
+    }
+    for (const literal of localSingleCandidates) {
+      let matched = false;
+      for (const ns of fileNamespaces) {
+        const candidate = `${ns}.${literal}`;
+        if (allFlatKeys.has(candidate)) {
+          exact.add(candidate);
+          matched = true;
+        }
+      }
+      if (!matched && consumesTranslationFn) {
+        for (const ns of topLevelNamespaces) {
+          const candidate = `${ns}.${literal}`;
+          if (allFlatKeys.has(candidate)) exact.add(candidate);
+        }
+      }
+    }
+    for (const literal of strongSingleCandidates) {
+      // Prefer per-file namespaces when the file has a `useT(...)` /
+      // heuristic alias bound (e.g. `statusLabelKey` returning `'statusPending'`
+      // in a file that does `useT('todoList')` should only mark
+      // `todoList.statusPending`, not every other namespace that happens
+      // to also have a `statusPending` key). Fall back to a global
+      // namespace search only when the file binds nothing — the
+      // canonical case is a translation-key map declared in a util that
+      // is consumed by another file (e.g. `CATEGORY_I18N_KEY` in
+      // `sanitize-chat-error.ts`).
+      let matched = false;
+      for (const ns of fileNamespaces) {
+        const candidate = `${ns}.${literal}`;
+        if (allFlatKeys.has(candidate)) {
+          exact.add(candidate);
+          matched = true;
+        }
+      }
+      if (!matched && fileNamespaces.size === 0) {
+        for (const ns of topLevelNamespaces) {
+          const candidate = `${ns}.${literal}`;
+          if (allFlatKeys.has(candidate)) exact.add(candidate);
+        }
+      }
+    }
+
     for (const m of content.matchAll(DOTTED_LITERAL_RE)) {
       const literal = m[1];
       if (allFlatKeys.has(literal)) {
         exact.add(literal);
-      } else {
-        const firstSegment = literal.split('.')[0];
-        if (allNamespaces.has(firstSegment)) exact.add(literal);
+        continue;
+      }
+      let matched = false;
+      for (const ns of fileNamespaces) {
+        const candidate = `${ns}.${literal}`;
+        if (allFlatKeys.has(candidate)) {
+          exact.add(candidate);
+          matched = true;
+        }
+      }
+      if (matched) continue;
+      if (lookupTableLiterals.has(literal)) {
+        for (const ns of topLevelNamespaces) {
+          const candidate = `${ns}.${literal}`;
+          if (allFlatKeys.has(candidate)) exact.add(candidate);
+        }
       }
     }
   }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -278,11 +278,21 @@
       "duration": "Dauer",
       "triggeredBy": "Ausgelöst von",
       "teams": "Teams",
-      "uploadedBy": "Hochgeladen von"
+      "uploadedBy": "Hochgeladen von",
+      "actions": "Aktionen",
+      "created": "Erstellt",
+      "description": "Beschreibung",
+      "email": "E-Mail",
+      "product": "Produkt",
+      "scanned": "Gescannt",
+      "stock": "Bestand",
+      "title": "Titel",
+      "website": "Website"
     },
     "cells": {
       "unknown": "Unbekannt",
-      "empty": "-"
+      "empty": "-",
+      "noEmail": "Keine E-Mail"
     }
   },
   "toast": {
@@ -432,7 +442,9 @@
     },
     "forcedChange": {
       "title": "Passwortänderung erforderlich",
-      "submit": "Passwort aktualisieren"
+      "submit": "Passwort aktualisieren",
+      "description": "Dein Passwort ist gemäß der Rotationsrichtlinie der Organisation abgelaufen. Lege ein neues Passwort fest, um fortzufahren.",
+      "descriptionAdminSet": "Dein Passwort wurde von einem Administrator festgelegt. Bitte wähle ein neues Passwort, um fortzufahren."
     },
     "setPassword": {
       "title": "Passwort festlegen",
@@ -531,7 +543,8 @@
       "saveChanges": "Änderungen speichern",
       "loadingMembers": "Wird geladen...",
       "unknownMember": "Unbekannt",
-      "memberChecklistHint": "Ein Mitglied kann mehreren Teams angehören. Wenn niemand ausgewählt wird, wirst du automatisch hinzugefügt."
+      "memberChecklistHint": "Ein Mitglied kann mehreren Teams angehören. Wenn niemand ausgewählt wird, wirst du automatisch hinzugefügt.",
+      "description": "Teams innerhalb deiner Organisation erstellen und verwalten für granulare Zugriffskontrolle"
     },
     "agents": {
       "title": "Agents",
@@ -901,7 +914,8 @@
         "disconnectConfirmDescription": "Möchtest du diese Integration wirklich trennen? Du kannst sie später erneut verbinden.",
         "deleteConfirmTitle": "Integration löschen",
         "deleteConfirmDescription": "Möchtest du diese Integration wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
-        "deleteIntegration": "Integration löschen"
+        "deleteIntegration": "Integration löschen",
+        "saveChanges": "Änderungen speichern"
       },
       "authMethods": {
         "api_key": "API-Schlüssel",
@@ -937,7 +951,31 @@
         "roleDeveloper": "Entwickler",
         "roleEditor": "Redakteur",
         "roleMember": "Mitglied",
-        "roleDisabled": "Deaktiviert"
+        "roleDisabled": "Deaktiviert",
+        "autoProvisionRoleHelp": "Rollen automatisch basierend auf Jobtitel oder App-Rollen aus Entra ID zuweisen",
+        "autoProvisionRoleLabel": "Rollen automatisch zuweisen",
+        "autoProvisionTeamHelp": "Team-Mitgliedschaften automatisch aus Entra ID-Gruppen synchronisieren",
+        "autoProvisionTeamLabel": "Teams automatisch bereitstellen",
+        "clientIdHelp": "Die Anwendungs-ID (Client-ID) aus der Azure-App-Registrierung",
+        "clientIdLabel": "Client-ID",
+        "clientSecretHelp": "Das Client-Secret aus der Azure-App-Registrierung",
+        "clientSecretLabel": "Client-Secret",
+        "configuring": "Wird konfiguriert...",
+        "connectedToEntra": "Verbunden mit Microsoft Entra ID",
+        "defaultRoleHelp": "Rolle, die zugewiesen wird, wenn keine Zuordnungsregeln zutreffen",
+        "defaultRoleHelpNoAutoProvision": "Rolle, die allen SSO-Benutzern zugewiesen wird",
+        "defaultRoleLabel": "Standardrolle",
+        "excludeGroupsHelp": "Kommagetrennte Liste von Entra-Gruppen, die von der Team-Synchronisierung ausgeschlossen werden",
+        "excludeGroupsLabel": "Gruppen ausschließen",
+        "issuerHelp": "Die OIDC-Aussteller-URL für deinen Entra ID-Mandanten",
+        "issuerLabel": "Aussteller-URL",
+        "oneDriveAccessHelp": "Benutzern erlauben, mit ihren SSO-Zugangsdaten auf OneDrive- und SharePoint-Dateien zuzugreifen",
+        "oneDriveAccessLabel": "OneDrive/SharePoint-Zugriff aktivieren",
+        "testConnection": "Verbindung testen",
+        "testPassed": "Gültig",
+        "testing": "Wird getestet...",
+        "title": "SSO-Konfiguration",
+        "updating": "Wird aktualisiert..."
       }
     },
     "providers": {
@@ -1038,7 +1076,11 @@
       "modelApiKeyOverrideIndicator": "Eigener Key",
       "deleteModelApiKey": "Entfernen",
       "undoRemoveKey": "Rückgängig",
-      "costHelp": "Wird für die Budgetverfolgung verwendet. Leer lassen für Standardschätzungen."
+      "costHelp": "Wird für die Budgetverfolgung verwendet. Leer lassen für Standardschätzungen.",
+      "description": "Beschreibung",
+      "tagImageEdit": "Bildbearbeitung",
+      "tagImageGeneration": "Bildgenerierung",
+      "tagTranscription": "Transkription"
     },
     "form": {
       "name": "Name",
@@ -1090,7 +1132,9 @@
           "never": "Nie"
         }
       },
-      "neverUsed": "Nie verwendet"
+      "neverUsed": "Nie verwendet",
+      "description": "API-Schlüssel für externe Integrationen verwalten",
+      "title": "API-Schlüssel"
     },
     "apiDocs": {
       "openDocs": "API-Dokumentation"
@@ -1671,6 +1715,16 @@
       "all": "Alle",
       "read": "Gelesen",
       "unread": "Ungelesen"
+    },
+    "category": {
+      "churnSurvey": "Abwanderungsumfrage",
+      "productRecommendation": "Produktempfehlung",
+      "serviceRequest": "Serviceanfrage"
+    },
+    "priority": {
+      "high": "Hoch",
+      "low": "Niedrig",
+      "medium": "Mittel"
     }
   },
   "composer": {
@@ -1693,7 +1747,12 @@
     "paneResizeHandle": "Planbereich vergrößern",
     "stripOpen": "Recherche-Plan öffnen",
     "showMoreSources": "{count} weitere Quellen anzeigen",
-    "hideSources": "Zusätzliche Quellen ausblenden"
+    "hideSources": "Zusätzliche Quellen ausblenden",
+    "statusCancelled": "Abgebrochen",
+    "statusDone": "Erledigt",
+    "statusFailed": "Fehlgeschlagen",
+    "statusInProgress": "In Bearbeitung",
+    "statusPending": "Offen"
   },
   "humanInputRequest": {
     "questionTitle": "Frage",
@@ -1906,7 +1965,15 @@
       "noResults": "Keine Modelle gefunden",
       "auto": "Auto",
       "autoDescription": "Wählt automatisch das beste verfügbare Modell mit Fallback",
-      "noModelsAvailable": "Keine Modelle verfügbar"
+      "noModelsAvailable": "Keine Modelle verfügbar",
+      "tags": {
+        "chat": "Chat",
+        "embedding": "Embedding",
+        "imageEdit": "Bildbearbeitung",
+        "imageGeneration": "Bildgenerierung",
+        "transcription": "Transkription",
+        "vision": "Vision"
+      }
     },
     "searchChat": "Chat durchsuchen",
     "hideSearch": "Suche ausblenden",
@@ -2167,7 +2234,18 @@
     "savePromptMenu": "Speicheroptionen",
     "unsavePrompt": "Prompt entfernen",
     "unsavePromptConfirm": "Der gespeicherte Prompt wird entfernt. Du kannst ihn jederzeit erneut speichern.",
-    "unsavePromptAction": "Entfernen"
+    "unsavePromptAction": "Entfernen",
+    "errorGeneratingDescription": "Beim Generieren einer Antwort ist ein Fehler aufgetreten. Bitte versuche es erneut.",
+    "errorHintAuthError": "Der API-Schlüssel ist ungültig oder hat keinen Zugriff auf dieses Modell. Kontaktiere deinen Administrator.",
+    "errorHintContentFilter": "Die Nachricht wurde vom Inhaltsfilter markiert. Versuche, deine Nachricht umzuformulieren.",
+    "errorHintContextLength": "Die Konversation ist zu lang für das Kontextfenster des Modells. Versuche, einen neuen Chat zu starten.",
+    "errorHintCreditExhausted": "Das Guthaben des KI-Anbieters wurde überschritten. Kontaktiere deinen Administrator, um Guthaben aufzuladen.",
+    "errorHintMissingApiKey": "Für diese Organisation ist noch kein API-Schlüssel konfiguriert. Öffne Einstellungen → KI-Anbieter und füge einen hinzu, um den Chat zu starten.",
+    "errorHintModelNotFound": "Das ausgewählte Modell wurde nicht gefunden oder ist nicht verfügbar. Kontaktiere deinen Administrator.",
+    "errorHintProviderError": "Der KI-Anbieter hat vorübergehend technische Probleme. Bitte versuche es in einem Moment erneut.",
+    "errorHintRateLimited": "Zu viele Anfragen. Bitte warte einen Moment und versuche es erneut.",
+    "errorHintTokenLimit": "Das Token-Limit des Modells wurde überschritten. Versuche eine kürzere Anfrage oder bitte deinen Administrator, die Modelleinstellungen anzupassen.",
+    "errorHintToolFailure": "Der Agent hat beim Datenzugriff einen Fehler festgestellt. Versuche, deine Anfrage umzuformulieren oder weniger Daten anzufordern."
   },
   "documents": {
     "searchPlaceholder": "Dokumente suchen",
@@ -2398,6 +2476,13 @@
           "unknownError": "Unbekannter Fehler aufgetreten"
         }
       }
+    },
+    "sourceType": {
+      "oneDrive": "OneDrive",
+      "oneDriveSynced": "OneDrive (synchronisiert)",
+      "sharePoint": "SharePoint",
+      "sharePointSynced": "SharePoint (synchronisiert)",
+      "uploaded": "Upload"
     }
   },
   "products": {
@@ -2454,7 +2539,10 @@
       "clickToUpload": "Klicken zum Hochladen",
       "supportedFormats": ".xlsx, .xls oder .csv",
       "expectedColumns": "Erwartete Spalten: name, description, imageUrl, stock, price, currency, category, status",
-      "draftStatusNote": "Importierte Produkte werden standardmässig mit dem Status \"Entwurf\" erstellt."
+      "draftStatusNote": "Importierte Produkte werden standardmässig mit dem Status \"Entwurf\" erstellt.",
+      "errorCodes": {
+        "unknown": "Ein unerwarteter Fehler ist aufgetreten"
+      }
     },
     "actions": {
       "deleteFailed": "Produkt konnte nicht gelöscht werden",
@@ -2535,8 +2623,16 @@
       "error": "Importfehler",
       "addCustomers": "Kunden hinzufügen",
       "uploadCustomers": "Kunden hochladen",
-      "import": "Importieren"
-    }
+      "import": "Importieren",
+      "errorCodes": {
+        "duplicate_email": "Ein Kunde mit dieser E-Mail existiert bereits",
+        "duplicate_external_id": "Ein Kunde mit dieser externen ID existiert bereits",
+        "unknown": "Ein unerwarteter Fehler ist aufgetreten"
+      }
+    },
+    "deleteConfirmation": "Möchtest du {name} wirklich löschen?",
+    "deleteError": "Kunde konnte nicht gelöscht werden",
+    "deleteWarning": "Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "vendors": {
     "title": "Lieferanten",
@@ -2578,8 +2674,15 @@
       "provideData": "Bitte gib Lieferantendaten ein",
       "success": "Import erfolgreich",
       "successDescription": "{success} Lieferanten erfolgreich importiert{failed, select, 0 {} other {, {failed} fehlgeschlagen}}",
-      "error": "Lieferanten konnten nicht importiert werden"
-    }
+      "error": "Lieferanten konnten nicht importiert werden",
+      "errorCodes": {
+        "duplicate_email": "Ein Lieferant mit dieser E-Mail existiert bereits",
+        "duplicate_external_id": "Ein Lieferant mit dieser externen ID existiert bereits",
+        "unknown": "Ein unerwarteter Fehler ist aufgetreten"
+      }
+    },
+    "deleteConfirmation": "Möchtest du {name} wirklich löschen?",
+    "deleteError": "Lieferant konnte nicht gelöscht werden"
   },
   "websites": {
     "title": "Websites",
@@ -2611,7 +2714,8 @@
       "updateSuccess": "Website erfolgreich aktualisiert",
       "updateError": "Website konnte nicht aktualisiert werden",
       "fetchPagesError": "Seiten konnten nicht geladen werden",
-      "searchError": "Suche fehlgeschlagen"
+      "searchError": "Suche fehlgeschlagen",
+      "deleteError": "Website konnte nicht gelöscht werden"
     },
     "adding": "Wird hinzugefügt...",
     "viewDialog": {
@@ -2659,6 +2763,10 @@
         "7d": "Alle 7 Tage",
         "30d": "Alle 30 Tage"
       }
+    },
+    "delete": {
+      "confirmation": "Möchtest du diese Website wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "title": "Website löschen"
     }
   },
   "twoFactor": {
@@ -2710,7 +2818,9 @@
     },
     "lowBackupCodes": {
       "body": "Erzeuge einen neuen Satz, damit du dein Konto wiederherstellen kannst, falls du deine Authenticator-App verlierst.",
-      "regenerateLink": "Jetzt neu erzeugen"
+      "regenerateLink": "Jetzt neu erzeugen",
+      "titleOne": "Nur noch 1 Backup-Code übrig",
+      "titleOther": "Nur noch {count} Backup-Codes übrig"
     },
     "enroll": {
       "title": "Zwei-Faktor erforderlich",
@@ -2718,7 +2828,9 @@
     },
     "grace": {
       "body": "Deine Organisation wird von allen Mitgliedern einen zweiten Faktor verlangen. Richte ihn jetzt ein, um Unterbrechungen zu vermeiden.",
-      "setupLink": "Jetzt einrichten"
+      "setupLink": "Jetzt einrichten",
+      "titleOne": "Zwei-Faktor-Authentifizierung in {days} Tag erforderlich",
+      "titleOther": "Zwei-Faktor-Authentifizierung in {days} Tagen erforderlich"
     },
     "admin": {
       "resetButton": "Zwei-Faktor zurücksetzen",
@@ -2744,7 +2856,8 @@
     "branding": "Du benötigst Admin-Berechtigungen, um auf die Branding-Einstellungen zuzugreifen.",
     "knowledge": "Dein Konto hat keine Berechtigung, auf Wissen zuzugreifen.",
     "workspaceNotFound": "Der gesuchte Workspace existiert nicht oder wurde möglicherweise entfernt.",
-    "disabled": "Dein Konto wurde deaktiviert. Kontaktiere den Support für Unterstützung."
+    "disabled": "Dein Konto wurde deaktiviert. Kontaktiere den Support für Unterstützung.",
+    "noMembership": "Du bist kein Mitglied dieses Workspace. Bitte kontaktiere einen Administrator für Zugriff."
   },
   "metadata": {
     "suffix": "Tale",
@@ -2999,7 +3112,11 @@
       "noProvidersFound": "Keine Anbieter gefunden",
       "noModelsFound": "Keine Modelle gefunden",
       "noTeamsFound": "Keine Teams gefunden",
-      "confirm": "Bestätigen"
+      "confirm": "Bestätigen",
+      "allowlistConflictWarning": "Dieses Modell ist derzeit nicht durch die Allowlist der Modellzugriffsrichtlinie für diesen Geltungsbereich zugelassen. Betroffene Benutzer weichen auf ein erlaubtes Modell aus.",
+      "allowlistConflictWarningTitle": "Modell nicht in Allowlist",
+      "blocklistConflictWarning": "Dieses Modell ist derzeit durch die Modellzugriffsrichtlinie für diesen Geltungsbereich blockiert. Betroffene Benutzer weichen auf ein erlaubtes Modell aus.",
+      "blocklistConflictWarningTitle": "Modell ist blockiert"
     },
     "uploadPolicy": {
       "title": "Upload-Richtlinie",
@@ -3451,7 +3568,15 @@
       "testResultCircuit": "Circuit",
       "testResultCircuitOpened": "Durch diesen Fehler geöffnet",
       "saved": "Moderations-Anbieter gespeichert",
-      "saveFailed": "Speichern fehlgeschlagen"
+      "saveFailed": "Speichern fehlgeschlagen",
+      "presetAzure": "Azure Content Safety verwenden",
+      "presetAzureActive": "Azure Content Safety",
+      "presetAzureNote": "Ersetze die Subdomain durch den Namen deiner eigenen Azure-Ressource.",
+      "presetOpenai": "OpenAI Moderation verwenden",
+      "presetOpenaiActive": "OpenAI Moderation",
+      "presetPerspective": "Perspective API verwenden",
+      "presetPerspectiveActive": "Perspective API",
+      "presetPerspectiveNote": "Perspective authentifiziert per URL-Query-Parameter, nicht per Header. Nach dem Anwenden des Presets öffne „Endpoint“ und hänge ?key=DEIN_PERSPECTIVE_KEY an die URL an. (Das unten verschlüsselte API-Schlüsselfeld wird von Perspective nicht verwendet.)"
     },
     "groups": {
       "contentAndModels": "Inhalte & Modelle",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -278,11 +278,21 @@
       "duration": "Duration",
       "triggeredBy": "Triggered by",
       "teams": "Teams",
-      "uploadedBy": "Uploaded by"
+      "uploadedBy": "Uploaded by",
+      "actions": "Actions",
+      "created": "Created",
+      "description": "Description",
+      "email": "Email",
+      "product": "Product",
+      "scanned": "Scanned",
+      "stock": "Stock",
+      "title": "Title",
+      "website": "Website"
     },
     "cells": {
       "unknown": "Unknown",
-      "empty": "-"
+      "empty": "-",
+      "noEmail": "No email"
     }
   },
   "toast": {
@@ -432,7 +442,9 @@
     },
     "forcedChange": {
       "title": "Password change required",
-      "submit": "Update password"
+      "submit": "Update password",
+      "description": "Your password has expired per the organization's rotation policy. Set a new password to continue.",
+      "descriptionAdminSet": "Your password was set by an administrator. Please choose a new password to continue."
     },
     "setPassword": {
       "title": "Set password",
@@ -531,7 +543,8 @@
       "saveChanges": "Save changes",
       "loadingMembers": "Loading...",
       "unknownMember": "Unknown",
-      "memberChecklistHint": "A member can be part of multiple teams. If no one is selected, you will be added automatically."
+      "memberChecklistHint": "A member can be part of multiple teams. If no one is selected, you will be added automatically.",
+      "description": "Create and manage teams within your organization for granular access control"
     },
     "agents": {
       "title": "Agents",
@@ -901,7 +914,8 @@
         "disconnectConfirmDescription": "Are you sure you want to disconnect this integration? You can reconnect it later.",
         "deleteConfirmTitle": "Delete integration",
         "deleteConfirmDescription": "Are you sure you want to delete this integration? This action cannot be undone.",
-        "deleteIntegration": "Delete integration"
+        "deleteIntegration": "Delete integration",
+        "saveChanges": "Save changes"
       },
       "authMethods": {
         "api_key": "API key",
@@ -937,7 +951,31 @@
         "roleDeveloper": "Developer",
         "roleEditor": "Editor",
         "roleMember": "Member",
-        "roleDisabled": "Disabled"
+        "roleDisabled": "Disabled",
+        "autoProvisionRoleHelp": "Automatically assign roles based on job title or app roles from Entra ID",
+        "autoProvisionRoleLabel": "Auto-provision roles",
+        "autoProvisionTeamHelp": "Automatically sync team memberships from Entra ID groups",
+        "autoProvisionTeamLabel": "Auto-provision teams",
+        "clientIdHelp": "The Application (client) ID from Azure App Registration",
+        "clientIdLabel": "Client ID",
+        "clientSecretHelp": "The client secret from Azure App Registration",
+        "clientSecretLabel": "Client secret",
+        "configuring": "Configuring...",
+        "connectedToEntra": "Connected to Microsoft Entra ID",
+        "defaultRoleHelp": "Role assigned when no mapping rules match",
+        "defaultRoleHelpNoAutoProvision": "Role assigned to all SSO users",
+        "defaultRoleLabel": "Default role",
+        "excludeGroupsHelp": "Comma-separated list of Entra groups to exclude from team sync",
+        "excludeGroupsLabel": "Exclude groups",
+        "issuerHelp": "The OIDC issuer URL for your Entra ID tenant",
+        "issuerLabel": "Issuer URL",
+        "oneDriveAccessHelp": "Allow users to access OneDrive and SharePoint files using their SSO credentials",
+        "oneDriveAccessLabel": "Enable OneDrive/SharePoint access",
+        "testConnection": "Test connection",
+        "testPassed": "Valid",
+        "testing": "Testing...",
+        "title": "SSO configuration",
+        "updating": "Updating..."
       }
     },
     "providers": {
@@ -1038,7 +1076,11 @@
       "modelApiKeyOverrideIndicator": "Custom key",
       "deleteModelApiKey": "Remove",
       "undoRemoveKey": "Undo",
-      "costHelp": "Used for budget tracking. Leave empty to use default estimates."
+      "costHelp": "Used for budget tracking. Leave empty to use default estimates.",
+      "description": "Description",
+      "tagImageEdit": "Image edit",
+      "tagImageGeneration": "Image generation",
+      "tagTranscription": "Transcription"
     },
     "form": {
       "name": "Name",
@@ -1090,7 +1132,9 @@
           "never": "Never"
         }
       },
-      "neverUsed": "Never used"
+      "neverUsed": "Never used",
+      "description": "Manage API keys for external integrations",
+      "title": "API keys"
     },
     "apiDocs": {
       "openDocs": "API docs"
@@ -1671,6 +1715,16 @@
       "all": "All",
       "read": "Read",
       "unread": "Unread"
+    },
+    "category": {
+      "churnSurvey": "Churn survey",
+      "productRecommendation": "Product recommendation",
+      "serviceRequest": "Service request"
+    },
+    "priority": {
+      "high": "High",
+      "low": "Low",
+      "medium": "Medium"
     }
   },
   "composer": {
@@ -1693,7 +1747,12 @@
     "paneResizeHandle": "Resize plan panel",
     "stripOpen": "Open research plan",
     "showMoreSources": "Show {count} more sources",
-    "hideSources": "Hide additional sources"
+    "hideSources": "Hide additional sources",
+    "statusCancelled": "Cancelled",
+    "statusDone": "Done",
+    "statusFailed": "Failed",
+    "statusInProgress": "In progress",
+    "statusPending": "Pending"
   },
   "humanInputRequest": {
     "questionTitle": "Question",
@@ -1906,7 +1965,15 @@
       "noResults": "No models found",
       "auto": "Auto",
       "autoDescription": "Automatically selects the best available model with fallback",
-      "noModelsAvailable": "No models available"
+      "noModelsAvailable": "No models available",
+      "tags": {
+        "chat": "Chat",
+        "embedding": "Embedding",
+        "imageEdit": "Image editing",
+        "imageGeneration": "Image generation",
+        "transcription": "Transcription",
+        "vision": "Vision"
+      }
     },
     "searchChat": "Search chat",
     "hideSearch": "Hide search",
@@ -2167,7 +2234,18 @@
     "savePromptMenu": "Save options",
     "unsavePrompt": "Unsave prompt",
     "unsavePromptConfirm": "This will remove the saved prompt. You can always save it again later.",
-    "unsavePromptAction": "Unsave"
+    "unsavePromptAction": "Unsave",
+    "errorGeneratingDescription": "There was an error generating a response. Please try again.",
+    "errorHintAuthError": "The API key is invalid or does not have access to this model. Contact your administrator.",
+    "errorHintContentFilter": "The message was flagged by the content filter. Try rephrasing your message.",
+    "errorHintContextLength": "The conversation is too long for the model's context window. Try starting a new chat.",
+    "errorHintCreditExhausted": "The AI provider's credit limit was exceeded. Contact your administrator to add credits.",
+    "errorHintMissingApiKey": "No API key is configured for this organization yet. Open Settings → AI providers and add one to start chatting.",
+    "errorHintModelNotFound": "The selected model was not found or is unavailable. Contact your administrator.",
+    "errorHintProviderError": "The AI provider is temporarily experiencing issues. Please try again in a moment.",
+    "errorHintRateLimited": "Too many requests. Please wait a moment and try again.",
+    "errorHintTokenLimit": "The model's output token limit was exceeded. Try a shorter request or ask your administrator to adjust the model settings.",
+    "errorHintToolFailure": "The agent encountered an error while accessing data. Try rephrasing your request or asking for a smaller set of data."
   },
   "documents": {
     "searchPlaceholder": "Search documents",
@@ -2398,6 +2476,13 @@
           "unknownError": "Unknown error occurred"
         }
       }
+    },
+    "sourceType": {
+      "oneDrive": "OneDrive",
+      "oneDriveSynced": "OneDrive (synced)",
+      "sharePoint": "SharePoint",
+      "sharePointSynced": "SharePoint (synced)",
+      "uploaded": "Upload"
     }
   },
   "products": {
@@ -2454,7 +2539,10 @@
       "clickToUpload": "Click to upload",
       "supportedFormats": ".xlsx, .xls or .csv",
       "expectedColumns": "Expected columns: name, description, imageUrl, stock, price, currency, category, status",
-      "draftStatusNote": "Imported products are created with 'draft' status by default."
+      "draftStatusNote": "Imported products are created with 'draft' status by default.",
+      "errorCodes": {
+        "unknown": "An unexpected error occurred"
+      }
     },
     "actions": {
       "deleteFailed": "Failed to delete product",
@@ -2535,8 +2623,16 @@
       "error": "Import error",
       "addCustomers": "Add customers",
       "uploadCustomers": "Upload customers",
-      "import": "Import"
-    }
+      "import": "Import",
+      "errorCodes": {
+        "duplicate_email": "A customer with this email already exists",
+        "duplicate_external_id": "A customer with this external ID already exists",
+        "unknown": "An unexpected error occurred"
+      }
+    },
+    "deleteConfirmation": "Are you sure you want to delete {name}?",
+    "deleteError": "Failed to delete customer",
+    "deleteWarning": "This action cannot be undone."
   },
   "vendors": {
     "title": "Vendors",
@@ -2578,8 +2674,15 @@
       "provideData": "Please provide vendor data",
       "success": "Import successful",
       "successDescription": "Successfully imported {success} vendors{failed, select, 0 {} other {, {failed} failed}}",
-      "error": "Failed to import vendors"
-    }
+      "error": "Failed to import vendors",
+      "errorCodes": {
+        "duplicate_email": "A vendor with this email already exists",
+        "duplicate_external_id": "A vendor with this external ID already exists",
+        "unknown": "An unexpected error occurred"
+      }
+    },
+    "deleteConfirmation": "Are you sure you want to delete {name}?",
+    "deleteError": "Failed to delete vendor"
   },
   "websites": {
     "title": "Websites",
@@ -2611,7 +2714,8 @@
       "updateSuccess": "Website updated successfully",
       "updateError": "Failed to update website",
       "fetchPagesError": "Failed to load pages",
-      "searchError": "Search failed"
+      "searchError": "Search failed",
+      "deleteError": "Failed to delete website"
     },
     "adding": "Adding...",
     "viewDialog": {
@@ -2659,6 +2763,10 @@
         "7d": "Every 7 days",
         "30d": "Every 30 days"
       }
+    },
+    "delete": {
+      "confirmation": "Are you sure you want to delete this website? This action cannot be undone.",
+      "title": "Delete website"
     }
   },
   "twoFactor": {
@@ -2710,7 +2818,9 @@
     },
     "lowBackupCodes": {
       "body": "Generate a new batch so you can still recover your account if you lose your authenticator.",
-      "regenerateLink": "Regenerate now"
+      "regenerateLink": "Regenerate now",
+      "titleOne": "Only 1 backup code remaining",
+      "titleOther": "Only {count} backup codes remaining"
     },
     "enroll": {
       "title": "Two-factor required",
@@ -2718,7 +2828,9 @@
     },
     "grace": {
       "body": "Your organization will require all members to use a second factor. Enrol now to avoid interruption.",
-      "setupLink": "Set up now"
+      "setupLink": "Set up now",
+      "titleOne": "Two-factor authentication required in {days} day",
+      "titleOther": "Two-factor authentication required in {days} days"
     },
     "admin": {
       "resetButton": "Reset two-factor",
@@ -2744,7 +2856,8 @@
     "branding": "You need Admin permissions to access branding settings.",
     "knowledge": "Your account does not have permission to access knowledge.",
     "workspaceNotFound": "The workspace you're looking for doesn't exist or may have been removed.",
-    "disabled": "Your account has been disabled. Contact support for assistance."
+    "disabled": "Your account has been disabled. Contact support for assistance.",
+    "noMembership": "You are not a member of this workspace. Please contact an administrator for access."
   },
   "metadata": {
     "suffix": "Tale",
@@ -2999,7 +3112,11 @@
       "noProvidersFound": "No providers found",
       "noModelsFound": "No models found",
       "noTeamsFound": "No teams found",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "allowlistConflictWarning": "This model isn't currently permitted by the Model access allowlist for this scope. Users receiving this default will fall back to an allowlist-permitted model.",
+      "allowlistConflictWarningTitle": "Model not in allowlist",
+      "blocklistConflictWarning": "This model is currently blocked by the Model access policy for this scope. Users receiving this default will fall back to a permitted model.",
+      "blocklistConflictWarningTitle": "Model is blocked"
     },
     "uploadPolicy": {
       "title": "Upload policy",
@@ -3451,7 +3568,15 @@
       "testResultCircuit": "Circuit",
       "testResultCircuitOpened": "Opened by this failure",
       "saved": "Moderation provider saved",
-      "saveFailed": "Save failed"
+      "saveFailed": "Save failed",
+      "presetAzure": "Use Azure Content Safety",
+      "presetAzureActive": "Azure Content Safety",
+      "presetAzureNote": "Replace the subdomain with your own Azure resource name.",
+      "presetOpenai": "Use OpenAI Moderation",
+      "presetOpenaiActive": "OpenAI Moderation",
+      "presetPerspective": "Use Perspective API",
+      "presetPerspectiveActive": "Perspective API",
+      "presetPerspectiveNote": "Perspective authenticates via a URL query parameter, not a header. After applying the preset, open Endpoint and append ?key=YOUR_PERSPECTIVE_KEY to the URL. (The encrypted API-key field below is not used by Perspective.)"
     },
     "groups": {
       "contentAndModels": "Content & Models",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -278,11 +278,21 @@
       "duration": "Durée",
       "triggeredBy": "Déclenché par",
       "teams": "Équipes",
-      "uploadedBy": "Téléversé par"
+      "uploadedBy": "Téléversé par",
+      "actions": "Actions",
+      "created": "Créé",
+      "description": "Description",
+      "email": "E-mail",
+      "product": "Produit",
+      "scanned": "Analysé",
+      "stock": "Stock",
+      "title": "Titre",
+      "website": "Site web"
     },
     "cells": {
       "unknown": "Inconnu",
-      "empty": "-"
+      "empty": "-",
+      "noEmail": "Aucun e-mail"
     }
   },
   "toast": {
@@ -432,7 +442,9 @@
     },
     "forcedChange": {
       "title": "Changement de mot de passe requis",
-      "submit": "Mettre à jour le mot de passe"
+      "submit": "Mettre à jour le mot de passe",
+      "description": "Ton mot de passe a expiré selon la politique de rotation de l'organisation. Définis un nouveau mot de passe pour continuer.",
+      "descriptionAdminSet": "Ton mot de passe a été défini par un administrateur. Choisis un nouveau mot de passe pour continuer."
     },
     "setPassword": {
       "title": "Définir un mot de passe",
@@ -531,7 +543,8 @@
       "saveChanges": "Enregistrer les modifications",
       "loadingMembers": "Chargement...",
       "unknownMember": "Inconnu",
-      "memberChecklistHint": "Un membre peut appartenir à plusieurs équipes. Si personne n'est sélectionné, tu seras ajouté automatiquement."
+      "memberChecklistHint": "Un membre peut appartenir à plusieurs équipes. Si personne n'est sélectionné, tu seras ajouté automatiquement.",
+      "description": "Crée et gère des équipes au sein de ton organisation pour un contrôle d'accès granulaire"
     },
     "agents": {
       "title": "Agents",
@@ -901,7 +914,8 @@
         "disconnectConfirmDescription": "Es-tu sûr de vouloir déconnecter cette intégration ? Tu pourras la reconnecter ultérieurement.",
         "deleteConfirmTitle": "Supprimer l'intégration",
         "deleteConfirmDescription": "Es-tu sûr de vouloir supprimer cette intégration ? Cette action est irréversible.",
-        "deleteIntegration": "Supprimer l'intégration"
+        "deleteIntegration": "Supprimer l'intégration",
+        "saveChanges": "Enregistrer les modifications"
       },
       "authMethods": {
         "api_key": "Clé API",
@@ -937,7 +951,31 @@
         "roleDeveloper": "Développeur",
         "roleEditor": "Éditeur",
         "roleMember": "Membre",
-        "roleDisabled": "Désactivé"
+        "roleDisabled": "Désactivé",
+        "autoProvisionRoleHelp": "Attribuer automatiquement des rôles en fonction de l'intitulé de poste ou des rôles d'application depuis Entra ID",
+        "autoProvisionRoleLabel": "Provisionnement automatique des rôles",
+        "autoProvisionTeamHelp": "Synchroniser automatiquement les appartenances aux équipes depuis les groupes Entra ID",
+        "autoProvisionTeamLabel": "Provisionnement automatique des équipes",
+        "clientIdHelp": "L'ID d'application (client) depuis l'inscription d'application Azure",
+        "clientIdLabel": "ID client",
+        "clientSecretHelp": "Le secret client depuis l'inscription d'application Azure",
+        "clientSecretLabel": "Secret client",
+        "configuring": "Configuration...",
+        "connectedToEntra": "Connecté à Microsoft Entra ID",
+        "defaultRoleHelp": "Rôle attribué lorsqu'aucune règle de correspondance ne s'applique",
+        "defaultRoleHelpNoAutoProvision": "Rôle attribué à tous les utilisateurs SSO",
+        "defaultRoleLabel": "Rôle par défaut",
+        "excludeGroupsHelp": "Liste de groupes Entra séparés par des virgules à exclure de la synchronisation des équipes",
+        "excludeGroupsLabel": "Exclure des groupes",
+        "issuerHelp": "L'URL de l'émetteur OIDC pour ton locataire Entra ID",
+        "issuerLabel": "URL de l'émetteur",
+        "oneDriveAccessHelp": "Permettre aux utilisateurs d'accéder aux fichiers OneDrive et SharePoint en utilisant leurs identifiants SSO",
+        "oneDriveAccessLabel": "Activer l'accès OneDrive/SharePoint",
+        "testConnection": "Tester la connexion",
+        "testPassed": "Valide",
+        "testing": "Test en cours...",
+        "title": "Configuration SSO",
+        "updating": "Mise à jour..."
       }
     },
     "providers": {
@@ -1038,7 +1076,11 @@
       "modelApiKeyOverrideIndicator": "Clé personnalisée",
       "deleteModelApiKey": "Supprimer",
       "undoRemoveKey": "Annuler",
-      "costHelp": "Utilisé pour le suivi du budget. Laisse vide pour utiliser les estimations par défaut."
+      "costHelp": "Utilisé pour le suivi du budget. Laisse vide pour utiliser les estimations par défaut.",
+      "description": "Description",
+      "tagImageEdit": "Édition d'images",
+      "tagImageGeneration": "Génération d'images",
+      "tagTranscription": "Transcription"
     },
     "form": {
       "name": "Nom",
@@ -1090,7 +1132,9 @@
           "never": "Jamais"
         }
       },
-      "neverUsed": "Jamais utilisée"
+      "neverUsed": "Jamais utilisée",
+      "description": "Gérer les clés API pour les intégrations externes",
+      "title": "Clés API"
     },
     "apiDocs": {
       "openDocs": "Documentation API"
@@ -1671,6 +1715,16 @@
       "all": "Tous",
       "read": "Lus",
       "unread": "Non lus"
+    },
+    "category": {
+      "churnSurvey": "Enquête de désabonnement",
+      "productRecommendation": "Recommandation de produit",
+      "serviceRequest": "Demande de service"
+    },
+    "priority": {
+      "high": "Haute",
+      "low": "Basse",
+      "medium": "Moyenne"
     }
   },
   "composer": {
@@ -1693,7 +1747,12 @@
     "paneResizeHandle": "Redimensionner le panneau de plan",
     "stripOpen": "Ouvrir le plan de recherche",
     "showMoreSources": "Afficher {count} sources de plus",
-    "hideSources": "Masquer les sources supplémentaires"
+    "hideSources": "Masquer les sources supplémentaires",
+    "statusCancelled": "Annulé",
+    "statusDone": "Terminé",
+    "statusFailed": "Échoué",
+    "statusInProgress": "En cours",
+    "statusPending": "En attente"
   },
   "humanInputRequest": {
     "questionTitle": "Question",
@@ -1906,7 +1965,15 @@
       "noResults": "Aucun modèle trouvé",
       "auto": "Auto",
       "autoDescription": "Sélectionne automatiquement le meilleur modèle disponible avec repli",
-      "noModelsAvailable": "Aucun modèle disponible"
+      "noModelsAvailable": "Aucun modèle disponible",
+      "tags": {
+        "chat": "Chat",
+        "embedding": "Embedding",
+        "imageEdit": "Édition d'images",
+        "imageGeneration": "Génération d'images",
+        "transcription": "Transcription",
+        "vision": "Vision"
+      }
     },
     "searchChat": "Rechercher dans le chat",
     "hideSearch": "Masquer la recherche",
@@ -2167,7 +2234,18 @@
     "savePromptMenu": "Options d'enregistrement",
     "unsavePrompt": "Retirer le prompt",
     "unsavePromptConfirm": "Le prompt enregistré sera supprimé. Tu pourras toujours le sauvegarder à nouveau plus tard.",
-    "unsavePromptAction": "Retirer"
+    "unsavePromptAction": "Retirer",
+    "errorGeneratingDescription": "Une erreur est survenue lors de la génération de la réponse. Merci de réessayer.",
+    "errorHintAuthError": "La clé API est invalide ou n'a pas accès à ce modèle. Contacte ton administrateur.",
+    "errorHintContentFilter": "Le message a été signalé par le filtre de contenu. Essaie de reformuler ton message.",
+    "errorHintContextLength": "La conversation est trop longue pour la fenêtre de contexte du modèle. Essaie de démarrer un nouveau chat.",
+    "errorHintCreditExhausted": "Le plafond de crédits du fournisseur d'IA a été dépassé. Contacte ton administrateur pour ajouter des crédits.",
+    "errorHintMissingApiKey": "Aucune clé API n'est encore configurée pour cette organisation. Ouvre Paramètres → Fournisseurs d'IA et ajoute-en une pour commencer à discuter.",
+    "errorHintModelNotFound": "Le modèle sélectionné est introuvable ou indisponible. Contacte ton administrateur.",
+    "errorHintProviderError": "Le fournisseur d'IA rencontre temporairement des problèmes. Merci de réessayer dans un instant.",
+    "errorHintRateLimited": "Trop de requêtes. Merci de patienter un moment et réessayer.",
+    "errorHintTokenLimit": "La limite de tokens en sortie du modèle a été dépassée. Essaie une requête plus courte ou demande à ton administrateur d'ajuster les paramètres du modèle.",
+    "errorHintToolFailure": "L'agent a rencontré une erreur lors de l'accès aux données. Essaie de reformuler ta demande ou de demander un ensemble de données plus restreint."
   },
   "documents": {
     "searchPlaceholder": "Rechercher des documents",
@@ -2398,6 +2476,13 @@
           "unknownError": "Erreur inconnue survenue"
         }
       }
+    },
+    "sourceType": {
+      "oneDrive": "OneDrive",
+      "oneDriveSynced": "OneDrive (synchronisé)",
+      "sharePoint": "SharePoint",
+      "sharePointSynced": "SharePoint (synchronisé)",
+      "uploaded": "Téléversement"
     }
   },
   "products": {
@@ -2454,7 +2539,10 @@
       "clickToUpload": "Clique pour téléverser",
       "supportedFormats": ".xlsx, .xls ou .csv",
       "expectedColumns": "Colonnes attendues : name, description, imageUrl, stock, price, currency, category, status",
-      "draftStatusNote": "Les produits importés sont créés avec le statut « brouillon » par défaut."
+      "draftStatusNote": "Les produits importés sont créés avec le statut « brouillon » par défaut.",
+      "errorCodes": {
+        "unknown": "Une erreur inattendue s'est produite"
+      }
     },
     "actions": {
       "deleteFailed": "Échec de la suppression du produit",
@@ -2535,8 +2623,16 @@
       "error": "Erreur d'importation",
       "addCustomers": "Ajouter des clients",
       "uploadCustomers": "Téléverser des clients",
-      "import": "Importer"
-    }
+      "import": "Importer",
+      "errorCodes": {
+        "duplicate_email": "Un client avec cette adresse e-mail existe déjà",
+        "duplicate_external_id": "Un client avec cet identifiant externe existe déjà",
+        "unknown": "Une erreur inattendue s'est produite"
+      }
+    },
+    "deleteConfirmation": "Es-tu sûr de vouloir supprimer {name} ?",
+    "deleteError": "Échec de la suppression du client",
+    "deleteWarning": "Cette action est irréversible."
   },
   "vendors": {
     "title": "Fournisseurs",
@@ -2578,8 +2674,15 @@
       "provideData": "Fournis les données du fournisseur",
       "success": "Importation réussie",
       "successDescription": "Importation réussie de {success} fournisseurs{failed, select, 0 {} other {, {failed} échoué(s)}}",
-      "error": "Échec de l'importation des fournisseurs"
-    }
+      "error": "Échec de l'importation des fournisseurs",
+      "errorCodes": {
+        "duplicate_email": "Un fournisseur avec cette adresse e-mail existe déjà",
+        "duplicate_external_id": "Un fournisseur avec cet identifiant externe existe déjà",
+        "unknown": "Une erreur inattendue s'est produite"
+      }
+    },
+    "deleteConfirmation": "Es-tu sûr de vouloir supprimer {name} ?",
+    "deleteError": "Échec de la suppression du fournisseur"
   },
   "websites": {
     "title": "Sites web",
@@ -2611,7 +2714,8 @@
       "updateSuccess": "Site web mis à jour avec succès",
       "updateError": "Échec de la mise à jour du site web",
       "fetchPagesError": "Échec du chargement des pages",
-      "searchError": "La recherche a échoué"
+      "searchError": "La recherche a échoué",
+      "deleteError": "Échec de la suppression du site web"
     },
     "adding": "Ajout en cours...",
     "viewDialog": {
@@ -2659,6 +2763,10 @@
         "7d": "Tous les 7 jours",
         "30d": "Tous les 30 jours"
       }
+    },
+    "delete": {
+      "confirmation": "Es-tu sûr de vouloir supprimer ce site web ? Cette action est irréversible.",
+      "title": "Supprimer le site web"
     }
   },
   "accessDenied": {
@@ -2673,7 +2781,8 @@
     "branding": "Tu dois disposer des permissions Admin pour accéder aux paramètres de marque.",
     "knowledge": "Ton compte n'a pas l'autorisation d'accéder à la base de connaissances.",
     "workspaceNotFound": "L'espace de travail que tu recherches n'existe pas ou a été supprimé.",
-    "disabled": "Ton compte a été désactivé. Contacte le support pour obtenir de l'aide."
+    "disabled": "Ton compte a été désactivé. Contacte le support pour obtenir de l'aide.",
+    "noMembership": "Tu n'es pas membre de cet espace de travail. Merci de contacter un administrateur pour obtenir l'accès."
   },
   "metadata": {
     "suffix": "Tale",
@@ -2928,7 +3037,11 @@
       "noProvidersFound": "Aucun fournisseur trouvé",
       "noModelsFound": "Aucun modèle trouvé",
       "noTeamsFound": "Aucune équipe trouvée",
-      "confirm": "Confirmer"
+      "confirm": "Confirmer",
+      "allowlistConflictWarning": "Ce modèle n'est actuellement pas autorisé par la politique d'accès aux modèles pour cette portée. Les utilisateurs concernés basculeront vers un modèle autorisé.",
+      "allowlistConflictWarningTitle": "Modèle absent de la liste d'autorisation",
+      "blocklistConflictWarning": "Ce modèle est actuellement bloqué par la politique d'accès aux modèles pour cette portée. Les utilisateurs concernés basculeront vers un modèle autorisé.",
+      "blocklistConflictWarningTitle": "Modèle bloqué"
     },
     "uploadPolicy": {
       "title": "Politique de téléversement",
@@ -3367,7 +3480,15 @@
       "testResultCircuit": "Circuit",
       "testResultCircuitOpened": "Ouvert par cet échec",
       "saved": "Fournisseur de modération enregistré",
-      "saveFailed": "Échec de l'enregistrement"
+      "saveFailed": "Échec de l'enregistrement",
+      "presetAzure": "Utiliser Azure Content Safety",
+      "presetAzureActive": "Azure Content Safety",
+      "presetAzureNote": "Remplace le sous-domaine par le nom de ta propre ressource Azure.",
+      "presetOpenai": "Utiliser OpenAI Moderation",
+      "presetOpenaiActive": "OpenAI Moderation",
+      "presetPerspective": "Utiliser Perspective API",
+      "presetPerspectiveActive": "Perspective API",
+      "presetPerspectiveNote": "Perspective s'authentifie via un paramètre de requête URL, pas un header. Après avoir appliqué le preset, ouvre « Endpoint » et ajoute ?key=TA_CLE_PERSPECTIVE à l'URL. (Le champ de clé API chiffrée ci-dessous n'est pas utilisé par Perspective.)"
     },
     "groups": {
       "contentAndModels": "Contenu et modèles",
@@ -3620,7 +3741,9 @@
     },
     "lowBackupCodes": {
       "body": "Génère un nouveau lot afin de pouvoir récupérer ton compte en cas de perte de ton application d'authentification.",
-      "regenerateLink": "Régénérer maintenant"
+      "regenerateLink": "Régénérer maintenant",
+      "titleOne": "Il ne reste qu'1 code de secours",
+      "titleOther": "Il ne reste que {count} codes de secours"
     },
     "enroll": {
       "title": "Double facteur requis",
@@ -3628,7 +3751,9 @@
     },
     "grace": {
       "body": "Ton organisation exigera bientôt que tous les membres utilisent un second facteur. Active-le maintenant pour éviter toute interruption.",
-      "setupLink": "Configurer maintenant"
+      "setupLink": "Configurer maintenant",
+      "titleOne": "Authentification à double facteur requise dans {days} jour",
+      "titleOther": "Authentification à double facteur requise dans {days} jours"
     },
     "admin": {
       "resetButton": "Réinitialiser le double facteur",


### PR DESCRIPTION
## Summary

PR #1632 introduced an orphan-key test that wrongly classified 109 in-use translations as unused and stripped them from `en/de/fr.json`. This PR hardens the detector and restores the lost keys.

The detector previously only recognised translation aliases destructured directly from `useT(...)` in the current file. It missed:

- **Callback aliases** — `({ tTables }) => tTables('headers.product')` where the alias arrives via a destructured callback parameter (`use-products-table-config.tsx`, `use-customers-table-config.tsx`, `use-vendors-table-config.tsx`).
- **Custom-hook returns** — `use-sso-config-form.ts` does `const { t } = useT('settings')` and returns `t`; consumers like `sso-config-dialog.tsx` destructure it from the hook return without a local `useT(...)`.
- **Lookup tables** — keys stored in `*Key:` properties, `keys: { ... }` blocks, `as const` casts, or const records named `*_I18N_KEY` (e.g. `CATEGORY_I18N_KEY` in `sanitize-chat-error.ts`).
- **Ternaries inside `t(...)`** — `t(isDisabled ? 'disabled' : 'noMembership')` in `dashboard/$id.tsx`.
- **`*Key()` functions** returning translation-key suffixes consumed via `t(fn(args))` (`statusLabelKey` in `todo-list-card.tsx`).

## Detector changes — [services/platform/lib/i18n/messages-usage.test.ts](services/platform/lib/i18n/messages-usage.test.ts)

- **Per-file namespace search** for dotted suffixes — `'headers.product'` in a file binding `tables` resolves to `tables.headers.product`.
- **`tFoo` heuristic** — `tTables`, `tCustomers`, etc. register as aliases for the corresponding namespace when called, even without `useT(...)` in the same file. Skipped for ambiguous names like `tEntity`.
- **Single-segment lookup-table candidates** — `xxxKey:` property values, `keys: { ... }` blocks, `as const` casts, and `*_I18N_KEY`-named const records. Per-file namespace resolution by default; global fallback only when the file has no namespace bound (cross-file consumer pattern).
- **Ternary-aware call-body capture** — `t(...)` calls now scan the whole argument body (one level of nested parens) for string literals.
- **`*Key` function body parsing** — header regex + brace-counting walk to extract the true function body and find every `return '...'` literal inside.
- **`TFunction` / parameter-`t` fallback** — files importing `TFunction` or declaring a `t: (key: string) => string` parameter trigger global namespace search for their dotted literals.

The per-file restriction prevents the previous over-permissive matching from re-appearing — coincidental literals like `'pii.blocked'` (a discriminator code in chat governance) no longer resurrect genuinely orphan translations such as `governance.pii.blocked`.

## Restoration

Restored 109 keys to [en.json](services/platform/messages/en.json), [de.json](services/platform/messages/de.json), [fr.json](services/platform/messages/fr.json) by reading their values from the pre-#1632 commit. Examples:

- `tables.headers.{product,description,email,scanned,stock,website,actions,created,title,message}` and `tables.cells.noEmail`
- All 24 of `settings.integrations.sso.*` consumed by `sso-config-dialog.tsx` via the hook pattern
- `chat.modelSelector.tags.*` (6 keys) consumed via `labelKey:` lookup
- `chat.errorHint*` (10 keys) and `chat.errorGeneratingDescription` consumed via `CATEGORY_I18N_KEY` map
- `customers.delete{Confirmation,Error,Warning}`, `vendors.delete{Confirmation,Error}`, `websites.toast.deleteError` consumed via `useDeleteDialogTranslations`
- `todoList.status*` (5 keys) consumed via the `statusLabelKey` function
- `accessDenied.noMembership` consumed via a ternary
- `auth.forcedChange.{description,descriptionAdminSet}`, `conversations.priority.*`, `conversations.category.*`, `documents.sourceType.*`, `governance.defaultModels.*ConflictWarning*`, `governance.moderationProvider.preset*`, `twoFactor.{grace,lowBackupCodes}.title{One,Other}`, and the `*.import.errorCodes.*` clusters

## Verification on the remaining 961 deletions

I ran four independent audits to confirm nothing else is in use:

1. Full-key literal grep (`'<full.key>'`) across all source — **0 hits**.
2. Namespace-suffix literal grep — 8 hits, all confirmed false positives where the actual key lives under a different namespace.
3. Aggressive cross-file scanner with the new ternary support — **0 remaining suspicious matches**.
4. Manual spot-check of suspicious clusters (`automations.execution.*`, `automations.monitoring.*`, `chat.share.*`, `auth.signup/login/oauth2.*`, `governance.tabs.*`, `governance.modelAccess.{allowlist,blocklist}`, `documents.rag.*`, `mcpServers.oauth2.*`, `settings.integrations.{circuly,gmail,outlook,protel,shopify}.*`, etc.) — none referenced at runtime; all stale entries from features that were renamed or removed.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — 21/21 tasks pass.
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [ ] Updated `docs/{,de/,fr/}` for every user-visible change — N/A (restores translations the runtime already expects; no UI/text changes).
- [ ] Ran `bun run --filter @tale/docs lint` — N/A.
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.

## Test plan

- [x] `bunx vitest run lib/i18n/` — 8/8 (orphan-key test passes against the restored JSON).
- [x] `bunx tsc --noEmit` — clean.
- [x] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors.
- [x] `bun run check` — all 21 workspace tasks succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded UI translations across English, German, and French with new labels and messaging for authentication flows, team management, integrations, model configuration, data import/export, and security features.

* **Tests**
  * Improved i18n key usage analysis to better detect and validate translation key patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->