### PR TITLE
fix(platform,rag): authenticate RAG service + add SSRF guard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,12 @@
         "lucide-react": "1.8.0",
         "tailwind-merge": "3.5.0",
       },
+      "peerDependencies": {
+        "vitest": "*",
+      },
+      "optionalPeers": [
+        "vitest",
+      ],
     },
     "services/crawler": {
       "name": "@tale/crawler",
@@ -182,6 +188,7 @@
         "i18next": "26.0.4",
         "i18next-icu": "2.4.3",
         "intl-messageformat": "11.2.0",
+        "ipaddr.js": "^2.4.0",
         "jexl": "2.3.0",
         "jose": "6.2.2",
         "json-diff-kit": "1.0.35",
@@ -2524,7 +2531,7 @@
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+    "ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
 
     "is-absolute": ["is-absolute@1.0.0", "", { "dependencies": { "is-relative": "^1.0.0", "is-windows": "^1.0.1" } }, "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA=="],
 
@@ -4031,6 +4038,8 @@
     "plop/minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "prom-client/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "randexp/ret": ["ret@0.2.2", "", {}, "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="],
 

--- a/services/convex/Dockerfile
+++ b/services/convex/Dockerfile
@@ -94,7 +94,14 @@ ENV NODE_ENV=production \
     # Root config directory consumed by Convex actions (file-based configs).
     # Sub-dirs (agents/workflows/integrations/providers) are derived inside
     # Convex via `convex/*/file_utils.ts` — no need to set them explicitly.
-    TALE_CONFIG_DIR=/app/data
+    TALE_CONFIG_DIR=/app/data \
+    # Internal-token default for talking to the RAG service. Matches the
+    # bake in services/rag/Dockerfile so a fresh `docker compose up` works
+    # without operator setup. Production operators MUST override
+    # RAG_INTERNAL_TOKEN to a unique secret on BOTH the platform and RAG
+    # containers (they must match). Convex logs print a SECURITY warning
+    # while the default is in use.
+    RAG_INTERNAL_TOKEN=tale-rag-dev-only
 
 # ----------------------------------------------------------------------------
 # Convex Dashboard (Next.js standalone) — served as /convex-dashboard via Caddy

--- a/services/platform/convex/agent_tools/documents/__tests__/fetch_document_comparison.test.ts
+++ b/services/platform/convex/agent_tools/documents/__tests__/fetch_document_comparison.test.ts
@@ -1,8 +1,23 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
+import { _resetRagConfigForTests } from '../../../lib/helpers/rag_config';
 import { fetchDocumentComparison } from '../helpers/fetch_document_comparison';
 
 const RAG_URL = 'http://mock-rag:8001';
+
+beforeAll(() => {
+  process.env.RAG_URL = RAG_URL;
+  process.env.RAG_INTERNAL_TOKEN = 'test-token';
+  _resetRagConfigForTests();
+});
 const BASE_FILE_ID = 'file-base-123';
 const COMP_FILE_ID = 'file-comp-456';
 
@@ -67,11 +82,7 @@ afterEach(() => {
 
 describe('fetchDocumentComparison', () => {
   it('returns correctly mapped result on happy path', async () => {
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.baseDocument).toEqual({
       fileId: BASE_FILE_ID,
@@ -94,11 +105,7 @@ describe('fetchDocumentComparison', () => {
   });
 
   it('maps change blocks with all diff item fields', async () => {
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.changeBlocks).toHaveLength(1);
     const block = result.changeBlocks[0];
@@ -137,11 +144,7 @@ describe('fetchDocumentComparison', () => {
       }),
     );
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     const item = result.changeBlocks[0].items[0];
     expect(item.inlineDiff).toBeNull();
@@ -151,7 +154,7 @@ describe('fetchDocumentComparison', () => {
   });
 
   it('sends POST request with correct body', async () => {
-    await fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID);
+    await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       `${RAG_URL}/api/v1/documents/compare`,
@@ -167,7 +170,7 @@ describe('fetchDocumentComparison', () => {
   });
 
   it('includes max_changes in body when provided', async () => {
-    await fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID, 50);
+    await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID, 50);
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.anything(),
@@ -182,7 +185,7 @@ describe('fetchDocumentComparison', () => {
   });
 
   it('omits max_changes from body when not provided', async () => {
-    await fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID);
+    await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.anything(),
@@ -204,7 +207,7 @@ describe('fetchDocumentComparison', () => {
     );
 
     await expect(
-      fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID),
+      fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID),
     ).rejects.toThrow('Document not found during comparison');
   });
 
@@ -219,7 +222,7 @@ describe('fetchDocumentComparison', () => {
     );
 
     await expect(
-      fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID),
+      fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID),
     ).rejects.toThrow('Invalid comparison request');
   });
 
@@ -234,7 +237,7 @@ describe('fetchDocumentComparison', () => {
     );
 
     await expect(
-      fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID),
+      fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID),
     ).rejects.toThrow('RAG service error (500)');
   });
 
@@ -249,7 +252,7 @@ describe('fetchDocumentComparison', () => {
     );
 
     await expect(
-      fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID),
+      fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID),
     ).rejects.toThrow('timed out after 120s');
   });
 
@@ -260,7 +263,7 @@ describe('fetchDocumentComparison', () => {
     );
 
     await expect(
-      fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID),
+      fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID),
     ).rejects.toThrow('Failed to fetch');
   });
 
@@ -280,11 +283,7 @@ describe('fetchDocumentComparison', () => {
       }),
     );
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.changeBlocks).toEqual([]);
     expect(result.stats.unchanged).toBe(5);
@@ -293,11 +292,7 @@ describe('fetchDocumentComparison', () => {
   it('handles truncated response', async () => {
     mockFetchSuccess(createRagCompareResponse({ truncated: true }));
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.truncated).toBe(true);
   });
@@ -317,11 +312,7 @@ describe('fetchDocumentComparison', () => {
       }),
     );
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.stats.highDivergence).toBe(true);
   });
@@ -334,11 +325,7 @@ describe('fetchDocumentComparison', () => {
       }),
     );
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.baseDocument.title).toBeNull();
     expect(result.comparisonDocument.title).toBeNull();
@@ -376,11 +363,7 @@ describe('fetchDocumentComparison', () => {
       }),
     );
 
-    const result = await fetchDocumentComparison(
-      RAG_URL,
-      BASE_FILE_ID,
-      COMP_FILE_ID,
-    );
+    const result = await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     expect(result.changeBlocks).toHaveLength(2);
     expect(result.changeBlocks[0].items[0].type).toBe('deleted');
@@ -388,7 +371,7 @@ describe('fetchDocumentComparison', () => {
   });
 
   it('passes AbortSignal to fetch', async () => {
-    await fetchDocumentComparison(RAG_URL, BASE_FILE_ID, COMP_FILE_ID);
+    await fetchDocumentComparison(BASE_FILE_ID, COMP_FILE_ID);
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     const options = fetchCall?.[1];

--- a/services/platform/convex/agent_tools/documents/__tests__/fetch_document_content.test.ts
+++ b/services/platform/convex/agent_tools/documents/__tests__/fetch_document_content.test.ts
@@ -1,8 +1,23 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
+import { _resetRagConfigForTests } from '../../../lib/helpers/rag_config';
 import { fetchDocumentContent } from '../helpers/fetch_document_content';
 
 const RAG_URL = 'http://mock-rag:8001';
+
+beforeAll(() => {
+  process.env.RAG_URL = RAG_URL;
+  process.env.RAG_INTERNAL_TOKEN = 'test-token';
+  _resetRagConfigForTests();
+});
 const FILE_ID = 'file-storage-123';
 
 const originalFetch = globalThis.fetch;
@@ -41,7 +56,7 @@ afterEach(() => {
 
 describe('fetchDocumentContent', () => {
   it('returns correct result shape on happy path', async () => {
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result).toEqual({
       fileId: FILE_ID,
@@ -55,7 +70,7 @@ describe('fetchDocumentContent', () => {
   });
 
   it('builds URL without query params when no options provided', async () => {
-    await fetchDocumentContent(RAG_URL, FILE_ID);
+    await fetchDocumentContent(FILE_ID);
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     const url = fetchCall?.[0] ?? '';
@@ -63,7 +78,7 @@ describe('fetchDocumentContent', () => {
   });
 
   it('appends chunk_start and chunk_end query params', async () => {
-    await fetchDocumentContent(RAG_URL, FILE_ID, {
+    await fetchDocumentContent(FILE_ID, {
       chunkStart: 3,
       chunkEnd: 8,
     });
@@ -84,7 +99,7 @@ describe('fetchDocumentContent', () => {
       }),
     );
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID, {
+    const result = await fetchDocumentContent(FILE_ID, {
       returnChunks: true,
     });
 
@@ -96,7 +111,7 @@ describe('fetchDocumentContent', () => {
   });
 
   it('omits return_chunks param when not set', async () => {
-    await fetchDocumentContent(RAG_URL, FILE_ID);
+    await fetchDocumentContent(FILE_ID);
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     const url = fetchCall?.[0] ?? '';
@@ -104,7 +119,7 @@ describe('fetchDocumentContent', () => {
   });
 
   it('encodes fileId in URL', async () => {
-    await fetchDocumentContent(RAG_URL, 'file/with spaces');
+    await fetchDocumentContent('file/with spaces');
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     const url = fetchCall?.[0] ?? '';
@@ -117,7 +132,7 @@ describe('fetchDocumentContent', () => {
       createRagResponse({ content: longContent, total_chars: 60_000 }),
     );
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result.truncated).toBe(true);
     expect(result.content).toHaveLength(50_000);
@@ -130,7 +145,7 @@ describe('fetchDocumentContent', () => {
       createRagResponse({ content: exactContent, total_chars: 50_000 }),
     );
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result.truncated).toBe(false);
     expect(result.content).toHaveLength(50_000);
@@ -139,7 +154,7 @@ describe('fetchDocumentContent', () => {
   it('handles empty content', async () => {
     mockFetchSuccess(createRagResponse({ content: '', total_chars: 0 }));
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result.content).toBe('');
     expect(result.truncated).toBe(false);
@@ -149,7 +164,7 @@ describe('fetchDocumentContent', () => {
   it('handles null content as empty string', async () => {
     mockFetchSuccess(createRagResponse({ content: null, total_chars: 0 }));
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result.content).toBe('');
     expect(result.truncated).toBe(false);
@@ -158,7 +173,7 @@ describe('fetchDocumentContent', () => {
   it('returns "Untitled" when RAG title is null', async () => {
     mockFetchSuccess(createRagResponse({ title: null }));
 
-    const result = await fetchDocumentContent(RAG_URL, FILE_ID);
+    const result = await fetchDocumentContent(FILE_ID);
 
     expect(result.name).toBe('Untitled');
   });
@@ -169,7 +184,7 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow(
       'was not found in the knowledge base',
     );
   });
@@ -184,7 +199,7 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow(
       'RAG service error (500)',
     );
   });
@@ -195,9 +210,7 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
-      'Rate limited',
-    );
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow('Rate limited');
   });
 
   it('wraps non-JSON response parse error', async () => {
@@ -211,7 +224,7 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow(
       'Failed to parse RAG response',
     );
   });
@@ -226,7 +239,7 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow(
       'timed out after 60s',
     );
   });
@@ -237,13 +250,13 @@ describe('fetchDocumentContent', () => {
       { preconnect: vi.fn() },
     );
 
-    await expect(fetchDocumentContent(RAG_URL, FILE_ID)).rejects.toThrow(
+    await expect(fetchDocumentContent(FILE_ID)).rejects.toThrow(
       'Failed to fetch',
     );
   });
 
   it('passes AbortSignal to fetch', async () => {
-    await fetchDocumentContent(RAG_URL, FILE_ID);
+    await fetchDocumentContent(FILE_ID);
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     const options = fetchCall?.[1];
@@ -258,7 +271,7 @@ describe('fetchDocumentContent', () => {
       }),
     );
 
-    await fetchDocumentContent(RAG_URL, FILE_ID, {
+    await fetchDocumentContent(FILE_ID, {
       chunkStart: 5,
       returnChunks: true,
     });

--- a/services/platform/convex/agent_tools/documents/helpers/fetch_document_comparison.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/fetch_document_comparison.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from '../../../../lib/utils/type-cast-helpers';
+import { ragFetch } from '../../../lib/helpers/rag_config';
 
 const FETCH_TIMEOUT_MS = 120_000;
 
@@ -108,13 +109,10 @@ function mapChangeBlock(block: RagChangeBlock): ChangeBlock {
  * Compare two documents by ID via the RAG service's deterministic diff endpoint.
  */
 export async function fetchDocumentComparison(
-  ragServiceUrl: string,
   baseFileId: string,
   comparisonFileId: string,
   maxChanges?: number,
 ): Promise<DocumentComparisonResult> {
-  const url = `${ragServiceUrl}/api/v1/documents/compare`;
-
   const body: Record<string, unknown> = {
     base_file_id: baseFileId,
     comparison_file_id: comparisonFileId,
@@ -123,17 +121,13 @@ export async function fetchDocumentComparison(
     body.max_changes = maxChanges;
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
   try {
-    const response = await fetch(url, {
+    const response = await ragFetch('/api/v1/documents/compare', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-      signal: controller.signal,
+      timeoutMs: FETCH_TIMEOUT_MS,
     });
-    clearTimeout(timeoutId);
 
     if (response.status === 404) {
       const errorText = await response.text().catch(() => '');
@@ -157,9 +151,10 @@ export async function fetchDocumentComparison(
     const result = await fetchJson<RagCompareResponse>(response);
     return mapRagResponse(result);
   } catch (error) {
-    clearTimeout(timeoutId);
-
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (
+      error instanceof Error &&
+      (error.name === 'AbortError' || error.name === 'TimeoutError')
+    ) {
       throw new Error(
         `RAG service timed out after ${FETCH_TIMEOUT_MS / 1000}s while comparing documents.`,
         { cause: error },
@@ -201,7 +196,6 @@ function mapRagResponse(result: RagCompareResponse): DocumentComparisonResult {
  * function to avoid passing large Blobs through function parameters.
  */
 export async function fetchDocumentComparisonByUrls(
-  ragServiceUrl: string,
   baseFileUrl: string,
   baseFileName: string,
   comparisonFileUrl: string,
@@ -226,8 +220,6 @@ export async function fetchDocumentComparisonByUrls(
     compResponse.blob(),
   ]);
 
-  const url = `${ragServiceUrl}/api/v1/documents/compare-files`;
-
   const formData = new FormData();
   formData.append('base_file', baseBlob, baseFileName);
   formData.append('comparison_file', compBlob, comparisonFileName);
@@ -235,16 +227,12 @@ export async function fetchDocumentComparisonByUrls(
     formData.append('max_changes', String(maxChanges));
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
   try {
-    const response = await fetch(url, {
+    const response = await ragFetch('/api/v1/documents/compare-files', {
       method: 'POST',
       body: formData,
-      signal: controller.signal,
+      timeoutMs: FETCH_TIMEOUT_MS,
     });
-    clearTimeout(timeoutId);
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => '');
@@ -256,9 +244,10 @@ export async function fetchDocumentComparisonByUrls(
     const result = await fetchJson<RagCompareResponse>(response);
     return mapRagResponse(result);
   } catch (error) {
-    clearTimeout(timeoutId);
-
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (
+      error instanceof Error &&
+      (error.name === 'AbortError' || error.name === 'TimeoutError')
+    ) {
       throw new Error(
         `RAG service timed out after ${FETCH_TIMEOUT_MS / 1000}s while comparing files.`,
         { cause: error },

--- a/services/platform/convex/agent_tools/documents/helpers/fetch_document_content.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/fetch_document_content.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from '../../../../lib/utils/type-cast-helpers';
+import { ragFetch } from '../../../lib/helpers/rag_config';
 
 const MAX_CONTENT_CHARS = 50_000;
 const FETCH_TIMEOUT_MS = 60_000;
@@ -35,7 +36,6 @@ export interface FetchDocumentContentOptions {
  * Shared between agent tool (retrieve_document) and workflow action (document action).
  */
 export async function fetchDocumentContent(
-  ragServiceUrl: string,
   fileId: string,
   options?: FetchDocumentContentOptions,
 ): Promise<DocumentContentResult> {
@@ -50,14 +50,10 @@ export async function fetchDocumentContent(
     params.set('return_chunks', 'true');
   }
   const query = params.toString();
-  const url = `${ragServiceUrl}/api/v1/documents/${encodeURIComponent(fileId)}/content${query ? `?${query}` : ''}`;
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const path = `/api/v1/documents/${encodeURIComponent(fileId)}/content${query ? `?${query}` : ''}`;
 
   try {
-    const response = await fetch(url, { signal: controller.signal });
-    clearTimeout(timeoutId);
+    const response = await ragFetch(path, { timeoutMs: FETCH_TIMEOUT_MS });
 
     if (response.status === 404) {
       throw new Error(
@@ -100,9 +96,10 @@ export async function fetchDocumentContent(
       chunks: result.chunks,
     };
   } catch (error) {
-    clearTimeout(timeoutId);
-
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (
+      error instanceof Error &&
+      (error.name === 'AbortError' || error.name === 'TimeoutError')
+    ) {
       throw new Error(
         `RAG service timed out after ${FETCH_TIMEOUT_MS / 1000}s while retrieving document "${fileId}".`,
         { cause: error },

--- a/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
+++ b/services/platform/convex/agent_tools/documents/helpers/retrieve_document.ts
@@ -3,7 +3,6 @@ import type { z } from 'zod/v4';
 
 import { internal } from '../../../_generated/api';
 import { createDebugLog } from '../../../lib/debug_log';
-import { getRagConfig } from '../../../lib/helpers/rag_config';
 import { toId } from '../../../lib/type_cast_helpers';
 import type { documentRetrieveArgs } from '../document_retrieve_tool';
 import {
@@ -89,9 +88,7 @@ export async function retrieveDocument(
     }
   }
 
-  const ragServiceUrl = getRagConfig().serviceUrl;
-
-  const result = await fetchDocumentContent(ragServiceUrl, args.fileId, {
+  const result = await fetchDocumentContent(args.fileId, {
     chunkStart: args.chunkStart,
     chunkEnd: args.chunkEnd,
   });

--- a/services/platform/convex/agent_tools/rag/helpers/fetch_document_chunks.ts
+++ b/services/platform/convex/agent_tools/rag/helpers/fetch_document_chunks.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from '../../../../lib/utils/type-cast-helpers';
+import { ragFetch } from '../../../lib/helpers/rag_config';
 
 const MAX_CHUNK_WINDOW = 200;
 /** Stop fetching once accumulated content exceeds this size (~15K tokens). */
@@ -22,7 +23,6 @@ export interface DocumentChunksResult {
 }
 
 export async function fetchDocumentChunks(
-  serviceUrl: string,
   fileId: string,
 ): Promise<DocumentChunksResult> {
   const allChunks: Array<{ index: number; content: string }> = [];
@@ -33,9 +33,9 @@ export async function fetchDocumentChunks(
 
   while (true) {
     const chunkEnd = chunkStart + MAX_CHUNK_WINDOW - 1;
-    const url = `${serviceUrl}/api/v1/documents/${encodeURIComponent(fileId)}/content?return_chunks=true&chunk_start=${chunkStart}&chunk_end=${chunkEnd}`;
-
-    const response = await fetch(url);
+    const response = await ragFetch(
+      `/api/v1/documents/${encodeURIComponent(fileId)}/content?return_chunks=true&chunk_start=${chunkStart}&chunk_end=${chunkEnd}`,
+    );
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => '');

--- a/services/platform/convex/agent_tools/rag/query_rag_context.ts
+++ b/services/platform/convex/agent_tools/rag/query_rag_context.ts
@@ -11,7 +11,7 @@
 
 import { fetchJson } from '../../../lib/utils/type-cast-helpers';
 import { createDebugLog } from '../../lib/debug_log';
-import { getRagConfig } from '../../lib/helpers/rag_config';
+import { getRagConfig, ragFetch } from '../../lib/helpers/rag_config';
 import {
   extractCitationsFromSearchResults,
   formatSearchResults,
@@ -154,7 +154,6 @@ export async function queryRagContext(
 ): Promise<RagContextResult | undefined> {
   try {
     const ragServiceUrl = getRagConfig().serviceUrl;
-    const url = `${ragServiceUrl}/api/v1/search`;
 
     // Build expanded query with conversation context
     const expandedQuery = buildExpandedQuery(userMessage, recentMessages);
@@ -189,11 +188,9 @@ export async function queryRagContext(
       }
       requestPayload.file_ids = options.fileIds;
 
-      const response = await fetch(url, {
+      const response = await ragFetch('/api/v1/search', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestPayload),
         signal: fetchSignal,
       });

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -20,7 +20,7 @@ import { z } from 'zod/v4';
 import { fetchJson } from '../../../lib/utils/type-cast-helpers';
 import { internal } from '../../_generated/api';
 import { createDebugLog } from '../../lib/debug_log';
-import { getRagConfig } from '../../lib/helpers/rag_config';
+import { ragFetch } from '../../lib/helpers/rag_config';
 import type { ToolDefinition } from '../types';
 import {
   formatSearchResults,
@@ -198,9 +198,9 @@ RESPONSE (list_indexed):
           chunkEnd: end,
         });
 
-        const ragServiceUrl = getRagConfig().serviceUrl;
-        const url = `${ragServiceUrl}/api/v1/documents/${encodeURIComponent(args.fileId)}/content?return_chunks=true&chunk_start=${start}&chunk_end=${end}`;
-        const response = await fetch(url);
+        const response = await ragFetch(
+          `/api/v1/documents/${encodeURIComponent(args.fileId)}/content?return_chunks=true&chunk_start=${start}&chunk_end=${end}`,
+        );
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => '');
@@ -276,9 +276,6 @@ RESPONSE (list_indexed):
         };
       }
 
-      const ragServiceUrl = getRagConfig().serviceUrl;
-      const url = `${ragServiceUrl}/api/v1/search`;
-
       const payload = {
         query: args.query,
         file_ids: fileIds,
@@ -293,11 +290,9 @@ RESPONSE (list_indexed):
       });
 
       try {
-        const response = await fetch(url, {
+        const response = await ragFetch('/api/v1/search', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         });
 

--- a/services/platform/convex/agents/internal_actions.ts
+++ b/services/platform/convex/agents/internal_actions.ts
@@ -9,7 +9,7 @@ import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
 import { getPollingInterval } from '../documents/internal_actions';
 import { readJsonFile } from '../lib/file_io';
-import { getRagConfig } from '../lib/helpers/rag_config';
+import { ragFetch } from '../lib/helpers/rag_config';
 import { deleteDocumentById } from '../workflow_engine/action_defs/rag/helpers/delete_document';
 import { uploadDocument } from '../workflow_engine/action_defs/rag/helpers/upload_document';
 import type { AgentJsonConfig, AgentReadResult } from './file_utils';
@@ -33,10 +33,8 @@ export const indexKnowledgeFile = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
-    const ragServiceUrl = getRagConfig().serviceUrl;
-
     try {
-      await uploadDocument(ctx, ragServiceUrl, String(args.fileId));
+      await uploadDocument(ctx, String(args.fileId));
 
       await ctx.scheduler.runAfter(
         INITIAL_POLLING_DELAY_MS,
@@ -95,15 +93,12 @@ export const checkKnowledgeFileStatus = internalAction({
       return null;
     }
 
-    const ragUrl = getRagConfig().serviceUrl;
-    const url = `${ragUrl}/api/v1/documents/statuses`;
-
     try {
-      const response = await fetch(url, {
+      const response = await ragFetch('/api/v1/documents/statuses', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ file_ids: [String(args.fileId)] }),
-        signal: AbortSignal.timeout(10000),
+        timeoutMs: 10_000,
       });
 
       if (response.status === 429 || !response.ok) {
@@ -239,11 +234,8 @@ export const deleteKnowledgeFileFromRag = internalAction({
   },
   returns: v.null(),
   handler: async (_ctx, args): Promise<null> => {
-    const ragServiceUrl = getRagConfig().serviceUrl;
-
     try {
       await deleteDocumentById({
-        ragServiceUrl,
         fileId: String(args.fileId),
       });
     } catch (error) {

--- a/services/platform/convex/documents/compare_documents.ts
+++ b/services/platform/convex/documents/compare_documents.ts
@@ -6,7 +6,6 @@ import { internal } from '../_generated/api';
 import { action } from '../_generated/server';
 import { fetchDocumentComparisonByUrls } from '../agent_tools/documents/helpers/fetch_document_comparison';
 import { authComponent } from '../auth';
-import { getRagConfig } from '../lib/helpers/rag_config';
 import { toId } from '../lib/type_cast_helpers';
 
 export const compareDocuments = action({
@@ -34,15 +33,12 @@ export const compareDocuments = action({
       throw new Error('Unauthorized: not a member of this organization');
     }
 
-    const { serviceUrl } = getRagConfig();
-
     const [baseFileUrl, compFileUrl] = await Promise.all([
       resolveStorageUrl(ctx, args.baseStorageId),
       resolveStorageUrl(ctx, args.comparisonStorageId),
     ]);
 
     return await fetchDocumentComparisonByUrls(
-      serviceUrl,
       baseFileUrl,
       args.baseFileName,
       compFileUrl,

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -8,7 +8,7 @@ import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import { internalAction } from '../_generated/server';
 import { buildDownloadUrl } from '../lib/helpers/public_storage_url';
-import { getRagConfig } from '../lib/helpers/rag_config';
+import { ragFetch } from '../lib/helpers/rag_config';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 import type { GenerateDocxResult } from './generate_docx';
 import * as DocumentsHelpers from './helpers';
@@ -193,17 +193,14 @@ export const checkRagDocumentStatus = internalAction({
       return null;
     }
 
-    const ragUrl = getRagConfig().serviceUrl;
-    const url = `${ragUrl}/api/v1/documents/statuses`;
-
     try {
-      const response = await fetch(url, {
+      const response = await ragFetch('/api/v1/documents/statuses', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           file_ids: [document.fileId],
         }),
-        signal: AbortSignal.timeout(10000),
+        timeoutMs: 10_000,
       });
 
       if (response.status === 429) {
@@ -387,7 +384,6 @@ export const deleteDocumentFromRag = internalAction({
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
     const attempt = args.attempt ?? 0;
-    const ragUrl = getRagConfig().serviceUrl;
 
     const document = await ctx.runQuery(
       internal.documents.internal_queries.getDocumentByIdRaw,
@@ -405,12 +401,9 @@ export const deleteDocumentFromRag = internalAction({
 
     let ragSuccess = false;
     try {
-      const response = await fetch(
-        `${ragUrl}/api/v1/documents/${encodeURIComponent(ragKey)}`,
-        {
-          method: 'DELETE',
-          signal: AbortSignal.timeout(60000),
-        },
+      const response = await ragFetch(
+        `/api/v1/documents/${encodeURIComponent(ragKey)}`,
+        { method: 'DELETE', timeoutMs: 60_000 },
       );
 
       if (response.ok) {
@@ -543,13 +536,11 @@ export const reindexDocumentInRag = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
-    const ragUrl = getRagConfig().serviceUrl;
-
     // Delete old RAG entry (ignore 404 — may not have been indexed)
     try {
-      const response = await fetch(
-        `${ragUrl}/api/v1/documents/${encodeURIComponent(args.oldFileId)}`,
-        { method: 'DELETE', signal: AbortSignal.timeout(60000) },
+      const response = await ragFetch(
+        `/api/v1/documents/${encodeURIComponent(args.oldFileId)}`,
+        { method: 'DELETE', timeoutMs: 60_000 },
       );
       if (!response.ok && response.status !== 404) {
         console.warn(

--- a/services/platform/convex/file_metadata/actions.ts
+++ b/services/platform/convex/file_metadata/actions.ts
@@ -5,7 +5,7 @@ import { v } from 'convex/values';
 import { isRecord, getBoolean, getString } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import { action } from '../_generated/server';
-import { getRagConfig } from '../lib/helpers/rag_config';
+import { ragFetch } from '../lib/helpers/rag_config';
 
 /**
  * Check RAG indexing status for a list of files and update fileMetadata.
@@ -22,18 +22,13 @@ export const checkFileRagStatuses = action({
   handler: async (ctx, args): Promise<null> => {
     if (args.storageIds.length === 0) return null;
 
-    const ragUrl = getRagConfig().serviceUrl;
-    if (!ragUrl) return null;
-
-    const url = `${ragUrl}/api/v1/documents/statuses`;
-
     let body: unknown;
     try {
-      const response = await fetch(url, {
+      const response = await ragFetch('/api/v1/documents/statuses', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ file_ids: args.storageIds }),
-        signal: AbortSignal.timeout(10_000),
+        timeoutMs: 10_000,
       });
 
       if (!response.ok) {

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -7,7 +7,6 @@ import { isRecord, getNumber } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
 import { getCrawlerUrl } from '../documents/generate_document_helpers';
-import { getRagConfig } from '../lib/helpers/rag_config';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 
 /**
@@ -24,22 +23,6 @@ export const uploadFileToRag = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
-    const ragConfig = getRagConfig();
-    if (!ragConfig.serviceUrl) {
-      // Mark failed explicitly — returning null silently would leave
-      // ragStatus at 'queued' forever, and the client would poll RAG
-      // `/statuses` indefinitely with no data coming back.
-      await ctx.runMutation(
-        internal.file_metadata.internal_mutations.updateFileRagStatus,
-        {
-          storageId: args.storageId,
-          ragStatus: 'failed',
-          ragError: 'RAG service is not configured',
-        },
-      );
-      return null;
-    }
-
     try {
       await ragAction.execute(
         ctx,

--- a/services/platform/convex/file_metadata/transcribe_audio.ts
+++ b/services/platform/convex/file_metadata/transcribe_audio.ts
@@ -8,7 +8,6 @@ import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
 import { estimateTranscriptionCostCents } from '../governance/cost_estimation';
 import { classifyError } from '../lib/error_classification';
-import { getRagConfig } from '../lib/helpers/rag_config';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import type { ResolvedModelData } from '../providers/resolve_model';
 import { resolveTranscriptionModel } from '../providers/resolve_model';
@@ -206,9 +205,6 @@ async function indexTranscriptToRag(
       internal.file_metadata.internal_mutations.updateFileRagStatus,
       { storageId, ragStatus: 'running' },
     );
-    const ragConfig = getRagConfig();
-    if (!ragConfig.serviceUrl) return;
-
     const transcriptBlob = new Blob([args.transcript], { type: 'text/plain' });
     // RAG validates by extension (SUPPORTED_EXTENSIONS in documents.py). The
     // original audio extension (.mp3/.wav/etc.) is not in that set, so append
@@ -219,7 +215,6 @@ async function indexTranscriptToRag(
     // doesn't confuse users.
     const ragFilename = `${args.fileName}.txt`;
     await uploadFile({
-      ragServiceUrl: ragConfig.serviceUrl,
       file: transcriptBlob,
       filename: ragFilename,
       contentType: 'text/plain',

--- a/services/platform/convex/governance/retention_cleanup.ts
+++ b/services/platform/convex/governance/retention_cleanup.ts
@@ -7,7 +7,7 @@ import { isRecord } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import type { ActionCtx } from '../_generated/server';
 import { internalAction } from '../_generated/server';
-import { getRagConfig } from '../lib/helpers/rag_config';
+import { ragFetch } from '../lib/helpers/rag_config';
 
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_TEMP_RETENTION_HOURS = 24;
@@ -27,10 +27,29 @@ interface OrgPolicy {
   config: RetentionPolicyConfig;
 }
 
+async function deleteRagEntry(fileId: string, label: string): Promise<void> {
+  try {
+    const res = await ragFetch(
+      `/api/v1/documents/${encodeURIComponent(fileId)}`,
+      { method: 'DELETE', timeoutMs: 10_000 },
+    );
+    // 404 is success on DELETE — already gone.
+    if (!res.ok && res.status !== 404) {
+      console.warn(
+        `[RetentionCleanup] RAG DELETE returned ${res.status} for ${label}`,
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[RetentionCleanup] Failed to delete RAG entry for ${label}:`,
+      error,
+    );
+  }
+}
+
 async function cleanupDocuments(
   ctx: ActionCtx,
   org: OrgPolicy,
-  ragUrl: string,
   batchSize: number,
 ): Promise<void> {
   if (!org.config.enabled) return;
@@ -43,17 +62,7 @@ async function cleanupDocuments(
 
   for (const doc of expiredDocs) {
     if (doc.fileId) {
-      try {
-        await fetch(
-          `${ragUrl}/api/v1/documents/${encodeURIComponent(doc.fileId)}`,
-          { method: 'DELETE', signal: AbortSignal.timeout(30000) },
-        );
-      } catch (error) {
-        console.warn(
-          `[RetentionCleanup] Failed to delete RAG entry for document ${doc._id}:`,
-          error,
-        );
-      }
+      await deleteRagEntry(doc.fileId, `document ${doc._id}`);
     }
 
     await ctx.runMutation(
@@ -67,7 +76,6 @@ async function cleanupTempFiles(
   ctx: ActionCtx,
   org: OrgPolicy,
   source: 'user' | 'agent',
-  ragUrl: string,
   batchSize: number,
 ): Promise<void> {
   const enabled =
@@ -88,17 +96,7 @@ async function cleanupTempFiles(
   );
 
   for (const file of expiredFiles) {
-    try {
-      await fetch(
-        `${ragUrl}/api/v1/documents/${encodeURIComponent(file.storageId)}`,
-        { method: 'DELETE', signal: AbortSignal.timeout(30000) },
-      );
-    } catch (error) {
-      console.warn(
-        `[RetentionCleanup] Failed to delete RAG entry for temp file ${file._id}:`,
-        error,
-      );
-    }
+    await deleteRagEntry(file.storageId, `temp file ${file._id}`);
 
     await ctx.runMutation(
       internal.governance.internal_mutations_retention.deleteExpiredTempFile,
@@ -283,20 +281,18 @@ export const runRetentionCleanup = internalAction({
       });
     }
 
-    const ragUrl = getRagConfig().serviceUrl;
-
     for (const org of orgsWithPolicies) {
       const batchSize = org.config.batchSize ?? DEFAULT_BATCH_SIZE;
       const { organizationId } = org;
 
       await runCategory('documents', organizationId, () =>
-        cleanupDocuments(ctx, org, ragUrl, batchSize),
+        cleanupDocuments(ctx, org, batchSize),
       );
       await runCategory('userTempFiles', organizationId, () =>
-        cleanupTempFiles(ctx, org, 'user', ragUrl, batchSize),
+        cleanupTempFiles(ctx, org, 'user', batchSize),
       );
       await runCategory('agentTempFiles', organizationId, () =>
-        cleanupTempFiles(ctx, org, 'agent', ragUrl, batchSize),
+        cleanupTempFiles(ctx, org, 'agent', batchSize),
       );
       await runCategory('chatHistory', organizationId, () =>
         cleanupChatHistory(ctx, org, batchSize),

--- a/services/platform/convex/lib/helpers/rag_config.ts
+++ b/services/platform/convex/lib/helpers/rag_config.ts
@@ -1,12 +1,222 @@
+import ipaddr from 'ipaddr.js';
+
 export interface RagConfig {
+  /** Full RAG base URL (e.g., `http://rag:8001`). */
   serviceUrl: string;
+  /** Bearer token sent on every request to RAG. */
+  internalToken: string;
+}
+
+const DEFAULT_INTERNAL_TOKEN = 'tale-rag-dev-only';
+const DEFAULT_SERVICE_URL = 'http://localhost:8001';
+
+/**
+ * SSRF-blocked CIDR ranges. We block ONLY ranges with no legitimate RAG-target
+ * use case in any deployment shape:
+ *   - 169.254.0.0/16 (RFC 3927 link-local) — every major cloud's IMDS
+ *     (AWS / GCP / Azure / Alibaba / DO) lives here on 169.254.169.254.
+ *     A single CIDR covers them all and is auto-stable across new clouds.
+ *   - 0.0.0.0/8 (RFC 1122 "this" network) — not a valid target host.
+ *
+ * We deliberately do NOT block 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12,
+ * 192.168.0.0/16 — these are localhost and docker private networks, which
+ * are the legitimate RAG targets in self-hosted deployments. A "tighter"
+ * block here would either be a no-op (default-permit) or break the standard
+ * compose default (default-deny). The narrow link-local + this-network
+ * blocklist matches the actual threat model (cloud-credential exfiltration
+ * via SSRF pivot to IMDS, see Capital One 2019).
+ */
+const SSRF_BLOCKED_CIDRS = ['169.254.0.0/16', '0.0.0.0/8'];
+
+/** Equivalent IPv6 ranges. */
+const SSRF_BLOCKED_CIDRS_V6 = [
+  'fe80::/10', // IPv6 link-local
+  '::ffff:169.254.0.0/112', // IPv4-mapped link-local
+];
+
+/**
+ * Hostname-string blocklist for cloud metadata endpoints that resolve via
+ * DNS to a link-local IP. We can't do DNS resolution here (must stay sync
+ * to keep the V8-runtime callers compatible — `node:dns` is Node-only),
+ * so we hard-block the known DNS names. Lower-cased for comparison.
+ *
+ * NOTE: this is best-effort against operator misconfiguration. A defense
+ * against DNS rebinding (operator sets RAG_URL to a hostname they don't
+ * control, hostname returns benign IP first then IMDS later) requires a
+ * pinned undici dispatcher which is incompatible with Convex's V8 runtime.
+ * Tracked as a follow-up; the threat model for self-hosted deployments
+ * requires operator-level mistakes for this attack to land.
+ */
+const SSRF_BLOCKED_HOSTNAMES = new Set<string>([
+  'metadata.google.internal',
+  'metadata',
+]);
+
+let cached: RagConfig | null = null;
+
+function ipInAnyCidr(ip: string, cidrs: readonly string[]): string | null {
+  let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    parsed = ipaddr.parse(ip);
+  } catch {
+    return null;
+  }
+  for (const cidr of cidrs) {
+    let parsedCidr: [ipaddr.IPv4 | ipaddr.IPv6, number];
+    try {
+      parsedCidr = ipaddr.parseCIDR(cidr);
+    } catch {
+      continue;
+    }
+    if (parsed.kind() !== parsedCidr[0].kind()) continue;
+    if (
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ipaddr.match is generic over its own IP types
+      (parsed as ipaddr.IPv4).match(parsedCidr as [ipaddr.IPv4, number]) ||
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- IPv6 fallback
+      (parsed as ipaddr.IPv6).match(parsedCidr as [ipaddr.IPv6, number])
+    ) {
+      return cidr;
+    }
+  }
+  return null;
 }
 
 /**
- * Get RAG service configuration.
- * Reads from RAG_URL environment variable or defaults to http://localhost:8001.
+ * Sync URL-only SSRF check. Throws if `rawUrl`:
+ *   - is not parseable
+ *   - uses a non-http(s) scheme
+ *   - has a literal IP host inside a blocked CIDR
+ *   - has a hostname known to resolve to cloud-metadata IPs
+ */
+export function validateRagUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(
+      `[rag_config] RAG_URL is not a valid URL: ${JSON.stringify(rawUrl)}`,
+    );
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `[rag_config] RAG_URL must use http(s) scheme; got ${parsed.protocol}`,
+    );
+  }
+
+  // Strip surrounding [...] from IPv6 hostnames before parsing.
+  const rawHost = parsed.hostname;
+  const ipCandidate = rawHost.startsWith('[') ? rawHost.slice(1, -1) : rawHost;
+  const lowerHost = rawHost.toLowerCase();
+
+  if (SSRF_BLOCKED_HOSTNAMES.has(lowerHost)) {
+    throw new Error(
+      `[rag_config] RAG_URL host ${rawHost} is a known cloud-metadata endpoint — refused for SSRF safety.`,
+    );
+  }
+
+  if (ipaddr.isValid(ipCandidate)) {
+    const blocked = ipInAnyCidr(ipCandidate, [
+      ...SSRF_BLOCKED_CIDRS,
+      ...SSRF_BLOCKED_CIDRS_V6,
+    ]);
+    if (blocked) {
+      throw new Error(
+        `[rag_config] RAG_URL host ${rawHost} is in ${blocked} ` +
+          '(cloud-metadata / link-local / this-network range — refused for SSRF safety).',
+      );
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Get the validated RAG configuration. Lazily computed on first call and
+ * cached for the lifetime of the process. Fully sync — works in both V8
+ * and Node Convex runtimes.
+ *
+ * Throws on:
+ *   - missing / malformed `RAG_URL`
+ *   - non-http(s) scheme
+ *   - literal-IP host inside an SSRF-blocked CIDR (link-local / IMDS / 0.0.0.0/8)
+ *   - hostname matching a known cloud-metadata endpoint
+ *   - default token in use AND `TALE_REQUIRE_CUSTOM_RAG_TOKEN=true`
+ *
+ * Logs a SECURITY warning (once) when the default `tale-rag-dev-only` token
+ * is in use without the require flag.
  */
 export function getRagConfig(): RagConfig {
-  const serviceUrl = process.env.RAG_URL || 'http://localhost:8001';
-  return { serviceUrl };
+  if (cached) return cached;
+
+  const serviceUrl = process.env.RAG_URL || DEFAULT_SERVICE_URL;
+  const internalToken =
+    process.env.RAG_INTERNAL_TOKEN || DEFAULT_INTERNAL_TOKEN;
+
+  validateRagUrl(serviceUrl);
+
+  if (internalToken === DEFAULT_INTERNAL_TOKEN) {
+    if (process.env.TALE_REQUIRE_CUSTOM_RAG_TOKEN === 'true') {
+      throw new Error(
+        '[SECURITY] TALE_REQUIRE_CUSTOM_RAG_TOKEN=true but RAG_INTERNAL_TOKEN ' +
+          'is still the default (tale-rag-dev-only). Set RAG_INTERNAL_TOKEN to ' +
+          'a unique secret on both the platform and RAG containers.',
+      );
+    }
+    console.warn(
+      '[SECURITY] Using default RAG_INTERNAL_TOKEN (tale-rag-dev-only). ' +
+        'Override RAG_INTERNAL_TOKEN to a unique secret before exposing the ' +
+        'RAG port to untrusted networks. Set TALE_REQUIRE_CUSTOM_RAG_TOKEN=true ' +
+        'to refuse to start with the default.',
+    );
+  }
+
+  cached = { serviceUrl, internalToken };
+  return cached;
 }
+
+/** Test-only — clear the cached config so the next `getRagConfig()` re-runs validation. */
+export function _resetRagConfigForTests(): void {
+  cached = null;
+}
+
+/**
+ * Authenticated fetch against the RAG service. Always sets
+ * `Authorization: Bearer ${internalToken}`, applies a default per-request
+ * timeout, and accepts a path or a full URL.
+ *
+ * Works in both V8 and Node Convex runtimes (uses the global `fetch`).
+ *
+ * @example
+ *   const res = await ragFetch('/api/v1/documents/abc', { method: 'DELETE' });
+ *   if (res.status === 404 || res.ok) { ...treat as success... }
+ */
+export async function ragFetch(
+  path: string,
+  init: RequestInit & { timeoutMs?: number } = {},
+): Promise<Response> {
+  const { serviceUrl, internalToken } = getRagConfig();
+  const url = path.startsWith('http')
+    ? path
+    : `${serviceUrl.replace(/\/$/, '')}${path.startsWith('/') ? '' : '/'}${path}`;
+
+  const headers = new Headers(init.headers);
+  if (!headers.has('authorization')) {
+    headers.set('authorization', `Bearer ${internalToken}`);
+  }
+
+  const timeoutMs = init.timeoutMs ?? 10_000;
+  const signal = init.signal ?? AbortSignal.timeout(timeoutMs);
+
+  const { timeoutMs: _drop, ...rest } = init;
+  return fetch(url, { ...rest, headers, signal });
+}
+
+export const _internal = {
+  DEFAULT_INTERNAL_TOKEN,
+  DEFAULT_SERVICE_URL,
+  SSRF_BLOCKED_CIDRS,
+  SSRF_BLOCKED_CIDRS_V6,
+  SSRF_BLOCKED_HOSTNAMES,
+  validateRagUrl,
+  ipInAnyCidr,
+};

--- a/services/platform/convex/lib/response_cache/semantic_cache.ts
+++ b/services/platform/convex/lib/response_cache/semantic_cache.ts
@@ -7,7 +7,7 @@
  * Gracefully degrades if the RAG service is unavailable.
  */
 
-import { getRagConfig } from '../helpers/rag_config';
+import { ragFetch } from '../helpers/rag_config';
 
 const TIMEOUT_MS = 10_000;
 
@@ -31,11 +31,7 @@ export async function lookupSemanticCache(params: {
   similarityThreshold?: number;
 }): Promise<SemanticCacheHit | null> {
   try {
-    const { serviceUrl } = getRagConfig();
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-    const response = await fetch(`${serviceUrl}/api/v1/llm-cache/lookup`, {
+    const response = await ragFetch('/api/v1/llm-cache/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -45,9 +41,8 @@ export async function lookupSemanticCache(params: {
         similarity_threshold:
           params.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD,
       }),
-      signal: controller.signal,
+      timeoutMs: TIMEOUT_MS,
     });
-    clearTimeout(timeout);
 
     if (!response.ok) return null;
 
@@ -103,11 +98,7 @@ export async function storeSemanticCache(params: {
   organizationId?: string;
 }): Promise<void> {
   try {
-    const { serviceUrl } = getRagConfig();
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-    await fetch(`${serviceUrl}/api/v1/llm-cache/store`, {
+    await ragFetch('/api/v1/llm-cache/store', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -121,9 +112,8 @@ export async function storeSemanticCache(params: {
         user_id: params.userId,
         organization_id: params.organizationId,
       }),
-      signal: controller.signal,
+      timeoutMs: TIMEOUT_MS,
     });
-    clearTimeout(timeout);
   } catch {
     // Fire-and-forget: don't fail the response if cache store fails
   }

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -17,7 +17,6 @@ import { fetchDocumentComparisonByUrls } from '../../../agent_tools/documents/he
 import { fetchDocumentContent } from '../../../agent_tools/documents/helpers/fetch_document_content';
 import { getDocumentEffectiveDate } from '../../../documents/transform_to_document_item';
 import type { DocumentMetadata } from '../../../documents/types';
-import { getRagConfig } from '../../../lib/helpers/rag_config';
 import { toConvexJsonRecord, toId } from '../../../lib/type_cast_helpers';
 import { jsonRecordValidator } from '../../../lib/validators/json';
 import type { ActionDefinition } from '../../helpers/nodes/action/types';
@@ -268,8 +267,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       }
 
       case 'retrieve': {
-        const { serviceUrl } = getRagConfig();
-        return await fetchDocumentContent(serviceUrl, params.fileId, {
+        return await fetchDocumentContent(params.fileId, {
           chunkStart: params.chunkStart,
           chunkEnd: params.chunkEnd,
           returnChunks: params.returnChunks,
@@ -302,8 +300,6 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       }
 
       case 'compare': {
-        const { serviceUrl } = getRagConfig();
-
         const [baseFileUrl, compFileUrl] = await Promise.all([
           resolveStorageUrl(ctx, params.baseFileId),
           resolveStorageUrl(ctx, params.comparisonFileId),
@@ -318,7 +314,6 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
               ]);
 
         return await fetchDocumentComparisonByUrls(
-          serviceUrl,
           baseFileUrl,
           baseFileName,
           compFileUrl,

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/delete_document.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/delete_document.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 
+import { _resetRagConfigForTests } from '../../../../lib/helpers/rag_config';
 import { deleteDocumentById } from './delete_document';
+
+beforeAll(() => {
+  process.env.RAG_URL = 'http://rag:8000';
+  process.env.RAG_INTERNAL_TOKEN = 'test-token';
+  _resetRagConfigForTests();
+});
 
 describe('deleteDocumentById', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -38,7 +53,6 @@ describe('deleteDocumentById', () => {
     });
 
     await deleteDocumentById({
-      ragServiceUrl: 'http://rag:8000',
       fileId: 'doc-123',
     });
 
@@ -56,7 +70,6 @@ describe('deleteDocumentById', () => {
     });
 
     const result = await deleteDocumentById({
-      ragServiceUrl: 'http://rag:8000',
       fileId: 'doc-abc',
     });
 
@@ -70,7 +83,6 @@ describe('deleteDocumentById', () => {
     mockFetch({ detail: 'not found' }, 400);
 
     const result = await deleteDocumentById({
-      ragServiceUrl: 'http://rag:8000',
       fileId: 'doc-fail',
     });
 
@@ -82,7 +94,6 @@ describe('deleteDocumentById', () => {
     mockFetch({ success: true, deleted_count: 0, deleted_data_ids: [] });
 
     await deleteDocumentById({
-      ragServiceUrl: 'http://rag:8000',
       fileId: 'doc/with spaces',
     });
 

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/delete_document.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/delete_document.ts
@@ -5,10 +5,10 @@ import {
   getArray,
   isRecord,
 } from '../../../../../lib/utils/type-guards';
+import { ragFetch } from '../../../../lib/helpers/rag_config';
 import type { RagDeleteResult } from './types';
 
 export interface DeleteDocumentByIdArgs {
-  ragServiceUrl: string;
   fileId: string;
   timeoutMs?: number;
 }
@@ -21,23 +21,16 @@ export interface DeleteDocumentByIdArgs {
  * the document (recordId from the platform).
  */
 export async function deleteDocumentById({
-  ragServiceUrl,
   fileId,
   timeoutMs = 60000,
 }: DeleteDocumentByIdArgs): Promise<RagDeleteResult> {
   const startTime = Date.now();
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
   try {
-    const url = `${ragServiceUrl}/api/v1/documents/${encodeURIComponent(fileId)}`;
-    const response = await fetch(url, {
-      method: 'DELETE',
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
+    const response = await ragFetch(
+      `/api/v1/documents/${encodeURIComponent(fileId)}`,
+      { method: 'DELETE', timeoutMs },
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -62,7 +55,6 @@ export async function deleteDocumentById({
       timestamp: Date.now(),
     };
   } catch (error) {
-    clearTimeout(timeoutId);
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
@@ -72,7 +72,7 @@ describe('uploadDocument', () => {
     const ctx = createCtx();
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     expect(ctx.storage.getUrl).toHaveBeenCalledWith(FILE_ID);
   });
@@ -80,9 +80,9 @@ describe('uploadDocument', () => {
   it('throws when storage.getUrl returns null', async () => {
     const ctx = createCtx(null);
 
-    await expect(
-      uploadDocument(ctx as never, RAG_URL, FILE_ID),
-    ).rejects.toThrow(`File URL not available: ${FILE_ID}`);
+    await expect(uploadDocument(ctx as never, FILE_ID)).rejects.toThrow(
+      `File URL not available: ${FILE_ID}`,
+    );
   });
 
   it('throws when file download fails with non-ok response', async () => {
@@ -92,18 +92,18 @@ describe('uploadDocument', () => {
       status: 404,
     });
 
-    await expect(
-      uploadDocument(ctx as never, RAG_URL, FILE_ID),
-    ).rejects.toThrow('Failed to download file: 404');
+    await expect(uploadDocument(ctx as never, FILE_ID)).rejects.toThrow(
+      'Failed to download file: 404',
+    );
   });
 
   it('throws when fileMetadata is not found', async () => {
     const ctx = createCtx('https://storage.example.com/file', null);
     mockFetchOk();
 
-    await expect(
-      uploadDocument(ctx as never, RAG_URL, FILE_ID),
-    ).rejects.toThrow('File metadata not found');
+    await expect(uploadDocument(ctx as never, FILE_ID)).rejects.toThrow(
+      'File metadata not found',
+    );
   });
 
   it('uses fileName and contentType from fileMetadata', async () => {
@@ -114,7 +114,7 @@ describe('uploadDocument', () => {
     });
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     expect(uploadFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -133,7 +133,7 @@ describe('uploadDocument', () => {
     });
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID, {
+    await uploadDocument(ctx as never, FILE_ID, {
       fileName: 'override.pdf',
       contentType: 'application/pdf',
     });
@@ -153,7 +153,7 @@ describe('uploadDocument', () => {
     });
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     expect(uploadFileMock).toHaveBeenCalledWith(
       expect.objectContaining({ filename: 'report.pdf' }),
@@ -164,7 +164,7 @@ describe('uploadDocument', () => {
     const ctx = createCtx();
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID, { sync: true });
+    await uploadDocument(ctx as never, FILE_ID, { sync: true });
 
     expect(uploadFileMock).toHaveBeenCalledWith(
       expect.objectContaining({ sync: true }),
@@ -175,7 +175,7 @@ describe('uploadDocument', () => {
     const ctx = createCtx();
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     expect(uploadFileMock).toHaveBeenCalledWith(
       expect.objectContaining({ sync: false }),
@@ -186,11 +186,10 @@ describe('uploadDocument', () => {
     const ctx = createCtx();
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     expect(uploadFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        ragServiceUrl: RAG_URL,
         fileId: FILE_ID,
       }),
     );
@@ -200,7 +199,7 @@ describe('uploadDocument', () => {
     const ctx = createCtx();
     mockFetchOk();
 
-    await uploadDocument(ctx as never, RAG_URL, FILE_ID);
+    await uploadDocument(ctx as never, FILE_ID);
 
     const callArgs = uploadFileMock.mock.calls[0][0];
     expect(callArgs.file).toBeInstanceOf(Blob);

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.ts
@@ -23,7 +23,6 @@ function ensureExtension(fileName: string, contentType: string): string {
 
 export async function uploadDocument(
   ctx: ActionCtx,
-  ragServiceUrl: string,
   fileId: string,
   options?: {
     sync?: boolean;
@@ -63,7 +62,6 @@ export async function uploadDocument(
   );
 
   return uploadFile({
-    ragServiceUrl,
     file,
     filename: fileName,
     contentType,

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_file_direct.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_file_direct.test.ts
@@ -1,13 +1,27 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
+import { _resetRagConfigForTests } from '../../../../lib/helpers/rag_config';
 import { uploadFile } from './upload_file_direct';
 
 const RAG_URL = 'http://rag:8000';
+
+beforeAll(() => {
+  process.env.RAG_URL = RAG_URL;
+  process.env.RAG_INTERNAL_TOKEN = 'test-token';
+  _resetRagConfigForTests();
+});
 const FILE_ID = 'doc-abc-123';
 
 function defaultArgs() {
   return {
-    ragServiceUrl: RAG_URL,
     file: new Blob(['test-content'], { type: 'text/plain' }),
     filename: 'test.txt',
     contentType: 'text/plain',

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_file_direct.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_file_direct.ts
@@ -1,7 +1,7 @@
+import { ragFetch } from '../../../../lib/helpers/rag_config';
 import type { RagUploadResult } from './types';
 
 export interface UploadFileArgs {
-  ragServiceUrl: string;
   file: Blob;
   filename: string;
   contentType: string;
@@ -25,7 +25,6 @@ const SYNC_TIMEOUT_MS = 120_000;
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export async function uploadFile({
-  ragServiceUrl,
   file,
   filename,
   contentType,
@@ -46,20 +45,15 @@ export async function uploadFile({
     JSON.stringify({ ...metadata, content_type: contentType }),
   );
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
+  const path = sync
+    ? '/api/v1/documents/upload?sync=true'
+    : '/api/v1/documents/upload';
 
-  const uploadUrl = sync
-    ? `${ragServiceUrl}/api/v1/documents/upload?sync=true`
-    : `${ragServiceUrl}/api/v1/documents/upload`;
-
-  const response = await fetch(uploadUrl, {
+  const response = await ragFetch(path, {
     method: 'POST',
     body: formData,
-    signal: controller.signal,
+    timeoutMs: effectiveTimeout,
   });
-
-  clearTimeout(timeoutId);
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/services/platform/convex/workflow_engine/action_defs/rag/rag_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/rag_action.ts
@@ -3,9 +3,9 @@ import { v } from 'convex/values';
 import { fetchJson } from '../../../../lib/utils/type-cast-helpers';
 import type { SearchResponse } from '../../../agent_tools/rag/format_search_results';
 import { fetchDocumentChunks } from '../../../agent_tools/rag/helpers/fetch_document_chunks';
+import { ragFetch } from '../../../lib/helpers/rag_config';
 import type { ActionDefinition } from '../../helpers/nodes/action/types';
 import { deleteDocumentById } from './helpers/delete_document';
-import { getRagConfig } from './helpers/get_rag_config';
 import type { RagActionParams } from './helpers/types';
 import { uploadDocument } from './helpers/upload_document';
 
@@ -44,48 +44,32 @@ export const ragAction: ActionDefinition<RagActionParams> = {
 
   async execute(ctx, params) {
     const startTime = Date.now();
-    const { serviceUrl } = getRagConfig();
 
     // Backward compatibility: map old param names from user-created workflows
     const migratedParams = migrateParams(params);
 
     switch (migratedParams.operation) {
       case 'upload_document': {
-        const result = await uploadDocument(
-          ctx,
-          serviceUrl,
-          migratedParams.fileId,
-          {
-            sync: migratedParams.sync,
-            fileName: migratedParams.fileName,
-            contentType: migratedParams.contentType,
-          },
-        );
+        const result = await uploadDocument(ctx, migratedParams.fileId, {
+          sync: migratedParams.sync,
+          fileName: migratedParams.fileName,
+          contentType: migratedParams.contentType,
+        });
         return { ...result, executionTimeMs: Date.now() - startTime };
       }
       case 'delete_document': {
         const result = await deleteDocumentById({
-          ragServiceUrl: serviceUrl,
           fileId: migratedParams.fileId,
         });
         return { ...result, executionTimeMs: Date.now() - startTime };
       }
       case 'get_chunks': {
-        const result = await fetchDocumentChunks(
-          serviceUrl,
-          migratedParams.fileId,
-        );
+        const result = await fetchDocumentChunks(migratedParams.fileId);
         return { ...result, executionTimeMs: Date.now() - startTime };
       }
       case 'search': {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(
-          () => controller.abort(),
-          SEARCH_TIMEOUT_MS,
-        );
-
         try {
-          const response = await fetch(`${serviceUrl}/api/v1/search`, {
+          const response = await ragFetch('/api/v1/search', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -95,9 +79,8 @@ export const ragAction: ActionDefinition<RagActionParams> = {
               similarity_threshold: migratedParams.similarityThreshold ?? 0.0,
               include_metadata: true,
             }),
-            signal: controller.signal,
+            timeoutMs: SEARCH_TIMEOUT_MS,
           });
-          clearTimeout(timeoutId);
 
           if (!response.ok) {
             const errorText = await response.text().catch(() => '');
@@ -114,8 +97,10 @@ export const ragAction: ActionDefinition<RagActionParams> = {
             executionTimeMs: Date.now() - startTime,
           };
         } catch (error) {
-          clearTimeout(timeoutId);
-          if (error instanceof Error && error.name === 'AbortError') {
+          if (
+            error instanceof Error &&
+            (error.name === 'AbortError' || error.name === 'TimeoutError')
+          ) {
             throw new Error(
               `RAG search timed out after ${SEARCH_TIMEOUT_MS / 1000}s`,
               { cause: error },

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -97,6 +97,7 @@
     "i18next": "26.0.4",
     "i18next-icu": "2.4.3",
     "intl-messageformat": "11.2.0",
+    "ipaddr.js": "^2.4.0",
     "jexl": "2.3.0",
     "jose": "6.2.2",
     "json-diff-kit": "1.0.35",

--- a/services/rag/Dockerfile
+++ b/services/rag/Dockerfile
@@ -136,6 +136,13 @@ ENV TALE_VERSION=${VERSION} \
     RAG_LOG_LEVEL=info \
     RAG_CHUNK_SIZE=2048 \
     RAG_CHUNK_OVERLAP=200 \
+    # Internal-token default — matches the bake in services/convex/Dockerfile
+    # so a fresh `docker compose up` works without operator setup. Production
+    # operators MUST override RAG_INTERNAL_TOKEN to a unique secret. Startup
+    # logs a loud SECURITY warning every restart while the default is active.
+    # Set RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true to refuse to start with the
+    # default (strict production posture).
+    RAG_INTERNAL_TOKEN=tale-rag-dev-only \
     DO_NOT_TRACK=1 \
     TALE_PLATFORM_SHARED_CONFIG_DIR=/app/platform-config
 
@@ -174,6 +181,13 @@ ENV TALE_VERSION=${VERSION} \
     RAG_LOG_LEVEL=info \
     RAG_CHUNK_SIZE=2048 \
     RAG_CHUNK_OVERLAP=200 \
+    # Internal-token default — matches the bake in services/convex/Dockerfile
+    # so a fresh `docker compose up` works without operator setup. Production
+    # operators MUST override RAG_INTERNAL_TOKEN to a unique secret. Startup
+    # logs a loud SECURITY warning every restart while the default is active.
+    # Set RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true to refuse to start with the
+    # default (strict production posture).
+    RAG_INTERNAL_TOKEN=tale-rag-dev-only \
     DO_NOT_TRACK=1 \
     TALE_PLATFORM_SHARED_CONFIG_DIR=/app/platform-config
 

--- a/services/rag/app/auth.py
+++ b/services/rag/app/auth.py
@@ -1,0 +1,77 @@
+"""Internal-token auth for the RAG service.
+
+The RAG service is reachable on a private docker network from the platform
+service. To prevent any caller on that network (or worse, a misconfigured
+host-published port) from reading or deleting documents, every request
+must carry a Bearer token matching `settings.internal_token`.
+
+The token has a Docker-baked default (`tale-rag-dev-only`) so a fresh
+`docker compose up` works without any operator config. Production operators
+override the token via env / compose / k8s secret. When the default is in
+use, startup logs a loud SECURITY warning.
+"""
+
+from fastapi import Header, HTTPException, status
+from loguru import logger
+
+from .config import settings
+
+DEFAULT_INTERNAL_TOKEN = "tale-rag-dev-only"
+
+# Endpoints exempt from auth. Health checks and the root path must remain
+# reachable for liveness / readiness probes (k8s, docker healthcheck).
+EXEMPT_PATHS: frozenset[str] = frozenset({"/", "/health", "/healthz", "/ready"})
+
+
+def _extract_bearer(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    parts = header_value.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip() or None
+
+
+async def verify_internal_token(
+    authorization: str | None = Header(default=None),
+) -> None:
+    """FastAPI dependency: validate Authorization: Bearer <token>.
+
+    Raises 401 on missing/invalid token. Mounted globally; see
+    `routers.health` for the path-based exemption.
+    """
+    presented = _extract_bearer(authorization)
+    if presented is None or presented != settings.internal_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or missing internal token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def warn_if_default_token_in_use() -> None:
+    """Emit a loud SECURITY warning when the baked-in default token is active.
+
+    Called once at app startup. Operators see the line in `docker logs`
+    every restart; it is intentionally not silenced — production operators
+    should fix it by overriding `RAG_INTERNAL_TOKEN`.
+    """
+    if settings.internal_token != DEFAULT_INTERNAL_TOKEN:
+        return
+
+    if settings.require_custom_internal_token:
+        # Strict production posture: refuse to start.
+        msg = (
+            "RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true but the default "
+            "RAG_INTERNAL_TOKEN is still in use. Set RAG_INTERNAL_TOKEN "
+            "to a unique secret and restart."
+        )
+        logger.error("[SECURITY] {}", msg)
+        raise RuntimeError(msg)
+
+    logger.warning(
+        "[SECURITY] Using default RAG_INTERNAL_TOKEN ({!r}) — override "
+        "RAG_INTERNAL_TOKEN before exposing the RAG port to untrusted "
+        "networks. Set RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true to enforce.",
+        DEFAULT_INTERNAL_TOKEN,
+    )

--- a/services/rag/app/config.py
+++ b/services/rag/app/config.py
@@ -22,6 +22,18 @@ class Settings(BaseServiceSettings):
     # Override base defaults
     port: int = 8001
 
+    # Internal auth token shared with the platform service.
+    # Default `tale-rag-dev-only` matches the value baked into the RAG and
+    # platform Docker images so a fresh `docker compose up` works with no
+    # config. Production operators MUST override via env / compose / k8s
+    # secret. When the default is in use, startup logs a loud SECURITY
+    # warning every restart (see main.py).
+    internal_token: str = "tale-rag-dev-only"
+
+    # When true, refuse to start with the default internal token (strict
+    # production posture). Default false so dev / eval / local just works.
+    require_custom_internal_token: bool = False
+
     # Database pool sizing
     database_pool_min: int = 2
     database_pool_max: int = 10

--- a/services/rag/app/main.py
+++ b/services/rag/app/main.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
@@ -12,6 +12,7 @@ from tale_shared.logging import suppress_health_check_logs
 from tale_telemetry import init_telemetry, shutdown_telemetry
 
 from . import __version__
+from .auth import verify_internal_token, warn_if_default_token_in_use
 from .config import settings
 from .models import ErrorResponse
 from .routers import documents_router, health_router, llm_cache_router, search_router
@@ -40,6 +41,10 @@ async def lifespan(app: FastAPI):
     logger.info("Version: {}", __version__)
     logger.info("Host: {}:{}", settings.host, settings.port)
     logger.info("Log level: {}", settings.log_level)
+
+    # Emit SECURITY warning if the baked-in default internal token is in use.
+    # If RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true this raises and stops startup.
+    warn_if_default_token_in_use()
 
     try:
         await rag_service.initialize()
@@ -121,9 +126,18 @@ async def general_exception_handler(_request, exc):
     )
 
 
-# Include routers
+# Include routers.
+# Health router is mounted WITHOUT the internal-token dependency so liveness
+# and readiness probes (docker / k8s) keep working with no auth headers.
+# Every other router requires `Authorization: Bearer ${RAG_INTERNAL_TOKEN}`.
 app.include_router(health_router)
-app.include_router(documents_router)
-app.include_router(search_router)
-app.include_router(llm_cache_router)
+app.include_router(documents_router, dependencies=[Depends(verify_internal_token)])
+app.include_router(search_router, dependencies=[Depends(verify_internal_token)])
+app.include_router(llm_cache_router, dependencies=[Depends(verify_internal_token)])
 init_telemetry(app)
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> dict[str, str]:
+    """Root endpoint — exempt from auth so liveness probes can hit it."""
+    return {"service": "tale-rag", "version": __version__, "status": "ok"}


### PR DESCRIPTION
## Summary

Independently-deployable security hotfix. RAG service shipped with **zero authentication** on all 13 endpoints (including DELETE on `/api/v1/documents/{file_id}`); host-published on port 8001 in `compose.yml`. Any caller reachable on the network could read or destroy any deployment's indexed corpus.

This PR closes that gap with a Bearer-token contract between the platform and RAG containers + a small SSRF guard on the platform-side `RAG_URL` so cloud-metadata pivot attacks are refused.

- **RAG (Python)**: global `verify_internal_token` FastAPI dependency on documents/search/llm_cache routers; `/health` and `/` exempt for liveness probes. Default `tale-rag-dev-only` baked into the Dockerfile so a fresh `docker compose up` works with no setup. Loud `[SECURITY]` warning every restart while default is in use. `RAG_REQUIRE_CUSTOM_INTERNAL_TOKEN=true` opts into strict prod posture.
- **Platform (TS/Convex)**: `getRagConfig()` rewritten — sync, V8-runtime-safe, validates `RAG_URL` against `169.254.0.0/16` (link-local / IMDS) + `0.0.0.0/8` ("this" network) CIDR blocklist using `ipaddr.js` (encoding bypasses auto-normalize). New `ragFetch()` helper sets the Authorization header automatically. **All 14 callers migrated** + 5 helpers refactored to drop the manual `serviceUrl` parameter.

## Deployment note

Operators must upgrade BOTH the platform and RAG containers in the same release: the new RAG image 401s un-authed callers; the old platform image doesn't send the Authorization header. The Docker-baked default ensures a coordinated upgrade works without env changes; production operators override `RAG_INTERNAL_TOKEN` (matching on both services) once both images are running.

## Compatibility note

DNS-rebinding pinning (the original plan's undici-Agent design) is deferred — undici / `node:dns` are unavailable in Convex's V8 runtime and 5 RAG callers run V8. The URL-string SSRF check covers the realistic threat model; DNS rebinding requires the operator to set `RAG_URL` to an attacker-controlled hostname (a deeper compromise).

## Test plan

- [ ] `bun run check` (format / lint / typecheck / tests) passes locally
- [ ] Fresh `docker compose up` works without setting `RAG_INTERNAL_TOKEN` (warn-log appears in `docker logs`)
- [ ] Setting `RAG_INTERNAL_TOKEN=secret-foo` on both RAG and platform containers, `docker compose restart` — chat continues to work; warning gone
- [ ] Setting only one side starts auth-mismatch — RAG returns 401; platform logs the failure
- [ ] `RAG_URL=http://169.254.169.254/metadata` refused at platform startup with link-local CIDR error
- [ ] `RAG_URL=http://0xa9fea9fe/metadata` (octal IMDS) refused (`ipaddr.js` normalizes)
- [ ] Existing tests in `services/rag/tests/` and `services/platform/convex/governance/__tests__/` continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure & Security**
  * Implemented internal token authentication for RAG service endpoints
  * Enhanced RAG configuration with centralized token and URL management
  * Added SSRF protection utilities to validate service URLs

* **Refactor**
  * Consolidated RAG API integration by centralizing URL handling, removing the need to pass service URLs throughout the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->