### PR TITLE
perf(docs): drop mermaid-vendor from preload, coalesce lucide chunks

### DIFF
--- a/services/docs/vite.config.ts
+++ b/services/docs/vite.config.ts
@@ -40,6 +40,16 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     chunkSizeWarningLimit: 2000,
+    modulePreload: {
+      // mermaid-vendor is ~700 KB gzipped and only used on doc pages that
+      // include a `mermaid` code block. The wrapper component already calls
+      // `import('mermaid')` lazily, but Rolldown adds the chunk to the entry
+      // HTML's <link rel="modulepreload"> list anyway, forcing every cold
+      // visit to download it. Strip it from the preload graph; the dynamic
+      // import still resolves on demand when a diagram actually renders.
+      resolveDependencies: (_filename, deps) =>
+        deps.filter((d) => !d.includes('mermaid-vendor')),
+    },
     rollupOptions: {
       output: {
         manualChunks(id) {
@@ -56,6 +66,11 @@ export default defineConfig({
           }
           if (id.includes('node_modules/@radix-ui/')) {
             return 'radix-vendor';
+          }
+          if (id.includes('node_modules/lucide-react/')) {
+            // Without this lucide ships ~30 separate icon chunks; bundling
+            // them into one keeps the modulepreload list short.
+            return 'lucide-vendor';
           }
           if (
             id.includes('node_modules/react-markdown/') ||


### PR DESCRIPTION
## Summary

Cuts the docs cold-load payload by ~60% (from ~1.2 MB compressed to ~430 KB) on pages that don't use Mermaid diagrams.

Measured on the live deployment after enabling Caddy compression:

| Chunk           | Gzipped |
|-----------------|--------:|
| **mermaid-vendor**  | **719 KB** |
| main entry      |   257 KB |
| react-vendor    |    56 KB |
| markdown-vendor |    46 KB |
| i18n-vendor     |    29 KB |
| router-vendor   |    26 KB |
| radix-vendor    |    12 KB |
| **total**           | **1.17 MB** |

mermaid-vendor alone is over half the cold load. Removing it gets us under 450 KB.

## Changes

### 1. Strip `mermaid-vendor` from the preload graph

The `Mermaid` wrapper component already lazy-loads the library via `import('mermaid')`, so the chunk should only load when a doc page actually contains a `mermaid` code block. But Rolldown adds dynamic chunks to the entry HTML's `<link rel="modulepreload">` list regardless, forcing every cold visit to download mermaid-vendor whether the page uses it or not.

Use `build.modulePreload.resolveDependencies` to filter mermaid-vendor out of the preload list. The dynamic import still resolves on demand when a diagram renders — net effect: pages without diagrams skip the 719 KB download entirely; pages with diagrams pay the same cost as before.

### 2. Coalesce lucide-react icons into one chunk

Before this change, each statically-imported lucide icon shipped as its own ~5 KB chunk. The cold-load HTML had ~30 individual `<link rel="modulepreload">` lines for them (`arrow-left`, `arrow-right`, `bot`, `check`, `chevron-down`, ...). Bundling them into a single `lucide-vendor` chunk:

- shortens the critical request waterfall (one chunk instead of 30 streams)
- compresses better (a single zstd frame > 30 separate ones)
- keeps the modulepreload list scannable

## Pre-PR checklist

- [ ] Ran `bun run check` — _not run by author; please verify locally_
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no UI strings changed)
- [x] Updated `/docs/{en,de,fr}/` — N/A (build infra only)
- [ ] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — _not run by author; please verify locally_
- [x] Updated `README.md` and translations — N/A

## Test plan

- [ ] On a docs route **without** a mermaid block (e.g. `/docs/`): confirm `mermaid-vendor-*.js` is **not** in the cold-load network waterfall and is **not** in the `<link rel="modulepreload">` list. Total transferred bytes for the doc HTML + its preloaded chunks should be ~430 KB compressed.
- [ ] On a docs route **with** a mermaid block: confirm `mermaid-vendor-*.js` is fetched lazily once the diagram component mounts, and the diagram renders correctly.
- [ ] Confirm only one `lucide-vendor-*.js` chunk in the asset directory; no individual icon chunks.
- [ ] Confirm no regressions in client-side route navigation (TanStack Router preload on hover/click should still work).