### PR TITLE
fix(platform): remove auto-open Canvas on assistant messages

### DIFF
--- a/services/platform/app/features/chat/components/message-bubble/code-block.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/code-block.tsx
@@ -87,30 +87,6 @@ export const HighlightedCode = memo(function HighlightedCode({
  * sub-pixel rounding and lets the user be a few px off and still auto-follow. */
 const STICK_TO_BOTTOM_THRESHOLD_PX = 24;
 
-/** Tracks messageIds that have already auto-opened Canvas once. Prevents
- * re-opening on re-renders and ensures only the first renderable block in
- * a message claims the slot. Survives across re-renders but not reloads. */
-const autoOpenedMessages = new Set<string>();
-
-/** Extract the first fenced code block whose language maps to a renderable
- * CanvasContentType. Reads from the full markdown source (messageContent)
- * rather than the DOM so the result is complete even while the typewriter
- * is still progressively revealing the block. */
-function extractFirstRenderableBlock(
-  markdown: string,
-): { content: string; lang: string; type: CanvasContentType } | null {
-  const regex = /```([\w-]*)\n([\s\S]*?)\n```/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(markdown)) !== null) {
-    const lang = match[1] || '';
-    const type = resolveCanvasType(lang);
-    if (type !== 'code') {
-      return { content: match[2], lang, type };
-    }
-  }
-  return null;
-}
-
 export function CodeBlock({
   lang,
   children,
@@ -188,28 +164,6 @@ export function CodeBlock({
         : undefined,
     );
   }, [canvasContext, lang, messageContext]);
-
-  useEffect(() => {
-    if (!canvasContext) return;
-    if (!messageContext?.messageId) return;
-    if (messageContext.isStreaming) return;
-    if (resolveCanvasType(lang) === 'code') return;
-    if (autoOpenedMessages.has(messageContext.messageId)) return;
-    const block = extractFirstRenderableBlock(messageContext.messageContent);
-    if (!block) return;
-    autoOpenedMessages.add(messageContext.messageId);
-    canvasContext.openCanvas(
-      block.content,
-      block.type,
-      block.lang || 'code',
-      block.lang,
-      {
-        messageId: messageContext.messageId,
-        messageContent: messageContext.messageContent,
-        threadId: messageContext.threadId,
-      },
-    );
-  }, [canvasContext, messageContext, lang]);
 
   return (
     <div className="border-border bg-background my-4 overflow-hidden rounded-lg border">


### PR DESCRIPTION
## Summary

- The chat UI was auto-opening the Canvas / HTML preview panel for the first renderable code block in any non-streaming assistant message. This fired too eagerly and surprised users (e.g. opening a panel for a stray ```html block in a comparison table).
- Drop the auto-open `useEffect` and the helpers it relied on (`autoOpenedMessages`, `extractFirstRenderableBlock`).
- The manual **Open in Canvas** button on each code block is unchanged and still works for `html` / `svg` / `mermaid` / `markdown` blocks.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no user-visible strings changed).
- [x] Updated `docs/{,de/,fr/}` for every user-visible change — N/A (behavior change only, no docs reference auto-open).
- [x] Ran `bun run --filter @tale/docs lint` — N/A (no docs changes).
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.

## Test plan

- [ ] Send an assistant message containing an `html` / `svg` / `mermaid` fenced block — Canvas should NOT auto-open.
- [ ] Click **Open in Canvas** on the same block — Canvas opens with the correct content.
- [ ] Send an assistant message with only plain `code` blocks — no change in behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic Canvas opening triggered by streamed markdown content. Users can still manually open Canvas when needed, and code highlighting, syntax formatting, and copying features continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->