### PR TITLE
feat(cli): version-pinned installs and refreshed install/integration docs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,9 @@
   "recommendations": [
     "oxc.oxc-vscode",
     "foxundermoon.shell-format",
-    "charliermarsh.ruff"
+    "charliermarsh.ruff",
+    "ms-vscode.powershell",
+    "ms-python.python",
+    "ms-vscode.vscode-typescript-next"
   ]
 }

--- a/docs/de/develop/integrations.md
+++ b/docs/de/develop/integrations.md
@@ -1,0 +1,283 @@
+---
+title: Integration bauen
+description: Einen Tale-Konnektor schreiben — config.json, connector.ts, Sandbox-APIs und Paketierung.
+---
+
+Ein Konnektor ist eine `config.json` plus eine `connector.ts` (oder `.js`) plus ein Icon. Das Manifest deklariert Identität, Authentifizierung, erlaubte Hosts und die benannten Operationen, die die Integration veröffentlicht; der Konnektor-Code führt jede Operation in einer Sandbox aus. SQL-Integrationen sind ein Sonderfall — sie liefern keinen Code, sondern nur parametrisierte Abfragen im Manifest.
+
+Diese Seite ist die Autoring-Referenz. Sie setzt voraus, dass du den [Integrationen-Überblick](/de/platform/integrations/overview) für die nutzerseitigen Konzepte gelesen hast. Zum Editor-Workflow mit KI-Assistenten siehe [KI-gestützte Entwicklung](/de/develop/ai-assisted-development).
+
+## Dateilayout
+
+Ein Konnektor lebt in einem einzigen Verzeichnis. Der Verzeichnisname ist der **Slug** — die stabile Kennung, die die Plattform verwendet; er ist kein Feld innerhalb der `config.json`.
+
+```text
+integrations/<slug>/
+├── config.json     ← Manifest (erforderlich)
+├── connector.ts    ← sandboxierter Code (nur REST-Konnektoren)
+└── icon.svg        ← in der Add-integration-Liste angezeigt
+```
+
+Es gibt zwei Wege, dieses Verzeichnis auszuliefern: leg es in den `integrations/`-Ordner eines per `tale init` erstellten Projekts, oder zippe die Dateien und lade sie über **Einstellungen > Integrationen > Integration hinzufügen** hoch (max. 1 MB). Beide Pfade ergeben denselben Server-State.
+
+## `config.json`-Schema
+
+Das Manifest wird serverseitig gegen ein Zod-Schema in [services/platform/lib/shared/schemas/integrations.ts](https://github.com/tale-project/tale/blob/main/services/platform/lib/shared/schemas/integrations.ts) validiert. Die folgenden Felder sind die kanonische Oberfläche; bei Zweifel die Quelle konsultieren.
+
+| Feld                   | Pflicht              | Typ                                                                 | Was es tut                                                                                                                       |
+| ---------------------- | -------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | ja                   | string (1-200)                                                      | Lesbarer Name in der Integrationen-Liste.                                                                                        |
+| `description`          | nein                 | string (≤2000)                                                      | Ein-Satz-Zusammenfassung neben dem Titel.                                                                                        |
+| `version`              | nein                 | integer                                                             | Hochsetzen, wenn sich Operationen oder Parameterformen ändern, damit Konsumenten Drift erkennen.                                 |
+| `type`                 | nein                 | `'rest_api'` \| `'sql'`                                             | Default `rest_api`. Auf `sql` setzen für DB-Konnektoren.                                                                         |
+| `authMethod`           | ja                   | `'api_key'` \| `'bearer_token'` \| `'basic_auth'` \| `'oauth2'`     | Die Authentifizierungsmethode dieses Konnektors.                                                                                 |
+| `supportedAuthMethods` | nein                 | Array desselben Enums                                               | Wenn ein Konnektor mehrere Methoden akzeptiert; Nutzer wählt beim Installieren.                                                  |
+| `secretBindings`       | nein                 | string[]                                                            | Namen der Credential-Schlüssel, die der Konnektor zur Laufzeit über `secrets.get('<key>')` liest. Die UI fragt genau diese ab.   |
+| `allowedHosts`         | nein                 | string[]                                                            | Netzwerk-Allowlist. Der Konnektor kann nur die hier gelisteten Hosts erreichen.                                                  |
+| `operations`           | rest_api-Konnektoren | Array von `Operation`                                               | Die benannten REST-Operationen des Konnektors. Siehe [Operations-Form](#operations-form).                                        |
+| `oauth2Config`         | oauth2-Konnektoren   | `{ authorizationUrl, tokenUrl, scopes? }`                           | Endpunkte für den Authorization-Code-Flow.                                                                                       |
+| `sqlConnectionConfig`  | sql-Konnektoren      | `{ engine, readOnly?, options?, security? }`                        | `engine` ist `'mssql'`, `'postgres'` oder `'mysql'`. `readOnly` ist ein UI-Hinweis; das Datenbankkonto ist die echte Begrenzung. |
+| `sqlOperations`        | sql-Konnektoren      | Array von `SqlOperation`                                            | Benannte Abfragen mit Parameter-Platzhaltern. Siehe [SQL-Konnektoren](#sql-konnektoren).                                         |
+| `connectionConfig`     | nein                 | `{ domain?, apiVersion?, apiEndpoint?, timeout?, rateLimit?, ... }` | Optionale Verbindungs-Hints; zusätzliche Schlüssel sind erlaubt.                                                                 |
+| `capabilities`         | nein                 | `{ canSync?, canPush?, canWebhook?, syncFrequency? }`               | Deklariert optionale Fähigkeiten, gegen die die Plattform planen kann (z. B. periodischer Sync).                                 |
+| `exposeAsCapability`   | nein                 | `{ label, icon?, tooltip?, order? }`                                | Stellt diese Integration als benannte Capability in der UI dar.                                                                  |
+| `setupGuide`           | nein                 | string (≤5000)                                                      | Markdown, gerendert unter **Konfigurationsanleitung** im Manage-Dialog. Sag den Nutzern, wo Schlüssel zu erzeugen sind, etc.     |
+| `metadata`             | nein                 | object                                                              | Freie Metadaten für Tooling; wird von der Plattform nicht interpretiert.                                                         |
+
+## Operations-Form
+
+Eine REST-Operation beschreibt eine aufrufbare Aktion. Der Agent wählt eine Operation per `name` und liefert validierte Parameter; deine `connector.ts` dispatcht auf `ctx.operation` und nutzt `ctx.params`.
+
+| Feld               | Pflicht | Typ                   | Was es tut                                                                                               |
+| ------------------ | ------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `name`             | ja      | string                | Stabile Kennung, die der Agent nutzt. Snake_case per Konvention.                                         |
+| `title`            | nein    | string                | Lesbares Label in der UI-Operationsliste.                                                                |
+| `description`      | nein    | string                | Was die Operation tut und wann zu nutzen. Der Agent liest das — schreib für das LLM, nicht den Menschen. |
+| `operationType`    | nein    | `'read'` \| `'write'` | Steuert das Genehmigungs-Gate. Default ist read-artiges Verhalten, wenn weggelassen.                     |
+| `requiresApproval` | nein    | boolean               | Erzwingt die Genehmigungs-Karte auch bei Read, oder überspringt sie bei einem genuin sicheren Write.     |
+| `requiredScopes`   | nein    | string[]              | OAuth-Scopes, die diese Operation braucht; beim Verbinden dem Nutzer angezeigt.                          |
+| `parametersSchema` | nein    | JSON-Schema (object)  | Standard-JSON-Schema. Heute wird `type: 'object'` mit `properties` und `required` ausgewertet.           |
+
+Ein kompaktes REST-Beispiel aus [examples/integrations/tavily/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/config.json):
+
+```json
+{
+  "name": "search",
+  "title": "Search the web",
+  "description": "Search the open web via Tavily. Use 'basic' depth for quick facts, 'advanced' for deeper research.",
+  "operationType": "read",
+  "parametersSchema": {
+    "type": "object",
+    "required": ["query"],
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Natural-language search query. Be specific."
+      },
+      "max_results": {
+        "type": "number",
+        "description": "Max results to return (1-10)."
+      }
+    }
+  }
+}
+```
+
+## Die Konnektor-Sandbox
+
+Konnektor-Code läuft nicht als gewöhnliches Node. Er wird transpiliert und in einem isolierten Kontext mit kleiner, kontrollierter API-Oberfläche ausgeführt. Plane entsprechend: kein `fs`, kein `child_process`, kein freies `import`, kein `process.env`, kein ambient `fetch`. Die einzigen Seiten­effekte sind HTTP über `ctx.http` und Credential-Reads über `ctx.secrets`.
+
+### `ConnectorContext`
+
+Jede Operation erhält ein Kontext-Objekt. Die Form:
+
+```typescript
+interface ConnectorContext {
+  operation: string; // Name der aufgerufenen Operation
+  params: Record<string, unknown>; // gegen parametersSchema validiert
+  http: HttpApi;
+  secrets: SecretsApi;
+  base64Encode(input: string): string;
+  base64Decode(input: string): string;
+}
+
+interface HttpApi {
+  get(url: string, options?: HttpMethodOptions): HttpResponse;
+  post(url: string, options?: BodyMethodOptions): HttpResponse;
+  put(url: string, options?: BodyMethodOptions): HttpResponse;
+  patch(url: string, options?: BodyMethodOptions): HttpResponse;
+  delete(url: string, options?: BodyMethodOptions): HttpResponse;
+}
+
+interface HttpMethodOptions {
+  headers?: Record<string, string>;
+  responseType?: 'base64'; // base64-kodierten Body für binäre Downloads anfordern
+}
+
+interface BodyMethodOptions extends HttpMethodOptions {
+  body?: string; // bereits serialisierter Payload (z. B. JSON.stringify(...))
+  binaryBody?: string; // base64-kodierter Request-Body
+}
+
+interface HttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  text(): string;
+  json(): unknown;
+}
+
+interface SecretsApi {
+  get(key: string): string | undefined;
+}
+```
+
+Der `http`-Client erreicht nur die Hosts, die in `allowedHosts` gelistet sind. Eine Anfrage an alles andere scheitert vor dem Netzwerkaufruf.
+
+### Was die Sandbox nicht bietet
+
+- **Keine Node-Built-ins** — kein `fs`, `child_process`, `crypto`, `path`, `os`, `net`. Nutze `base64Encode`/`base64Decode` für Binärdaten; für Hashing oder Signaturen serverseitig oder vorab erledigen.
+- **Kein Top-Level-`import` oder `require`** — schreib selbst-enthaltenen Code. TypeScript-Typdeklarationen oben in der Datei werden beim Transpile entfernt und dienen nur der Editor-Unterstützung.
+- **Keine Umgebungsvariablen** — lies jedes Credential über `ctx.secrets.get(...)`.
+- **Keine Hintergrundarbeit** — `setTimeout`, `setInterval` und nicht-awaited Promises sind nicht Teil des Vertrags. Eine Operation läuft synchron zu Ende (die Sandbox behandelt deine Funktion als synchron) und gibt einen Wert zurück.
+
+## Die zwei Funktionen, die ein Konnektor exportiert
+
+Ein Konnektor definiert zwei Funktionen: eine zur Verbindungsprüfung beim Installieren, eine zum Ausführen der Operationen.
+
+| Funktion              | Wann sie läuft                                                 | Was sie tun soll                                                                                                                    |
+| --------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `testConnection(ctx)` | Wenn der Nutzer **Verbindung testen** im Manage-Dialog klickt. | Den günstigsten authentifizierten Request, den die API bietet. Bei Fehlschlag einen klaren `Error` mit Hinweis zur Behebung werfen. |
+| `execute(ctx)`        | Bei jedem Operations-Aufruf.                                   | Auf `ctx.operation` dispatchen, Inputs validieren, API aufrufen, Response formen. Bei jeglichem Fehler `Error` werfen.              |
+
+Beide können entweder als einzelnes `connector`-Objektliteral (Tavily, Discord) oder als Top-Level-Funktionen exportiert werden; beide Formen sind erlaubt. Die Objektform ist empfohlen, weil sie die zwei Einstiegspunkte nahe an einer Operations-Liste hält und die Dispatch-Tabelle offensichtlich macht.
+
+Per Konvention gibt ein erfolgreiches `execute` ein Objekt der Form `{ success: true, operation, data, count?, cost?: { cents }, timestamp }` zurück. Die Plattform erzwingt diese Form nicht, aber Agents und Execution-Logs rendern sie sauber.
+
+## Durchgespieltes Beispiel — Tavily
+
+Hier das kleinste End-to-End-Bild, gezogen aus [examples/integrations/tavily/](https://github.com/tale-project/tale/tree/main/examples/integrations/tavily).
+
+Das Manifest deklariert Auth-Methode, allow-gelisteten Host, Secret-Binding und zwei Operationen:
+
+```json
+{
+  "title": "Tavily",
+  "type": "rest_api",
+  "authMethod": "api_key",
+  "secretBindings": ["apiKey"],
+  "allowedHosts": ["api.tavily.com"],
+  "operations": [
+    {
+      "name": "search",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    },
+    {
+      "name": "extract",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    }
+  ],
+  "setupGuide": "1. Sign up at https://tavily.com\n2. Create an API key\n3. Paste it below and Test connection."
+}
+```
+
+Der Konnektor exportiert `testConnection` (eine günstige authentifizierte Probe) und `execute` (Dispatch zu Per-Operation-Helpern):
+
+```typescript
+const API_BASE = 'https://api.tavily.com';
+
+const connector = {
+  testConnection(ctx: TestConnectionContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+
+    const response = ctx.http.post(API_BASE + '/search', {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, query: 'ping', max_results: 1 }),
+    });
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Tavily authentication failed. Verify the API key.');
+    }
+    if (response.status !== 200) {
+      throw new Error(
+        'Tavily connection failed (' +
+          response.status +
+          '): ' +
+          response.text(),
+      );
+    }
+    return { status: 'ok' };
+  },
+
+  execute(ctx: ConnectorContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+    if (ctx.operation === 'search') return search(ctx.http, apiKey, ctx.params);
+    if (ctx.operation === 'extract')
+      return extractUrls(ctx.http, apiKey, ctx.params);
+    throw new Error('Unknown operation: ' + ctx.operation);
+  },
+};
+```
+
+Achte auf die Form der Fehlermeldungen — sie sagen dem Nutzer, was zu tun ist (`Verify the API key`), nicht nur dass etwas fehlschlug. Fehler aus `testConnection` erscheinen inline im Manage-Dialog; Fehler aus `execute` erscheinen in der Agent-Antwort und im Execution-Log. Mach sie umsetzbar.
+
+Die vollständige Datei unter [tavily/connector.ts](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/connector.ts) zeigt die Per-Operation-Helper, ein `handleHttpError`-Hilfswerkzeug, das Status auf nutzerlesbare Meldungen mappt, und Result-Truncation, um Token-Nutzung vorhersehbar zu halten. Übernimm diese Muster.
+
+## SQL-Konnektoren
+
+SQL-Integrationen überspringen `connector.ts` komplett. Die Plattform führt die im Manifest deklarierten Abfragen gegen die konfigurierte Datenbank aus; du schreibst nur das SQL und das Parameterschema.
+
+```json
+{
+  "name": "list_reservations",
+  "title": "List Reservations",
+  "description": "Fetch reservations with optional status and date filters.",
+  "operationType": "read",
+  "query": "SELECT id, guest_id, check_in FROM reservations WHERE (@status IS NULL OR status = @status) AND check_in >= @fromDate ORDER BY check_in DESC",
+  "parametersSchema": {
+    "type": "object",
+    "properties": {
+      "status": { "type": "string", "description": "Optional status filter." },
+      "fromDate": {
+        "type": "string",
+        "format": "date",
+        "description": "ISO date."
+      }
+    }
+  }
+}
+```
+
+Platzhalter nutzen `@paramName`, gemappt auf Schlüssel in `parametersSchema.properties`. Markiere mutierende Abfragen mit `operationType: 'write'` und (üblicherweise) `requiresApproval: true`; die Plattform leitet sie durch den Genehmigungs-Flow. Siehe [examples/integrations/protel/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/protel/config.json) für einen vollständigen Hotel-PMS-Konnektor mit über zwanzig Read-Operationen und einer Handvoll genehmigungs-gegateter Writes.
+
+`sqlConnectionConfig.engine` akzeptiert `'mssql'`, `'postgres'` oder `'mysql'`. Optionales `security.maxResultRows` und `security.queryTimeoutMs` sind Obergrenzen, die die Plattform zusätzlich zu den DB-eigenen erzwingt.
+
+## Paketierung und Auslieferung
+
+- **Projekt-Flow.** Lege `integrations/<slug>/{config.json, connector.ts, icon.svg}` in ein per `tale init` erstelltes Projekt. Die Plattform lädt live nach; Speichern reicht.
+- **UI-Upload.** Zippe die Dateien (oder lade sie einzeln hoch) über **Einstellungen > Integrationen > Integration hinzufügen**. Das Gesamtpaket ist auf 1 MB begrenzt.
+- **Versionierung.** Hebe `version` in `config.json`, sobald sich der Operations-Satz oder eine Parameterform ändert, damit Konsumenten den Drift erkennen.
+- **Icons.** SVG, PNG, JPG oder WebP, unter 256 KB. SVG rendert in dunklen und hellen Themes am saubersten.
+- **Slugs.** Der Verzeichnisname ist der Slug. Halt ihn über Versionen stabil; Umbenennen ist eine breaking change.
+
+## Häufige Fehler
+
+- **Lange Schleifen oder unbegrenzte Result-Sets.** Operationen sollten zügig mit paginierten oder gekürzten Daten zurückkommen. Der Tavily-Konnektor begrenzt Ergebnisse auf 5 und kürzt jede Seite auf 2 000 Zeichen — als Referenz.
+- **Geheimnisse im Code.** Bette nie API-Schlüssel oder Tokens in `connector.ts` ein. Lies sie immer über `ctx.secrets.get('<binding>')` und deklariere das Binding in `secretBindings`.
+- **Hosts nicht in `allowedHosts`.** Eine Anfrage an einen ungelisteten Host scheitert. Trag jede Base-URL ein, die der Konnektor anfasst — inklusive jedes Redirect-Ziels, von dem du abhängst.
+- **Vage Fehlermeldungen.** `Failed` ist nicht umsetzbar. Sag dem Nutzer, welches Credential falsch ist, welcher Scope fehlt oder welche Quote überschritten wurde.
+- **Fehlendes `operationType: 'write'` bei mutierenden Calls.** Ohne das greift das Genehmigungs-Gate nicht und ein Write läuft unbeaufsichtigt.
+
+## Verwandt
+
+- [Integrationen-Überblick](/de/platform/integrations/overview) — Konzepte und wie Konnektoren konsumiert werden.
+- [KI-gestützte Entwicklung](/de/develop/ai-assisted-development) — Claude Code, Cursor, GitHub Copilot oder Windsurf nutzen, um Konnektoren gegen den Referenz-Quellcode der Plattform zu schreiben.
+- [API-Referenz](/de/develop/api-reference) — die Tale-API selbst, getrennt von Konnektoren.

--- a/docs/de/platform/integrations/overview.md
+++ b/docs/de/platform/integrations/overview.md
@@ -1,45 +1,83 @@
 ---
 title: Integrationen – Überblick
-description: Tale mit REST-APIs, SQL-Datenbanken, E-Mail und Cloud-Storage verbinden.
+description: Tale per entwicklergebauten Konnektoren mit REST-APIs und SQL-Datenbanken verbinden.
 ---
 
-Integrationen erlauben Tale, mit externen Systemen zu sprechen. Developer konfigurieren sie einmal; Agents, Automatisierungen und der Chat-Assistent nutzen sie dann, um Daten in diesen Systemen zu lesen und zu schreiben. Die Konfiguration lebt unter **Einstellungen > Integrationen** und erfordert die Developer-Rolle oder höher.
+Eine Integration ist ein vom Entwickler definierter Konnektor, der die Fähigkeiten eines fremden Systems — REST-Endpoints oder SQL-Abfragen — als feste Liste benannter Operationen verfügbar macht. Einmal installiert, sind diese Operationen Werkzeuge, die der Chat-Assistent, Agents und Action-Schritte in Automatisierungen namentlich mit typisierten Parametern aufrufen. Die Konfiguration lebt unter **Einstellungen > Integrationen** und erfordert mindestens die Developer-Rolle; die Konsumenten rufen einfach die Operationen auf, die der Konnektor publiziert.
+
+Die Plattform unterstützt zwei Konnektor-Typen: `rest_api` für HTTP-Dienste und `sql` für direkten Datenbankzugriff. Alles andere, was unter **Einstellungen > Integrationen** in der UI auftaucht — E-Mail-Postfächer, Microsoft OneDrive, API-Schlüssel für die Tale-API selbst — sind verwandte Verbindungen mit eigener Konfigurationsoberfläche, kein Konnektor-Modell. Diese decken wir am Ende der Seite ab.
 
 ## Integrationen-Typen
 
 ### REST-API
 
-Verbinde jede HTTP-basierte API, indem du Base-URL und Credentials eingibst. Unterstützte Authentifizierungsmethoden:
+REST-Konnektoren kapseln einen beliebigen HTTP-Dienst. Das Manifest des Konnektors listet die unterstützten Auth-Methoden und die Hosts, die er erreichen darf; sandboxierter Konnektor-Code übernimmt jede Operation. Unterstützte Authentifizierungsmethoden:
 
-| Methode           | So funktioniert sie                                               |
-| ----------------- | ----------------------------------------------------------------- |
-| **API-Schlüssel** | Einen Schlüssel in einem Header oder Query-Parameter mitschicken. |
-| **Bearer-Token**  | `Authorization: Bearer <token>`-Header bei jedem Request.         |
-| **Basic Auth**    | Benutzername und Passwort, base64-kodiert.                        |
-| **OAuth 2.0**     | Authorization-Code-Flow mit automatischem Token-Refresh.          |
+| Methode           | So funktioniert sie                                       |
+| ----------------- | --------------------------------------------------------- |
+| **API-Schlüssel** | Schlüssel in einem Header oder Query-Parameter mitsenden. |
+| **Bearer-Token**  | `Authorization: Bearer <token>`-Header bei jedem Request. |
+| **Basic Auth**    | Benutzername und Passwort, base64-kodiert.                |
+| **OAuth 2.0**     | Authorization-Code-Flow mit automatischem Token-Refresh.  |
 
-Einmal hinzugefügt, bietet die Integration jeden konfigurierten Endpoint als Tool an, das der KI-Agent aufrufen kann. Siehe [Agent erstellen](/de/platform/agents/create) für die Tool-Freigabe.
+Das Feld `allowedHosts` im Manifest wirkt als Netzwerk-Allowlist — der Konnektor kann nur die deklarierten Hosts erreichen. Siehe [Agent erstellen](/de/platform/agents/create), wie ein Agent Zugriff auf die Operationen einer Integration erhält.
 
 ### SQL
 
-Verbinde eine PostgreSQL-, MySQL- oder Microsoft-SQL-Server-Datenbank. Der KI-Agent und Automatisierungen können sie in natürlicher Sprache abfragen, die gegen das registrierte Schema nach SQL übersetzt wird.
+SQL-Konnektoren verbinden mit PostgreSQL, MySQL oder Microsoft SQL Server. Der Agent schreibt **kein** SQL freihändig. Stattdessen registriert das Manifest eine feste Liste benannter Operationen, jede mit vorgeschriebener Abfrage und Parameterschema; der Agent wählt eine Operation und liefert Werte für die Platzhalter. Nur-Lese-Credentials sind weiterhin dringend empfohlen — Schreib-Operationen und Genehmigungs-Gates beschränken nur, was der Konnektor publiziert, nicht, was das Datenbankkonto selbst darf.
 
-Nur-Lese-Credentials sind dringend empfohlen — die vom KI generierten Abfragen werden wie sie sind gegen die Datenbank ausgeführt.
+## Operationen
 
-### E-Mail (Konversationen)
+Jede Integration veröffentlicht eine Liste von Operationen. Eine Operation hat einen `name` (die Kennung, die der Agent aufruft), eine `description` (was sie tut und wann sie genutzt werden soll), ein `parametersSchema` (ein JSON-Schema, das Eingaben beschreibt), ein optionales `operationType` von `read` oder `write` sowie ein optionales `requiresApproval`-Flag. Der Agent wählt eine Operation per Name und liefert validierte Parameter; er komponiert nie Ad-hoc-HTTP-Calls oder SQL. So bleibt ein Konnektor vorhersehbar: Eine neue Operation existiert nur, wenn ein Entwickler sie ins Manifest aufnimmt.
 
-Verbinde ein IMAP- und SMTP-Postfach, um den [Konversationen](/de/platform/workspace/conversations)-Posteingang zu versorgen. Eingehende E-Mails werden zu Konversationen. Antworten aus der Plattform werden als normale E-Mails zugestellt.
+## Lesen, Schreiben und Genehmigungen
 
-### Microsoft OneDrive
+Operationen mit `operationType: write` erfordern standardmässig eine Genehmigung vor der Ausführung. Wenn ein Agent oder eine Automatisierung eine solche Operation auslöst, erscheint eine Genehmigungs-Karte im Chat — ein Mensch akzeptiert oder lehnt ab, und nur bei Akzeptanz wird der Aufruf ausgeführt. Siehe [Genehmigungen](/de/platform/workspace/approvals) für den vollständigen Ablauf. Nutze das für Billing-Aktionen, Massen-E-Mails, Schreibvorgänge auf Produktionsdaten und alles, wo du einen Menschen in der Schleife willst. Lese-Operationen werden ohne Genehmigungsschritt ausgeführt.
 
-Verbinde ein Microsoft-365-Konto, um OneDrive-Dokumenten-Sync zu aktivieren. Nutzer können dann Dateien direkt aus OneDrive in die Wissensdatenbank importieren, ohne sie vorher auf ihr Gerät zu laden. Siehe [Wissensdatenbank](/de/platform/workspace/knowledge-base).
+## Authentifizierung und Geheimnisse
+
+Das Array `secretBindings` im Manifest benennt die Credential-Schlüssel, die ein Konnektor zur Laufzeit über `secrets.get('<key>')` liest. Wenn du die Integration unter **Einstellungen > Integrationen** verbindest, fragt die UI genau diese Schlüssel ab und speichert die Werte verschlüsselt im Ruhezustand, gebunden an deine Organisation. OAuth-2.0-Konnektoren nutzen den Standard-Authorization-Code-Flow, speichern Access- und Refresh-Tokens und erneuern Access-Tokens automatisch beim Ablauf. SQL-Konnektoren speichern Server, Port, Datenbankname, Benutzername und Passwort im selben verschlüsselten Speicher.
+
+## Konfigurationsanleitung und Verbindungstest
+
+Konnektoren können einen Markdown-`setupGuide` ausliefern, den die Plattform unter **Konfigurationsanleitung** im Manage-Dialog rendert — nutze ihn, um auf den richtigen Ort für den API-Schlüssel hinzuweisen, welche OAuth-Scopes nötig sind oder welche Datenbankrolle anzulegen ist. Nach Eingabe der Credentials ruft **Verbindung testen** den leichtgewichtigen `testConnection`-Hook des Konnektors vor dem Speichern auf; ein Fehlversuch zeigt die Fehlermeldung des Konnektors inline, sodass Nutzer Credentials beheben können, ohne den Dialog zu verlassen.
+
+## Mitgelieferte Beispiele
+
+Das Repository liefert dreizehn einsatzbereite Konnektoren unter [github.com/tale-project/tale/tree/main/examples/integrations](https://github.com/tale-project/tale/tree/main/examples/integrations). Forke einen als Ausgangspunkt für einen eigenen Konnektor gegen denselben Anbieter, oder installiere einen so wie er ist.
+
+| Beispiel         | Typ      | Auth         | Was es abdeckt                                                          |
+| ---------------- | -------- | ------------ | ----------------------------------------------------------------------- |
+| **AI image**     | rest_api | bearer_token | Bildgenerierung gegen OpenAI-kompatible Anbieter.                       |
+| **Circuly**      | rest_api | basic_auth   | Produkte, Kunden und Abonnements in Circuly.                            |
+| **Discord**      | rest_api | bearer_token | Guilds, Kanäle und Nachrichten über die Discord-Bot-API.                |
+| **GitHub**       | rest_api | bearer_token | Repositories, Issues, Pull Requests und Code-Suche.                     |
+| **Gmail**        | rest_api | oauth2       | Nachrichten, Labels, Threads und Entwürfe in Gmail.                     |
+| **Google Drive** | rest_api | oauth2       | Dateien aus Drive-Ordnern in Tale-Dokumente synchronisieren.            |
+| **Outlook**      | rest_api | oauth2       | Mail, Kalender und Kontakte über Microsoft Graph.                       |
+| **Protel**       | sql      | basic_auth   | Direkter SQL-Zugriff auf ein Protel-Hotel-PMS — Reservierungen, Folios. |
+| **Shopify**      | rest_api | api_key      | Produkte, Kunden und Bestellungen in der Shopify Admin API.             |
+| **Slack**        | rest_api | oauth2       | Kanäle, Nachrichten, Nutzer und Datei-Uploads.                          |
+| **Tavily**       | rest_api | api_key      | Offene Web-Suche und Page-Extraction für LLM-Agents.                    |
+| **Teams**        | rest_api | oauth2       | Teams, Kanäle, Nachrichten und Chats über Microsoft Graph.              |
+| **Twilio**       | rest_api | basic_auth   | SMS, Sprachanrufe und Telefonnummern-Verwaltung.                        |
+
+## Eine eigene Integration installieren oder bauen
+
+Es gibt zwei Wege, einen Konnektor zu installieren. Beide enden mit derselben `config.json` plus Konnektor-Code auf dem Server.
+
+**Aus der UI hochladen.** Öffne **Einstellungen > Integrationen**, klicke **Integration hinzufügen** und lege ein `.zip`-Paket ab, oder wähle `config.json`, den Konnektor-Quelltext (`connector.ts` oder `connector.js`) und ein Icon einzeln aus. Der Gesamt-Upload ist auf 1 MB begrenzt. Nach dem Upload Credentials eingeben und **Verbindung testen** klicken.
+
+**Als Projekt-Code schreiben.** Ein per `tale init` aufgesetztes Projekt hat ein `integrations/`-Verzeichnis; jedes Unterverzeichnis ist ein Konnektor (`integrations/<slug>/{config.json, connector.ts, icon.svg}`). Die Plattform lädt bei Speichern live nach, das Iterieren ist also wie das Bearbeiten jeder anderen Quelldatei. Das vollständige Dateiformat und die Sandbox-API sind unter [Integration bauen](/de/develop/integrations) dokumentiert; für KI-gestütztes Schreiben im Editor siehe [KI-gestützte Entwicklung](/de/develop/ai-assisted-development).
+
+## Verwandte Verbindungen
+
+Ein paar weitere Punkte stehen unter **Einstellungen > Integrationen** zur besseren Auffindbarkeit, sind aber keine `rest_api`- oder `sql`-Konnektoren — sie haben eigene Konfigurationsoberflächen.
+
+**E-Mail (Konversationen-Posteingang).** Verbinde ein IMAP- und SMTP-Postfach, um den [Konversationen](/de/platform/workspace/conversations)-Posteingang zu versorgen. Eingehende E-Mails werden zu Threads; aus der Plattform versendete Antworten gehen als normale E-Mails raus. Konfiguration getrennt von Konnektoren.
+
+**Microsoft OneDrive.** Verbinde ein Microsoft-365-Konto, sodass Nutzer OneDrive-Dateien direkt in die [Wissensdatenbank](/de/platform/workspace/knowledge-base) importieren können, ohne sie vorher herunterzuladen. Konfiguriert über den Knowledge-Base-Importfluss, nicht als Konnektor.
 
 ## API-Schlüssel
 
-Erzeuge API-Schlüssel für den programmatischen Zugriff auf die Tale-API. Schlüssel erben die Berechtigungen des Nutzers, der sie erstellt hat, gebunden an dessen Rolle. Schlüssel lassen sich jederzeit unter **Einstellungen > Integrationen > API-Schlüssel** widerrufen.
-
-Für Endpoint-Details siehe die [API-Referenz](/de/develop/api-reference).
-
-## Freigaben
-
-Integrationen können vor jeder Operation eine Freigabe erfordern. Wenn ein Agent oder eine Automatisierung einen Integrationen-Aufruf auslöst, erscheint eine Freigabe-Karte im Chat — siehe [Freigaben](/de/platform/workspace/approvals). Das ist nützlich bei destruktiven oder teuren Operationen (Billing-Aktionen, Massen-Mails, Änderungen an Produktionsdaten).
+API-Schlüssel gewähren programmatischen Zugriff auf die Tale-API selbst. Sie leben unter **Einstellungen > Integrationen > API-Schlüssel**, weil das die gleiche Admin-Oberfläche ist, nicht weil sie Konnektoren wären. Jeder Schlüssel erbt die Rolle des Nutzers, der ihn erstellt hat; jederzeit auf demselben Bildschirm widerrufbar. Endpoint-Details siehe [API-Referenz](/de/develop/api-reference).

--- a/docs/de/platform/member/overview.md
+++ b/docs/de/platform/member/overview.md
@@ -1,164 +1,47 @@
 ---
-title: Erste Schritte
-description: Installiere Tale und öffne die App — eine freundliche Anleitung für deine ersten 10 Minuten.
+title: Erste Schritte als Member
+description: Anmelden, chatten, die Wissensdatenbank durchsuchen sowie geteilte Konversationen und Freigaben lesen — die Tag-1-Orientierung für Members.
 ---
 
-Das hier ist der schnellste Weg, von Null zu einer laufenden Tale-Instanz zu kommen. Du musst kein Entwickler sein — wenn du einen Befehl im Terminal ausführen kannst, kommst du mit. Für selbst gehostete Produktions-Setups siehe stattdessen [Produktions-Deployment](/de/self-hosted/install/linux-server).
+Willkommen bei Tale. Als **Member** hast du lesenden Zugriff auf den Arbeitsbereich deiner Organisation: Du kannst mit KI-Modellen und Agenten chatten, die Wissensdatenbank durchsuchen sowie Konversationen und Freigaben lesen, die mit dir geteilt wurden. Editors und Developers in deiner Organisation erstellen die Inhalte; Mitglieder nutzen sie.
 
-## Voraussetzungen
+Wenn du selbst eine Tale-Instanz installieren oder betreiben willst, siehe [Lokaler Schnellstart](/de/self-hosted/install/quickstart) oder [Produktions-Deployment](/de/self-hosted/install/linux-server).
 
-| Software       | Mindestversion | Bezugsquelle                                   |
-| -------------- | -------------- | ---------------------------------------------- |
-| Docker Desktop | 24.0+          | https://www.docker.com/products/docker-desktop |
+## Anmelden
 
-### API-Schlüssel besorgen
+Es ist nichts zu installieren — Tale läuft vollständig im Browser. Dein Admin schaltet dich auf eine von drei Arten frei, je nachdem, wie deine Organisation konfiguriert ist.
 
-Tale nutzt standardmäßig OpenRouter als KI-Gateway, das dir über einen einzigen API-Schlüssel Zugriff auf Hunderte von Modellen gibt.
+- **E-Mail und Passwort.** Dein Admin legt dein Konto unter **Einstellungen → Mitglieder** mit einem initialen Passwort an und teilt es dir mit. Du wirst beim ersten Login aufgefordert, es zu ändern.
+- **SSO (Microsoft Entra).** Melde dich mit deinem vorhandenen Microsoft-Konto an; dein Tale-Konto wird beim ersten Anmelden automatisch angelegt.
+- **Reverse Proxy (Trusted Headers).** Wenn Tale hinter Authelia, Authentik, oauth2-proxy o. ä. läuft, authentifiziert dich der Proxy und dein Konto wird bei der ersten Anfrage automatisch angelegt.
 
-1. Gehe auf https://openrouter.ai und erstelle ein kostenloses Konto.
-2. Navigiere in deinem Kontomenü zu Keys und erstelle einen neuen API-Schlüssel.
-3. Kopiere den Schlüssel. Du brauchst ihn während der Einrichtung.
+Wenn du dich nicht anmelden kannst, frage deinen Admin, welche Methode aktiv ist. (Admins: siehe [Authentifizierung](/de/self-hosted/admin/authentication) für die instanzweite Konfiguration.)
 
-> **Tipp:** Du kannst jeden OpenAI-kompatiblen Anbieter nutzen, auch eine lokale Ollama-Instanz. OpenRouter ist wegen der Modellvielfalt und einfachen Preisgestaltung der empfohlene Standard.
+## Was du tun kannst
 
-## Einrichtung
+### Chat
 
-### Schritt 1: CLI installieren
+Starte eine Konversation auf der Startseite. Wähle ein Modell, schreibe eine Nachricht und antworte. Der Chat-Eingabebereich unterstützt zusätzlich:
 
-**Linux / macOS:**
+- Dateien anhängen (Bilder, PDFs, Dokumente) — siehe [Anhänge](/de/platform/chat/attachments).
+- Einen Agent erwähnen, den ein Editor oder Developer erstellt hat — siehe [Agents im Chat](/de/platform/chat/agents-in-chat).
+- Zwei Modelle nebeneinander vergleichen im [Arena-Modus](/de/platform/chat/arena-mode).
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
-```
+Vollständige Feature-Referenz: [Chat-Grundlagen](/de/platform/chat/basics).
 
-**Windows (PowerShell):**
+### Wissensdatenbank durchsuchen
 
-```powershell
-irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
-```
+Die Wissensdatenbank enthält Dokumente, die deine Organisation hochgeladen oder gecrawlt hat. Durchsuche sie, öffne Dokumente und referenziere sie im Chat. Als Member kannst du nichts hochladen oder löschen — das ist Aufgabe der Editors. Siehe [Wissensdatenbank](/de/platform/workspace/knowledge-base).
 
-Oder lade die Binary direkt von [GitHub Releases](https://github.com/tale-project/tale/releases):
+### Konversationen und Freigaben lesen
 
-```bash
-# Linux
-curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
-  -o /usr/local/bin/tale
-chmod +x /usr/local/bin/tale
-```
+- **[Konversationen](/de/platform/workspace/conversations)** — geteilte Chat-Threads von Kolleg:innen.
+- **[Freigaben](/de/platform/workspace/approvals)** — Outputs aus Automatisierungen, die auf eine menschliche Prüfung warten. Mitglieder können lesen; nur Editors und höher entscheiden.
 
-### Schritt 2: Projekt anlegen
+## Konto personalisieren
 
-```bash
-tale init my-project
-cd my-project
-```
+Display-Name, Sprache, Theme und Benachrichtigungseinstellungen findest du im Avatar-Menü. Details: [Einstellungen](/de/platform/member/preferences).
 
-Die CLI fragt nach deiner Domain, dem API-Schlüssel und dem TLS-Modus. Sicherheits-Secrets (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) werden automatisch erzeugt.
+## Mehr machen?
 
-> **Tipp:** Die CLI erzeugt außerdem Konfigurationsdateien für KI-Editoren (Claude Code, Cursor, GitHub Copilot, Windsurf) und extrahiert den vollständigen Plattform-Quellcode nach `.tale/reference/`. Öffne dein Projekt in einem dieser Editoren, um Agents, Workflows und Integrationen in natürlicher Sprache zu erstellen und zu bearbeiten. Siehe [AI-assisted development](/de/develop/ai-assisted-development).
-
-### Schritt 3: Tale starten
-
-```bash
-tale start
-```
-
-Warte auf die Ready-Meldung:
-
-```text
-Tale Dev v0.x.x  Ready.
-```
-
-> **Hinweis:** Die Versionsnummer variiert. Während die Dienste starten, siehst du einen Strom von Health-Check-Meldungen. Das ist normal. Warte auf die "Ready"-Meldung, bevor du den Browser öffnest.
-
-### Schritt 4: App öffnen
-
-Gehe in deinem Browser auf https://localhost (oder deine konfigurierte Domain). Beim ersten Öffnen wirst du zu einer Sign-up-Seite geleitet, wo du dein Admin-Konto erstellst.
-
-## Täglicher Ablauf
-
-### Starten und Stoppen
-
-```bash
-tale start              # Alle Dienste starten
-tale start --detach     # Im Hintergrund starten
-```
-
-Um alle Dienste zu stoppen, aber die Daten zu behalten:
-
-```bash
-docker compose -p tale-dev down
-```
-
-Das Flag `-p tale-dev` ist erforderlich, weil `tale start` ein Compose-Projekt namens `tale-dev` anlegt, statt eine Standard-`docker-compose.yml` zu verwenden.
-
-> **Wichtig:** Führe niemals `docker compose -p tale-dev down -v` aus. Das Flag `-v` löscht alle Docker-Volumes, was Datenbank, hochgeladene Dokumente, Crawler-Status und sämtliche Plattformdaten unwiderruflich vernichtet.
-
-### Upgrade
-
-```bash
-tale upgrade            # CLI upgraden und Projektdateien synchronisieren
-```
-
-### Backend-Daten ansehen
-
-```bash
-tale convex admin       # Admin-Schlüssel für das Convex-Dashboard erzeugen
-```
-
-Öffne `/convex-dashboard` im Browser und füge den Schlüssel ein, um die Datenbank zu inspizieren, Function-Logs zu sehen und Hintergrundjobs zu verwalten.
-
-## Alternative: aus Quellcode bauen
-
-Wenn du zu Tale beitragen oder den Plattform-Code anpassen willst, kannst du statt der vorgebauten Images aus dem Quellcode starten.
-
-```bash
-git clone https://github.com/tale-project/tale.git
-cd tale
-cp .env.example .env
-```
-
-Bearbeite `.env` und fülle die erforderlichen Werte aus:
-
-| Variable                | Wie du sie setzt                                 |
-| ----------------------- | ------------------------------------------------ |
-| `BETTER_AUTH_SECRET`    | Erzeugen mit: `openssl rand -base64 32`          |
-| `ENCRYPTION_SECRET_HEX` | Erzeugen mit: `openssl rand -hex 32`             |
-| `DB_PASSWORD`           | Ein beliebiges Passwort für die lokale Datenbank |
-
-> **Wichtig:** Die Datei `.env.example` enthält Beispiel-Secrets, die vor dem Start ersetzt werden müssen.
-
-Dann bauen und starten:
-
-```bash
-docker compose up --build
-```
-
-Die Build-Zeiten variieren je nach Dienst (alle 5 Dienste bauen parallel in ca. 3 Minuten auf einem modernen System). Folgende Builds sind dank Docker-Layer-Caching deutlich schneller.
-
-### Lokale Entwicklung mit Hot-Reload
-
-Für einen schnelleren Edit-Reload-Zyklus während der Entwicklung nutze den Development-Override:
-
-```bash
-docker compose -f compose.yml -f compose.dev.yml up --build
-```
-
-Dadurch werden deine lokalen Quellverzeichnisse in die Container gemountet, sodass Änderungen sofort sichtbar sind, ohne dass Images neu gebaut werden.
-
-### Container-Tests ausführen
-
-Nachdem du Dockerfiles oder Abhängigkeiten geändert hast, prüfe deine Änderungen:
-
-```bash
-# Smoke Test: bauen, starten, Health Check, abbauen
-bun run docker:test
-
-# Image-Validierung: OCI-Labels, Secrets, Größen-Budgets
-bun run docker:test:image
-
-# Vulnerability Scan (benötigt Trivy)
-bun run docker:test:vulnerability
-```
-
-Weitere Details siehe [Contributing Docker guide](/de/develop/contributing-docker).
+Mitglieder haben nur lesenden Zugriff. Um Agenten zu erstellen, Wissen zu bearbeiten oder Automatisierungen auszuführen, frage deinen Admin nach einer Rollenerhöhung. Die vollständige Rollenmatrix steht unter [Mitglieder und Rollen](/de/platform/admin/members-and-roles).

--- a/docs/de/self-hosted/install/linux-server.md
+++ b/docs/de/self-hosted/install/linux-server.md
@@ -23,7 +23,7 @@ Tale lädt vorgebaute Images aus der GitHub Container Registry. Aktuelle Image-G
 | DB       | `ghcr.io/tale-project/tale/tale-db`       | ~1.1 GB |
 | Proxy    | `ghcr.io/tale-project/tale/tale-proxy`    | ~88 MB  |
 
-> **Tipp:** Der erste Pull lädt ca. 4,4 GB (komprimiert). Folgende Updates laden nur geänderte Layer. Die Werte gelten post-Phase-2 (split-Convex) — das Platform-Image ist jetzt deutlich kleiner, weil das Convex-Backend einen eigenen Dienst hat.
+> **Tipp:** Der erste Pull lädt ca. 4,4 GB (komprimiert). Folgende Updates laden nur geänderte Layer.
 
 ## Die Tale-CLI installieren
 
@@ -40,6 +40,24 @@ curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_li
   -o /usr/local/bin/tale
 chmod +x /usr/local/bin/tale
 ```
+
+### Bestimmte Version festlegen
+
+Um eine bestimmte CLI-Version statt des neuesten Releases zu installieren, setze die Umgebungsvariable `VERSION`:
+
+```bash
+VERSION=0.9.0 curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+Oder lade die Binary direkt mit dem Version-Tag in der URL:
+
+```bash
+curl -fsSL https://github.com/tale-project/tale/releases/download/v0.9.0/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+Verfügbare Versionen listet die [GitHub-Releases-Seite](https://github.com/tale-project/tale/releases).
 
 ## Erste Einrichtung
 
@@ -76,20 +94,37 @@ Die CLI lädt vorgebaute Images, startet alle Dienste, wartet auf Health-Checks 
 
 ## Deployments verwalten
 
-### Eine neue Version deployen
+### Auf eine neue Version upgraden
+
+`tale deploy` deployt immer die Version der laufenden CLI-Binary, ein Upgrade besteht also aus zwei Schritten:
 
 ```bash
-# Aktuelle CLI-Version deployen
-tale deploy
-
-# Änderungen ohne Deploy anzeigen
-tale deploy --dry-run
-
-# Infrastruktur-Dienste (DB, Proxy) mitaktualisieren
-tale deploy --all
+tale upgrade            # 1. CLI auf das neueste Release aktualisieren
+tale deploy             # 2. Neue Version ausrollen
 ```
 
-`tale deploy` deployt immer die Version der laufenden CLI. Um auf einen neueren Release zu gehen, zuerst `tale upgrade` und danach `tale deploy` ausführen.
+#### Auf eine bestimmte Version migrieren oder downgraden
+
+```bash
+tale upgrade --version 0.9.0       # CLI auf v0.9.0 wechseln (up oder down)
+tale deploy                        # Diese Version ausrollen
+```
+
+`--version` akzeptiert `0.9.0` oder `v0.9.0`. Downgrades sind erlaubt, aber **forward-only Schema-Änderungen gelten weiterhin** — siehe [Schema-Kompatibilität und Rollback](#schema-kompatibilität-und-rollback). Verfügbare Versionen listet die [GitHub-Releases-Seite](https://github.com/tale-project/tale/releases).
+
+#### Vor dem Upgrade
+
+- Lies die [Release Notes](https://github.com/tale-project/tale/releases) auf Breaking Changes und Migrationshinweise.
+- Sichere die Datenbank — das Postgres-Volume enthält alle Plattformdaten und hochgeladenen Dateien.
+- Wenn die Instanz produktionskritisch ist, teste das Upgrade vorher auf einer Staging-Instanz. `tale init` in einem separaten Verzeichnis auf einem anderen Host gibt dir einen isolierten Stack.
+
+### Deploy
+
+```bash
+tale deploy             # Aktuelle CLI-Version deployen
+tale deploy --dry-run   # Änderungen ohne Deploy anzeigen
+tale deploy --all       # Infrastruktur-Dienste (DB, Proxy) mitaktualisieren
+```
 
 ### Status prüfen
 
@@ -110,11 +145,8 @@ tale logs db --tail 100
 ### Rollback
 
 ```bash
-# Zur vorherigen Version zurückkehren
-tale rollback
-
-# Zu einer bestimmten Version zurück
-tale rollback --version 0.9.0
+tale rollback                       # Zur vorherigen Version zurück
+tale rollback --version 0.9.0       # Zu einer bestimmten Version zurück
 ```
 
 > **Nur Vorwärts-Schema-Änderungen.** `tale rollback` tauscht nur Container-Images, **nicht** Convex-Daten oder Indexes. Siehe [Schema-Kompatibilität und Rollback](#schema-kompatibilität-und-rollback) für Details.
@@ -122,11 +154,8 @@ tale rollback --version 0.9.0
 ### Cleanup
 
 ```bash
-# Inaktive Container entfernen
-tale cleanup
-
-# ALLE Container entfernen (Bestätigung nötig)
-tale reset --force
+tale cleanup            # Inaktive Container entfernen
+tale reset --force      # ALLE Container entfernen (Bestätigung nötig)
 ```
 
 ## Zero-Downtime-Deployment
@@ -387,6 +416,18 @@ docker pull ghcr.io/tale-project/tale/tale-platform:1.2.0
 # Das neueste Release pullen
 docker pull ghcr.io/tale-project/tale/tale-platform:latest
 ```
+
+### Eine bestimmte Image-Version festschreiben
+
+`tale deploy` wählt Images anhand der CLI-Version. Um einzelne Service-Images unabhängig zu pinnen — zum Beispiel um ein einzelnes neues Image zu testen, ohne den ganzen Stack zu upgraden — lege eine `compose.override.yml` neben deine `.env`:
+
+```yaml
+services:
+  platform:
+    image: ghcr.io/tale-project/tale/tale-platform:1.2.0
+```
+
+`tale deploy` führt das Override automatisch zusammen.
 
 ## Zugriff aufs Convex-Dashboard
 

--- a/docs/de/self-hosted/install/quickstart.md
+++ b/docs/de/self-hosted/install/quickstart.md
@@ -1,0 +1,145 @@
+---
+title: Lokaler Schnellstart
+description: Tale lokal mit Docker Desktop in etwa zehn Minuten starten — für Evaluierung, Demos und Beiträge.
+---
+
+Das hier ist der schnellste Weg, eine lokale Tale-Instanz auf deinem Laptop laufen zu lassen. Nutze diesen Schnellstart, um das Produkt zu evaluieren, eine Demo zu zeigen oder gegen die Plattform zu entwickeln. Für eine öffentlich erreichbare Instanz mit TLS und unterbrechungsfreien Upgrades folge stattdessen dem [Produktions-Deployment](/de/self-hosted/install/linux-server).
+
+## Voraussetzungen
+
+| Software       | Mindestversion | Bezugsquelle                                   |
+| -------------- | -------------- | ---------------------------------------------- |
+| Docker Desktop | 24.0+          | https://www.docker.com/products/docker-desktop |
+
+### API-Schlüssel besorgen
+
+Tale nutzt standardmäßig OpenRouter als KI-Gateway, das dir über einen einzigen API-Schlüssel Zugriff auf Hunderte von Modellen gibt.
+
+1. Gehe auf https://openrouter.ai und erstelle ein kostenloses Konto.
+2. Navigiere im Kontomenü zu **Keys** und erzeuge einen neuen API-Schlüssel.
+3. Kopiere den Schlüssel — du fügst ihn während der Einrichtung ein.
+
+> **Tipp:** Jeder OpenAI-kompatible Anbieter funktioniert, auch eine lokale Ollama-Instanz. OpenRouter ist wegen der Modellvielfalt und einfachen Preisgestaltung der empfohlene Standard.
+
+## Einrichtung
+
+### Schritt 1: CLI installieren
+
+**Linux / macOS:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
+```
+
+> **Bestimmte Version festlegen:** Beide Installer berücksichtigen die Umgebungsvariable `VERSION`. Auf Linux/macOS: `VERSION=0.9.0 curl -fsSL …/install-cli.sh | bash`, auf Windows: `$env:VERSION = '0.9.0'; irm …/install-cli.ps1 | iex`. Verfügbare Tags listet die [GitHub-Releases-Seite](https://github.com/tale-project/tale/releases).
+
+Oder lade die Binary direkt — ersetze `latest` durch einen Version-Tag (z. B. `v0.9.0`), um zu pinnen:
+
+```bash
+# Linux
+curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+### Schritt 2: Projekt anlegen
+
+```bash
+tale init my-project
+cd my-project
+```
+
+Die CLI fragt nach deiner Domain, dem API-Schlüssel und dem TLS-Modus. Sicherheits-Secrets (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) werden automatisch erzeugt.
+
+> **Tipp:** `tale init` legt zusätzlich Konfigurationsdateien für KI-Editoren (Claude Code, Cursor, GitHub Copilot, Windsurf) ab und extrahiert den Plattform-Quellcode nach `.tale/reference/`. Öffne dein Projekt in einem dieser Editoren, um Agents, Workflows und Integrationen in natürlicher Sprache zu erstellen und zu bearbeiten. Siehe [AI-assisted development](/de/develop/ai-assisted-development).
+
+### Schritt 3: Tale starten
+
+```bash
+tale start
+```
+
+Warte auf `Tale Dev v0.x.x  Ready.` Health-Check-Meldungen während des Starts sind normal — warte auf die `Ready`-Zeile, bevor du den Browser öffnest.
+
+### Schritt 4: App öffnen
+
+Gehe in deinem Browser auf https://localhost (oder deine konfigurierte Domain). Beim ersten Aufruf landest du auf einer Sign-up-Seite, um dein Admin-Konto zu erstellen.
+
+> **Warnung wegen selbstsigniertem Zertifikat.** Der TLS-Modus `selfsigned` erzeugt ein lokales Zertifikat, daher zeigt der Browser beim ersten Aufruf eine „Ihre Verbindung ist nicht privat"-Warnung. Klick dich durch (Chrome: **Erweitert → Weiter**, Firefox: **Erweitert → Risiko akzeptieren**). Für ein öffentliches Deployment wähle bei `tale init` `letsencrypt` oder folge dem [Produktions-Deployment](/de/self-hosted/install/linux-server)-Leitfaden.
+
+## Täglicher Ablauf
+
+### Starten und Stoppen
+
+```bash
+tale start              # Alle Dienste starten
+tale start --detach     # Im Hintergrund starten
+```
+
+Um die Dienste zu stoppen, ohne Daten zu verlieren:
+
+```bash
+# Stoppt die Container, behält aber die Volumes (deine Daten).
+# Niemals -v hinzufügen: das löscht Datenbank, Uploads und Crawler-Status — keine Wiederherstellung möglich.
+docker compose -p tale-dev down
+```
+
+Das Flag `-p tale-dev` ist erforderlich, weil `tale start` ein Compose-Projekt namens `tale-dev` anlegt, statt eine Standard-`docker-compose.yml` zu verwenden.
+
+### Upgrade
+
+```bash
+tale upgrade                       # Auf das neueste Release aktualisieren und Projektdateien synchronisieren
+tale upgrade --version 0.9.0       # Auf eine bestimmte Version migrieren oder downgraden
+tale start                         # Mit der neuen Version neu starten
+```
+
+Breaking Changes stehen in den [Release Notes](https://github.com/tale-project/tale/releases).
+
+### Backend-Daten ansehen
+
+```bash
+tale convex admin       # Admin-Schlüssel für das Convex-Dashboard erzeugen
+```
+
+Öffne `/convex-dashboard` im Browser und füge den Schlüssel ein, um die Datenbank zu inspizieren, Function-Logs zu sehen und Hintergrundjobs zu verwalten.
+
+## Alternative: aus Quellcode bauen
+
+Wenn du zu Tale beitragen oder den Plattform-Code anpassen willst, kannst du statt der vorgebauten Images aus dem Quellcode starten.
+
+```bash
+git clone https://github.com/tale-project/tale.git
+cd tale
+cp .env.example .env
+```
+
+Bearbeite `.env` und ersetze die Beispielwerte:
+
+| Variable                | Wie du sie setzt                                 |
+| ----------------------- | ------------------------------------------------ |
+| `BETTER_AUTH_SECRET`    | `openssl rand -base64 32`                        |
+| `ENCRYPTION_SECRET_HEX` | `openssl rand -hex 32`                           |
+| `DB_PASSWORD`           | Ein beliebiges Passwort für die lokale Datenbank |
+
+> **Wichtig:** Die Datei `.env.example` enthält Platzhalter-Secrets, die vor dem Start ersetzt werden müssen.
+
+Dann bauen und starten:
+
+```bash
+docker compose up --build
+```
+
+Für einen schnelleren Edit-Reload-Zyklus nutze den Development-Override, der deine lokalen Quellverzeichnisse in die Container mountet:
+
+```bash
+docker compose -f compose.yml -f compose.dev.yml up --build
+```
+
+Nach Änderungen an Dockerfiles oder Abhängigkeiten kannst du mit `bun run docker:test` einen Smoke-Test fahren. Der [Contributing-Docker-Guide](/de/develop/contributing-docker) beschreibt Image-Validierung und Vulnerability-Scan-Skripte.

--- a/docs/develop/integrations.md
+++ b/docs/develop/integrations.md
@@ -1,0 +1,283 @@
+---
+title: Build an integration
+description: Author a Tale connector — config.json, connector.ts, sandbox APIs, and packaging.
+---
+
+A connector is a `config.json` plus a `connector.ts` (or `.js`) plus an icon. The manifest declares the integration's identity, authentication, allowed hosts, and the named operations it exposes; the connector code runs each operation inside a sandbox. SQL integrations are a special case — they don't ship code, only parameterised queries in the manifest.
+
+This page is the authoring reference. It assumes you've already read [Integrations overview](/platform/integrations/overview) for the user-facing concepts. For the editor-side workflow with AI assistants, see [AI-assisted development](/develop/ai-assisted-development).
+
+## File layout
+
+A connector lives in a single directory. The directory name is the **slug** — the stable identifier used by the platform; it is not a field inside `config.json`.
+
+```text
+integrations/<slug>/
+├── config.json     ← manifest (required)
+├── connector.ts    ← sandboxed code (REST connectors only)
+└── icon.svg        ← shown in the Add integration list
+```
+
+There are two ways to ship this directory: drop it into the `integrations/` folder of a project scaffolded by `tale init`, or zip the files and upload them via **Settings > Integrations > Add integration** (max 1 MB). Both paths produce the same server-side state.
+
+## `config.json` schema
+
+The manifest is validated server-side against a Zod schema in [services/platform/lib/shared/schemas/integrations.ts](https://github.com/tale-project/tale/blob/main/services/platform/lib/shared/schemas/integrations.ts). The fields below are the canonical surface; consult the source if anything looks out of date.
+
+| Field                  | Required            | Type                                                                | What it does                                                                                                                     |
+| ---------------------- | ------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | yes                 | string (1-200)                                                      | Human-readable name shown in the integrations list.                                                                              |
+| `description`          | no                  | string (≤2000)                                                      | One-sentence summary shown next to the title.                                                                                    |
+| `version`              | no                  | integer                                                             | Bump when operations or parameter shapes change so consumers can detect drift.                                                   |
+| `type`                 | no                  | `'rest_api'` \| `'sql'`                                             | Defaults to `rest_api`. Set `sql` for database connectors.                                                                       |
+| `authMethod`           | yes                 | `'api_key'` \| `'bearer_token'` \| `'basic_auth'` \| `'oauth2'`     | The authentication method this connector requires.                                                                               |
+| `supportedAuthMethods` | no                  | array of the same enum                                              | Use when a connector accepts more than one auth method; the user picks at install time.                                          |
+| `secretBindings`       | no                  | array of strings                                                    | Names of credential keys the connector reads at runtime via `secrets.get('<key>')`. The UI prompts for exactly these.            |
+| `allowedHosts`         | no                  | array of strings                                                    | Network allow-list. The connector cannot reach hosts not listed here.                                                            |
+| `operations`           | rest_api connectors | array of `Operation`                                                | The named REST operations the connector exposes. See [Operation shape](#operation-shape).                                        |
+| `oauth2Config`         | oauth2 connectors   | `{ authorizationUrl, tokenUrl, scopes? }`                           | Endpoints for the authorization-code flow.                                                                                       |
+| `sqlConnectionConfig`  | sql connectors      | `{ engine, readOnly?, options?, security? }`                        | `engine` is `'mssql'`, `'postgres'`, or `'mysql'`. `readOnly` is a hint to the UI; the database account itself is the real gate. |
+| `sqlOperations`        | sql connectors      | array of `SqlOperation`                                             | Named queries with parameter placeholders. See [SQL connectors](#sql-connectors).                                                |
+| `connectionConfig`     | no                  | `{ domain?, apiVersion?, apiEndpoint?, timeout?, rateLimit?, ... }` | Optional connection hints; extra keys are accepted.                                                                              |
+| `capabilities`         | no                  | `{ canSync?, canPush?, canWebhook?, syncFrequency? }`               | Declares optional capabilities the platform can schedule against (e.g. periodic sync).                                           |
+| `exposeAsCapability`   | no                  | `{ label, icon?, tooltip?, order? }`                                | Surface this integration as a named capability in the UI.                                                                        |
+| `setupGuide`           | no                  | string (≤5000)                                                      | Markdown rendered under **Configuration guide** in the manage dialog. Tell users where to generate keys, which scopes, etc.      |
+| `metadata`             | no                  | object                                                              | Free-form metadata for tooling; not interpreted by the platform.                                                                 |
+
+## Operation shape
+
+A REST operation describes one callable action. The agent picks an operation by `name` and supplies validated parameters; your `connector.ts` dispatches on `ctx.operation` and uses `ctx.params`.
+
+| Field              | Required | Type                  | What it does                                                                                            |
+| ------------------ | -------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `name`             | yes      | string                | Stable identifier the agent uses. Snake_case by convention.                                             |
+| `title`            | no       | string                | Human-readable label in the UI's operation list.                                                        |
+| `description`      | no       | string                | What the operation does and when to use it. The agent reads this — write it for the LLM, not the human. |
+| `operationType`    | no       | `'read'` \| `'write'` | Drives the approval gate. Defaults to read-style behaviour when omitted.                                |
+| `requiresApproval` | no       | boolean               | Force the approval card even on a read, or skip it on a write that is genuinely safe.                   |
+| `requiredScopes`   | no       | array of strings      | OAuth scopes this operation needs; surfaced to the user during connect.                                 |
+| `parametersSchema` | no       | JSON Schema (object)  | Standard JSON Schema. Only `type: 'object'` with `properties` and `required` is exercised today.        |
+
+A compact REST example, lifted from [examples/integrations/tavily/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/config.json):
+
+```json
+{
+  "name": "search",
+  "title": "Search the web",
+  "description": "Search the open web via Tavily. Use 'basic' depth for quick facts, 'advanced' for deeper research.",
+  "operationType": "read",
+  "parametersSchema": {
+    "type": "object",
+    "required": ["query"],
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Natural-language search query. Be specific."
+      },
+      "max_results": {
+        "type": "number",
+        "description": "Max results to return (1-10)."
+      }
+    }
+  }
+}
+```
+
+## The connector sandbox
+
+Connector code does not run as ordinary Node. It is transpiled and executed inside an isolated context with a small, controlled API surface. Plan accordingly: there is no `fs`, no `child_process`, no arbitrary `import`, no `process.env`, no ambient `fetch`. The only side-effects available are HTTP through `ctx.http` and credential reads through `ctx.secrets`.
+
+### `ConnectorContext`
+
+Every operation receives a context object. The shape is:
+
+```typescript
+interface ConnectorContext {
+  operation: string; // the operation name being invoked
+  params: Record<string, unknown>; // validated against parametersSchema
+  http: HttpApi;
+  secrets: SecretsApi;
+  base64Encode(input: string): string;
+  base64Decode(input: string): string;
+}
+
+interface HttpApi {
+  get(url: string, options?: HttpMethodOptions): HttpResponse;
+  post(url: string, options?: BodyMethodOptions): HttpResponse;
+  put(url: string, options?: BodyMethodOptions): HttpResponse;
+  patch(url: string, options?: BodyMethodOptions): HttpResponse;
+  delete(url: string, options?: BodyMethodOptions): HttpResponse;
+}
+
+interface HttpMethodOptions {
+  headers?: Record<string, string>;
+  responseType?: 'base64'; // request a base64-encoded body for binary downloads
+}
+
+interface BodyMethodOptions extends HttpMethodOptions {
+  body?: string; // already-serialised payload (e.g. JSON.stringify(...))
+  binaryBody?: string; // base64-encoded request body
+}
+
+interface HttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  text(): string;
+  json(): unknown;
+}
+
+interface SecretsApi {
+  get(key: string): string | undefined;
+}
+```
+
+The `http` client only reaches hosts listed in `allowedHosts`. A request to anything else fails before the network call.
+
+### What the sandbox does not provide
+
+- **No Node built-ins** — no `fs`, `child_process`, `crypto`, `path`, `os`, `net`. Use `base64Encode`/`base64Decode` for binary work; for hashing or signing, do it server-side or pre-compute.
+- **No top-level `import` or `require`** — write self-contained code. TypeScript type declarations at the top of the file are stripped during transpile and are only there for editor support.
+- **No environment variables** — read every credential through `ctx.secrets.get(...)`.
+- **No background work** — `setTimeout`, `setInterval`, and unawaited promises are not part of the contract. An operation runs to completion synchronously (the sandbox treats your function as synchronous) and returns a value.
+
+## The two functions a connector exports
+
+A connector defines two functions: one to validate a connection during install, one to run operations.
+
+| Function              | When it runs                                                   | What it should do                                                                                                   |
+| --------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `testConnection(ctx)` | When the user clicks **Test connection** in the manage dialog. | Make the cheapest authenticated request the API supports. Throw a clear `Error` with a remediation hint on failure. |
+| `execute(ctx)`        | Every time an operation is invoked.                            | Dispatch on `ctx.operation`, validate inputs, call the API, shape the response. Throw `Error` for any failure.      |
+
+Both can be exported either as a single `connector` object literal (Tavily, Discord) or as top-level functions; both shapes are accepted. The `connector` object form is recommended because it keeps the two entry points close to a list of operations and makes the dispatch table obvious.
+
+By convention, successful `execute` returns an object of the shape `{ success: true, operation, data, count?, cost?: { cents }, timestamp }`. The platform does not enforce this shape, but agents and execution logs render it cleanly.
+
+## Worked example — Tavily
+
+Here is the smallest end-to-end picture, drawn from [examples/integrations/tavily/](https://github.com/tale-project/tale/tree/main/examples/integrations/tavily).
+
+The manifest declares the auth method, allow-listed host, secret binding, and two operations:
+
+```json
+{
+  "title": "Tavily",
+  "type": "rest_api",
+  "authMethod": "api_key",
+  "secretBindings": ["apiKey"],
+  "allowedHosts": ["api.tavily.com"],
+  "operations": [
+    {
+      "name": "search",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    },
+    {
+      "name": "extract",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    }
+  ],
+  "setupGuide": "1. Sign up at https://tavily.com\n2. Create an API key\n3. Paste it below and Test connection."
+}
+```
+
+The connector exports `testConnection` (a cheap authenticated probe) and `execute` (dispatch to per-operation helpers):
+
+```typescript
+const API_BASE = 'https://api.tavily.com';
+
+const connector = {
+  testConnection(ctx: TestConnectionContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+
+    const response = ctx.http.post(API_BASE + '/search', {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, query: 'ping', max_results: 1 }),
+    });
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Tavily authentication failed. Verify the API key.');
+    }
+    if (response.status !== 200) {
+      throw new Error(
+        'Tavily connection failed (' +
+          response.status +
+          '): ' +
+          response.text(),
+      );
+    }
+    return { status: 'ok' };
+  },
+
+  execute(ctx: ConnectorContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+    if (ctx.operation === 'search') return search(ctx.http, apiKey, ctx.params);
+    if (ctx.operation === 'extract')
+      return extractUrls(ctx.http, apiKey, ctx.params);
+    throw new Error('Unknown operation: ' + ctx.operation);
+  },
+};
+```
+
+Notice the shape of the error messages — they tell the user what to do (`Verify the API key`), not just that something failed. Errors from `testConnection` surface inline in the manage dialog; errors from `execute` surface in the agent's response and execution log. Make them actionable.
+
+The full file at [tavily/connector.ts](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/connector.ts) shows the per-operation helpers, an `handleHttpError` utility that maps statuses to user-readable messages, and result truncation to keep token usage predictable. Reuse those patterns.
+
+## SQL connectors
+
+SQL integrations skip `connector.ts` entirely. The platform runs the queries you declare in the manifest against the configured database; you only write the SQL and the parameter schema.
+
+```json
+{
+  "name": "list_reservations",
+  "title": "List Reservations",
+  "description": "Fetch reservations with optional status and date filters.",
+  "operationType": "read",
+  "query": "SELECT id, guest_id, check_in FROM reservations WHERE (@status IS NULL OR status = @status) AND check_in >= @fromDate ORDER BY check_in DESC",
+  "parametersSchema": {
+    "type": "object",
+    "properties": {
+      "status": { "type": "string", "description": "Optional status filter." },
+      "fromDate": {
+        "type": "string",
+        "format": "date",
+        "description": "ISO date."
+      }
+    }
+  }
+}
+```
+
+Placeholders use `@paramName`, matched to keys in `parametersSchema.properties`. Mark queries that mutate data with `operationType: 'write'` and (usually) `requiresApproval: true`; the platform will gate them through the approval flow. See [examples/integrations/protel/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/protel/config.json) for a full hotel-PMS connector with twenty-plus read operations and a handful of approval-gated writes.
+
+`sqlConnectionConfig.engine` accepts `'mssql'`, `'postgres'`, or `'mysql'`. The optional `security.maxResultRows` and `security.queryTimeoutMs` are caps the platform enforces on top of whatever the database itself permits.
+
+## Packaging and shipping
+
+- **Project flow.** Drop `integrations/<slug>/{config.json, connector.ts, icon.svg}` into a `tale init` project. The platform live-reloads; saving a file applies the change.
+- **UI upload.** Zip the same files (or upload them individually) via **Settings > Integrations > Add integration**. The total package is capped at 1 MB.
+- **Versioning.** Bump `version` in `config.json` whenever you change the operation set or any parameter shape, so consumers can notice the drift.
+- **Icons.** SVG, PNG, JPG, or WebP, under 256 KB. SVG renders cleanest in dark and light themes.
+- **Slugs.** The directory name is the slug. Keep it stable across versions; renaming is a breaking change.
+
+## Common mistakes to avoid
+
+- **Long-running loops or unbounded result sets.** Operations should return quickly with paginated or truncated data. The Tavily connector caps results at 5 and truncates each page to 2 000 characters — use it as a reference.
+- **Secrets in code.** Never embed API keys or tokens in `connector.ts`. Always read them through `ctx.secrets.get('<binding>')` and declare the binding in `secretBindings`.
+- **Hosts not in `allowedHosts`.** A request to an unlisted host fails. Add every base URL the connector touches, including any redirect target you depend on.
+- **Vague error messages.** `Failed` is not actionable. Tell the user which credential is wrong, which scope is missing, or which quota was exceeded.
+- **Missing `operationType: 'write'` on mutating calls.** Without it, the approval gate doesn't engage and a write may run unattended.
+
+## Related
+
+- [Integrations overview](/platform/integrations/overview) — concepts and how connectors are consumed.
+- [AI-assisted development](/develop/ai-assisted-development) — using Claude Code, Cursor, GitHub Copilot, or Windsurf to author connectors against the platform's reference source.
+- [API reference](/develop/api-reference) — the Tale API itself, distinct from connectors.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -83,7 +83,10 @@
               "self-hosted/overview",
               {
                 "group": "Install",
-                "pages": ["self-hosted/install/linux-server"]
+                "pages": [
+                  "self-hosted/install/quickstart",
+                  "self-hosted/install/linux-server"
+                ]
               },
               {
                 "group": "Configuration",
@@ -239,6 +242,7 @@
               "develop/api-reference",
               "develop/webhooks",
               "develop/ai-assisted-development",
+              "develop/integrations",
               "develop/contributing-docker"
             ]
           },
@@ -285,7 +289,10 @@
               "de/self-hosted/overview",
               {
                 "group": "Installation",
-                "pages": ["de/self-hosted/install/linux-server"]
+                "pages": [
+                  "de/self-hosted/install/quickstart",
+                  "de/self-hosted/install/linux-server"
+                ]
               },
               {
                 "group": "Konfiguration",
@@ -441,6 +448,7 @@
               "de/develop/api-reference",
               "de/develop/webhooks",
               "de/develop/ai-assisted-development",
+              "de/develop/integrations",
               "de/develop/contributing-docker"
             ]
           },
@@ -487,7 +495,10 @@
               "fr/self-hosted/overview",
               {
                 "group": "Installation",
-                "pages": ["fr/self-hosted/install/linux-server"]
+                "pages": [
+                  "fr/self-hosted/install/quickstart",
+                  "fr/self-hosted/install/linux-server"
+                ]
               },
               {
                 "group": "Configuration",
@@ -643,6 +654,7 @@
               "fr/develop/api-reference",
               "fr/develop/webhooks",
               "fr/develop/ai-assisted-development",
+              "fr/develop/integrations",
               "fr/develop/contributing-docker"
             ]
           },
@@ -696,7 +708,7 @@
         "items": [
           {
             "label": "Getting started",
-            "href": "/platform/member/overview"
+            "href": "/self-hosted/install/quickstart"
           },
           {
             "label": "Environment reference",

--- a/docs/fr/develop/integrations.md
+++ b/docs/fr/develop/integrations.md
@@ -1,0 +1,283 @@
+---
+title: Construire une intégration
+description: Écrire un connecteur Tale — config.json, connector.ts, APIs sandbox et empaquetage.
+---
+
+Un connecteur, c'est un `config.json` plus un `connector.ts` (ou `.js`) plus une icône. Le manifeste déclare l'identité de l'intégration, l'authentification, les hôtes autorisés et les opérations nommées qu'elle expose ; le code du connecteur exécute chaque opération dans un sandbox. Les intégrations SQL sont un cas particulier — elles ne livrent pas de code, seulement des requêtes paramétrées dans le manifeste.
+
+Cette page est la référence d'écriture. Elle suppose que tu as déjà lu l'[aperçu des intégrations](/fr/platform/integrations/overview) pour les concepts côté utilisateur. Pour le workflow d'éditeur avec des assistants IA, voir [Développement assisté par IA](/fr/develop/ai-assisted-development).
+
+## Disposition des fichiers
+
+Un connecteur vit dans un seul dossier. Le nom du dossier est le **slug** — l'identifiant stable utilisé par la plateforme ; ce n'est pas un champ de `config.json`.
+
+```text
+integrations/<slug>/
+├── config.json     ← manifeste (requis)
+├── connector.ts    ← code sandboxé (connecteurs REST uniquement)
+└── icon.svg        ← affichée dans la liste Ajouter une intégration
+```
+
+Deux façons de livrer ce dossier : pose-le dans le dossier `integrations/` d'un projet créé par `tale init`, ou zippe les fichiers et téléverse-les via **Paramètres > Intégrations > Ajouter une intégration** (max 1 Mo). Les deux chemins produisent le même état serveur.
+
+## Schéma `config.json`
+
+Le manifeste est validé côté serveur contre un schéma Zod dans [services/platform/lib/shared/schemas/integrations.ts](https://github.com/tale-project/tale/blob/main/services/platform/lib/shared/schemas/integrations.ts). Les champs ci-dessous sont la surface canonique ; consulte la source en cas de doute.
+
+| Champ                  | Requis               | Type                                                                | Ce qu'il fait                                                                                                                   |
+| ---------------------- | -------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | oui                  | string (1-200)                                                      | Nom lisible affiché dans la liste des intégrations.                                                                             |
+| `description`          | non                  | string (≤2000)                                                      | Résumé d'une phrase à côté du titre.                                                                                            |
+| `version`              | non                  | integer                                                             | Incrémente quand les opérations ou les formes de paramètres changent, pour que les consommateurs détectent le drift.            |
+| `type`                 | non                  | `'rest_api'` \| `'sql'`                                             | Par défaut `rest_api`. Mets `sql` pour les connecteurs base de données.                                                         |
+| `authMethod`           | oui                  | `'api_key'` \| `'bearer_token'` \| `'basic_auth'` \| `'oauth2'`     | La méthode d'authentification requise par ce connecteur.                                                                        |
+| `supportedAuthMethods` | non                  | tableau du même enum                                                | Quand un connecteur accepte plusieurs méthodes ; l'utilisateur choisit à l'installation.                                        |
+| `secretBindings`       | non                  | string[]                                                            | Noms des clés de credentials que le connecteur lit à l'exécution via `secrets.get('<key>')`. L'UI demande exactement celles-ci. |
+| `allowedHosts`         | non                  | string[]                                                            | Allow-list réseau. Le connecteur ne peut joindre que les hôtes listés.                                                          |
+| `operations`           | connecteurs rest_api | tableau d'`Operation`                                               | Les opérations REST nommées exposées par le connecteur. voir la section sur la forme des opérations ci-dessous.                 |
+| `oauth2Config`         | connecteurs oauth2   | `{ authorizationUrl, tokenUrl, scopes? }`                           | Endpoints du authorization-code flow.                                                                                           |
+| `sqlConnectionConfig`  | connecteurs sql      | `{ engine, readOnly?, options?, security? }`                        | `engine` vaut `'mssql'`, `'postgres'` ou `'mysql'`. `readOnly` est un indice pour l'UI ; le compte DB est la vraie barrière.    |
+| `sqlOperations`        | connecteurs sql      | tableau de `SqlOperation`                                           | Requêtes nommées avec placeholders. Voir [Connecteurs SQL](#connecteurs-sql).                                                   |
+| `connectionConfig`     | non                  | `{ domain?, apiVersion?, apiEndpoint?, timeout?, rateLimit?, ... }` | Indices de connexion optionnels ; clés supplémentaires acceptées.                                                               |
+| `capabilities`         | non                  | `{ canSync?, canPush?, canWebhook?, syncFrequency? }`               | Déclare des capacités optionnelles que la plateforme peut planifier (ex. sync périodique).                                      |
+| `exposeAsCapability`   | non                  | `{ label, icon?, tooltip?, order? }`                                | Expose cette intégration comme capacité nommée dans l'UI.                                                                       |
+| `setupGuide`           | non                  | string (≤5000)                                                      | Markdown rendu sous **Guide de configuration** dans le manage dialog. Indique où générer les clés, quels scopes, etc.           |
+| `metadata`             | non                  | object                                                              | Métadonnées libres pour l'outillage ; non interprétées par la plateforme.                                                       |
+
+## Forme d'une opération
+
+Une opération REST décrit une action appelable. L'agent choisit une opération par `name` et fournit des paramètres validés ; ton `connector.ts` dispatche sur `ctx.operation` et utilise `ctx.params`.
+
+| Champ              | Requis | Type                  | Ce qu'il fait                                                                                         |
+| ------------------ | ------ | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `name`             | oui    | string                | Identifiant stable utilisé par l'agent. Snake_case par convention.                                    |
+| `title`            | non    | string                | Label lisible dans la liste des opérations en UI.                                                     |
+| `description`      | non    | string                | Ce que fait l'opération et quand l'utiliser. L'agent lit ça — écris pour le LLM, pas pour l'humain.   |
+| `operationType`    | non    | `'read'` \| `'write'` | Pilote la porte d'approbation. Par défaut, comportement style read si omis.                           |
+| `requiresApproval` | non    | boolean               | Force la carte d'approbation même sur un read, ou la saute sur un write réellement sûr.               |
+| `requiredScopes`   | non    | string[]              | Scopes OAuth dont cette opération a besoin ; remontés à l'utilisateur lors de la connexion.           |
+| `parametersSchema` | non    | JSON Schema (object)  | JSON Schema standard. Aujourd'hui seul `type: 'object'` avec `properties` et `required` est exploité. |
+
+Un exemple REST compact, tiré de [examples/integrations/tavily/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/config.json) :
+
+```json
+{
+  "name": "search",
+  "title": "Search the web",
+  "description": "Search the open web via Tavily. Use 'basic' depth for quick facts, 'advanced' for deeper research.",
+  "operationType": "read",
+  "parametersSchema": {
+    "type": "object",
+    "required": ["query"],
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Natural-language search query. Be specific."
+      },
+      "max_results": {
+        "type": "number",
+        "description": "Max results to return (1-10)."
+      }
+    }
+  }
+}
+```
+
+## Le sandbox du connecteur
+
+Le code du connecteur ne tourne pas comme du Node ordinaire. Il est transpilé et exécuté dans un contexte isolé avec une petite surface d'API contrôlée. Planifie en conséquence : pas de `fs`, pas de `child_process`, pas d'`import` arbitraire, pas de `process.env`, pas de `fetch` ambiant. Les seuls effets de bord disponibles sont HTTP via `ctx.http` et lecture de credentials via `ctx.secrets`.
+
+### `ConnectorContext`
+
+Chaque opération reçoit un objet contexte. La forme :
+
+```typescript
+interface ConnectorContext {
+  operation: string; // nom de l'opération invoquée
+  params: Record<string, unknown>; // validé contre parametersSchema
+  http: HttpApi;
+  secrets: SecretsApi;
+  base64Encode(input: string): string;
+  base64Decode(input: string): string;
+}
+
+interface HttpApi {
+  get(url: string, options?: HttpMethodOptions): HttpResponse;
+  post(url: string, options?: BodyMethodOptions): HttpResponse;
+  put(url: string, options?: BodyMethodOptions): HttpResponse;
+  patch(url: string, options?: BodyMethodOptions): HttpResponse;
+  delete(url: string, options?: BodyMethodOptions): HttpResponse;
+}
+
+interface HttpMethodOptions {
+  headers?: Record<string, string>;
+  responseType?: 'base64'; // demander un body encodé base64 pour téléchargements binaires
+}
+
+interface BodyMethodOptions extends HttpMethodOptions {
+  body?: string; // payload déjà sérialisé (ex. JSON.stringify(...))
+  binaryBody?: string; // body de requête encodé base64
+}
+
+interface HttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  text(): string;
+  json(): unknown;
+}
+
+interface SecretsApi {
+  get(key: string): string | undefined;
+}
+```
+
+Le client `http` ne joint que les hôtes listés dans `allowedHosts`. Une requête vers autre chose échoue avant l'appel réseau.
+
+### Ce que le sandbox ne fournit pas
+
+- **Aucune builtin Node** — pas de `fs`, `child_process`, `crypto`, `path`, `os`, `net`. Utilise `base64Encode`/`base64Decode` pour le binaire ; pour le hashing ou la signature, fais-le côté serveur ou pré-calcule.
+- **Pas d'`import` ni `require` au niveau racine** — écris du code autonome. Les déclarations TypeScript en haut de fichier sont retirées au transpile et n'existent que pour l'éditeur.
+- **Pas de variables d'environnement** — lis chaque credential via `ctx.secrets.get(...)`.
+- **Pas de travail en arrière-plan** — `setTimeout`, `setInterval` et les promesses non awaited ne font pas partie du contrat. Une opération s'exécute jusqu'au bout de manière synchrone (le sandbox traite ta fonction comme synchrone) et renvoie une valeur.
+
+## Les deux fonctions qu'un connecteur exporte
+
+Un connecteur définit deux fonctions : une pour valider la connexion à l'installation, une pour exécuter les opérations.
+
+| Fonction              | Quand elle tourne                                                         | Ce qu'elle doit faire                                                                                                                   |
+| --------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `testConnection(ctx)` | Quand l'utilisateur clique **Tester la connexion** dans le manage dialog. | La requête authentifiée la moins coûteuse que l'API supporte. Lance un `Error` clair avec une indication de remédiation en cas d'échec. |
+| `execute(ctx)`        | À chaque invocation d'opération.                                          | Dispatcher sur `ctx.operation`, valider les entrées, appeler l'API, mettre en forme la réponse. Lancer `Error` pour tout échec.         |
+
+Les deux peuvent être exportées soit comme un seul objet `connector` (Tavily, Discord) soit comme fonctions de niveau racine ; les deux formes sont acceptées. La forme objet est recommandée parce qu'elle garde les deux entrées proches d'une liste d'opérations et rend la table de dispatch évidente.
+
+Par convention, un `execute` réussi renvoie un objet de la forme `{ success: true, operation, data, count?, cost?: { cents }, timestamp }`. La plateforme n'impose pas cette forme, mais agents et logs d'exécution la rendent proprement.
+
+## Exemple de bout en bout — Tavily
+
+Voici l'image la plus compacte de bout en bout, tirée de [examples/integrations/tavily/](https://github.com/tale-project/tale/tree/main/examples/integrations/tavily).
+
+Le manifeste déclare la méthode d'auth, l'hôte allow-listé, le secret binding et deux opérations :
+
+```json
+{
+  "title": "Tavily",
+  "type": "rest_api",
+  "authMethod": "api_key",
+  "secretBindings": ["apiKey"],
+  "allowedHosts": ["api.tavily.com"],
+  "operations": [
+    {
+      "name": "search",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    },
+    {
+      "name": "extract",
+      "operationType": "read",
+      "parametersSchema": {
+        /* ... */
+      }
+    }
+  ],
+  "setupGuide": "1. Sign up at https://tavily.com\n2. Create an API key\n3. Paste it below and Test connection."
+}
+```
+
+Le connecteur exporte `testConnection` (une sonde authentifiée pas chère) et `execute` (dispatch vers les helpers par opération) :
+
+```typescript
+const API_BASE = 'https://api.tavily.com';
+
+const connector = {
+  testConnection(ctx: TestConnectionContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+
+    const response = ctx.http.post(API_BASE + '/search', {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, query: 'ping', max_results: 1 }),
+    });
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Tavily authentication failed. Verify the API key.');
+    }
+    if (response.status !== 200) {
+      throw new Error(
+        'Tavily connection failed (' +
+          response.status +
+          '): ' +
+          response.text(),
+      );
+    }
+    return { status: 'ok' };
+  },
+
+  execute(ctx: ConnectorContext) {
+    const apiKey = ctx.secrets.get('apiKey');
+    if (!apiKey) throw new Error('Tavily API key is required.');
+    if (ctx.operation === 'search') return search(ctx.http, apiKey, ctx.params);
+    if (ctx.operation === 'extract')
+      return extractUrls(ctx.http, apiKey, ctx.params);
+    throw new Error('Unknown operation: ' + ctx.operation);
+  },
+};
+```
+
+Note la forme des messages d'erreur — ils disent à l'utilisateur quoi faire (`Verify the API key`), pas seulement que ça a échoué. Les erreurs de `testConnection` apparaissent inline dans le manage dialog ; celles d'`execute` apparaissent dans la réponse de l'agent et le log d'exécution. Rends-les actionnables.
+
+Le fichier complet à [tavily/connector.ts](https://github.com/tale-project/tale/blob/main/examples/integrations/tavily/connector.ts) montre les helpers par opération, un utilitaire `handleHttpError` qui mappe les statuts à des messages lisibles, et la troncature des résultats pour garder l'usage de tokens prévisible. Reprends ces motifs.
+
+## Connecteurs SQL
+
+Les intégrations SQL sautent `connector.ts` complètement. La plateforme exécute les requêtes que tu déclares dans le manifeste contre la base configurée ; tu n'écris que le SQL et le schéma de paramètres.
+
+```json
+{
+  "name": "list_reservations",
+  "title": "List Reservations",
+  "description": "Fetch reservations with optional status and date filters.",
+  "operationType": "read",
+  "query": "SELECT id, guest_id, check_in FROM reservations WHERE (@status IS NULL OR status = @status) AND check_in >= @fromDate ORDER BY check_in DESC",
+  "parametersSchema": {
+    "type": "object",
+    "properties": {
+      "status": { "type": "string", "description": "Optional status filter." },
+      "fromDate": {
+        "type": "string",
+        "format": "date",
+        "description": "ISO date."
+      }
+    }
+  }
+}
+```
+
+Les placeholders utilisent `@paramName`, mappés sur les clés de `parametersSchema.properties`. Marque les requêtes mutantes avec `operationType: 'write'` et (généralement) `requiresApproval: true` ; la plateforme les passera par le flux d'approbation. Voir [examples/integrations/protel/config.json](https://github.com/tale-project/tale/blob/main/examples/integrations/protel/config.json) pour un connecteur PMS hôtelier complet avec une vingtaine d'opérations en lecture et une poignée de writes gated par approbation.
+
+`sqlConnectionConfig.engine` accepte `'mssql'`, `'postgres'` ou `'mysql'`. Les `security.maxResultRows` et `security.queryTimeoutMs` optionnels sont des plafonds que la plateforme applique en sus de ce que la base permet.
+
+## Empaquetage et livraison
+
+- **Flux projet.** Pose `integrations/<slug>/{config.json, connector.ts, icon.svg}` dans un projet `tale init`. La plateforme recharge à chaud ; sauvegarder applique le changement.
+- **Flux upload UI.** Zippe les fichiers (ou téléverse-les individuellement) via **Paramètres > Intégrations > Ajouter une intégration**. Le paquet total est plafonné à 1 Mo.
+- **Versionnage.** Incrémente `version` dans `config.json` dès que tu changes l'ensemble d'opérations ou la forme d'un paramètre, pour que les consommateurs voient le drift.
+- **Icônes.** SVG, PNG, JPG ou WebP, sous 256 Ko. SVG rend le mieux en thèmes clair et sombre.
+- **Slugs.** Le nom de dossier est le slug. Garde-le stable entre versions ; le renommer est un breaking change.
+
+## Erreurs courantes à éviter
+
+- **Boucles longues ou résultats sans limite.** Les opérations doivent revenir vite avec des données paginées ou tronquées. Le connecteur Tavily plafonne à 5 résultats et tronque chaque page à 2 000 caractères — sers-t'en de référence.
+- **Secrets en dur dans le code.** N'incorpore jamais de clés API ou de jetons dans `connector.ts`. Lis-les toujours via `ctx.secrets.get('<binding>')` et déclare le binding dans `secretBindings`.
+- **Hôtes non listés dans `allowedHosts`.** Une requête vers un hôte non listé échoue. Ajoute chaque base URL que le connecteur touche, y compris les cibles de redirection dont tu dépends.
+- **Messages d'erreur vagues.** `Failed` n'est pas actionnable. Dis à l'utilisateur quel credential est faux, quel scope manque, ou quel quota a été dépassé.
+- **Oubli de `operationType: 'write'` sur les calls mutants.** Sans ça, la porte d'approbation ne s'enclenche pas et un write peut s'exécuter sans surveillance.
+
+## Pages liées
+
+- [Aperçu des intégrations](/fr/platform/integrations/overview) — concepts et consommation des connecteurs.
+- [Développement assisté par IA](/fr/develop/ai-assisted-development) — utiliser Claude Code, Cursor, GitHub Copilot ou Windsurf pour écrire des connecteurs contre le code de référence de la plateforme.
+- [Référence API](/fr/develop/api-reference) — l'API Tale elle-même, distincte des connecteurs.

--- a/docs/fr/platform/integrations/overview.md
+++ b/docs/fr/platform/integrations/overview.md
@@ -1,45 +1,83 @@
 ---
 title: Intégrations — aperçu
-description: Connecte Tale aux REST API, bases SQL, e-mail et stockage cloud.
+description: Connecte Tale à des REST API et bases SQL via des connecteurs développés sur mesure.
 ---
 
-Les intégrations permettent à Tale de parler à des systèmes externes. Les Developers les configurent une fois ; agents, automatisations et chat assistant les utilisent ensuite pour lire et écrire des données dans ces systèmes. La configuration vit sous **Paramètres > Intégrations** et demande le rôle Developer ou plus.
+Une intégration est un connecteur défini par un développeur qui expose les capacités d'un système distant — endpoints REST ou requêtes SQL — comme une liste fixe d'opérations nommées. Une fois installées, ces opérations deviennent des outils que le chat assistant, les agents et les étapes d'action des automatisations appellent par leur nom avec des paramètres typés. La configuration vit sous **Paramètres > Intégrations** et demande au minimum le rôle Developer ; les consommateurs appellent simplement les opérations que le connecteur publie.
+
+La plateforme prend en charge deux types de connecteurs : `rest_api` pour les services HTTP et `sql` pour l'accès direct à une base de données. Tout le reste qui apparaît sous **Paramètres > Intégrations** dans l'UI — boîtes e-mail, Microsoft OneDrive, clés API de l'API Tale elle-même — sont des connexions apparentées avec leur propre surface de configuration, pas le modèle connecteur. Elles sont couvertes en bas de cette page.
 
 ## Types d'intégration
 
 ### REST API
 
-Connecte n'importe quelle API HTTP en entrant base URL et credentials. Méthodes d'auth supportées :
+Les connecteurs REST encapsulent n'importe quel service HTTP. Le manifeste du connecteur liste les méthodes d'authentification supportées et les hôtes qu'il peut joindre ; du code de connecteur sandboxé gère chaque opération. Méthodes d'authentification supportées :
 
-| Méthode          | Fonctionnement                                           |
-| ---------------- | -------------------------------------------------------- |
-| **API key**      | passe une clé dans un header ou un query parameter.      |
-| **Bearer token** | header `Authorization: Bearer <token>` à chaque requête. |
-| **Basic auth**   | user/password encodés en base64.                         |
-| **OAuth 2.0**    | authorization code flow avec refresh automatique.        |
+| Méthode          | Fonctionnement                                               |
+| ---------------- | ------------------------------------------------------------ |
+| **API key**      | Passe une clé dans un header ou un query parameter.          |
+| **Bearer token** | Header `Authorization: Bearer <token>` à chaque requête.     |
+| **Basic auth**   | Utilisateur et mot de passe encodés en base64.               |
+| **OAuth 2.0**    | Authorization-code flow avec rafraîchissement de jeton auto. |
 
-Une fois ajoutée, l'intégration expose chaque endpoint configuré comme outil appelable par l'agent IA. Voir [Créer un agent](/fr/platform/agents/create) pour accorder l'accès.
+Le champ `allowedHosts` du manifeste agit comme une allow-list réseau — le connecteur ne peut joindre que les hôtes qu'il déclare. Voir [Créer un agent](/fr/platform/agents/create) pour accorder à un agent l'accès aux opérations d'une intégration.
 
 ### SQL
 
-Connecte une base PostgreSQL, MySQL ou Microsoft SQL Server. L'agent IA et les automatisations peuvent l'interroger en langage naturel, traduit en SQL contre le schéma enregistré.
+Les connecteurs SQL se branchent sur PostgreSQL, MySQL ou Microsoft SQL Server. L'agent **n'écrit pas** de SQL libre. Le manifeste de l'intégration enregistre une liste fixe d'opérations nommées, chacune avec une requête pré-écrite et un schéma de paramètres ; l'agent choisit une opération et fournit des valeurs pour les placeholders. Des credentials en lecture seule restent fortement recommandés — les opérations en écriture et les portes d'approbation ne contraignent que ce que le connecteur publie, pas ce que le compte de base de données est lui-même autorisé à faire.
 
-Des credentials en lecture seule sont fortement recommandés — les requêtes générées par l'IA sont exécutées telles quelles.
+## Opérations
 
-### E-mail (Conversations)
+Chaque intégration publie une liste d'opérations. Une opération a un `name` (l'identifiant que l'agent appelle), une `description` (ce qu'elle fait et quand l'utiliser), un `parametersSchema` (un JSON Schema décrivant les entrées), un `operationType` optionnel (`read` ou `write`) et un drapeau `requiresApproval` optionnel. L'agent choisit une opération par son nom et fournit des paramètres validés ; il ne compose jamais d'appels HTTP ad hoc ni de SQL libre. C'est ce qui rend un connecteur prévisible : une nouvelle opération n'existe que si un développeur l'ajoute au manifeste.
 
-Connecte une boîte IMAP+SMTP pour alimenter l'inbox [Conversations](/fr/platform/workspace/conversations). Les e-mails entrants deviennent des fils. Les réponses envoyées depuis la plateforme sont livrées comme e-mails normaux.
+## Lecture, écriture et approbations
 
-### Microsoft OneDrive
+Les opérations marquées `operationType: write` exigent par défaut une approbation avant exécution. Quand un agent ou une automatisation déclenche une telle opération, une carte d'approbation apparaît dans le chat — un humain accepte ou refuse, et seule l'acceptation lance l'appel. Voir [Approbations](/fr/platform/workspace/approvals) pour le flux complet. Utile pour la facturation, les e-mails de masse, l'écriture en données de production, et tout ce où tu veux un humain dans la boucle. Les opérations en lecture s'exécutent directement, sans étape d'approbation.
 
-Connecte un compte Microsoft 365 pour activer la synchro OneDrive. Les utilisateurs peuvent alors importer des fichiers directement depuis OneDrive dans la base de connaissances sans les télécharger. Voir [Base de connaissances](/fr/platform/workspace/knowledge-base).
+## Authentification et secrets
+
+Le tableau `secretBindings` du manifeste nomme les clés de credentials qu'un connecteur lit à l'exécution via `secrets.get('<key>')`. Quand tu connectes l'intégration sous **Paramètres > Intégrations**, l'UI demande exactement ces clés et stocke les valeurs chiffrées au repos, dans le périmètre de ton organisation. Les connecteurs OAuth 2.0 utilisent l'authorization-code flow standard, stockent jeton d'accès et de rafraîchissement, et rafraîchissent les jetons d'accès automatiquement à expiration. Les connecteurs SQL stockent serveur, port, nom de base, utilisateur et mot de passe dans le même coffre chiffré.
+
+## Guide de configuration et test de connexion
+
+Les connecteurs peuvent livrer un `setupGuide` Markdown que la plateforme rend sous **Guide de configuration** dans le manage dialog — utilise-le pour pointer vers où générer la clé API, quels scopes OAuth accorder, ou quel rôle de base créer. Une fois les credentials saisis, **Tester la connexion** invoque le hook `testConnection` léger du connecteur avant de sauvegarder ; un échec affiche le message d'erreur du connecteur en ligne, sans quitter le dialogue.
+
+## Exemples livrés
+
+Le dépôt fournit treize connecteurs prêts à l'emploi à [github.com/tale-project/tale/tree/main/examples/integrations](https://github.com/tale-project/tale/tree/main/examples/integrations). Forke-en un comme point de départ pour un connecteur sur mesure contre le même fournisseur, ou installe-en un tel quel.
+
+| Exemple          | Type     | Auth         | Ce qu'il couvre                                                     |
+| ---------------- | -------- | ------------ | ------------------------------------------------------------------- |
+| **AI image**     | rest_api | bearer_token | Génération d'images contre des fournisseurs compatibles OpenAI.     |
+| **Circuly**      | rest_api | basic_auth   | Produits, clients et abonnements dans Circuly.                      |
+| **Discord**      | rest_api | bearer_token | Guildes, salons et messages via la Discord Bot API.                 |
+| **GitHub**       | rest_api | bearer_token | Dépôts, issues, pull requests et recherche de code.                 |
+| **Gmail**        | rest_api | oauth2       | Messages, labels, threads et brouillons dans Gmail.                 |
+| **Google Drive** | rest_api | oauth2       | Synchronise les fichiers de dossiers Drive vers des documents Tale. |
+| **Outlook**      | rest_api | oauth2       | Mail, calendrier et contacts via Microsoft Graph.                   |
+| **Protel**       | sql      | basic_auth   | Accès SQL direct à un PMS hôtelier Protel — réservations et folios. |
+| **Shopify**      | rest_api | api_key      | Produits, clients et commandes dans la Shopify Admin API.           |
+| **Slack**        | rest_api | oauth2       | Salons, messages, utilisateurs et uploads de fichiers.              |
+| **Tavily**       | rest_api | api_key      | Recherche web ouverte et extraction de pages pour agents LLM.       |
+| **Teams**        | rest_api | oauth2       | Équipes, salons, messages et chats via Microsoft Graph.             |
+| **Twilio**       | rest_api | basic_auth   | SMS, appels vocaux et gestion des numéros de téléphone.             |
+
+## Installer ou construire une intégration sur mesure
+
+Il y a deux façons d'installer un connecteur. Les deux finissent avec le même `config.json` plus le code du connecteur sur le serveur.
+
+**Téléverser depuis l'UI.** Ouvre **Paramètres > Intégrations**, clique **Ajouter une intégration**, puis dépose un paquet `.zip` ou choisis `config.json`, le code du connecteur (`connector.ts` ou `connector.js`) et une icône individuellement. Le total est plafonné à 1 Mo. Après l'upload, renseigne les credentials et clique **Tester la connexion**.
+
+**Écrire comme code de projet.** Un projet créé par `tale init` possède un dossier `integrations/` ; chaque sous-dossier est un connecteur (`integrations/<slug>/{config.json, connector.ts, icon.svg}`). La plateforme recharge à chaud à la sauvegarde, donc itérer revient à éditer n'importe quelle source. Le format de fichier complet et l'API du sandbox sont documentés dans [Construire une intégration](/fr/develop/integrations) ; pour l'écriture assistée par IA dans l'éditeur, voir [Développement assisté par IA](/fr/develop/ai-assisted-development).
+
+## Connexions apparentées
+
+Quelques autres éléments vivent sous **Paramètres > Intégrations** par souci de découvrabilité, mais ne sont pas des connecteurs `rest_api` ou `sql` — ils ont leur propre surface de configuration.
+
+**E-mail (boîte Conversations).** Connecte une boîte IMAP+SMTP pour alimenter l'inbox [Conversations](/fr/platform/workspace/conversations). Les e-mails entrants deviennent des fils ; les réponses envoyées depuis la plateforme partent comme des e-mails normaux. Configuré séparément des connecteurs.
+
+**Microsoft OneDrive.** Connecte un compte Microsoft 365 pour permettre aux utilisateurs d'importer des fichiers OneDrive directement dans la [base de connaissances](/fr/platform/workspace/knowledge-base) sans téléchargement préalable. Configuré via le flux d'import de la base de connaissances, pas comme connecteur.
 
 ## Clés API
 
-Génère des clés API pour l'accès programmatique à l'API Tale. Les clés héritent des permissions de l'utilisateur qui les a créées, limitées à son rôle. Révocables à tout moment depuis **Paramètres > Intégrations > Clés API**.
-
-Pour les endpoints, voir la [référence API](/fr/develop/api-reference).
-
-## Approbations
-
-Les intégrations peuvent exiger une approbation avant chaque opération. Quand un agent ou une automatisation déclenche un appel, une carte d'approbation apparaît dans le chat — voir [Approbations](/fr/platform/workspace/approvals). Utile pour des opérations destructrices ou coûteuses (facturation, e-mails en masse, changements de données prod).
+Les clés API donnent un accès programmatique à l'API Tale elle-même. Elles vivent sous **Paramètres > Intégrations > Clés API** parce que c'est la même surface admin, pas parce qu'elles sont des connecteurs. Chaque clé hérite du rôle de l'utilisateur qui l'a créée ; révocable à tout moment depuis le même écran. Détails des endpoints dans la [référence API](/fr/develop/api-reference).

--- a/docs/fr/platform/member/overview.md
+++ b/docs/fr/platform/member/overview.md
@@ -1,164 +1,47 @@
 ---
-title: Pour commencer
-description: Installe Tale et ouvre l'application — un parcours convivial pour tes 10 premières minutes.
+title: Pour commencer en tant que Member
+description: Se connecter, discuter, parcourir la base de connaissances et lire les conversations et approbations partagées — l'orientation jour 1 pour les Members.
 ---
 
-C'est le chemin le plus rapide pour passer de rien à une instance Tale qui tourne. Pas besoin d'être développeur — si tu sais lancer une commande dans un terminal, tu peux suivre. Pour les setups de production auto-hébergés, va plutôt sur [Déploiement en production](/fr/self-hosted/install/linux-server).
+Bienvenue dans Tale. En tant que **Member**, tu as un accès en lecture seule à l'espace de travail de ton organisation : tu peux discuter avec des modèles IA et des agents, parcourir la base de connaissances et lire les conversations et approbations partagées avec toi. Les Editors et Developers de ton organisation créent le contenu ; les Members le consomment.
 
-## Prérequis
+Si tu dois aussi installer ou faire tourner une instance Tale toi-même, va voir [Démarrage rapide local](/fr/self-hosted/install/quickstart) ou [Déploiement en production](/fr/self-hosted/install/linux-server).
 
-| Logiciel       | Version minimale | Où l'obtenir                                   |
-| -------------- | ---------------- | ---------------------------------------------- |
-| Docker Desktop | 24.0+            | https://www.docker.com/products/docker-desktop |
+## Se connecter
 
-### Obtenir une clé API
+Rien à installer — Tale tourne entièrement dans le navigateur. Ton admin te fait entrer via l'une des trois méthodes, selon la configuration de ton organisation.
 
-Tale utilise OpenRouter comme passerelle IA par défaut, ce qui donne accès à des centaines de modèles via une seule clé API.
+- **E-mail et mot de passe.** Ton admin crée ton compte depuis **Paramètres → Membres** avec un mot de passe initial et te le transmet. Tu seras obligé·e de le changer à la première connexion.
+- **SSO (Microsoft Entra).** Connecte-toi avec ton compte Microsoft existant ; ton compte Tale est provisionné automatiquement à la première connexion.
+- **Reverse proxy (trusted headers).** Si Tale est derrière Authelia, Authentik, oauth2-proxy ou similaire, le proxy t'authentifie et ton compte est provisionné automatiquement à la première requête.
 
-1. Va sur https://openrouter.ai et crée un compte gratuit.
-2. Dans ton tableau de bord, va dans Keys et génère une nouvelle clé API.
-3. Copie la clé. Tu en auras besoin pendant l'installation.
+Si tu n'arrives pas à te connecter, demande à ton admin quelle méthode est activée. (Admins : voir [Authentification](/fr/self-hosted/admin/authentication) pour la configuration côté instance.)
 
-> **Astuce :** Tu peux utiliser n'importe quel fournisseur compatible OpenAI, y compris une instance Ollama locale. OpenRouter est la valeur par défaut recommandée pour la variété de modèles et sa tarification simple.
+## Ce que tu peux faire
 
-## Installation
+### Chat
 
-### Étape 1 : installer le CLI
+Lance une conversation depuis l'écran d'accueil. Choisis un modèle, écris un message, et réponds. La saisie du chat prend aussi en charge :
 
-**Linux / macOS :**
+- Joindre des fichiers (images, PDF, documents) — voir [pièces jointes](/fr/platform/chat/attachments).
+- Mentionner un agent créé par un Editor ou un Developer — voir [agents dans le chat](/fr/platform/chat/agents-in-chat).
+- Comparer deux modèles côte à côte avec le [Mode Arène](/fr/platform/chat/arena-mode).
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
-```
+Référence complète : [bases du chat](/fr/platform/chat/basics).
 
-**Windows (PowerShell) :**
+### Parcourir la base de connaissances
 
-```powershell
-irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
-```
+La base de connaissances contient les documents uploadés ou crawlés par ton organisation. Cherche-la, ouvre des documents et référence-les depuis le chat. En tant que Member, tu ne peux ni uploader ni supprimer — c'est le rôle des Editors. Voir [base de connaissances](/fr/platform/workspace/knowledge-base).
 
-Ou télécharge le binaire directement depuis [GitHub Releases](https://github.com/tale-project/tale/releases) :
+### Lire les conversations et approbations
 
-```bash
-# Linux
-curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
-  -o /usr/local/bin/tale
-chmod +x /usr/local/bin/tale
-```
+- **[Conversations](/fr/platform/workspace/conversations)** — threads de chat partagés par tes collègues.
+- **[Approbations](/fr/platform/workspace/approvals)** — sorties d'automatisations en attente de revue humaine. Les Members peuvent lire ; seuls les Editors et au-dessus décident.
 
-### Étape 2 : créer un projet
+## Personnaliser ton compte
 
-```bash
-tale init my-project
-cd my-project
-```
+Nom affiché, langue, thème et préférences de notification se règlent depuis le menu de l'avatar. Détails : [préférences](/fr/platform/member/preferences).
 
-Le CLI te demande ton domaine, ta clé API et le mode TLS. Les secrets de sécurité (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) sont générés automatiquement.
+## Aller plus loin ?
 
-> **Astuce :** Le CLI génère aussi des fichiers de configuration pour les éditeurs IA (Claude Code, Cursor, GitHub Copilot, Windsurf) et extrait le code source complet de la plateforme dans `.tale/reference/`. Ouvre ton projet dans l'un de ces éditeurs pour créer et modifier agents, workflows et intégrations en décrivant ce que tu veux en langage naturel. Voir [AI-assisted development](/fr/develop/ai-assisted-development).
-
-### Étape 3 : lancer Tale
-
-```bash
-tale start
-```
-
-Attends le message Ready :
-
-```text
-Tale Dev v0.x.x  Ready.
-```
-
-> **Note :** Le numéro de version varie. Tu verras des messages de health-check pendant que les services démarrent. C'est normal. Attends le message "Ready" avant d'ouvrir ton navigateur.
-
-### Étape 4 : ouvrir l'application
-
-Va sur https://localhost (ou ton domaine) dans ton navigateur. À la première ouverture, tu es dirigé vers une page d'inscription pour créer ton compte admin.
-
-## Usage quotidien
-
-### Démarrer et arrêter
-
-```bash
-tale start              # démarrer tous les services
-tale start --detach     # démarrer en arrière-plan
-```
-
-Pour arrêter tous les services en conservant tes données :
-
-```bash
-docker compose -p tale-dev down
-```
-
-Le flag `-p tale-dev` est requis parce que `tale start` crée un projet Compose nommé `tale-dev` au lieu d'utiliser un `docker-compose.yml` standard.
-
-> **Important :** Ne lance jamais `docker compose -p tale-dev down -v`. Le flag `-v` supprime tous les volumes Docker, ce qui efface définitivement ta base de données, tes documents et l'état du crawler.
-
-### Upgrade
-
-```bash
-tale upgrade            # mettre le CLI à jour et synchroniser les fichiers du projet
-```
-
-### Voir les données backend
-
-```bash
-tale convex admin       # générer une clé admin pour le Convex Dashboard
-```
-
-Ouvre `/convex-dashboard` dans ton navigateur et colle la clé pour inspecter la base de données, voir les logs des fonctions et gérer les tâches de fond.
-
-## Alternative : build depuis les sources
-
-Pour contribuer à Tale ou personnaliser le code, tu peux lancer depuis les sources au lieu des images pré-construites.
-
-```bash
-git clone https://github.com/tale-project/tale.git
-cd tale
-cp .env.example .env
-```
-
-Édite `.env` et remplis les valeurs requises :
-
-| Variable                | Comment la définir                          |
-| ----------------------- | ------------------------------------------- |
-| `BETTER_AUTH_SECRET`    | Générer avec : `openssl rand -base64 32`    |
-| `ENCRYPTION_SECRET_HEX` | Générer avec : `openssl rand -hex 32`       |
-| `DB_PASSWORD`           | Choisir un mot de passe pour la base locale |
-
-> **Important :** Le fichier `.env.example` contient des secrets d'exemple qu'il faut remplacer avant le premier démarrage.
-
-Ensuite build et start :
-
-```bash
-docker compose up --build
-```
-
-Les temps de build varient selon le service (les 5 services se construisent en parallèle en ~3 minutes sur un système moderne). Les builds suivants sont bien plus rapides grâce au cache des couches Docker.
-
-### Développement local avec hot-reload
-
-Pour un cycle édit-reload plus rapide pendant le dev, utilise l'override de développement :
-
-```bash
-docker compose -f compose.yml -f compose.dev.yml up --build
-```
-
-Tes répertoires sources locaux sont montés dans les conteneurs, donc les changements sont visibles immédiatement sans reconstruire les images.
-
-### Tests conteneurs
-
-Après modification des Dockerfiles ou dépendances, valide tes changements :
-
-```bash
-# Smoke test : build, start, health check, teardown
-bun run docker:test
-
-# Validation d'image : labels OCI, secrets, budgets de taille
-bun run docker:test:image
-
-# Scan de vulnérabilités (nécessite Trivy)
-bun run docker:test:vulnerability
-```
-
-Voir [Contributing Docker guide](/fr/develop/contributing-docker) pour plus de détails.
+Les Members sont en lecture seule. Pour créer des agents, modifier du savoir ou exécuter des automatisations, demande à ton admin une montée de rôle. La matrice complète des rôles est sur [Membres et rôles](/fr/platform/admin/members-and-roles).

--- a/docs/fr/self-hosted/install/linux-server.md
+++ b/docs/fr/self-hosted/install/linux-server.md
@@ -39,6 +39,24 @@ curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_li
 chmod +x /usr/local/bin/tale
 ```
 
+### Épingler une version précise
+
+Pour installer une version précise du CLI au lieu de la dernière release, définis la variable d'environnement `VERSION` sur l'installeur :
+
+```bash
+VERSION=0.9.0 curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+Ou télécharge le binaire directement avec le tag de version dans l'URL :
+
+```bash
+curl -fsSL https://github.com/tale-project/tale/releases/download/v0.9.0/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+Les versions disponibles sont sur la [page GitHub Releases](https://github.com/tale-project/tale/releases).
+
 ## Installation initiale
 
 ### Étape 1 : initialiser le répertoire
@@ -74,15 +92,37 @@ Le CLI tire les images pré-construites, démarre tous les services, attend les 
 
 ## Gérer les déploiements
 
-### Déployer une nouvelle version
+### Passer à une nouvelle version
+
+`tale deploy` déploie toujours la version du binaire CLI en cours, donc un upgrade se fait en deux étapes :
 
 ```bash
-tale deploy                # déployer la version courante du CLI
-tale deploy --dry-run      # prévisualiser sans déployer
-tale deploy --all          # mettre aussi à jour DB et proxy
+tale upgrade            # 1. mettre à jour le CLI vers la dernière release
+tale deploy             # 2. dérouler la nouvelle version
 ```
 
-`tale deploy` déploie toujours la version du CLI en cours. Pour passer à une version plus récente, `tale upgrade` d'abord puis `tale deploy`.
+#### Migrer ou redescendre vers une version précise
+
+```bash
+tale upgrade --version 0.9.0       # bascule le CLI vers v0.9.0 (montée ou descente)
+tale deploy                        # dérouler ensuite cette version
+```
+
+`--version` accepte `0.9.0` ou `v0.9.0`. Les downgrades sont autorisés, mais **les changements de schéma restent forward-only** — voir [Compatibilité de schéma et rollback](#compatibilité-de-schéma-et-rollback). Les versions disponibles sont sur la [page GitHub Releases](https://github.com/tale-project/tale/releases).
+
+#### Avant l'upgrade
+
+- Lis les [release notes](https://github.com/tale-project/tale/releases) pour les ruptures de compatibilité et les notes de migration.
+- Sauvegarde la base — le volume Postgres contient toutes les données plateforme et les fichiers uploadés.
+- Si l'instance est critique, teste l'upgrade sur une instance de staging d'abord. `tale init` dans un répertoire séparé sur un autre hôte te donne un stack isolé.
+
+### Déployer
+
+```bash
+tale deploy             # déployer la version courante du CLI
+tale deploy --dry-run   # prévisualiser sans déployer
+tale deploy --all       # mettre aussi à jour DB et proxy
+```
 
 ### Statut
 
@@ -103,8 +143,8 @@ tale logs db --tail 100
 ### Rollback
 
 ```bash
-tale rollback                      # revenir à la précédente
-tale rollback --version 0.9.0      # revenir à une version précise
+tale rollback                       # revenir à la précédente
+tale rollback --version 0.9.0       # revenir à une version précise
 ```
 
 > **Changements de schéma forward-only.** `tale rollback` n'échange que les images ; il ne **rollback pas** les données Convex. Voir [Compatibilité de schéma et rollback](#compatibilité-de-schéma-et-rollback).
@@ -112,8 +152,8 @@ tale rollback --version 0.9.0      # revenir à une version précise
 ### Nettoyage
 
 ```bash
-tale cleanup              # retirer les conteneurs inactifs
-tale reset --force        # retirer TOUS les conteneurs (demande confirmation)
+tale cleanup            # retirer les conteneurs inactifs
+tale reset --force      # retirer TOUS les conteneurs (demande confirmation)
 ```
 
 ## Zero-downtime
@@ -372,6 +412,18 @@ docker pull ghcr.io/tale-project/tale/tale-platform:1.2.0
 # Pull de la dernière release
 docker pull ghcr.io/tale-project/tale/tale-platform:latest
 ```
+
+### Épingler une version d'image
+
+`tale deploy` choisit les images selon la version du CLI. Pour verrouiller des images de service indépendamment — par exemple pour tester une seule image sans upgrader tout le stack — crée un `compose.override.yml` à côté de ton `.env` :
+
+```yaml
+services:
+  platform:
+    image: ghcr.io/tale-project/tale/tale-platform:1.2.0
+```
+
+`tale deploy` fusionne l'override automatiquement.
 
 ## Accès au Convex Dashboard
 

--- a/docs/fr/self-hosted/install/quickstart.md
+++ b/docs/fr/self-hosted/install/quickstart.md
@@ -1,0 +1,145 @@
+---
+title: Démarrage rapide local
+description: Faire tourner Tale en local avec Docker Desktop en une dizaine de minutes — pour évaluer, faire des démos ou contribuer.
+---
+
+C'est le chemin le plus rapide pour avoir une instance Tale qui tourne sur ton portable. Utilise ce démarrage rapide pour évaluer le produit, faire une démo ou développer contre la plateforme. Pour une instance publique avec TLS et upgrades sans interruption, suis plutôt le guide [déploiement en production](/fr/self-hosted/install/linux-server).
+
+## Prérequis
+
+| Logiciel       | Version minimale | Où l'obtenir                                   |
+| -------------- | ---------------- | ---------------------------------------------- |
+| Docker Desktop | 24.0+            | https://www.docker.com/products/docker-desktop |
+
+### Obtenir une clé API
+
+Tale utilise OpenRouter comme passerelle IA par défaut, ce qui donne accès à des centaines de modèles via une seule clé API.
+
+1. Va sur https://openrouter.ai et crée un compte gratuit.
+2. Dans ton tableau de bord, va dans **Keys** et génère une nouvelle clé API.
+3. Copie la clé — tu la colleras pendant l'installation.
+
+> **Astuce :** N'importe quel fournisseur compatible OpenAI fonctionne, y compris une instance Ollama locale. OpenRouter est la valeur par défaut recommandée pour la variété de modèles et sa tarification simple.
+
+## Installation
+
+### Étape 1 : installer le CLI
+
+**Linux / macOS :**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+**Windows (PowerShell) :**
+
+```powershell
+irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
+```
+
+> **Épingler une version précise :** Les deux installeurs respectent la variable d'environnement `VERSION`. Sur Linux/macOS : `VERSION=0.9.0 curl -fsSL …/install-cli.sh | bash`, sur Windows : `$env:VERSION = '0.9.0'; irm …/install-cli.ps1 | iex`. Les tags disponibles sont sur la [page GitHub Releases](https://github.com/tale-project/tale/releases).
+
+Ou télécharge le binaire directement — remplace `latest` par un tag (par exemple `v0.9.0`) pour épingler :
+
+```bash
+# Linux
+curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+### Étape 2 : créer un projet
+
+```bash
+tale init my-project
+cd my-project
+```
+
+Le CLI te demande ton domaine, ta clé API et le mode TLS. Les secrets de sécurité (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) sont générés automatiquement.
+
+> **Astuce :** `tale init` dépose aussi des fichiers de configuration pour les éditeurs IA (Claude Code, Cursor, GitHub Copilot, Windsurf) et extrait le code source de la plateforme dans `.tale/reference/`. Ouvre ton projet dans un de ces éditeurs pour créer et modifier agents, workflows et intégrations en langage naturel. Voir [AI-assisted development](/fr/develop/ai-assisted-development).
+
+### Étape 3 : lancer Tale
+
+```bash
+tale start
+```
+
+Attends `Tale Dev v0.x.x  Ready.` Les messages de health-check pendant le démarrage sont normaux — attends la ligne `Ready` avant d'ouvrir le navigateur.
+
+### Étape 4 : ouvrir l'application
+
+Va sur https://localhost (ou ton domaine configuré) dans le navigateur. À la première ouverture, tu es dirigé·e vers une page d'inscription pour créer ton compte admin.
+
+> **Avertissement de certificat auto-signé.** Le mode TLS `selfsigned` génère un certificat local, donc le navigateur affiche un avertissement de connexion non privée à la première visite. Passe outre (Chrome : **Paramètres avancés → Continuer**, Firefox : **Avancé → Accepter le risque**). Pour un déploiement public, choisis `letsencrypt` lors de `tale init` ou suis le guide [déploiement en production](/fr/self-hosted/install/linux-server).
+
+## Usage quotidien
+
+### Démarrer et arrêter
+
+```bash
+tale start              # démarrer tous les services
+tale start --detach     # démarrer en arrière-plan
+```
+
+Pour arrêter en conservant les données :
+
+```bash
+# Arrête les conteneurs mais conserve les volumes (tes données).
+# Ne jamais ajouter -v : ça supprime base, uploads et état du crawler — aucune récupération possible.
+docker compose -p tale-dev down
+```
+
+Le flag `-p tale-dev` est requis parce que `tale start` utilise ce nom de projet Compose au lieu d'un `docker-compose.yml` standard.
+
+### Upgrade
+
+```bash
+tale upgrade                       # mettre à jour vers la dernière release et synchroniser les fichiers
+tale upgrade --version 0.9.0       # migrer ou redescendre vers une version précise
+tale start                         # redémarrer avec la nouvelle version
+```
+
+Les ruptures de compatibilité sont signalées dans les [release notes](https://github.com/tale-project/tale/releases).
+
+### Inspecter les données backend
+
+```bash
+tale convex admin       # génère une clé admin pour le Convex Dashboard
+```
+
+Ouvre `/convex-dashboard` dans le navigateur et colle la clé pour inspecter la base de données, voir les logs des fonctions et gérer les tâches de fond.
+
+## Alternative : build depuis les sources
+
+Pour contribuer à Tale ou personnaliser le code, lance depuis les sources au lieu des images pré-construites.
+
+```bash
+git clone https://github.com/tale-project/tale.git
+cd tale
+cp .env.example .env
+```
+
+Édite `.env` et remplace les valeurs d'exemple :
+
+| Variable                | Comment la définir                  |
+| ----------------------- | ----------------------------------- |
+| `BETTER_AUTH_SECRET`    | `openssl rand -base64 32`           |
+| `ENCRYPTION_SECRET_HEX` | `openssl rand -hex 32`              |
+| `DB_PASSWORD`           | Un mot de passe pour la base locale |
+
+> **Important :** `.env.example` contient des secrets d'exemple qu'il faut remplacer avant le premier démarrage.
+
+Ensuite build et start :
+
+```bash
+docker compose up --build
+```
+
+Pour un cycle édit-reload plus rapide, utilise l'override de développement, qui monte tes répertoires sources locaux dans les conteneurs :
+
+```bash
+docker compose -f compose.yml -f compose.dev.yml up --build
+```
+
+Après modification des Dockerfiles ou dépendances, lance `bun run docker:test` pour un smoke-test du build. Le [guide Contributing Docker](/fr/develop/contributing-docker) couvre la validation d'images et les scripts de scan de vulnérabilités.

--- a/docs/platform/integrations/overview.md
+++ b/docs/platform/integrations/overview.md
@@ -1,15 +1,17 @@
 ---
 title: Integrations overview
-description: Connect Tale to REST APIs, SQL databases, email, and cloud storage.
+description: Connect Tale to REST APIs and SQL databases through developer-defined connectors.
 ---
 
-Integrations let Tale talk to external systems. Developers configure them once; agents, automations, and the chat assistant then use them to read and write data in those systems. Configuration lives in **Settings > Integrations** and requires the Developer role or higher.
+An integration is a developer-defined connector that exposes a remote system's capabilities — REST endpoints or SQL queries — as a fixed set of named operations. Once installed, those operations are tools the chat assistant, agents, and automation steps can call by name with typed parameters. Configuration lives in **Settings > Integrations** and requires the Developer role or higher; consumers just call the operations the connector publishes.
+
+The platform supports two connector types: `rest_api` for HTTP services and `sql` for direct database access. Anything else listed under **Settings > Integrations** in the UI — e-mail mailboxes, Microsoft OneDrive, API keys for the Tale API itself — is a related connection that uses its own configuration surface, not the connector model. Those are covered at the bottom of this page.
 
 ## Integration types
 
 ### REST API
 
-Connect any HTTP-based API by entering the base URL and credentials. Supported authentication methods:
+REST connectors wrap any HTTP-based service. The connector's manifest lists the supported authentication methods and the hosts it is allowed to reach; sandboxed connector code handles each operation. Supported authentication methods:
 
 | Method           | How it works                                             |
 | ---------------- | -------------------------------------------------------- |
@@ -18,28 +20,64 @@ Connect any HTTP-based API by entering the base URL and credentials. Supported a
 | **Basic auth**   | Username and password, base64-encoded.                   |
 | **OAuth 2.0**    | Authorization-code flow with automatic token refresh.    |
 
-Once added, the integration exposes each configured endpoint as a tool the AI agent can call. See [Create an agent](/platform/agents/create) for how to grant tool access.
+The `allowedHosts` field in the manifest acts as a network allow-list — the connector can only reach the hosts it declares. See [Create an agent](/platform/agents/create) for how to grant an agent access to an integration's operations.
 
 ### SQL
 
-Connect a PostgreSQL, MySQL, or Microsoft SQL Server database. The AI agent and automations can query it using plain language that is translated to SQL against the schema you've registered.
+SQL connectors connect to PostgreSQL, MySQL, or Microsoft SQL Server. The agent does **not** write SQL freehand. Instead, the integration's manifest registers a fixed list of named operations, each with a pre-written query and a parameter schema; the agent picks an operation and supplies values for the placeholders. Read-only credentials are still strongly recommended, because write operations and approval gates only constrain what the connector publishes — they do not constrain what the database account itself is allowed to do.
 
-Read-only credentials are strongly recommended — queries the AI generates are executed as-is against the database.
+## Operations
 
-### E-mail (conversations)
+Every integration exposes a list of operations. An operation has a `name` (the identifier the agent calls), a `description` (what it does and when to use it), a `parametersSchema` (a JSON Schema describing inputs), an optional `operationType` of `read` or `write`, and an optional `requiresApproval` flag. The agent picks an operation by name and supplies validated parameters; it never composes ad-hoc HTTP calls or SQL. This is how a connector stays predictable: a new operation only exists if a developer adds it to the manifest.
 
-Connect an IMAP + SMTP mailbox to power the [Conversations](/platform/workspace/conversations) inbox. Incoming e-mails become conversation threads. Replies sent from the platform are delivered as normal e-mail responses.
+## Read, write, and approvals
 
-### Microsoft OneDrive
+Operations marked `operationType: write` default to requiring approval before they execute. When an agent or automation invokes such an operation, an approval card appears in the chat — a human accepts or rejects it, and only on accept does the call run. See [Approvals](/platform/workspace/approvals) for the full flow. Use this for billing actions, mass e-mail, production data writes, and anything else where you want a human in the loop. Read operations execute directly with no approval step.
 
-Connect a Microsoft 365 account to enable OneDrive document sync. Users can then import files from OneDrive directly into the knowledge base without downloading them to their device first. See [Knowledge base](/platform/workspace/knowledge-base).
+## Authentication and secrets
+
+The manifest's `secretBindings` array names the credential keys a connector reads at runtime via `secrets.get('<key>')`. When you connect the integration in **Settings > Integrations**, the UI prompts for exactly those keys and stores the values encrypted at rest, scoped to your organisation. OAuth 2.0 connectors use the standard authorisation-code flow, store both access and refresh tokens, and refresh access tokens automatically when they expire. SQL connectors store the database server, port, database name, username, and password in the same encrypted store.
+
+## Setup guide and test connection
+
+Connectors can ship a Markdown `setupGuide` that the platform renders under **Configuration guide** in the manage dialog — use it to point users at where to generate the API key, which OAuth scopes to grant, or what database role to create. After credentials are entered, **Test connection** invokes the connector's lightweight `testConnection` hook before saving; a failed test surfaces the connector's error message inline so users can fix the credentials without leaving the dialog.
+
+## Bundled examples
+
+The repository ships thirteen ready-to-use connectors at [github.com/tale-project/tale/tree/main/examples/integrations](https://github.com/tale-project/tale/tree/main/examples/integrations). Fork one as the starting point for a custom connector against the same vendor, or install one as-is.
+
+| Example          | Type     | Auth         | What it covers                                                     |
+| ---------------- | -------- | ------------ | ------------------------------------------------------------------ |
+| **AI image**     | rest_api | bearer_token | Image generation against OpenAI-compatible providers.              |
+| **Circuly**      | rest_api | basic_auth   | Products, customers, and subscriptions in Circuly.                 |
+| **Discord**      | rest_api | bearer_token | Guilds, channels, and messages via the Discord Bot API.            |
+| **GitHub**       | rest_api | bearer_token | Repositories, issues, pull requests, and code search.              |
+| **Gmail**        | rest_api | oauth2       | Messages, labels, threads, and drafts in Gmail.                    |
+| **Google Drive** | rest_api | oauth2       | Sync files from Drive folders into Tale documents.                 |
+| **Outlook**      | rest_api | oauth2       | Mail, calendar, and contacts via Microsoft Graph.                  |
+| **Protel**       | sql      | basic_auth   | Direct SQL access to a Protel hotel PMS — reservations and folios. |
+| **Shopify**      | rest_api | api_key      | Products, customers, and orders in the Shopify Admin API.          |
+| **Slack**        | rest_api | oauth2       | Channels, messages, users, and file uploads.                       |
+| **Tavily**       | rest_api | api_key      | Open-web search and page extraction tuned for LLM agents.          |
+| **Teams**        | rest_api | oauth2       | Teams, channels, messages, and chats via Microsoft Graph.          |
+| **Twilio**       | rest_api | basic_auth   | SMS, voice calls, and phone-number management.                     |
+
+## Install or build a custom integration
+
+There are two ways to install a connector. Both end up with the same `config.json` plus connector code on the server.
+
+**Upload from the UI.** Open **Settings > Integrations**, click **Add integration**, then drop a `.zip` package or select `config.json`, the connector source (`connector.ts` or `connector.js`), and an icon individually. The total upload is capped at 1 MB. After upload, fill in credentials and click **Test connection**.
+
+**Author as project code.** A project scaffolded by `tale init` has an `integrations/` directory; each subdirectory is one connector (`integrations/<slug>/{config.json, connector.ts, icon.svg}`). The platform live-reloads on save, so iterating is the same as editing any other source file. The full file format and sandbox API are documented in [Build an integration](/develop/integrations); for AI-assisted authoring inside an editor, see [AI-assisted development](/develop/ai-assisted-development).
+
+## Related connections
+
+A few other items live under **Settings > Integrations** for discoverability but are not `rest_api` or `sql` connectors — they have their own configuration surfaces.
+
+**E-mail (Conversations inbox).** Connect an IMAP+SMTP mailbox to power the [Conversations](/platform/workspace/conversations) inbox. Incoming e-mails become threads; replies sent from the platform are delivered as normal e-mails. Configured separately from connectors.
+
+**Microsoft OneDrive.** Connect a Microsoft 365 account so users can import OneDrive files directly into the [knowledge base](/platform/workspace/knowledge-base) without downloading them first. Configured through the knowledge-base import flow, not as a connector.
 
 ## API keys
 
-Generate API keys for programmatic access to the Tale API. Keys inherit the permissions of the user who created them, scoped to that user's role. Keys can be revoked at any time from **Settings > Integrations > API keys**.
-
-For endpoint details see the [API reference](/develop/api-reference).
-
-## Approvals
-
-Integrations can require approval before each operation. When an agent or automation triggers an integration call, an approval card appears in the chat — see [Approvals](/platform/workspace/approvals). This is useful for destructive or expensive operations (billing actions, mass e-mails, production data changes).
+API keys grant programmatic access to the Tale API itself. They live under **Settings > Integrations > API keys** because that is the same admin surface, not because they are connectors. Each key inherits the role of the user who created it; revoke at any time from the same screen. Endpoint details are in the [API reference](/develop/api-reference).

--- a/docs/platform/member/overview.md
+++ b/docs/platform/member/overview.md
@@ -1,164 +1,47 @@
 ---
-title: Getting started
-description: Install Tale and open the app — a friendly walkthrough for your first 10 minutes.
+title: Getting started as a Member
+description: Sign in, chat, browse the knowledge base, and read shared conversations and approvals — the day-one orientation for Members.
 ---
 
-This is the fastest way to go from nothing to a running Tale instance. You don't need to be a developer — if you can run a command in a terminal, you can follow along. For self-hosted production setups, see [Production deployment](/self-hosted/install/linux-server) instead.
+Welcome to Tale. As a **Member** you have read-only access to your organisation's workspace: you can chat with AI models and agents, browse the knowledge base, and read conversations and approvals shared with you. Editors and Developers in your org create the content; Members consume it.
 
-## Prerequisites
+If you also need to install or run a Tale instance yourself, see [Local quickstart](/self-hosted/install/quickstart) or [Production deployment](/self-hosted/install/linux-server).
 
-| Software       | Minimum version | Where to get it                                |
-| -------------- | --------------- | ---------------------------------------------- |
-| Docker Desktop | 24.0+           | https://www.docker.com/products/docker-desktop |
+## Sign in
 
-### Get an API key
+There is nothing to install — Tale runs entirely in the browser. Your admin gets you in via one of three methods, depending on how your organisation is configured.
 
-Tale uses OpenRouter as its default AI gateway, which gives you access to hundreds of models through a single API key.
+- **Email and password.** Your admin creates the account from **Settings → Members** with an initial password and shares it with you. You will be required to change it on first sign-in.
+- **SSO (Microsoft Entra).** Sign in with your existing Microsoft account; your Tale account is provisioned automatically the first time.
+- **Reverse proxy (trusted headers).** If Tale sits behind Authelia, Authentik, oauth2-proxy, or similar, the proxy authenticates you and your account is auto-provisioned on first request.
 
-1. Go to https://openrouter.ai and create a free account.
-2. Navigate to Keys in your account dashboard and generate a new API key.
-3. Copy the key. You will need it during setup.
+If you cannot sign in, ask your admin which method is enabled. (Admins: see [authentication](/self-hosted/admin/authentication) for the instance-wide configuration.)
 
-> **Tip:** You can use any OpenAI-compatible provider, including a local Ollama instance. OpenRouter is the recommended default for its model variety and simple pricing.
+## What you can do
 
-## Setup
+### Chat
 
-### Step 1: Install the CLI
+Start a conversation from the home screen. Pick a model, type a message, and reply. The chat input also supports:
 
-**Linux / macOS:**
+- Attaching files (images, PDFs, docs) — see [attachments](/platform/chat/attachments).
+- Mentioning an agent created by an Editor or Developer — see [agents in chat](/platform/chat/agents-in-chat).
+- Comparing two models side-by-side in [Arena Mode](/platform/chat/arena-mode).
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
-```
+Full feature reference: [chat basics](/platform/chat/basics).
 
-**Windows (PowerShell):**
+### Browse the knowledge base
 
-```powershell
-irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
-```
+The knowledge base holds documents your org has uploaded or crawled. Search it, open documents, and reference them from chat. As a Member you cannot upload or delete — that is an Editor task. See [knowledge base](/platform/workspace/knowledge-base).
 
-Or download the binary directly from [GitHub Releases](https://github.com/tale-project/tale/releases):
+### Read conversations and approvals
 
-```bash
-# Linux
-curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
-  -o /usr/local/bin/tale
-chmod +x /usr/local/bin/tale
-```
+- **[Conversations](/platform/workspace/conversations)** — shared chat threads from teammates.
+- **[Approvals](/platform/workspace/approvals)** — outputs from automations awaiting human review. Members can read; only Editors and above can decide.
 
-### Step 2: Create a project
+## Personalise your account
 
-```bash
-tale init my-project
-cd my-project
-```
+Set your display name, language, theme, and notification preferences from the avatar menu. Details: [preferences](/platform/member/preferences).
 
-The CLI prompts for your domain, API key, and TLS mode. Security secrets (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) are generated automatically.
+## Want to do more?
 
-> **Tip:** The CLI also generates configuration files for AI-powered editors (Claude Code, Cursor, GitHub Copilot, Windsurf) and extracts the full platform source code to `.tale/reference/`. Open your project in any of these editors to create and edit agents, workflows, and integrations by describing what you want in natural language. See [AI-assisted development](/develop/ai-assisted-development) for details.
-
-### Step 3: Start Tale
-
-```bash
-tale start
-```
-
-Wait for the ready message:
-
-```text
-Tale Dev v0.x.x  Ready.
-```
-
-> **Note:** The version number will vary. You will see a stream of health check messages while services are starting. Those are normal. Wait for the "Ready" message before opening your browser.
-
-### Step 4: Open the app
-
-Go to https://localhost (or your configured domain) in your browser. The first time you open it, you will be taken to a sign-up page to create your admin account.
-
-## Daily workflow
-
-### Starting and stopping
-
-```bash
-tale start              # Start all services
-tale start --detach     # Start in background
-```
-
-To stop all services while keeping your data:
-
-```bash
-docker compose -p tale-dev down
-```
-
-The `-p tale-dev` flag is required because `tale start` creates a compose project named `tale-dev` rather than using a standard `docker-compose.yml` file.
-
-> **Important:** Never run `docker compose -p tale-dev down -v`. The `-v` flag deletes all Docker volumes, which permanently erases your database, uploaded documents, crawler state, and all platform data. There is no recovery from this.
-
-### Upgrading
-
-```bash
-tale upgrade            # Upgrade CLI and sync project files
-```
-
-### Viewing backend data
-
-```bash
-tale convex admin       # Generate admin key for the Convex Dashboard
-```
-
-Open `/convex-dashboard` in your browser and paste the key to inspect the database, view function logs, and manage background jobs.
-
-## Alternative: build from source
-
-If you want to contribute to Tale or customize the platform code, you can run from source instead of using pre-built images.
-
-```bash
-git clone https://github.com/tale-project/tale.git
-cd tale
-cp .env.example .env
-```
-
-Edit `.env` and fill in the required values:
-
-| Variable                | How to fill it in                          |
-| ----------------------- | ------------------------------------------ |
-| `BETTER_AUTH_SECRET`    | Generate with: `openssl rand -base64 32`   |
-| `ENCRYPTION_SECRET_HEX` | Generate with: `openssl rand -hex 32`      |
-| `DB_PASSWORD`           | Choose any password for the local database |
-
-> **Important:** The `.env.example` file ships with example secrets that must be replaced before starting.
-
-Then build and start:
-
-```bash
-docker compose up --build
-```
-
-Build times vary by service (all 5 services build in ~3 minutes in parallel on a modern system). Subsequent builds are much faster thanks to Docker layer caching.
-
-### Local development with hot-reload
-
-For a faster edit-reload cycle during development, use the development override:
-
-```bash
-docker compose -f compose.yml -f compose.dev.yml up --build
-```
-
-This mounts your local source directories into the containers so changes are reflected immediately without rebuilding images.
-
-### Running container tests
-
-After modifying Dockerfiles or dependencies, validate your changes:
-
-```bash
-# Smoke test: build, start, health check, tear down
-bun run docker:test
-
-# Image validation: OCI labels, secrets, size budgets
-bun run docker:test:image
-
-# Vulnerability scan (requires trivy installed)
-bun run docker:test:vulnerability
-```
-
-See [Contributing Docker guide](/develop/contributing-docker) for more details.
+Members are read-only. To create agents, edit knowledge, or run automations, ask your admin to upgrade your role. The full role matrix is on [Members and roles](/platform/admin/members-and-roles).

--- a/docs/self-hosted/install/linux-server.md
+++ b/docs/self-hosted/install/linux-server.md
@@ -23,7 +23,7 @@ Tale pulls pre-built images from GitHub Container Registry. Here are the current
 | DB       | `ghcr.io/tale-project/tale/tale-db`       | ~1.1 GB |
 | Proxy    | `ghcr.io/tale-project/tale/tale-proxy`    | ~88 MB  |
 
-> **Tip:** First pull downloads ~4.4 GB total (compressed). Subsequent updates only download changed layers. Sizes shown are post-Phase-2 (split-Convex) — the Platform image is significantly smaller now that the Convex backend lives in its own service.
+> **Tip:** First pull downloads ~4.4 GB total (compressed). Subsequent updates only download changed layers.
 
 ## Installing the Tale CLI
 
@@ -40,6 +40,24 @@ curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_li
   -o /usr/local/bin/tale
 chmod +x /usr/local/bin/tale
 ```
+
+### Pin to a specific version
+
+To install a specific CLI version instead of the latest release, set the `VERSION` environment variable on the installer:
+
+```bash
+VERSION=0.9.0 curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+Or download the binary directly with the version tag in the URL:
+
+```bash
+curl -fsSL https://github.com/tale-project/tale/releases/download/v0.9.0/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+Available versions are listed on the [GitHub Releases](https://github.com/tale-project/tale/releases) page.
 
 ## Initial setup
 
@@ -76,22 +94,37 @@ The CLI pulls pre-built images, starts all services, waits for health checks, an
 
 ## Managing deployments
 
-### Deploy a new version
+### Upgrade to a new version
+
+`tale deploy` always deploys the version of the CLI binary you are running, so an upgrade is two steps:
 
 ```bash
-# Deploy the current CLI version
-tale deploy
-
-# Preview changes without deploying
-tale deploy --dry-run
-
-# Also update infrastructure services (db, proxy)
-tale deploy --all
+tale upgrade            # 1. Update the CLI to the latest release
+tale deploy             # 2. Roll the new version out
 ```
 
-`tale deploy` always deploys the version of the CLI you are running. To
-move to a newer release, run `tale upgrade` first to update the CLI,
-then `tale deploy`.
+#### Migrate or downgrade to a specific version
+
+```bash
+tale upgrade --version 0.9.0       # Switch the CLI to v0.9.0 (up or down)
+tale deploy                        # Then roll that version out
+```
+
+`--version` accepts `0.9.0` or `v0.9.0`. Downgrades are allowed but **forward-only schema changes still apply** — see [Schema compatibility and rollback](#schema-compatibility-and-rollback). Available versions are listed on the [GitHub Releases](https://github.com/tale-project/tale/releases) page.
+
+#### Before upgrading
+
+- Read the [release notes](https://github.com/tale-project/tale/releases) for breaking changes and migration notes.
+- Back up the database — the Postgres volume holds all platform data and uploaded files.
+- If the instance is production-critical, test the upgrade on a staging instance first. Running `tale init` in a separate directory on another host gives you an isolated stack.
+
+### Deploy
+
+```bash
+tale deploy             # Deploy the current CLI version
+tale deploy --dry-run   # Preview changes without deploying
+tale deploy --all       # Also update infrastructure services (db, proxy)
+```
 
 ### Check status
 
@@ -112,26 +145,17 @@ tale logs db --tail 100
 ### Rollback
 
 ```bash
-# Rollback to the previous version
-tale rollback
-
-# Rollback to a specific version
-tale rollback --version 0.9.0
+tale rollback                       # Roll back to the previous version
+tale rollback --version 0.9.0       # Roll back to a specific version
 ```
 
-> **Forward-only schema changes.** `tale rollback` reverts container
-> images only; it does **not** roll back Convex data or indexes. See
-> [Schema compatibility and rollback](#schema-compatibility-and-rollback)
-> for what to watch out for.
+> **Forward-only schema changes.** `tale rollback` reverts container images only; it does **not** roll back Convex data or indexes. See [Schema compatibility and rollback](#schema-compatibility-and-rollback) for what to watch out for.
 
 ### Cleanup
 
 ```bash
-# Remove inactive containers
-tale cleanup
-
-# Remove ALL containers (requires confirmation)
-tale reset --force
+tale cleanup            # Remove inactive containers
+tale reset --force      # Remove ALL containers (requires confirmation)
 ```
 
 ## Zero-downtime deployment
@@ -405,6 +429,18 @@ docker pull ghcr.io/tale-project/tale/tale-platform:1.2.0
 # Pull the latest release
 docker pull ghcr.io/tale-project/tale/tale-platform:latest
 ```
+
+### Pin a specific image version
+
+`tale deploy` selects images based on the CLI version. To lock individual service images independently — for example, to test a single new image without upgrading the whole stack — create `compose.override.yml` next to your `.env`:
+
+```yaml
+services:
+  platform:
+    image: ghcr.io/tale-project/tale/tale-platform:1.2.0
+```
+
+`tale deploy` merges the override automatically.
 
 ## Convex dashboard access
 

--- a/docs/self-hosted/install/quickstart.md
+++ b/docs/self-hosted/install/quickstart.md
@@ -1,0 +1,145 @@
+---
+title: Local quickstart
+description: Run Tale locally with Docker Desktop in about ten minutes — for evaluation, demos, and contributing.
+---
+
+This is the fastest way to get a local Tale instance running on your laptop. Use this quickstart to evaluate the product, run a demo, or develop against the platform. For a public-facing instance with TLS and zero-downtime upgrades, follow the [production deployment](/self-hosted/install/linux-server) guide instead.
+
+## Prerequisites
+
+| Software       | Minimum version | Where to get it                                |
+| -------------- | --------------- | ---------------------------------------------- |
+| Docker Desktop | 24.0+           | https://www.docker.com/products/docker-desktop |
+
+### Get an API key
+
+Tale uses OpenRouter as its default AI gateway, which gives you access to hundreds of models through a single API key.
+
+1. Go to https://openrouter.ai and create a free account.
+2. Navigate to **Keys** in your account dashboard and generate a new API key.
+3. Copy the key — you will paste it during setup.
+
+> **Tip:** Any OpenAI-compatible provider works, including a local Ollama instance. OpenRouter is the recommended default for its model variety and simple pricing.
+
+## Setup
+
+### Step 1: Install the CLI
+
+**Linux / macOS:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
+```
+
+> **Pin a specific version:** Both installers honor a `VERSION` environment variable. Run `VERSION=0.9.0 curl -fsSL …/install-cli.sh | bash` on Linux/macOS, or `$env:VERSION = '0.9.0'; irm …/install-cli.ps1 | iex` on Windows. Available tags are on the [GitHub Releases](https://github.com/tale-project/tale/releases) page.
+
+Or download the binary directly — replace `latest` with a tag (e.g. `v0.9.0`) to pin:
+
+```bash
+# Linux
+curl -fsSL https://github.com/tale-project/tale/releases/latest/download/tale_linux \
+  -o /usr/local/bin/tale
+chmod +x /usr/local/bin/tale
+```
+
+### Step 2: Create a project
+
+```bash
+tale init my-project
+cd my-project
+```
+
+The CLI prompts for your domain, API key, and TLS mode. Security secrets (`BETTER_AUTH_SECRET`, `ENCRYPTION_SECRET_HEX`) are generated automatically.
+
+> **Tip:** `tale init` also drops configuration files for AI-powered editors (Claude Code, Cursor, GitHub Copilot, Windsurf) and extracts the platform source to `.tale/reference/`. Open the project in any of these editors to create and edit agents, workflows, and integrations in natural language. See [AI-assisted development](/develop/ai-assisted-development).
+
+### Step 3: Start Tale
+
+```bash
+tale start
+```
+
+Wait for `Tale Dev v0.x.x  Ready.` Health-check messages while services boot are normal — wait for the `Ready` line before opening your browser.
+
+### Step 4: Open the app
+
+Go to https://localhost (or your configured domain). The first visit takes you to a sign-up page to create your admin account.
+
+> **Self-signed certificate warning.** The default `selfsigned` TLS mode generates a local certificate, so your browser will show a "Your connection is not private" warning the first time. Click through (Chrome: **Advanced → Proceed**, Firefox: **Advanced → Accept the Risk**). For a public deployment, choose `letsencrypt` during `tale init` or follow the [production deployment](/self-hosted/install/linux-server) guide.
+
+## Daily workflow
+
+### Start and stop
+
+```bash
+tale start              # Start all services
+tale start --detach     # Start in background
+```
+
+To stop while keeping your data:
+
+```bash
+# Stops containers but keeps volumes (your data).
+# Never add -v: it deletes the database, uploads, crawler state — there is no recovery.
+docker compose -p tale-dev down
+```
+
+The `-p tale-dev` flag is required because `tale start` uses that compose project name rather than a standard `docker-compose.yml`.
+
+### Upgrade
+
+```bash
+tale upgrade                       # Update to the latest release and sync project files
+tale upgrade --version 0.9.0       # Migrate or downgrade to a specific version
+tale start                         # Restart with the new version
+```
+
+Breaking changes are called out in the [release notes](https://github.com/tale-project/tale/releases).
+
+### Inspect backend data
+
+```bash
+tale convex admin       # Generate an admin key for the Convex Dashboard
+```
+
+Open `/convex-dashboard` in your browser and paste the key to inspect the database, view function logs, and manage background jobs.
+
+## Alternative: build from source
+
+If you want to contribute to Tale or customize the platform, run from source instead of pulling pre-built images.
+
+```bash
+git clone https://github.com/tale-project/tale.git
+cd tale
+cp .env.example .env
+```
+
+Edit `.env` and replace the example values:
+
+| Variable                | How to fill it in                   |
+| ----------------------- | ----------------------------------- |
+| `BETTER_AUTH_SECRET`    | `openssl rand -base64 32`           |
+| `ENCRYPTION_SECRET_HEX` | `openssl rand -hex 32`              |
+| `DB_PASSWORD`           | Any password for the local database |
+
+> **Important:** `.env.example` ships with placeholder secrets that must be replaced before starting.
+
+Then build and start:
+
+```bash
+docker compose up --build
+```
+
+For a faster edit-reload cycle, use the development override which mounts your local source into the containers:
+
+```bash
+docker compose -f compose.yml -f compose.dev.yml up --build
+```
+
+After modifying Dockerfiles or dependencies, run `bun run docker:test` to smoke-test the build. See the [Contributing Docker guide](/develop/contributing-docker) for image validation and vulnerability scan scripts.

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -1,47 +1,27 @@
-# Tale CLI Installer for Windows
-# Usage: irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
+# Tale CLI installer for Windows.
+#
+# Usage:           irm https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.ps1 | iex
+# Pin a version:   $env:VERSION = '0.9.0'; irm ... | iex
+#
+# Mirrors scripts/install-cli.sh (the Linux/macOS installer) function for
+# function and message for message — keep them in sync when changing either.
 
 $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $Repo = "tale-project/tale"
 $BinaryName = "tale.exe"
-$InstallDir = "$env:LOCALAPPDATA\Programs\tale"
+$Platform = "windows"
+$DefaultInstallDir = "$env:LOCALAPPDATA\Programs\tale"
+$RequestedVersion = $env:VERSION
 
+# Colored log helpers — info=cyan, success=green, error=red (then exit 1).
 function Write-Info { param($msg) Write-Host $msg -ForegroundColor Cyan }
 function Write-Ok { param($msg) Write-Host $msg -ForegroundColor Green }
 function Write-Err { param($msg) Write-Host "Error: $msg" -ForegroundColor Red; exit 1 }
 
-# Detect existing installation
-$existing = Get-Command tale -ErrorAction SilentlyContinue
-if ($existing) {
-    $existingDir = Split-Path $existing.Source
-    Write-Info "Found existing installation at $existingDir"
-    $InstallDir = $existingDir
-}
-
-# Find latest release that has the CLI binary asset
-# This handles the window where a release exists but CLI binaries haven't been uploaded yet
-Write-Info "Fetching latest version with CLI binary..."
-$tag = $null
-try {
-    $releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases" -Headers @{ "User-Agent" = "tale-installer/1.0" }
-    foreach ($rel in $releases) {
-        if ($rel.assets.name -contains "tale_windows.exe") {
-            $tag = $rel.tag_name
-            break
-        }
-    }
-} catch {
-    Write-Err "Failed to fetch releases. $_"
-}
-if (-not $tag) { Write-Err "No release found with tale_windows.exe binary" }
-Write-Info "Latest version: $tag"
-
-# Download binary
-$url = "https://github.com/$Repo/releases/download/$tag/tale_windows.exe"
-$tempFile = Join-Path $env:TEMP "tale_download_$([guid]::NewGuid()).tmp"
-
+# Format a byte count for the download progress display. (PowerShell-specific —
+# the bash script lets curl --progress-bar handle this.)
 function Format-FileSize {
     param([long]$bytes)
     if ($bytes -ge 1MB) { return "{0:N1} MB" -f ($bytes / 1MB) }
@@ -49,105 +29,207 @@ function Format-FileSize {
     return "$bytes B"
 }
 
-$httpClient = $null
-$response = $null
-$stream = $null
-$fileStream = $null
-try {
+# Stream a URL to a file with a visible progress bar, then announce completion.
+# ResponseHeadersRead avoids buffering the whole body in memory and lets us
+# track progress as bytes flow in.
+function Download-File {
+    param($url, $dest)
     Write-Info "Downloading from $url"
+
     Add-Type -AssemblyName System.Net.Http -ErrorAction SilentlyContinue
     $httpClient = New-Object System.Net.Http.HttpClient
     $httpClient.DefaultRequestHeaders.Add("User-Agent", "tale-installer/1.0")
     $httpClient.Timeout = [timespan]::FromMinutes(10)
-    $response = $httpClient.GetAsync($url, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
-    [void]$response.EnsureSuccessStatusCode()
 
-    $totalBytes = $response.Content.Headers.ContentLength
-    $stream = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
-    $fileStream = [System.IO.File]::Create($tempFile)
+    $response = $null
+    $stream = $null
+    $fileStream = $null
+    $downloadOk = $false
+    try {
+        $response = $httpClient.GetAsync($url, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+            [void]$response.EnsureSuccessStatusCode()
+        }
 
-    $buffer = [byte[]]::new(65536)
-    $totalRead = [long]0
-    $lastUpdate = [datetime]::MinValue
-    $bytesRead = 0
+        $totalBytes = $response.Content.Headers.ContentLength
+        $stream = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+        $fileStream = [System.IO.File]::Create($dest)
 
-    while (($bytesRead = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
-        $fileStream.Write($buffer, 0, $bytesRead)
-        $totalRead += $bytesRead
-        $now = [datetime]::UtcNow
-        if (($now - $lastUpdate).TotalMilliseconds -ge 250) {
-            $lastUpdate = $now
-            $received = Format-FileSize $totalRead
-            if ($totalBytes) {
-                $total = Format-FileSize $totalBytes
-                $pct = [math]::Floor($totalRead * 100 / $totalBytes)
-                Write-Host ("`r  {0} / {1} ({2}%)   " -f $received, $total, $pct) -NoNewline -ForegroundColor Cyan
-            } else {
-                Write-Host ("`r  {0} downloaded   " -f $received) -NoNewline -ForegroundColor Cyan
+        $buffer = [byte[]]::new(65536)
+        $totalRead = [long]0
+        $lastUpdate = [datetime]::MinValue
+        $bytesRead = 0
+
+        while (($bytesRead = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            $fileStream.Write($buffer, 0, $bytesRead)
+            $totalRead += $bytesRead
+            # Throttle redraws to ~4 fps so the spinner doesn't flood the terminal.
+            $now = [datetime]::UtcNow
+            if (($now - $lastUpdate).TotalMilliseconds -ge 250) {
+                $lastUpdate = $now
+                $received = Format-FileSize $totalRead
+                if ($totalBytes) {
+                    $total = Format-FileSize $totalBytes
+                    $pct = [math]::Floor($totalRead * 100 / $totalBytes)
+                    Write-Host ("`r  {0} / {1} ({2}%)   " -f $received, $total, $pct) -NoNewline -ForegroundColor Cyan
+                } else {
+                    Write-Host ("`r  {0} downloaded   " -f $received) -NoNewline -ForegroundColor Cyan
+                }
             }
         }
-    }
 
-    # Validate download integrity
-    if ($totalBytes -and $totalRead -ne $totalBytes) {
-        throw "Download incomplete: received $(Format-FileSize $totalRead) of $(Format-FileSize $totalBytes)"
-    }
-    if ($totalRead -eq 0) {
-        throw "Download failed: received 0 bytes"
-    }
+        # Validate download integrity before we hand the file to install_binary.
+        if ($totalBytes -and $totalRead -ne $totalBytes) {
+            throw "Download incomplete: received $(Format-FileSize $totalRead) of $(Format-FileSize $totalBytes)"
+        }
+        if ($totalRead -eq 0) {
+            throw "Download failed: received 0 bytes"
+        }
 
-    # Final progress line
-    $received = Format-FileSize $totalRead
-    if ($totalBytes) {
-        $total = Format-FileSize $totalBytes
-        Write-Host ("`r  {0} / {1} (100%)   " -f $received, $total) -NoNewline -ForegroundColor Cyan
-    }
-    Write-Host ""
-    Write-Ok "Download complete"
-    $downloadOk = $true
-} catch {
-    $errMsg = if ($_.Exception.InnerException) { $_.Exception.InnerException.Message } else { "$_" }
-    Write-Err "Failed to download: $errMsg"
-} finally {
-    if ($null -ne $fileStream) { $fileStream.Dispose() }
-    if ($null -ne $stream) { $stream.Dispose() }
-    if ($null -ne $response) { $response.Dispose() }
-    if ($null -ne $httpClient) { $httpClient.Dispose() }
-    if (-not $downloadOk -and (Test-Path $tempFile)) {
-        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+        # Snap the progress line to 100% so it doesn't end mid-update.
+        $received = Format-FileSize $totalRead
+        if ($totalBytes) {
+            $total = Format-FileSize $totalBytes
+            Write-Host ("`r  {0} / {1} (100%)   " -f $received, $total) -NoNewline -ForegroundColor Cyan
+        }
+        Write-Host ""
+        Write-Ok "Download complete"
+        $downloadOk = $true
+    } catch {
+        $errMsg = if ($_.Exception.InnerException) { $_.Exception.InnerException.Message } else { "$_" }
+        Write-Err "Failed to download: $errMsg"
+    } finally {
+        if ($null -ne $fileStream) { $fileStream.Dispose() }
+        if ($null -ne $stream) { $stream.Dispose() }
+        if ($null -ne $response) { $response.Dispose() }
+        if ($null -ne $httpClient) { $httpClient.Dispose() }
+        if (-not $downloadOk -and (Test-Path $dest)) {
+            Remove-Item $dest -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 
-# Ensure install directory exists
-if (-not (Test-Path $InstallDir)) {
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-}
-
-# Move binary to install directory
-$dest = Join-Path $InstallDir $BinaryName
-Move-Item -Path $tempFile -Destination $dest -Force
-
-# Add to user PATH if not already present
-$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($userPath -notlike "*$InstallDir*") {
-    $newPath = "$userPath;$InstallDir"
-    if ($newPath.Length -gt 8192) {
-        Write-Err "User PATH would exceed 8192 characters. Manually add $InstallDir to your PATH."
+# Find the first release whose assets include our platform binary.
+function Get-LatestTag {
+    $assetName = "tale_${Platform}.exe"
+    try {
+        $releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases" -Headers @{ "User-Agent" = "tale-installer/1.0" }
+    } catch {
+        Write-Err "Failed to fetch releases. $_"
     }
-    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-    $env:Path = "$env:Path;$InstallDir"
-    Write-Info "Added $InstallDir to user PATH."
+    foreach ($rel in $releases) {
+        if ($rel.assets.name -contains $assetName) {
+            return $rel.tag_name
+        }
+    }
+    Write-Err "No release found with $assetName binary"
 }
 
-# Verify
-try {
-    $version = & $dest --version 2>&1
-    Write-Ok "Tale CLI installed successfully! ($version)"
-} catch {
-    Write-Ok "Tale CLI installed to $dest"
+# Pick the install directory. If `tale` is already on PATH, replace it in
+# place; otherwise default to %LOCALAPPDATA%\Programs\tale. Sets $script:InstallDir
+# and $script:ExistingTale for later consumers.
+function Detect-InstallDir {
+    $script:ExistingTale = Get-Command tale -ErrorAction SilentlyContinue
+    if ($script:ExistingTale) {
+        $script:InstallDir = Split-Path $script:ExistingTale.Source
+        Write-Info "Found existing installation at $script:InstallDir"
+    } else {
+        $script:InstallDir = $DefaultInstallDir
+    }
 }
 
-Write-Ok "Run 'tale --help' to get started."
-if (-not $existing) {
-    Write-Info "Restart your terminal for PATH changes to take effect."
+# Decide which tag to install: $env:VERSION (with optional "v" prefix) when
+# set, otherwise the result of Get-LatestTag.
+function Resolve-Tag {
+    if (-not $RequestedVersion) {
+        return Get-LatestTag
+    }
+    # Accept "v0.9.0" or "0.9.0" — release tags are prefixed with "v".
+    if ($RequestedVersion.StartsWith("v")) { return $RequestedVersion }
+    return "v$RequestedVersion"
 }
+
+# Pre-flight HEAD probe. Fails fast with a friendly message when the user
+# pinned a non-existent VERSION, instead of letting the binary download error
+# out halfway through.
+function Verify-ReleaseExists {
+    param($url)
+    try {
+        Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -MaximumRedirection 5 `
+            -Headers @{ "User-Agent" = "tale-installer/1.0" } -ErrorAction Stop | Out-Null
+    } catch {
+        $statusCode = $null
+        if ($_.Exception.Response) { $statusCode = [int]$_.Exception.Response.StatusCode }
+        if ($statusCode -eq 404) {
+            Write-Err "Version $RequestedVersion not found. See https://github.com/$Repo/releases for available versions."
+        }
+        # Other transient errors will surface during the actual download.
+    }
+}
+
+# Orchestrate: resolve tag → verify (when pinned) → download → move into
+# place → ensure the install directory is on the user PATH.
+function Install-Binary {
+    $tag = Resolve-Tag
+    if ($RequestedVersion) {
+        Write-Info "Pinned version: $tag"
+    } else {
+        Write-Info "Latest version: $tag"
+    }
+
+    $binaryUrl = "https://github.com/$Repo/releases/download/$tag/tale_${Platform}.exe"
+    $tmpFile = Join-Path $env:TEMP "tale_download_$([guid]::NewGuid()).tmp"
+
+    if ($RequestedVersion) { Verify-ReleaseExists $binaryUrl }
+
+    Download-File $binaryUrl $tmpFile
+
+    if (-not (Test-Path $script:InstallDir)) {
+        New-Item -ItemType Directory -Path $script:InstallDir -Force | Out-Null
+    }
+    $script:DestPath = Join-Path $script:InstallDir $BinaryName
+    Move-Item -Path $tmpFile -Destination $script:DestPath -Force
+
+    # Add the install directory to the user PATH so `tale` resolves in new shells.
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$script:InstallDir*") {
+        $newPath = "$userPath;$script:InstallDir"
+        # Windows truncates user PATH at 8192 chars; refuse to silently corrupt it.
+        if ($newPath.Length -gt 8192) {
+            Write-Err "User PATH would exceed 8192 characters. Manually add $script:InstallDir to your PATH."
+        }
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        $env:Path = "$env:Path;$script:InstallDir"
+        Write-Info "Added $script:InstallDir to user PATH."
+    }
+}
+
+# Smoke-test the freshly installed binary by running --version. The version
+# string is folded into the success message when available.
+function Verify-Installation {
+    if (-not (Test-Path $script:DestPath)) {
+        Write-Err "Installation failed. tale not found at $script:DestPath"
+    }
+    try {
+        $version = & $script:DestPath --version 2>&1
+        Write-Ok "Successfully installed tale ($version)"
+    } catch {
+        Write-Ok "Successfully installed tale"
+    }
+}
+
+function Main {
+    Write-Info "Installing Tale CLI..."
+    Write-Info "Detected platform: $Platform"
+
+    Detect-InstallDir
+    Install-Binary
+    Verify-Installation
+
+    Write-Ok "Run 'tale --help' to get started."
+    if (-not $script:ExistingTale) {
+        Write-Info "Restart your terminal for PATH changes to take effect."
+    }
+}
+
+Main

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
+# Tale CLI installer for Linux and macOS.
+#
+# Usage:           curl -fsSL https://raw.githubusercontent.com/tale-project/tale/main/scripts/install-cli.sh | bash
+# Pin a version:   VERSION=0.9.0 curl -fsSL ... | bash
+#
+# Mirrors scripts/install-cli.ps1 (the Windows installer) function for function
+# and message for message — keep them in sync when changing either.
+
 set -euo pipefail
 
 REPO="tale-project/tale"
 BINARY_NAME="tale"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 
-info() { printf "\033[1;34m%s\033[0m\n" "$1"; }
+# Colored log helpers — info=cyan, success=green, error=red (then exit 1).
+info() { printf "\033[1;36m%s\033[0m\n" "$1"; }
 success() { printf "\033[1;32m%s\033[0m\n" "$1"; }
 error() { printf "\033[1;31mError: %s\033[0m\n" "$1" >&2; exit 1; }
 
+# Map `uname -s` to the platform suffix used in our release asset names
+# (tale_linux, tale_macos). Sets the $PLATFORM global.
 detect_platform() {
     local os
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -20,6 +31,9 @@ detect_platform() {
     esac
 }
 
+# Ensure curl or wget is available. curl is preferred — both the GitHub API
+# fetch and the HEAD probe in verify_release_exists have a cleaner curl path.
+# Sets the $DOWNLOADER global.
 check_dependencies() {
     if command -v curl &>/dev/null; then
         DOWNLOADER="curl"
@@ -30,16 +44,25 @@ check_dependencies() {
     fi
 }
 
-download() {
+# Stream a URL to a file with a visible progress bar, then announce completion.
+# wget --show-progress is preferred when available; fall back to plain quiet
+# mode on ancient wgets that don't recognize the flag.
+download_file() {
     local url=$1 dest=$2
     info "Downloading from $url"
     if [ "$DOWNLOADER" = "curl" ]; then
-        curl -fsSL "$url" -o "$dest"
+        curl -fL --progress-bar "$url" -o "$dest"
+    elif wget --help 2>&1 | grep -q -- --show-progress; then
+        wget -q --show-progress "$url" -O "$dest"
     else
         wget -q "$url" -O "$dest"
     fi
+    success "Download complete"
 }
 
+# Find the first release whose assets include our platform binary. Walks the
+# JSON line-by-line: remembers the most recent tag_name and prints it the
+# moment the expected asset filename appears in the same release block.
 get_latest_tag() {
     local api_url="https://api.github.com/repos/${REPO}/releases"
     local asset_name="${BINARY_NAME}_${PLATFORM}"
@@ -53,9 +76,6 @@ get_latest_tag() {
 
     [ -z "$releases_json" ] && error "Failed to fetch releases"
 
-    # Find first release that has our platform binary in its assets.
-    # Iterates the JSON line-by-line: remembers the most recent tag_name,
-    # and prints it on the first occurrence of the expected asset filename.
     local tag=""
     tag=$(echo "$releases_json" | sed -n '/"tag_name"/{ s/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/; h; }; /'"$asset_name"'/{ g; p; q; }')
 
@@ -63,29 +83,80 @@ get_latest_tag() {
     echo "$tag"
 }
 
+# Pick the install directory. If `tale` is already on PATH, replace it in
+# place; otherwise default to /usr/local/bin. Sets the $INSTALL_DIR global.
 detect_install_dir() {
     local existing
     existing=$(command -v "$BINARY_NAME" 2>/dev/null || true)
     if [ -n "$existing" ]; then
         INSTALL_DIR=$(dirname "$existing")
+        info "Found existing installation at ${INSTALL_DIR}"
     else
         INSTALL_DIR="$DEFAULT_INSTALL_DIR"
     fi
 }
 
+# Decide which tag to install: $VERSION (with optional "v" prefix) when set,
+# otherwise the result of get_latest_tag.
+resolve_tag() {
+    local requested="${VERSION:-}"
+    if [ -z "$requested" ]; then
+        get_latest_tag
+        return
+    fi
+
+    # Accept "v0.9.0" or "0.9.0" — release tags are prefixed with "v".
+    case "$requested" in
+        v*) echo "$requested" ;;
+        *)  echo "v${requested}" ;;
+    esac
+}
+
+# Pre-flight HEAD probe. Fails fast with a friendly message when the user
+# pinned a non-existent VERSION, instead of letting the binary download error
+# out halfway through. Also surfaces network errors before we kick off the
+# (potentially slow) full download.
+verify_release_exists() {
+    local url=$1
+    local http_code="000"
+    if [ "$DOWNLOADER" = "curl" ]; then
+        http_code=$(curl -sIL -o /dev/null -w "%{http_code}" "$url" || echo "000")
+    else
+        # wget --spider sends a HEAD; --server-response prints status lines to
+        # stderr. Tolerate non-2xx exits so we can inspect 404 explicitly.
+        local response
+        response=$(wget --spider --server-response --max-redirect=5 "$url" 2>&1) || true
+        http_code=$(printf '%s\n' "$response" | awk '/^[[:space:]]*HTTP\// {code=$2} END {print (code==""?"000":code)}')
+    fi
+    if [ "$http_code" = "404" ]; then
+        error "Version ${VERSION} not found. See https://github.com/${REPO}/releases for available versions."
+    fi
+    if [ "$http_code" = "000" ]; then
+        error "Could not reach ${url} to verify version ${VERSION}. Check your network connection or try again later."
+    fi
+}
+
+# Orchestrate: resolve tag → verify (when pinned) → download → chmod → move
+# into place (with sudo if the install directory isn't writable).
 install_binary() {
     local binary_url tmp_file tag
 
     tmp_dir=$(mktemp -d)
     trap 'rm -rf "$tmp_dir"' EXIT
 
-    tag=$(get_latest_tag)
-    info "Latest version: ${tag}"
+    tag=$(resolve_tag)
+    if [ -n "${VERSION:-}" ]; then
+        info "Pinned version: ${tag}"
+    else
+        info "Latest version: ${tag}"
+    fi
 
     binary_url="https://github.com/${REPO}/releases/download/${tag}/${BINARY_NAME}_${PLATFORM}"
     tmp_file="${tmp_dir}/${BINARY_NAME}"
 
-    download "$binary_url" "$tmp_file"
+    [ -n "${VERSION:-}" ] && verify_release_exists "$binary_url"
+
+    download_file "$binary_url" "$tmp_file"
     chmod +x "$tmp_file"
 
     if [ -w "$INSTALL_DIR" ]; then
@@ -96,10 +167,17 @@ install_binary() {
     fi
 }
 
+# Smoke-test the freshly installed binary by running --version. The version
+# string is folded into the success message when available.
 verify_installation() {
     if command -v "$BINARY_NAME" &>/dev/null; then
-        success "Successfully installed ${BINARY_NAME}"
-        "$BINARY_NAME" --version 2>/dev/null || true
+        local version
+        version=$("$BINARY_NAME" --version 2>/dev/null || true)
+        if [ -n "$version" ]; then
+            success "Successfully installed ${BINARY_NAME} (${version})"
+        else
+            success "Successfully installed ${BINARY_NAME}"
+        fi
     else
         error "Installation failed. ${BINARY_NAME} not found in PATH"
     fi
@@ -116,7 +194,7 @@ main() {
     install_binary
     verify_installation
 
-    success "Run 'tale --help' to get started"
+    success "Run 'tale --help' to get started."
 }
 
 main

--- a/tools/cli/src/commands/upgrade/index.ts
+++ b/tools/cli/src/commands/upgrade/index.ts
@@ -6,7 +6,13 @@ import * as logger from '../../utils/logger';
 export function createUpgradeCommand(): Command {
   return new Command('upgrade')
     .alias('update')
-    .description('Upgrade CLI to the latest version and sync project files')
+    .description(
+      'Upgrade or migrate the CLI to a specific version, then sync project files',
+    )
+    .option(
+      '-v, --version <version>',
+      'install this exact version (e.g. 0.9.0) instead of the latest release; allows downgrades',
+    )
     .option(
       '-f, --force',
       'force re-download and overwrite locally modified files',
@@ -17,12 +23,14 @@ export function createUpgradeCommand(): Command {
     )
     .action(
       async (opts: {
+        version?: string;
         force?: boolean;
         dryRun?: boolean;
         internalSyncOnly?: boolean;
       }) => {
         try {
           await upgrade({
+            version: opts.version,
             force: opts.force,
             dryRun: opts.dryRun,
             internalSyncOnly: opts.internalSyncOnly,

--- a/tools/cli/src/lib/actions/upgrade.ts
+++ b/tools/cli/src/lib/actions/upgrade.ts
@@ -17,9 +17,16 @@ const SUPPORTED_TARGETS: Record<string, string> = {
 };
 
 interface UpgradeOptions {
+  /** Install this exact version (e.g. "0.9.0" or "v0.9.0") instead of latest. */
+  version?: string;
   force?: boolean;
   dryRun?: boolean;
   internalSyncOnly?: boolean;
+}
+
+function normalizeTag(input: string): string {
+  const trimmed = input.trim();
+  return trimmed.startsWith('v') ? trimmed : `v${trimmed}`;
 }
 
 interface ReleaseInfo {
@@ -133,6 +140,50 @@ async function fetchLatestReadyRelease(
   });
 
   return { release: best, skipped };
+}
+
+async function fetchReleaseByTag(
+  asset: string,
+  tag: string,
+): Promise<ReleaseInfo> {
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${encodeURIComponent(tag)}`;
+  const response = await fetch(url, {
+    headers: {
+      ...getAuthHeaders(),
+      'User-Agent': `tale-cli/${pkg.version}`,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (response.status === 404) {
+    throw new Error(
+      `Release ${tag} not found. See https://github.com/${GITHUB_REPO}/releases for available versions.`,
+    );
+  }
+  if (response.status === 403) {
+    throw new Error(
+      'GitHub API returned 403. This may be rate limiting or an auth issue. ' +
+        'Set GITHUB_TOKEN or GH_TOKEN for higher limits.',
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch release ${tag}: GitHub API returned ${response.status}.`,
+    );
+  }
+
+  const entry = (await response.json()) as Record<string, unknown>;
+  const release = parseRelease(entry);
+  if (!release) {
+    throw new Error(`Release ${tag} has no valid version metadata.`);
+  }
+  if (!release.assetNames.includes(asset)) {
+    throw new Error(
+      `Release ${tag} does not include the ${asset} binary for this platform. ` +
+        `Check https://github.com/${GITHUB_REPO}/releases/tag/${tag} for available assets.`,
+    );
+  }
+  return release;
 }
 
 function getAssetName(): string {
@@ -353,27 +404,40 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
   requireProject();
 
   const prefix = options.dryRun ? '[DRY-RUN] ' : '';
-  logger.header(`${prefix}Upgrading Tale CLI`);
+  const pinnedVersion = options.version;
+  logger.header(
+    pinnedVersion
+      ? `${prefix}Migrating Tale CLI to ${pinnedVersion}`
+      : `${prefix}Upgrading Tale CLI`,
+  );
 
-  // Phase 1: Version check
+  // Phase 1: Resolve target release (latest, or pinned)
   const asset = getAssetName();
-  logger.step(`${prefix}Checking for updates...`);
   let release: ReleaseInfo;
-  let skipped: string[];
-  try {
-    ({ release, skipped } = await fetchLatestReadyRelease(asset));
-  } catch (err) {
-    throw new Error(
-      `Could not check for updates. ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
+  let skipped: string[] = [];
+  if (pinnedVersion) {
+    const tag = normalizeTag(pinnedVersion);
+    logger.step(`${prefix}Looking up release ${tag}...`);
+    release = await fetchReleaseByTag(asset, tag);
+  } else {
+    logger.step(`${prefix}Checking for updates...`);
+    try {
+      ({ release, skipped } = await fetchLatestReadyRelease(asset));
+    } catch (err) {
+      throw new Error(
+        `Could not check for updates. ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
   }
 
   const currentVersion = pkg.version;
   const comparison = compareVersions(release.version, currentVersion);
 
   logger.info(`Current version: ${currentVersion}`);
-  if (skipped.length > 0) {
+  if (pinnedVersion) {
+    logger.info(`Target version:  ${release.version}`);
+  } else if (skipped.length > 0) {
     logger.info(
       `Latest version:  ${skipped[0].replace(/^v/, '')} (binary not yet available)`,
     );
@@ -386,12 +450,26 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
     logger.info(`Latest version:  ${release.version}`);
   }
 
+  if (pinnedVersion && comparison < 0) {
+    logger.warn(
+      `Downgrading from ${currentVersion} to ${release.version}. ` +
+        `Schema changes from the newer version persist in the database — see the rollback notes in the docs.`,
+    );
+  }
+
   const isDevBuild = currentVersion.includes('dev');
-  const needsBinaryUpgrade = isDevBuild || comparison > 0 || options.force;
+  // When pinnedVersion, always replace unless the user is already on the exact target.
+  const needsBinaryUpgrade = pinnedVersion
+    ? comparison !== 0 || isDevBuild || options.force
+    : isDevBuild || comparison > 0 || options.force;
 
   if (!needsBinaryUpgrade) {
-    logger.success(`CLI is up to date (v${currentVersion})`);
-    if (skipped.length > 0) {
+    logger.success(
+      pinnedVersion
+        ? `CLI is already on v${currentVersion}`
+        : `CLI is up to date (v${currentVersion})`,
+    );
+    if (!pinnedVersion && skipped.length > 0) {
       logger.info(
         `Note: ${skipped[0].replace(/^v/, '')} is available but binary not yet uploaded — re-run 'tale upgrade' later.`,
       );


### PR DESCRIPTION
## Summary

- **CLI installers (`scripts/install-cli.{sh,ps1}`):** honor a `VERSION` env var to pin a specific release (downgrades included), surface 404s with a friendly message, and add a pre-flight HEAD probe so a bad pin fails fast. The two scripts are now mirrored function-for-function.
- **`tale upgrade` command:** new `--version <tag>` flag to migrate (or downgrade) to an exact release, plus a warning when downgrading that schema changes from the newer version persist in the database.
- **Docs:** new `self-hosted/install/quickstart.md` (Docker Desktop, ~10 min) for evaluation/dev, and new `develop/integrations.md` covering `config.json`, `connector.ts`, and the sandbox API. Reframed `platform/member/overview.md` as a Member-role orientation (it was an installer guide before), and reworked `platform/integrations/overview.md` around the connector model with a bundled-examples table. Translated to `de/`, `fr/`. Footer "Getting started" link now points at the new quickstart.

## Test plan

- [ ] `bun run check` passes (formatting, lint, typecheck, all 2994 platform tests)
- [ ] `bun run --filter @tale/docs lint` passes (oxlint + Mintlify broken-link checker)
- [ ] Manual: run the bash installer with `VERSION=0.9.0` and confirm the pinned-version banner + 404 path
- [ ] Manual: run the PowerShell installer with `$env:VERSION = '0.9.0'` and confirm the same flow
- [ ] Manual: `tale upgrade --version 0.9.0` from a newer build → confirm the downgrade warning and that the binary actually rolls back
- [ ] Spot-check the new `quickstart` and `develop/integrations` pages render in the en/de/fr nav

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no UI-string changes).
- [x] Updated `docs/{,de/,fr/}` for every user-visible change.
- [x] Ran `bun run --filter @tale/docs lint`.
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A (no top-level README-relevant changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for building custom integrations with REST and SQL operations
  * New local quickstart guide for self-hosted deployment with Docker Desktop
  * Expanded integration overview documentation with operation definitions and examples
  * Updated Member role guidance clarifying read-only access and capabilities

* **New Features**
  * CLI now supports version pinning during installation and upgrades

* **Chores**
  * Updated VS Code extension recommendations
  * Enhanced CLI installer robustness and error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->