### PR TITLE
fix(platform): treat NoProviderAvailableError as terminal in failover

### DIFF
--- a/services/platform/convex/providers/errors.test.ts
+++ b/services/platform/convex/providers/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   isTransientProviderError,
+  NoProviderAvailableError,
   ProviderUnavailableError,
   shouldFailoverToNextModel,
 } from './errors';
@@ -132,6 +133,46 @@ describe('shouldFailoverToNextModel', () => {
     ).toBe(false);
   });
 
+  it('returns false for NoProviderAvailableError (no_providers)', () => {
+    expect(
+      shouldFailoverToNextModel(
+        new NoProviderAvailableError('no providers', 'no_providers', [
+          'directory missing',
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for NoProviderAvailableError (missing_api_key)', () => {
+    expect(
+      shouldFailoverToNextModel(
+        new NoProviderAvailableError('no key', 'missing_api_key', [
+          'openrouter: ENOENT secrets',
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for NoProviderAvailableError (load_failed)', () => {
+    expect(
+      shouldFailoverToNextModel(
+        new NoProviderAvailableError('load failed', 'load_failed', [
+          'openrouter: parse error',
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for cross-action serialized NoProviderAvailableError', () => {
+    // Convex `ctx.runAction()` reserializes thrown errors as plain Error
+    // whose message is prefixed "Uncaught <ClassName>: ...". The class
+    // identity is lost, so detection has to fall back to message matching.
+    const serialized = new Error(
+      'Uncaught NoProviderAvailableError: No API key is configured for this organization yet. Open Settings → AI providers and add one to start chatting.\n    at loadAllProviders (../../convex/providers/file_actions.ts:145:6)',
+    );
+    expect(shouldFailoverToNextModel(serialized)).toBe(false);
+  });
+
   // --- Should failover: transient errors (superset) ---
 
   it('returns true for 429 (rate limit)', () => {
@@ -248,5 +289,19 @@ describe('ProviderUnavailableError', () => {
     expect(err.model).toBe('test/model');
     expect(err.statusCode).toBe(502);
     expect(err.name).toBe('ProviderUnavailableError');
+  });
+});
+
+describe('NoProviderAvailableError', () => {
+  it('stores reason and details', () => {
+    const err = new NoProviderAvailableError(
+      'no key configured',
+      'missing_api_key',
+      ['openrouter: ENOENT secrets'],
+    );
+    expect(err.reason).toBe('missing_api_key');
+    expect(err.details).toEqual(['openrouter: ENOENT secrets']);
+    expect(err.name).toBe('NoProviderAvailableError');
+    expect(err.message).toBe('no key configured');
   });
 });

--- a/services/platform/convex/providers/errors.ts
+++ b/services/platform/convex/providers/errors.ts
@@ -25,6 +25,27 @@ export class ProviderUnavailableError extends Error {
   }
 }
 
+/**
+ * User-facing error thrown when no usable AI provider can be loaded for an
+ * org. The condition is org-wide — every fallback model would hit the same
+ * empty provider list — so callers should treat this as terminal and not
+ * walk the fallback chain.
+ */
+export class NoProviderAvailableError extends Error {
+  readonly reason: 'missing_api_key' | 'no_providers' | 'load_failed';
+  readonly details: string[];
+  constructor(
+    message: string,
+    reason: 'missing_api_key' | 'no_providers' | 'load_failed',
+    details: string[] = [],
+  ) {
+    super(message);
+    this.name = 'NoProviderAvailableError';
+    this.reason = reason;
+    this.details = details;
+  }
+}
+
 const TRANSIENT_STATUS_CODES = new Set([429, 502, 503, 504]);
 
 /**
@@ -133,12 +154,6 @@ const RESOLUTION_ERROR_PATTERNS = [
 export function shouldFailoverToNextModel(error: unknown): boolean {
   if (error === null || error === undefined) return false;
 
-  // All transient errors are failoverable (superset).
-  if (isTransientProviderError(error) !== null) return true;
-
-  // Explicit provider-unavailable errors always qualify.
-  if (error instanceof ProviderUnavailableError) return true;
-
   // Extract properties from the error object.
   const isObject = (val: unknown): val is Record<string, unknown> =>
     val !== null && typeof val === 'object';
@@ -155,6 +170,25 @@ export function shouldFailoverToNextModel(error: unknown): boolean {
   const message = (
     typeof err.message === 'string' ? err.message : ''
   ).toLowerCase();
+
+  // Org has no usable provider at all — every fallback model would hit the
+  // same empty provider list. Surface the actionable error immediately
+  // instead of walking the chain. Match by class name AND by message
+  // pattern: Convex's ctx.runAction() reserializes thrown errors as plain
+  // Error whose message is prefixed "Uncaught NoProviderAvailableError: ...",
+  // so `instanceof` alone misses cross-action throws.
+  if (
+    error instanceof NoProviderAvailableError ||
+    message.includes('noprovideravailableerror')
+  ) {
+    return false;
+  }
+
+  // All transient errors are failoverable (superset).
+  if (isTransientProviderError(error) !== null) return true;
+
+  // Explicit provider-unavailable errors always qualify.
+  if (error instanceof ProviderUnavailableError) return true;
 
   // Exclude universal errors that would fail on any model.
   if (NO_FAILOVER_PATTERNS.some((p) => message.includes(p))) return false;

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -22,6 +22,7 @@ import { authComponent } from '../auth';
 import { deriveAgePublicKey } from '../lib/age_keygen';
 import { atomicWrite, readJsonFile, sha256 } from '../lib/file_io';
 import { decryptSecretsFile } from '../lib/sops';
+import { NoProviderAvailableError } from './errors';
 import type { ProviderJson, ProviderReadResult } from './file_utils';
 import {
   MAX_FILE_SIZE_BYTES,
@@ -63,27 +64,6 @@ interface ProviderWithSecrets {
   name: string;
   config: ProviderJson;
   secrets: ProviderSecrets;
-}
-
-/**
- * User-facing error thrown when no usable AI provider can be loaded.
- * Carries a friendly message plus structured context so the chat UI can
- * surface actionable guidance (e.g. a link to Settings → Providers) and
- * operators can still find filesystem details in logs.
- */
-export class NoProviderAvailableError extends Error {
-  readonly reason: 'missing_api_key' | 'no_providers' | 'load_failed';
-  readonly details: string[];
-  constructor(
-    message: string,
-    reason: 'missing_api_key' | 'no_providers' | 'load_failed',
-    details: string[] = [],
-  ) {
-    super(message);
-    this.name = 'NoProviderAvailableError';
-    this.reason = reason;
-    this.details = details;
-  }
 }
 
 const FRIENDLY_NO_PROVIDER =


### PR DESCRIPTION
## Summary
- Move `NoProviderAvailableError` from `providers/file_actions.ts` to `providers/errors.ts` so the failover predicate can reference it without a circular import.
- Short-circuit `shouldFailoverToNextModel` for `NoProviderAvailableError`: the condition is org-wide (no API key / no providers / load failed), so walking the fallback chain would hit the same empty provider list on every model.
- Also match by message pattern (`noprovideravailableerror`) — Convex's `ctx.runAction()` reserializes thrown errors as plain `Error` with an `"Uncaught NoProviderAvailableError: ..."` prefix, so `instanceof` alone misses cross-action throws.

## Test plan
- [ ] `bun run check`
- [ ] `npx vitest run services/platform/convex/providers/errors.test.ts` — new cases cover all three reasons plus the cross-action serialized form
- [ ] Manual: with no provider configured, confirm chat surfaces the friendly "Open Settings → AI providers" message instead of cycling through fallback models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of provider unavailability errors to prevent unnecessary fallback attempts when no usable AI providers are available.

* **Refactor**
  * Consolidated provider error definitions into a centralized errors module for better code organization.

* **Tests**
  * Expanded test coverage for provider unavailability scenarios and error serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->