### PR TITLE
fix(platform): precise attribution for governance usage tables

### DIFF
--- a/services/platform/app/features/analytics/usage/top-agents-table.tsx
+++ b/services/platform/app/features/analytics/usage/top-agents-table.tsx
@@ -9,7 +9,12 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { Text } from '@/app/components/ui/typography/text';
 import { useListAgents } from '@/app/features/agents/hooks/queries';
 import { useT } from '@/lib/i18n/client';
-import { isDirectApiSlug } from '@/lib/shared/constants/usage';
+import {
+  isDirectApiSlug,
+  isIntegrationSlug,
+  isSyntheticAgentSlug,
+  isTranscriptionSlug,
+} from '@/lib/shared/constants/usage';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 import { formatCostCents, formatNumber } from '@/lib/utils/format/number';
 
@@ -59,6 +64,8 @@ export function TopAgentsTable({
   const resolveName = useCallback(
     (slug: string): string => {
       if (isDirectApiSlug(slug)) return t('usage.directApi');
+      if (isIntegrationSlug(slug)) return t('usage.integration');
+      if (isTranscriptionSlug(slug)) return t('usage.transcription');
       return displayNameMap.get(slug) ?? slug;
     },
     [displayNameMap, t],
@@ -67,9 +74,21 @@ export function TopAgentsTable({
   const handleRowClick = useCallback(
     (row: Row<TopAgentRow>) => {
       const slug = row.original.agentSlug;
-      if (!isDirectApiSlug(slug)) onSelectAgent(slug);
+      if (!isSyntheticAgentSlug(slug)) onSelectAgent(slug);
     },
     [onSelectAgent],
+  );
+
+  // Suppress the pointer/hover affordance on synthetic rows — clicking them
+  // is a no-op (no real agent to drill into), so the row should not look
+  // clickable. tailwind-merge resolves cursor-default over the row-wide
+  // cursor-pointer applied by DataTable when onRowClick is set.
+  const rowClassName = useCallback(
+    (row: Row<TopAgentRow>) =>
+      isSyntheticAgentSlug(row.original.agentSlug)
+        ? 'cursor-default hover:bg-transparent'
+        : '',
+    [],
   );
 
   const columns = useMemo<ColumnDef<TopAgentRow>[]>(
@@ -142,6 +161,7 @@ export function TopAgentsTable({
         isLoading={isLoading}
         approxRowCount={isLoading ? 5 : rows.length}
         onRowClick={handleRowClick}
+        rowClassName={rowClassName}
         emptyState={{
           icon: BarChart3,
           title: t('usage.empty.title'),

--- a/services/platform/app/features/analytics/usage/top-agents-table.tsx
+++ b/services/platform/app/features/analytics/usage/top-agents-table.tsx
@@ -9,11 +9,12 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { Text } from '@/app/components/ui/typography/text';
 import { useListAgents } from '@/app/features/agents/hooks/queries';
 import { useT } from '@/lib/i18n/client';
+import { isDirectApiSlug } from '@/lib/shared/constants/usage';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 import { formatCostCents, formatNumber } from '@/lib/utils/format/number';
 
 export interface TopAgentRow {
-  agentSlug: string | null;
+  agentSlug: string;
   requests: number;
   tokens: number;
   costCents: number;
@@ -56,8 +57,8 @@ export function TopAgentsTable({
   }, [agents, locale]);
 
   const resolveName = useCallback(
-    (slug: string | null): string => {
-      if (!slug) return t('usage.unknownAgent');
+    (slug: string): string => {
+      if (isDirectApiSlug(slug)) return t('usage.directApi');
       return displayNameMap.get(slug) ?? slug;
     },
     [displayNameMap, t],
@@ -65,7 +66,8 @@ export function TopAgentsTable({
 
   const handleRowClick = useCallback(
     (row: Row<TopAgentRow>) => {
-      if (row.original.agentSlug) onSelectAgent(row.original.agentSlug);
+      const slug = row.original.agentSlug;
+      if (!isDirectApiSlug(slug)) onSelectAgent(slug);
     },
     [onSelectAgent],
   );
@@ -136,7 +138,7 @@ export function TopAgentsTable({
       <DataTable
         columns={columns}
         data={rows}
-        getRowId={(row) => row.agentSlug ?? '__unknown__'}
+        getRowId={(row) => row.agentSlug}
         isLoading={isLoading}
         approxRowCount={isLoading ? 5 : rows.length}
         onRowClick={handleRowClick}

--- a/services/platform/app/features/analytics/usage/top-models-table.tsx
+++ b/services/platform/app/features/analytics/usage/top-models-table.tsx
@@ -11,8 +11,8 @@ import { useT } from '@/lib/i18n/client';
 import { formatCostCents, formatNumber } from '@/lib/utils/format/number';
 
 export interface TopModelRow {
-  provider: string | null;
-  model: string | null;
+  provider: string;
+  model: string;
   requests: number;
   tokens: number;
   costCents: number;
@@ -33,7 +33,7 @@ export function TopModelsTable({
 
   const handleRowClick = useCallback(
     (row: Row<TopModelRow>) => {
-      if (row.original.model) onSelectModel(row.original.model);
+      onSelectModel(row.original.model);
     },
     [onSelectModel],
   );
@@ -50,11 +50,9 @@ export function TopModelsTable({
               variant="label"
               className="block flex-1 truncate text-sm"
             >
-              {row.original.model ?? t('usage.unknownModel')}
+              {row.original.model}
             </Text>
-            {row.original.provider ? (
-              <Badge variant="outline">{row.original.provider}</Badge>
-            ) : null}
+            <Badge variant="outline">{row.original.provider}</Badge>
           </div>
         ),
         size: 260,
@@ -109,9 +107,7 @@ export function TopModelsTable({
       <DataTable
         columns={columns}
         data={rows}
-        getRowId={(row) =>
-          `${row.provider ?? '_'}::${row.model ?? '__unknown__'}`
-        }
+        getRowId={(row) => `${row.provider}::${row.model}`}
         isLoading={isLoading}
         approxRowCount={isLoading ? 5 : rows.length}
         onRowClick={handleRowClick}

--- a/services/platform/app/features/analytics/usage/top-models-table.tsx
+++ b/services/platform/app/features/analytics/usage/top-models-table.tsx
@@ -113,8 +113,8 @@ export function TopModelsTable({
         onRowClick={handleRowClick}
         emptyState={{
           icon: BarChart3,
-          title: t('usage.empty.title'),
-          description: t('usage.empty.description'),
+          title: t('usage.emptyModels.title'),
+          description: t('usage.emptyModels.description'),
         }}
       />
     </div>

--- a/services/platform/convex/agent_tools/integrations/integration_tool.ts
+++ b/services/platform/convex/agent_tools/integrations/integration_tool.ts
@@ -9,6 +9,7 @@ import type { ToolCtx } from '@convex-dev/agent';
 import { createTool } from '@convex-dev/agent';
 import { z } from 'zod/v4';
 
+import { INTEGRATION_SLUG } from '../../../lib/shared/constants/usage';
 import { getBoolean, isRecord } from '../../../lib/utils/type-guards';
 import { internal } from '../../_generated/api';
 import { wrapUntrusted } from '../../lib/untrusted_content';
@@ -177,7 +178,12 @@ Write operations create approval cards. When telling the user an approval card i
 
         const userId = readStringContextField(ctx, 'userId');
         const teamId = readStringContextField(ctx, 'teamId');
-        const agentSlug = readStringContextField(ctx, 'agentSlug');
+        // Public chat entrypoints always populate agentSlug, so the fallback
+        // only kicks in for agentless callers (scheduled jobs, internal
+        // tooling). Use the sentinel so the row gets attributed to the
+        // "Integration" bucket rather than collapsing under "Direct API".
+        const agentSlug =
+          readStringContextField(ctx, 'agentSlug') ?? INTEGRATION_SLUG;
         if (userId) {
           await ctx.runMutation(
             internal.governance.internal_mutations.recordIntegrationUsage,

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -2,6 +2,7 @@
 
 import { v } from 'convex/values';
 
+import { TRANSCRIPTION_SLUG } from '../../lib/shared/constants/usage';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
@@ -518,6 +519,10 @@ export const transcribeAudio = internalAction({
           {
             organizationId: args.organizationId,
             userId,
+            // File-pipeline transcription has no invoking agent; the sentinel
+            // routes the row to the "Transcription" bucket in Top Assistants
+            // and keeps the writer's required-agentSlug invariant intact.
+            agentSlug: TRANSCRIPTION_SLUG,
             model: modelData.modelId,
             provider: modelData.providerName,
             audioDurationSec: totalDurationSec,

--- a/services/platform/convex/governance/get_org_usage_metrics.ts
+++ b/services/platform/convex/governance/get_org_usage_metrics.ts
@@ -1,4 +1,7 @@
-import { DIRECT_API_SLUG } from '../../lib/shared/constants/usage';
+import {
+  bucketAgentSlug,
+  classifyUsageRow,
+} from '../../lib/shared/constants/usage';
 import type { QueryCtx } from '../_generated/server';
 import { getUserNamesBatch } from '../documents/get_user_names_batch';
 import { buildPeriodKeyFromTimestamp } from './helpers';
@@ -29,9 +32,11 @@ export interface UsageSeriesPoint {
 }
 
 export interface UsageTopAgent {
-  // Either a real agent slug or the DIRECT_API_SLUG sentinel for OpenAI-compat
-  // direct-model calls (no assistant context). Never null — every ledger row
-  // resolves to one of these two precise categories.
+  // Real agent slug, or one of DIRECT_API_SLUG / INTEGRATION_SLUG /
+  // TRANSCRIPTION_SLUG when the row has no owning assistant (direct-model
+  // API call, agentless integration call, or file-pipeline transcription).
+  // Never null — every ledger row resolves to exactly one bucket via
+  // bucketAgentSlug() so the UI can render a precise label.
   agentSlug: string;
   requests: number;
   tokens: number;
@@ -182,10 +187,11 @@ export async function getOrgUsageMetrics(
     totalCostCents += row.costEstimate;
     if (row.requestCount > 0) activeUserIds.add(row.userId);
 
-    // Bucket under the real agent slug, or under the DIRECT_API_SLUG sentinel
-    // for LLM rows that came from the OpenAI-compat direct-model endpoint
-    // (no assistant context). Integration rows always carry agentSlug.
-    const agentSlugForBucket = row.agentSlug ?? DIRECT_API_SLUG;
+    // Classify by schema discriminator (integrationName / audioDurationSec /
+    // model) so integration and transcription rows route to their own buckets
+    // instead of collapsing under the LLM "Direct API" sentinel.
+    const kind = classifyUsageRow(row);
+    const agentSlugForBucket = bucketAgentSlug(row, kind);
     let agentBucket = agentBuckets.get(agentSlugForBucket);
     if (!agentBucket) {
       agentBucket = {
@@ -200,9 +206,14 @@ export async function getOrgUsageMetrics(
     agentBucket.tokens += row.totalTokens;
     agentBucket.costCents += row.costEstimate;
 
-    // Top Models is LLM-only. Integration rows have no model by design — their
-    // cost is still attributed to the calling agent above.
-    if (row.model !== undefined && row.provider !== undefined) {
+    // Top Models is LLM-only — integration rows lack a model and transcription
+    // rows have model+provider but tokens=0 (billed per audio minute), so
+    // including them would render misleading "0 tokens" entries.
+    if (
+      kind === 'llm' &&
+      row.model !== undefined &&
+      row.provider !== undefined
+    ) {
       const modelKey = `${row.provider}::${row.model}`;
       let modelBucket = modelBuckets.get(modelKey);
       if (!modelBucket) {
@@ -241,18 +252,37 @@ export async function getOrgUsageMetrics(
     userBucket.requests += row.requestCount;
   }
 
+  // Sort by cost descending — it's the only metric that compares fairly across
+  // mixed row kinds. Token-desc penalises non-LLM activity: transcription rows
+  // are billed per audio minute (tokens=0) and image-generation models use
+  // prompt-token counts that are tiny relative to per-image cost. Cost-desc
+  // matches what admins actually care about ($$ ranking). Tokens and slug
+  // serve as deterministic tiebreakers so Top-N stays stable across calls.
   const topAgents: UsageTopAgent[] = [...agentBuckets.values()]
-    .sort((a, b) => b.tokens - a.tokens)
+    .sort(
+      (a, b) =>
+        b.costCents - a.costCents ||
+        b.tokens - a.tokens ||
+        a.agentSlug.localeCompare(b.agentSlug),
+    )
     .slice(0, TOP_N);
 
   const topModels: UsageTopModel[] = [...modelBuckets.values()]
-    .sort((a, b) => b.tokens - a.tokens)
+    .sort(
+      (a, b) =>
+        b.costCents - a.costCents ||
+        b.tokens - a.tokens ||
+        `${a.provider}::${a.model}`.localeCompare(`${b.provider}::${b.model}`),
+    )
     .slice(0, TOP_N);
 
   // Full user list (no Top-N cap) — admins need to see every user's usage
   // for team/budget drill-down, matching the pre-analytics UsageDashboard.
   const sortedUsers = [...userBuckets.values()].sort(
-    (a, b) => b.tokens - a.tokens,
+    (a, b) =>
+      b.costCents - a.costCents ||
+      b.tokens - a.tokens ||
+      a.userId.localeCompare(b.userId),
   );
   const userNameMap = await getUserNamesBatch(
     ctx,

--- a/services/platform/convex/governance/get_org_usage_metrics.ts
+++ b/services/platform/convex/governance/get_org_usage_metrics.ts
@@ -1,3 +1,4 @@
+import { DIRECT_API_SLUG } from '../../lib/shared/constants/usage';
 import type { QueryCtx } from '../_generated/server';
 import { getUserNamesBatch } from '../documents/get_user_names_batch';
 import { buildPeriodKeyFromTimestamp } from './helpers';
@@ -28,15 +29,18 @@ export interface UsageSeriesPoint {
 }
 
 export interface UsageTopAgent {
-  agentSlug: string | null;
+  // Either a real agent slug or the DIRECT_API_SLUG sentinel for OpenAI-compat
+  // direct-model calls (no assistant context). Never null — every ledger row
+  // resolves to one of these two precise categories.
+  agentSlug: string;
   requests: number;
   tokens: number;
   costCents: number;
 }
 
 export interface UsageTopModel {
-  provider: string | null;
-  model: string | null;
+  provider: string;
+  model: string;
   requests: number;
   tokens: number;
   costCents: number;
@@ -178,36 +182,43 @@ export async function getOrgUsageMetrics(
     totalCostCents += row.costEstimate;
     if (row.requestCount > 0) activeUserIds.add(row.userId);
 
-    const agentKey = row.agentSlug ?? '__unknown__';
-    let agentBucket = agentBuckets.get(agentKey);
+    // Bucket under the real agent slug, or under the DIRECT_API_SLUG sentinel
+    // for LLM rows that came from the OpenAI-compat direct-model endpoint
+    // (no assistant context). Integration rows always carry agentSlug.
+    const agentSlugForBucket = row.agentSlug ?? DIRECT_API_SLUG;
+    let agentBucket = agentBuckets.get(agentSlugForBucket);
     if (!agentBucket) {
       agentBucket = {
-        agentSlug: row.agentSlug ?? null,
+        agentSlug: agentSlugForBucket,
         requests: 0,
         tokens: 0,
         costCents: 0,
       };
-      agentBuckets.set(agentKey, agentBucket);
+      agentBuckets.set(agentSlugForBucket, agentBucket);
     }
     agentBucket.requests += row.requestCount;
     agentBucket.tokens += row.totalTokens;
     agentBucket.costCents += row.costEstimate;
 
-    const modelKey = `${row.provider ?? '__unknown__'}::${row.model ?? '__unknown__'}`;
-    let modelBucket = modelBuckets.get(modelKey);
-    if (!modelBucket) {
-      modelBucket = {
-        provider: row.provider ?? null,
-        model: row.model ?? null,
-        requests: 0,
-        tokens: 0,
-        costCents: 0,
-      };
-      modelBuckets.set(modelKey, modelBucket);
+    // Top Models is LLM-only. Integration rows have no model by design — their
+    // cost is still attributed to the calling agent above.
+    if (row.model !== undefined && row.provider !== undefined) {
+      const modelKey = `${row.provider}::${row.model}`;
+      let modelBucket = modelBuckets.get(modelKey);
+      if (!modelBucket) {
+        modelBucket = {
+          provider: row.provider,
+          model: row.model,
+          requests: 0,
+          tokens: 0,
+          costCents: 0,
+        };
+        modelBuckets.set(modelKey, modelBucket);
+      }
+      modelBucket.requests += row.requestCount;
+      modelBucket.tokens += row.totalTokens;
+      modelBucket.costCents += row.costEstimate;
     }
-    modelBucket.requests += row.requestCount;
-    modelBucket.tokens += row.totalTokens;
-    modelBucket.costCents += row.costEstimate;
 
     const userKey = `${row.userId}::${row.teamId ?? ''}`;
     let userBucket = userBuckets.get(userKey);

--- a/services/platform/convex/governance/internal_mutations.ts
+++ b/services/platform/convex/governance/internal_mutations.ts
@@ -269,7 +269,10 @@ export const recordIntegrationUsage = internalMutation({
     organizationId: v.string(),
     userId: v.string(),
     teamId: v.optional(v.string()),
-    agentSlug: v.optional(v.string()),
+    // Required: callers must pass either the calling agent's slug or
+    // INTEGRATION_SLUG when invoked outside an agent context. Enforces the
+    // attribution invariant the analytics aggregator relies on.
+    agentSlug: v.string(),
     integrationName: v.string(),
     integrationOperation: v.string(),
     costEstimateCents: v.number(),
@@ -342,7 +345,9 @@ export const recordTranscriptionUsage = internalMutation({
     organizationId: v.string(),
     userId: v.string(),
     teamId: v.optional(v.string()),
-    agentSlug: v.optional(v.string()),
+    // Required: callers must pass either the invoking agent's slug or
+    // TRANSCRIPTION_SLUG when running from the file pipeline (no agent ctx).
+    agentSlug: v.string(),
     model: v.string(),
     provider: v.string(),
     audioDurationSec: v.number(),

--- a/services/platform/lib/shared/constants/usage.ts
+++ b/services/platform/lib/shared/constants/usage.ts
@@ -2,16 +2,16 @@
 // owning the call. The governance/usage aggregation buckets each kind under
 // its own sentinel so the Top Assistants table renders precise labels
 // instead of collapsing everything into a single fallback.
-export const DIRECT_API_SLUG = '__direct_api__';
+const DIRECT_API_SLUG = '__direct_api__';
 export const INTEGRATION_SLUG = '__integration__';
 export const TRANSCRIPTION_SLUG = '__transcription__';
 
-export type UsageRowKind = 'llm' | 'integration' | 'transcription';
+type UsageRowKind = 'llm' | 'integration' | 'transcription';
 
 // Subset of usageLedger fields needed to classify a row by kind. Kept
 // intentionally narrow so client and server code can share the helper without
 // pulling in Convex schema types.
-export interface UsageLedgerDiscriminators {
+interface UsageLedgerDiscriminators {
   agentSlug?: string;
   model?: string;
   provider?: string;

--- a/services/platform/lib/shared/constants/usage.ts
+++ b/services/platform/lib/shared/constants/usage.ts
@@ -1,9 +1,70 @@
-// Sentinel agentSlug for ledger rows produced by the OpenAI-compat
-// direct-model API, which has no assistant context. The governance/usage
-// aggregation buckets these rows under this key so the Top Assistants
-// table can render a precise "Direct API" label instead of a fallback.
+// Synthetic agentSlug sentinels for ledger rows that have no real assistant
+// owning the call. The governance/usage aggregation buckets each kind under
+// its own sentinel so the Top Assistants table renders precise labels
+// instead of collapsing everything into a single fallback.
 export const DIRECT_API_SLUG = '__direct_api__';
+export const INTEGRATION_SLUG = '__integration__';
+export const TRANSCRIPTION_SLUG = '__transcription__';
+
+export type UsageRowKind = 'llm' | 'integration' | 'transcription';
+
+// Subset of usageLedger fields needed to classify a row by kind. Kept
+// intentionally narrow so client and server code can share the helper without
+// pulling in Convex schema types.
+export interface UsageLedgerDiscriminators {
+  agentSlug?: string;
+  model?: string;
+  provider?: string;
+  integrationName?: string;
+  audioDurationSec?: number;
+}
+
+// Classify a usageLedger row by precedence over its natural discriminators.
+// Order matters: integrationName beats audioDurationSec because a hypothetical
+// audio-bearing integration is still an integration row first.
+export function classifyUsageRow(row: UsageLedgerDiscriminators): UsageRowKind {
+  if (row.integrationName !== undefined) return 'integration';
+  if (row.audioDurationSec !== undefined) return 'transcription';
+  return 'llm';
+}
+
+// Resolve the bucket key for Top Assistants. Returns the real agentSlug when
+// present, else the kind-appropriate sentinel so legacy rows (and any future
+// edge case) still get attributed to the right category instead of collapsing
+// into a generic fallback.
+export function bucketAgentSlug(
+  row: UsageLedgerDiscriminators,
+  kind: UsageRowKind = classifyUsageRow(row),
+): string {
+  if (row.agentSlug !== undefined && row.agentSlug !== '') return row.agentSlug;
+  switch (kind) {
+    case 'integration':
+      return INTEGRATION_SLUG;
+    case 'transcription':
+      return TRANSCRIPTION_SLUG;
+    case 'llm':
+      return DIRECT_API_SLUG;
+  }
+}
 
 export function isDirectApiSlug(slug: string): boolean {
   return slug === DIRECT_API_SLUG;
+}
+
+export function isIntegrationSlug(slug: string): boolean {
+  return slug === INTEGRATION_SLUG;
+}
+
+export function isTranscriptionSlug(slug: string): boolean {
+  return slug === TRANSCRIPTION_SLUG;
+}
+
+// True for any sentinel slug — used by the UI to suppress drilldown click
+// affordance on rows that don't represent a real agent.
+export function isSyntheticAgentSlug(slug: string): boolean {
+  return (
+    isDirectApiSlug(slug) ||
+    isIntegrationSlug(slug) ||
+    isTranscriptionSlug(slug)
+  );
 }

--- a/services/platform/lib/shared/constants/usage.ts
+++ b/services/platform/lib/shared/constants/usage.ts
@@ -1,0 +1,9 @@
+// Sentinel agentSlug for ledger rows produced by the OpenAI-compat
+// direct-model API, which has no assistant context. The governance/usage
+// aggregation buckets these rows under this key so the Top Assistants
+// table can render a precise "Direct API" label instead of a fallback.
+export const DIRECT_API_SLUG = '__direct_api__';
+
+export function isDirectApiSlug(slug: string): boolean {
+  return slug === DIRECT_API_SLUG;
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3766,8 +3766,7 @@
       "description": "Tokenverbrauch, Anfragen und aktive Benutzer im Zeitverlauf.",
       "cappedNotice": "Ergebnisse sind begrenzt, weil der Zeitraum zu viele Datensätze enthält. Verringere den Zeitraum für vollständige Daten.",
       "activeUsersTooltip": "Benutzer, die in diesem Zeitraum KI-Anfragen gestellt haben.",
-      "unknownAgent": "Unbekannter Assistent",
-      "unknownModel": "Unbekanntes Modell",
+      "directApi": "Direkter API-Aufruf",
       "period": {
         "label": "Zeitraum",
         "last7Days": "Letzte 7 Tage",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3767,6 +3767,8 @@
       "cappedNotice": "Ergebnisse sind begrenzt, weil der Zeitraum zu viele Datensätze enthält. Verringere den Zeitraum für vollständige Daten.",
       "activeUsersTooltip": "Benutzer, die in diesem Zeitraum KI-Anfragen gestellt haben.",
       "directApi": "Direkter API-Aufruf",
+      "integration": "Integration",
+      "transcription": "Transkription",
       "period": {
         "label": "Zeitraum",
         "last7Days": "Letzte 7 Tage",
@@ -3830,6 +3832,10 @@
       "empty": {
         "title": "Noch keine Nutzung",
         "description": "Für den ausgewählten Zeitraum wurde keine KI-Nutzung erfasst."
+      },
+      "emptyModels": {
+        "title": "Noch keine Modellnutzung",
+        "description": "Für den ausgewählten Zeitraum wurden keine LLM-Aufrufe erfasst. Integrations- und Transkriptionsnutzung wird unter Top-Assistenten angezeigt."
       }
     }
   },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3766,8 +3766,7 @@
       "description": "Token consumption, requests, and active users over time.",
       "cappedNotice": "Results are capped because the time range contains too many records. Narrow the range for complete data.",
       "activeUsersTooltip": "Users who made AI requests during this period.",
-      "unknownAgent": "Unknown assistant",
-      "unknownModel": "Unknown model",
+      "directApi": "Direct API",
       "period": {
         "label": "Period",
         "last7Days": "Last 7 days",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3767,6 +3767,8 @@
       "cappedNotice": "Results are capped because the time range contains too many records. Narrow the range for complete data.",
       "activeUsersTooltip": "Users who made AI requests during this period.",
       "directApi": "Direct API",
+      "integration": "Integration",
+      "transcription": "Transcription",
       "period": {
         "label": "Period",
         "last7Days": "Last 7 days",
@@ -3830,6 +3832,10 @@
       "empty": {
         "title": "No usage yet",
         "description": "No AI usage has been recorded for the selected period."
+      },
+      "emptyModels": {
+        "title": "No model usage yet",
+        "description": "No LLM calls have been recorded for the selected period. Integration and transcription usage is shown under Top Assistants."
       }
     }
   },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3774,6 +3774,8 @@
       "cappedNotice": "Les résultats sont limités car la plage temporelle contient trop d'enregistrements. Réduisez la plage pour obtenir des données complètes.",
       "activeUsersTooltip": "Utilisateurs ayant effectué des requêtes IA durant cette période.",
       "directApi": "Appel API direct",
+      "integration": "Intégration",
+      "transcription": "Transcription",
       "period": {
         "label": "Période",
         "last7Days": "7 derniers jours",
@@ -3837,6 +3839,10 @@
       "empty": {
         "title": "Aucune utilisation pour l'instant",
         "description": "Aucune utilisation IA n'a été enregistrée pour la période sélectionnée."
+      },
+      "emptyModels": {
+        "title": "Aucune utilisation de modèle",
+        "description": "Aucun appel LLM n'a été enregistré pour la période sélectionnée. L'utilisation des intégrations et des transcriptions est affichée dans Top assistants."
       }
     }
   }

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3773,8 +3773,7 @@
       "description": "Consommation de tokens, requêtes et utilisateurs actifs au fil du temps.",
       "cappedNotice": "Les résultats sont limités car la plage temporelle contient trop d'enregistrements. Réduisez la plage pour obtenir des données complètes.",
       "activeUsersTooltip": "Utilisateurs ayant effectué des requêtes IA durant cette période.",
-      "unknownAgent": "Assistant inconnu",
-      "unknownModel": "Modèle inconnu",
+      "directApi": "Appel API direct",
       "period": {
         "label": "Période",
         "last7Days": "7 derniers jours",


### PR DESCRIPTION
## Summary
- Replace the **"Unknown assistant"** fallback in Top Assistants with a precise **"Direct API"** label for OpenAI-compat direct-model calls (rows with no `agentSlug` by design).
- Filter integration-only rows out of **Top Models** (they have no `model` by design — Tavily/SQL/etc.). Their cost is still attributed to the calling agent in Top Assistants, so no information is lost.
- Drops the `usage.unknownAgent` / `usage.unknownModel` i18n keys (en/de/fr); adds `usage.directApi`.
- Tightens `UsageTopAgent.agentSlug` and `UsageTopModel.{provider,model}` from `string | null` to `string`.

A new shared sentinel `DIRECT_API_SLUG = '__direct_api__'` lives in `lib/shared/constants/usage.ts` so the backend aggregation and the Top Assistants table agree on the wire value.

## Test plan
- [ ] `bun run check` passes (already green locally).
- [ ] Visit `/dashboard/{org}/settings/governance/usage` on a deployment with both direct-API and integration usage:
  - [ ] Top Assistants: previous "Unknown assistant" rows render as "Direct API"; clicking that row is a no-op.
  - [ ] Top Models: no "Unknown model" entry; sum of model rows = LLM-only token cost.
  - [ ] Top Assistants total cost still includes integration calls under the calling agent (e.g. Researcher + Tavily).
- [ ] Switch UI language to de/fr — labels translate ("Direkter API-Aufruf" / "Appel API direct").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct API calls are now explicitly labeled as "Direct API" in usage analytics, replacing the previous "unknown" categorization for improved clarity.

* **Bug Fixes**
  * Improved handling of direct API usage data to ensure accurate tracking and display in analytics views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->