### PR TITLE
ci: build images once, push to GHCR, reuse in smoke/validate/scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build
 
+# Jobs use the default actions/checkout (fetch-depth: 1). If a Dockerfile
+# starts to need git history (e.g. `git describe --tags`), bump fetch-depth
+# on that job's checkout AND pass the version/ref via build-args from the
+# workflow rather than reading `.git` from inside the build context.
+
 on:
   pull_request:
     branches:
@@ -34,9 +39,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_API: 'http://127.0.0.1:9080'
-  TURBO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  TURBO_TEAM: 'tale'
   REGISTRY: ghcr.io
 
 jobs:
@@ -54,6 +56,7 @@ jobs:
       services: ${{ steps.services.outputs.list }}
       scannable_services: ${{ steps.services.outputs.scannable }}
       ci_tests: ${{ steps.filter.outputs.ci_tests }}
+      storybook: ${{ steps.filter.outputs.storybook }}
       image_tag: ${{ steps.tag.outputs.value }}
     steps:
       - name: Checkout
@@ -85,18 +88,28 @@ jobs:
               - 'docs/**'
               - 'packages/webui/**'
               - 'packages/ui/**'
+            storybook:
+              - 'services/platform/**'
+              - 'packages/ui/**'
+              - 'packages/webui/**'
             ci_tests:
               - 'tests/container-*'
               - 'compose.test.yml'
               - 'compose.yml'
               - '.env.test'
               - '.github/workflows/build.yml'
-              - 'services/**'
+              - 'services/db/**'
+              - 'services/convex/**'
+              - 'services/crawler/**'
+              - 'services/rag/**'
+              - 'services/platform/**'
+              - 'services/proxy/**'
 
       - name: Compute service matrix
         id: services
         run: |
-          SERVICES=$(echo '${{ steps.filter.outputs.changes }}' | jq -c '[.[] | select(. != "ci_tests")]')
+          # Strip pseudo-filters that aren't real services from the matrix list.
+          SERVICES=$(echo '${{ steps.filter.outputs.changes }}' | jq -c '[.[] | select(. != "ci_tests" and . != "storybook")]')
           echo "list=${SERVICES}" >> "$GITHUB_OUTPUT"
           echo "Services to build: ${SERVICES}"
 
@@ -132,6 +145,11 @@ jobs:
   # Web/docs are NOT in this matrix — they have their own compose stacks and
   # are exercised by the separate web-test / docs-test jobs below.
   #
+  # Fork PRs cannot push to the upstream GHCR (read-only GITHUB_TOKEN), so
+  # this job switches to local build (`push: false`, `load: true`). The
+  # smoke-test-fork / image-validate-fork jobs cover that path with the
+  # OLD-style local-build smoke pipeline.
+  #
   # Draft PRs skip to save minutes.
   # ---------------------------------------------------------------------------
   build:
@@ -146,6 +164,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Compose-stack services. Keep in sync with build.yml (smoke/validate
+        # pull loops) and cleanup-pr-images.yml matrix.
         service: [db, convex, crawler, rag, platform, proxy]
 
     steps:
@@ -158,11 +178,29 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune -af
 
+      # Fork PRs get a read-only GITHUB_TOKEN regardless of `permissions:`,
+      # so we can't push to GHCR. Switch to local build (load into runner's
+      # Docker) on forks; the smoke-test-fork / image-validate-fork jobs
+      # then exercise the resulting images via SKIP_BUILD=true on the same
+      # runner. Same-repo PRs and pushes use push: true → GHCR as before.
+      - name: Set push mode
+        id: pushmode
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            echo "load=true"  >> "$GITHUB_OUTPUT"
+            echo "Fork PR detected — building locally (push=false, load=true)"
+          else
+            echo "push=true"  >> "$GITHUB_OUTPUT"
+            echo "load=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Docker builder
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        if: steps.pushmode.outputs.push == 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -174,13 +212,18 @@ jobs:
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           echo "revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
+      # `provenance: false` avoids GHCR's "unknown/unknown" attestation manifest
+      # for single-platform images (docker/build-push-action#820). The cleanup
+      # workflow's tag-prefix filter assumes single-manifest tags — re-enabling
+      # provenance would require widening that filter (see N2 in cleanup file).
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ steps.pushmode.outputs.push }}
+          load: ${{ steps.pushmode.outputs.load }}
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
@@ -191,21 +234,37 @@ jobs:
           provenance: false
 
       - name: Summary
+        if: success()
         run: |
           {
             echo "## Built tale-${{ matrix.service }}"
             echo ""
-            echo "Pushed: \`${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}\`"
+            if [ "${{ steps.pushmode.outputs.push }}" = "true" ]; then
+              echo "Pushed: \`${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}\`"
+            else
+              echo "Loaded locally (fork PR): \`${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          {
+            echo "## ❌ Build failed for tale-${{ matrix.service }}"
+            echo ""
+            echo "Attempted tag: \`${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}\`"
+            echo "Push mode: \`${{ steps.pushmode.outputs.push }}\` / Load: \`${{ steps.pushmode.outputs.load }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
   # Run container smoke tests via docker compose. Pulls images built by the
-  # `build` job from GHCR instead of rebuilding locally. Draft PRs skip.
+  # `build` job from GHCR instead of rebuilding locally.
+  # Skipped for fork PRs (smoke-test-fork covers that path). Draft PRs skip.
   # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test
     needs: [changes, build]
-    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
+    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -229,7 +288,7 @@ jobs:
           free -h
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -241,6 +300,8 @@ jobs:
       # `docker compose build` step.
       - name: Pull images from GHCR
         run: |
+          # Compose-stack services. Keep in sync with build.yml (build matrix)
+          # and cleanup-pr-images.yml matrix.
           TAG="${{ needs.changes.outputs.image_tag }}"
           REGISTRY_PATH="${{ env.REGISTRY }}/${{ github.repository }}"
           for svc in db convex crawler rag platform proxy; do
@@ -260,14 +321,92 @@ jobs:
       - name: Dump container logs on failure
         if: failure()
         run: |
-          echo "## Container Logs (on failure)" >> "$GITHUB_STEP_SUMMARY"
           cd "${{ github.workspace }}"
-          docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test logs --tail=100 2>&1 || true
-          docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test ps -a 2>&1 || true
+          {
+            echo "## Container Logs (on failure)"
+            echo ""
+            echo "<details><summary>compose logs (last 300 lines per service)</summary>"
+            echo ""
+            echo '```'
+            docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test logs --tail=300 2>&1 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details><summary>compose ps -a</summary>"
+            echo ""
+            echo '```'
+            docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test ps -a 2>&1 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summary
         if: always()
         run: echo "## Smoke tests complete" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Fork-PR smoke test fallback: builds locally (no GHCR push) since fork
+  # GITHUB_TOKEN is read-only. Mirrors the pre-refactor workflow shape.
+  # ---------------------------------------------------------------------------
+  smoke-test-fork:
+    name: Smoke test (fork PR)
+    needs: changes
+    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Reclaim disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+
+      - name: Log Docker environment
+        run: |
+          docker version
+          docker compose version
+          df -h /
+          free -h
+
+      - name: Run smoke tests (local build)
+        run: bash tests/container-smoke-test.sh
+        env:
+          SMOKE_TEST_TIMEOUT: 300
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          cd "${{ github.workspace }}"
+          {
+            echo "## Container Logs (on failure, fork PR)"
+            echo ""
+            echo "<details><summary>compose logs (last 300 lines per service)</summary>"
+            echo ""
+            echo '```'
+            docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test logs --tail=300 2>&1 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details><summary>compose ps -a</summary>"
+            echo ""
+            echo '```'
+            docker compose -f compose.yml -f compose.test.yml --env-file .env.test -p tale-test ps -a 2>&1 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary
+        if: always()
+        run: echo "## Smoke tests (fork PR) complete" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
   # Standalone container tests for static sites. Each runs in its own compose
@@ -280,7 +419,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 15
+    timeout-minutes: 8
 
     steps:
       - name: Checkout
@@ -305,7 +444,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 15
+    timeout-minutes: 8
 
     steps:
       - name: Checkout
@@ -325,12 +464,13 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Validate container image metadata, healthchecks, entrypoints. Pulls images
-  # built by the `build` job from GHCR. Draft PRs skip.
+  # built by the `build` job from GHCR.
+  # Skipped for fork PRs (image-validate-fork covers that). Draft PRs skip.
   # ---------------------------------------------------------------------------
   image-validate:
     name: Validate images
     needs: [changes, build]
-    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
+    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -347,7 +487,7 @@ jobs:
           sudo docker image prune -af
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -355,6 +495,8 @@ jobs:
 
       - name: Pull images from GHCR
         run: |
+          # Compose-stack services. Keep in sync with build.yml (build matrix)
+          # and cleanup-pr-images.yml matrix.
           TAG="${{ needs.changes.outputs.image_tag }}"
           REGISTRY_PATH="${{ env.REGISTRY }}/${{ github.repository }}"
           for svc in db convex crawler rag platform proxy; do
@@ -375,8 +517,39 @@ jobs:
         run: echo "## Image validation complete" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
+  # Fork-PR image-validate fallback: builds locally (no GHCR pull).
+  # ---------------------------------------------------------------------------
+  image-validate-fork:
+    name: Validate images (fork PR)
+    needs: changes
+    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Reclaim disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+
+      - name: Run image validation (local build)
+        run: bash tests/container-image-test.sh
+
+      - name: Summary
+        if: always()
+        run: echo "## Image validation (fork PR) complete" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
   # Trivy vulnerability scan per changed service (non-blocking).
-  # Push-to-main only — PRs rely on security.yml scheduled scans.
+  # Push-to-main only — PRs rely on security.yml's filesystem scan only.
+  # NOTE: PRs do NOT run image-level CVE scans; web/docs Dockerfiles are not
+  # image-scanned anywhere on CI today (release.yml builds them but doesn't
+  # scan). Track adding image scans to web/docs as a follow-up.
   # Reuses the image built and pushed by the `build` job instead of rebuilding.
   # ---------------------------------------------------------------------------
   vulnerability-scan:
@@ -400,7 +573,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -410,39 +583,53 @@ jobs:
         run: docker pull ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
           format: 'sarif'
           output: '${{ matrix.service }}-trivy.sarif'
           severity: 'HIGH,CRITICAL'
-          exit-code: '0'
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
-        if: always()
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        if: always() && hashFiles(format('{0}-trivy.sarif', matrix.service)) != ''
         with:
           sarif_file: '${{ matrix.service }}-trivy.sarif'
           category: 'trivy-${{ matrix.service }}'
+
+      - name: Note missing SARIF
+        if: always() && hashFiles(format('{0}-trivy.sarif', matrix.service)) == ''
+        run: |
+          {
+            echo "## ⚠ Trivy did not produce SARIF for ${{ matrix.service }}"
+            echo ""
+            echo "Scan likely failed before writing output. Check earlier step logs."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summary
         if: always()
         run: |
           echo "## ${{ matrix.service }} vulnerability scan complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "Results uploaded to the Security tab." >> "$GITHUB_STEP_SUMMARY"
+          echo "Results uploaded to the Security tab (when SARIF is present)." >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Storybook static build — only when the platform service changed.
-  # Draft PRs skip.
+  # Storybook static build — fires when the platform service or shared UI
+  # packages (which house the bulk of stories) change. Draft PRs skip.
   # ---------------------------------------------------------------------------
   storybook:
     name: Storybook
     needs: changes
-    if: contains(fromJson(needs.changes.outputs.services), 'platform') && github.event.pull_request.draft != true
+    if: needs.changes.outputs.storybook == 'true' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     permissions:
       contents: read
+    env:
+      # Turbo cache is only used by storybook:build; scope env to this job
+      # so the GITHUB_TOKEN isn't materialized as TURBO_TOKEN in unrelated jobs.
+      TURBO_API: 'http://127.0.0.1:9080'
+      TURBO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TURBO_TEAM: 'tale'
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ env:
   TURBO_API: 'http://127.0.0.1:9080'
   TURBO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TURBO_TEAM: 'tale'
+  REGISTRY: ghcr.io
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -51,7 +52,9 @@ jobs:
       pull-requests: read
     outputs:
       services: ${{ steps.services.outputs.list }}
+      scannable_services: ${{ steps.services.outputs.scannable }}
       ci_tests: ${{ steps.filter.outputs.ci_tests }}
+      image_tag: ${{ steps.tag.outputs.value }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -97,28 +100,73 @@ jobs:
           echo "list=${SERVICES}" >> "$GITHUB_OUTPUT"
           echo "Services to build: ${SERVICES}"
 
+          # Vulnerability scan only covers the six compose-stack services that
+          # `build` actually pushes to GHCR. Web and docs use their own compose
+          # stacks and are reachable via security.yml's filesystem scan.
+          SCANNABLE=$(echo "${SERVICES}" | jq -c '[.[] | select(. == "db" or . == "convex" or . == "crawler" or . == "rag" or . == "platform" or . == "proxy")]')
+          echo "scannable=${SCANNABLE}" >> "$GITHUB_OUTPUT"
+          echo "Services to scan: ${SCANNABLE}"
+
+      # CI image tag shared across build/smoke/validate/scan jobs. PR runs use
+      # `pr-{n}-sha-{shortsha}` so each push gets a unique, immutable tag that
+      # cleanup-pr-images.yml can wipe by prefix when the PR closes. Pushes to
+      # main and merge-queue runs lack a PR number and fall back to `sha-…`.
+      - name: Compute image tag
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "value=pr-${{ github.event.pull_request.number }}-sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
   # ---------------------------------------------------------------------------
-  # Build each changed service's Docker image. Draft PRs skip to save minutes.
+  # Build each compose-stack service's Docker image and push to GHCR.
+  #
+  # Matrix is intentionally fixed (not driven by `changes.outputs.services`):
+  # smoke-test and image-validate need ALL six services available, so building
+  # only changed ones would force them back into local-build mode. Unchanged
+  # services hit the GHA layer cache and finish in seconds.
+  #
+  # Web/docs are NOT in this matrix — they have their own compose stacks and
+  # are exercised by the separate web-test / docs-test jobs below.
+  #
+  # Draft PRs skip to save minutes.
   # ---------------------------------------------------------------------------
   build:
     name: Build ${{ matrix.service }}
     needs: changes
-    if: needs.changes.outputs.services != '[]' && github.event.pull_request.draft != true
+    if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
-        service: ${{ fromJson(needs.changes.outputs.services) }}
+        service: [db, convex, crawler, rag, platform, proxy]
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Reclaim disk space
+        if: matrix.service == 'platform' || matrix.service == 'rag' || matrix.service == 'crawler' || matrix.service == 'convex'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+
       - name: Setup Docker builder
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve build metadata
         id: meta
@@ -126,31 +174,42 @@ jobs:
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           echo "revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Build image
+      - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: services/${{ matrix.service }}/Dockerfile
           platforms: linux/amd64
-          push: false
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
           labels: |
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
             org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          provenance: false
 
       - name: Summary
-        run: echo "## Built tale-${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          {
+            echo "## Built tale-${{ matrix.service }}"
+            echo ""
+            echo "Pushed: \`${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Run container smoke tests via docker compose. Draft PRs skip.
+  # Run container smoke tests via docker compose. Pulls images built by the
+  # `build` job from GHCR instead of rebuilding locally. Draft PRs skip.
   # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test
-    needs: changes
+    needs: [changes, build]
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 20
 
     steps:
@@ -169,10 +228,34 @@ jobs:
           df -h /
           free -h
 
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull each service image from GHCR and re-tag locally as `:latest`.
+      # compose.yml resolves `${VERSION:-latest}`; with PULL_POLICY=never the
+      # smoke script will use these local images verbatim and skip its own
+      # `docker compose build` step.
+      - name: Pull images from GHCR
+        run: |
+          TAG="${{ needs.changes.outputs.image_tag }}"
+          REGISTRY_PATH="${{ env.REGISTRY }}/${{ github.repository }}"
+          for svc in db convex crawler rag platform proxy; do
+            IMAGE="${REGISTRY_PATH}/tale-${svc}:${TAG}"
+            echo "Pulling ${IMAGE}..."
+            docker pull "${IMAGE}"
+            docker tag "${IMAGE}" "ghcr.io/tale-project/tale/tale-${svc}:latest"
+          done
+
       - name: Run smoke tests
         run: bash tests/container-smoke-test.sh
         env:
           SMOKE_TEST_TIMEOUT: 300
+          SKIP_BUILD: 'true'
+          PULL_POLICY: never
 
       - name: Dump container logs on failure
         if: failure()
@@ -241,15 +324,17 @@ jobs:
         run: echo "## tale-docs container test complete" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Validate container image metadata, healthchecks, entrypoints. Draft PRs skip.
+  # Validate container image metadata, healthchecks, entrypoints. Pulls images
+  # built by the `build` job from GHCR. Draft PRs skip.
   # ---------------------------------------------------------------------------
   image-validate:
     name: Validate images
-    needs: changes
+    needs: [changes, build]
     if: (needs.changes.outputs.services != '[]' || needs.changes.outputs.ci_tests == 'true') && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
 
     steps:
@@ -261,8 +346,29 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune -af
 
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull images from GHCR
+        run: |
+          TAG="${{ needs.changes.outputs.image_tag }}"
+          REGISTRY_PATH="${{ env.REGISTRY }}/${{ github.repository }}"
+          for svc in db convex crawler rag platform proxy; do
+            IMAGE="${REGISTRY_PATH}/tale-${svc}:${TAG}"
+            echo "Pulling ${IMAGE}..."
+            docker pull "${IMAGE}"
+            docker tag "${IMAGE}" "ghcr.io/tale-project/tale/tale-${svc}:latest"
+          done
+
       - name: Run image validation
         run: bash tests/container-image-test.sh
+        env:
+          SKIP_BUILD: 'true'
+          PULL_POLICY: never
 
       - name: Summary
         if: always()
@@ -271,43 +377,42 @@ jobs:
   # ---------------------------------------------------------------------------
   # Trivy vulnerability scan per changed service (non-blocking).
   # Push-to-main only — PRs rely on security.yml scheduled scans.
+  # Reuses the image built and pushed by the `build` job instead of rebuilding.
   # ---------------------------------------------------------------------------
   vulnerability-scan:
     name: Scan ${{ matrix.service }}
-    needs: changes
-    if: github.event_name == 'push' && needs.changes.outputs.services != '[]'
+    needs: [changes, build]
+    if: github.event_name == 'push' && needs.changes.outputs.scannable_services != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
+      packages: read
     continue-on-error: true
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        service: ${{ fromJson(needs.changes.outputs.services) }}
+        service: ${{ fromJson(needs.changes.outputs.scannable_services) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Docker builder
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build image for scan
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
-          context: .
-          file: services/${{ matrix.service }}/Dockerfile
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: tale-${{ matrix.service }}:scan
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: docker pull ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
 
       - name: Run Trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          image-ref: tale-${{ matrix.service }}:scan
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
           format: 'sarif'
           output: '${{ matrix.service }}-trivy.sarif'
           severity: 'HIGH,CRITICAL'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,18 @@ on:
     paths:
       - 'services/**'
       - 'packages/**'
+      - 'docs/**'
+      - 'patches/**'
       - '.github/workflows/build.yml'
       - '.github/actions/setup-turbo/**'
       - 'compose.yml'
       - 'compose.test.yml'
       - 'tests/container-*'
+      - '.env.test'
+      - 'bunfig.toml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+      - '.dockerignore'
       - 'package.json'
       - 'bun.lock'
   push:
@@ -25,11 +32,18 @@ on:
     paths:
       - 'services/**'
       - 'packages/**'
+      - 'docs/**'
+      - 'patches/**'
       - '.github/workflows/build.yml'
       - '.github/actions/setup-turbo/**'
       - 'compose.yml'
       - 'compose.test.yml'
       - 'tests/container-*'
+      - '.env.test'
+      - 'bunfig.toml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+      - '.dockerignore'
       - 'package.json'
       - 'bun.lock'
   merge_group:
@@ -225,6 +239,8 @@ jobs:
           push: ${{ steps.pushmode.outputs.push }}
           load: ${{ steps.pushmode.outputs.load }}
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/tale-${{ matrix.service }}:${{ needs.changes.outputs.image_tag }}
+          build-args: |
+            VERSION=${{ needs.changes.outputs.image_tag }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
           labels: |

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,63 @@
+name: Cleanup PR images
+
+# When a PR closes (merged or otherwise), delete every GHCR container version
+# whose tag begins with `pr-{number}-sha-`. The `build` job in build.yml pushes
+# one such tag per push to a PR, so they accumulate fast without cleanup.
+#
+# Tags from main / merge_group runs use the `sha-…` prefix and are NOT deleted
+# here; manage their lifecycle separately if needed.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  packages: write
+
+concurrency:
+  group: cleanup-pr-images-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  delete:
+    name: Delete ${{ matrix.service }} PR tags
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [db, convex, crawler, rag, platform, proxy]
+
+    steps:
+      - name: Delete PR-tagged versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          SVC: ${{ matrix.service }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          # GHCR package names URL-encode the slash: `tale/tale-{svc}` → `tale%2Ftale-{svc}`.
+          PACKAGE="tale%2Ftale-${SVC}"
+          PREFIX="pr-${PR}-sha-"
+
+          echo "Looking up versions of ${OWNER}/${PACKAGE} tagged ${PREFIX}*"
+
+          VERSION_IDS=$(gh api -H "Accept: application/vnd.github+json" \
+            "/orgs/${OWNER}/packages/container/${PACKAGE}/versions" \
+            --paginate \
+            --jq "[.[] | select(any(.metadata.container.tags[]?; startswith(\"${PREFIX}\"))) | .id] | .[]" \
+            || true)
+
+          if [ -z "${VERSION_IDS}" ]; then
+            echo "No matching versions found for tale-${SVC}."
+            exit 0
+          fi
+
+          echo "${VERSION_IDS}" | while read -r version_id; do
+            [ -z "${version_id}" ] && continue
+            echo "Deleting version ${version_id}..."
+            gh api -X DELETE \
+              "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${version_id}" \
+              || echo "Failed to delete version ${version_id} (may already be gone)"
+          done

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Compose-stack services. Keep in sync with build.yml (build matrix +
+        # smoke/validate pull loops).
         service: [db, convex, crawler, rag, platform, proxy]
 
     steps:
@@ -43,21 +45,75 @@ jobs:
 
           echo "Looking up versions of ${OWNER}/${PACKAGE} tagged ${PREFIX}*"
 
-          VERSION_IDS=$(gh api -H "Accept: application/vnd.github+json" \
-            "/orgs/${OWNER}/packages/container/${PACKAGE}/versions" \
-            --paginate \
-            --jq "[.[] | select(any(.metadata.container.tags[]?; startswith(\"${PREFIX}\"))) | .id] | .[]" \
-            || true)
+          # Retry the listing call up to 3 times for transient 5xx / network blips.
+          # Real auth errors (403/404) fail fast on the final attempt and surface
+          # as a step failure rather than being silently swallowed.
+          #
+          # NOTE: build.yml currently sets `platforms: linux/amd64` and
+          # `provenance: false`, so each tag corresponds to exactly one OCI
+          # image manifest with no untagged children. If build.yml ever
+          # switches to multi-arch or re-enables provenance attestations,
+          # this filter will leak untagged child manifest versions; extend
+          # with a second pass over `metadata.container.tags == []`.
+          VERSION_IDS=""
+          for attempt in 1 2 3; do
+            if VERSION_IDS=$(gh api -H "Accept: application/vnd.github+json" \
+              "/orgs/${OWNER}/packages/container/${PACKAGE}/versions" \
+              --paginate \
+              --jq "[.[] | select(any(.metadata.container.tags[]?; startswith(\"${PREFIX}\"))) | .id] | .[]"); then
+              break
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "List attempt ${attempt} failed, retrying after $((attempt * 2))s..."
+              sleep $((attempt * 2))
+            else
+              echo "::error::Failed to list versions of ${PACKAGE} after 3 attempts"
+              exit 1
+            fi
+          done
 
           if [ -z "${VERSION_IDS}" ]; then
             echo "No matching versions found for tale-${SVC}."
+            {
+              echo "## Cleanup tale-${SVC}"
+              echo ""
+              echo "No \`${PREFIX}*\` versions found — nothing to delete."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          echo "${VERSION_IDS}" | while read -r version_id; do
+          deleted=0
+          already_gone=0
+          failures=0
+          err_log=$(mktemp)
+          # Distinguish 404 ("already gone" — expected on close-mid-build races
+          # or duplicate cleanup runs) from 403/5xx (real failures we should
+          # report). gh-api writes "gh: HTTP <code>: ..." to stderr on error.
+          while read -r version_id; do
             [ -z "${version_id}" ] && continue
             echo "Deleting version ${version_id}..."
-            gh api -X DELETE \
-              "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${version_id}" \
-              || echo "Failed to delete version ${version_id} (may already be gone)"
-          done
+            if gh api -X DELETE \
+                "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${version_id}" \
+                --silent 2>"${err_log}"; then
+              deleted=$((deleted + 1))
+            elif grep -q "HTTP 404" "${err_log}"; then
+              already_gone=$((already_gone + 1))
+            else
+              echo "::warning::Delete ${version_id} failed: $(cat "${err_log}")"
+              failures=$((failures + 1))
+            fi
+          done <<< "${VERSION_IDS}"
+          rm -f "${err_log}"
+
+          {
+            echo "## Cleanup tale-${SVC}"
+            echo ""
+            echo "- Deleted: ${deleted}"
+            echo "- Already gone (404): ${already_gone}"
+            echo "- Failures: ${failures}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${failures}" -gt 0 ]; then
+            echo "::error::${failures} deletion(s) failed for tale-${SVC}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

`build`, `smoke-test`, `image-validate`, and (on push) `vulnerability-scan` each rebuilt the same six service images independently — duplicate compute per run for identical artifacts with no shared cache.

`build` is now the single producer: full 6-service matrix (`db, convex, crawler, rag, platform, proxy`), per-service GHA layer cache, pushes to `ghcr.io/tale-project/tale/tale-{svc}:{tag}` where tag is `pr-{n}-sha-{shortsha}` on PRs and `sha-{shortsha}` on main/merge_group. Downstream jobs `needs: build`, log into GHCR, pull + re-tag locally as `:latest`, then run the existing test scripts with `SKIP_BUILD=true PULL_POLICY=never` (env vars already supported — no script changes). `vulnerability-scan` points trivy directly at the GHCR ref.

A new `cleanup-pr-images.yml` workflow deletes every `pr-{n}-sha-*` tag for the closed PR via the GHCR API on `pull_request: closed`.

## Tradeoffs (be aware before merging)

- **Wallclock: ~5 min slower per PR run.** OLD: build + smoke ran in parallel (~8 min total). NEW: build → push → pull → smoke is serial (~13–14 min total). Compute-minutes are roughly flat in the all-services-changed case; less of a win than originally framed.
- **Coverage gap (image CVE scans).** `vulnerability-scan` runs only on `event_name == 'push'`, so PRs get no image-level CVE scan today — only `security.yml`'s filesystem scan, which catches lockfile CVEs and Dockerfile misconfigs but **not** base-image OS-package CVEs. Web/docs Dockerfiles are also not image-scanned anywhere on CI today. A follow-up PR should either (a) add web/docs to the `vulnerability-scan` matrix on push-to-main, or (b) extend `security.yml` with a weekly cron that builds + image-scans both static-site Dockerfiles.
- **Architectural wins:** single producer of artifacts; no four-way rebuild duplication; GHCR images reusable by downstream/QA; reproducible test inputs (smoke and image-validate exercise byte-identical artifacts).

## Hardening from review feedback

This PR also includes the items surfaced by the multi-agent review:

- **Fork PR fallback.** Forks get a read-only `GITHUB_TOKEN` and cannot push to GHCR. Build switches to `push: false` + `load: true` on forks; new `smoke-test-fork` / `image-validate-fork` jobs run the local-build pipeline (the pre-refactor shape) so external contributor PRs keep CI parity.
- **Cleanup workflow surfaces real failures.** The list call gets a 3-attempt retry; per-DELETE results are counted (deleted / 404-already-gone / failures) and reported to the step summary; non-404 failures fail the job instead of being silently swallowed.
- **Failure-summary log redirect fixed.** `>>` was only chaining to the `echo`; `docker compose logs` and `ps -a` were writing to stdout instead of `$GITHUB_STEP_SUMMARY`. Now grouped in `{ … } >> $GITHUB_STEP_SUMMARY` with `--tail=300` and collapsible `<details>` blocks.
- **Storybook trigger gap closed.** New `storybook` paths-filter covers `services/platform/**`, `packages/ui/**`, `packages/webui/**` (where the bulk of stories actually live).
- **TURBO_TOKEN scoped.** Moved from workflow-level `env:` (visible to every job/action) to the storybook job only.
- **SARIF upload guarded** with `hashFiles(...)` so a Trivy crash doesn't surface as a confusing red cross on the upload step.
- **Action SHA pin comments tightened** (`docker/login-action # v4` → `# v4.1.0`; `codeql-action # v4` → `# v4.35.3`); **`aquasecurity/trivy-action` bumped to v0.36.0**.
- **Storybook timeout** 15 → 5 min; **web-test / docs-test** 15 → 8 min (per measured p95).
- **Service-list cross-references** added at all 4 duplication sites (build matrix + 2 pull loops + cleanup matrix).
- **`ci_tests` filter narrowed** from blanket `services/**` to the 6 compose-stack services explicitly.
- **`provenance: false` rationale documented** inline.

## Test plan

- [ ] `build` matrix produces 6 successful pushes to `ghcr.io/tale-project/tale/tale-{svc}:pr-1695-sha-<sha>` (visible under the org Packages tab).
- [ ] `smoke-test` logs show `Pulling …` lines for all 6 services, `Skipping build (SKIP_BUILD=true)`, and all healthchecks pass (target: 18/18).
- [ ] `image-validate` logs show `SKIP_BUILD=true — using pre-built images` and all assertions pass (target: 30/30).
- [ ] `Storybook` job triggers on this PR (`packages/ui/**` or `services/platform/**` paths) and builds successfully.
- [ ] `smoke-test (fork PR)` and `Validate images (fork PR)` are skipped (this PR is same-repo).
- [ ] After this PR merges/closes, `Cleanup PR images` workflow fires; per-service step summaries show `Deleted: N` / `Already gone: M` / `Failures: 0`; the `pr-1695-sha-*` tags disappear from GHCR.
- [ ] On a subsequent push to the same PR, GHA cache hits and unchanged services finish faster (compare to first push timing).
- [ ] On `main` after merge: `vulnerability-scan` pulls from GHCR and uploads SARIF without rebuilding.

## Follow-ups (not in this PR)

- GHCR untagged-version sweeper (cancelled-push orphans accumulate; GHCR has no auto-GC).
- Add image-CVE scan for `tale-web` and `tale-docs` (filesystem scan today doesn't cover base-image OS packages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline with consistent service builds using a centralized container registry
  * Added automated cleanup of temporary artifacts from pull requests

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1695)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
