### PR TITLE
fix(web,docs): unbreak prefixed-locale routes and /docs redirects

### DIFF
--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -71,12 +71,16 @@ LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.description="Tale documentation site"
 
 ARG LOCALE_COOKIE_DOMAIN=
+# Re-declare DOCS_BASE_URL here so the runner stage can promote it to ENV;
+# the server uses it as the public mount prefix for locale redirects.
+ARG DOCS_BASE_URL=/
 ENV NODE_ENV=production \
     TALE_VERSION=${VERSION} \
     PORT=3002 \
     HOSTNAME="0.0.0.0" \
     DO_NOT_TRACK=1 \
-    LOCALE_COOKIE_DOMAIN=${LOCALE_COOKIE_DOMAIN}
+    LOCALE_COOKIE_DOMAIN=${LOCALE_COOKIE_DOMAIN} \
+    DOCS_BASE_URL=${DOCS_BASE_URL}
 
 WORKDIR /app
 

--- a/services/docs/server.ts
+++ b/services/docs/server.ts
@@ -19,6 +19,13 @@ const HOSTNAME = process.env.HOSTNAME ?? '0.0.0.0';
 const DIST = resolve(import.meta.dir, 'dist');
 const DIST_PREFIX = DIST + sep;
 const LOCALE_COOKIE_DOMAIN = process.env.LOCALE_COOKIE_DOMAIN || undefined;
+// When mounted under a sub-path by the front proxy (e.g. Caddy's
+// `handle_path /docs*` strips `/docs` before proxying), redirects emitted
+// by this server are origin-relative — `Location: /de` lands on the web
+// site, not /docs/de. `BASE_PATH` is the public mount prefix; we prepend
+// it to the negotiator's redirect target so the browser stays inside
+// /docs. Empty (default) when served at the origin root.
+const BASE_PATH = (process.env.DOCS_BASE_URL ?? '/').replace(/\/+$/, '');
 
 function contentTypeFor(path: string): string | null {
   if (path.endsWith('.md')) return 'text/markdown; charset=utf-8';
@@ -103,7 +110,7 @@ Bun.serve({
 
     if (negotiation.redirectTo) {
       const headers = new Headers({
-        Location: negotiation.redirectTo,
+        Location: BASE_PATH + negotiation.redirectTo,
         Vary: 'Accept-Language, Cookie',
       });
       if (negotiation.setCookieValue) {

--- a/services/web/vite.config.ts
+++ b/services/web/vite.config.ts
@@ -3,7 +3,10 @@ import viteReact from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: './',
+  // Absolute base so the SPA shell loads its assets correctly when served
+  // as the fallback for nested URLs (e.g. /de/pricing) — relative './assets/'
+  // resolves against the request path and 404s under any /<locale>/<route>.
+  base: '/',
   resolve: {
     dedupe: ['react', 'react-dom'],
     tsconfigPaths: true,


### PR DESCRIPTION
## Summary
Two regressions surfaced after #1690's locale-negotiation rollout:

- **services/web** — Vite's `base: './'` made `dist/index.html` reference `./assets/...`. The SPA shell is the fallback for any non-prerendered route, so the new redirect `/pricing` → `/de/pricing` resolved the relative URL against `/de/` and requested `/de/assets/index-XXX.js`. That path falls back to `index.html` again with `Content-Type: text/html`, the browser refuses the module, page is blank. Switch to `base: '/'` so the shell is self-contained at any depth.
- **services/docs** — Caddy mounts docs at `/docs` via `handle_path /docs*` (strips the prefix). The server emitted `Location: /de`, which is origin-relative → browser landed on the **web** site's `/de` instead of `/docs/de`. Promote `DOCS_BASE_URL` to a runtime env on the runner stage and prepend it to the redirect target. Default (`/`) is a no-op, preserving the existing docs.tale.dev deployment.

## Reproduction (before)
```
$ curl -sI -H "Cookie: tale_locale=de" https://tale.dev/docs
HTTP/2 302
location: /de            ← should be /docs/de

$ curl -sI https://tale.dev/de/assets/index-CLmaLWA4.js
HTTP/2 200
content-length: 2090     ← the SPA fallback HTML, not JS
```
Playwright at `/de/pricing`: blank, console error `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"`.

## Test plan
- [ ] After deploy, `curl -sI -H "Cookie: tale_locale=de" https://tale.dev/docs` returns `Location: /docs/de`
- [ ] After deploy, `https://tale.dev/de/pricing` renders the German pricing page (no module-MIME error in devtools)
- [ ] `https://tale.dev/pricing` (English) still renders correctly
- [ ] `https://tale.dev/docs` (English) still renders the docs landing page
- [ ] `i18n` package tests still pass (45 tests, verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Documentation service now supports deployment under custom paths for flexible hosting configurations.
  * Web application asset loading updated for consistent reference handling across different URL structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->