### PR TITLE
fix(db): stop init-scripts racing on first start

### DIFF
--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -63,7 +63,15 @@ RUN mkdir -p /docker-entrypoint-initdb.d \
 # grants). Service-specific tables live in per-service dbmate migrations at
 # services/<service>/migrations/ and are applied at each service's startup —
 # not here.
-COPY services/db/init-scripts/ /docker-entrypoint-initdb.d/
+#
+# Scripts live ONLY under /etc/postgresql/init-scripts/ — the entrypoint
+# wrapper runs them idempotently on every container start (see
+# docker-entrypoint-wrapper.sh). They must NOT be placed in
+# /docker-entrypoint-initdb.d/: the upstream entrypoint runs that directory
+# against a temporary local-only server during initdb, while the wrapper's
+# background loop probes the same socket and races in to run them too —
+# producing concurrent ALTER DEFAULT PRIVILEGES that collide on
+# pg_default_acl's unique key.
 COPY services/db/init-scripts/ /etc/postgresql/init-scripts/
 
 # Copy custom PostgreSQL configuration

--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -55,8 +55,7 @@ LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.licenses="MIT"
 
 # Create required directories
-RUN mkdir -p /docker-entrypoint-initdb.d \
-             /etc/postgresql/conf.d \
+RUN mkdir -p /etc/postgresql/conf.d \
              /var/lib/postgresql/backup
 
 # Copy initialization scripts (create databases, extensions, schema namespaces,

--- a/services/db/init-scripts/03-create-knowledge-database.sql
+++ b/services/db/init-scripts/03-create-knowledge-database.sql
@@ -69,6 +69,6 @@ BEGIN
     ALTER DEFAULT PRIVILEGES IN SCHEMA public_web        GRANT ALL ON SEQUENCES TO tale;
     ALTER DEFAULT PRIVILEGES IN SCHEMA private_knowledge GRANT ALL ON SEQUENCES TO tale;
 EXCEPTION WHEN unique_violation THEN
-    RAISE NOTICE 'pg_default_acl already populated, skipping ALTER DEFAULT PRIVILEGES';
+    RAISE NOTICE 'pg_default_acl already populated, skipping ALTER DEFAULT PRIVILEGES (% / %)', SQLSTATE, SQLERRM;
 END;
 $$;

--- a/services/db/init-scripts/03-create-knowledge-database.sql
+++ b/services/db/init-scripts/03-create-knowledge-database.sql
@@ -57,7 +57,18 @@ GRANT ALL ON ALL TABLES IN SCHEMA public_web TO tale;
 GRANT ALL ON ALL TABLES IN SCHEMA private_knowledge TO tale;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA public_web TO tale;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA private_knowledge TO tale;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public_web GRANT ALL ON TABLES TO tale;
-ALTER DEFAULT PRIVILEGES IN SCHEMA private_knowledge GRANT ALL ON TABLES TO tale;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public_web GRANT ALL ON SEQUENCES TO tale;
-ALTER DEFAULT PRIVILEGES IN SCHEMA private_knowledge GRANT ALL ON SEQUENCES TO tale;
+-- Wrap in a DO/EXCEPTION block so concurrent or repeated invocations don't
+-- abort the script with a unique_violation on pg_default_acl. SetDefaultACL
+-- is an UPSERT, but two transactions racing on the same (role, schema,
+-- objtype) can both see "no row" via syscache and both INSERT — the second
+-- then fails on pg_default_acl_role_nsp_obj_index. Treat that as success.
+DO $$
+BEGIN
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public_web        GRANT ALL ON TABLES    TO tale;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA private_knowledge GRANT ALL ON TABLES    TO tale;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public_web        GRANT ALL ON SEQUENCES TO tale;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA private_knowledge GRANT ALL ON SEQUENCES TO tale;
+EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE 'pg_default_acl already populated, skipping ALTER DEFAULT PRIVILEGES';
+END;
+$$;


### PR DESCRIPTION
## Summary

`tale start` against a fresh volume failed during DB container init with:

```
ERROR: duplicate key value violates unique constraint "pg_default_acl_role_nsp_obj_index"
DETAIL: Key (defaclrole, defaclnamespace, defaclobjtype)=(10, 17658, r) already exists.
```

The init-scripts were baked into the image at **two** locations — `/docker-entrypoint-initdb.d/` (run by upstream `docker-entrypoint.sh` against its temporary local-only server during initdb) and `/etc/postgresql/init-scripts/` (run by `docker-entrypoint-wrapper.sh`'s background loop). Both probe the same unix socket, so on first init they raced. Two concurrent transactions hit `ALTER DEFAULT PRIVILEGES`, both saw an empty `pg_default_acl` via syscache, both `INSERT`ed, and the second aborted on the unique index — leaving the container unhealthy and the whole stack unable to come up. Subsequent retries hit the same wall on the half-initialized volume.

## Changes

- **`services/db/Dockerfile`** — drop the `COPY services/db/init-scripts/ /docker-entrypoint-initdb.d/` line. The wrapper is now the single runner; the upstream entrypoint has no scripts to fire and never starts a temp server in script-running mode for this container.
- **`services/db/init-scripts/03-create-knowledge-database.sql`** — wrap the four `ALTER DEFAULT PRIVILEGES` statements in a `DO ... EXCEPTION WHEN unique_violation` block. Defense in depth against any future race or partial rerun (the script header advertises idempotency).

`01-init-extensions.sql` and `02-create-convex-database.sql` already use only `CREATE * IF NOT EXISTS` / `GRANT` statements, which are inherently safe under concurrent runs — no changes needed.

## Test plan

- [ ] Reproduce on `main`: `tale start` against a fresh `db-data` volume → confirm the duplicate-key error on `03-create-knowledge-database.sql:60`.
- [ ] Build the patched image: `docker build -f services/db/Dockerfile -t tale-db:dev-fix .`
- [ ] Verify single source of truth in the image:
  - `docker run --rm tale-db:dev-fix ls /docker-entrypoint-initdb.d/` → empty
  - `docker run --rm tale-db:dev-fix ls /etc/postgresql/init-scripts/` → 01..03 sql
- [ ] Re-run with patched image against a fresh volume → db container goes healthy on first try, `/tmp/.db_ready` exists, full stack comes up.
- [ ] Catalog check inside the container — expect 4 rows:
  ```bash
  docker exec <project>-db psql -U tale -d tale_knowledge \
    -c "SELECT defaclrole::regrole, defaclnamespace::regnamespace, defaclobjtype FROM pg_default_acl;"
  ```
- [ ] Restart the container and confirm the wrapper re-runs the scripts cleanly with no errors.

## Notes for release

The image is pulled, not built locally (`${registry}/tale-db:${version}` in `tools/cli/src/lib/compose/services/create-db-service.ts`). Affected users with a half-initialized volume need to remove it before retrying:

```bash
tale stop
docker volume rm <project-id>-dev_db-data
tale upgrade
tale start
```

Worth surfacing in the release notes for the version that ships this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization reliability by preventing concurrent execution conflicts.
  * Enhanced error handling to gracefully manage repeated initialization attempts without failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->