### PR TITLE
fix(platform): chat markdown link routing + PII precheck send wedge

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble/markdown-renderer.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/markdown-renderer.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useRouter } from '@tanstack/react-router';
 import {
   Children,
   ComponentPropsWithoutRef,
   isValidElement,
   memo,
+  MouseEvent,
   ReactNode,
   useState,
 } from 'react';
@@ -20,6 +22,7 @@ import {
 } from '@/app/components/ui/data-display/table';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
+import { classifyLink } from '@/lib/utils/link-classifier';
 
 import { useCitationsContext } from '../../context/citations-context';
 import { CitationLink } from '../citation-link';
@@ -114,6 +117,65 @@ const markdownImageComponent = ({
 }: { node?: unknown } & React.ImgHTMLAttributes<HTMLImageElement>) => (
   <MarkdownImage {...props} />
 );
+
+function MarkdownAnchor({
+  href,
+  children,
+  ...rest
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const router = useRouter();
+  const classified = classifyLink(href);
+
+  if (!classified) {
+    return (
+      <a {...rest} href={href}>
+        {children}
+      </a>
+    );
+  }
+
+  if (classified.kind === 'internal') {
+    const to = classified.to;
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      event.preventDefault();
+      void router.navigate({ to });
+    };
+    return (
+      <a {...rest} href={href} onClick={handleClick}>
+        {children}
+      </a>
+    );
+  }
+
+  if (classified.kind === 'external') {
+    return (
+      <a
+        {...rest}
+        href={classified.href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a {...rest} href={classified.href}>
+      {children}
+    </a>
+  );
+}
 
 function MarkdownParagraph({ children }: { children?: ReactNode }) {
   const childArray = Children.toArray(children);
@@ -233,12 +295,9 @@ export const markdownComponents = {
   img: markdownImageComponent,
   a: ({
     node: _node,
-    children,
     ...props
   }: { node?: unknown } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a {...props} target="_blank" rel="noopener noreferrer">
-      {children}
-    </a>
+    <MarkdownAnchor {...props} />
   ),
   cite: function InlineCitation({
     'data-n': dataN,

--- a/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
+++ b/services/platform/app/features/chat/hooks/__tests__/use-send-message.test.ts
@@ -27,6 +27,11 @@ vi.mock('@/app/hooks/use-toast', () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
+const mockConvexAction = vi.fn();
+vi.mock('@/app/hooks/use-convex-client', () => ({
+  useConvexClient: () => ({ action: mockConvexAction }),
+}));
+
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({ t: (key: string) => key }),
 }));
@@ -59,6 +64,7 @@ describe('useSendMessage — error handling', () => {
       messageAlreadyExists: false,
       streamId: 'stream_1',
     });
+    mockConvexAction.mockResolvedValue({ blocked: false });
   });
 
   it('calls clearChatState and resetGlobalFreeze on error', async () => {
@@ -129,6 +135,28 @@ describe('useSendMessage — error handling', () => {
 
     expect(mockChatWithAgent).not.toHaveBeenCalled();
     expect(params.setPendingMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows toast every time precheck blocks (does not wedge sendingRef)', async () => {
+    mockConvexAction.mockResolvedValue({
+      blocked: true,
+      code: 'pii.blocked',
+      categoryIds: ['ssn'],
+      categoryLabels: ['SSN'],
+    });
+
+    const params = createParams();
+    const { result } = renderHook(() => useSendMessage(params));
+
+    await act(async () => {
+      await result.current.sendMessage('My SSN is 123-45-6789');
+    });
+    await act(async () => {
+      await result.current.sendMessage('My SSN is 987-65-4321');
+    });
+
+    expect(mockToast).toHaveBeenCalledTimes(2);
+    expect(mockChatWithAgent).not.toHaveBeenCalled();
   });
 
   it('allows sending a new message after a previous error', async () => {

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -170,6 +170,7 @@ export function useSendMessage({
           const description =
             labels && labels.length > 0 ? labels.join(', ') : undefined;
           toast({ title, description, variant: 'destructive' });
+          sendingRef.current = false;
           return;
         }
         if (precheck.maskedText !== undefined) {

--- a/services/platform/lib/utils/link-classifier.ts
+++ b/services/platform/lib/utils/link-classifier.ts
@@ -1,0 +1,35 @@
+export type LinkKind =
+  | { kind: 'internal'; to: string }
+  | { kind: 'external'; href: string }
+  | { kind: 'hash'; href: string }
+  | { kind: 'special'; href: string };
+
+export function classifyLink(href: string | undefined): LinkKind | null {
+  if (!href) return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('#')) return { kind: 'hash', href: trimmed };
+
+  if (/^(mailto:|tel:|sms:)/i.test(trimmed)) {
+    return { kind: 'special', href: trimmed };
+  }
+
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+    return { kind: 'internal', to: trimmed };
+  }
+
+  if (typeof window === 'undefined') {
+    return { kind: 'external', href: trimmed };
+  }
+
+  try {
+    const url = new URL(trimmed, window.location.href);
+    if (url.origin === window.location.origin) {
+      return { kind: 'internal', to: url.pathname + url.search + url.hash };
+    }
+    return { kind: 'external', href: url.toString() };
+  } catch {
+    return { kind: 'external', href: trimmed };
+  }
+}

--- a/services/platform/lib/utils/link-classifier.ts
+++ b/services/platform/lib/utils/link-classifier.ts
@@ -1,4 +1,4 @@
-export type LinkKind =
+type LinkKind =
   | { kind: 'internal'; to: string }
   | { kind: 'external'; href: string }
   | { kind: 'hash'; href: string }


### PR DESCRIPTION
## Summary
- Route same-origin markdown anchors through TanStack router instead of always opening in a new tab; external links keep `target=_blank` + `rel=noopener noreferrer`. Adds `lib/utils/link-classifier.ts` to classify internal/external/hash/special hrefs.
- Reset `sendingRef` when the PII precheck blocks a message so subsequent sends aren't silently no-oped (toast now fires every time).

## Test plan
- [ ] Send a message with a markdown link to an in-app path — verify it navigates client-side without a full reload.
- [ ] Send a message with an external link — verify it opens in a new tab.
- [ ] Send a message with `mailto:` / hash anchors — verify default browser behavior.
- [ ] Trigger PII detection twice in a row — toast should appear both times and chat input should remain usable.
- [ ] `bun run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link handling in chat messages: internal links now navigate within the app, while external links open in new tabs.

* **Bug Fixes**
  * Fixed message sending becoming stuck after guardrails-blocked messages are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->