### PR TITLE
feat(platform): add "Export as PDF" to canvas artifacts

### DIFF
--- a/services/platform/app/features/chat/components/canvas/__tests__/canvas-html-renderer.test.tsx
+++ b/services/platform/app/features/chat/components/canvas/__tests__/canvas-html-renderer.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
-import { CanvasHtmlRenderer } from '../canvas-html-renderer';
+import {
+  CanvasHtmlRenderer,
+  type CanvasHtmlRendererHandle,
+} from '../canvas-html-renderer';
 
 describe('CanvasHtmlRenderer', () => {
   test('renders a hidden form pointing at /canvas-preview targeting the iframe', () => {
@@ -21,7 +25,9 @@ describe('CanvasHtmlRenderer', () => {
     expect(iframe.getAttribute('src')).toBeNull();
     // `allow-scripts` without `allow-same-origin` keeps the iframe in an
     // opaque origin so AI HTML cannot reach parent storage / cookies.
-    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    // `allow-modals` is required so window.print() (PDF export path)
+    // actually opens the print dialog.
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-modals');
     expect(iframe.getAttribute('name')).toMatch(/^canvas-preview-/);
 
     const form = iframe.previousElementSibling as HTMLFormElement;
@@ -78,6 +84,30 @@ describe('CanvasHtmlRenderer', () => {
     ) as HTMLTextAreaElement;
     expect(input.value).toBe('<h1>v2</h1>');
     submit.mockRestore();
+  });
+
+  test('requestPrint() postMessages the print signal to the iframe', () => {
+    const ref = createRef<CanvasHtmlRendererHandle>();
+    render(
+      <CanvasHtmlRenderer
+        ref={ref}
+        html="<p>x</p>"
+        isEditing={false}
+        onContentChange={vi.fn()}
+      />,
+    );
+    const iframe = screen.getByTitle('HTML preview') as HTMLIFrameElement;
+    const postMessage = vi.fn();
+    // jsdom gives the iframe a contentWindow; spy on its postMessage.
+    Object.defineProperty(iframe.contentWindow, 'postMessage', {
+      value: postMessage,
+      configurable: true,
+    });
+    ref.current?.requestPrint();
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'tale:canvas:print' },
+      '*',
+    );
   });
 
   test('renders the textarea (no iframe / form) in editing mode', async () => {

--- a/services/platform/app/features/chat/components/canvas/__tests__/canvas-pane.test.tsx
+++ b/services/platform/app/features/chat/components/canvas/__tests__/canvas-pane.test.tsx
@@ -55,6 +55,8 @@ vi.mock('@/lib/i18n/client', () => ({
         'canvas.preview': 'Preview',
         'canvas.copy': 'Copy',
         'canvas.download': 'Download',
+        'canvas.exportPdf': 'Export as PDF',
+        'canvas.exportPdfFailed': 'Failed to export as PDF',
         'canvas.copied': 'Copied!',
         'canvas.resizeHandle': 'Resize canvas',
         'canvas.mermaidError': 'Failed to render diagram',
@@ -185,6 +187,65 @@ describe('CanvasPane', () => {
       screen.getByRole('button', { name: 'Fullscreen' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('does not show the PDF export button for code artifacts', async () => {
+    const user = userEvent.setup();
+    render(<TestHarness />);
+    await user.click(screen.getByText('Open'));
+    expect(
+      screen.queryByRole('button', { name: 'Export as PDF' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the PDF export button for HTML artifacts', async () => {
+    const user = userEvent.setup();
+    artifactHolder.current = {
+      ...BASE_ARTIFACT,
+      type: 'html',
+      title: 'index.html',
+      content: '<p>hi</p>',
+      language: undefined,
+    };
+    render(<TestHarness />);
+    await user.click(screen.getByText('Open'));
+    expect(
+      screen.getByRole('button', { name: 'Export as PDF' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the PDF export button for markdown artifacts', async () => {
+    const user = userEvent.setup();
+    artifactHolder.current = {
+      ...BASE_ARTIFACT,
+      type: 'markdown',
+      title: 'doc.md',
+      content: '# hello',
+      language: undefined,
+    };
+    render(<TestHarness />);
+    await user.click(screen.getByText('Open'));
+    expect(
+      screen.getByRole('button', { name: 'Export as PDF' }),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the PDF export button while a stream is in flight', async () => {
+    const user = userEvent.setup();
+    artifactHolder.current = {
+      ...BASE_ARTIFACT,
+      type: 'html',
+      title: 'index.html',
+      content: '<p>hi</p>',
+      language: undefined,
+      streamingContent: '<p>partial',
+      liveStreamMode: 'create',
+    };
+    render(<TestHarness />);
+    await user.click(screen.getByText('Open'));
+    expect(
+      screen.getByRole('button', { name: 'Export as PDF' }),
+    ).toBeDisabled();
   });
 
   it('shows the streaming source as plain text during a create stream', async () => {

--- a/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-html-renderer.tsx
@@ -1,9 +1,24 @@
 'use client';
 
-import { memo, useId, useLayoutEffect, useRef } from 'react';
+import {
+  forwardRef,
+  memo,
+  useId,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 
 import { getEnv } from '@/lib/env';
 import { cn } from '@/lib/utils/cn';
+
+export interface CanvasHtmlRendererHandle {
+  // postMessage `tale:canvas:print` into the iframe; the shell listener
+  // (lib/canvas-preview-shell.ts) calls window.print() on receipt. The
+  // parent cannot call iframe.contentWindow.print() directly — the sandbox
+  // runs without `allow-same-origin`, so cross-realm access throws.
+  requestPrint: () => void;
+}
 
 interface CanvasHtmlRendererProps {
   html: string;
@@ -11,14 +26,26 @@ interface CanvasHtmlRendererProps {
   onContentChange: (content: string) => void;
 }
 
-function CanvasHtmlRendererComponent({
-  html,
-  isEditing,
-  onContentChange,
-}: CanvasHtmlRendererProps) {
+function CanvasHtmlRendererComponent(
+  { html, isEditing, onContentChange }: CanvasHtmlRendererProps,
+  ref: React.Ref<CanvasHtmlRendererHandle>,
+) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const htmlInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      requestPrint: () => {
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: 'tale:canvas:print' },
+          '*',
+        );
+      },
+    }),
+    [],
+  );
 
   // Each renderer instance gets a unique iframe `name` so the form's
   // `target` resolves to this iframe and not some other frame on the page.
@@ -74,7 +101,11 @@ function CanvasHtmlRendererComponent({
       <iframe
         ref={iframeRef}
         name={iframeName}
-        sandbox="allow-scripts"
+        // `allow-modals` is required for `window.print()` to actually open
+        // the print dialog — the spec gates print, alert, confirm, prompt,
+        // and beforeunload modals on this flag. Used by the toolbar's
+        // "Export as PDF" action via `requestPrint()`.
+        sandbox="allow-scripts allow-modals"
         title="HTML preview"
         className="h-full w-full border-0 bg-white"
       />
@@ -82,4 +113,4 @@ function CanvasHtmlRendererComponent({
   );
 }
 
-export const CanvasHtmlRenderer = memo(CanvasHtmlRendererComponent);
+export const CanvasHtmlRenderer = memo(forwardRef(CanvasHtmlRendererComponent));

--- a/services/platform/app/features/chat/components/canvas/canvas-markdown-renderer.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-markdown-renderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo } from 'react';
+import { forwardRef, memo, useImperativeHandle, useRef } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -11,18 +11,34 @@ import {
 } from '../message-bubble/markdown-renderer';
 import { TypewriterText } from '../typewriter-text';
 
+export interface CanvasMarkdownRendererHandle {
+  // Returns the live rendered HTML of the article (the same DOM the user is
+  // looking at). Used by the PDF export path so the printed document is
+  // pixel-parity with the on-screen rendering — re-running react-markdown
+  // could drift if components/plugins change.
+  getRenderedHtml: () => string | null;
+}
+
 interface CanvasMarkdownRendererProps {
   content: string;
   isEditing: boolean;
   onContentChange: (content: string) => void;
 }
 
-function CanvasMarkdownRendererComponent({
-  content,
-  isEditing,
-  onContentChange,
-}: CanvasMarkdownRendererProps) {
+function CanvasMarkdownRendererComponent(
+  { content, isEditing, onContentChange }: CanvasMarkdownRendererProps,
+  ref: React.Ref<CanvasMarkdownRendererHandle>,
+) {
   const { t } = useT('chat');
+  const articleRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getRenderedHtml: () => articleRef.current?.innerHTML ?? null,
+    }),
+    [],
+  );
 
   if (isEditing) {
     return (
@@ -41,7 +57,7 @@ function CanvasMarkdownRendererComponent({
 
   return (
     <div className="h-full overflow-auto p-4">
-      <div className={cn('text-sm', markdownWrapperStyles)}>
+      <div ref={articleRef} className={cn('text-sm', markdownWrapperStyles)}>
         <TypewriterText
           text={content}
           isStreaming={false}
@@ -52,4 +68,6 @@ function CanvasMarkdownRendererComponent({
   );
 }
 
-export const CanvasMarkdownRenderer = memo(CanvasMarkdownRendererComponent);
+export const CanvasMarkdownRenderer = memo(
+  forwardRef(CanvasMarkdownRendererComponent),
+);

--- a/services/platform/app/features/chat/components/canvas/canvas-pane.tsx
+++ b/services/platform/app/features/chat/components/canvas/canvas-pane.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
   Download,
   Eye,
+  FileDown,
   FileText,
   GitBranch,
   Globe,
@@ -25,12 +26,16 @@ import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { Button } from '@/app/components/ui/primitives/button';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
+import { getEnv } from '@/lib/env';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 
 import { useStreamedArtifactContent } from '../../hooks/use-streamed-artifact-content';
 import { useCanvas, type CanvasContentType } from './canvas-context';
+import type { CanvasHtmlRendererHandle } from './canvas-html-renderer';
+import type { CanvasMarkdownRendererHandle } from './canvas-markdown-renderer';
+import { printHtmlInHiddenIframe } from './print-via-iframe';
 
 const CanvasCodeRenderer = lazyComponent(() =>
   import('./canvas-code-renderer').then((m) => ({
@@ -38,7 +43,12 @@ const CanvasCodeRenderer = lazyComponent(() =>
   })),
 );
 
-const CanvasHtmlRenderer = lazyComponent(() =>
+const CanvasHtmlRenderer = lazyComponent<
+  React.ComponentProps<
+    typeof import('./canvas-html-renderer').CanvasHtmlRenderer
+  >,
+  CanvasHtmlRendererHandle
+>(() =>
   import('./canvas-html-renderer').then((m) => ({
     default: m.CanvasHtmlRenderer,
   })),
@@ -50,11 +60,79 @@ const CanvasMermaidRenderer = lazyComponent(() =>
   })),
 );
 
-const CanvasMarkdownRenderer = lazyComponent(() =>
+const CanvasMarkdownRenderer = lazyComponent<
+  React.ComponentProps<
+    typeof import('./canvas-markdown-renderer').CanvasMarkdownRenderer
+  >,
+  CanvasMarkdownRendererHandle
+>(() =>
   import('./canvas-markdown-renderer').then((m) => ({
     default: m.CanvasMarkdownRenderer,
   })),
 );
+
+// Print-friendly typography stylesheet for markdown PDF export. Inlined so
+// we don't need to ship Tailwind's prose styles into the iframe — these
+// rules cover the elements react-markdown emits (headings, paragraphs, code,
+// pre, lists, tables, blockquotes, hr, links). Pixel parity with the
+// on-screen prose styles is a non-goal; "looks good as a printed document"
+// is. The @page margin handles paper margins; @media print hides body
+// margin so the @page margin alone controls spacing.
+const MARKDOWN_PRINT_STYLES = `
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      'Helvetica Neue', Arial, 'Noto Sans', 'PingFang SC', 'Hiragino Sans GB',
+      'Microsoft YaHei', sans-serif;
+    color: #111;
+    line-height: 1.7;
+    max-width: 760px;
+    margin: 2em auto;
+    padding: 0 1em;
+  }
+  h1, h2, h3, h4, h5, h6 { line-height: 1.25; margin: 1.6em 0 0.6em; }
+  h1 { font-size: 1.9em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #eee; padding-bottom: .3em; }
+  h3 { font-size: 1.25em; }
+  p, ul, ol, blockquote, pre, table { margin: 0.8em 0; }
+  ul, ol { padding-left: 1.5em; }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #f4f4f5;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.92em;
+  }
+  pre {
+    background: #f4f4f5;
+    padding: 0.9em 1em;
+    border-radius: 4px;
+    overflow-x: auto;
+    line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; font-size: 0.9em; }
+  blockquote {
+    border-left: 3px solid #ddd;
+    padding: 0 1em;
+    color: #555;
+  }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #ddd; padding: 6px 10px; text-align: left; }
+  th { background: #f9fafb; }
+  hr { border: none; border-top: 1px solid #eee; margin: 1.5em 0; }
+  a { color: #0366d6; text-decoration: underline; }
+  img { max-width: 100%; }
+  @page { margin: 1in; }
+  @media print {
+    body { margin: 0; max-width: none; padding: 0; }
+    pre, blockquote, table { page-break-inside: avoid; }
+  }
+`;
+
+function buildMarkdownPrintHtml(renderedHtml: string): string {
+  // No title preamble: the markdown's own h1 (if any) lives inside
+  // renderedHtml — re-prepending the artifact title would double-up.
+  return `<style>${MARKDOWN_PRINT_STYLES}</style><article>${renderedHtml}</article>`;
+}
 
 const TYPE_ICONS: Record<CanvasContentType, typeof Code> = {
   code: Code,
@@ -118,6 +196,8 @@ function CanvasPaneComponent() {
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const resizeRef = useRef<HTMLDivElement>(null);
   const paneRef = useRef<HTMLDivElement>(null);
+  const htmlRendererRef = useRef<CanvasHtmlRendererHandle>(null);
+  const markdownRendererRef = useRef<CanvasMarkdownRendererHandle>(null);
   const isDraggingRef = useRef(false);
   const dragRafRef = useRef<number | null>(null);
 
@@ -430,6 +510,35 @@ function CanvasPaneComponent() {
     URL.revokeObjectURL(url);
   }, [displayedContent, canvasType, canvasTitle, canvasLanguage]);
 
+  // Trigger the browser's "Save as PDF" flow by calling window.print() inside
+  // the artifact's own iframe — fidelity is identical to what's on screen
+  // (Chinese fonts, gradients, complex CSS all rendered by the real browser),
+  // and the print dialog only sees the artifact, not the surrounding chat UI.
+  const handleExportPdf = useCallback(async () => {
+    if (canvasType === 'html') {
+      htmlRendererRef.current?.requestPrint();
+      return;
+    }
+    if (canvasType === 'markdown') {
+      const renderedHtml = markdownRendererRef.current?.getRenderedHtml();
+      if (!renderedHtml) {
+        console.warn('canvas: markdown export requested before render');
+        return;
+      }
+      try {
+        await printHtmlInHiddenIframe({
+          html: buildMarkdownPrintHtml(renderedHtml),
+          basePath: getEnv('BASE_PATH'),
+        });
+      } catch (err) {
+        console.error('canvas: PDF export failed', err);
+        toast({ title: t('canvas.exportPdfFailed'), variant: 'destructive' });
+      }
+    }
+  }, [canvasType, toast, t]);
+
+  const canExportPdf = canvasType === 'html' || canvasType === 'markdown';
+
   const toggleEdit = useCallback(() => {
     setIsEditing((prev) => {
       const next = !prev;
@@ -602,6 +711,21 @@ function CanvasPaneComponent() {
             </Button>
           </Tooltip>
 
+          {canExportPdf && (
+            <Tooltip content={t('canvas.exportPdf')} side="bottom">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={handleExportPdf}
+                disabled={isStreaming}
+                aria-label={t('canvas.exportPdf')}
+              >
+                <FileDown className="size-3.5" />
+              </Button>
+            </Tooltip>
+          )}
+
           <Tooltip content={t('canvas.download')} side="bottom">
             <Button
               variant="ghost"
@@ -681,6 +805,7 @@ function CanvasPaneComponent() {
         )}
         {!showStreamingSource && canvasType === 'html' && (
           <CanvasHtmlRenderer
+            ref={htmlRendererRef}
             html={displayedContent}
             isEditing={isEditing}
             onContentChange={onContentChange}
@@ -702,6 +827,7 @@ function CanvasPaneComponent() {
         )}
         {!showStreamingSource && canvasType === 'markdown' && (
           <CanvasMarkdownRenderer
+            ref={markdownRendererRef}
             content={displayedContent}
             isEditing={isEditing}
             onContentChange={onContentChange}

--- a/services/platform/app/features/chat/components/canvas/print-via-iframe.ts
+++ b/services/platform/app/features/chat/components/canvas/print-via-iframe.ts
@@ -1,0 +1,90 @@
+// Print arbitrary HTML through the same /canvas-preview shell that powers
+// the HTML artifact renderer, by mounting a hidden iframe, POSTing the HTML
+// to it, and triggering window.print() inside via postMessage. The shell's
+// fresh-realm + permissive-CSP wrapper means we get the same isolation guarantees
+// as the on-screen HTML viewer — and the print dialog only sees the artifact,
+// not the surrounding chat UI.
+//
+// Used by the Markdown export path in canvas-pane.tsx; HTML artifacts have
+// their own iframe already and call requestPrint() directly on the renderer ref.
+
+interface PrintHtmlOptions {
+  html: string;
+  basePath: string;
+}
+
+const LOAD_TIMEOUT_MS = 30_000;
+const CLEANUP_TIMEOUT_MS = 60_000;
+
+export function printHtmlInHiddenIframe(opts: PrintHtmlOptions): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.setAttribute('sandbox', 'allow-scripts allow-modals');
+    iframe.title = 'PDF export';
+    iframe.style.position = 'fixed';
+    iframe.style.left = '-10000px';
+    iframe.style.top = '0';
+    iframe.style.width = '1px';
+    iframe.style.height = '1px';
+    iframe.style.border = '0';
+    iframe.style.opacity = '0';
+    iframe.name = `canvas-print-${Math.random().toString(36).slice(2)}`;
+
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = `${opts.basePath}/canvas-preview`;
+    form.target = iframe.name;
+    form.enctype = 'application/x-www-form-urlencoded';
+    form.style.display = 'none';
+
+    const input = document.createElement('textarea');
+    input.name = 'html';
+    input.value = opts.html;
+    form.appendChild(input);
+
+    let cleaned = false;
+    function cleanup() {
+      if (cleaned) return;
+      cleaned = true;
+      window.removeEventListener('afterprint', onAfterPrint);
+      iframe.removeEventListener('load', onLoad);
+      clearTimeout(loadTimer);
+      clearTimeout(cleanupTimer);
+      iframe.remove();
+      form.remove();
+    }
+
+    function onAfterPrint() {
+      cleanup();
+      resolve();
+    }
+
+    function onLoad() {
+      // Iframe just navigated to the /canvas-preview response. The shell's
+      // print listener (lib/canvas-preview-shell.ts PRINT_LISTENER) is
+      // installed before <body>, so it's already wired by the time we post.
+      clearTimeout(loadTimer);
+      iframe.contentWindow?.postMessage({ type: 'tale:canvas:print' }, '*');
+    }
+
+    iframe.addEventListener('load', onLoad);
+    window.addEventListener('afterprint', onAfterPrint);
+
+    // Safety nets: if /canvas-preview never responds, or if afterprint never
+    // fires (e.g. user closed the dialog without printing on a browser that
+    // skips afterprint), still tear the iframe down so it doesn't accumulate.
+    const loadTimer = setTimeout(() => {
+      cleanup();
+      reject(new Error('canvas-preview iframe did not load within 30s'));
+    }, LOAD_TIMEOUT_MS);
+    const cleanupTimer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, CLEANUP_TIMEOUT_MS);
+
+    document.body.appendChild(form);
+    document.body.appendChild(iframe);
+    form.submit();
+  });
+}

--- a/services/platform/lib/canvas-preview-shell.browser.test.ts
+++ b/services/platform/lib/canvas-preview-shell.browser.test.ts
@@ -70,6 +70,80 @@ describe('canvas-preview storage shim (real opaque-origin iframe)', () => {
     expect(report.crossStore).toBeNull();
   });
 
+  test('print listener: window.print() fires on tale:canvas:print, ignores unrelated messages', async () => {
+    // The shell installs a listener that only acts on
+    // `{ type: 'tale:canvas:print' }`. Patch `window.print` inside the
+    // iframe to record calls, send a tale:canvas:print AND a noise
+    // message, then ask the iframe to report what it saw.
+    const userHtml = `<script>
+      var calls = 0;
+      window.print = function () { calls++; };
+      window.addEventListener('message', function (event) {
+        if (event && event.data && event.data.type === 'tale:report-print-calls') {
+          parent.postMessage({ printCalls: calls }, '*');
+        }
+      });
+      // Tell the parent we are ready to receive print signals.
+      parent.postMessage({ ready: true }, '*');
+    </script>`;
+    const wrapped = wrapCanvasPreviewHtml(userHtml);
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('sandbox', 'allow-scripts allow-modals');
+    iframe.srcdoc = wrapped;
+
+    const ready = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('iframe never reported ready')),
+        5000,
+      );
+      function onReady(e: MessageEvent) {
+        if (e.source !== iframe.contentWindow) return;
+        const data = e.data as { ready?: boolean };
+        if (data?.ready) {
+          clearTimeout(timer);
+          window.removeEventListener('message', onReady);
+          resolve();
+        }
+      }
+      window.addEventListener('message', onReady);
+    });
+
+    document.body.appendChild(iframe);
+    try {
+      await ready;
+      // Send the real print signal AND a noise message; only the first
+      // should bump the counter.
+      iframe.contentWindow?.postMessage({ type: 'tale:canvas:print' }, '*');
+      iframe.contentWindow?.postMessage({ type: 'something:else' }, '*');
+
+      const report = await new Promise<{ printCalls: number }>(
+        (resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error('iframe never reported print calls')),
+            5000,
+          );
+          function onReport(e: MessageEvent) {
+            if (e.source !== iframe.contentWindow) return;
+            const data = e.data as { printCalls?: number };
+            if (typeof data?.printCalls === 'number') {
+              clearTimeout(timer);
+              window.removeEventListener('message', onReport);
+              resolve({ printCalls: data.printCalls });
+            }
+          }
+          window.addEventListener('message', onReport);
+          iframe.contentWindow?.postMessage(
+            { type: 'tale:report-print-calls' },
+            '*',
+          );
+        },
+      );
+      expect(report.printCalls).toBe(1);
+    } finally {
+      iframe.remove();
+    }
+  });
+
   test('quota cap throws QuotaExceededError inside the iframe', async () => {
     const userHtml = `<script>
       var report = { thrown: false };

--- a/services/platform/lib/canvas-preview-shell.ts
+++ b/services/platform/lib/canvas-preview-shell.ts
@@ -112,12 +112,30 @@ const STORAGE_SHIM = `<script>
 })();
 </script>`;
 
+// Listens for `{ type: 'tale:canvas:print' }` from the embedder and triggers
+// the iframe's own `window.print()`. The parent cannot call `print()` on the
+// iframe directly because the sandbox runs without `allow-same-origin` — the
+// iframe must invoke it itself. Requires `allow-modals` on the sandbox
+// attribute, since `print()` is gated on that flag.
+const PRINT_LISTENER = `<script>
+(function () {
+  window.addEventListener('message', function (event) {
+    if (event && event.data && event.data.type === 'tale:canvas:print') {
+      try { window.print(); } catch (e) {
+        console.warn('canvas-preview: print() failed', e);
+      }
+    }
+  });
+})();
+</script>`;
+
 const HEAD = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8" />
 <title>Canvas preview</title>
 ${STORAGE_SHIM}
+${PRINT_LISTENER}
 </head>
 <body>`;
 

--- a/services/platform/lib/utils/lazy-component.tsx
+++ b/services/platform/lib/utils/lazy-component.tsx
@@ -2,7 +2,13 @@
 
 // oxlint-disable typescript/no-explicit-any -- React.lazy uses ComponentType<any> internally; we need the same flexibility for dynamic imports with named exports
 
-import { lazy, Suspense, type ComponentType, type ReactNode } from 'react';
+import {
+  forwardRef,
+  lazy,
+  Suspense,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
 
 interface LazyComponentOptions {
   loading?: () => ReactNode;
@@ -15,17 +21,20 @@ interface LazyComponentOptions {
  * @param options - Configuration options including loading fallback
  * @returns A wrapped component that lazy loads the actual component
  */
-export function lazyComponent<P extends Record<string, any>>(
+export function lazyComponent<P extends Record<string, any>, R = unknown>(
   importFn: () => Promise<{ default: ComponentType<any> }>,
   options: LazyComponentOptions = {},
-): ComponentType<P> {
+) {
   const LazyComponent = lazy(importFn);
 
-  const WrappedComponent = (props: P) => (
-    <Suspense fallback={options.loading?.() ?? null}>
-      <LazyComponent {...props} />
-    </Suspense>
-  );
-
-  return WrappedComponent;
+  // forwardRef so callers can grab imperative handles (`useRef` +
+  // `useImperativeHandle`) on the underlying component — without it, the
+  // Suspense wrapper would swallow the ref.
+  return forwardRef<R, P>(function LazyComponentWrapper(props, ref) {
+    return (
+      <Suspense fallback={options.loading?.() ?? null}>
+        <LazyComponent {...props} ref={ref} />
+      </Suspense>
+    );
+  });
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2224,6 +2224,8 @@
       "edit": "Bearbeiten",
       "copy": "Kopieren",
       "download": "Herunterladen",
+      "exportPdf": "Als PDF exportieren",
+      "exportPdfFailed": "PDF-Export fehlgeschlagen",
       "copied": "Kopiert!",
       "mermaidError": "Diagramm konnte nicht gerendert werden",
       "resizeHandle": "Canvas-Größe ändern",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2224,6 +2224,8 @@
       "edit": "Edit",
       "copy": "Copy",
       "download": "Download",
+      "exportPdf": "Export as PDF",
+      "exportPdfFailed": "Failed to export as PDF",
       "copied": "Copied!",
       "mermaidError": "Failed to render diagram",
       "resizeHandle": "Resize canvas",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2224,6 +2224,8 @@
       "edit": "Modifier",
       "copy": "Copier",
       "download": "Télécharger",
+      "exportPdf": "Exporter en PDF",
+      "exportPdfFailed": "Échec de l'export PDF",
       "copied": "Copié !",
       "mermaidError": "Échec du rendu du diagramme",
       "resizeHandle": "Redimensionner le canevas",


### PR DESCRIPTION
## Summary

- Adds a PDF export button to the canvas toolbar for **HTML** and **Markdown** artifacts. Code, SVG, and Mermaid keep only the existing source-file Download — PDF for those is low-value.
- Uses the browser's native print flow inside the artifact's iframe via `postMessage` — **zero new dependencies**, full CSS / font fidelity (Chinese characters, gradients, complex layouts all render exactly as on screen), and the print dialog only sees the artifact, not the surrounding chat UI.
- The HTML iframe sandbox gains `allow-modals` (the HTML spec gates `window.print()` on this flag). Markdown is routed through the same `/canvas-preview` shell in a hidden iframe with an inline print stylesheet so we keep one isolation model.

## Why

For long-form, document-style artifacts (e.g. AI-generated articles), users want a fixed-format, shareable rendering. The assistant itself was already offering "导出为 Word 文档" mid-thread — so we're closing a known gap with the smallest possible change to the existing architecture. The browser-native approach was chosen over `html2pdf` (~150-300KB bundle, weak CJK support) and Puppeteer (deployment cost) because the print dialog gives identical fidelity to the on-screen artifact for free.

## Implementation notes

- `lib/canvas-preview-shell.ts` — new `PRINT_LISTENER` IIFE injected before `<body>` listens for `{ type: 'tale:canvas:print' }` and calls `window.print()`. Sandboxed iframe can't be print-driven by parent (opaque origin), so it must trigger itself.
- `canvas-html-renderer.tsx` — wrapped in `forwardRef`, exposes `requestPrint()` imperative handle.
- `canvas-markdown-renderer.tsx` — exposes `getRenderedHtml()` returning the live article DOM's `innerHTML` (rather than re-rendering markdown — guarantees print parity with what the user just read).
- `print-via-iframe.ts` — new utility for the markdown path: hidden iframe + form-POST to `/canvas-preview` + postMessage + `afterprint`/timeout cleanup.
- `lib/utils/lazy-component.tsx` — converted to `forwardRef` so refs survive the Suspense wrapper. Backward-compatible.
- All locale files updated (en, de, fr); de-CH falls back via base de.json (no ß in new strings); de-AT/fr-CH are empty override files.

## Test plan

- [x] `bun run check` — typecheck, lint, format, all 2704+ unit tests passing
- [x] New unit tests: `requestPrint` ref API, sandbox-flag assertion update, 4 canvas-pane tests for button visibility (HTML/Markdown shows, code/svg/mermaid hides, disabled while streaming)
- [x] New browser-e2e test (real Chromium): print listener fires `window.print()` on `tale:canvas:print` and ignores unrelated messages
- [ ] Manual: open an HTML artifact in dev (esp. one with CJK and gradients/tables — the panda demo is ideal), click PDF, save and verify fidelity
- [ ] Manual: open a Markdown artifact, click PDF, verify code blocks / lists / tables render with the inline typography styles
- [ ] Manual: confirm streaming artifacts disable the PDF button until settled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF export support for HTML and Markdown canvas artifacts
  * New "Export PDF" toolbar button (disabled while content is streaming)
  * Expanded browser print permissions to support modal dialogs
  * Added translations for export labels across multiple languages

* **Tests**
  * Added comprehensive tests for PDF export and print functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->