### PR TITLE
feat(platform): governance feedback analytics page

### DIFF
--- a/services/platform/app/features/analytics/feedback/arena-summary.tsx
+++ b/services/platform/app/features/analytics/feedback/arena-summary.tsx
@@ -13,48 +13,50 @@ interface ArenaSummaryProps {
   total: number;
 }
 
-const VERDICT_ORDER: ArenaVerdict[] = [
-  'a_better',
-  'b_better',
-  'tie',
-  'both_bad',
-];
-
-const VERDICT_I18N_KEY: Record<ArenaVerdict, string> = {
-  a_better: 'aBetter',
-  b_better: 'bBetter',
-  tie: 'tie',
-  both_bad: 'bothBad',
+// A vs B is a user-picked position (model selector), not random — so
+// aggregating "A wins" / "B wins" across rows mixes different model
+// pairs and yields no actionable signal. We surface a position-agnostic
+// triple instead: decisive votes, ties, and both-bad. Per-pair
+// matchups live in `top-matchups-feedback-table.tsx`.
+type ArenaSummaryCell = {
+  key: 'decisive' | 'tie' | 'bothBad';
+  count: number;
 };
 
 export function ArenaSummary({ byVerdict, total }: ArenaSummaryProps) {
   const { t: tAnalytics } = useT('analytics');
-  const { t: tChat } = useT('chat');
   const { i18n } = useTranslation();
 
   if (total === 0) return null;
+
+  const cells: ArenaSummaryCell[] = [
+    {
+      key: 'decisive',
+      count: (byVerdict.a_better ?? 0) + (byVerdict.b_better ?? 0),
+    },
+    { key: 'tie', count: byVerdict.tie ?? 0 },
+    { key: 'bothBad', count: byVerdict.both_bad ?? 0 },
+  ];
 
   return (
     <div className="flex flex-col gap-3">
       <Text as="h3" className="text-foreground text-base font-semibold">
         {tAnalytics('feedback.arena.title')}
       </Text>
-      <div className="border-border grid grid-cols-2 overflow-hidden rounded-lg border md:grid-cols-4">
-        {VERDICT_ORDER.map((verdict, idx) => (
+      <div className="border-border grid grid-cols-3 overflow-hidden rounded-lg border">
+        {cells.map((cell, idx) => (
           <div
-            key={verdict}
+            key={cell.key}
             className={
               'flex flex-col gap-1 px-5 py-6 ' +
-              (idx === VERDICT_ORDER.length - 1
-                ? ''
-                : 'border-border border-b md:border-r md:border-b-0')
+              (idx === cells.length - 1 ? '' : 'border-border border-r')
             }
           >
             <Text className="text-muted-foreground text-sm">
-              {tChat(`arena.${VERDICT_I18N_KEY[verdict]}`)}
+              {tAnalytics(`feedback.arena.cells.${cell.key}`)}
             </Text>
             <Text className="text-foreground font-mono text-2xl font-semibold">
-              {formatNumber(byVerdict[verdict] ?? 0, i18n.language)}
+              {formatNumber(cell.count, i18n.language)}
             </Text>
           </div>
         ))}

--- a/services/platform/app/features/analytics/feedback/arena-summary.tsx
+++ b/services/platform/app/features/analytics/feedback/arena-summary.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+
+import type { ArenaVerdict } from './types';
+
+interface ArenaSummaryProps {
+  byVerdict: Record<ArenaVerdict, number>;
+  total: number;
+}
+
+const VERDICT_ORDER: ArenaVerdict[] = [
+  'a_better',
+  'b_better',
+  'tie',
+  'both_bad',
+];
+
+const VERDICT_I18N_KEY: Record<ArenaVerdict, string> = {
+  a_better: 'aBetter',
+  b_better: 'bBetter',
+  tie: 'tie',
+  both_bad: 'bothBad',
+};
+
+export function ArenaSummary({ byVerdict, total }: ArenaSummaryProps) {
+  const { t: tAnalytics } = useT('analytics');
+  const { t: tChat } = useT('chat');
+  const { i18n } = useTranslation();
+
+  if (total === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {tAnalytics('feedback.arena.title')}
+      </Text>
+      <div className="border-border grid grid-cols-2 overflow-hidden rounded-lg border md:grid-cols-4">
+        {VERDICT_ORDER.map((verdict, idx) => (
+          <div
+            key={verdict}
+            className={
+              'flex flex-col gap-1 px-5 py-6 ' +
+              (idx === VERDICT_ORDER.length - 1
+                ? ''
+                : 'border-border border-b md:border-r md:border-b-0')
+            }
+          >
+            <Text className="text-muted-foreground text-sm">
+              {tChat(`arena.${VERDICT_I18N_KEY[verdict]}`)}
+            </Text>
+            <Text className="text-foreground font-mono text-2xl font-semibold">
+              {formatNumber(byVerdict[verdict] ?? 0, i18n.language)}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
@@ -206,23 +206,6 @@ export function FeedbackMetricsPage({
               aria-label={t('feedback.period.label')}
             />
           </div>
-          <div className="w-36">
-            <Select
-              options={kindOptions}
-              value={kind}
-              onValueChange={handleChangeKind}
-              size="sm"
-              aria-label={t('feedback.kind.label')}
-            />
-          </div>
-          <label className="flex items-center gap-2 text-sm">
-            <Switch
-              checked={withCommentOnly}
-              onCheckedChange={onToggleCommentOnly}
-              aria-label={t('feedback.commentsOnly')}
-            />
-            <span>{t('feedback.commentsOnly')}</span>
-          </label>
         </HStack>
       </div>
 
@@ -309,6 +292,27 @@ export function FeedbackMetricsPage({
         hasMore={recent.status === 'CanLoadMore'}
         isLoadingMore={recent.status === 'LoadingMore'}
         onLoadMore={() => recent.loadMore(PAGE_SIZE)}
+        headerActions={
+          <HStack gap={2} className="flex-wrap">
+            <div className="w-36">
+              <Select
+                options={kindOptions}
+                value={kind}
+                onValueChange={handleChangeKind}
+                size="sm"
+                aria-label={t('feedback.kind.label')}
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <Switch
+                checked={withCommentOnly}
+                onCheckedChange={onToggleCommentOnly}
+                aria-label={t('feedback.commentsOnly')}
+              />
+              <span>{t('feedback.commentsOnly')}</span>
+            </label>
+          </HStack>
+        }
       />
     </Stack>
   );

--- a/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+
+import { Alert } from '@/app/components/ui/feedback/alert';
+import { Skeleton } from '@/app/components/ui/feedback/skeleton';
+import { Select } from '@/app/components/ui/forms/select';
+import { Switch } from '@/app/components/ui/forms/switch';
+import { HStack, Stack } from '@/app/components/ui/layout/layout';
+import { Button } from '@/app/components/ui/primitives/button';
+import { Text } from '@/app/components/ui/typography/text';
+import { useCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+import { useT } from '@/lib/i18n/client';
+
+import { ArenaSummary } from './arena-summary';
+import { FeedbackSummaryCards } from './feedback-summary-cards';
+import { FilterChips } from './filter-chips';
+import { RecentFeedbackTable } from './recent-feedback-table';
+import { TopAgentsFeedbackTable } from './top-agents-feedback-table';
+import { TopModelsFeedbackTable } from './top-models-feedback-table';
+
+export type FeedbackPeriod = '1' | '7' | '30' | '90' | 'all';
+export type FeedbackKind = 'all' | 'message' | 'arena';
+
+interface FeedbackMetricsPageProps {
+  organizationId: string;
+  period: FeedbackPeriod;
+  kind: FeedbackKind;
+  withCommentOnly: boolean;
+  agentSlug?: string;
+  model?: string;
+  provider?: string;
+  onChangePeriod: (next: FeedbackPeriod) => void;
+  onChangeKind: (next: FeedbackKind) => void;
+  onToggleCommentOnly: (next: boolean) => void;
+  onSelectAgent: (slug: string | null) => void;
+  onSelectModel: (model: string | null, provider: string | null) => void;
+  onClearFilters: () => void;
+}
+
+const PAGE_SIZE = 25;
+
+function periodToDays(p: FeedbackPeriod): 1 | 7 | 30 | 90 | undefined {
+  if (p === 'all') return undefined;
+  if (p === '1') return 1;
+  if (p === '7') return 7;
+  if (p === '30') return 30;
+  return 90;
+}
+
+export function FeedbackMetricsPage({
+  organizationId,
+  period,
+  kind,
+  withCommentOnly,
+  agentSlug,
+  model,
+  provider,
+  onChangePeriod,
+  onChangeKind,
+  onToggleCommentOnly,
+  onSelectAgent,
+  onSelectModel,
+  onClearFilters,
+}: FeedbackMetricsPageProps) {
+  const { t } = useT('analytics');
+
+  const periodDays = periodToDays(period);
+
+  const {
+    data: stats,
+    isLoading: statsLoading,
+    error: statsError,
+  } = useConvexQuery(api.feedback.queries.getFeedbackStats, {
+    organizationId,
+    periodDays,
+    agentSlug,
+    model,
+    provider,
+  });
+
+  const recent = useCachedPaginatedQuery(
+    api.feedback.queries.listRecentFeedback,
+    {
+      organizationId,
+      periodDays,
+      kind,
+      withCommentOnly,
+      agentSlug,
+      model,
+      provider,
+    },
+    { initialNumItems: PAGE_SIZE },
+  );
+
+  const periodOptions = useMemo(
+    () => [
+      { value: '1', label: t('feedback.period.last24Hours') },
+      { value: '7', label: t('feedback.period.last7Days') },
+      { value: '30', label: t('feedback.period.last30Days') },
+      { value: '90', label: t('feedback.period.last90Days') },
+      { value: 'all', label: t('feedback.period.allTime') },
+    ],
+    [t],
+  );
+
+  const kindOptions = useMemo(
+    () => [
+      { value: 'all', label: t('feedback.kind.all') },
+      { value: 'message', label: t('feedback.kind.message') },
+      { value: 'arena', label: t('feedback.kind.arena') },
+    ],
+    [t],
+  );
+
+  const handleChangePeriod = useCallback(
+    (v: string) => {
+      if (v === '1' || v === '7' || v === '30' || v === '90' || v === 'all') {
+        onChangePeriod(v);
+      }
+    },
+    [onChangePeriod],
+  );
+  const handleChangeKind = useCallback(
+    (v: string) => {
+      if (v === 'all' || v === 'message' || v === 'arena') {
+        onChangeKind(v);
+      }
+    },
+    [onChangeKind],
+  );
+
+  const hasFilters = !!(agentSlug || model || provider);
+
+  if (statsLoading) {
+    return (
+      <Stack gap={6} aria-busy="true">
+        <Skeleton className="h-10 w-full max-w-2xl rounded-md" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-66 w-full rounded-md" />
+        <Skeleton className="h-66 w-full rounded-md" />
+      </Stack>
+    );
+  }
+
+  if (statsError) {
+    return (
+      <Alert
+        variant="destructive"
+        icon={AlertTriangle}
+        title={t('feedback.errors.loadFailed')}
+        description={statsError.message}
+      />
+    );
+  }
+
+  if (!stats) {
+    return (
+      <Alert
+        variant="destructive"
+        icon={AlertTriangle}
+        title={t('feedback.errors.unauthorized')}
+      />
+    );
+  }
+
+  // Org-empty: never collected feedback. Replace cards with a teaching panel.
+  if (!stats.hasAnyFeedback) {
+    return (
+      <Stack gap={6}>
+        <Header
+          title={t('feedback.title')}
+          description={t('feedback.description')}
+        />
+        <Alert
+          title={t('feedback.empty.title')}
+          description={t('feedback.empty.description')}
+        />
+      </Stack>
+    );
+  }
+
+  const totalMessages = stats.message.total;
+  const totalArena = stats.arena.total;
+  const isFilteredZero = hasFilters && totalMessages + totalArena === 0;
+  const isPeriodEmpty = !hasFilters && totalMessages + totalArena === 0;
+
+  return (
+    <Stack gap={6}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <Header
+          title={t('feedback.title')}
+          description={t('feedback.description')}
+        />
+        <HStack gap={2} className="flex-wrap">
+          <div className="w-36">
+            <Select
+              options={periodOptions}
+              value={period}
+              onValueChange={handleChangePeriod}
+              size="sm"
+              aria-label={t('feedback.period.label')}
+            />
+          </div>
+          <div className="w-36">
+            <Select
+              options={kindOptions}
+              value={kind}
+              onValueChange={handleChangeKind}
+              size="sm"
+              aria-label={t('feedback.kind.label')}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={withCommentOnly}
+              onCheckedChange={onToggleCommentOnly}
+              aria-label={t('feedback.commentsOnly')}
+            />
+            <span>{t('feedback.commentsOnly')}</span>
+          </label>
+        </HStack>
+      </div>
+
+      <FilterChips
+        agentSlug={agentSlug}
+        model={model}
+        provider={provider}
+        onClearAgent={() => onSelectAgent(null)}
+        onClearModel={() => onSelectModel(null, null)}
+        onClearAll={onClearFilters}
+      />
+
+      {stats.capped ? (
+        <Alert
+          variant="warning"
+          icon={AlertTriangle}
+          title={t('feedback.cappedNotice.title')}
+          description={t('feedback.cappedNotice.description')}
+        />
+      ) : null}
+
+      {isPeriodEmpty ? (
+        <Alert
+          title={t('feedback.periodEmpty.title')}
+          description={
+            <span>
+              {t('feedback.periodEmpty.description')}{' '}
+              <Button
+                variant="link"
+                size="sm"
+                onClick={() => onChangePeriod('all')}
+              >
+                {t('feedback.periodEmpty.expand')}
+              </Button>
+            </span>
+          }
+        />
+      ) : null}
+
+      {isFilteredZero ? (
+        <Alert
+          title={t('feedback.filterEmpty.title')}
+          description={
+            <span>
+              {t('feedback.filterEmpty.description')}{' '}
+              <Button variant="link" size="sm" onClick={onClearFilters}>
+                {t('feedback.filterEmpty.clear')}
+              </Button>
+            </span>
+          }
+        />
+      ) : null}
+
+      <FeedbackSummaryCards
+        helpful={stats.message.byRating.positive}
+        notHelpful={stats.message.byRating.negative}
+        capped={stats.capped}
+      />
+
+      <ArenaSummary
+        byVerdict={stats.arena.byVerdict}
+        total={stats.arena.total}
+      />
+
+      <TopAgentsFeedbackTable
+        rows={stats.topAgents}
+        isLoading={false}
+        onSelectAgent={(slug) => onSelectAgent(slug)}
+      />
+
+      <TopModelsFeedbackTable
+        rows={stats.topModels}
+        isLoading={false}
+        onSelectModel={(m, p) => onSelectModel(m, p)}
+      />
+
+      <RecentFeedbackTable
+        organizationId={organizationId}
+        rows={recent.results}
+        isLoading={recent.status === 'LoadingFirstPage'}
+        hasMore={recent.status === 'CanLoadMore'}
+        isLoadingMore={recent.status === 'LoadingMore'}
+        onLoadMore={() => recent.loadMore(PAGE_SIZE)}
+      />
+    </Stack>
+  );
+}
+
+function Header({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {title}
+      </Text>
+      <Text variant="caption">{description}</Text>
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
@@ -299,7 +299,6 @@ export function FeedbackMetricsPage({
       />
 
       <RecentFeedbackTable
-        organizationId={organizationId}
         rows={recent.results}
         isLoading={recent.status === 'LoadingFirstPage'}
         hasMore={recent.status === 'CanLoadMore'}

--- a/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-metrics-page.tsx
@@ -20,6 +20,7 @@ import { FeedbackSummaryCards } from './feedback-summary-cards';
 import { FilterChips } from './filter-chips';
 import { RecentFeedbackTable } from './recent-feedback-table';
 import { TopAgentsFeedbackTable } from './top-agents-feedback-table';
+import { TopMatchupsFeedbackTable } from './top-matchups-feedback-table';
 import { TopModelsFeedbackTable } from './top-models-feedback-table';
 
 export type FeedbackPeriod = '1' | '7' | '30' | '90' | 'all';
@@ -285,6 +286,10 @@ export function FeedbackMetricsPage({
         byVerdict={stats.arena.byVerdict}
         total={stats.arena.total}
       />
+
+      {stats.topMatchups.length > 0 ? (
+        <TopMatchupsFeedbackTable rows={stats.topMatchups} isLoading={false} />
+      ) : null}
 
       <TopAgentsFeedbackTable
         rows={stats.topAgents}

--- a/services/platform/app/features/analytics/feedback/feedback-summary-cards.tsx
+++ b/services/platform/app/features/analytics/feedback/feedback-summary-cards.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Stack } from '@/app/components/ui/layout/layout';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+import { formatNumber } from '@/lib/utils/format/number';
+
+interface FeedbackSummaryCardsProps {
+  helpful: number;
+  notHelpful: number;
+  /** When true, sentiment cell is greyed out — partial-sample percentages mislead. */
+  capped: boolean;
+}
+
+function formatPercent(
+  positive: number,
+  total: number,
+  locale: string,
+): string {
+  if (total === 0) return '—';
+  const ratio = positive / total;
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'percent',
+      maximumFractionDigits: 1,
+    }).format(ratio);
+  } catch {
+    return `${Math.round(ratio * 100)}%`;
+  }
+}
+
+export function FeedbackSummaryCards({
+  helpful,
+  notHelpful,
+  capped,
+}: FeedbackSummaryCardsProps) {
+  const { t } = useT('analytics');
+  const { i18n } = useTranslation();
+  const total = helpful + notHelpful;
+  const positivePct = total === 0 ? 0 : helpful / total;
+  const negativePct = total === 0 ? 0 : notHelpful / total;
+  const sentimentLabel = formatPercent(helpful, total, i18n.language);
+
+  return (
+    <div className="border-border grid grid-cols-2 overflow-hidden rounded-lg border md:grid-cols-4">
+      <div className="border-border col-span-2 flex flex-col gap-3 border-b px-5 py-6 md:border-r md:border-b-0">
+        <Text className="text-muted-foreground text-sm">
+          {t('feedback.cards.sentiment')}
+        </Text>
+        <div className="flex items-baseline gap-2">
+          <Text
+            className={cn(
+              'text-foreground font-mono text-3xl font-semibold',
+              capped && 'text-muted-foreground opacity-60',
+            )}
+            aria-label={
+              capped
+                ? t('feedback.cards.sentimentCapped')
+                : t('feedback.cards.sentimentAriaLabel', {
+                    pct: sentimentLabel,
+                    helpful: formatNumber(helpful, i18n.language),
+                    total: formatNumber(total, i18n.language),
+                  })
+            }
+          >
+            {capped ? '—' : sentimentLabel}
+          </Text>
+          {!capped && total > 0 ? (
+            <Text variant="caption">
+              {t('feedback.cards.sentimentDenominator', {
+                helpful: formatNumber(helpful, i18n.language),
+                total: formatNumber(total, i18n.language),
+              })}
+            </Text>
+          ) : null}
+        </div>
+        {total > 0 ? (
+          <div
+            className="bg-muted relative h-2 w-full overflow-hidden rounded-full"
+            role="img"
+            aria-hidden="true"
+          >
+            <div
+              className="absolute inset-y-0 left-0 bg-emerald-500"
+              style={{ width: `${positivePct * 100}%` }}
+            />
+            <div
+              className="absolute inset-y-0 bg-rose-500"
+              style={{
+                left: `${positivePct * 100}%`,
+                width: `${negativePct * 100}%`,
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+      <Cell
+        label={t('feedback.cards.helpful')}
+        value={formatNumber(helpful, i18n.language)}
+        accent="positive"
+      />
+      <Cell
+        label={t('feedback.cards.notHelpful')}
+        value={formatNumber(notHelpful, i18n.language)}
+        accent="negative"
+      />
+    </div>
+  );
+}
+
+function Cell({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent: 'positive' | 'negative';
+}) {
+  return (
+    <Stack className="border-border border-b px-5 py-6 md:border-r md:border-b-0 last:md:border-r-0">
+      <Text className="text-muted-foreground text-sm">{label}</Text>
+      <Text
+        className={cn(
+          'text-foreground font-mono text-2xl font-semibold',
+          accent === 'positive' && 'text-emerald-600 dark:text-emerald-400',
+          accent === 'negative' && 'text-rose-600 dark:text-rose-400',
+        )}
+      >
+        {value}
+      </Text>
+    </Stack>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/filter-chips.tsx
+++ b/services/platform/app/features/analytics/feedback/filter-chips.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { X } from 'lucide-react';
+
+import { Badge } from '@/app/components/ui/feedback/badge';
+import { HStack } from '@/app/components/ui/layout/layout';
+import { Button } from '@/app/components/ui/primitives/button';
+import { useT } from '@/lib/i18n/client';
+
+interface FilterChipsProps {
+  agentSlug?: string;
+  model?: string;
+  provider?: string;
+  onClearAgent: () => void;
+  onClearModel: () => void;
+  onClearAll: () => void;
+}
+
+export function FilterChips({
+  agentSlug,
+  model,
+  provider,
+  onClearAgent,
+  onClearModel,
+  onClearAll,
+}: FilterChipsProps) {
+  const { t } = useT('analytics');
+
+  if (!agentSlug && !model && !provider) {
+    return null;
+  }
+
+  return (
+    <HStack gap={2} className="flex-wrap items-center">
+      {agentSlug ? (
+        <Badge
+          variant="outline"
+          className="cursor-pointer"
+          onClick={onClearAgent}
+        >
+          {t('feedback.filterChips.agent', { value: agentSlug })}
+          <X className="ml-1 size-3" />
+        </Badge>
+      ) : null}
+      {model ? (
+        <Badge
+          variant="outline"
+          className="cursor-pointer"
+          onClick={onClearModel}
+        >
+          {t('feedback.filterChips.model', { value: model })}
+          <X className="ml-1 size-3" />
+        </Badge>
+      ) : null}
+      {provider && !model ? (
+        <Badge
+          variant="outline"
+          className="cursor-pointer"
+          onClick={onClearModel}
+        >
+          {t('feedback.filterChips.provider', { value: provider })}
+          <X className="ml-1 size-3" />
+        </Badge>
+      ) : null}
+      <Button variant="ghost" size="sm" onClick={onClearAll}>
+        {t('feedback.filterChips.clear')}
+      </Button>
+    </HStack>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { Link } from '@tanstack/react-router';
+import type { ColumnDef, Row } from '@tanstack/react-table';
+import {
+  ExternalLink,
+  MessageSquare,
+  ThumbsDown,
+  ThumbsUp,
+} from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+
+import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Badge } from '@/app/components/ui/feedback/badge';
+import { Stack } from '@/app/components/ui/layout/layout';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import type { ArenaVerdict, RecentFeedbackItem } from './types';
+
+const VERDICT_I18N_KEY: Record<ArenaVerdict, string> = {
+  a_better: 'aBetter',
+  b_better: 'bBetter',
+  tie: 'tie',
+  both_bad: 'bothBad',
+};
+
+interface RecentFeedbackTableProps {
+  organizationId: string;
+  rows: RecentFeedbackItem[];
+  isLoading: boolean;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+}
+
+export function RecentFeedbackTable({
+  organizationId,
+  rows,
+  isLoading,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+}: RecentFeedbackTableProps) {
+  const { t: tAnalytics } = useT('analytics');
+  const { t: tChat } = useT('chat');
+
+  const columns = useMemo<ColumnDef<RecentFeedbackItem>[]>(
+    () => [
+      {
+        id: 'time',
+        header: tAnalytics('feedback.recent.columns.time'),
+        cell: ({ row }) => (
+          <TableDateCell date={row.original.createdAt} preset="relative" />
+        ),
+        size: 120,
+      },
+      {
+        id: 'user',
+        header: tAnalytics('feedback.recent.columns.user'),
+        cell: ({ row }) => (
+          <Text
+            as="span"
+            variant="label"
+            className="block max-w-[180px] truncate text-sm"
+          >
+            {row.original.userDisplayName}
+          </Text>
+        ),
+        size: 180,
+      },
+      {
+        id: 'type',
+        header: tAnalytics('feedback.recent.columns.type'),
+        cell: ({ row }) => (
+          <Badge variant={row.original.isArena ? 'blue' : 'outline'}>
+            {tAnalytics(
+              row.original.isArena
+                ? 'feedback.recent.types.arena'
+                : 'feedback.recent.types.message',
+            )}
+          </Badge>
+        ),
+        size: 100,
+      },
+      {
+        id: 'rating',
+        header: tAnalytics('feedback.recent.columns.rating'),
+        cell: ({ row }) =>
+          row.original.isArena && row.original.arenaVerdict ? (
+            <Text className="text-xs">
+              {tChat(`arena.${VERDICT_I18N_KEY[row.original.arenaVerdict]}`)}
+            </Text>
+          ) : row.original.rating === 'positive' ? (
+            <ThumbsUp
+              className="size-4 text-emerald-600 dark:text-emerald-400"
+              aria-label={tAnalytics('feedback.recent.helpfulAria')}
+            />
+          ) : (
+            <ThumbsDown
+              className="size-4 text-rose-600 dark:text-rose-400"
+              aria-label={tAnalytics('feedback.recent.notHelpfulAria')}
+            />
+          ),
+        size: 100,
+      },
+      {
+        id: 'agent',
+        header: tAnalytics('feedback.recent.columns.agent'),
+        cell: ({ row }) => (
+          <Text
+            as="span"
+            className="text-muted-foreground block max-w-[140px] truncate text-xs"
+          >
+            {row.original.agentSlug ?? '—'}
+          </Text>
+        ),
+        size: 140,
+      },
+      {
+        id: 'model',
+        header: tAnalytics('feedback.recent.columns.model'),
+        cell: ({ row }) => {
+          if (row.original.isArena) {
+            const a = row.original.arenaModelA;
+            const b = row.original.arenaModelB;
+            if (a && b) {
+              return (
+                <Text
+                  as="span"
+                  className="text-muted-foreground block max-w-[200px] truncate text-xs"
+                >
+                  {a} vs {b}
+                </Text>
+              );
+            }
+          }
+          return (
+            <Text
+              as="span"
+              className="text-muted-foreground block max-w-[180px] truncate text-xs"
+            >
+              {row.original.model ?? '—'}
+            </Text>
+          );
+        },
+        size: 200,
+      },
+      {
+        id: 'comment',
+        header: tAnalytics('feedback.recent.columns.comment'),
+        cell: ({ row }) => (
+          <Text as="span" className="block max-w-[300px] truncate text-sm">
+            {row.original.comment ?? '—'}
+          </Text>
+        ),
+        size: 300,
+      },
+      {
+        id: 'thread',
+        header: () => (
+          <div className="text-right">
+            {tAnalytics('feedback.recent.columns.thread')}
+          </div>
+        ),
+        cell: ({ row }) => {
+          if (row.original.threadDeleted) {
+            return <div className="text-muted-foreground text-right">—</div>;
+          }
+          return (
+            <div className="text-right">
+              <Link
+                to="/dashboard/$id/chat/$threadId"
+                params={{ id: organizationId, threadId: row.original.threadId }}
+                onClick={(e) => e.stopPropagation()}
+                aria-label={tAnalytics('feedback.recent.openThread')}
+                className="text-muted-foreground hover:text-foreground inline-flex items-center"
+              >
+                <ExternalLink className="size-4" />
+              </Link>
+            </div>
+          );
+        },
+        meta: { align: 'right' as const },
+        size: 80,
+      },
+    ],
+    [tAnalytics, tChat, organizationId],
+  );
+
+  const renderExpandedRow = useCallback(
+    (row: Row<RecentFeedbackItem>) => (
+      <Stack className="bg-muted/30 px-5 py-4" gap={3}>
+        <Stack gap={1}>
+          <Text className="text-muted-foreground text-xs tracking-wide uppercase">
+            {tAnalytics('feedback.recent.expanded.comment')}
+          </Text>
+          <Text className="text-sm whitespace-pre-wrap">
+            {row.original.comment ?? tAnalytics('feedback.recent.noComment')}
+          </Text>
+        </Stack>
+        {row.original.isArena ? (
+          <Stack gap={1}>
+            <Text className="text-muted-foreground text-xs tracking-wide uppercase">
+              {tAnalytics('feedback.recent.expanded.arena')}
+            </Text>
+            <Text className="text-sm">
+              {row.original.arenaModelA ?? '—'} vs{' '}
+              {row.original.arenaModelB ?? '—'}
+              {row.original.arenaVerdict
+                ? ' · ' +
+                  tChat(`arena.${VERDICT_I18N_KEY[row.original.arenaVerdict]}`)
+                : ''}
+            </Text>
+          </Stack>
+        ) : (
+          <Stack gap={1}>
+            <Text className="text-muted-foreground text-xs tracking-wide uppercase">
+              {tAnalytics('feedback.recent.expanded.attribution')}
+            </Text>
+            <Text className="text-sm">
+              {row.original.agentSlug ?? '—'} · {row.original.provider ?? '—'} /{' '}
+              {row.original.model ?? '—'}
+            </Text>
+          </Stack>
+        )}
+      </Stack>
+    ),
+    [tAnalytics, tChat],
+  );
+
+  return (
+    <div className={cn('flex flex-col gap-3')}>
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {tAnalytics('feedback.recent.title')}
+      </Text>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowId={(row) => row._id}
+        enableExpanding
+        renderExpandedRow={renderExpandedRow}
+        isLoading={isLoading}
+        approxRowCount={isLoading ? 8 : rows.length}
+        infiniteScroll={{
+          hasMore,
+          onLoadMore,
+          isLoadingMore,
+          isInitialLoading: isLoading,
+        }}
+        emptyState={{
+          icon: MessageSquare,
+          title: tAnalytics('feedback.recent.emptyTitle'),
+          description: tAnalytics('feedback.recent.emptyDescription'),
+        }}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef, Row } from '@tanstack/react-table';
 import { MessageSquare, ThumbsDown, ThumbsUp } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { type ReactNode, useCallback, useMemo } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
@@ -27,6 +27,8 @@ interface RecentFeedbackTableProps {
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
+  /** Right-aligned controls in the section header — kind/comments-only filters scoped to this table only. */
+  headerActions?: ReactNode;
 }
 
 export function RecentFeedbackTable({
@@ -35,6 +37,7 @@ export function RecentFeedbackTable({
   hasMore,
   isLoadingMore,
   onLoadMore,
+  headerActions,
 }: RecentFeedbackTableProps) {
   const { t: tAnalytics } = useT('analytics');
   const { t: tChat } = useT('chat');
@@ -197,9 +200,12 @@ export function RecentFeedbackTable({
 
   return (
     <div className={cn('flex flex-col gap-3')}>
-      <Text as="h3" className="text-foreground text-base font-semibold">
-        {tAnalytics('feedback.recent.title')}
-      </Text>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <Text as="h3" className="text-foreground text-base font-semibold">
+          {tAnalytics('feedback.recent.title')}
+        </Text>
+        {headerActions}
+      </div>
       <DataTable
         columns={columns}
         data={rows}

--- a/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
@@ -104,7 +104,7 @@ export function RecentFeedbackTable({
         cell: ({ row }) => (
           <Text
             as="span"
-            className="text-muted-foreground block max-w-[140px] truncate text-xs"
+            className="text-muted-foreground block text-xs break-all"
           >
             {row.original.agentSlug ?? '—'}
           </Text>
@@ -122,7 +122,7 @@ export function RecentFeedbackTable({
               return (
                 <Text
                   as="span"
-                  className="text-muted-foreground block max-w-[200px] truncate text-xs"
+                  className="text-muted-foreground block text-xs break-all"
                 >
                   {a} vs {b}
                 </Text>
@@ -132,7 +132,7 @@ export function RecentFeedbackTable({
           return (
             <Text
               as="span"
-              className="text-muted-foreground block max-w-[180px] truncate text-xs"
+              className="text-muted-foreground block text-xs break-all"
             >
               {row.original.model ?? '—'}
             </Text>

--- a/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import { Link } from '@tanstack/react-router';
 import type { ColumnDef, Row } from '@tanstack/react-table';
-import {
-  ExternalLink,
-  MessageSquare,
-  ThumbsDown,
-  ThumbsUp,
-} from 'lucide-react';
+import { MessageSquare, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -28,7 +22,6 @@ const VERDICT_I18N_KEY: Record<ArenaVerdict, string> = {
 };
 
 interface RecentFeedbackTableProps {
-  organizationId: string;
   rows: RecentFeedbackItem[];
   isLoading: boolean;
   hasMore: boolean;
@@ -37,7 +30,6 @@ interface RecentFeedbackTableProps {
 }
 
 export function RecentFeedbackTable({
-  organizationId,
   rows,
   isLoading,
   hasMore,
@@ -158,36 +150,8 @@ export function RecentFeedbackTable({
         ),
         size: 300,
       },
-      {
-        id: 'thread',
-        header: () => (
-          <div className="text-right">
-            {tAnalytics('feedback.recent.columns.thread')}
-          </div>
-        ),
-        cell: ({ row }) => {
-          if (row.original.threadDeleted) {
-            return <div className="text-muted-foreground text-right">—</div>;
-          }
-          return (
-            <div className="text-right">
-              <Link
-                to="/dashboard/$id/chat/$threadId"
-                params={{ id: organizationId, threadId: row.original.threadId }}
-                onClick={(e) => e.stopPropagation()}
-                aria-label={tAnalytics('feedback.recent.openThread')}
-                className="text-muted-foreground hover:text-foreground inline-flex items-center"
-              >
-                <ExternalLink className="size-4" />
-              </Link>
-            </div>
-          );
-        },
-        meta: { align: 'right' as const },
-        size: 80,
-      },
     ],
-    [tAnalytics, tChat, organizationId],
+    [tAnalytics, tChat],
   );
 
   const renderExpandedRow = useCallback(

--- a/services/platform/app/features/analytics/feedback/top-agents-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/top-agents-feedback-table.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import type { ColumnDef, Row } from '@tanstack/react-table';
+import { BarChart3 } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Text } from '@/app/components/ui/typography/text';
+import { useListAgents } from '@/app/features/agents/hooks/queries';
+import { useT } from '@/lib/i18n/client';
+import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
+import { formatNumber } from '@/lib/utils/format/number';
+
+import { UNATTRIBUTED_AGENT_SLUG, type FeedbackAgentBucket } from './types';
+
+interface TopAgentsFeedbackTableProps {
+  rows: FeedbackAgentBucket[];
+  isLoading: boolean;
+  onSelectAgent: (agentSlug: string) => void;
+}
+
+function formatPercent(
+  positive: number,
+  total: number,
+  locale: string,
+): string {
+  if (total === 0) return '—';
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'percent',
+      maximumFractionDigits: 1,
+    }).format(positive / total);
+  } catch {
+    return `${Math.round((positive / total) * 100)}%`;
+  }
+}
+
+export function TopAgentsFeedbackTable({
+  rows,
+  isLoading,
+  onSelectAgent,
+}: TopAgentsFeedbackTableProps) {
+  const { t } = useT('analytics');
+  const { agents } = useListAgents('default');
+  const { i18n: i18nCtx } = useTranslation();
+  const locale = i18nCtx.language;
+
+  const displayNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    if (Array.isArray(agents)) {
+      for (const a of agents) {
+        if (
+          a &&
+          typeof a === 'object' &&
+          'name' in a &&
+          typeof (a as { name: unknown }).name === 'string' &&
+          !('status' in a)
+        ) {
+          const name = (a as { name: string }).name;
+          const resolved = resolveAgentLocale(a, locale);
+          map.set(name, resolved.displayName || name);
+        }
+      }
+    }
+    return map;
+  }, [agents, locale]);
+
+  const resolveName = useCallback(
+    (slug: string): string => {
+      if (slug === UNATTRIBUTED_AGENT_SLUG) {
+        return t('feedback.tables.topAgents.unattributed');
+      }
+      return displayNameMap.get(slug) ?? slug;
+    },
+    [displayNameMap, t],
+  );
+
+  const handleRowClick = useCallback(
+    (row: Row<FeedbackAgentBucket>) => {
+      const slug = row.original.agentSlug;
+      if (slug === UNATTRIBUTED_AGENT_SLUG) return;
+      onSelectAgent(slug);
+    },
+    [onSelectAgent],
+  );
+
+  const rowClassName = useCallback(
+    (row: Row<FeedbackAgentBucket>) =>
+      row.original.agentSlug === UNATTRIBUTED_AGENT_SLUG
+        ? 'cursor-default hover:bg-transparent'
+        : '',
+    [],
+  );
+
+  const columns = useMemo<ColumnDef<FeedbackAgentBucket>[]>(
+    () => [
+      {
+        id: 'agent',
+        header: t('feedback.tables.topAgents.agent'),
+        cell: ({ row }) => (
+          <Text
+            as="span"
+            variant="label"
+            className="block max-w-[260px] truncate text-sm"
+          >
+            {resolveName(row.original.agentSlug)}
+          </Text>
+        ),
+        size: 260,
+      },
+      {
+        id: 'helpful',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topAgents.helpful')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.positive, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'notHelpful',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topAgents.notHelpful')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.negative, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'sentiment',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topAgents.sentiment')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatPercent(row.original.positive, row.original.total, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+    ],
+    [t, resolveName, locale],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {t('feedback.tables.topAgents.title')}
+      </Text>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowId={(row) => row.agentSlug}
+        isLoading={isLoading}
+        approxRowCount={isLoading ? 5 : rows.length}
+        onRowClick={handleRowClick}
+        rowClassName={rowClassName}
+        emptyState={{
+          icon: BarChart3,
+          title: t('feedback.tables.topAgents.emptyTitle'),
+          description: t('feedback.tables.topAgents.emptyDescription'),
+        }}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/top-matchups-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/top-matchups-feedback-table.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { Swords } from 'lucide-react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+
+import type { FeedbackMatchupBucket } from './types';
+
+interface TopMatchupsFeedbackTableProps {
+  rows: FeedbackMatchupBucket[];
+  isLoading: boolean;
+}
+
+export function TopMatchupsFeedbackTable({
+  rows,
+  isLoading,
+}: TopMatchupsFeedbackTableProps) {
+  const { t } = useT('analytics');
+  const { i18n: i18nCtx } = useTranslation();
+  const locale = i18nCtx.language;
+
+  const columns = useMemo<ColumnDef<FeedbackMatchupBucket>[]>(
+    () => [
+      {
+        id: 'matchup',
+        header: t('feedback.tables.topMatchups.matchup'),
+        cell: ({ row }) => (
+          <div className="flex max-w-[420px] items-center gap-2 text-sm">
+            <Text as="span" variant="label" className="truncate">
+              {row.original.modelLeft}
+            </Text>
+            <span className="text-muted-foreground text-xs">
+              {t('feedback.tables.topMatchups.vs')}
+            </span>
+            <Text as="span" variant="label" className="truncate">
+              {row.original.modelRight}
+            </Text>
+          </div>
+        ),
+        size: 420,
+      },
+      {
+        id: 'score',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topMatchups.score')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.leftWins, locale)}
+            <span className="text-muted-foreground mx-1">–</span>
+            {formatNumber(row.original.rightWins, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'ties',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topMatchups.ties')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.ties, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'bothBad',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topMatchups.bothBad')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.bothBad, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'total',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topMatchups.total')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.total, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+    ],
+    [t, locale],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {t('feedback.tables.topMatchups.title')}
+      </Text>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowId={(row) => `${row.modelLeft}::${row.modelRight}`}
+        isLoading={isLoading}
+        approxRowCount={isLoading ? 5 : rows.length}
+        emptyState={{
+          icon: Swords,
+          title: t('feedback.tables.topMatchups.emptyTitle'),
+          description: t('feedback.tables.topMatchups.emptyDescription'),
+        }}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/top-matchups-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/top-matchups-feedback-table.tsx
@@ -31,14 +31,14 @@ export function TopMatchupsFeedbackTable({
         id: 'matchup',
         header: t('feedback.tables.topMatchups.matchup'),
         cell: ({ row }) => (
-          <div className="flex max-w-[420px] items-center gap-2 text-sm">
-            <Text as="span" variant="label" className="truncate">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+            <Text as="span" variant="label" className="break-all">
               {row.original.modelLeft}
             </Text>
-            <span className="text-muted-foreground text-xs">
+            <span className="text-muted-foreground shrink-0 text-xs">
               {t('feedback.tables.topMatchups.vs')}
             </span>
-            <Text as="span" variant="label" className="truncate">
+            <Text as="span" variant="label" className="break-all">
               {row.original.modelRight}
             </Text>
           </div>

--- a/services/platform/app/features/analytics/feedback/top-models-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/top-models-feedback-table.tsx
@@ -57,15 +57,13 @@ export function TopModelsFeedbackTable({
         id: 'model',
         header: t('feedback.tables.topModels.model'),
         cell: ({ row }) => (
-          <div className="flex max-w-[260px] items-center gap-2">
-            <Text
-              as="span"
-              variant="label"
-              className="block flex-1 truncate text-sm"
-            >
+          <div className="flex items-baseline gap-2">
+            <Text as="span" variant="label" className="text-sm break-all">
               {row.original.model}
             </Text>
-            <Badge variant="outline">{row.original.provider}</Badge>
+            <Badge variant="outline" className="shrink-0">
+              {row.original.provider}
+            </Badge>
           </div>
         ),
         size: 260,

--- a/services/platform/app/features/analytics/feedback/top-models-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/top-models-feedback-table.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import type { ColumnDef, Row } from '@tanstack/react-table';
+import { BarChart3 } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { Badge } from '@/app/components/ui/feedback/badge';
+import { Text } from '@/app/components/ui/typography/text';
+import { useT } from '@/lib/i18n/client';
+import { formatNumber } from '@/lib/utils/format/number';
+
+import type { FeedbackModelBucket } from './types';
+
+interface TopModelsFeedbackTableProps {
+  rows: FeedbackModelBucket[];
+  isLoading: boolean;
+  onSelectModel: (model: string, provider: string) => void;
+}
+
+function formatPercent(
+  positive: number,
+  total: number,
+  locale: string,
+): string {
+  if (total === 0) return '—';
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'percent',
+      maximumFractionDigits: 1,
+    }).format(positive / total);
+  } catch {
+    return `${Math.round((positive / total) * 100)}%`;
+  }
+}
+
+export function TopModelsFeedbackTable({
+  rows,
+  isLoading,
+  onSelectModel,
+}: TopModelsFeedbackTableProps) {
+  const { t } = useT('analytics');
+  const { i18n: i18nCtx } = useTranslation();
+  const locale = i18nCtx.language;
+
+  const handleRowClick = useCallback(
+    (row: Row<FeedbackModelBucket>) => {
+      onSelectModel(row.original.model, row.original.provider);
+    },
+    [onSelectModel],
+  );
+
+  const columns = useMemo<ColumnDef<FeedbackModelBucket>[]>(
+    () => [
+      {
+        id: 'model',
+        header: t('feedback.tables.topModels.model'),
+        cell: ({ row }) => (
+          <div className="flex max-w-[260px] items-center gap-2">
+            <Text
+              as="span"
+              variant="label"
+              className="block flex-1 truncate text-sm"
+            >
+              {row.original.model}
+            </Text>
+            <Badge variant="outline">{row.original.provider}</Badge>
+          </div>
+        ),
+        size: 260,
+      },
+      {
+        id: 'helpful',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topModels.helpful')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.positive, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'notHelpful',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topModels.notHelpful')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatNumber(row.original.negative, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+      {
+        id: 'sentiment',
+        header: () => (
+          <div className="text-right">
+            {t('feedback.tables.topModels.sentiment')}
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-xs">
+            {formatPercent(row.original.positive, row.original.total, locale)}
+          </div>
+        ),
+        meta: { align: 'right' as const },
+      },
+    ],
+    [t, locale],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {t('feedback.tables.topModels.title')}
+      </Text>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowId={(row) => `${row.provider}::${row.model}`}
+        isLoading={isLoading}
+        approxRowCount={isLoading ? 5 : rows.length}
+        onRowClick={handleRowClick}
+        emptyState={{
+          icon: BarChart3,
+          title: t('feedback.tables.topModels.emptyTitle'),
+          description: t('feedback.tables.topModels.emptyDescription'),
+        }}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/features/analytics/feedback/types.ts
+++ b/services/platform/app/features/analytics/feedback/types.ts
@@ -22,6 +22,16 @@ export interface FeedbackModelBucket {
   total: number;
 }
 
+export interface FeedbackMatchupBucket {
+  modelLeft: string;
+  modelRight: string;
+  leftWins: number;
+  rightWins: number;
+  ties: number;
+  bothBad: number;
+  total: number;
+}
+
 export interface RecentFeedbackItem {
   _id: string;
   threadId: string;

--- a/services/platform/app/features/analytics/feedback/types.ts
+++ b/services/platform/app/features/analytics/feedback/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Mirror of the discriminated types produced by the feedback Convex queries.
+ * Kept in a feature-local module so storybook / unit tests can import without
+ * pulling in `convex/_generated/api.d.ts` (which depends on a generated
+ * runtime).
+ */
+
+export type ArenaVerdict = 'a_better' | 'b_better' | 'tie' | 'both_bad';
+
+export interface FeedbackAgentBucket {
+  agentSlug: string;
+  positive: number;
+  negative: number;
+  total: number;
+}
+
+export interface FeedbackModelBucket {
+  provider: string;
+  model: string;
+  positive: number;
+  negative: number;
+  total: number;
+}
+
+export interface RecentFeedbackItem {
+  _id: string;
+  threadId: string;
+  messageId: string;
+  userId: string;
+  userDisplayName: string;
+  rating: 'positive' | 'negative';
+  comment: string | null;
+  agentSlug: string | null;
+  model: string | null;
+  provider: string | null;
+  arenaVerdict: ArenaVerdict | null;
+  arenaModelA: string | null;
+  arenaModelB: string | null;
+  isArena: boolean;
+  threadDeleted: boolean;
+  createdAt: number;
+}
+
+export const UNATTRIBUTED_AGENT_SLUG = '__unattributed__';

--- a/services/platform/app/features/analytics/feedback/types.ts
+++ b/services/platform/app/features/analytics/feedback/types.ts
@@ -37,7 +37,6 @@ export interface RecentFeedbackItem {
   arenaModelA: string | null;
   arenaModelB: string | null;
   isArena: boolean;
-  threadDeleted: boolean;
   createdAt: number;
 }
 

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -65,6 +65,7 @@ import { Route as DashboardIdSettingsGovernanceUsageRouteImport } from './routes
 import { Route as DashboardIdSettingsGovernanceSecurityMonitoringRouteImport } from './routes/dashboard/$id/settings/governance/security-monitoring'
 import { Route as DashboardIdSettingsGovernancePoliciesLimitsRouteImport } from './routes/dashboard/$id/settings/governance/policies-limits'
 import { Route as DashboardIdSettingsGovernanceGuardrailsRouteImport } from './routes/dashboard/$id/settings/governance/guardrails'
+import { Route as DashboardIdSettingsGovernanceFeedbackRouteImport } from './routes/dashboard/$id/settings/governance/feedback'
 import { Route as DashboardIdSettingsGovernanceContentModelsRouteImport } from './routes/dashboard/$id/settings/governance/content-models'
 import { Route as DashboardIdChatSharedShareTokenRouteImport } from './routes/dashboard/$id/chat/shared/$shareToken'
 import { Route as DashboardIdAutomationsAmIdTriggersRouteImport } from './routes/dashboard/$id/automations/$amId/triggers'
@@ -387,6 +388,12 @@ const DashboardIdSettingsGovernanceGuardrailsRoute =
     path: '/guardrails',
     getParentRoute: () => DashboardIdSettingsGovernanceRouteRoute,
   } as any)
+const DashboardIdSettingsGovernanceFeedbackRoute =
+  DashboardIdSettingsGovernanceFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => DashboardIdSettingsGovernanceRouteRoute,
+  } as any)
 const DashboardIdSettingsGovernanceContentModelsRoute =
   DashboardIdSettingsGovernanceContentModelsRouteImport.update({
     id: '/content-models',
@@ -512,6 +519,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/$id/automations/$amId/triggers': typeof DashboardIdAutomationsAmIdTriggersRoute
   '/dashboard/$id/chat/shared/$shareToken': typeof DashboardIdChatSharedShareTokenRoute
   '/dashboard/$id/settings/governance/content-models': typeof DashboardIdSettingsGovernanceContentModelsRoute
+  '/dashboard/$id/settings/governance/feedback': typeof DashboardIdSettingsGovernanceFeedbackRoute
   '/dashboard/$id/settings/governance/guardrails': typeof DashboardIdSettingsGovernanceGuardrailsRoute
   '/dashboard/$id/settings/governance/policies-limits': typeof DashboardIdSettingsGovernancePoliciesLimitsRoute
   '/dashboard/$id/settings/governance/security-monitoring': typeof DashboardIdSettingsGovernanceSecurityMonitoringRoute
@@ -570,6 +578,7 @@ export interface FileRoutesByTo {
   '/dashboard/$id/automations/$amId/triggers': typeof DashboardIdAutomationsAmIdTriggersRoute
   '/dashboard/$id/chat/shared/$shareToken': typeof DashboardIdChatSharedShareTokenRoute
   '/dashboard/$id/settings/governance/content-models': typeof DashboardIdSettingsGovernanceContentModelsRoute
+  '/dashboard/$id/settings/governance/feedback': typeof DashboardIdSettingsGovernanceFeedbackRoute
   '/dashboard/$id/settings/governance/guardrails': typeof DashboardIdSettingsGovernanceGuardrailsRoute
   '/dashboard/$id/settings/governance/policies-limits': typeof DashboardIdSettingsGovernancePoliciesLimitsRoute
   '/dashboard/$id/settings/governance/security-monitoring': typeof DashboardIdSettingsGovernanceSecurityMonitoringRoute
@@ -640,6 +649,7 @@ export interface FileRoutesById {
   '/dashboard/$id/automations/$amId/triggers': typeof DashboardIdAutomationsAmIdTriggersRoute
   '/dashboard/$id/chat/shared/$shareToken': typeof DashboardIdChatSharedShareTokenRoute
   '/dashboard/$id/settings/governance/content-models': typeof DashboardIdSettingsGovernanceContentModelsRoute
+  '/dashboard/$id/settings/governance/feedback': typeof DashboardIdSettingsGovernanceFeedbackRoute
   '/dashboard/$id/settings/governance/guardrails': typeof DashboardIdSettingsGovernanceGuardrailsRoute
   '/dashboard/$id/settings/governance/policies-limits': typeof DashboardIdSettingsGovernancePoliciesLimitsRoute
   '/dashboard/$id/settings/governance/security-monitoring': typeof DashboardIdSettingsGovernanceSecurityMonitoringRoute
@@ -709,6 +719,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/automations/$amId/triggers'
     | '/dashboard/$id/chat/shared/$shareToken'
     | '/dashboard/$id/settings/governance/content-models'
+    | '/dashboard/$id/settings/governance/feedback'
     | '/dashboard/$id/settings/governance/guardrails'
     | '/dashboard/$id/settings/governance/policies-limits'
     | '/dashboard/$id/settings/governance/security-monitoring'
@@ -767,6 +778,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/automations/$amId/triggers'
     | '/dashboard/$id/chat/shared/$shareToken'
     | '/dashboard/$id/settings/governance/content-models'
+    | '/dashboard/$id/settings/governance/feedback'
     | '/dashboard/$id/settings/governance/guardrails'
     | '/dashboard/$id/settings/governance/policies-limits'
     | '/dashboard/$id/settings/governance/security-monitoring'
@@ -836,6 +848,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/automations/$amId/triggers'
     | '/dashboard/$id/chat/shared/$shareToken'
     | '/dashboard/$id/settings/governance/content-models'
+    | '/dashboard/$id/settings/governance/feedback'
     | '/dashboard/$id/settings/governance/guardrails'
     | '/dashboard/$id/settings/governance/policies-limits'
     | '/dashboard/$id/settings/governance/security-monitoring'
@@ -1250,6 +1263,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIdSettingsGovernanceGuardrailsRouteImport
       parentRoute: typeof DashboardIdSettingsGovernanceRouteRoute
     }
+    '/dashboard/$id/settings/governance/feedback': {
+      id: '/dashboard/$id/settings/governance/feedback'
+      path: '/feedback'
+      fullPath: '/dashboard/$id/settings/governance/feedback'
+      preLoaderRoute: typeof DashboardIdSettingsGovernanceFeedbackRouteImport
+      parentRoute: typeof DashboardIdSettingsGovernanceRouteRoute
+    }
     '/dashboard/$id/settings/governance/content-models': {
       id: '/dashboard/$id/settings/governance/content-models'
       path: '/content-models'
@@ -1478,6 +1498,7 @@ const DashboardIdConversationsRouteWithChildren =
 
 interface DashboardIdSettingsGovernanceRouteRouteChildren {
   DashboardIdSettingsGovernanceContentModelsRoute: typeof DashboardIdSettingsGovernanceContentModelsRoute
+  DashboardIdSettingsGovernanceFeedbackRoute: typeof DashboardIdSettingsGovernanceFeedbackRoute
   DashboardIdSettingsGovernanceGuardrailsRoute: typeof DashboardIdSettingsGovernanceGuardrailsRoute
   DashboardIdSettingsGovernancePoliciesLimitsRoute: typeof DashboardIdSettingsGovernancePoliciesLimitsRoute
   DashboardIdSettingsGovernanceSecurityMonitoringRoute: typeof DashboardIdSettingsGovernanceSecurityMonitoringRoute
@@ -1489,6 +1510,8 @@ const DashboardIdSettingsGovernanceRouteRouteChildren: DashboardIdSettingsGovern
   {
     DashboardIdSettingsGovernanceContentModelsRoute:
       DashboardIdSettingsGovernanceContentModelsRoute,
+    DashboardIdSettingsGovernanceFeedbackRoute:
+      DashboardIdSettingsGovernanceFeedbackRoute,
     DashboardIdSettingsGovernanceGuardrailsRoute:
       DashboardIdSettingsGovernanceGuardrailsRoute,
     DashboardIdSettingsGovernancePoliciesLimitsRoute:

--- a/services/platform/app/routes/dashboard/$id/settings/governance/feedback.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/feedback.tsx
@@ -1,0 +1,86 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useCallback } from 'react';
+import { z } from 'zod';
+
+import {
+  FeedbackMetricsPage,
+  type FeedbackKind,
+  type FeedbackPeriod,
+} from '@/app/features/analytics/feedback/feedback-metrics-page';
+
+const searchSchema = z.object({
+  period: z.enum(['1', '7', '30', '90', 'all']).optional(),
+  kind: z.enum(['all', 'message', 'arena']).optional(),
+  comments: z.enum(['1']).optional(),
+  agent: z.string().optional(),
+  model: z.string().optional(),
+  provider: z.string().optional(),
+});
+
+type SearchValues = z.infer<typeof searchSchema>;
+
+export const Route = createFileRoute(
+  '/dashboard/$id/settings/governance/feedback',
+)({
+  validateSearch: searchSchema,
+  component: FeedbackRoute,
+});
+
+function FeedbackRoute() {
+  const { id: organizationId } = Route.useParams();
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+
+  const period: FeedbackPeriod = search.period ?? '7';
+  const kind: FeedbackKind = search.kind ?? 'all';
+  const withCommentOnly = search.comments === '1';
+  const agentSlug = search.agent;
+  const model = search.model;
+  const provider = search.provider;
+
+  const updateSearch = useCallback(
+    (next: Partial<SearchValues>) => {
+      void navigate({
+        to: '/dashboard/$id/settings/governance/feedback',
+        params: { id: organizationId },
+        search: (prev) => ({ ...prev, ...next }),
+        replace: true,
+      });
+    },
+    [navigate, organizationId],
+  );
+
+  return (
+    <div className="pb-8">
+      <FeedbackMetricsPage
+        organizationId={organizationId}
+        period={period}
+        kind={kind}
+        withCommentOnly={withCommentOnly}
+        agentSlug={agentSlug}
+        model={model}
+        provider={provider}
+        onChangePeriod={(p) =>
+          updateSearch({ period: p === '7' ? undefined : p })
+        }
+        onChangeKind={(k) =>
+          updateSearch({ kind: k === 'all' ? undefined : k })
+        }
+        onToggleCommentOnly={(on) =>
+          updateSearch({ comments: on ? '1' : undefined })
+        }
+        onSelectAgent={(slug) => updateSearch({ agent: slug ?? undefined })}
+        onSelectModel={(m, p) =>
+          updateSearch({ model: m ?? undefined, provider: p ?? undefined })
+        }
+        onClearFilters={() =>
+          updateSearch({
+            agent: undefined,
+            model: undefined,
+            provider: undefined,
+          })
+        }
+      />
+    </div>
+  );
+}

--- a/services/platform/app/routes/dashboard/$id/settings/governance/route.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/route.tsx
@@ -19,6 +19,7 @@ export const GOVERNANCE_GROUPS = [
   'security-monitoring',
   'guardrails',
   'usage',
+  'feedback',
 ] as const;
 export type GovernanceGroup = (typeof GOVERNANCE_GROUPS)[number];
 
@@ -92,6 +93,7 @@ function GovernanceLayout() {
   const securityMonitoring = linkClass(`${basePath}/security-monitoring`);
   const guardrails = linkClass(`${basePath}/guardrails`);
   const usage = linkClass(`${basePath}/usage`);
+  const feedback = linkClass(`${basePath}/feedback`);
 
   return (
     <div className={LAYOUT_ROOT_CLASSNAME}>
@@ -135,6 +137,14 @@ function GovernanceLayout() {
           aria-current={usage.isActive ? 'page' : undefined}
         >
           {t('groups.usage')}
+        </Link>
+        <Link
+          to="/dashboard/$id/settings/governance/feedback"
+          params={{ id: organizationId }}
+          className={feedback.className}
+          aria-current={feedback.isActive ? 'page' : undefined}
+        >
+          {t('groups.feedback')}
         </Link>
       </nav>
       <div ref={contentRef} className={CONTENT_CLASSNAME}>

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -293,6 +293,7 @@ import type * as documents_upload_base64_to_storage from "../documents/upload_ba
 import type * as documents_validators from "../documents/validators.js";
 import type * as feedback_mutations from "../feedback/mutations.js";
 import type * as feedback_queries from "../feedback/queries.js";
+import type * as feedback_stats from "../feedback/stats.js";
 import type * as file_metadata_actions from "../file_metadata/actions.js";
 import type * as file_metadata_audio_preprocess from "../file_metadata/audio_preprocess.js";
 import type * as file_metadata_helpers from "../file_metadata/helpers.js";
@@ -1326,6 +1327,7 @@ declare const fullApi: ApiFromModules<{
   "documents/validators": typeof documents_validators;
   "feedback/mutations": typeof feedback_mutations;
   "feedback/queries": typeof feedback_queries;
+  "feedback/stats": typeof feedback_stats;
   "file_metadata/actions": typeof file_metadata_actions;
   "file_metadata/audio_preprocess": typeof file_metadata_audio_preprocess;
   "file_metadata/helpers": typeof file_metadata_helpers;

--- a/services/platform/convex/feedback/__tests__/stats.test.ts
+++ b/services/platform/convex/feedback/__tests__/stats.test.ts
@@ -188,8 +188,78 @@ describe('computeFeedbackStats', () => {
     expect(out.arena.total).toBe(0);
     expect(out.topAgents).toEqual([]);
     expect(out.topModels).toEqual([]);
+    expect(out.topMatchups).toEqual([]);
     expect(out.capped).toBe(false);
     expect(out.scanned).toBe(0);
+  });
+
+  it('aggregates arena matchups in canonical (lexicographic) model order', () => {
+    const out = computeFeedbackStats(
+      [
+        // alpha (A) vs zeta (B), A wins. Canonical [alpha, zeta] → leftWins.
+        row({
+          metadata: {
+            arenaVerdict: 'a_better',
+            modelA: 'alpha',
+            modelB: 'zeta',
+          },
+        }),
+        // zeta (A) vs alpha (B), A wins. Canonical [alpha, zeta] → rightWins
+        // (because A is now the larger of the two).
+        row({
+          metadata: {
+            arenaVerdict: 'a_better',
+            modelA: 'zeta',
+            modelB: 'alpha',
+          },
+        }),
+        // alpha (A) vs zeta (B), tie.
+        row({
+          metadata: { arenaVerdict: 'tie', modelA: 'alpha', modelB: 'zeta' },
+        }),
+        // alpha (A) vs zeta (B), both bad.
+        row({
+          metadata: {
+            arenaVerdict: 'both_bad',
+            modelA: 'alpha',
+            modelB: 'zeta',
+          },
+        }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.topMatchups).toEqual([
+      {
+        modelLeft: 'alpha',
+        modelRight: 'zeta',
+        leftWins: 1,
+        rightWins: 1,
+        ties: 1,
+        bothBad: 1,
+        total: 4,
+      },
+    ]);
+  });
+
+  it('skips matchups when arena rows have a self-pair or missing models', () => {
+    const out = computeFeedbackStats(
+      [
+        row({
+          metadata: {
+            arenaVerdict: 'a_better',
+            modelA: 'gpt-4',
+            modelB: 'gpt-4',
+          },
+        }),
+        row({ metadata: { arenaVerdict: 'a_better', modelA: 'gpt-4' } }),
+        row({ metadata: { arenaVerdict: 'a_better', modelB: 'gpt-4' } }),
+        row({ metadata: { arenaVerdict: 'a_better' } }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.topMatchups).toEqual([]);
+    // Arena totals still increment; only matchup rollup is skipped.
+    expect(out.arena.total).toBe(4);
   });
 
   it('ignores arena rows with unknown verdict in byVerdict', () => {

--- a/services/platform/convex/feedback/__tests__/stats.test.ts
+++ b/services/platform/convex/feedback/__tests__/stats.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Doc } from '../../_generated/dataModel';
+import { computeFeedbackStats, UNATTRIBUTED_AGENT_SLUG } from '../stats';
+
+type FeedbackRow = Doc<'messageFeedback'>;
+
+let nextId = 1;
+
+function row(overrides: Partial<FeedbackRow>): FeedbackRow {
+  return {
+    _id: `mf_${nextId++}` as FeedbackRow['_id'],
+    _creationTime: 0,
+    organizationId: 'org_1',
+    threadId: 't_1',
+    messageId: 'm_1',
+    userId: 'u_1',
+    rating: 'positive',
+    createdAt: 1_000,
+    ...overrides,
+  } as FeedbackRow;
+}
+
+const NO_FILTER = {
+  cutoffMs: null,
+  maxScan: 1000,
+};
+
+describe('computeFeedbackStats', () => {
+  it('splits positive/negative on message-only rows', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ rating: 'positive' }),
+        row({ rating: 'positive' }),
+        row({ rating: 'negative' }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.message.byRating).toEqual({ positive: 2, negative: 1 });
+    expect(out.message.total).toBe(3);
+    expect(out.arena.total).toBe(0);
+  });
+
+  it('classifies arena rows by metadata.arenaVerdict presence', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ metadata: { arenaVerdict: 'a_better' } }),
+        row({ metadata: { arenaVerdict: 'b_better' } }),
+        row({ metadata: { arenaVerdict: 'tie' } }),
+        row({ metadata: { arenaVerdict: 'both_bad' } }),
+        row({ metadata: { arenaVerdict: 'a_better' } }),
+        row({ rating: 'positive' }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.arena.total).toBe(5);
+    expect(out.arena.byVerdict.a_better).toBe(2);
+    expect(out.arena.byVerdict.b_better).toBe(1);
+    expect(out.arena.byVerdict.tie).toBe(1);
+    expect(out.arena.byVerdict.both_bad).toBe(1);
+    expect(out.message.total).toBe(1);
+  });
+
+  it('applies agentSlug post-filter', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ agentSlug: 'alpha', rating: 'positive' }),
+        row({ agentSlug: 'beta', rating: 'positive' }),
+        row({ agentSlug: 'alpha', rating: 'negative' }),
+      ],
+      { ...NO_FILTER, agentSlug: 'alpha' },
+    );
+    expect(out.message.total).toBe(2);
+    expect(out.message.byRating.positive).toBe(1);
+    expect(out.message.byRating.negative).toBe(1);
+  });
+
+  it('applies model + provider post-filter together', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ provider: 'openai', model: 'gpt-4', rating: 'positive' }),
+        row({ provider: 'openai', model: 'gpt-3.5', rating: 'positive' }),
+        row({ provider: 'anthropic', model: 'gpt-4', rating: 'negative' }),
+      ],
+      { ...NO_FILTER, model: 'gpt-4', provider: 'openai' },
+    );
+    expect(out.message.total).toBe(1);
+  });
+
+  it('ranks topAgents by total desc with stable tiebreak on slug', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ agentSlug: 'beta', rating: 'positive' }),
+        row({ agentSlug: 'beta', rating: 'positive' }),
+        row({ agentSlug: 'alpha', rating: 'positive' }),
+        row({ agentSlug: 'alpha', rating: 'negative' }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.topAgents.map((a) => a.agentSlug)).toEqual(['alpha', 'beta']);
+    expect(out.topAgents[0].total).toBe(2);
+    expect(out.topAgents[1].total).toBe(2);
+  });
+
+  it('puts unattributed rows under the sentinel slug', () => {
+    const out = computeFeedbackStats(
+      [row({ rating: 'positive' }), row({ rating: 'negative' })],
+      NO_FILTER,
+    );
+    expect(out.topAgents.length).toBe(1);
+    expect(out.topAgents[0].agentSlug).toBe(UNATTRIBUTED_AGENT_SLUG);
+    expect(out.topAgents[0].total).toBe(2);
+  });
+
+  it('only ranks topModels when both provider and model are present', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ provider: 'openai', model: 'gpt-4', rating: 'positive' }),
+        row({ provider: undefined, model: 'gpt-4', rating: 'positive' }),
+        row({ provider: 'openai', model: undefined, rating: 'negative' }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.topModels).toEqual([
+      {
+        provider: 'openai',
+        model: 'gpt-4',
+        positive: 1,
+        negative: 0,
+        total: 1,
+      },
+    ]);
+  });
+
+  it('arena rows are excluded from topAgents and topModels', () => {
+    const out = computeFeedbackStats(
+      [
+        row({
+          metadata: {
+            arenaVerdict: 'a_better',
+            modelA: 'gpt-4',
+            modelB: 'opus',
+          },
+          provider: 'openai',
+          model: 'gpt-4',
+        }),
+        row({
+          provider: 'openai',
+          model: 'gpt-4',
+          agentSlug: 'alpha',
+          rating: 'positive',
+        }),
+      ],
+      NO_FILTER,
+    );
+    expect(out.topAgents).toEqual([
+      { agentSlug: 'alpha', positive: 1, negative: 0, total: 1 },
+    ]);
+    expect(out.topModels[0].total).toBe(1);
+  });
+
+  it('flips capped flag and stops once maxScan is exceeded', () => {
+    const rows = [
+      row({ rating: 'positive' }),
+      row({ rating: 'positive' }),
+      row({ rating: 'positive' }),
+    ];
+    const out = computeFeedbackStats(rows, { cutoffMs: null, maxScan: 2 });
+    expect(out.capped).toBe(true);
+    expect(out.scanned).toBe(3);
+    expect(out.message.total).toBe(2);
+  });
+
+  it('belt-and-suspenders skip when row.createdAt < cutoffMs', () => {
+    const out = computeFeedbackStats(
+      [
+        row({ createdAt: 5_000, rating: 'positive' }),
+        row({ createdAt: 500, rating: 'positive' }),
+      ],
+      { cutoffMs: 1_000, maxScan: 100 },
+    );
+    expect(out.message.total).toBe(1);
+  });
+
+  it('produces a defined empty shape on empty input', () => {
+    const out = computeFeedbackStats([], NO_FILTER);
+    expect(out.message.total).toBe(0);
+    expect(out.arena.total).toBe(0);
+    expect(out.topAgents).toEqual([]);
+    expect(out.topModels).toEqual([]);
+    expect(out.capped).toBe(false);
+    expect(out.scanned).toBe(0);
+  });
+
+  it('ignores arena rows with unknown verdict in byVerdict', () => {
+    const out = computeFeedbackStats(
+      [row({ metadata: { arenaVerdict: 'unknown_verdict' } })],
+      NO_FILTER,
+    );
+    expect(out.arena.total).toBe(1);
+    // None of the known buckets received the unknown verdict.
+    expect(out.arena.byVerdict.a_better).toBe(0);
+    expect(out.arena.byVerdict.b_better).toBe(0);
+    expect(out.arena.byVerdict.tie).toBe(0);
+    expect(out.arena.byVerdict.both_bad).toBe(0);
+  });
+});

--- a/services/platform/convex/feedback/mutations.ts
+++ b/services/platform/convex/feedback/mutations.ts
@@ -3,6 +3,9 @@ import { v } from 'convex/values';
 import { mutation } from '../_generated/server';
 import { authComponent } from '../auth';
 import { getOrganizationMember } from '../lib/rls';
+import { OrganizationMismatchError } from '../lib/rls/errors';
+
+const ARENA_MESSAGE_ID_PREFIX = 'arena:';
 
 export const submitFeedback = mutation({
   args: {
@@ -26,6 +29,43 @@ export const submitFeedback = mutation({
 
     await getOrganizationMember(ctx, args.organizationId);
 
+    // Reject cross-org writes: feedback must be tagged with the org that
+    // owns the source thread, not whatever the client supplies. Arena rows
+    // use a synthetic messageId (arena:<a>:<b>) but still reference a real
+    // threadId, so the same check applies.
+    const threadMeta = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
+      .first();
+    if (
+      threadMeta &&
+      threadMeta.organizationId &&
+      threadMeta.organizationId !== args.organizationId
+    ) {
+      throw new OrganizationMismatchError();
+    }
+
+    // Server-side attribution capture: read the source message's metadata
+    // (model / provider / agentSlug) and copy into the feedback row. We do
+    // not trust client-supplied attribution. Arena rows skip the lookup —
+    // their messageId is synthetic, and arena attribution lives in
+    // metadata.modelA/modelB which the client supplies and we do not bind
+    // to an agent.
+    let agentSlug: string | undefined;
+    let model: string | undefined;
+    let provider: string | undefined;
+    if (!args.messageId.startsWith(ARENA_MESSAGE_ID_PREFIX)) {
+      const msgMeta = await ctx.db
+        .query('messageMetadata')
+        .withIndex('by_messageId', (q) => q.eq('messageId', args.messageId))
+        .first();
+      if (msgMeta) {
+        agentSlug = msgMeta.agentSlug;
+        model = msgMeta.model || undefined;
+        provider = msgMeta.provider || undefined;
+      }
+    }
+
     const userId = String(authUser._id);
 
     const existing = await ctx.db
@@ -40,6 +80,9 @@ export const submitFeedback = mutation({
         rating: args.rating,
         comment: args.comment,
         metadata: args.metadata,
+        agentSlug: agentSlug ?? existing.agentSlug,
+        model: model ?? existing.model,
+        provider: provider ?? existing.provider,
       });
       return existing._id;
     }
@@ -52,6 +95,9 @@ export const submitFeedback = mutation({
       rating: args.rating,
       comment: args.comment,
       metadata: args.metadata,
+      agentSlug,
+      model,
+      provider,
       createdAt: Date.now(),
     });
   },
@@ -79,6 +125,14 @@ export const deleteFeedback = mutation({
       .first();
 
     if (existing) {
+      // Defense in depth: never delete a row whose stored organizationId
+      // does not match the one the caller claims to be operating in. The
+      // by_messageId_userId scope already constrains by userId, but cross-
+      // membership users could theoretically delete the wrong row if the
+      // mutation trusted args.organizationId blindly.
+      if (existing.organizationId !== args.organizationId) {
+        throw new OrganizationMismatchError();
+      }
       await ctx.db.delete(existing._id);
     }
 

--- a/services/platform/convex/feedback/queries.ts
+++ b/services/platform/convex/feedback/queries.ts
@@ -1,8 +1,51 @@
+import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import { authComponent } from '../auth';
+import { getUserNamesBatch } from '../documents/get_user_names_batch';
 import { getOrganizationMember } from '../lib/rls';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import {
+  computeFeedbackStats,
+  type FeedbackStats,
+  type FeedbackStatsAgentBucket,
+  type FeedbackStatsModelBucket,
+  ARENA_VERDICTS,
+  type ArenaVerdict,
+} from './stats';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Defensive cap when no period filter is supplied. With the
+// by_org_createdAt index and a period bound, the iterator is naturally
+// limited to the requested window — this only matters for "all-time".
+const MAX_SCAN_ALL_TIME = 50_000;
+
+const COMMENT_PROJECTION_MAX = 4_096;
+
+const periodDaysValidator = v.optional(
+  v.union(v.literal(1), v.literal(7), v.literal(30), v.literal(90)),
+);
+
+/**
+ * Compute the inclusive lower-bound timestamp for a `periodDays` value.
+ * Day-aligned UTC so totals reconcile with the Usage Analytics page,
+ * which buckets by daily / weekly / monthly UTC keys.
+ */
+function periodCutoffMs(
+  periodDays: 1 | 7 | 30 | 90 | undefined,
+  now: number,
+): number | null {
+  if (periodDays === undefined) return null;
+  const earliest = new Date(now - (periodDays - 1) * DAY_MS);
+  const startOfDay = Date.UTC(
+    earliest.getUTCFullYear(),
+    earliest.getUTCMonth(),
+    earliest.getUTCDate(),
+  );
+  return startOfDay;
+}
 
 export const getMessageFeedback = query({
   args: {
@@ -23,30 +66,217 @@ export const getMessageFeedback = query({
   },
 });
 
+export interface FeedbackStatsResult extends FeedbackStats {
+  hasAnyFeedback: boolean;
+}
+
 export const getFeedbackStats = query({
   args: {
     organizationId: v.string(),
+    periodDays: periodDaysValidator,
+    agentSlug: v.optional(v.string()),
+    model: v.optional(v.string()),
+    provider: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<FeedbackStatsResult | null> => {
     const authUser = await authComponent.getAuthUser(ctx);
     if (!authUser) return null;
 
-    await getOrganizationMember(ctx, args.organizationId);
+    const member = await getOrganizationMember(ctx, args.organizationId, {
+      userId: String(authUser._id),
+      email: authUser.email,
+      name: authUser.name,
+    });
+    if (!isAdmin(member.role)) {
+      throw new Error('Only admins can view feedback metrics');
+    }
 
-    let positive = 0;
-    let negative = 0;
+    const now = Date.now();
+    const cutoffMs = periodCutoffMs(args.periodDays, now);
 
-    const feedbackQuery = ctx.db
+    // hasAnyFeedback is a single org-scoped existence probe, used by the UI
+    // to distinguish "org has never collected feedback" from "no feedback
+    // in the selected window." Cheap — the index lets Convex stop at the
+    // first row.
+    const probe = await ctx.db
       .query('messageFeedback')
       .withIndex('by_organizationId', (q) =>
         q.eq('organizationId', args.organizationId),
-      );
+      )
+      .first();
+    const hasAnyFeedback = probe !== null;
 
-    for await (const feedback of feedbackQuery) {
-      if (feedback.rating === 'positive') positive++;
-      else negative++;
+    const baseQuery = ctx.db
+      .query('messageFeedback')
+      .withIndex('by_org_createdAt', (q) => {
+        const eq = q.eq('organizationId', args.organizationId);
+        return cutoffMs !== null ? eq.gte('createdAt', cutoffMs) : eq;
+      })
+      .order('desc');
+
+    const rows: Awaited<ReturnType<typeof baseQuery.collect>> = [];
+    for await (const row of baseQuery) {
+      rows.push(row);
+      // The reducer applies its own MAX_SCAN cap; this loop is bounded by
+      // the index range when cutoffMs is set. For all-time we still pull
+      // a full slab into memory — tighten if it ever bites.
+      if (cutoffMs === null && rows.length > MAX_SCAN_ALL_TIME) break;
     }
 
-    return { positive, negative, total: positive + negative };
+    const stats = computeFeedbackStats(rows, {
+      cutoffMs,
+      agentSlug: args.agentSlug,
+      model: args.model,
+      provider: args.provider,
+      maxScan: cutoffMs === null ? MAX_SCAN_ALL_TIME : Number.POSITIVE_INFINITY,
+    });
+
+    return { ...stats, hasAnyFeedback };
   },
 });
+
+export interface RecentFeedbackItem {
+  _id: string;
+  threadId: string;
+  messageId: string;
+  userId: string;
+  userDisplayName: string;
+  rating: 'positive' | 'negative';
+  comment: string | null;
+  agentSlug: string | null;
+  model: string | null;
+  provider: string | null;
+  arenaVerdict: ArenaVerdict | null;
+  arenaModelA: string | null;
+  arenaModelB: string | null;
+  isArena: boolean;
+  threadDeleted: boolean;
+  createdAt: number;
+}
+
+export const listRecentFeedback = query({
+  args: {
+    organizationId: v.string(),
+    paginationOpts: paginationOptsValidator,
+    periodDays: periodDaysValidator,
+    kind: v.optional(
+      v.union(v.literal('all'), v.literal('message'), v.literal('arena')),
+    ),
+    withCommentOnly: v.optional(v.boolean()),
+    agentSlug: v.optional(v.string()),
+    model: v.optional(v.string()),
+    provider: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) {
+      throw new Error('Unauthenticated');
+    }
+
+    const member = await getOrganizationMember(ctx, args.organizationId, {
+      userId: String(authUser._id),
+      email: authUser.email,
+      name: authUser.name,
+    });
+    if (!isAdmin(member.role)) {
+      throw new Error('Only admins can view feedback metrics');
+    }
+
+    const now = Date.now();
+    const cutoffMs = periodCutoffMs(args.periodDays, now);
+
+    const baseQuery = ctx.db
+      .query('messageFeedback')
+      .withIndex('by_org_createdAt', (q) => {
+        const eq = q.eq('organizationId', args.organizationId);
+        return cutoffMs !== null ? eq.gte('createdAt', cutoffMs) : eq;
+      })
+      .order('desc');
+
+    const filteredQuery = baseQuery.filter((q) => {
+      let predicate = q.eq(q.field('organizationId'), args.organizationId);
+      if (args.agentSlug !== undefined) {
+        predicate = q.and(
+          predicate,
+          q.eq(q.field('agentSlug'), args.agentSlug),
+        );
+      }
+      if (args.model !== undefined) {
+        predicate = q.and(predicate, q.eq(q.field('model'), args.model));
+      }
+      if (args.provider !== undefined) {
+        predicate = q.and(predicate, q.eq(q.field('provider'), args.provider));
+      }
+      return predicate;
+    });
+
+    const result = await filteredQuery.paginate(args.paginationOpts);
+
+    // Apply the kind / withCommentOnly post-filters in-memory. Convex's
+    // filter() expression set doesn't currently support the "field is
+    // defined / not defined" check we need for arenaVerdict cleanly, and
+    // these filters narrow rows the index already shrunk by org+window.
+    const wanted = result.page.filter((row) => {
+      const isArena = row.metadata?.arenaVerdict !== undefined;
+      if (args.kind === 'message' && isArena) return false;
+      if (args.kind === 'arena' && !isArena) return false;
+      if (args.withCommentOnly && !row.comment) return false;
+      return true;
+    });
+
+    // Resolve user display names + thread-deleted state in a single pass
+    // each. getUserNamesBatch already dedupes; threadMetadata lookup is by
+    // primary key so cheap.
+    const userIds = [...new Set(wanted.map((r) => r.userId))];
+    const userNameMap = await getUserNamesBatch(ctx, userIds);
+
+    const threadIds = [...new Set(wanted.map((r) => r.threadId))];
+    const threadStatusMap = new Map<string, boolean>();
+    for (const threadId of threadIds) {
+      const meta = await ctx.db
+        .query('threadMetadata')
+        .withIndex('by_threadId', (q) => q.eq('threadId', threadId))
+        .first();
+      threadStatusMap.set(
+        threadId,
+        !meta || meta.status === 'deleted' || meta.status === 'archived',
+      );
+    }
+
+    const items: RecentFeedbackItem[] = wanted.map((row) => {
+      const verdictRaw = row.metadata?.arenaVerdict;
+      const arenaVerdict: ArenaVerdict | null =
+        ARENA_VERDICTS.find((verdict) => verdict === verdictRaw) ?? null;
+      return {
+        _id: String(row._id),
+        threadId: row.threadId,
+        messageId: row.messageId,
+        userId: row.userId,
+        userDisplayName: userNameMap.get(row.userId) ?? row.userId,
+        rating: row.rating,
+        comment: row.comment
+          ? row.comment.length > COMMENT_PROJECTION_MAX
+            ? row.comment.slice(0, COMMENT_PROJECTION_MAX) + '…'
+            : row.comment
+          : null,
+        agentSlug: row.agentSlug ?? null,
+        model: row.model ?? null,
+        provider: row.provider ?? null,
+        arenaVerdict,
+        arenaModelA: row.metadata?.modelA ?? null,
+        arenaModelB: row.metadata?.modelB ?? null,
+        isArena: row.metadata?.arenaVerdict !== undefined,
+        threadDeleted: threadStatusMap.get(row.threadId) ?? false,
+        createdAt: row.createdAt,
+      };
+    });
+
+    return {
+      ...result,
+      page: items,
+    };
+  },
+});
+
+// Re-export bucket types so the page module imports them from one place.
+export type { FeedbackStatsAgentBucket, FeedbackStatsModelBucket };

--- a/services/platform/convex/feedback/queries.ts
+++ b/services/platform/convex/feedback/queries.ts
@@ -10,6 +10,7 @@ import {
   computeFeedbackStats,
   type FeedbackStats,
   type FeedbackStatsAgentBucket,
+  type FeedbackStatsMatchupBucket,
   type FeedbackStatsModelBucket,
   ARENA_VERDICTS,
   type ArenaVerdict,
@@ -261,4 +262,8 @@ export const listRecentFeedback = query({
 });
 
 // Re-export bucket types so the page module imports them from one place.
-export type { FeedbackStatsAgentBucket, FeedbackStatsModelBucket };
+export type {
+  FeedbackStatsAgentBucket,
+  FeedbackStatsMatchupBucket,
+  FeedbackStatsModelBucket,
+};

--- a/services/platform/convex/feedback/queries.ts
+++ b/services/platform/convex/feedback/queries.ts
@@ -150,7 +150,6 @@ export interface RecentFeedbackItem {
   arenaModelA: string | null;
   arenaModelB: string | null;
   isArena: boolean;
-  threadDeleted: boolean;
   createdAt: number;
 }
 
@@ -224,24 +223,8 @@ export const listRecentFeedback = query({
       return true;
     });
 
-    // Resolve user display names + thread-deleted state in a single pass
-    // each. getUserNamesBatch already dedupes; threadMetadata lookup is by
-    // primary key so cheap.
     const userIds = [...new Set(wanted.map((r) => r.userId))];
     const userNameMap = await getUserNamesBatch(ctx, userIds);
-
-    const threadIds = [...new Set(wanted.map((r) => r.threadId))];
-    const threadStatusMap = new Map<string, boolean>();
-    for (const threadId of threadIds) {
-      const meta = await ctx.db
-        .query('threadMetadata')
-        .withIndex('by_threadId', (q) => q.eq('threadId', threadId))
-        .first();
-      threadStatusMap.set(
-        threadId,
-        !meta || meta.status === 'deleted' || meta.status === 'archived',
-      );
-    }
 
     const items: RecentFeedbackItem[] = wanted.map((row) => {
       const verdictRaw = row.metadata?.arenaVerdict;
@@ -266,7 +249,6 @@ export const listRecentFeedback = query({
         arenaModelA: row.metadata?.modelA ?? null,
         arenaModelB: row.metadata?.modelB ?? null,
         isArena: row.metadata?.arenaVerdict !== undefined,
-        threadDeleted: threadStatusMap.get(row.threadId) ?? false,
         createdAt: row.createdAt,
       };
     });

--- a/services/platform/convex/feedback/schema.ts
+++ b/services/platform/convex/feedback/schema.ts
@@ -15,9 +15,17 @@ export const messageFeedbackTable = defineTable({
       modelB: v.optional(v.string()),
     }),
   ),
+  // Server-side attribution copied from messageMetadata at submit time so
+  // governance/feedback dashboards can slice by agent / model / provider.
+  // Optional because (a) arena rows use a synthetic messageId and rely on
+  // metadata.modelA/B instead, and (b) legacy rows pre-date the capture.
+  agentSlug: v.optional(v.string()),
+  model: v.optional(v.string()),
+  provider: v.optional(v.string()),
   createdAt: v.number(),
 })
   .index('by_messageId_userId', ['messageId', 'userId'])
   .index('by_organizationId', ['organizationId'])
   .index('by_org_rating', ['organizationId', 'rating'])
-  .index('by_threadId', ['threadId']);
+  .index('by_threadId', ['threadId'])
+  .index('by_org_createdAt', ['organizationId', 'createdAt']);

--- a/services/platform/convex/feedback/stats.ts
+++ b/services/platform/convex/feedback/stats.ts
@@ -1,0 +1,219 @@
+import type { Doc } from '../_generated/dataModel';
+
+export type ArenaVerdict = 'a_better' | 'b_better' | 'tie' | 'both_bad';
+export const ARENA_VERDICTS: ArenaVerdict[] = [
+  'a_better',
+  'b_better',
+  'tie',
+  'both_bad',
+];
+
+const SYNTHETIC_AGENT_DIRECT_API = '__direct_api__';
+const SYNTHETIC_AGENT_INTEGRATION = '__integration__';
+// Sentinel slug used in the ranking when a row has no agent attribution
+// (typically arena rows or legacy / pre-attribution rows). Distinct from
+// the Usage-page synthetic slugs so the UI can label it differently.
+export const UNATTRIBUTED_AGENT_SLUG = '__unattributed__';
+
+export interface ComputeFeedbackStatsOptions {
+  /** Lower bound (inclusive) on `createdAt`. `null` = no period filter. */
+  cutoffMs: number | null;
+  /** Optional attribution filters applied during reduction. */
+  agentSlug?: string;
+  model?: string;
+  provider?: string;
+  /**
+   * Defensive scan cap. The caller is expected to bound the query by
+   * `createdAt >= cutoffMs` via the `by_org_createdAt` index, so this only
+   * matters when `cutoffMs === null` (all-time).
+   */
+  maxScan: number;
+}
+
+export interface FeedbackStatsAgentBucket {
+  agentSlug: string;
+  positive: number;
+  negative: number;
+  total: number;
+}
+
+export interface FeedbackStatsModelBucket {
+  provider: string;
+  model: string;
+  positive: number;
+  negative: number;
+  total: number;
+}
+
+export interface FeedbackStats {
+  message: {
+    byRating: { positive: number; negative: number };
+    total: number;
+  };
+  arena: {
+    byVerdict: Record<ArenaVerdict, number>;
+    total: number;
+  };
+  topAgents: FeedbackStatsAgentBucket[];
+  topModels: FeedbackStatsModelBucket[];
+  capped: boolean;
+  scanned: number;
+  windowStartMs: number | null;
+}
+
+const TOP_N = 10;
+
+function isArenaRow(row: Doc<'messageFeedback'>): boolean {
+  return row.metadata?.arenaVerdict !== undefined;
+}
+
+function arenaVerdictOf(row: Doc<'messageFeedback'>): ArenaVerdict | null {
+  const v = row.metadata?.arenaVerdict;
+  if (v === 'a_better' || v === 'b_better' || v === 'tie' || v === 'both_bad') {
+    return v;
+  }
+  return null;
+}
+
+/**
+ * Pure reducer for feedback aggregates. No Convex `ctx` — accepts any
+ * iterable (live query iterator, in-memory test array) and produces the
+ * aggregate shape the page consumes.
+ *
+ * Caller is responsible for opening the iterator with the appropriate
+ * index range (org + period). This function only applies the optional
+ * agent/model/provider post-filters and produces the topAgents/topModels
+ * rankings.
+ */
+export function computeFeedbackStats(
+  rows: Iterable<Doc<'messageFeedback'>>,
+  opts: ComputeFeedbackStatsOptions,
+): FeedbackStats {
+  const messageByRating = { positive: 0, negative: 0 };
+  let messageTotal = 0;
+
+  const arenaByVerdict: Record<ArenaVerdict, number> = {
+    a_better: 0,
+    b_better: 0,
+    tie: 0,
+    both_bad: 0,
+  };
+  let arenaTotal = 0;
+
+  const agentBuckets = new Map<string, FeedbackStatsAgentBucket>();
+  const modelBuckets = new Map<string, FeedbackStatsModelBucket>();
+
+  let scanned = 0;
+  let capped = false;
+
+  for (const row of rows) {
+    scanned++;
+    if (scanned > opts.maxScan) {
+      capped = true;
+      break;
+    }
+
+    if (opts.cutoffMs !== null && row.createdAt < opts.cutoffMs) {
+      // Iterator was supposed to be window-bounded already — this is a
+      // belt-and-suspenders check for callers that pass unbounded data.
+      continue;
+    }
+    if (opts.agentSlug !== undefined && row.agentSlug !== opts.agentSlug) {
+      continue;
+    }
+    if (opts.model !== undefined && row.model !== opts.model) {
+      continue;
+    }
+    if (opts.provider !== undefined && row.provider !== opts.provider) {
+      continue;
+    }
+
+    if (isArenaRow(row)) {
+      arenaTotal++;
+      const verdict = arenaVerdictOf(row);
+      if (verdict) arenaByVerdict[verdict]++;
+    } else {
+      messageTotal++;
+      if (row.rating === 'positive') messageByRating.positive++;
+      else messageByRating.negative++;
+
+      // topAgents / topModels are message-level only. Arena rows have no
+      // single agent owner; folding them in would double-count and produce
+      // misleading sentiment ratios per agent.
+      const agentKey = row.agentSlug ?? UNATTRIBUTED_AGENT_SLUG;
+      let agentBucket = agentBuckets.get(agentKey);
+      if (!agentBucket) {
+        agentBucket = {
+          agentSlug: agentKey,
+          positive: 0,
+          negative: 0,
+          total: 0,
+        };
+        agentBuckets.set(agentKey, agentBucket);
+      }
+      agentBucket.total++;
+      if (row.rating === 'positive') agentBucket.positive++;
+      else agentBucket.negative++;
+
+      if (row.model && row.provider) {
+        const modelKey = `${row.provider}::${row.model}`;
+        let modelBucket = modelBuckets.get(modelKey);
+        if (!modelBucket) {
+          modelBucket = {
+            provider: row.provider,
+            model: row.model,
+            positive: 0,
+            negative: 0,
+            total: 0,
+          };
+          modelBuckets.set(modelKey, modelBucket);
+        }
+        modelBucket.total++;
+        if (row.rating === 'positive') modelBucket.positive++;
+        else modelBucket.negative++;
+      }
+    }
+  }
+
+  // Sort by total desc, stable tiebreak on slug / model id. Drops the
+  // unattributed bucket out of the top-N display when there is real
+  // agent traffic — but keep it in the data so the caller can render
+  // a "(unattributed)" row if it dominates.
+  const topAgents = [...agentBuckets.values()]
+    .sort((a, b) => b.total - a.total || a.agentSlug.localeCompare(b.agentSlug))
+    .slice(0, TOP_N);
+
+  const topModels = [...modelBuckets.values()]
+    .sort(
+      (a, b) =>
+        b.total - a.total ||
+        `${a.provider}::${a.model}`.localeCompare(`${b.provider}::${b.model}`),
+    )
+    .slice(0, TOP_N);
+
+  return {
+    message: { byRating: messageByRating, total: messageTotal },
+    arena: { byVerdict: arenaByVerdict, total: arenaTotal },
+    topAgents,
+    topModels,
+    capped,
+    scanned,
+    windowStartMs: opts.cutoffMs,
+  };
+}
+
+/**
+ * Synthetic-slug helpers — kept colocated with the reducer because the
+ * UI needs them too (label resolution).
+ */
+export function isUnattributedAgentSlug(slug: string): boolean {
+  return slug === UNATTRIBUTED_AGENT_SLUG;
+}
+
+export function isFeedbackSyntheticAgentSlug(slug: string): boolean {
+  return (
+    slug === UNATTRIBUTED_AGENT_SLUG ||
+    slug === SYNTHETIC_AGENT_DIRECT_API ||
+    slug === SYNTHETIC_AGENT_INTEGRATION
+  );
+}

--- a/services/platform/convex/feedback/stats.ts
+++ b/services/platform/convex/feedback/stats.ts
@@ -45,6 +45,18 @@ export interface FeedbackStatsModelBucket {
   total: number;
 }
 
+export interface FeedbackStatsMatchupBucket {
+  /** Models in canonical (lexicographic) order so (X,Y) and (Y,X) merge. */
+  modelLeft: string;
+  modelRight: string;
+  /** Wins counted against the canonical orientation, not user-picked A/B. */
+  leftWins: number;
+  rightWins: number;
+  ties: number;
+  bothBad: number;
+  total: number;
+}
+
 export interface FeedbackStats {
   message: {
     byRating: { positive: number; negative: number };
@@ -56,6 +68,7 @@ export interface FeedbackStats {
   };
   topAgents: FeedbackStatsAgentBucket[];
   topModels: FeedbackStatsModelBucket[];
+  topMatchups: FeedbackStatsMatchupBucket[];
   capped: boolean;
   scanned: number;
   windowStartMs: number | null;
@@ -102,6 +115,7 @@ export function computeFeedbackStats(
 
   const agentBuckets = new Map<string, FeedbackStatsAgentBucket>();
   const modelBuckets = new Map<string, FeedbackStatsModelBucket>();
+  const matchupBuckets = new Map<string, FeedbackStatsMatchupBucket>();
 
   let scanned = 0;
   let capped = false;
@@ -132,6 +146,46 @@ export function computeFeedbackStats(
       arenaTotal++;
       const verdict = arenaVerdictOf(row);
       if (verdict) arenaByVerdict[verdict]++;
+
+      const modelA = row.metadata?.modelA;
+      const modelB = row.metadata?.modelB;
+      // Model-pair matchups are only meaningful when both sides are
+      // attributed and distinct. Drop self-matches (modelA === modelB) —
+      // verdict on those carries no comparative signal.
+      if (verdict && modelA && modelB && modelA !== modelB) {
+        const swapped = modelA > modelB;
+        const left = swapped ? modelB : modelA;
+        const right = swapped ? modelA : modelB;
+        const matchupKey = `${left}::${right}`;
+        let bucket = matchupBuckets.get(matchupKey);
+        if (!bucket) {
+          bucket = {
+            modelLeft: left,
+            modelRight: right,
+            leftWins: 0,
+            rightWins: 0,
+            ties: 0,
+            bothBad: 0,
+            total: 0,
+          };
+          matchupBuckets.set(matchupKey, bucket);
+        }
+        bucket.total++;
+        if (verdict === 'tie') {
+          bucket.ties++;
+        } else if (verdict === 'both_bad') {
+          bucket.bothBad++;
+        } else if (verdict === 'a_better') {
+          // a_better == originalA wins. If we swapped (modelA > modelB),
+          // originalA is now on the right side of the canonical pair.
+          if (swapped) bucket.rightWins++;
+          else bucket.leftWins++;
+        } else {
+          // b_better == originalB wins.
+          if (swapped) bucket.leftWins++;
+          else bucket.rightWins++;
+        }
+      }
     } else {
       messageTotal++;
       if (row.rating === 'positive') messageByRating.positive++;
@@ -191,11 +245,22 @@ export function computeFeedbackStats(
     )
     .slice(0, TOP_N);
 
+  const topMatchups = [...matchupBuckets.values()]
+    .sort(
+      (a, b) =>
+        b.total - a.total ||
+        `${a.modelLeft}::${a.modelRight}`.localeCompare(
+          `${b.modelLeft}::${b.modelRight}`,
+        ),
+    )
+    .slice(0, TOP_N);
+
   return {
     message: { byRating: messageByRating, total: messageTotal },
     arena: { byVerdict: arenaByVerdict, total: arenaTotal },
     topAgents,
     topModels,
+    topMatchups,
     capped,
     scanned,
     windowStartMs: opts.cutoffMs,

--- a/services/platform/convex/lib/agent_completion/on_agent_complete.ts
+++ b/services/platform/convex/lib/agent_completion/on_agent_complete.ts
@@ -145,6 +145,7 @@ export async function onAgentComplete(
               threadId,
               model: result.model,
               provider: result.provider,
+              agentSlug: args.agentSlug,
               inputTokens: result.usage?.inputTokens,
               outputTokens: result.usage?.outputTokens,
               totalTokens: result.usage?.totalTokens,

--- a/services/platform/convex/message_metadata/internal_mutations.ts
+++ b/services/platform/convex/message_metadata/internal_mutations.ts
@@ -16,6 +16,7 @@ export const saveMessageMetadata = internalMutation({
     threadId: v.string(),
     model: v.optional(v.string()),
     provider: v.optional(v.string()),
+    agentSlug: v.optional(v.string()),
     inputTokens: v.optional(v.number()),
     outputTokens: v.optional(v.number()),
     totalTokens: v.optional(v.number()),
@@ -57,6 +58,7 @@ export const saveMessageMetadata = internalMutation({
       await ctx.db.patch(existing._id, {
         model: args.model ?? existing.model,
         provider: args.provider ?? existing.provider,
+        agentSlug: args.agentSlug ?? existing.agentSlug,
         inputTokens: args.inputTokens ?? existing.inputTokens,
         outputTokens: args.outputTokens ?? existing.outputTokens,
         totalTokens: args.totalTokens ?? existing.totalTokens,
@@ -82,6 +84,7 @@ export const saveMessageMetadata = internalMutation({
       threadId: args.threadId,
       model: args.model ?? '',
       provider: args.provider ?? '',
+      agentSlug: args.agentSlug,
       inputTokens: args.inputTokens,
       outputTokens: args.outputTokens,
       totalTokens: args.totalTokens,

--- a/services/platform/convex/streaming/schema.ts
+++ b/services/platform/convex/streaming/schema.ts
@@ -8,6 +8,10 @@ export const messageMetadataTable = defineTable({
   threadId: v.string(),
   model: v.string(),
   provider: v.string(),
+  // Owning assistant slug. Optional for backward compatibility with rows
+  // written before the field existed; new writes should populate it from
+  // OnAgentCompleteArgs.agentSlug so feedback rows can attribute by agent.
+  agentSlug: v.optional(v.string()),
   inputTokens: v.optional(v.number()),
   outputTokens: v.optional(v.number()),
   totalTokens: v.optional(v.number()),

--- a/services/platform/convex/streaming/validators.ts
+++ b/services/platform/convex/streaming/validators.ts
@@ -45,6 +45,7 @@ export const messageMetadataValidator = v.object({
   threadId: v.string(),
   model: v.string(),
   provider: v.string(),
+  agentSlug: v.optional(v.string()),
   inputTokens: v.optional(v.number()),
   outputTokens: v.optional(v.number()),
   totalTokens: v.optional(v.number()),

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3617,7 +3617,8 @@
       "policiesAndLimits": "Richtlinien & Limits",
       "securityAndMonitoring": "Sicherheit & Überwachung",
       "guardrails": "Guardrails",
-      "usage": "Nutzung"
+      "usage": "Nutzung",
+      "feedback": "Feedback"
     },
     "modelAccess": {
       "title": "Modellzugriff",
@@ -3870,6 +3871,113 @@
       "emptyModels": {
         "title": "Noch keine Modellnutzung",
         "description": "Für den ausgewählten Zeitraum wurden keine LLM-Aufrufe erfasst. Integrations- und Transkriptionsnutzung wird unter Top-Assistenten angezeigt."
+      }
+    },
+    "feedback": {
+      "title": "Feedback-Analyse",
+      "description": "Daumen-Bewertungen und Arena-Urteile zu Assistenten-Antworten.",
+      "commentsOnly": "Nur Kommentare",
+      "errors": {
+        "loadFailed": "Feedback-Metriken konnten nicht geladen werden",
+        "unauthorized": "Du hast keinen Zugriff auf diese Seite"
+      },
+      "period": {
+        "label": "Zeitraum",
+        "last24Hours": "Letzte 24 Stunden",
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "last90Days": "Letzte 90 Tage",
+        "allTime": "Gesamter Zeitraum"
+      },
+      "kind": {
+        "label": "Typ",
+        "all": "Alle Typen",
+        "message": "Nachrichten-Bewertung",
+        "arena": "Arena-Urteile"
+      },
+      "cards": {
+        "sentiment": "Sentiment",
+        "sentimentAriaLabel": "{{pct}} hilfreich, {{helpful}} von {{total}}",
+        "sentimentCapped": "Sentiment nicht verfügbar bei Teilergebnissen",
+        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "helpful": "Hilfreich",
+        "notHelpful": "Nicht hilfreich"
+      },
+      "arena": {
+        "title": "Arena-Urteile"
+      },
+      "tables": {
+        "topAgents": {
+          "title": "Top-Assistenten nach Feedback",
+          "agent": "Assistent",
+          "helpful": "Hilfreich",
+          "notHelpful": "Nicht hilfreich",
+          "sentiment": "Sentiment",
+          "unattributed": "Ohne Zuordnung",
+          "emptyTitle": "Noch kein Assistenten-Feedback",
+          "emptyDescription": "Die Aufschlüsselung pro Assistent erscheint hier, sobald Nutzer Antworten bewerten."
+        },
+        "topModels": {
+          "title": "Top-Modelle nach Feedback",
+          "model": "Modell",
+          "helpful": "Hilfreich",
+          "notHelpful": "Nicht hilfreich",
+          "sentiment": "Sentiment",
+          "emptyTitle": "Noch kein Modell-Feedback",
+          "emptyDescription": "Die Aufschlüsselung pro Modell erscheint hier, sobald Nutzer Antworten bewerten, deren Modell erfasst wurde."
+        }
+      },
+      "filterChips": {
+        "agent": "Assistent: {{value}}",
+        "model": "Modell: {{value}}",
+        "provider": "Anbieter: {{value}}",
+        "clear": "Filter zurücksetzen"
+      },
+      "empty": {
+        "title": "Noch kein Feedback erfasst",
+        "description": "Sobald Nutzer Daumen hoch/runter geben oder ein Arena-Urteil fällen, erscheint es hier."
+      },
+      "periodEmpty": {
+        "title": "Kein Feedback in diesem Zeitraum",
+        "description": "Versuche, den Zeitraum zu erweitern.",
+        "expand": "Gesamter Zeitraum"
+      },
+      "filterEmpty": {
+        "title": "Keine Treffer für die aktiven Filter",
+        "description": "Entferne oder lockere die aktiven Filter.",
+        "clear": "Filter zurücksetzen"
+      },
+      "cappedNotice": {
+        "title": "Teilergebnisse werden angezeigt",
+        "description": "Deine Organisation hat mehr als 50.000 Einträge im gewählten Zeitraum. Verkleinere den Zeitraum für genaue Werte."
+      },
+      "recent": {
+        "title": "Aktuelles Feedback",
+        "emptyTitle": "Kein Feedback in diesem Zeitraum",
+        "emptyDescription": "Passe Zeitraum oder Filter an, um mehr zu sehen.",
+        "noComment": "(kein Kommentar)",
+        "openThread": "Chat öffnen",
+        "helpfulAria": "Hilfreich",
+        "notHelpfulAria": "Nicht hilfreich",
+        "types": {
+          "message": "Chat",
+          "arena": "Arena"
+        },
+        "columns": {
+          "time": "Zeit",
+          "user": "Benutzer",
+          "type": "Typ",
+          "rating": "Bewertung",
+          "agent": "Assistent",
+          "model": "Modell",
+          "comment": "Kommentar",
+          "thread": "Chat"
+        },
+        "expanded": {
+          "comment": "Kommentar",
+          "arena": "Arena-Paarung",
+          "attribution": "Zuordnung"
+        }
       }
     }
   },

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3904,7 +3904,12 @@
         "notHelpful": "Nicht hilfreich"
       },
       "arena": {
-        "title": "Arena-Urteile"
+        "title": "Arena-Urteile",
+        "cells": {
+          "decisive": "Eindeutig",
+          "tie": "Unentschieden",
+          "bothBad": "Beide schlecht"
+        }
       },
       "tables": {
         "topAgents": {
@@ -3925,6 +3930,17 @@
           "sentiment": "Sentiment",
           "emptyTitle": "Noch kein Modell-Feedback",
           "emptyDescription": "Die Aufschlüsselung pro Modell erscheint hier, sobald Nutzer Antworten bewerten, deren Modell erfasst wurde."
+        },
+        "topMatchups": {
+          "title": "Top Modell-Duelle",
+          "matchup": "Duell",
+          "vs": "vs",
+          "score": "Ergebnis",
+          "ties": "Unentschieden",
+          "bothBad": "Beide schlecht",
+          "total": "Urteile",
+          "emptyTitle": "Noch keine Modell-Duelle",
+          "emptyDescription": "Direkte Vergleiche pro Paar erscheinen hier, sobald Nutzer im Arena-Modus zwei Modelle gegeneinander antreten lassen."
         }
       },
       "filterChips": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3897,9 +3897,9 @@
       },
       "cards": {
         "sentiment": "Sentiment",
-        "sentimentAriaLabel": "{{pct}} hilfreich, {{helpful}} von {{total}}",
+        "sentimentAriaLabel": "{pct} hilfreich, {helpful} von {total}",
         "sentimentCapped": "Sentiment nicht verfügbar bei Teilergebnissen",
-        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "sentimentDenominator": "{helpful} / {total}",
         "helpful": "Hilfreich",
         "notHelpful": "Nicht hilfreich"
       },
@@ -3928,9 +3928,9 @@
         }
       },
       "filterChips": {
-        "agent": "Assistent: {{value}}",
-        "model": "Modell: {{value}}",
-        "provider": "Anbieter: {{value}}",
+        "agent": "Assistent: {value}",
+        "model": "Modell: {value}",
+        "provider": "Anbieter: {value}",
         "clear": "Filter zurücksetzen"
       },
       "empty": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3956,7 +3956,6 @@
         "emptyTitle": "Kein Feedback in diesem Zeitraum",
         "emptyDescription": "Passe Zeitraum oder Filter an, um mehr zu sehen.",
         "noComment": "(kein Kommentar)",
-        "openThread": "Chat öffnen",
         "helpfulAria": "Hilfreich",
         "notHelpfulAria": "Nicht hilfreich",
         "types": {
@@ -3970,8 +3969,7 @@
           "rating": "Bewertung",
           "agent": "Assistent",
           "model": "Modell",
-          "comment": "Kommentar",
-          "thread": "Chat"
+          "comment": "Kommentar"
         },
         "expanded": {
           "comment": "Kommentar",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3904,7 +3904,12 @@
         "notHelpful": "Not helpful"
       },
       "arena": {
-        "title": "Arena verdicts"
+        "title": "Arena verdicts",
+        "cells": {
+          "decisive": "Decisive",
+          "tie": "Tie",
+          "bothBad": "Both bad"
+        }
       },
       "tables": {
         "topAgents": {
@@ -3925,6 +3930,17 @@
           "sentiment": "Sentiment",
           "emptyTitle": "No model feedback yet",
           "emptyDescription": "Per-model breakdown appears here once users rate replies whose model is captured."
+        },
+        "topMatchups": {
+          "title": "Top Model Matchups",
+          "matchup": "Matchup",
+          "vs": "vs",
+          "score": "Score",
+          "ties": "Ties",
+          "bothBad": "Both bad",
+          "total": "Verdicts",
+          "emptyTitle": "No model matchups yet",
+          "emptyDescription": "Per-pair head-to-head wins appear here once users compare two models in arena mode."
         }
       },
       "filterChips": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3897,9 +3897,9 @@
       },
       "cards": {
         "sentiment": "Sentiment",
-        "sentimentAriaLabel": "{{pct}} helpful, {{helpful}} of {{total}}",
+        "sentimentAriaLabel": "{pct} helpful, {helpful} of {total}",
         "sentimentCapped": "Sentiment unavailable while results are partial",
-        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "sentimentDenominator": "{helpful} / {total}",
         "helpful": "Helpful",
         "notHelpful": "Not helpful"
       },
@@ -3928,9 +3928,9 @@
         }
       },
       "filterChips": {
-        "agent": "Assistant: {{value}}",
-        "model": "Model: {{value}}",
-        "provider": "Provider: {{value}}",
+        "agent": "Assistant: {value}",
+        "model": "Model: {value}",
+        "provider": "Provider: {value}",
         "clear": "Clear filters"
       },
       "empty": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3956,7 +3956,6 @@
         "emptyTitle": "No feedback in this window",
         "emptyDescription": "Adjust the period or filters to see more.",
         "noComment": "(no comment)",
-        "openThread": "Open chat",
         "helpfulAria": "Helpful",
         "notHelpfulAria": "Not helpful",
         "types": {
@@ -3970,8 +3969,7 @@
           "rating": "Rating",
           "agent": "Assistant",
           "model": "Model",
-          "comment": "Comment",
-          "thread": "Thread"
+          "comment": "Comment"
         },
         "expanded": {
           "comment": "Comment",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3617,7 +3617,8 @@
       "policiesAndLimits": "Policies & Limits",
       "securityAndMonitoring": "Security & Monitoring",
       "guardrails": "Guardrails",
-      "usage": "Usage"
+      "usage": "Usage",
+      "feedback": "Feedback"
     },
     "modelAccess": {
       "title": "Model access",
@@ -3870,6 +3871,113 @@
       "emptyModels": {
         "title": "No model usage yet",
         "description": "No LLM calls have been recorded for the selected period. Integration and transcription usage is shown under Top Assistants."
+      }
+    },
+    "feedback": {
+      "title": "Feedback Analytics",
+      "description": "User-submitted thumbs up/down and arena verdicts on assistant responses.",
+      "commentsOnly": "Comments only",
+      "errors": {
+        "loadFailed": "Couldn't load feedback metrics",
+        "unauthorized": "You don't have access to this page"
+      },
+      "period": {
+        "label": "Period",
+        "last24Hours": "Last 24 hours",
+        "last7Days": "Last 7 days",
+        "last30Days": "Last 30 days",
+        "last90Days": "Last 90 days",
+        "allTime": "All time"
+      },
+      "kind": {
+        "label": "Type",
+        "all": "All types",
+        "message": "Message thumbs",
+        "arena": "Arena verdicts"
+      },
+      "cards": {
+        "sentiment": "Sentiment",
+        "sentimentAriaLabel": "{{pct}} helpful, {{helpful}} of {{total}}",
+        "sentimentCapped": "Sentiment unavailable while results are partial",
+        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "helpful": "Helpful",
+        "notHelpful": "Not helpful"
+      },
+      "arena": {
+        "title": "Arena verdicts"
+      },
+      "tables": {
+        "topAgents": {
+          "title": "Top Assistants by feedback",
+          "agent": "Assistant",
+          "helpful": "Helpful",
+          "notHelpful": "Not helpful",
+          "sentiment": "Sentiment",
+          "unattributed": "Unattributed",
+          "emptyTitle": "No assistant feedback yet",
+          "emptyDescription": "Per-assistant breakdown appears here once users rate assistant replies."
+        },
+        "topModels": {
+          "title": "Top Models by feedback",
+          "model": "Model",
+          "helpful": "Helpful",
+          "notHelpful": "Not helpful",
+          "sentiment": "Sentiment",
+          "emptyTitle": "No model feedback yet",
+          "emptyDescription": "Per-model breakdown appears here once users rate replies whose model is captured."
+        }
+      },
+      "filterChips": {
+        "agent": "Assistant: {{value}}",
+        "model": "Model: {{value}}",
+        "provider": "Provider: {{value}}",
+        "clear": "Clear filters"
+      },
+      "empty": {
+        "title": "No feedback collected yet",
+        "description": "When users tap thumbs up/down on a chat reply or pick a winner in arena mode, it shows up here."
+      },
+      "periodEmpty": {
+        "title": "No feedback in this window",
+        "description": "Try widening the period.",
+        "expand": "Show all time"
+      },
+      "filterEmpty": {
+        "title": "No feedback matches your filters",
+        "description": "Try removing or relaxing the active filters.",
+        "clear": "Clear filters"
+      },
+      "cappedNotice": {
+        "title": "Showing partial results",
+        "description": "Your organization has more than 50,000 entries in the selected window. Narrow the window for accurate counts."
+      },
+      "recent": {
+        "title": "Recent feedback",
+        "emptyTitle": "No feedback in this window",
+        "emptyDescription": "Adjust the period or filters to see more.",
+        "noComment": "(no comment)",
+        "openThread": "Open chat",
+        "helpfulAria": "Helpful",
+        "notHelpfulAria": "Not helpful",
+        "types": {
+          "message": "Chat",
+          "arena": "Arena"
+        },
+        "columns": {
+          "time": "Time",
+          "user": "User",
+          "type": "Type",
+          "rating": "Rating",
+          "agent": "Assistant",
+          "model": "Model",
+          "comment": "Comment",
+          "thread": "Thread"
+        },
+        "expanded": {
+          "comment": "Comment",
+          "arena": "Arena pairing",
+          "attribution": "Attribution"
+        }
       }
     }
   },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3529,7 +3529,8 @@
       "policiesAndLimits": "Politiques et limites",
       "securityAndMonitoring": "Sécurité et surveillance",
       "guardrails": "Guardrails",
-      "usage": "Utilisation"
+      "usage": "Utilisation",
+      "feedback": "Retours"
     },
     "modelAccess": {
       "title": "Accès aux modèles",
@@ -3877,6 +3878,113 @@
       "emptyModels": {
         "title": "Aucune utilisation de modèle",
         "description": "Aucun appel LLM n'a été enregistré pour la période sélectionnée. L'utilisation des intégrations et des transcriptions est affichée dans Top assistants."
+      }
+    },
+    "feedback": {
+      "title": "Analyse des retours",
+      "description": "Évaluations pouce levé/baissé et verdicts d'arène sur les réponses de l'assistant.",
+      "commentsOnly": "Commentaires uniquement",
+      "errors": {
+        "loadFailed": "Impossible de charger les métriques de retour",
+        "unauthorized": "Tu n'as pas accès à cette page"
+      },
+      "period": {
+        "label": "Période",
+        "last24Hours": "Dernières 24 heures",
+        "last7Days": "7 derniers jours",
+        "last30Days": "30 derniers jours",
+        "last90Days": "90 derniers jours",
+        "allTime": "Tout l'historique"
+      },
+      "kind": {
+        "label": "Type",
+        "all": "Tous les types",
+        "message": "Évaluations de messages",
+        "arena": "Verdicts d'arène"
+      },
+      "cards": {
+        "sentiment": "Sentiment",
+        "sentimentAriaLabel": "{{pct}} utile, {{helpful}} sur {{total}}",
+        "sentimentCapped": "Sentiment indisponible avec des résultats partiels",
+        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "helpful": "Utile",
+        "notHelpful": "Pas utile"
+      },
+      "arena": {
+        "title": "Verdicts d'arène"
+      },
+      "tables": {
+        "topAgents": {
+          "title": "Top assistants par retour",
+          "agent": "Assistant",
+          "helpful": "Utile",
+          "notHelpful": "Pas utile",
+          "sentiment": "Sentiment",
+          "unattributed": "Non attribué",
+          "emptyTitle": "Aucun retour d'assistant",
+          "emptyDescription": "La répartition par assistant apparaît ici dès que les utilisateurs évaluent des réponses."
+        },
+        "topModels": {
+          "title": "Top modèles par retour",
+          "model": "Modèle",
+          "helpful": "Utile",
+          "notHelpful": "Pas utile",
+          "sentiment": "Sentiment",
+          "emptyTitle": "Aucun retour sur les modèles",
+          "emptyDescription": "La répartition par modèle apparaît ici dès que les utilisateurs évaluent des réponses dont le modèle a été enregistré."
+        }
+      },
+      "filterChips": {
+        "agent": "Assistant : {{value}}",
+        "model": "Modèle : {{value}}",
+        "provider": "Fournisseur : {{value}}",
+        "clear": "Effacer les filtres"
+      },
+      "empty": {
+        "title": "Aucun retour collecté pour le moment",
+        "description": "Quand les utilisateurs cliquent sur pouce levé/baissé ou choisissent un gagnant en mode arène, cela apparaît ici."
+      },
+      "periodEmpty": {
+        "title": "Aucun retour sur cette période",
+        "description": "Essaie d'élargir la période.",
+        "expand": "Tout l'historique"
+      },
+      "filterEmpty": {
+        "title": "Aucun retour ne correspond aux filtres",
+        "description": "Essaie de retirer ou d'assouplir les filtres actifs.",
+        "clear": "Effacer les filtres"
+      },
+      "cappedNotice": {
+        "title": "Résultats partiels affichés",
+        "description": "Ton organisation a plus de 50 000 entrées dans la fenêtre choisie. Réduis la fenêtre pour des chiffres exacts."
+      },
+      "recent": {
+        "title": "Retours récents",
+        "emptyTitle": "Aucun retour sur cette période",
+        "emptyDescription": "Ajuste la période ou les filtres pour en voir davantage.",
+        "noComment": "(aucun commentaire)",
+        "openThread": "Ouvrir le chat",
+        "helpfulAria": "Utile",
+        "notHelpfulAria": "Pas utile",
+        "types": {
+          "message": "Chat",
+          "arena": "Arène"
+        },
+        "columns": {
+          "time": "Heure",
+          "user": "Utilisateur",
+          "type": "Type",
+          "rating": "Évaluation",
+          "agent": "Assistant",
+          "model": "Modèle",
+          "comment": "Commentaire",
+          "thread": "Chat"
+        },
+        "expanded": {
+          "comment": "Commentaire",
+          "arena": "Pairing d'arène",
+          "attribution": "Attribution"
+        }
       }
     }
   },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3911,7 +3911,12 @@
         "notHelpful": "Pas utile"
       },
       "arena": {
-        "title": "Verdicts d'arène"
+        "title": "Verdicts d'arène",
+        "cells": {
+          "decisive": "Tranché",
+          "tie": "Égalité",
+          "bothBad": "Les deux mauvais"
+        }
       },
       "tables": {
         "topAgents": {
@@ -3932,6 +3937,17 @@
           "sentiment": "Sentiment",
           "emptyTitle": "Aucun retour sur les modèles",
           "emptyDescription": "La répartition par modèle apparaît ici dès que les utilisateurs évaluent des réponses dont le modèle a été enregistré."
+        },
+        "topMatchups": {
+          "title": "Top duels de modèles",
+          "matchup": "Duel",
+          "vs": "vs",
+          "score": "Score",
+          "ties": "Égalités",
+          "bothBad": "Les deux mauvais",
+          "total": "Verdicts",
+          "emptyTitle": "Aucun duel de modèles",
+          "emptyDescription": "Les confrontations directes par paire apparaissent ici dès que les utilisateurs comparent deux modèles en mode arène."
         }
       },
       "filterChips": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3963,7 +3963,6 @@
         "emptyTitle": "Aucun retour sur cette période",
         "emptyDescription": "Ajuste la période ou les filtres pour en voir davantage.",
         "noComment": "(aucun commentaire)",
-        "openThread": "Ouvrir le chat",
         "helpfulAria": "Utile",
         "notHelpfulAria": "Pas utile",
         "types": {
@@ -3977,8 +3976,7 @@
           "rating": "Évaluation",
           "agent": "Assistant",
           "model": "Modèle",
-          "comment": "Commentaire",
-          "thread": "Chat"
+          "comment": "Commentaire"
         },
         "expanded": {
           "comment": "Commentaire",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3904,9 +3904,9 @@
       },
       "cards": {
         "sentiment": "Sentiment",
-        "sentimentAriaLabel": "{{pct}} utile, {{helpful}} sur {{total}}",
+        "sentimentAriaLabel": "{pct} utile, {helpful} sur {total}",
         "sentimentCapped": "Sentiment indisponible avec des résultats partiels",
-        "sentimentDenominator": "{{helpful}} / {{total}}",
+        "sentimentDenominator": "{helpful} / {total}",
         "helpful": "Utile",
         "notHelpful": "Pas utile"
       },
@@ -3935,9 +3935,9 @@
         }
       },
       "filterChips": {
-        "agent": "Assistant : {{value}}",
-        "model": "Modèle : {{value}}",
-        "provider": "Fournisseur : {{value}}",
+        "agent": "Assistant : {value}",
+        "model": "Modèle : {value}",
+        "provider": "Fournisseur : {value}",
         "clear": "Effacer les filtres"
       },
       "empty": {


### PR DESCRIPTION
## Summary

- New **Settings → Governance → Feedback** admin page surfacing chat thumbs and arena verdicts, with first-class agent / model / provider attribution.
- Hardens `submitFeedback` / `deleteFeedback` with thread↔org checks and reads attribution from `messageMetadata` server-side instead of trusting the client.
- Schema additions: `messageFeedback.{agentSlug,model,provider}` + `by_org_createdAt` index; `messageMetadata.agentSlug` (additive only).
- New aggregations: top agents, top models, and per-pair model matchups (canonical lexicographic orientation, decisive / tie / both-bad triple), with a pure reducer covered by a 12-case unit suite.
- Recent feedback uses `paginationOptsValidator` + `DataTable` with expandable rows; kind / comments-only filters are scoped to the section to match their effect, period stays global.
- i18n: 70+ `analytics.feedback.*` keys + `governance.groups.feedback` added to en / de / fr (single-brace placeholders, parity).

## Pre-PR checklist

- [x] Translation parity en/de/fr maintained on every commit.
- [ ] Ran `bun run check` — please run before merge; not executed in this session.
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [ ] Updated `docs/{,de/,fr/}` — **not yet**; admin governance docs still describe pre-feedback state. Recommend follow-up doc PR or extending this one before merge.
- [ ] Ran `bun run --filter @tale/docs lint` — N/A pending docs update.
- [x] `README*` updates — N/A (no top-level surface change).

## Test plan

- [ ] Visit `/dashboard/<org>/settings/governance/feedback` as an org admin; verify period, kind, comments-only, agent, model, provider URL state round-trips.
- [ ] Submit thumbs up/down on a chat message; confirm the row shows up in *Recent feedback* and increments the sentiment hero / Top Assistants / Top Models.
- [ ] Submit an arena verdict (A better / B better / tie / both bad); confirm it lands in *Top Model Matchups* under the canonical pair regardless of which slot got which model.
- [ ] Try `submitFeedback` with a `threadId` from another org — should be rejected.
- [ ] Self-pair / one-side-missing arena rows should not appear in matchups.
- [ ] Empty states: brand-new org (org-empty), org with feedback but none in selected period (period-empty), filters that match nothing (filter-empty).
- [ ] Chat per-message metadata (cost / tokens / model popover) still loads — regression guard for the `messageMetadataValidator` fix in 564958d66.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Feedback analytics dashboard to governance settings, displaying sentiment metrics, arena verdict summaries, and rankings of top agents, models, and model matchups by user satisfaction
  * Added filtering by time period (1, 7, 30, 90 days, or all), feedback type (message feedback or arena battles), and optional comment-only view
  * Added recent feedback listings with agent and model attribution, expandable details, and pagination support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->