### PR TITLE
fix(platform): stop subscription leaks and access bypass on deleted-org threads

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -333,7 +333,7 @@ export function ChatInterface({
   // Thread status — disable input for archived threads
   // Always check the URL threadId (root thread), not dataThreadId (which may
   // be a branch thread that wasn't individually archived).
-  const threadStatus = useThreadStatus(threadId);
+  const threadStatus = useThreadStatus(threadId, organizationId);
   const isArchived = threadStatus === 'archived';
 
   const { mutate: unarchiveThread, isPending: isUnarchiving } =

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -181,7 +181,10 @@ export function ChatMessages({
   // `sourceMessageId` never resolves to a visible message id (e.g.
   // generation crashed before the resolver ran) stay invisible here
   // and remain manageable from /settings/personalization.
-  const personalizationActive = usePersonalizationActiveForThread(threadId);
+  const personalizationActive = usePersonalizationActiveForThread(
+    threadId,
+    organizationId,
+  );
   const pendingMemories = useQuery(
     api.user_memories.queries.listPendingMemories,
     personalizationActive && threadId ? { threadId } : 'skip',

--- a/services/platform/app/features/chat/context/branch-context.tsx
+++ b/services/platform/app/features/chat/context/branch-context.tsx
@@ -45,6 +45,7 @@ export function useBranchContext() {
 
 interface BranchProviderProps {
   threadId: string | undefined;
+  organizationId: string;
   children: ReactNode;
 }
 
@@ -115,7 +116,11 @@ function resolveActiveBranch(
   return currentThreadId;
 }
 
-export function BranchProvider({ threadId, children }: BranchProviderProps) {
+export function BranchProvider({
+  threadId,
+  organizationId,
+  children,
+}: BranchProviderProps) {
   const [branchSelections, setBranchSelections] = useState<
     Record<string, string>
   >({});
@@ -124,7 +129,7 @@ export function BranchProvider({ threadId, children }: BranchProviderProps) {
   // Load persisted branch selections from DB
   const persistedSelections = useQuery(
     api.threads.queries.getThreadBranchSelections,
-    threadId ? { threadId } : 'skip',
+    threadId ? { threadId, organizationId } : 'skip',
   );
 
   // Initialize from persisted data once on load
@@ -179,7 +184,7 @@ export function BranchProvider({ threadId, children }: BranchProviderProps) {
   const rawBranches =
     useQuery(
       api.threads.queries.getThreadBranches,
-      threadId ? { rootThreadId: threadId } : 'skip',
+      threadId ? { rootThreadId: threadId, organizationId } : 'skip',
     ) ?? [];
 
   const branchesKey = JSON.stringify(rawBranches);

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -116,10 +116,13 @@ export function useArchivedThreads({
   };
 }
 
-export function useThreadStatus(threadId: string | undefined) {
+export function useThreadStatus(
+  threadId: string | undefined,
+  organizationId: string,
+) {
   const { data } = useConvexQuery(
     api.threads.queries.getThreadStatus,
-    threadId ? { threadId } : 'skip',
+    threadId ? { threadId, organizationId } : 'skip',
   );
   return data ?? null;
 }

--- a/services/platform/app/features/chat/hooks/use-personalization-active.ts
+++ b/services/platform/app/features/chat/hooks/use-personalization-active.ts
@@ -11,10 +11,11 @@ import { api } from '@/convex/_generated/api';
  */
 export function usePersonalizationActiveForThread(
   threadId: string | undefined,
+  organizationId: string,
 ): boolean {
   const result = useQuery(
     api.personalization.queries.isPersonalizationActiveForChat,
-    threadId ? { threadId } : 'skip',
+    threadId ? { threadId, organizationId } : 'skip',
   );
   return result === true;
 }

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -25,7 +25,12 @@ export function createRouter() {
       queries: {
         queryKeyHashFn: convexQueryClient.hashFn(),
         queryFn: convexQueryClient.queryFn(),
-        gcTime: 120 * 60 * 1000,
+        // 15min: bounds stale Convex subscription leak when components unmount
+        // (the @convex-dev/react-query integration ties WS subscription teardown
+        // to React Query's cache 'removed' event, which fires only after gcTime
+        // expires with zero observers). Aligned with the codebase's 5min staleTime
+        // and TanStack defaults.
+        gcTime: 15 * 60 * 1000,
       },
     },
   });

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -143,25 +143,35 @@ function DashboardLayout() {
     }
   }, [status, navigate]);
 
-  // Early bailout: when the user has no valid member context (not_found,
-  // not_member, or disabled), do NOT render the layout chrome (Navigation,
-  // MobileNavigation, NotificationBell, TeamFilterProvider). Those components
-  // subscribe to Convex queries scoped to organizationId; if they stay mounted
-  // with a stale org id, their observers pin the cache entries and gcTime
-  // never starts ticking — leaving the WebSocket subscriptions firing RLS
-  // errors indefinitely. Keep rendering chrome during isLoading so the
-  // happy-path doesn't flash.
-  if (!isLoading && !hasRole) {
+  // Gate the entire child tree behind a confirmed-access answer. Until
+  // memberContext resolves with status === 'ok', do NOT render the layout
+  // chrome or Outlet. Child routes (chat, agents, …) mount Convex
+  // subscriptions on mount; several use convex/react's useQuery, which
+  // *throws* to React on UnauthorizedError. If the user lands on a deleted
+  // or unauthorized org URL, those throws hit the inner LayoutErrorBoundary
+  // and surface "Something went wrong" before this layout has a chance to
+  // bail out. Showing a centred spinner while the access check is in flight
+  // also avoids a brief chrome flash on cold loads.
+  if (!hasRole) {
+    if (memberContext && status !== 'ok') {
+      return (
+        <FullPageCenter>
+          {status === 'not_found' ? (
+            <AccessDenied
+              title={tNotFound('notFound.title')}
+              message={t('workspaceNotFound')}
+            />
+          ) : (
+            <AccessDenied
+              message={t(isDisabled ? 'disabled' : 'noMembership')}
+            />
+          )}
+        </FullPageCenter>
+      );
+    }
     return (
       <FullPageCenter>
-        {status === 'not_found' ? (
-          <AccessDenied
-            title={tNotFound('notFound.title')}
-            message={t('workspaceNotFound')}
-          />
-        ) : (
-          <AccessDenied message={t(isDisabled ? 'disabled' : 'noMembership')} />
-        )}
+        <Spinner size="lg" />
       </FullPageCenter>
     );
   }

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@tale/ui/spinner';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Outlet, createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
@@ -126,6 +126,46 @@ function DashboardLayout() {
     }
   }, [isDisabled, t]);
 
+  // Bounce away from a deleted-org URL. Handles cross-tab live deletion (tab A
+  // deletes the org; tab B's getCurrentMemberContext subscription pushes
+  // 'not_found' via Convex reactivity), bookmarks/history into deleted orgs,
+  // and racy fallthrough during deletion. /dashboard/ index has fallback logic
+  // (persistedStillMember) that prevents looping back to the deleted org.
+  // 'not_member' intentionally not redirected — preserve the AccessDenied
+  // "you've been removed" message; the early-bailout below already prevents
+  // its layout-chrome subscription leak.
+  const navigate = useNavigate();
+  const redirectedRef = useRef(false);
+  useEffect(() => {
+    if (status === 'not_found' && !redirectedRef.current) {
+      redirectedRef.current = true;
+      void navigate({ to: '/dashboard', replace: true });
+    }
+  }, [status, navigate]);
+
+  // Early bailout: when the user has no valid member context (not_found,
+  // not_member, or disabled), do NOT render the layout chrome (Navigation,
+  // MobileNavigation, NotificationBell, TeamFilterProvider). Those components
+  // subscribe to Convex queries scoped to organizationId; if they stay mounted
+  // with a stale org id, their observers pin the cache entries and gcTime
+  // never starts ticking — leaving the WebSocket subscriptions firing RLS
+  // errors indefinitely. Keep rendering chrome during isLoading so the
+  // happy-path doesn't flash.
+  if (!isLoading && !hasRole) {
+    return (
+      <FullPageCenter>
+        {status === 'not_found' ? (
+          <AccessDenied
+            title={tNotFound('notFound.title')}
+            message={t('workspaceNotFound')}
+          />
+        ) : (
+          <AccessDenied message={t(isDisabled ? 'disabled' : 'noMembership')} />
+        )}
+      </FullPageCenter>
+    );
+  }
+
   return (
     <AbilityContext.Provider value={ability}>
       <AbilityLoadingContext.Provider value={isLoading}>
@@ -166,17 +206,8 @@ function DashboardLayout() {
                       </Text>
                     </VStack>
                   </FullPageCenter>
-                ) : hasRole || isLoading ? (
-                  <Outlet />
-                ) : status === 'not_found' ? (
-                  <AccessDenied
-                    title={tNotFound('notFound.title')}
-                    message={t('workspaceNotFound')}
-                  />
                 ) : (
-                  <AccessDenied
-                    message={t(isDisabled ? 'disabled' : 'noMembership')}
-                  />
+                  <Outlet />
                 )}
               </main>
             </div>

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -107,7 +107,7 @@ function ThreadGate({
   // Returns undefined while loading, null if thread not found / not owned.
   const threadStatus = useQuery(
     api.threads.queries.getThreadStatus,
-    threadId && !isJustCreated ? { threadId } : 'skip',
+    threadId && !isJustCreated ? { threadId, organizationId } : 'skip',
   );
 
   // No threadId or just-created thread → render immediately. BranchProvider
@@ -283,7 +283,7 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
               and request the right thread's artifacts. Without this, the bar
               shows the URL's root thread regardless of which branch the user
               is viewing. */}
-          <BranchProvider threadId={threadId}>
+          <BranchProvider threadId={threadId} organizationId={organizationId}>
             <BudgetBanner organizationId={organizationId} />
             {threadId && (
               <BranchAwareArtifactBar organizationId={organizationId} />

--- a/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
@@ -141,7 +141,7 @@ afterEach(() => {
 });
 
 describe('DashboardLayout', () => {
-  it('renders outlet when Convex auth is loading', () => {
+  it('shows spinner (not outlet) while Convex auth is loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: true,
       isAuthenticated: false,
@@ -154,10 +154,13 @@ describe('DashboardLayout', () => {
 
     render(<DashboardLayout />);
 
-    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    // Outlet must not render until access is confirmed — child routes mount
+    // org-scoped Convex subscriptions that throw on UnauthorizedError.
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('renders outlet when member context query is loading', () => {
+  it('shows spinner (not outlet) while member context query is loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -170,10 +173,11 @@ describe('DashboardLayout', () => {
 
     render(<DashboardLayout />);
 
-    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('renders outlet when both auth and query are loading', () => {
+  it('shows spinner when both auth and query are loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: true,
       isAuthenticated: false,
@@ -186,7 +190,8 @@ describe('DashboardLayout', () => {
 
     render(<DashboardLayout />);
 
-    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders child routes when auth complete and member has role', () => {
@@ -322,7 +327,7 @@ describe('DashboardLayout', () => {
     expect(mockUseCurrentMemberContext.mock.calls[0]?.[1]).toBe(false);
   });
 
-  it('renders outlet when query errors (treats error as loading)', () => {
+  it('shows spinner (not outlet) when query errors without prior data', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -335,10 +340,15 @@ describe('DashboardLayout', () => {
 
     render(<DashboardLayout />);
 
-    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    // Without resolved memberContext we can't confirm access — fall through
+    // to the loading spinner rather than rendering Outlet (which would mount
+    // org-scoped subscriptions) or AccessDenied (which would be misleading
+    // for a transient error).
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
     expect(
       screen.queryByText('accessDenied.noMembership'),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('keeps outlet visible when query errors but has previous data', () => {

--- a/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/__tests__/dashboard-layout.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // --- Mocks ---
 
 const mockUseParams = vi.fn(() => ({ id: 'test-org-id' }));
+const mockNavigate = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (config: Record<string, unknown>) => ({
@@ -13,7 +14,7 @@ vi.mock('@tanstack/react-router', () => ({
     ...config,
   }),
   Outlet: () => <div data-testid="outlet" />,
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: '/dashboard/test-org-id' }),
   useParams: () => mockUseParams(),
 }));
@@ -210,7 +211,7 @@ describe('DashboardLayout', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
-  it('shows access denied when user is not a member', () => {
+  it('shows access denied when user is not a member (no redirect)', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -225,9 +226,12 @@ describe('DashboardLayout', () => {
 
     expect(screen.getByText('accessDenied.noMembership')).toBeInTheDocument();
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+    // not_member intentionally preserves the AccessDenied "you've been removed"
+    // UX — should NOT trigger redirect.
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('shows not-found when organization does not exist', () => {
+  it('redirects to /dashboard/ when organization does not exist', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -240,11 +244,33 @@ describe('DashboardLayout', () => {
 
     render(<DashboardLayout />);
 
-    expect(screen.getByText('common.notFound.title')).toBeInTheDocument();
-    expect(
-      screen.getByText('accessDenied.workspaceNotFound'),
-    ).toBeInTheDocument();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/dashboard',
+      replace: true,
+    });
+    // Until redirect commits, the AccessDenied fallback is shown without
+    // layout chrome (no outlet, no Navigation/MobileNavigation subscriptions).
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+  });
+
+  it('does not redirect twice on re-render with not_found status', () => {
+    mockUseConvexAuth.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    mockUseCurrentMemberContext.mockReturnValue({
+      data: { status: 'not_found' },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { rerender } = render(<DashboardLayout />);
+    rerender(<DashboardLayout />);
+    rerender(<DashboardLayout />);
+
+    // useRef guard keeps redirect a one-shot effect across re-renders.
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
   it('passes organizationId from route params to useCurrentMemberContext', () => {

--- a/services/platform/convex/artifacts/queries.ts
+++ b/services/platform/convex/artifacts/queries.ts
@@ -55,7 +55,12 @@ export const getById = query({
     if (!authUser) return null;
     const artifact = await ctx.db.get(artifactId);
     if (!artifact) return null;
-    const metadata = await canAccessThread(ctx, artifact.threadId, authUser);
+    const metadata = await canAccessThread(
+      ctx,
+      artifact.threadId,
+      authUser,
+      artifact.organizationId,
+    );
     if (!metadata || metadata.organizationId !== artifact.organizationId) {
       return null;
     }
@@ -84,7 +89,12 @@ export const listByThread = query({
   ): Promise<ArtifactListItem[]> => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return [];
-    const metadata = await canAccessThread(ctx, threadId, authUser);
+    const metadata = await canAccessThread(
+      ctx,
+      threadId,
+      authUser,
+      organizationId,
+    );
     if (!metadata || metadata.organizationId !== organizationId) return [];
 
     const cap = Math.max(
@@ -122,7 +132,12 @@ export const syncArtifactStream = query({
     if (!authUser) return undefined;
     const artifact = await ctx.db.get(artifactId);
     if (!artifact) return undefined;
-    const metadata = await canAccessThread(ctx, artifact.threadId, authUser);
+    const metadata = await canAccessThread(
+      ctx,
+      artifact.threadId,
+      authUser,
+      artifact.organizationId,
+    );
     if (!metadata || metadata.organizationId !== artifact.organizationId) {
       return undefined;
     }
@@ -143,7 +158,12 @@ export const listRevisions = query({
     if (!authUser) return [];
     const artifact = await ctx.db.get(artifactId);
     if (!artifact) return [];
-    const metadata = await canAccessThread(ctx, artifact.threadId, authUser);
+    const metadata = await canAccessThread(
+      ctx,
+      artifact.threadId,
+      authUser,
+      artifact.organizationId,
+    );
     if (!metadata || metadata.organizationId !== artifact.organizationId) {
       return [];
     }

--- a/services/platform/convex/lib/rls/auth/__tests__/can_access_thread.test.ts
+++ b/services/platform/convex/lib/rls/auth/__tests__/can_access_thread.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+      },
+    },
+  },
+}));
+
+const { canAccessThread, assertThreadAccess } =
+  await import('../can_access_thread');
+
+const authUser = { userId: 'user_1', email: 'larry@tale.dev' };
+
+interface MockMetadata {
+  _id: string;
+  threadId: string;
+  userId: string;
+  organizationId?: string;
+  isShared?: boolean;
+  status?: string;
+}
+
+interface BetterAuthMember {
+  _id: string;
+  organizationId: string;
+  userId: string;
+  role: string;
+}
+
+function createMockCtx(opts: {
+  metadata: MockMetadata | null;
+  members?: BetterAuthMember[]; // Better Auth `member` rows the user belongs to (active)
+}) {
+  return {
+    db: {
+      query: vi.fn().mockReturnValue({
+        withIndex: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(opts.metadata),
+        }),
+      }),
+    },
+    runQuery: vi
+      .fn()
+      .mockImplementation(
+        (_ref, args: { where: { field: string; value: string }[] }) => {
+          const orgIdFilter = args.where.find(
+            (w) => w.field === 'organizationId',
+          );
+          const userIdFilter = args.where.find((w) => w.field === 'userId');
+          const match = (opts.members ?? []).find(
+            (m) =>
+              m.organizationId === orgIdFilter?.value &&
+              m.userId === userIdFilter?.value,
+          );
+          return Promise.resolve({ page: match ? [match] : [] });
+        },
+      ),
+    auth: {},
+  };
+}
+
+describe('canAccessThread — owner branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns metadata when owner is still a member of the thread org (no hint)', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_1',
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_1',
+          userId: 'user_1',
+          role: 'admin',
+        },
+      ],
+    });
+
+    const result = await canAccessThread(ctx as never, 't_1', authUser);
+
+    expect(result).toEqual(meta);
+    // No hint passed → membership lookup happens sequentially after metadata
+    // read. Exactly one runQuery (Better Auth findMany).
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns metadata via fast path when matching hint is supplied', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_1',
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_1',
+          userId: 'user_1',
+          role: 'admin',
+        },
+      ],
+    });
+
+    const result = await canAccessThread(
+      ctx as never,
+      't_1',
+      authUser,
+      'org_1',
+    );
+
+    expect(result).toEqual(meta);
+    // Fast path reuses the parallel-fired membership lookup → single call.
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a second lookup when hint org mismatches actual org', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_actual',
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        // User is member of both, but only org_actual matters
+        {
+          _id: 'm_hint',
+          organizationId: 'org_hint',
+          userId: 'user_1',
+          role: 'member',
+        },
+        {
+          _id: 'm_actual',
+          organizationId: 'org_actual',
+          userId: 'user_1',
+          role: 'admin',
+        },
+      ],
+    });
+
+    const result = await canAccessThread(
+      ctx as never,
+      't_1',
+      authUser,
+      'org_hint',
+    );
+
+    expect(result).toEqual(meta);
+    // First call (parallel hint), then fallback against actual orgId.
+    expect(ctx.runQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when owner is no longer a member of the thread org (no hint)', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_deleted',
+    };
+    const ctx = createMockCtx({ metadata: meta, members: [] });
+
+    const result = await canAccessThread(ctx as never, 't_1', authUser);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on the fast path when the matching hint reveals non-membership', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_deleted',
+    };
+    const ctx = createMockCtx({ metadata: meta, members: [] });
+
+    const result = await canAccessThread(
+      ctx as never,
+      't_1',
+      authUser,
+      'org_deleted',
+    );
+
+    expect(result).toBeNull();
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns metadata for legacy threads without organizationId regardless of hint', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_legacy',
+      threadId: 't_legacy',
+      userId: 'user_1',
+      // organizationId intentionally omitted — pre-org-scoping legacy row
+    };
+    const ctx = createMockCtx({ metadata: meta, members: [] });
+
+    const result = await canAccessThread(
+      ctx as never,
+      't_legacy',
+      authUser,
+      'org_anything',
+    );
+
+    expect(result).toEqual(meta);
+  });
+});
+
+describe('canAccessThread — shared branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns metadata for non-owner who is a member of the shared org (fast path)', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_shared',
+      threadId: 't_shared',
+      userId: 'user_owner',
+      organizationId: 'org_shared',
+      isShared: true,
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_shared',
+          userId: 'user_1',
+          role: 'member',
+        },
+      ],
+    });
+
+    const result = await canAccessThread(
+      ctx as never,
+      't_shared',
+      authUser,
+      'org_shared',
+    );
+
+    expect(result).toEqual(meta);
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for non-owner who is not a member of the shared org', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_shared',
+      threadId: 't_shared',
+      userId: 'user_owner',
+      organizationId: 'org_shared',
+      isShared: true,
+    };
+    const ctx = createMockCtx({ metadata: meta, members: [] });
+
+    const result = await canAccessThread(ctx as never, 't_shared', authUser);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for non-owner when thread is not shared', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_private',
+      threadId: 't_private',
+      userId: 'user_owner',
+      organizationId: 'org_1',
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_1',
+          userId: 'user_1',
+          role: 'member',
+        },
+      ],
+    });
+
+    const result = await canAccessThread(ctx as never, 't_private', authUser);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('canAccessThread — missing thread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when threadMetadata row does not exist', async () => {
+    const ctx = createMockCtx({ metadata: null });
+
+    const result = await canAccessThread(ctx as never, 't_missing', authUser);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('assertThreadAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns metadata when accessible', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_1',
+    };
+    const ctx = createMockCtx({
+      metadata: meta,
+      members: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_1',
+          userId: 'user_1',
+          role: 'admin',
+        },
+      ],
+    });
+
+    const result = await assertThreadAccess(
+      ctx as never,
+      't_1',
+      authUser,
+      'org_1',
+    );
+
+    expect(result).toEqual(meta);
+  });
+
+  it('throws ConvexError(forbidden) when access is denied', async () => {
+    const meta: MockMetadata = {
+      _id: 'tm_1',
+      threadId: 't_1',
+      userId: 'user_1',
+      organizationId: 'org_deleted',
+    };
+    const ctx = createMockCtx({ metadata: meta, members: [] });
+
+    await expect(
+      assertThreadAccess(ctx as never, 't_1', authUser),
+    ).rejects.toMatchObject({ data: { code: 'forbidden' } });
+  });
+});

--- a/services/platform/convex/lib/rls/auth/can_access_thread.ts
+++ b/services/platform/convex/lib/rls/auth/can_access_thread.ts
@@ -8,25 +8,61 @@ import { isOrgMember } from './check_org_membership';
 export type ThreadMetadata = Doc<'threadMetadata'>;
 
 /**
- * Returns the thread's metadata if `authUser` is allowed to access it (owner,
- * or shared thread within an org the user is a member of). Returns `null`
- * when the thread does not exist or access is denied — callers can shape that
- * into an empty result for queries.
+ * Returns the thread's metadata if `authUser` is allowed to access it
+ * (current member of the thread's org — including the owner — or non-owner
+ * with the thread shared into an org they belong to). Returns `null` when
+ * the thread does not exist or access is denied; callers shape that into an
+ * empty result for queries.
+ *
+ * Owner-branch membership check: threads are an org-scoped resource, so
+ * once the user leaves (or the org is deleted) the thread is no longer
+ * accessible to them — even though the metadata row itself persists today
+ * (no cascade delete on org deletion). Without this, a removed-member owner
+ * could still load their old thread by URL.
+ *
+ * `expectedOrgId` is an optional hint, typically the URL's `organizationId`.
+ * When supplied, the membership lookup runs in parallel with the metadata
+ * read via `Promise.all`; the fast path costs `max(metadata_read, isOrgMember)`
+ * instead of `metadata_read + isOrgMember`. When the hint matches the thread's
+ * actual org (the common case), the parallel result is reused; when it does
+ * not, we fall through to a sequential lookup against the actual org.
  */
 export async function canAccessThread(
   ctx: QueryCtx | MutationCtx,
   threadId: string,
   authUser: AuthenticatedUser,
+  expectedOrgId?: string,
 ): Promise<ThreadMetadata | null> {
-  const metadata = await ctx.db
-    .query('threadMetadata')
-    .withIndex('by_threadId', (q) => q.eq('threadId', threadId))
-    .first();
+  const [metadata, expectedMembership] = await Promise.all([
+    ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', threadId))
+      .first(),
+    expectedOrgId
+      ? isOrgMember(ctx, authUser.userId, expectedOrgId)
+      : Promise.resolve(null),
+  ]);
   if (!metadata) return null;
 
-  if (metadata.userId === authUser.userId) return metadata;
+  // Owner branch
+  if (metadata.userId === authUser.userId) {
+    if (!metadata.organizationId) return metadata; // legacy: no org to check
+    if (expectedOrgId === metadata.organizationId) {
+      return expectedMembership ? metadata : null;
+    }
+    const isMember = await isOrgMember(
+      ctx,
+      authUser.userId,
+      metadata.organizationId,
+    );
+    return isMember ? metadata : null;
+  }
 
+  // Shared branch
   if (metadata.isShared && metadata.organizationId) {
+    if (expectedOrgId === metadata.organizationId) {
+      return expectedMembership ? metadata : null;
+    }
     const member = await isOrgMember(
       ctx,
       authUser.userId,
@@ -47,8 +83,14 @@ export async function assertThreadAccess(
   ctx: QueryCtx | MutationCtx,
   threadId: string,
   authUser: AuthenticatedUser,
+  expectedOrgId?: string,
 ): Promise<ThreadMetadata> {
-  const metadata = await canAccessThread(ctx, threadId, authUser);
+  const metadata = await canAccessThread(
+    ctx,
+    threadId,
+    authUser,
+    expectedOrgId,
+  );
   if (!metadata) {
     throw new ConvexError({
       code: 'forbidden',

--- a/services/platform/convex/personalization/queries.ts
+++ b/services/platform/convex/personalization/queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { query } from '../_generated/server';
 import { assertSelfAndOrgMember } from '../lib/rls/auth/assert_self_and_org_member';
 import { canAccessThread } from '../lib/rls/auth/can_access_thread';
+import { isOrgMember } from '../lib/rls/auth/check_org_membership';
 import { requireAuthenticatedUser } from '../lib/rls/auth/require_authenticated_user';
 import {
   evaluatePersonalizationGates,
@@ -18,7 +19,12 @@ import {
  *
  * Auth: caller must own the thread AND be a current member of the
  * thread's org. Returns false on any miss (never throws — the chat UI
- * treats false as "don't render the section").
+ * treats false as "don't render the section"). The non-throwing
+ * membership check is load-bearing: a thread can outlive its org (org
+ * deletion does not cascade-delete threadMetadata), so an owner reading
+ * an orphaned thread would otherwise hit an UnauthorizedError that
+ * propagates through convex/react's useQuery into the chat error
+ * boundary.
  */
 export const isPersonalizationActiveForChat = query({
   args: {
@@ -30,7 +36,7 @@ export const isPersonalizationActiveForChat = query({
     if (!meta || meta.userId !== authUser.userId) return false;
     const orgId = meta.organizationId;
     if (!orgId) return false;
-    await assertSelfAndOrgMember(ctx, authUser, authUser.userId, orgId);
+    if (!(await isOrgMember(ctx, authUser.userId, orgId))) return false;
 
     return evaluatePersonalizationGates(ctx, {
       userId: authUser.userId,

--- a/services/platform/convex/personalization/queries.ts
+++ b/services/platform/convex/personalization/queries.ts
@@ -3,7 +3,6 @@ import { v } from 'convex/values';
 import { query } from '../_generated/server';
 import { assertSelfAndOrgMember } from '../lib/rls/auth/assert_self_and_org_member';
 import { canAccessThread } from '../lib/rls/auth/can_access_thread';
-import { isOrgMember } from '../lib/rls/auth/check_org_membership';
 import { requireAuthenticatedUser } from '../lib/rls/auth/require_authenticated_user';
 import {
   evaluatePersonalizationGates,
@@ -18,25 +17,26 @@ import {
  * (`writeProposal`) paths so all three observe identical behavior.
  *
  * Auth: caller must own the thread AND be a current member of the
- * thread's org. Returns false on any miss (never throws — the chat UI
- * treats false as "don't render the section"). The non-throwing
- * membership check is load-bearing: a thread can outlive its org (org
- * deletion does not cascade-delete threadMetadata), so an owner reading
- * an orphaned thread would otherwise hit an UnauthorizedError that
- * propagates through convex/react's useQuery into the chat error
- * boundary.
+ * thread's org. Both checks live inside `canAccessThread`, which returns
+ * `null` (not throws) for orphaned/non-member access — keeping this
+ * handler's "never throws" contract the chat UI relies on.
  */
 export const isPersonalizationActiveForChat = query({
   args: {
     threadId: v.string(),
+    organizationId: v.string(),
   },
   handler: async (ctx, args): Promise<boolean> => {
     const authUser = await requireAuthenticatedUser(ctx);
-    const meta = await canAccessThread(ctx, args.threadId, authUser);
+    const meta = await canAccessThread(
+      ctx,
+      args.threadId,
+      authUser,
+      args.organizationId,
+    );
     if (!meta || meta.userId !== authUser.userId) return false;
     const orgId = meta.organizationId;
     if (!orgId) return false;
-    if (!(await isOrgMember(ctx, authUser.userId, orgId))) return false;
 
     return evaluatePersonalizationGates(ctx, {
       userId: authUser.userId,

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -200,14 +200,22 @@ export const getFailedMessageErrors = query({
 });
 
 export const getThreadStatus = query({
-  args: { threadId: v.string() },
+  args: {
+    threadId: v.string(),
+    organizationId: v.string(),
+  },
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
       return null;
     }
 
-    const metadata = await canAccessThread(ctx, args.threadId, authUser);
+    const metadata = await canAccessThread(
+      ctx,
+      args.threadId,
+      authUser,
+      args.organizationId,
+    );
     if (!metadata) return null;
 
     // Owner always gets the real status; non-owners reach this path only when
@@ -222,16 +230,20 @@ export const getThreadStatus = query({
 export { getSharedThread } from './get_shared_thread';
 
 export const getThreadBranches = query({
-  args: { rootThreadId: v.string() },
+  args: {
+    rootThreadId: v.string(),
+    organizationId: v.string(),
+  },
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return [];
 
-    const rootMetadata = await ctx.db
-      .query('threadMetadata')
-      .withIndex('by_threadId', (q) => q.eq('threadId', args.rootThreadId))
-      .first();
-
+    const rootMetadata = await canAccessThread(
+      ctx,
+      args.rootThreadId,
+      authUser,
+      args.organizationId,
+    );
     if (!rootMetadata || rootMetadata.userId !== authUser.userId) return [];
 
     const branches: Array<{
@@ -265,16 +277,20 @@ export const getThreadBranches = query({
 });
 
 export const getThreadBranchSelections = query({
-  args: { threadId: v.string() },
+  args: {
+    threadId: v.string(),
+    organizationId: v.string(),
+  },
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return null;
 
-    const metadata = await ctx.db
-      .query('threadMetadata')
-      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
-      .first();
-
+    const metadata = await canAccessThread(
+      ctx,
+      args.threadId,
+      authUser,
+      args.organizationId,
+    );
     if (!metadata || metadata.userId !== authUser.userId) return null;
 
     return metadata.branchSelections ?? null;


### PR DESCRIPTION
## Summary

Closes a chain of issues that surfaced when a user opened a thread/dashboard URL belonging to an org they no longer belong to (or that was deleted). Symptoms ranged from a "Something went wrong" boundary to silent Convex subscription leaks and, most importantly, continued thread access for the original owner after they left the org.

- **Layout subscription leak** ([dashboard/$id.tsx](services/platform/app/routes/dashboard/$id.tsx)): bail out of chrome (Navigation, MobileNavigation, NotificationBell) when memberContext is invalid so org-scoped Convex observers tear down. Redirect `not_found` org URLs while keeping the `not_member` AccessDenied UX. Tighten React Query `gcTime` to 15 min.
- **Premature child mount** ([dashboard/$id.tsx](services/platform/app/routes/dashboard/$id.tsx)): render a spinner until `status === 'ok'` is confirmed instead of mounting `<Outlet/>` while memberContext is loading — prevents chat from firing subscriptions and throwing into LayoutErrorBoundary.
- **Personalization query throw** ([personalization/queries.ts](services/platform/convex/personalization/queries.ts)): `isPersonalizationActiveForChat` now uses a non-throwing `isOrgMember` check and returns `false` on miss, honoring its docstring contract.
- **Owner bypass** ([can_access_thread.ts](services/platform/convex/lib/rls/auth/can_access_thread.ts)): `canAccessThread` no longer waves owners through unconditionally — it requires current org membership. Hot-path callers pass `expectedOrgId` so the membership read runs in parallel with metadata via `Promise.all`. `getThreadBranchSelections` now routes through the helper instead of duplicating the buggy check.

## Test plan

- [ ] `bun run check`
- [ ] New `can_access_thread.test.ts` covers owner-with-membership, owner-without-membership, expectedOrgId hint path, and mismatch fallback
- [ ] Updated `dashboard-layout.test.tsx` covers loading spinner, not_found redirect, not_member AccessDenied
- [ ] Manual: open a chat URL after being removed from its org → expect "Thread not found" empty state, no boundary
- [ ] Manual: delete an org in another tab while a member is on the dashboard → expect redirect, no leaked subscriptions in devtools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added redirect to dashboard when accessing a deleted organization.
  * Implemented explicit access confirmation with loading spinner on dashboard layout.

* **Bug Fixes**
  * Improved organization context handling across chat features.
  * Enhanced access denial display for various membership states.

* **Tests**
  * Added comprehensive authorization test coverage.
  * Updated access control test assertions for redirect and loading state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->