### PR TITLE
chore(workflow): move all jobs to free GitHub-hosted runners

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -26,9 +26,14 @@ OPENAI_VISION_MODEL=test-model
 EMBEDDING_DIMENSIONS=1536
 CRAWLER_EMBEDDING_DIMENSIONS=1536
 
-# Database - DB_ vars are used by the entrypoint wrapper to set POSTGRES_*
+# Database - DB_ vars are used by the db entrypoint wrapper to set POSTGRES_*.
+# DB_NAME is intentionally NOT set here: the db Dockerfile defaults it to `tale`
+# for the postgres server, while rag/crawler entrypoints fall through to their
+# own default (`tale_knowledge`) — the database where init-scripts/03 installs
+# the `vector` and `pg_search` extensions. Setting DB_NAME globally via env_file
+# would leak `tale` into rag/crawler and race with ParadeDB's bootstrap loading
+# `vector` into `tale`, which fails on slower runners (e.g. ubuntu-latest).
 DB_PASSWORD=test_password_e2e
-DB_NAME=tale
 DB_USER=tale
 
 # Also set POSTGRES_ vars directly for the PostgreSQL healthcheck in compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
   # ---------------------------------------------------------------------------
   changes:
     name: Detect changes
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
       contents: read
@@ -54,7 +54,7 @@ jobs:
       ci_tests: ${{ steps.filter.outputs.ci_tests }}
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Filter paths
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -97,7 +97,7 @@ jobs:
     name: Build ${{ matrix.service }}
     needs: changes
     if: needs.changes.outputs.services != '[]' && github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
       contents: read
@@ -141,7 +141,7 @@ jobs:
     name: Smoke test
     needs: changes
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     timeout-minutes: 20
@@ -186,7 +186,7 @@ jobs:
     name: Validate images
     needs: changes
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     timeout-minutes: 15
@@ -215,7 +215,7 @@ jobs:
     name: Scan ${{ matrix.service }}
     needs: changes
     if: github.event_name == 'push' && needs.changes.outputs.services != '[]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       security-events: write
@@ -273,14 +273,14 @@ jobs:
     name: Storybook
     needs: changes
     if: contains(fromJson(needs.changes.outputs.services), 'platform') && github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,15 +89,13 @@ jobs:
           echo "Services to build: ${SERVICES}"
 
   # ---------------------------------------------------------------------------
-  # Build each changed service's Docker image. Blacksmith caches layers on
-  # sticky disks automatically; no cache-from/cache-to directives needed.
-  # Draft PRs skip to save minutes.
+  # Build each changed service's Docker image. Draft PRs skip to save minutes.
   # ---------------------------------------------------------------------------
   build:
     name: Build ${{ matrix.service }}
     needs: changes
     if: needs.changes.outputs.services != '[]' && github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
@@ -108,10 +106,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Docker builder
-        uses: useblacksmith/setup-docker-builder@722e97d12b1d06a961800dd6c05d79d951ad3c80 # v1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Resolve build metadata
         id: meta
@@ -120,7 +118,7 @@ jobs:
           echo "revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build image
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile
@@ -141,14 +139,14 @@ jobs:
     name: Smoke test
     needs: changes
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 20
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Reclaim disk space
         run: |
@@ -186,14 +184,14 @@ jobs:
     name: Validate images
     needs: changes
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 15
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Reclaim disk space
         run: |
@@ -215,7 +213,7 @@ jobs:
     name: Scan ${{ matrix.service }}
     needs: changes
     if: github.event_name == 'push' && needs.changes.outputs.services != '[]'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
@@ -228,13 +226,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Docker builder
-        uses: useblacksmith/setup-docker-builder@722e97d12b1d06a961800dd6c05d79d951ad3c80 # v1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build image for scan
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,7 +27,7 @@ jobs:
   # ---------------------------------------------------------------------------
   prepare:
     name: Prepare
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -46,7 +46,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Build the CLI binary for each target platform.
-  # linux -> Blacksmith (cheap+fast). macos/windows -> GitHub-hosted.
+  # All platforms run on GitHub-hosted runners (free for public repos).
   # ---------------------------------------------------------------------------
   build:
     name: Build (${{ matrix.platform }})
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: ubuntu-latest
             platform: linux
             build_script: build:linux
             binary: tale
@@ -143,7 +143,7 @@ jobs:
     name: Attach to release
     needs: build
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,14 +13,14 @@ jobs:
   commitlint:
     name: Lint commits
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,14 +72,14 @@ jobs:
   # ---------------------------------------------------------------------------
   lint:
     name: Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo
@@ -94,14 +94,14 @@ jobs:
   # ---------------------------------------------------------------------------
   format:
     name: Format
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo
@@ -116,7 +116,7 @@ jobs:
   # ---------------------------------------------------------------------------
   typecheck:
     name: Type check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       contents: read
@@ -139,14 +139,14 @@ jobs:
   # ---------------------------------------------------------------------------
   knip:
     name: Knip
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,18 +112,18 @@ jobs:
         run: bun run format:check
 
   # ---------------------------------------------------------------------------
-  # tsc --noEmit across workspaces. Memory-sensitive, keep at 4vCPU.
+  # tsc --noEmit across workspaces.
   # ---------------------------------------------------------------------------
   typecheck:
     name: Type check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,7 @@ jobs:
           echo "- **Version Number**: ${{ steps.version.outputs.version_number }}" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Build and push each service image per architecture.
-  # Blacksmith caches layers on sticky disks automatically.
-  # max-parallel caps concurrent Blacksmith runners during a release.
+  # Build and push each service image per architecture on native runners.
   # ---------------------------------------------------------------------------
   build:
     name: Build ${{ matrix.service.name }} (${{ matrix.arch.name }})
@@ -78,20 +76,12 @@ jobs:
           - { name: proxy }
           - { name: convex }
         arch:
-          - {
-              name: amd64,
-              runner: blacksmith-2vcpu-ubuntu-2404,
-              platform: linux/amd64,
-            }
-          - {
-              name: arm64,
-              runner: blacksmith-2vcpu-ubuntu-2404-arm,
-              platform: linux/arm64,
-            }
+          - { name: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { name: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Reclaim disk space
         if: matrix.service.name == 'platform' || matrix.service.name == 'rag' || matrix.service.name == 'crawler' || matrix.service.name == 'convex'
@@ -100,7 +90,7 @@ jobs:
           sudo docker image prune -af
 
       - name: Setup Docker builder
-        uses: useblacksmith/setup-docker-builder@722e97d12b1d06a961800dd6c05d79d951ad3c80 # v1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -116,7 +106,7 @@ jobs:
           echo "revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: services/${{ matrix.service.name }}/Dockerfile
@@ -138,7 +128,7 @@ jobs:
   container-test:
     name: Container test gate
     needs: [prepare, build]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
@@ -146,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Reclaim disk space
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   # ---------------------------------------------------------------------------
   prepare:
     name: Prepare
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -80,12 +80,12 @@ jobs:
         arch:
           - {
               name: amd64,
-              runner: blacksmith-4vcpu-ubuntu-2404,
+              runner: blacksmith-2vcpu-ubuntu-2404,
               platform: linux/amd64,
             }
           - {
               name: arm64,
-              runner: blacksmith-4vcpu-ubuntu-2404-arm,
+              runner: blacksmith-2vcpu-ubuntu-2404-arm,
               platform: linux/arm64,
             }
 
@@ -138,7 +138,7 @@ jobs:
   container-test:
     name: Container test gate
     needs: [prepare, build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: read
@@ -196,7 +196,7 @@ jobs:
   manifest:
     name: Manifest ${{ matrix.service }}
     needs: [prepare, build, container-test]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       packages: write
@@ -239,14 +239,14 @@ jobs:
   create-release:
     name: Create release
     needs: [prepare, manifest]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Verify manifests are pullable
         run: |
@@ -277,7 +277,7 @@ jobs:
   trigger-cli:
     name: Trigger CLI build
     needs: [prepare, manifest]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
       actions: write
@@ -298,7 +298,7 @@ jobs:
   summary:
     name: Summary
     needs: [prepare, create-release, manifest, trigger-cli]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 3
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,14 +39,14 @@ jobs:
   bun-audit:
     name: Bun audit
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -72,7 +72,7 @@ jobs:
   trivy-fs:
     name: Trivy filesystem scan
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,14 +83,14 @@ jobs:
   test-ui:
     name: UI
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,14 +60,14 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     name: Unit
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup toolchain
         uses: ./.github/actions/setup-turbo
@@ -83,7 +83,7 @@ jobs:
   test-ui:
     name: UI
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
The repo is public, so ubuntu-latest is free. Move CI jobs off Blacksmith to cut spend.