### PR TITLE
feat(docs): add DOCS_BASE_URL build arg for sub-path mounting

### DIFF
--- a/compose.docs.yml
+++ b/compose.docs.yml
@@ -21,6 +21,7 @@ services:
       dockerfile: services/docs/Dockerfile
       args:
         VERSION: ${VERSION:-dev}
+        DOCS_BASE_URL: ${DOCS_BASE_URL:-/}
 
     env_file:
       - services/docs/.env

--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -44,7 +44,9 @@ COPY packages/webui ./packages/webui
 COPY services/docs ./services/docs
 COPY docs ./docs
 
-ENV NODE_ENV=production
+ARG DOCS_BASE_URL=/
+ENV NODE_ENV=production \
+    DOCS_BASE_URL=${DOCS_BASE_URL}
 WORKDIR /app/services/docs
 RUN bun --bun scripts/build-search-index.ts \
     && bun --bun vite build \

--- a/services/docs/app/components/docs/docs-footer.tsx
+++ b/services/docs/app/components/docs/docs-footer.tsx
@@ -20,7 +20,7 @@ export function DocsFooter() {
         t('copyrightLine1', { year: new Date().getFullYear() }),
         t('copyrightLine2'),
       ]}
-      llmsTxtUrl="/llms.txt"
+      llmsTxtUrl={`${import.meta.env.BASE_URL}llms.txt`}
       llmsTxtLabel={t('llmsTxtLabel')}
       bottomTrailing={
         <a

--- a/services/docs/app/entry-server.tsx
+++ b/services/docs/app/entry-server.tsx
@@ -16,10 +16,14 @@ interface RenderResult {
   html: string;
 }
 
+const basepath =
+  import.meta.env.BASE_URL.replace(/\/$/, '') || undefined;
+
 export async function render(url: string): Promise<RenderResult> {
   const router = createRouter({
     routeTree,
     defaultPreload: 'intent',
+    basepath,
     history: createMemoryHistory({ initialEntries: [url] }),
   });
   await router.load();

--- a/services/docs/app/router.tsx
+++ b/services/docs/app/router.tsx
@@ -2,9 +2,16 @@ import { createRouter } from '@tanstack/react-router';
 
 import { routeTree } from './routeTree.gen';
 
+// Vite injects BASE_URL from the `base` config (always trailing-slashed).
+// TanStack Router wants the prefix without the trailing slash, and undefined
+// when mounted at root.
+const basepath =
+  import.meta.env.BASE_URL.replace(/\/$/, '') || undefined;
+
 export const router = createRouter({
   routeTree,
   defaultPreload: 'intent',
+  basepath,
 });
 
 declare module '@tanstack/react-router' {

--- a/services/docs/index.html
+++ b/services/docs/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="icon" type="image/png" href="/images/favicon-light.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%images/favicon-light.png" />
     <link
       rel="icon"
       type="image/png"
-      href="/images/favicon-dark.png"
+      href="%BASE_URL%images/favicon-dark.png"
       media="(prefers-color-scheme: dark)"
     />
     <meta name="theme-color" content="#ffffff" />
@@ -35,7 +35,7 @@
     <link
       rel="alternate"
       type="application/rss+xml"
-      href="/llms.txt"
+      href="%BASE_URL%llms.txt"
       title="llms.txt"
     />
   </head>

--- a/services/docs/scripts/prerender.ts
+++ b/services/docs/scripts/prerender.ts
@@ -13,6 +13,9 @@ const ROOT = resolve(SCRIPT_DIR, '..');
 const DIST = resolve(ROOT, 'dist');
 const SSR_BUNDLE = resolve(ROOT, 'dist-ssr', 'entry-server.js');
 const SITE_URL = process.env.DOCS_SITE_URL ?? 'https://docs.tale.dev';
+// Mount-point prefix passed to the router during SSR so it resolves URLs
+// against the same basepath the client uses. Empty for root deployments.
+const BASE_PATH = (process.env.DOCS_BASE_URL ?? '/').replace(/\/$/, '');
 
 interface Route {
   url: string;
@@ -99,7 +102,7 @@ async function main() {
     if (seen.has(route.url)) continue;
     seen.add(route.url);
     process.stdout.write(`prerender ${route.url} ... `);
-    const { html } = await mod.render(route.url);
+    const { html } = await mod.render(`${BASE_PATH}${route.url}`);
     const withSeo = injectSeo(template, route);
     const final = withSeo.replace(
       '<div id="root"></div>',

--- a/services/docs/vite.config.ts
+++ b/services/docs/vite.config.ts
@@ -3,7 +3,10 @@ import viteReact from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: './',
+  // Build-time mount point. Defaults to '/' (e.g. docs.tale.dev). Set to a
+  // sub-path with trailing slash like '/docs/' to serve the docs app under
+  // that prefix — Vite then prefixes every asset URL accordingly.
+  base: process.env.DOCS_BASE_URL ?? '/',
   resolve: {
     dedupe: ['react', 'react-dom'],
     tsconfigPaths: true,


### PR DESCRIPTION
## Summary

Lets the docs app be deployed under a sub-path (e.g. `/docs/`) without breaking absolute asset URLs. The motivating use case is the temporary deploy on the ops droplet where `docs.tale.dev` DNS isn't set up yet, so both apps need to share a single hostname with web at `/` and docs at `/docs`.

The default of `/` keeps the existing `docs.tale.dev` deployment unchanged.

## How it works

- **`vite.config.ts`** reads `process.env.DOCS_BASE_URL` and uses it as Vite's `base` (defaults to `/`). Vite then prefixes every generated asset URL (CSS chunks, JS chunks, fonts, imported images) with that value.
- **`index.html`** uses Vite's `%BASE_URL%` placeholder for the favicon `<link>` tags and the `/llms.txt` alternate link.
- **`app/router.tsx`** + **`app/entry-server.tsx`** derive a TanStack Router `basepath` from `import.meta.env.BASE_URL` (stripping the trailing slash) so client-side and SSR routing both honour the prefix.
- **`scripts/prerender.ts`** prefixes the URL passed to `render()` with the same `basepath` so memory-history-based SSR matches the same routes the client sees.
- **`docs-footer.tsx`** swaps a hardcoded `/llms.txt` for `${import.meta.env.BASE_URL}llms.txt`.
- **`Dockerfile`** declares `ARG DOCS_BASE_URL` and exports it as `ENV` before `vite build` runs.
- **`compose.docs.yml`** forwards `DOCS_BASE_URL` from the host env to the build args (defaults `/`).

## Pre-PR checklist

- [ ] Ran `bun run check` — _not run by author; please verify locally_
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no UI strings changed)
- [x] Updated `/docs/{en,de,fr}/` — N/A (deployment infra only)
- [ ] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — _not run by author; please verify locally_
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A

## Test plan

- [ ] Build with default: `docker compose -f compose.docs.yml build` — confirm the `docs.tale.dev` deployment is unaffected (assets still at root).
- [ ] Build with prefix: `DOCS_BASE_URL=/docs/ docker compose -f compose.docs.yml build`, then run behind a reverse proxy that strips `/docs` before forwarding. Confirm CSS, fonts, JS, favicon, and `llms.txt` all load under `/docs/...` and that `<Link>` clicks keep the prefix in the address bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation service deployment flexibility by adding support for configurable base URLs. The documentation can now be served from any custom deployment path, with all asset references, navigation links, routing, and RSS feeds automatically resolving correctly regardless of whether the docs are hosted at the root path or deployed under any sub-path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->