### PR TITLE
feat(docs): forward DOCS_SITE_URL through Dockerfile build args

### DIFF
--- a/compose.docs.yml
+++ b/compose.docs.yml
@@ -22,6 +22,7 @@ services:
       args:
         VERSION: ${VERSION:-dev}
         DOCS_BASE_URL: ${DOCS_BASE_URL:-/}
+        DOCS_SITE_URL: ${DOCS_SITE_URL:-https://docs.tale.dev}
 
     env_file:
       - services/docs/.env

--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -45,8 +45,10 @@ COPY services/docs ./services/docs
 COPY docs ./docs
 
 ARG DOCS_BASE_URL=/
+ARG DOCS_SITE_URL=https://docs.tale.dev
 ENV NODE_ENV=production \
-    DOCS_BASE_URL=${DOCS_BASE_URL}
+    DOCS_BASE_URL=${DOCS_BASE_URL} \
+    DOCS_SITE_URL=${DOCS_SITE_URL}
 WORKDIR /app/services/docs
 RUN bun --bun scripts/build-search-index.ts \
     && bun --bun vite build \


### PR DESCRIPTION
## Summary

Follow-up to #1684. `prerender.ts` and `build-llms-artifacts.ts` both already read `process.env.DOCS_SITE_URL` to compose canonical URLs, `og:url`, sitemap entries, and the absolute URLs in `llms.txt` / `llms-full.txt`. But the value wasn't plumbed through the Dockerfile, so every production build silently fell back to the hardcoded `https://docs.tale.dev` default — the only knob the host had over canonical URLs was editing the source.

## Change

- `services/docs/Dockerfile` — add `ARG DOCS_SITE_URL` and `ENV DOCS_SITE_URL=...` next to the existing `DOCS_BASE_URL` plumbing.
- `compose.docs.yml` — forward `DOCS_SITE_URL` from the host env to the build args.

The default `https://docs.tale.dev` keeps the canonical `docs.tale.dev` deployment unchanged.

## Pre-PR checklist

- [x] Ran `bun run check` — N/A (Dockerfile + compose only, no JS/TS touched).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A.
- [x] Updated `/docs/{en,de,fr}/` — N/A.
- [x] Ran `bun run --filter @tale/docs lint`/`test` — N/A (no source changes).
- [x] Updated `README.md` and translations — N/A.

## Test plan

- [ ] `DOCS_SITE_URL=https://tale.dev/docs DOCS_BASE_URL=/docs/ docker compose -f compose.docs.yml build` → built HTML in `/dist/index.html` should have `<link rel="canonical" href="https://tale.dev/docs/" />` and matching `og:url`.
- [ ] Default build (no env) still produces `<link rel="canonical" href="https://docs.tale.dev/" />`.