### PR TITLE
feat(web): make docs URL configurable via WEB_DOCS_URL build arg

### DIFF
--- a/compose.web.yml
+++ b/compose.web.yml
@@ -26,6 +26,7 @@ services:
       dockerfile: services/web/Dockerfile
       args:
         VERSION: ${VERSION:-dev}
+        WEB_DOCS_URL: ${WEB_DOCS_URL:-https://docs.tale.dev}
 
     env_file:
       - services/web/.env

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -43,7 +43,10 @@ COPY packages/ui ./packages/ui
 COPY packages/webui ./packages/webui
 COPY services/web ./services/web
 
-ENV NODE_ENV=production
+ARG WEB_DOCS_URL=https://docs.tale.dev
+ENV NODE_ENV=production \
+    WEB_DOCS_URL=${WEB_DOCS_URL} \
+    VITE_DOCS_URL=${WEB_DOCS_URL}
 WORKDIR /app/services/web
 RUN bun --bun vite build \
     && bun build server.ts --target=bun --outfile=server.js --external bun

--- a/services/web/app/components/blocks/pricing-tiers.tsx
+++ b/services/web/app/components/blocks/pricing-tiers.tsx
@@ -17,6 +17,10 @@ import {
   type Region,
 } from '@/lib/pricing/region';
 
+// Vite injects VITE_DOCS_URL at build time; falls back to the canonical
+// docs.tale.dev origin for the default deployment.
+const DOCS_URL = import.meta.env.VITE_DOCS_URL ?? 'https://docs.tale.dev';
+
 const easeOut = [0.22, 1, 0.36, 1] as const;
 
 const PER_USER_MONTHLY: Record<Region, number> = { CH: 15, DE: 17 };
@@ -226,7 +230,7 @@ export function PricingTiers({
             <div className="mt-auto pt-2">
               <Button asChild variant="secondary" fullWidth>
                 <a
-                  href="https://docs.tale.dev"
+                  href={DOCS_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/services/web/app/components/layout/site-header.tsx
+++ b/services/web/app/components/layout/site-header.tsx
@@ -7,6 +7,11 @@ import { useEffect } from 'react';
 import { LocalizedLink } from '@/app/components/layout/localized-link';
 import { useT } from '@/lib/i18n/client';
 
+// Vite injects VITE_DOCS_URL at build time. Defaults to the canonical
+// docs.tale.dev origin; can be overridden (e.g. https://tale.dev/docs)
+// for path-based deployments where docs ship under the marketing domain.
+const DOCS_URL = import.meta.env.VITE_DOCS_URL ?? 'https://docs.tale.dev';
+
 interface NavItem {
   key: 'features' | 'pricing';
   to: '/' | '/pricing';
@@ -48,7 +53,7 @@ export function SiteHeader() {
     <>
       <Button asChild variant="secondary" size="sm">
         <a
-          href="https://docs.tale.dev"
+          href={DOCS_URL}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/services/web/scripts/build-llms-artifacts.ts
+++ b/services/web/scripts/build-llms-artifacts.ts
@@ -20,6 +20,9 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, '..');
 const OUT_DIR = resolve(ROOT, 'public');
 const SITE_URL = 'https://tale.dev';
+// Where the docs site lives. Defaults to its canonical subdomain; can be
+// overridden (e.g. https://tale.dev/docs) for path-based deployments.
+const DOCS_URL = process.env.WEB_DOCS_URL ?? 'https://docs.tale.dev';
 
 interface MarketingRoute {
   url: string;
@@ -91,7 +94,7 @@ async function main() {
       },
     ],
     optional: [
-      { title: 'Documentation', url: 'https://docs.tale.dev/llms.txt' },
+      { title: 'Documentation', url: `${DOCS_URL}/llms.txt` },
       { title: 'GitHub', url: 'https://github.com/tale-project/tale' },
     ],
   });
@@ -153,7 +156,7 @@ async function main() {
 
   // --- /robots.txt -------------------------------------------------------
   const robots = buildRobotsTxt({
-    sitemaps: [`${SITE_URL}/sitemap.xml`, `https://docs.tale.dev/sitemap.xml`],
+    sitemaps: [`${SITE_URL}/sitemap.xml`, `${DOCS_URL}/sitemap.xml`],
   });
   await writeFile(resolve(OUT_DIR, 'robots.txt'), robots);
   process.stdout.write('built robots.txt\n');


### PR DESCRIPTION
## Summary

The marketing site hardcoded `https://docs.tale.dev` in five places:

- **`app/components/layout/site-header.tsx`** — desktop and mobile "Read Docs" button (×2)
- **`app/components/blocks/pricing-tiers.tsx`** — "Read Docs" button on the pricing tier card
- **`scripts/build-llms-artifacts.ts`** — `llms.txt` "Documentation" entry, and the second sitemap URL in the generated `robots.txt`

This means a deployment serving docs under a different origin (e.g. `https://tale.dev/docs` for path-based deployments where the marketing site and docs share a hostname) had no way to point those links at the right place — every "Read Docs" click jumped users off to a hostname that may not exist for that environment.

## Change

Single build-time `WEB_DOCS_URL` env var:

- Component code reads `import.meta.env.VITE_DOCS_URL`
- Build scripts read `process.env.WEB_DOCS_URL`
- `Dockerfile` declares `ARG WEB_DOCS_URL=https://docs.tale.dev` and exports both `WEB_DOCS_URL` (for scripts) and `VITE_DOCS_URL` (for vite) as ENV
- `compose.web.yml` forwards `WEB_DOCS_URL` from the host env to the build args

The default keeps the canonical `docs.tale.dev` value, so the existing production deployment is unaffected.

## Pre-PR checklist

- [ ] Ran `bun run check` — _not run by author; please verify locally_
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no UI strings changed; the buttons still say "Read Docs")
- [x] Updated `/docs/{en,de,fr}/` — N/A (no user-facing surface changed)
- [ ] Ran `bun run --filter @tale/web lint` and `bun run --filter @tale/web test` — _not run by author; please verify locally_
- [x] Updated `README.md` and translations — N/A

## Test plan

- [ ] Default build: confirm "Read Docs" still links to `https://docs.tale.dev` and the generated `llms.txt`/`robots.txt` reference `docs.tale.dev`.
- [ ] Override: `WEB_DOCS_URL=https://tale.dev/docs docker compose -f compose.web.yml build` → confirm header/pricing buttons link to `https://tale.dev/docs` and that the generated artifacts use the same.