### PR TITLE
feat(platform): upload entry for automations and agents

### DIFF
--- a/services/platform/app/features/agents/components/agents-action-menu.tsx
+++ b/services/platform/app/features/agents/components/agents-action-menu.tsx
@@ -12,6 +12,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
 import { useSaveAgent } from '../hooks/mutations';
+import { useListAgents } from '../hooks/queries';
 import { CreateAgentDialog } from './agent-create-dialog';
 
 interface AgentsActionMenuProps {
@@ -23,6 +24,11 @@ export function AgentsActionMenu({ organizationId }: AgentsActionMenuProps) {
   const [uploadOpen, setUploadOpen] = useState(false);
   const { t } = useT('settings');
   const { mutateAsync: saveAgent } = useSaveAgent();
+  const { agents } = useListAgents('default');
+  const existingNames = useMemo(
+    () => collectStringField(agents, 'name'),
+    [agents],
+  );
 
   const menuItems = useMemo<DataTableActionMenuItem[]>(
     () => [
@@ -57,11 +63,13 @@ export function AgentsActionMenu({ organizationId }: AgentsActionMenuProps) {
         onOpenChange={setUploadOpen}
         title={t('agents.uploadDialog.title')}
         description={t('agents.uploadDialog.description')}
-        onSaveOne={async (entry) => {
+        existingKeys={existingNames}
+        getKey={(entry) => entry.baseName}
+        onSaveOne={async (entry, { overwrite }) => {
           await saveAgent({
             orgSlug: 'default',
             agentName: entry.baseName,
-            isNew: true,
+            isNew: !overwrite,
             config: entry.json,
             organizationId,
           });
@@ -75,4 +83,16 @@ export function AgentsActionMenu({ organizationId }: AgentsActionMenuProps) {
       />
     </>
   );
+}
+
+function collectStringField(items: unknown, field: string): Set<string> {
+  const set = new Set<string>();
+  if (!Array.isArray(items)) return set;
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    for (const [k, v] of Object.entries(item)) {
+      if (k === field && typeof v === 'string' && v.length > 0) set.add(v);
+    }
+  }
+  return set;
 }

--- a/services/platform/app/features/agents/components/agents-action-menu.tsx
+++ b/services/platform/app/features/agents/components/agents-action-menu.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { Plus } from 'lucide-react';
-import { useState } from 'react';
+import { Plus, Upload } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
-import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
+import {
+  DataTableActionMenu,
+  type DataTableActionMenuItem,
+} from '@/app/components/ui/data-table/data-table-action-menu';
+import { UploadConfigsDialog } from '@/app/features/shared/upload-configs/upload-configs-dialog';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
+import { useSaveAgent } from '../hooks/mutations';
 import { CreateAgentDialog } from './agent-create-dialog';
 
 interface AgentsActionMenuProps {
@@ -13,20 +19,59 @@ interface AgentsActionMenuProps {
 }
 
 export function AgentsActionMenu({ organizationId }: AgentsActionMenuProps) {
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
   const { t } = useT('settings');
+  const { mutateAsync: saveAgent } = useSaveAgent();
+
+  const menuItems = useMemo<DataTableActionMenuItem[]>(
+    () => [
+      {
+        label: t('agents.createAgent'),
+        icon: Plus,
+        onClick: () => setCreateOpen(true),
+      },
+      {
+        label: t('agents.uploadDialog.menuItem'),
+        icon: Upload,
+        onClick: () => setUploadOpen(true),
+      },
+    ],
+    [t],
+  );
 
   return (
     <>
       <DataTableActionMenu
         label={t('agents.createAgent')}
         icon={Plus}
-        onClick={() => setCreateDialogOpen(true)}
+        menuItems={menuItems}
       />
       <CreateAgentDialog
-        open={createDialogOpen}
-        onOpenChange={setCreateDialogOpen}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
         organizationId={organizationId}
+      />
+      <UploadConfigsDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        title={t('agents.uploadDialog.title')}
+        description={t('agents.uploadDialog.description')}
+        onSaveOne={async (entry) => {
+          await saveAgent({
+            orgSlug: 'default',
+            agentName: entry.baseName,
+            isNew: true,
+            config: entry.json,
+            organizationId,
+          });
+        }}
+        onAfterAllSaved={() => {
+          toast({
+            title: t('agents.uploadDialog.toastSuccess'),
+            variant: 'success',
+          });
+        }}
       />
     </>
   );

--- a/services/platform/app/features/automations/components/automations-action-menu.tsx
+++ b/services/platform/app/features/automations/components/automations-action-menu.tsx
@@ -1,11 +1,21 @@
 'use client';
 
-import { Plus, Sparkles } from 'lucide-react';
-import { useState } from 'react';
+import { LayoutTemplate, Plus, Sparkles, Upload } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
-import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
+import {
+  DataTableActionMenu,
+  type DataTableActionMenuItem,
+} from '@/app/components/ui/data-table/data-table-action-menu';
+import { UploadConfigsDialog } from '@/app/features/shared/upload-configs/upload-configs-dialog';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
+import {
+  useInstallWorkflow,
+  useInvalidateWorkflows,
+  useSaveWorkflow,
+} from '../hooks/file-mutations';
 import { CreateAutomationDialog } from './automation-create-dialog';
 
 export interface AutomationsActionMenuProps {
@@ -18,12 +28,41 @@ export function AutomationsActionMenu({
   organizationId,
   variant = 'create',
 }: AutomationsActionMenuProps) {
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createTab, setCreateTab] = useState<'blank' | 'template'>('blank');
+  const [uploadOpen, setUploadOpen] = useState(false);
   const { t: tAutomations } = useT('automations');
 
-  const handleCreateAutomation = () => {
-    setCreateDialogOpen(true);
-  };
+  const { mutateAsync: saveWorkflow } = useSaveWorkflow();
+  const { mutateAsync: installWorkflow } = useInstallWorkflow();
+  const invalidateWorkflows = useInvalidateWorkflows();
+
+  const menuItems = useMemo<DataTableActionMenuItem[]>(
+    () => [
+      {
+        label: tAutomations('createDialog.tabBlank'),
+        icon: Plus,
+        onClick: () => {
+          setCreateTab('blank');
+          setCreateOpen(true);
+        },
+      },
+      {
+        label: tAutomations('createDialog.tabTemplate'),
+        icon: LayoutTemplate,
+        onClick: () => {
+          setCreateTab('template');
+          setCreateOpen(true);
+        },
+      },
+      {
+        label: tAutomations('uploadDialog.menuItem'),
+        icon: Upload,
+        onClick: () => setUploadOpen(true),
+      },
+    ],
+    [tAutomations],
+  );
 
   return (
     <>
@@ -34,13 +73,49 @@ export function AutomationsActionMenu({
             : tAutomations('createButton')
         }
         icon={variant === 'ai' ? Sparkles : Plus}
-        onClick={handleCreateAutomation}
+        menuItems={menuItems}
       />
       <CreateAutomationDialog
-        open={createDialogOpen}
-        onOpenChange={setCreateDialogOpen}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
         organizationId={organizationId}
+        defaultTab={createTab}
+      />
+      <UploadConfigsDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        title={tAutomations('uploadDialog.title')}
+        description={tAutomations('uploadDialog.description')}
+        onSaveOne={async (entry) => {
+          const workflowSlug = entry.relPath
+            .replace(/\.json$/i, '')
+            .replace(/\\/g, '/');
+          const config = withFallbackName(entry.json, entry.baseName);
+          await saveWorkflow({
+            organizationId,
+            workflowSlug,
+            config,
+          });
+          await installWorkflow({ organizationId, workflowSlug });
+        }}
+        onAfterAllSaved={() => {
+          void invalidateWorkflows(organizationId);
+          window.dispatchEvent(new Event('workflow-updated'));
+          toast({
+            title: tAutomations('uploadDialog.toastSuccess'),
+            variant: 'success',
+          });
+        }}
       />
     </>
   );
+}
+
+function withFallbackName(json: unknown, fallback: string): unknown {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return json;
+  const obj: Record<string, unknown> = { ...json };
+  const existing = obj.name;
+  if (typeof existing === 'string' && existing.trim().length > 0) return obj;
+  obj.name = fallback;
+  return obj;
 }

--- a/services/platform/app/features/automations/components/automations-action-menu.tsx
+++ b/services/platform/app/features/automations/components/automations-action-menu.tsx
@@ -16,6 +16,7 @@ import {
   useInvalidateWorkflows,
   useSaveWorkflow,
 } from '../hooks/file-mutations';
+import { useListWorkflows } from '../hooks/file-queries';
 import { CreateAutomationDialog } from './automation-create-dialog';
 
 export interface AutomationsActionMenuProps {
@@ -36,6 +37,11 @@ export function AutomationsActionMenu({
   const { mutateAsync: saveWorkflow } = useSaveWorkflow();
   const { mutateAsync: installWorkflow } = useInstallWorkflow();
   const invalidateWorkflows = useInvalidateWorkflows();
+  const { workflows } = useListWorkflows(organizationId);
+  const existingSlugs = useMemo(
+    () => collectStringField(workflows, 'slug'),
+    [workflows],
+  );
 
   const menuItems = useMemo<DataTableActionMenuItem[]>(
     () => [
@@ -86,6 +92,10 @@ export function AutomationsActionMenu({
         onOpenChange={setUploadOpen}
         title={tAutomations('uploadDialog.title')}
         description={tAutomations('uploadDialog.description')}
+        existingKeys={existingSlugs}
+        getKey={(entry) =>
+          entry.relPath.replace(/\.json$/i, '').replace(/\\/g, '/')
+        }
         onSaveOne={async (entry) => {
           const workflowSlug = entry.relPath
             .replace(/\.json$/i, '')
@@ -118,4 +128,16 @@ function withFallbackName(json: unknown, fallback: string): unknown {
   if (typeof existing === 'string' && existing.trim().length > 0) return obj;
   obj.name = fallback;
   return obj;
+}
+
+function collectStringField(items: unknown, field: string): Set<string> {
+  const set = new Set<string>();
+  if (!Array.isArray(items)) return set;
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    for (const [k, v] of Object.entries(item)) {
+      if (k === field && typeof v === 'string' && v.length > 0) set.add(v);
+    }
+  }
+  return set;
 }

--- a/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.test.ts
+++ b/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.test.ts
@@ -1,0 +1,122 @@
+import JSZip from 'jszip';
+import { describe, it, expect } from 'vitest';
+
+import { parseUploadedConfigs } from './parse-uploaded-configs';
+
+function makeJsonFile(name: string, value: unknown, relPath?: string) {
+  const file = new File([JSON.stringify(value)], name, {
+    type: 'application/json',
+  });
+  if (relPath) {
+    Object.defineProperty(file, 'webkitRelativePath', { value: relPath });
+  }
+  return file;
+}
+
+async function makeZip(files: Record<string, unknown>, name = 'archive.zip') {
+  const zip = new JSZip();
+  for (const [path, value] of Object.entries(files)) {
+    zip.file(path, typeof value === 'string' ? value : JSON.stringify(value));
+  }
+  const blob = await zip.generateAsync({ type: 'blob' });
+  return new File([blob], name, { type: 'application/zip' });
+}
+
+describe('parseUploadedConfigs', () => {
+  it('parses a single .json file using its filename as relPath/baseName', async () => {
+    const file = makeJsonFile('agent.json', { hello: 'world' });
+    const result = await parseUploadedConfigs([file]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      relPath: 'agent.json',
+      baseName: 'agent',
+      json: { hello: 'world' },
+    });
+    expect(result[0].error).toBeUndefined();
+  });
+
+  it('marks invalid JSON files as errors but does not throw', async () => {
+    const bad = new File(['{ not json'], 'bad.json', {
+      type: 'application/json',
+    });
+    const good = makeJsonFile('good.json', { ok: true });
+    const result = await parseUploadedConfigs([bad, good]);
+    expect(result).toHaveLength(2);
+    expect(result[0].error).toBeDefined();
+    expect(result[0].json).toBeUndefined();
+    expect(result[1].json).toEqual({ ok: true });
+  });
+
+  it('rejects unsupported file types', async () => {
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const result = await parseUploadedConfigs([file]);
+    expect(result).toHaveLength(1);
+    expect(result[0].error).toMatch(/unsupported/i);
+  });
+
+  it('preserves nested folder structure from webkitRelativePath but strips the picked-folder prefix', async () => {
+    const file = makeJsonFile(
+      'sync.json',
+      { name: 'Sync' },
+      'workflows/google_drive/sync.json',
+    );
+    const result = await parseUploadedConfigs([file]);
+    expect(result).toHaveLength(1);
+    expect(result[0].relPath).toBe('google_drive/sync.json');
+    expect(result[0].baseName).toBe('sync');
+  });
+
+  it('extracts .json entries from a zip archive and ignores other files', async () => {
+    const zip = await makeZip({
+      'foo.json': { id: 'foo' },
+      'bar.json': { id: 'bar' },
+      'README.md': 'docs',
+    });
+    const result = await parseUploadedConfigs([zip]);
+    const slugs = result.map((r) => r.baseName).sort();
+    expect(slugs).toEqual(['bar', 'foo']);
+    expect(result.every((r) => r.error === undefined)).toBe(true);
+  });
+
+  it('strips a common root folder from a zip when every entry shares it', async () => {
+    const zip = await makeZip({
+      'workflows/general/foo.json': { id: 'foo' },
+      'workflows/general/bar.json': { id: 'bar' },
+    });
+    const result = await parseUploadedConfigs([zip]);
+    const paths = result.map((r) => r.relPath).sort();
+    expect(paths).toEqual(['general/bar.json', 'general/foo.json']);
+  });
+
+  it('keeps the original paths when zip entries do not share a root folder', async () => {
+    const zip = await makeZip({
+      'foo.json': { id: 'foo' },
+      'nested/bar.json': { id: 'bar' },
+    });
+    const result = await parseUploadedConfigs([zip]);
+    const paths = result.map((r) => r.relPath).sort();
+    expect(paths).toEqual(['foo.json', 'nested/bar.json']);
+  });
+
+  it('mixes file, folder, and zip inputs in a single call', async () => {
+    const flat = makeJsonFile('flat.json', { id: 'flat' });
+    const folderFile = makeJsonFile(
+      'foo.json',
+      { id: 'folder-foo' },
+      'pickedfolder/foo.json',
+    );
+    const zip = await makeZip({ 'inside.json': { id: 'inside' } });
+    const result = await parseUploadedConfigs([flat, folderFile, zip]);
+    const ids = result.map((r) => (r.json as { id: string }).id).sort();
+    expect(ids).toEqual(['flat', 'folder-foo', 'inside']);
+  });
+
+  it('reports an error on every entry when the upload exceeds the size limit', async () => {
+    const big = new File([new Uint8Array(11 * 1024 * 1024)], 'big.json', {
+      type: 'application/json',
+    });
+    const result = await parseUploadedConfigs([big]);
+    expect(result).toHaveLength(1);
+    expect(result[0].error).toMatch(/limit/i);
+  });
+});

--- a/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.test.ts
+++ b/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.test.ts
@@ -54,15 +54,15 @@ describe('parseUploadedConfigs', () => {
     expect(result[0].error).toMatch(/unsupported/i);
   });
 
-  it('preserves nested folder structure from webkitRelativePath but strips the picked-folder prefix', async () => {
+  it('preserves the picked folder as the first segment of relPath', async () => {
     const file = makeJsonFile(
       'sync.json',
       { name: 'Sync' },
-      'workflows/google_drive/sync.json',
+      'contracts/sync.json',
     );
     const result = await parseUploadedConfigs([file]);
     expect(result).toHaveLength(1);
-    expect(result[0].relPath).toBe('google_drive/sync.json');
+    expect(result[0].relPath).toBe('contracts/sync.json');
     expect(result[0].baseName).toBe('sync');
   });
 
@@ -105,6 +105,7 @@ describe('parseUploadedConfigs', () => {
       { id: 'folder-foo' },
       'pickedfolder/foo.json',
     );
+    // pickedfolder is preserved as the first slug segment
     const zip = await makeZip({ 'inside.json': { id: 'inside' } });
     const result = await parseUploadedConfigs([flat, folderFile, zip]);
     const ids = result.map((r) => (r.json as { id: string }).id).sort();

--- a/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.ts
+++ b/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.ts
@@ -1,0 +1,167 @@
+import JSZip from 'jszip';
+
+export interface ParsedEntry {
+  /**
+   * Relative path of the entry as it appears in the upload, without the
+   * leading folder prefix that some browsers prepend for `webkitdirectory`.
+   * Example: `general/conversation-sync.json`.
+   */
+  relPath: string;
+  /** Last path segment with the `.json` extension stripped. */
+  baseName: string;
+  /** Parsed JSON value. Undefined when `error` is set. */
+  json?: unknown;
+  /** Human-readable failure reason when this entry could not be parsed. */
+  error?: string;
+}
+
+const MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+
+function stripJsonExt(name: string): string {
+  return name.replace(/\.json$/i, '');
+}
+
+function lastSegment(relPath: string): string {
+  const parts = relPath.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? relPath;
+}
+
+function trimRoot(path: string): string {
+  const segments = path.split('/').filter(Boolean);
+  return segments.join('/');
+}
+
+/**
+ * Drop the leading directory segment that `webkitdirectory` prepends with
+ * the chosen folder's name. A user who picks a folder called `workflows/`
+ * containing `general/foo.json` should produce a slug of `general/foo`, not
+ * `workflows/general/foo` (which would also exceed the 2-level slug limit).
+ */
+function stripFolderPrefix(path: string): string {
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length <= 1) return segments.join('/');
+  return segments.slice(1).join('/');
+}
+
+async function parseJsonFile(
+  file: File,
+  relPath: string,
+): Promise<ParsedEntry> {
+  const baseName = stripJsonExt(lastSegment(relPath));
+  try {
+    const text = await file.text();
+    return { relPath, baseName, json: JSON.parse(text) };
+  } catch (err) {
+    return {
+      relPath,
+      baseName,
+      error: err instanceof Error ? err.message : 'Invalid JSON',
+    };
+  }
+}
+
+async function parseZipFile(file: File): Promise<ParsedEntry[]> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(await file.arrayBuffer());
+  } catch (err) {
+    return [
+      {
+        relPath: file.name,
+        baseName: stripJsonExt(file.name),
+        error: err instanceof Error ? err.message : 'Invalid zip archive',
+      },
+    ];
+  }
+
+  const entries: ParsedEntry[] = [];
+  const jsonEntries = Object.values(zip.files).filter(
+    (entry) => !entry.dir && entry.name.toLowerCase().endsWith('.json'),
+  );
+
+  const commonRoot = detectCommonRoot(jsonEntries.map((e) => e.name));
+
+  for (const entry of jsonEntries) {
+    const trimmed = trimRoot(entry.name);
+    const relPath = commonRoot
+      ? trimmed.replace(new RegExp(`^${commonRoot}/`), '')
+      : trimmed;
+    const baseName = stripJsonExt(lastSegment(relPath));
+    try {
+      const text = await entry.async('string');
+      entries.push({ relPath, baseName, json: JSON.parse(text) });
+    } catch (err) {
+      entries.push({
+        relPath,
+        baseName,
+        error: err instanceof Error ? err.message : 'Invalid JSON',
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * If every entry sits under the same first segment, return that segment.
+ * Used to strip a wrapper folder that some zip producers (macOS Archive
+ * Utility, `zip -r`) include around a folder selection.
+ */
+function detectCommonRoot(names: string[]): string | null {
+  if (names.length === 0) return null;
+  const firstSegments = names.map((n) => trimRoot(n).split('/')[0]);
+  const head = firstSegments[0];
+  if (!head) return null;
+  if (firstSegments.every((seg) => seg === head)) {
+    const hasNested = names.some(
+      (n) => trimRoot(n).split('/').filter(Boolean).length > 1,
+    );
+    return hasNested ? head : null;
+  }
+  return null;
+}
+
+/**
+ * Parse a list of files (from a file picker, folder picker, or drag-drop) into
+ * a flat list of JSON entries. Folder uploads are detected via
+ * `webkitRelativePath`. Zip files are extracted and their `.json` members are
+ * included in the output. Non-JSON, non-zip files are reported as errors so
+ * the caller can surface them to the user.
+ */
+export async function parseUploadedConfigs(
+  files: File[],
+): Promise<ParsedEntry[]> {
+  const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
+  if (totalBytes > MAX_TOTAL_BYTES) {
+    return files.map((file) => ({
+      relPath: getRelPath(file),
+      baseName: stripJsonExt(lastSegment(getRelPath(file))),
+      error: `Upload exceeds ${MAX_TOTAL_BYTES / 1024 / 1024}MB limit`,
+    }));
+  }
+
+  const results: ParsedEntry[] = [];
+  for (const file of files) {
+    const lower = file.name.toLowerCase();
+    const relPath = getRelPath(file);
+    if (lower.endsWith('.zip')) {
+      results.push(...(await parseZipFile(file)));
+    } else if (lower.endsWith('.json')) {
+      results.push(await parseJsonFile(file, relPath));
+    } else {
+      results.push({
+        relPath,
+        baseName: stripJsonExt(lastSegment(relPath)),
+        error: 'Unsupported file type (expected .json or .zip)',
+      });
+    }
+  }
+  return results;
+}
+
+function getRelPath(file: File): string {
+  const fromDir = (file as File & { webkitRelativePath?: string })
+    .webkitRelativePath;
+  if (fromDir && fromDir.length > 0) return stripFolderPrefix(fromDir);
+  return file.name;
+}

--- a/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.ts
+++ b/services/platform/app/features/shared/upload-configs/parse-uploaded-configs.ts
@@ -2,9 +2,11 @@ import JSZip from 'jszip';
 
 export interface ParsedEntry {
   /**
-   * Relative path of the entry as it appears in the upload, without the
-   * leading folder prefix that some browsers prepend for `webkitdirectory`.
-   * Example: `general/conversation-sync.json`.
+   * Relative path of the entry as it appears in the upload. For folder picks
+   * (`webkitdirectory`) this includes the chosen folder name as the first
+   * segment so the resulting slug groups files under that folder. Zip
+   * archives strip a single common root folder if every entry shares one.
+   * Example: `contracts/red-flag-dd.json`.
    */
   relPath: string;
   /** Last path segment with the `.json` extension stripped. */
@@ -29,18 +31,6 @@ function lastSegment(relPath: string): string {
 function trimRoot(path: string): string {
   const segments = path.split('/').filter(Boolean);
   return segments.join('/');
-}
-
-/**
- * Drop the leading directory segment that `webkitdirectory` prepends with
- * the chosen folder's name. A user who picks a folder called `workflows/`
- * containing `general/foo.json` should produce a slug of `general/foo`, not
- * `workflows/general/foo` (which would also exceed the 2-level slug limit).
- */
-function stripFolderPrefix(path: string): string {
-  const segments = path.split('/').filter(Boolean);
-  if (segments.length <= 1) return segments.join('/');
-  return segments.slice(1).join('/');
 }
 
 async function parseJsonFile(
@@ -162,6 +152,6 @@ export async function parseUploadedConfigs(
 function getRelPath(file: File): string {
   const fromDir = (file as File & { webkitRelativePath?: string })
     .webkitRelativePath;
-  if (fromDir && fromDir.length > 0) return stripFolderPrefix(fromDir);
+  if (fromDir && fromDir.length > 0) return trimRoot(fromDir);
   return file.name;
 }

--- a/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
+++ b/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  File as FileIcon,
+  FolderUp,
+  Loader2,
+  Upload,
+} from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { Dialog } from '@/app/components/ui/dialog/dialog';
+import { FileUpload } from '@/app/components/ui/forms/file-upload';
+import { HStack, Stack } from '@/app/components/ui/layout/layout';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import {
+  type ParsedEntry,
+  parseUploadedConfigs,
+} from './parse-uploaded-configs';
+
+type RowStatus = 'queued' | 'saving' | 'saved' | 'failed' | 'invalid';
+
+interface Row extends ParsedEntry {
+  status: RowStatus;
+  message?: string;
+}
+
+export interface UploadConfigsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  /**
+   * Save a single parsed entry. Throw to mark the row as failed; the thrown
+   * error's message is shown inline.
+   */
+  onSaveOne: (entry: ParsedEntry) => Promise<void>;
+  /** Optional callback fired after a successful save so callers can refresh. */
+  onAfterAllSaved?: () => void;
+}
+
+export function UploadConfigsDialog(props: UploadConfigsDialogProps) {
+  if (!props.open) return null;
+  return <UploadConfigsDialogContent {...props} />;
+}
+
+function UploadConfigsDialogContent({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onSaveOne,
+  onAfterAllSaved,
+}: UploadConfigsDialogProps) {
+  const { t } = useT('common');
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const filesInputRef = useRef<HTMLInputElement>(null);
+  const zipInputRef = useRef<HTMLInputElement>(null);
+
+  const [rows, setRows] = useState<Row[]>([]);
+  const [isImporting, setIsImporting] = useState(false);
+
+  const handleFilesPicked = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
+    const parsed = await parseUploadedConfigs(files);
+    setRows((current) => {
+      const existing = new Set(current.map((r) => r.relPath));
+      const added: Row[] = [];
+      for (const entry of parsed) {
+        if (existing.has(entry.relPath)) continue;
+        added.push({
+          relPath: entry.relPath,
+          baseName: entry.baseName,
+          json: entry.json,
+          error: entry.error,
+          status: entry.error ? 'invalid' : 'queued',
+          message: entry.error,
+        });
+      }
+      return [...current, ...added];
+    });
+  }, []);
+
+  const handleFilesInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const list = e.target.files;
+      if (list && list.length > 0) {
+        void handleFilesPicked(Array.from(list));
+      }
+      e.target.value = '';
+    },
+    [handleFilesPicked],
+  );
+
+  const handleImport = useCallback(async () => {
+    if (isImporting) return;
+    const queued = rows.filter((r) => r.status === 'queued');
+    if (queued.length === 0) return;
+
+    setIsImporting(true);
+    let successes = 0;
+    for (const row of queued) {
+      setRows((current) =>
+        current.map((r) =>
+          r.relPath === row.relPath
+            ? { ...r, status: 'saving' as const, message: undefined }
+            : r,
+        ),
+      );
+      try {
+        await onSaveOne({
+          relPath: row.relPath,
+          baseName: row.baseName,
+          json: row.json,
+        });
+        successes += 1;
+        setRows((current) =>
+          current.map((r) =>
+            r.relPath === row.relPath
+              ? { ...r, status: 'saved' as const, message: undefined }
+              : r,
+          ),
+        );
+      } catch (err) {
+        const message = extractErrorMessage(err);
+        setRows((current) =>
+          current.map((r) =>
+            r.relPath === row.relPath
+              ? { ...r, status: 'failed' as const, message }
+              : r,
+          ),
+        );
+      }
+    }
+    setIsImporting(false);
+    if (successes > 0) onAfterAllSaved?.();
+  }, [isImporting, rows, onSaveOne, onAfterAllSaved]);
+
+  const handleClose = useCallback(() => {
+    if (isImporting) return;
+    setRows([]);
+    onOpenChange(false);
+  }, [isImporting, onOpenChange]);
+
+  const queuedCount = useMemo(
+    () => rows.filter((r) => r.status === 'queued').length,
+    [rows],
+  );
+  const savedCount = useMemo(
+    () => rows.filter((r) => r.status === 'saved').length,
+    [rows],
+  );
+
+  const importDisabled = isImporting || queuedCount === 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleClose();
+      }}
+      title={title}
+      description={description}
+      size="lg"
+    >
+      <Stack gap={4}>
+        <FileUpload.Root>
+          <FileUpload.DropZone
+            onFilesSelected={handleFilesPicked}
+            accept=".json,.zip,application/json,application/zip"
+            multiple
+            inputId="upload-configs-drop"
+            className="border-border hover:border-border-hover relative flex min-h-[120px] cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6 transition-colors"
+            aria-label={t('upload.dropFilesHere')}
+          >
+            <Upload className="text-muted-foreground size-8" />
+            <Text variant="muted" className="text-center">
+              {t('upload.dropFilesHere')}
+            </Text>
+            <Text variant="caption" className="text-center">
+              {t('upload.acceptHint')}
+            </Text>
+          </FileUpload.DropZone>
+        </FileUpload.Root>
+
+        <HStack gap={2} className="flex-wrap">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => filesInputRef.current?.click()}
+            disabled={isImporting}
+          >
+            <FileIcon className="size-4" />
+            {t('upload.pickFiles')}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => folderInputRef.current?.click()}
+            disabled={isImporting}
+          >
+            <FolderUp className="size-4" />
+            {t('upload.pickFolder')}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => zipInputRef.current?.click()}
+            disabled={isImporting}
+          >
+            <Upload className="size-4" />
+            {t('upload.pickZip')}
+          </Button>
+        </HStack>
+
+        {/* Hidden inputs sized via ref so we can trigger native pickers per mode */}
+        <input
+          ref={filesInputRef}
+          type="file"
+          accept=".json,application/json"
+          multiple
+          className="hidden"
+          onChange={handleFilesInputChange}
+        />
+        <input
+          ref={folderInputRef}
+          type="file"
+          // The webkitdirectory attribute is non-standard but supported in
+          // Chromium, Safari, and recent Firefox; fall through to the file
+          // picker on browsers that ignore it.
+          {...({ webkitdirectory: '', directory: '' } as Record<
+            string,
+            string
+          >)}
+          multiple
+          className="hidden"
+          onChange={handleFilesInputChange}
+        />
+        <input
+          ref={zipInputRef}
+          type="file"
+          accept=".zip,application/zip"
+          className="hidden"
+          onChange={handleFilesInputChange}
+        />
+
+        {rows.length > 0 && (
+          <div className="border-border max-h-[40vh] overflow-y-auto rounded-md border">
+            <ul className="divide-border divide-y">
+              {rows.map((row) => (
+                <li
+                  key={row.relPath}
+                  className="flex items-center gap-3 px-3 py-2"
+                >
+                  <RowStatusIcon status={row.status} />
+                  <div className="min-w-0 flex-1">
+                    <Text className="truncate font-medium">{row.relPath}</Text>
+                    {row.message && (
+                      <Text
+                        variant={
+                          row.status === 'failed' || row.status === 'invalid'
+                            ? 'error'
+                            : 'muted'
+                        }
+                        className="truncate text-xs"
+                      >
+                        {row.message}
+                      </Text>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <Text variant="caption" className={cn(rows.length === 0 && 'hidden')}>
+            {t('upload.summary', {
+              total: rows.length,
+              saved: savedCount,
+              queued: queuedCount,
+            })}
+          </Text>
+          <HStack gap={2} className="sm:justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleClose}
+              disabled={isImporting}
+            >
+              {t('actions.close')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleImport}
+              disabled={importDisabled}
+            >
+              {isImporting ? t('actions.importing') : t('actions.import')}
+            </Button>
+          </HStack>
+        </div>
+      </Stack>
+    </Dialog>
+  );
+}
+
+function RowStatusIcon({ status }: { status: RowStatus }) {
+  if (status === 'saving') {
+    return (
+      <Loader2 className="text-muted-foreground size-4 shrink-0 animate-spin" />
+    );
+  }
+  if (status === 'saved') {
+    return <CheckCircle2 className="size-4 shrink-0 text-emerald-500" />;
+  }
+  if (status === 'failed' || status === 'invalid') {
+    return <AlertCircle className="text-destructive size-4 shrink-0" />;
+  }
+  return <FileIcon className="text-muted-foreground size-4 shrink-0" />;
+}
+
+function extractErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const data = (err as { data?: { message?: string } }).data;
+    if (data?.message) return data.message;
+  }
+  return 'Unknown error';
+}

--- a/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
+++ b/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
@@ -2,7 +2,9 @@
 
 import {
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
+  CircleSlash,
   File as FileIcon,
   FolderUp,
   Loader2,
@@ -11,6 +13,7 @@ import {
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { HStack, Stack } from '@/app/components/ui/layout/layout';
 import { Button } from '@/app/components/ui/primitives/button';
@@ -23,11 +26,19 @@ import {
   parseUploadedConfigs,
 } from './parse-uploaded-configs';
 
-type RowStatus = 'queued' | 'saving' | 'saved' | 'failed' | 'invalid';
+type RowStatus =
+  | 'queued'
+  | 'queued-overwrite'
+  | 'saving'
+  | 'saved'
+  | 'skipped'
+  | 'failed'
+  | 'invalid';
 
 interface Row extends ParsedEntry {
   status: RowStatus;
   message?: string;
+  conflicts: boolean;
 }
 
 export interface UploadConfigsDialogProps {
@@ -36,13 +47,33 @@ export interface UploadConfigsDialogProps {
   title: string;
   description?: string;
   /**
-   * Save a single parsed entry. Throw to mark the row as failed; the thrown
-   * error's message is shown inline.
+   * Set of identifiers (slugs / agent names) that already exist on disk.
+   * Used to mark colliding uploads so the user can decide whether to
+   * overwrite. Defaults to an empty set.
    */
-  onSaveOne: (entry: ParsedEntry) => Promise<void>;
+  existingKeys?: ReadonlySet<string>;
+  /**
+   * Map a parsed entry to the identifier that determines collision against
+   * `existingKeys`. Defaults to `entry.relPath` minus `.json`.
+   */
+  getKey?: (entry: ParsedEntry) => string;
+  /**
+   * Save a single parsed entry. Throw to mark the row as failed; the thrown
+   * error's message is shown inline. The second argument tells the callback
+   * whether the row was queued explicitly as an overwrite of an existing
+   * entry — useful for actions whose semantics depend on the distinction
+   * (e.g. agents pass `isNew: !overwrite`).
+   */
+  onSaveOne: (
+    entry: ParsedEntry,
+    opts: { overwrite: boolean },
+  ) => Promise<void>;
   /** Optional callback fired after a successful save so callers can refresh. */
   onAfterAllSaved?: () => void;
 }
+
+const defaultGetKey = (entry: ParsedEntry) =>
+  entry.relPath.replace(/\.json$/i, '');
 
 export function UploadConfigsDialog(props: UploadConfigsDialogProps) {
   if (!props.open) return null;
@@ -54,6 +85,8 @@ function UploadConfigsDialogContent({
   onOpenChange,
   title,
   description,
+  existingKeys,
+  getKey = defaultGetKey,
   onSaveOne,
   onAfterAllSaved,
 }: UploadConfigsDialogProps) {
@@ -64,27 +97,34 @@ function UploadConfigsDialogContent({
 
   const [rows, setRows] = useState<Row[]>([]);
   const [isImporting, setIsImporting] = useState(false);
+  const [overwriteConflicts, setOverwriteConflicts] = useState(false);
 
-  const handleFilesPicked = useCallback(async (files: File[]) => {
-    if (files.length === 0) return;
-    const parsed = await parseUploadedConfigs(files);
-    setRows((current) => {
-      const existing = new Set(current.map((r) => r.relPath));
-      const added: Row[] = [];
-      for (const entry of parsed) {
-        if (existing.has(entry.relPath)) continue;
-        added.push({
-          relPath: entry.relPath,
-          baseName: entry.baseName,
-          json: entry.json,
-          error: entry.error,
-          status: entry.error ? 'invalid' : 'queued',
-          message: entry.error,
-        });
-      }
-      return [...current, ...added];
-    });
-  }, []);
+  const handleFilesPicked = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
+      const parsed = await parseUploadedConfigs(files);
+      setRows((current) => {
+        const existing = new Set(current.map((r) => r.relPath));
+        const added: Row[] = [];
+        for (const entry of parsed) {
+          if (existing.has(entry.relPath)) continue;
+          const key = getKey(entry);
+          const conflicts = !entry.error && !!existingKeys?.has(key);
+          added.push({
+            relPath: entry.relPath,
+            baseName: entry.baseName,
+            json: entry.json,
+            error: entry.error,
+            conflicts,
+            status: entry.error ? 'invalid' : 'queued',
+            message: entry.error,
+          });
+        }
+        return [...current, ...added];
+      });
+    },
+    [existingKeys, getKey],
+  );
 
   const handleFilesInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -99,12 +139,28 @@ function UploadConfigsDialogContent({
 
   const handleImport = useCallback(async () => {
     if (isImporting) return;
-    const queued = rows.filter((r) => r.status === 'queued');
-    if (queued.length === 0) return;
+    const importable = rows.filter(
+      (r) => r.status === 'queued' && (overwriteConflicts || !r.conflicts),
+    );
+    const toSkip = rows.filter(
+      (r) => r.status === 'queued' && r.conflicts && !overwriteConflicts,
+    );
+    if (importable.length === 0 && toSkip.length === 0) return;
 
     setIsImporting(true);
+
+    if (toSkip.length > 0) {
+      setRows((current) =>
+        current.map((r) =>
+          r.status === 'queued' && r.conflicts && !overwriteConflicts
+            ? { ...r, status: 'skipped' as const, message: undefined }
+            : r,
+        ),
+      );
+    }
+
     let successes = 0;
-    for (const row of queued) {
+    for (const row of importable) {
       setRows((current) =>
         current.map((r) =>
           r.relPath === row.relPath
@@ -113,11 +169,14 @@ function UploadConfigsDialogContent({
         ),
       );
       try {
-        await onSaveOne({
-          relPath: row.relPath,
-          baseName: row.baseName,
-          json: row.json,
-        });
+        await onSaveOne(
+          {
+            relPath: row.relPath,
+            baseName: row.baseName,
+            json: row.json,
+          },
+          { overwrite: row.conflicts },
+        );
         successes += 1;
         setRows((current) =>
           current.map((r) =>
@@ -139,11 +198,12 @@ function UploadConfigsDialogContent({
     }
     setIsImporting(false);
     if (successes > 0) onAfterAllSaved?.();
-  }, [isImporting, rows, onSaveOne, onAfterAllSaved]);
+  }, [isImporting, rows, overwriteConflicts, onSaveOne, onAfterAllSaved]);
 
   const handleClose = useCallback(() => {
     if (isImporting) return;
     setRows([]);
+    setOverwriteConflicts(false);
     onOpenChange(false);
   }, [isImporting, onOpenChange]);
 
@@ -153,6 +213,10 @@ function UploadConfigsDialogContent({
   );
   const savedCount = useMemo(
     () => rows.filter((r) => r.status === 'saved').length,
+    [rows],
+  );
+  const conflictCount = useMemo(
+    () => rows.filter((r) => r.status === 'queued' && r.conflicts).length,
     [rows],
   );
 
@@ -252,6 +316,30 @@ function UploadConfigsDialogContent({
           onChange={handleFilesInputChange}
         />
 
+        {conflictCount > 0 && (
+          <div className="bg-warning/10 border-warning/40 flex items-start gap-3 rounded-md border p-3">
+            <AlertTriangle className="text-warning mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0 flex-1">
+              <Text className="text-sm font-medium">
+                {t('upload.conflictHeading', { count: conflictCount })}
+              </Text>
+              <Text variant="caption" className="mt-0.5">
+                {t('upload.conflictHint')}
+              </Text>
+              <div className="mt-2">
+                <Checkbox
+                  checked={overwriteConflicts}
+                  onCheckedChange={(value) =>
+                    setOverwriteConflicts(value === true)
+                  }
+                  disabled={isImporting}
+                  label={t('upload.overwriteToggle')}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
         {rows.length > 0 && (
           <div className="border-border max-h-[40vh] overflow-y-auto rounded-md border">
             <ul className="divide-border divide-y">
@@ -263,18 +351,12 @@ function UploadConfigsDialogContent({
                   <RowStatusIcon status={row.status} />
                   <div className="min-w-0 flex-1">
                     <Text className="truncate font-medium">{row.relPath}</Text>
-                    {row.message && (
-                      <Text
-                        variant={
-                          row.status === 'failed' || row.status === 'invalid'
-                            ? 'error'
-                            : 'muted'
-                        }
-                        className="truncate text-xs"
-                      >
-                        {row.message}
-                      </Text>
-                    )}
+                    <Text
+                      variant={rowMessageVariant(row.status)}
+                      className="truncate text-xs"
+                    >
+                      {rowMessage(row, overwriteConflicts, t) ?? ''}
+                    </Text>
                   </div>
                 </li>
               ))}
@@ -325,7 +407,31 @@ function RowStatusIcon({ status }: { status: RowStatus }) {
   if (status === 'failed' || status === 'invalid') {
     return <AlertCircle className="text-destructive size-4 shrink-0" />;
   }
+  if (status === 'skipped') {
+    return <CircleSlash className="text-muted-foreground size-4 shrink-0" />;
+  }
   return <FileIcon className="text-muted-foreground size-4 shrink-0" />;
+}
+
+function rowMessageVariant(status: RowStatus): 'error' | 'muted' | 'caption' {
+  if (status === 'failed' || status === 'invalid') return 'error';
+  if (status === 'skipped') return 'caption';
+  return 'muted';
+}
+
+function rowMessage(
+  row: Row,
+  overwriteConflicts: boolean,
+  t: (key: string) => string,
+): string | undefined {
+  if (row.message) return row.message;
+  if (row.status === 'skipped') return t('upload.statusSkipped');
+  if (row.status === 'queued' && row.conflicts) {
+    return overwriteConflicts
+      ? t('upload.willOverwrite')
+      : t('upload.statusExists');
+  }
+  return undefined;
 }
 
 function extractErrorMessage(err: unknown): string {

--- a/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
+++ b/services/platform/app/features/shared/upload-configs/upload-configs-dialog.tsx
@@ -192,6 +192,7 @@ function UploadConfigsDialogContent({
           <Button
             type="button"
             variant="secondary"
+            className="gap-2"
             onClick={() => filesInputRef.current?.click()}
             disabled={isImporting}
           >
@@ -201,6 +202,7 @@ function UploadConfigsDialogContent({
           <Button
             type="button"
             variant="secondary"
+            className="gap-2"
             onClick={() => folderInputRef.current?.click()}
             disabled={isImporting}
           >
@@ -210,6 +212,7 @@ function UploadConfigsDialogContent({
           <Button
             type="button"
             variant="secondary"
+            className="gap-2"
             onClick={() => zipInputRef.current?.click()}
             disabled={isImporting}
           >

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -862,6 +862,7 @@ import type * as workflow_engine_helpers_nodes_llm_utils_create_llm_result from 
 import type * as workflow_engine_helpers_nodes_llm_utils_extract_tool_diagnostics from "../workflow_engine/helpers/nodes/llm/utils/extract_tool_diagnostics.js";
 import type * as workflow_engine_helpers_nodes_llm_utils_process_agent_result from "../workflow_engine/helpers/nodes/llm/utils/process_agent_result.js";
 import type * as workflow_engine_helpers_nodes_llm_utils_process_prompts from "../workflow_engine/helpers/nodes/llm/utils/process_prompts.js";
+import type * as workflow_engine_helpers_nodes_llm_utils_resolve_chat_model from "../workflow_engine/helpers/nodes/llm/utils/resolve_chat_model.js";
 import type * as workflow_engine_helpers_nodes_llm_utils_resolve_knowledge_file_ids from "../workflow_engine/helpers/nodes/llm/utils/resolve_knowledge_file_ids.js";
 import type * as workflow_engine_helpers_nodes_llm_utils_validate_and_normalize_config from "../workflow_engine/helpers/nodes/llm/utils/validate_and_normalize_config.js";
 import type * as workflow_engine_helpers_nodes_loop_execute_loop_node from "../workflow_engine/helpers/nodes/loop/execute_loop_node.js";
@@ -1865,6 +1866,7 @@ declare const fullApi: ApiFromModules<{
   "workflow_engine/helpers/nodes/llm/utils/extract_tool_diagnostics": typeof workflow_engine_helpers_nodes_llm_utils_extract_tool_diagnostics;
   "workflow_engine/helpers/nodes/llm/utils/process_agent_result": typeof workflow_engine_helpers_nodes_llm_utils_process_agent_result;
   "workflow_engine/helpers/nodes/llm/utils/process_prompts": typeof workflow_engine_helpers_nodes_llm_utils_process_prompts;
+  "workflow_engine/helpers/nodes/llm/utils/resolve_chat_model": typeof workflow_engine_helpers_nodes_llm_utils_resolve_chat_model;
   "workflow_engine/helpers/nodes/llm/utils/resolve_knowledge_file_ids": typeof workflow_engine_helpers_nodes_llm_utils_resolve_knowledge_file_ids;
   "workflow_engine/helpers/nodes/llm/utils/validate_and_normalize_config": typeof workflow_engine_helpers_nodes_llm_utils_validate_and_normalize_config;
   "workflow_engine/helpers/nodes/loop/execute_loop_node": typeof workflow_engine_helpers_nodes_loop_execute_loop_node;

--- a/services/platform/convex/agent_tools/workflows/create_bound_workflow_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/create_bound_workflow_tool.ts
@@ -305,7 +305,8 @@ function buildDescription(
 
   lines.push(
     '',
-    'This creates an approval card. Do NOT mention its position. The user must approve before execution begins.',
+    'This creates an approval card rendered separately by the UI. The user must approve before execution begins.',
+    'When telling the user the card is ready, only say it has been created — never describe where it appears, how to find it, or its direction relative to the chat (no "above"/"below"/"上方"/"下方"/"oben"/"unten"/equivalents).',
   );
 
   return lines.join('\n');

--- a/services/platform/convex/agent_tools/workflows/create_workflow_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/create_workflow_tool.ts
@@ -87,7 +87,7 @@ export const createWorkflowTool = {
   name: 'create_workflow' as const,
   tool: createTool({
     description: `Create a new workflow definition with all steps.
-Requires user approval — an approval card will be created. When telling the user the card is ready, do not reference its position (no "above" / "below") — just say the approval card has been created.
+Requires user approval — an approval card rendered separately by the UI will be created. When telling the user the card is ready, only say it has been created — never describe where it appears, how to find it, or its direction relative to the chat (no "above"/"below"/"上方"/"下方"/"oben"/"unten"/equivalents).
 
 **⭐ IF THE USER PROVIDED A WORKFLOW JSON CONFIG:**
 Use the provided configuration DIRECTLY — do NOT recreate or rewrite it.

--- a/services/platform/convex/agent_tools/workflows/run_workflow_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/run_workflow_tool.ts
@@ -60,7 +60,7 @@ export const runWorkflowTool = {
 • Updating workflow steps — use update_workflow_step instead
 
 **APPROVAL REQUIRED:**
-This tool creates an approval card. The user must click "Run Workflow" to confirm execution. The workflow will NOT start until approved. When telling the user the card is ready, do not reference its position (no "above" / "below") — just say the approval card has been created.
+This tool creates an approval card rendered separately by the UI. The user must click "Run Workflow" to confirm execution; the workflow will NOT start until approved. When telling the user the card is ready, only say it has been created — never describe where it appears, how to find it, or its direction relative to the chat (no "above"/"below"/"上方"/"下方"/"oben"/"unten"/equivalents).
 
 **PARAMETERS:**
 • workflowSlug (required): The workflow file slug (e.g., "conversation-sync")

--- a/services/platform/convex/agent_tools/workflows/save_workflow_definition_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/save_workflow_definition_tool.ts
@@ -114,7 +114,7 @@ Map the JSON to this tool's schema: top-level fields → workflowConfig, steps a
 
 **APPROVAL:**
 When this tool returns { requiresApproval: true }, do NOT call this tool again.
-Inform the user the update is ready for review in the chat UI. Do not reference the card's position (no "above" / "below") — just say the approval card has been created.`,
+Inform the user the update is ready for review. Only say the approval card has been created — never describe where it appears, how to find it, or its direction relative to the chat (no "above"/"below"/"上方"/"下方"/"oben"/"unten"/equivalents).`,
     inputSchema: z.object({
       workflowConfig: workflowConfigSchema,
       stepsConfig: z

--- a/services/platform/convex/agent_tools/workflows/update_workflow_step_tool.ts
+++ b/services/platform/convex/agent_tools/workflows/update_workflow_step_tool.ts
@@ -207,7 +207,7 @@ export const updateWorkflowStepTool = {
 
 **APPROVAL:**
 When this tool returns { requiresApproval: true }, do NOT call this tool again.
-Inform the user the update is ready for review in the chat UI. Do not reference the card's position (no "above" / "below") — just say the approval card has been created.`,
+Inform the user the update is ready for review. Only say the approval card has been created — never describe where it appears, how to find it, or its direction relative to the chat (no "above"/"below"/"上方"/"下方"/"oben"/"unten"/equivalents).`,
     inputSchema: z.object({
       workflowSlug: z
         .string()

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -9,6 +9,7 @@ import {
 import type { ModelMessage } from 'ai';
 import type { FunctionHandle } from 'convex/server';
 import { v } from 'convex/values';
+import { snakeCase } from 'lodash';
 
 import { parseModelRef } from '../../../lib/shared/utils/model-ref';
 import {
@@ -28,10 +29,7 @@ import { fetchOperationsWithSchema } from '../../agent_tools/integrations/fetch_
 import { createBoundMcpTool } from '../../agent_tools/mcp/create_bound_mcp_tool';
 import { TOOL_NAMES, type ToolName } from '../../agent_tools/tool_names';
 import { getToolRegistryMap } from '../../agent_tools/tool_registry';
-import {
-  createBoundWorkflowTool,
-  sanitizeWorkflowName,
-} from '../../agent_tools/workflows/create_bound_workflow_tool';
+import { createBoundWorkflowTool } from '../../agent_tools/workflows/create_bound_workflow_tool';
 import { extractInputSchema } from '../../agent_tools/workflows/helpers/extract_input_schema';
 import { resolveOrgSlug } from '../../organizations/resolve_org_slug';
 import { recordFailure } from '../../providers/circuit_breaker';
@@ -820,18 +818,13 @@ async function buildWorkflowTools(
       const config = result.config as {
         name: string;
         description?: string;
-        enabled?: boolean;
         steps: Array<{ stepType: string; config?: unknown }>;
       };
-
-      if (!config.enabled) {
-        return null;
-      }
 
       const startStep = config.steps.find((s) => s.stepType === 'start');
       const inputSchema = extractInputSchema(startStep?.config);
 
-      const toolKey = `workflow_${sanitizeWorkflowName(config.name)}_${slug}`;
+      const toolKey = `workflow_${snakeCase(slug)}`;
       return {
         key: toolKey,
         tool: createBoundWorkflowTool(

--- a/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_llm_node.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/llm/execute_llm_node.ts
@@ -8,12 +8,11 @@
 import type { Id } from '../../../../_generated/dataModel';
 import type { ActionCtx } from '../../../../_generated/server';
 import { resolveOrgSlug } from '../../../../organizations/resolve_org_slug';
-import { resolveLanguageModelWithFallback } from '../../../../providers/failover';
-import { resolveLanguageModel } from '../../../../providers/resolve_model';
 import type { StepExecutionResult, LLMNodeConfig } from '../../../types';
 import { executeAgentWithTools } from './execute_agent_with_tools';
 import { createLLMResult } from './utils/create_llm_result';
 import { processPrompts } from './utils/process_prompts';
+import { assertChatTag, resolveChatModel } from './utils/resolve_chat_model';
 import { resolveKnowledgeFileIds } from './utils/resolve_knowledge_file_ids';
 import { validateAndNormalizeConfig } from './utils/validate_and_normalize_config';
 
@@ -38,13 +37,16 @@ export async function executeLLMNode(
   threadId?: string,
   stepSlug?: string,
 ): Promise<StepExecutionResult> {
-  // 1. Resolve default model from provider files, then validate and normalize config.
-  // Use fallback-aware resolution unless the step explicitly disables it.
-  // orgSlug ensures the workflow uses its owning org's providers / API keys.
+  // 1. Resolve the chat model. When the step pins `config.model`, route to that
+  // exact ref (with model-level failover unless `noFallback` is set);
+  // otherwise resolve via the org's `defaults.chat` tag-based path.
   const orgSlug = await resolveOrgSlug(ctx, organizationId);
-  const { languageModel, modelData: chatModelData } = config.noFallback
-    ? await resolveLanguageModel(ctx, { tag: 'chat', orgSlug })
-    : await resolveLanguageModelWithFallback(ctx, { tag: 'chat', orgSlug });
+  const { languageModel, modelData: chatModelData } = await resolveChatModel(
+    ctx,
+    config,
+    orgSlug,
+  );
+  assertChatTag(chatModelData, config.model);
   const normalizedConfig = validateAndNormalizeConfig(
     config,
     chatModelData.modelId,

--- a/services/platform/convex/workflow_engine/helpers/nodes/llm/utils/__tests__/resolve_chat_model.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/llm/utils/__tests__/resolve_chat_model.test.ts
@@ -1,0 +1,194 @@
+import { ConvexError } from 'convex/values';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ActionCtx } from '../../../../../../_generated/server';
+import type { LLMNodeConfig } from '../../../../../types';
+import { assertChatTag, resolveChatModel } from '../resolve_chat_model';
+
+vi.mock('../../../../../../providers/resolve_model', () => ({
+  resolveLanguageModel: vi.fn(),
+  resolveLanguageModelById: vi.fn(),
+}));
+vi.mock('../../../../../../providers/failover', () => ({
+  resolveLanguageModelWithFallback: vi.fn(),
+}));
+
+import { resolveLanguageModelWithFallback } from '../../../../../../providers/failover';
+import {
+  resolveLanguageModel,
+  resolveLanguageModelById,
+} from '../../../../../../providers/resolve_model';
+
+const ctx = {} as ActionCtx;
+const orgSlug = 'acme';
+
+const baseConfig: LLMNodeConfig = {
+  name: 'step',
+  systemPrompt: 'sys',
+};
+
+const stubResolved = (modelId = 'm', providerName = 'p') => ({
+  languageModel: { provider: 'mock' } as never,
+  modelData: {
+    providerName,
+    modelId,
+    baseUrl: 'http://example',
+    apiKey: 'key',
+    tags: ['chat'],
+    supportsStructuredOutputs: false,
+  },
+});
+
+beforeEach(() => {
+  vi.mocked(resolveLanguageModel).mockReset();
+  vi.mocked(resolveLanguageModelById).mockReset();
+  vi.mocked(resolveLanguageModelWithFallback).mockReset();
+});
+
+describe('resolveChatModel', () => {
+  it('falls back to tag-based resolution with failover when model is unset', async () => {
+    vi.mocked(resolveLanguageModelWithFallback).mockResolvedValue(
+      stubResolved(),
+    );
+    await resolveChatModel(ctx, baseConfig, orgSlug);
+    expect(resolveLanguageModelWithFallback).toHaveBeenCalledWith(ctx, {
+      tag: 'chat',
+      orgSlug,
+    });
+    expect(resolveLanguageModel).not.toHaveBeenCalled();
+    expect(resolveLanguageModelById).not.toHaveBeenCalled();
+  });
+
+  it('uses resolveLanguageModel (no failover) when model is unset and noFallback is true', async () => {
+    vi.mocked(resolveLanguageModel).mockResolvedValue(stubResolved());
+    await resolveChatModel(ctx, { ...baseConfig, noFallback: true }, orgSlug);
+    expect(resolveLanguageModel).toHaveBeenCalledWith(ctx, {
+      tag: 'chat',
+      orgSlug,
+    });
+    expect(resolveLanguageModelWithFallback).not.toHaveBeenCalled();
+  });
+
+  it('routes a qualified explicit model ref through the failover resolver', async () => {
+    vi.mocked(resolveLanguageModelWithFallback).mockResolvedValue(
+      stubResolved('claude-haiku-4.5', 'openrouter'),
+    );
+    await resolveChatModel(
+      ctx,
+      { ...baseConfig, model: 'openrouter:anthropic/claude-haiku-4.5' },
+      orgSlug,
+    );
+    expect(resolveLanguageModelWithFallback).toHaveBeenCalledWith(ctx, {
+      modelId: 'anthropic/claude-haiku-4.5',
+      providerName: 'openrouter',
+      tag: 'chat',
+      orgSlug,
+    });
+    expect(resolveLanguageModel).not.toHaveBeenCalled();
+    expect(resolveLanguageModelById).not.toHaveBeenCalled();
+  });
+
+  it('routes an unqualified explicit model ref (no provider) through the failover resolver', async () => {
+    vi.mocked(resolveLanguageModelWithFallback).mockResolvedValue(
+      stubResolved(),
+    );
+    await resolveChatModel(ctx, { ...baseConfig, model: 'gpt-5.2' }, orgSlug);
+    expect(resolveLanguageModelWithFallback).toHaveBeenCalledWith(ctx, {
+      modelId: 'gpt-5.2',
+      providerName: undefined,
+      tag: 'chat',
+      orgSlug,
+    });
+  });
+
+  it('uses resolveLanguageModelById (no failover) when explicit model + noFallback', async () => {
+    vi.mocked(resolveLanguageModelById).mockResolvedValue(stubResolved());
+    await resolveChatModel(
+      ctx,
+      {
+        ...baseConfig,
+        model: 'openrouter:deepseek/deepseek-v4-flash',
+        noFallback: true,
+      },
+      orgSlug,
+    );
+    expect(resolveLanguageModelById).toHaveBeenCalledWith(ctx, {
+      modelId: 'deepseek/deepseek-v4-flash',
+      providerName: 'openrouter',
+      orgSlug,
+    });
+    expect(resolveLanguageModelWithFallback).not.toHaveBeenCalled();
+  });
+
+  it('treats whitespace-only model as unset', async () => {
+    vi.mocked(resolveLanguageModelWithFallback).mockResolvedValue(
+      stubResolved(),
+    );
+    await resolveChatModel(ctx, { ...baseConfig, model: '   ' }, orgSlug);
+    expect(resolveLanguageModelWithFallback).toHaveBeenCalledWith(ctx, {
+      tag: 'chat',
+      orgSlug,
+    });
+  });
+
+  it('trims surrounding whitespace from explicit refs before parsing', async () => {
+    vi.mocked(resolveLanguageModelWithFallback).mockResolvedValue(
+      stubResolved(),
+    );
+    await resolveChatModel(
+      ctx,
+      { ...baseConfig, model: '  openrouter:foo  ' },
+      orgSlug,
+    );
+    expect(resolveLanguageModelWithFallback).toHaveBeenCalledWith(ctx, {
+      modelId: 'foo',
+      providerName: 'openrouter',
+      tag: 'chat',
+      orgSlug,
+    });
+  });
+});
+
+describe('assertChatTag', () => {
+  const modelData = (tags: string[]) => ({
+    providerName: 'openrouter',
+    modelId: 'foo/bar',
+    baseUrl: 'http://x',
+    apiKey: 'k',
+    tags,
+    supportsStructuredOutputs: false,
+  });
+
+  it('returns silently when the resolved model carries the chat tag', () => {
+    expect(() =>
+      assertChatTag(modelData(['chat', 'vision']), undefined),
+    ).not.toThrow();
+  });
+
+  it('throws INVALID_MODEL_FOR_LLM_STEP for non-chat models', () => {
+    let caught: unknown;
+    try {
+      assertChatTag(modelData(['embedding']), 'openrouter:foo/bar');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConvexError);
+    const data = (caught as ConvexError<{ code: string; message: string }>)
+      .data;
+    expect(data.code).toBe('INVALID_MODEL_FOR_LLM_STEP');
+    expect(data.message).toContain('openrouter:foo/bar');
+    expect(data.message).toContain('not tagged as a chat model');
+  });
+
+  it('omits the requested ref from the message when none was provided', () => {
+    let caught: unknown;
+    try {
+      assertChatTag(modelData(['transcription']), undefined);
+    } catch (err) {
+      caught = err;
+    }
+    const data = (caught as ConvexError<{ message: string }>).data;
+    expect(data.message).toContain('openrouter:foo/bar');
+    expect(data.message).not.toContain('resolved to');
+  });
+});

--- a/services/platform/convex/workflow_engine/helpers/nodes/llm/utils/resolve_chat_model.ts
+++ b/services/platform/convex/workflow_engine/helpers/nodes/llm/utils/resolve_chat_model.ts
@@ -1,0 +1,56 @@
+import { ConvexError } from 'convex/values';
+
+import { parseModelRef } from '../../../../../../lib/shared/utils/model-ref';
+import type { ActionCtx } from '../../../../../_generated/server';
+import { resolveLanguageModelWithFallback } from '../../../../../providers/failover';
+import {
+  type ResolvedModelData,
+  resolveLanguageModel,
+  resolveLanguageModelById,
+} from '../../../../../providers/resolve_model';
+import type { LLMNodeConfig } from '../../../../types';
+
+/**
+ * Resolve the chat model for an LLM workflow step. Routes to the explicit
+ * `config.model` ref when set (with model-level failover unless `noFallback`
+ * is true), otherwise resolves the org's `defaults.chat` tag.
+ */
+export async function resolveChatModel(
+  ctx: ActionCtx,
+  config: LLMNodeConfig,
+  orgSlug: string,
+) {
+  const explicit = typeof config.model === 'string' ? config.model.trim() : '';
+  if (explicit.length > 0) {
+    const { providerName, modelId } = parseModelRef(explicit);
+    return config.noFallback
+      ? resolveLanguageModelById(ctx, { modelId, providerName, orgSlug })
+      : resolveLanguageModelWithFallback(ctx, {
+          modelId,
+          providerName,
+          tag: 'chat',
+          orgSlug,
+        });
+  }
+  return config.noFallback
+    ? resolveLanguageModel(ctx, { tag: 'chat', orgSlug })
+    : resolveLanguageModelWithFallback(ctx, { tag: 'chat', orgSlug });
+}
+
+/**
+ * Reject a resolved model that is not tagged as a `chat` model. The
+ * tag-based resolution path implicitly enforces this; the explicit-ref path
+ * does not, so callers must invoke this guard.
+ */
+export function assertChatTag(
+  modelData: ResolvedModelData,
+  requestedRef: string | undefined,
+): void {
+  if (modelData.tags.includes('chat')) return;
+  throw new ConvexError({
+    code: 'INVALID_MODEL_FOR_LLM_STEP',
+    message: requestedRef
+      ? `Model ${requestedRef} resolved to ${modelData.providerName}:${modelData.modelId} which is not tagged as a chat model.`
+      : `Model ${modelData.providerName}:${modelData.modelId} is not tagged as a chat model.`,
+  });
+}

--- a/services/platform/convex/workflow_engine/types/nodes.ts
+++ b/services/platform/convex/workflow_engine/types/nodes.ts
@@ -48,12 +48,17 @@ export interface LLMNodeConfig {
   name: string;
   description?: string;
 
-  // Model configuration (provider-agnostic; any OpenAI-compatible model id)
-  // Model is resolved from provider configuration files and cannot be
-  // customized per step.
-  // Temperature is automatically determined based on outputFormat:
-  // - json → 0.2 (more deterministic for structured output)
-  // - text → 0.5 (balanced creativity)
+  /**
+   * Optional explicit model ref for this step. Format: `provider:modelId`
+   * (e.g. `openrouter:deepseek/deepseek-v4-flash`) or unqualified `modelId`
+   * (resolved against the org's providers; first match wins). When unset,
+   * the step uses the org's `defaults.chat`. The resolved model must carry
+   * the `chat` tag.
+   *
+   * Temperature is automatically determined based on outputFormat:
+   * - json → 0.2 (more deterministic for structured output)
+   * - text → 0.5 (balanced creativity)
+   */
   model?: string;
 
   // Core prompts

--- a/services/platform/lib/utils/link-classifier.test.ts
+++ b/services/platform/lib/utils/link-classifier.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { classifyLink } from './link-classifier';
+
+describe('classifyLink', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null for empty/undefined input', () => {
+    expect(classifyLink(undefined)).toBeNull();
+    expect(classifyLink('')).toBeNull();
+    expect(classifyLink('   ')).toBeNull();
+  });
+
+  it('classifies hash as hash', () => {
+    expect(classifyLink('#section')).toEqual({
+      kind: 'hash',
+      href: '#section',
+    });
+  });
+
+  it('classifies mailto/tel/sms as special', () => {
+    expect(classifyLink('mailto:foo@example.com')).toEqual({
+      kind: 'special',
+      href: 'mailto:foo@example.com',
+    });
+    expect(classifyLink('tel:+15555550123')).toEqual({
+      kind: 'special',
+      href: 'tel:+15555550123',
+    });
+  });
+
+  describe('path-only links', () => {
+    it('classifies SPA paths as internal', () => {
+      expect(classifyLink('/dashboard/foo')).toEqual({
+        kind: 'internal',
+        to: '/dashboard/foo',
+      });
+    });
+
+    it('classifies backend prefixes as external', () => {
+      expect(classifyLink('/http_api/storage?id=x&filename=y.docx')).toEqual({
+        kind: 'external',
+        href: '/http_api/storage?id=x&filename=y.docx',
+      });
+      expect(classifyLink('/api/storage/abc123')).toEqual({
+        kind: 'external',
+        href: '/api/storage/abc123',
+      });
+      expect(classifyLink('/ws_api/sync')).toEqual({
+        kind: 'external',
+        href: '/ws_api/sync',
+      });
+      expect(classifyLink('/metrics/platform')).toEqual({
+        kind: 'external',
+        href: '/metrics/platform',
+      });
+    });
+
+    it('treats a bare backend prefix (no trailing slash) as external', () => {
+      expect(classifyLink('/api')).toEqual({
+        kind: 'external',
+        href: '/api',
+      });
+    });
+
+    it('does not match paths that merely start with prefix-like text', () => {
+      // `/apirelated` is a hypothetical SPA route; it is not under `/api/`.
+      expect(classifyLink('/apirelated/foo')).toEqual({
+        kind: 'internal',
+        to: '/apirelated/foo',
+      });
+    });
+
+    it('protocol-relative // is not classified as path-internal', () => {
+      // Without a window, falls through to the external branch.
+      expect(classifyLink('//other.example.com/x')).toEqual({
+        kind: 'external',
+        href: '//other.example.com/x',
+      });
+    });
+  });
+
+  describe('absolute URLs (with window)', () => {
+    function stubWindow(href: string) {
+      vi.stubGlobal('window', {
+        location: { href, origin: new URL(href).origin },
+      });
+    }
+
+    it('classifies same-origin SPA path as internal', () => {
+      stubWindow('http://localhost:3000/dashboard');
+      expect(
+        classifyLink('http://localhost:3000/dashboard/foo?x=1#hash'),
+      ).toEqual({
+        kind: 'internal',
+        to: '/dashboard/foo?x=1#hash',
+      });
+    });
+
+    it('classifies same-origin backend path as external', () => {
+      stubWindow('http://localhost:3000/dashboard');
+      expect(
+        classifyLink(
+          'http://localhost:3000/http_api/storage?id=x&filename=y.docx',
+        ),
+      ).toEqual({
+        kind: 'external',
+        href: 'http://localhost:3000/http_api/storage?id=x&filename=y.docx',
+      });
+    });
+
+    it('classifies cross-origin URL as external', () => {
+      stubWindow('http://localhost:3000/dashboard');
+      expect(classifyLink('https://example.com/page')).toEqual({
+        kind: 'external',
+        href: 'https://example.com/page',
+      });
+    });
+  });
+
+  describe('absolute URLs without window', () => {
+    it('falls back to external', () => {
+      // No window stubbed — the global from happy-dom/jsdom might still exist
+      // in some envs. Skip if window is defined to keep this assertion crisp.
+      if (typeof window !== 'undefined') return;
+      expect(classifyLink('https://example.com/page')).toEqual({
+        kind: 'external',
+        href: 'https://example.com/page',
+      });
+    });
+  });
+});

--- a/services/platform/lib/utils/link-classifier.ts
+++ b/services/platform/lib/utils/link-classifier.ts
@@ -4,6 +4,17 @@ type LinkKind =
   | { kind: 'hash'; href: string }
   | { kind: 'special'; href: string };
 
+// Backend-proxied path prefixes: served by Caddy/Vite via reverse-proxy to
+// Convex or the platform server. They are NOT TanStack Router routes, so
+// `router.navigate` against them is a silent no-op (left-click does nothing).
+const BACKEND_PREFIXES = ['/api/', '/http_api/', '/ws_api/', '/metrics/'];
+
+function isBackendPath(pathname: string): boolean {
+  return BACKEND_PREFIXES.some(
+    (p) => pathname === p.slice(0, -1) || pathname.startsWith(p),
+  );
+}
+
 export function classifyLink(href: string | undefined): LinkKind | null {
   if (!href) return null;
   const trimmed = href.trim();
@@ -16,7 +27,9 @@ export function classifyLink(href: string | undefined): LinkKind | null {
   }
 
   if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
-    return { kind: 'internal', to: trimmed };
+    return isBackendPath(trimmed)
+      ? { kind: 'external', href: trimmed }
+      : { kind: 'internal', to: trimmed };
   }
 
   if (typeof window === 'undefined') {
@@ -26,7 +39,9 @@ export function classifyLink(href: string | undefined): LinkKind | null {
   try {
     const url = new URL(trimmed, window.location.href);
     if (url.origin === window.location.origin) {
-      return { kind: 'internal', to: url.pathname + url.search + url.hash };
+      return isBackendPath(url.pathname)
+        ? { kind: 'external', href: url.toString() }
+        : { kind: 'internal', to: url.pathname + url.search + url.hash };
     }
     return { kind: 'external', href: url.toString() };
   } catch {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -65,7 +65,12 @@
       "clickToUpload": "Klicken zum Hochladen",
       "supportedFormats": ".xlsx, .xls oder .csv",
       "pickADate": "Datum auswählen",
-      "dropFilesHere": "Dateien hier ablegen zum Hochladen"
+      "dropFilesHere": "Dateien hier ablegen zum Hochladen",
+      "acceptHint": "JSON-Dateien, Ordner oder .zip-Archive",
+      "pickFiles": "Dateien wählen",
+      "pickFolder": "Ordner wählen",
+      "pickZip": "ZIP wählen",
+      "summary": "{total} Einträge · {saved} gespeichert · {queued} ausstehend"
     },
     "labels": {
       "name": "Name",
@@ -595,6 +600,12 @@
         "modelPlaceholder": "Modell auswählen",
         "modelSearch": "Modelle suchen…",
         "modelEmpty": "Keine Modelle gefunden"
+      },
+      "uploadDialog": {
+        "menuItem": "Aus Datei hochladen…",
+        "title": "Agents hochladen",
+        "description": "Importiere Agent-JSON-Dateien, Ordner oder .zip-Archive. Jede .json-Datei wird als eigener Agent installiert.",
+        "toastSuccess": "Agents importiert"
       },
       "general": {
         "visibleInChat": "Im Chat sichtbar",
@@ -1443,6 +1454,12 @@
       "descriptionPlaceholder": "Beschreibe, was diese Automatisierung tut...",
       "creating": "Wird erstellt...",
       "continue": "Weiter"
+    },
+    "uploadDialog": {
+      "menuItem": "Aus Datei hochladen…",
+      "title": "Automatisierungen hochladen",
+      "description": "Importiere Workflow-JSON-Dateien, Ordner oder .zip-Archive. Jede .json-Datei wird als eigene Automatisierung installiert.",
+      "toastSuccess": "Automatisierungen importiert"
     },
     "templates": {
       "description": "Wähle eine Vorlage mit vorkonfigurierten Schritten.",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -70,7 +70,13 @@
       "pickFiles": "Dateien wählen",
       "pickFolder": "Ordner wählen",
       "pickZip": "ZIP wählen",
-      "summary": "{total} Einträge · {saved} gespeichert · {queued} ausstehend"
+      "summary": "{total} Einträge · {saved} gespeichert · {queued} ausstehend",
+      "conflictHeading": "{count, plural, one {# Eintrag existiert bereits} other {# Einträge existieren bereits}}",
+      "conflictHint": "Bestehende Einträge werden übersprungen, sofern du das Überschreiben nicht erlaubst. Beim Überschreiben wird die vorherige Version in der Historie gesichert.",
+      "overwriteToggle": "Bestehende Einträge überschreiben",
+      "statusExists": "Existiert bereits — wird übersprungen",
+      "willOverwrite": "Existiert bereits — wird überschrieben",
+      "statusSkipped": "Übersprungen"
     },
     "labels": {
       "name": "Name",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -65,7 +65,12 @@
       "clickToUpload": "Click to upload",
       "supportedFormats": ".xlsx, .xls or .csv",
       "pickADate": "Pick a date",
-      "dropFilesHere": "Drop files here to upload"
+      "dropFilesHere": "Drop files here to upload",
+      "acceptHint": "JSON files, folders, or .zip archives",
+      "pickFiles": "Choose files",
+      "pickFolder": "Choose folder",
+      "pickZip": "Choose zip",
+      "summary": "{total} entries · {saved} saved · {queued} pending"
     },
     "labels": {
       "name": "Name",
@@ -595,6 +600,12 @@
         "modelPlaceholder": "Select a model",
         "modelSearch": "Search models…",
         "modelEmpty": "No models found"
+      },
+      "uploadDialog": {
+        "menuItem": "Upload from file…",
+        "title": "Upload agents",
+        "description": "Import agent JSON files, folders, or .zip archives. Each .json file installs as a separate agent.",
+        "toastSuccess": "Agents imported"
       },
       "general": {
         "visibleInChat": "Visible in chat",
@@ -1443,6 +1454,12 @@
       "descriptionPlaceholder": "Describe what this automation does...",
       "creating": "Creating...",
       "continue": "Continue"
+    },
+    "uploadDialog": {
+      "menuItem": "Upload from file…",
+      "title": "Upload automations",
+      "description": "Import workflow JSON files, folders, or .zip archives. Each .json file installs as a separate automation.",
+      "toastSuccess": "Automations imported"
     },
     "templates": {
       "description": "Choose a template to get started with pre-configured steps.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -70,7 +70,13 @@
       "pickFiles": "Choose files",
       "pickFolder": "Choose folder",
       "pickZip": "Choose zip",
-      "summary": "{total} entries · {saved} saved · {queued} pending"
+      "summary": "{total} entries · {saved} saved · {queued} pending",
+      "conflictHeading": "{count, plural, one {# entry already exists} other {# entries already exist}}",
+      "conflictHint": "Existing entries will be skipped unless you allow overwrites. Overwriting saves the previous version to history.",
+      "overwriteToggle": "Overwrite existing entries",
+      "statusExists": "Already exists — will be skipped",
+      "willOverwrite": "Already exists — will overwrite",
+      "statusSkipped": "Skipped"
     },
     "labels": {
       "name": "Name",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -65,7 +65,12 @@
       "clickToUpload": "Clique pour téléverser",
       "supportedFormats": ".xlsx, .xls ou .csv",
       "pickADate": "Choisir une date",
-      "dropFilesHere": "Dépose les fichiers ici pour téléverser"
+      "dropFilesHere": "Dépose les fichiers ici pour téléverser",
+      "acceptHint": "Fichiers JSON, dossiers ou archives .zip",
+      "pickFiles": "Choisir des fichiers",
+      "pickFolder": "Choisir un dossier",
+      "pickZip": "Choisir un zip",
+      "summary": "{total} entrées · {saved} enregistrées · {queued} en attente"
     },
     "labels": {
       "name": "Nom",
@@ -594,6 +599,12 @@
         "modelPlaceholder": "Sélectionner un modèle",
         "modelSearch": "Rechercher des modèles…",
         "modelEmpty": "Aucun modèle trouvé"
+      },
+      "uploadDialog": {
+        "menuItem": "Téléverser depuis un fichier…",
+        "title": "Téléverser des agents",
+        "description": "Importe des fichiers JSON d'agent, des dossiers ou des archives .zip. Chaque fichier .json s'installe comme un agent distinct.",
+        "toastSuccess": "Agents importés"
       },
       "general": {
         "visibleInChat": "Visible dans le chat",
@@ -1443,6 +1454,12 @@
       "descriptionPlaceholder": "Décris ce que fait cette automatisation...",
       "creating": "Création...",
       "continue": "Continuer"
+    },
+    "uploadDialog": {
+      "menuItem": "Téléverser depuis un fichier…",
+      "title": "Téléverser des automatisations",
+      "description": "Importe des fichiers JSON de workflow, des dossiers ou des archives .zip. Chaque fichier .json s'installe comme une automatisation distincte.",
+      "toastSuccess": "Automatisations importées"
     },
     "templates": {
       "description": "Choisis un modèle pour démarrer avec des étapes préconfigurées.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -70,7 +70,13 @@
       "pickFiles": "Choisir des fichiers",
       "pickFolder": "Choisir un dossier",
       "pickZip": "Choisir un zip",
-      "summary": "{total} entrées · {saved} enregistrées · {queued} en attente"
+      "summary": "{total} entrées · {saved} enregistrées · {queued} en attente",
+      "conflictHeading": "{count, plural, one {# entrée existe déjà} other {# entrées existent déjà}}",
+      "conflictHint": "Les entrées existantes seront ignorées sauf si tu autorises l'écrasement. L'écrasement enregistre la version précédente dans l'historique.",
+      "overwriteToggle": "Écraser les entrées existantes",
+      "statusExists": "Existe déjà — sera ignorée",
+      "willOverwrite": "Existe déjà — sera écrasée",
+      "statusSkipped": "Ignorée"
     },
     "labels": {
       "name": "Nom",


### PR DESCRIPTION
## Summary

- Turn the `+ Create` button on the **Automations** and **Agents** dashboard pages into a dropdown (mirroring the Knowledge → Documents pattern) and add a new **Upload from file…** option to each.
- The upload dialog accepts JSON files, folder picks (`webkitdirectory`), or `.zip` archives. Each `.json` installs as a separate automation / agent, and per-file results are shown inline so one bad entry doesn't block the batch.
- Uses the existing `saveWorkflowWithSnapshot` + `installWorkflow` and `saveAgent` actions — no Convex backend changes.
- Uploaded workflow JSONs missing a top-level `name` fall back to the filename, so older exports install cleanly.

## Test plan

- [ ] Single file: pick one workflow `.json`, confirm it installs and shows up in the table.
- [ ] Multi-file: pick two `.json`s at once, both should land with ✓ status.
- [ ] Folder: pick a folder containing nested workflows (e.g. `general/foo.json`); confirm slug paths preserve the nesting and the picked-folder prefix is stripped.
- [ ] Zip: zip the `examples/workflows/` directory and upload; confirm the common-root folder is stripped and all `.json` entries install.
- [ ] Validation error: hand-edit a JSON to remove a required field, upload — that row shows the Zod error inline; siblings still succeed.
- [ ] Agents parity: repeat with files from `examples/agents/`.
- [ ] Locale check: switch UI to `de` / `fr`, confirm dropdown labels and dialog strings are translated.
- [ ] `bun run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now upload agent configurations via JSON files, folders, or ZIP archives through the Agents menu.
  * Users can now upload automation configurations via JSON files, folders, or ZIP archives through the Automations menu.
  * Added support for multiple locales: English, French, and German translations for upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->