### PR TITLE
fix(platform): allow saving agents that reference keyless providers

### DIFF
--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -179,8 +179,11 @@ export const saveAgent = action({
     // Cross-validate supportedModels against provider model lists.
     // Qualified entries ("provider:model") must resolve strictly;
     // unqualified entries that match multiple providers produce a soft warning.
+    // Use the secrets-free configured-models list: a provider config existing
+    // without an API key yet is a legitimate state and shouldn't block save.
+    // Runtime invocation enforces key availability separately.
     const allModels = await ctx.runAction(
-      internal.providers.file_actions.getAllModelIds,
+      internal.providers.file_actions.getAllConfiguredModelIds,
       { orgSlug: args.orgSlug },
     );
     const byProvider = new Map<string, Set<string>>();

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -588,6 +588,64 @@ export const getAllModelIds = internalAction({
 });
 
 /**
+ * Like getAllModelIds but reads provider JSON configs directly without
+ * requiring secrets. For config-time validation paths (e.g. saveAgent)
+ * where reference validity must be decoupled from runtime API-key
+ * availability — a provider config existing without an API key yet is a
+ * legitimate state, not a missing reference.
+ */
+export const getAllConfiguredModelIds = internalAction({
+  args: { orgSlug: v.optional(v.string()) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      tags: v.array(v.string()),
+      providerName: v.string(),
+      displayName: v.optional(v.string()),
+    }),
+  ),
+  handler: async (_ctx, args) => {
+    const orgSlug = args.orgSlug ?? 'default';
+    const dir = resolveProvidersDir(orgSlug);
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return [];
+    }
+    const jsonFiles = entries.filter(
+      (e) =>
+        e.endsWith('.json') &&
+        !e.startsWith('.') &&
+        !e.endsWith('.secrets.json'),
+    );
+    const models: Array<{
+      id: string;
+      tags: string[];
+      providerName: string;
+      displayName?: string;
+    }> = [];
+    await Promise.all(
+      jsonFiles.map(async (fileName) => {
+        const name = providerNameFromFileName(fileName);
+        if (!validateProviderName(name)) return;
+        const result = await readProviderFile(orgSlug, name);
+        if (!result.ok) return;
+        for (const m of result.config.models) {
+          models.push({
+            id: m.id,
+            tags: [...m.tags],
+            providerName: name,
+            displayName: m.displayName,
+          });
+        }
+      }),
+    );
+    return models;
+  },
+});
+
+/**
  * Get all provider configs (public data only, no secrets).
  */
 export const getAllProviderConfigs = action({


### PR DESCRIPTION
## Summary

- `saveAgent` validated `supportedModels` via `getAllModelIds`, which routes through `loadAllProviders` and **skips any provider whose secrets file is missing** (ENOENT). A provider configured without an API key yet was therefore treated as nonexistent and threw `UNKNOWN_PROVIDER`, even though Settings → AI providers happily lists it (that path uses `listProviders`, which reads JSON independently of secrets).
- Decouples config-time reference validity from runtime credential availability: adds `getAllConfiguredModelIds` (reads provider JSON directly, no secrets needed) and uses it in `saveAgent`.
- Runtime resolution paths — `resolveAgentConfig`, OpenAI-compat `/v1/models`, `resolveModelData`, `resolveModelByTag` — keep their existing secrets-gated semantics so chat UIs and API clients never present a model that can't actually be invoked.

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Save agent referencing model from configured-but-keyless provider | ❌ `UNKNOWN_PROVIDER` | ✅ saves |
| Save agent referencing nonexistent provider | ❌ `UNKNOWN_PROVIDER` | ❌ `UNKNOWN_PROVIDER` (preserved) |
| Save agent referencing unknown model id under known provider | ❌ `UNKNOWN_MODEL` | ❌ `UNKNOWN_MODEL` (preserved) |
| Chat model picker for a keyless provider | filtered out | filtered out (preserved) |
| Actually invoking a keyless model | "No API key configured" | "No API key configured" (preserved, via `NoProviderAvailableError` → `errorHintMissingApiKey`) |

## Test plan

- [x] `bun run check` — 21/21 turbo tasks, 2664 tests passing, lint + typecheck clean
- [ ] In a deployment with a provider JSON that has no `.secrets.json` (e.g. Vercel AI Gateway in the screenshot), open agent settings, add a `<provider>:<model>` from that provider to `supportedModels`, click Save → expect success
- [ ] Open the same agent in the chat UI → that model should NOT appear in the picker (runtime filtering still active)
- [ ] Add an API key for that provider → model becomes selectable, chat works
- [ ] Regression: reference a provider name that does not exist → still rejects with `UNKNOWN_PROVIDER`
- [ ] Regression: `GET /v1/models` (OpenAI-compat) still excludes models from keyless providers

## Pre-PR checklist

- [x] Ran `bun run check`
- [x] Updated `services/platform/messages/{en,de,fr}.json` — **N/A** (no new user-facing strings; existing `errorHintMissingApiKey` already covers the runtime path)
- [x] Updated `docs/{,de/,fr/}` — **N/A** (internal validation behavior; no documented contract changed)
- [x] Ran `bun run --filter @tale/docs lint` — **N/A**
- [x] Updated README.md/.de.md/.fr.md — **N/A**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Agent save validation now correctly allows saving agents when provider configurations have been established but API key credentials are not yet configured. This enables users to configure providers incrementally and save their agent setups without requiring all authentication credentials to be set up immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->