### PR TITLE
fix(web): apply WEB_DOCS_URL to mobile nav button and SEO artifacts

### DIFF
--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -48,7 +48,11 @@ ENV NODE_ENV=production \
     WEB_DOCS_URL=${WEB_DOCS_URL} \
     VITE_DOCS_URL=${WEB_DOCS_URL}
 WORKDIR /app/services/web
-RUN bun --bun vite build \
+# Generate llms.txt / llms-full.txt / sitemap.xml / robots.txt into public/
+# *before* vite build, so the build's public-directory copy picks up the
+# fresh artifacts instead of the stale checked-in robots.txt.
+RUN bun --bun scripts/build-llms-artifacts.ts \
+    && bun --bun vite build \
     && bun build server.ts --target=bun --outfile=server.js --external bun
 WORKDIR /app
 

--- a/services/web/app/components/layout/site-header.tsx
+++ b/services/web/app/components/layout/site-header.tsx
@@ -81,7 +81,7 @@ export function SiteHeader() {
       <div className="mt-2 flex flex-col gap-2">
         <Button asChild variant="secondary" fullWidth>
           <a
-            href="https://docs.tale.dev"
+            href={DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary

Two follow-ups to #1686 caught when verifying the deployment:

1. **Mobile-nav "Read Docs" button still hardcoded.** The previous `replace_all` in #1686 only matched the desktop button because the mobile one inside the `<div className="mt-2 flex flex-col gap-2">` block sits at a different indentation level. The bundle still ships a literal `https://docs.tale.dev` for the mobile menu. This commit switches it to `DOCS_URL` like the desktop sibling.

2. **`build-llms-artifacts.ts` changes never reached production.** The web `Dockerfile` only ran `vite build` + the server bundle — it never invoked `scripts/build-llms-artifacts.ts`, so `services/web/public/robots.txt` (a stale checked-in file containing `Sitemap: https://docs.tale.dev/sitemap.xml`) was what `vite build` copied into `dist/`. The npm `build` and `dev` scripts run the artifact builder *before* vite, so this is purely a Dockerfile inconsistency. Mirror that order in the Dockerfile.

## Pre-PR checklist

- [ ] Ran `bun run check` — _not run by author; please verify locally_
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A
- [x] Updated `/docs/{en,de,fr}/` — N/A
- [ ] Ran `bun run --filter @tale/web lint` and `bun run --filter @tale/web test` — _not run by author; please verify locally_
- [x] Updated `README.md` and translations — N/A

## Test plan

- [ ] Build with `WEB_DOCS_URL=https://tale.dev/docs`. Confirm the bundled JS no longer contains the literal `"https://docs.tale.dev"` outside of the fallback constant declaration, and that `dist/robots.txt`'s second `Sitemap:` line points at `https://tale.dev/docs/sitemap.xml`.
- [ ] Default build (no env): bundle and `robots.txt` still reference `https://docs.tale.dev` as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Build Updates**
  * Web build process now generates and includes additional site-related assets during the build phase.

* **Mobile Navigation**
  * The documentation link in mobile navigation is now configurable and can be customized through environment settings, replacing the previously hardcoded URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->