### PR TITLE
fix(platform): grant org owner role delete permission

### DIFF
--- a/services/platform/convex/auth.test.ts
+++ b/services/platform/convex/auth.test.ts
@@ -36,6 +36,7 @@ vi.mock('better-auth/plugins/access', () => ({
 vi.mock('better-auth/plugins/organization/access', () => ({
   defaultStatements: {},
   adminAc: { statements: {} },
+  ownerAc: { statements: {} },
 }));
 
 vi.mock('@convex-dev/better-auth/plugins', () => ({

--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -9,6 +9,7 @@ import { createAccessControl } from 'better-auth/plugins/access';
 import {
   defaultStatements,
   adminAc,
+  ownerAc,
 } from 'better-auth/plugins/organization/access';
 
 import { isRecord, getString } from '../lib/utils/type-guards';
@@ -206,7 +207,31 @@ const disabled = ac.newRole({
   mcpServers: [],
 });
 
-const owner = admin;
+const owner = ac.newRole({
+  ...ownerAc.statements,
+
+  agents: ['read', 'write'],
+  documents: ['read', 'write'],
+  products: ['read', 'write'],
+  customers: ['read', 'write'],
+  vendors: ['read', 'write'],
+  integrations: ['read', 'write'],
+  onedriveSyncConfigs: ['read', 'write'],
+  conversations: ['read', 'write'],
+  conversationMessages: ['read', 'write'],
+  wfDefinitions: ['read', 'write'], // @deprecated — DB table deprecated; permission for legacy data access only
+  wfStepDefs: ['read', 'write'], // @deprecated — DB table deprecated; permission for legacy data access only
+  wfStepAuditLogs: ['read', 'write'], // @deprecated — DB table deprecated; permission for legacy data access only
+  wfExecutions: ['read', 'write'],
+  workflowProcessingRecords: ['read', 'write'],
+  approvals: ['read', 'write'],
+  websites: ['read', 'write'],
+  auditLogs: ['read', 'write'],
+  governancePolicies: ['read', 'write'],
+  promptTemplates: ['read', 'write'],
+  messageFeedback: ['read', 'write'],
+  mcpServers: ['read', 'write'],
+});
 
 export const platformRoles = {
   owner,


### PR DESCRIPTION
## Summary

- The `owner` role in `services/platform/convex/auth.ts` was aliased to `admin`, which spreads Better Auth's `adminAc.statements` (`organization: ["update"]` — no `delete`).
- Org creators get `creatorRole: 'owner'`, so when they tried to delete their own org, Better Auth's `POST /api/auth/organization/delete` returned `403 Forbidden — You are not allowed to delete this organization`.
- Switch `owner` to a distinct role that spreads `ownerAc.statements` (`organization: ["update", "delete"]` plus full member/invitation/team/ac control) while keeping the same platform-resource permissions as `admin`. `admin` is unchanged and retains `organization: ["update"]` only — preserving the intended owner-vs-admin distinction.

Regressed in `fbce1b49c` (#786), which switched `creatorRole` to `'owner'` and aliased `owner = admin`.

## Test plan

- [ ] `bun run check` passes
- [ ] As a user who created a non-default org, click Delete in the org switcher — succeeds, `POST /api/auth/organization/delete` returns 200, success toast shown, navigation to `/dashboard/switching` (or `/dashboard/create-organization` if it was the last non-default org)
- [ ] An org member with role `admin` (not `owner`) does not see the delete button (frontend gate at `organization-list-panel.tsx:138`); a direct API call would still 403
- [ ] `@default` org delete remains blocked by the frontend slug gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated owner role access control configuration to use dedicated permissions settings instead of inheriting from admin role, ensuring appropriate authorization levels for owner-level users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->