### PR TITLE
feat(platform): quantization variants as first-class selectable models

### DIFF
--- a/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
@@ -102,8 +102,14 @@ export function ArenaModelSelector({
 
   const getDisplayName = useCallback(
     (ref: string) => {
-      const plain = stripModelRefQualifier(ref);
-      return modelInfoMap.get(plain)?.displayName ?? getModelShortName(plain);
+      const { modelId, quantization } = parseModelRef(ref);
+      const base =
+        modelInfoMap.get(modelId)?.displayName ?? getModelShortName(modelId);
+      // Append the variant in the closed trigger so fp8 vs fp4 selections
+      // are distinguishable without opening the menu.
+      return quantization
+        ? `${base} (${getVariantBadgeLabel(quantization)})`
+        : base;
     },
     [modelInfoMap],
   );
@@ -150,19 +156,35 @@ export function ArenaModelSelector({
     [filteredModels, getDisplayName, modelInfoMap],
   );
 
-  const currentModelA = modelA ?? filteredModels[0] ?? null;
-  const currentModelB =
-    modelB ?? filteredModels[1] ?? filteredModels[0] ?? null;
+  // A previously persisted selection may no longer appear in `filteredModels`
+  // — e.g. governance tightened, or expansion now offers `@fp8`/`@fp4`
+  // variants in place of a bare `glm-5.1` ref. Treat the stale value as
+  // empty when computing the trigger so SearchableSelect's `value` always
+  // matches an option.
+  const isInList = useCallback(
+    (ref: string | null): boolean =>
+      ref != null && filteredModels.includes(ref),
+    [filteredModels],
+  );
+  const currentModelA = isInList(modelA) ? modelA : (filteredModels[0] ?? null);
+  const currentModelB = isInList(modelB)
+    ? modelB
+    : (filteredModels[1] ?? filteredModels[0] ?? null);
 
-  // Sync default selections back to context so sendMessage can read them
+  // Sync default selections back to context so sendMessage can read them.
+  // Also clear stale values that no longer appear in `filteredModels` so the
+  // backend doesn't dispatch to a model the user can't see in the picker.
   useEffect(() => {
-    if (filteredModels.length >= 2) {
-      if (!modelA && filteredModels[0]) {
-        setModelA(filteredModels[0]);
-      }
-      if (!modelB && filteredModels[1]) {
-        setModelB(filteredModels[1]);
-      }
+    if (filteredModels.length < 2) return;
+    if (modelA && !filteredModels.includes(modelA)) {
+      setModelA(filteredModels[0]);
+    } else if (!modelA && filteredModels[0]) {
+      setModelA(filteredModels[0]);
+    }
+    if (modelB && !filteredModels.includes(modelB)) {
+      setModelB(filteredModels[1] ?? filteredModels[0]);
+    } else if (!modelB && filteredModels[1]) {
+      setModelB(filteredModels[1]);
     }
   }, [filteredModels, modelA, modelB, setModelA, setModelB]);
 

--- a/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@tale/ui/badge';
 import { ChevronDown, Cpu } from 'lucide-react';
 import {
   type ReactNode,
@@ -17,7 +18,14 @@ import { useAccessibleModels } from '@/app/features/settings/governance/hooks/qu
 import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
 import { useLocale } from '@/app/hooks/use-locale';
 import { useT } from '@/lib/i18n/client';
-import { stripModelRefQualifier } from '@/lib/shared/utils/model-ref';
+import {
+  expandModelVariants,
+  getVariantBadgeLabel,
+} from '@/lib/shared/utils/expand-model-variants';
+import {
+  parseModelRef,
+  stripModelRefQualifier,
+} from '@/lib/shared/utils/model-ref';
 import { resolveModelLocale } from '@/lib/shared/utils/resolve-provider-locale';
 
 import { useChatAgents } from '../../hooks/queries';
@@ -54,7 +62,12 @@ export function ArenaModelSelector({
   const modelInfoMap = useMemo(() => {
     const map = new Map<
       string,
-      { displayName: string; description?: string; tags: string[] }
+      {
+        displayName: string;
+        description?: string;
+        tags: string[];
+        quantizations?: string[];
+      }
     >();
     for (const provider of providers) {
       if (
@@ -69,6 +82,9 @@ export function ArenaModelSelector({
           displayName: resolved.displayName || model.displayName,
           description: resolved.description || undefined,
           tags: model.tags ?? [],
+          quantizations: Array.isArray(model.quantizations)
+            ? model.quantizations
+            : undefined,
         });
       }
     }
@@ -103,20 +119,34 @@ export function ArenaModelSelector({
   );
 
   const filteredModels = useMemo(() => {
-    if (!accessibleModelIds) return supportedModels;
-    const accessible = new Set(accessibleModelIds);
-    return supportedModels.filter((ref) =>
-      accessible.has(stripModelRefQualifier(ref)),
+    const accessible = accessibleModelIds ? new Set(accessibleModelIds) : null;
+    const accessFiltered = accessible
+      ? supportedModels.filter((ref) =>
+          accessible.has(stripModelRefQualifier(ref)),
+        )
+      : supportedModels;
+    return expandModelVariants(
+      accessFiltered,
+      (bareId) => modelInfoMap.get(bareId)?.quantizations,
     );
-  }, [supportedModels, accessibleModelIds]);
+  }, [supportedModels, accessibleModelIds, modelInfoMap]);
 
   const options = useMemo(
     () =>
-      filteredModels.map((ref) => ({
-        value: ref,
-        label: getDisplayName(ref),
-        description: modelInfoMap.get(stripModelRefQualifier(ref))?.description,
-      })),
+      filteredModels.map((ref) => {
+        const { quantization } = parseModelRef(ref);
+        return {
+          value: ref,
+          label: getDisplayName(ref),
+          labelBadge: quantization ? (
+            <Badge variant="outline" className="text-[10px] font-normal">
+              {getVariantBadgeLabel(quantization)}
+            </Badge>
+          ) : undefined,
+          description: modelInfoMap.get(stripModelRefQualifier(ref))
+            ?.description,
+        };
+      }),
     [filteredModels, getDisplayName, modelInfoMap],
   );
 

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -160,8 +160,14 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
 
   const getDisplayName = useCallback(
     (ref: string) => {
-      const plain = stripModelRefQualifier(ref);
-      return modelInfoMap.get(plain)?.displayName ?? getModelShortName(plain);
+      const { modelId, quantization } = parseModelRef(ref);
+      const base =
+        modelInfoMap.get(modelId)?.displayName ?? getModelShortName(modelId);
+      // Append the variant in the closed trigger and selected-row label so
+      // fp8 vs fp4 selections are distinguishable without opening the menu.
+      return quantization
+        ? `${base} (${getVariantBadgeLabel(quantization)})`
+        : base;
     },
     [modelInfoMap],
   );

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -22,6 +22,10 @@ import { useListProviders } from '@/app/features/settings/providers/hooks/querie
 import { useLocale } from '@/app/hooks/use-locale';
 import { useT } from '@/lib/i18n/client';
 import {
+  expandModelVariants,
+  getVariantBadgeLabel,
+} from '@/lib/shared/utils/expand-model-variants';
+import {
   parseModelRef,
   stripModelRefQualifier,
 } from '@/lib/shared/utils/model-ref';
@@ -75,6 +79,7 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
         description?: string;
         tags: string[];
         providerName: string;
+        quantizations?: string[];
       }
     >();
     for (const provider of providers) {
@@ -91,6 +96,9 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
           description: resolved.description || undefined,
           tags: model.tags ?? [],
           providerName: provider.name,
+          quantizations: Array.isArray(model.quantizations)
+            ? model.quantizations
+            : undefined,
         });
       }
     }
@@ -119,10 +127,17 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   );
 
   const chatModels = useMemo(() => {
-    return supportedModels.filter((ref) => {
+    const filteredByTag = supportedModels.filter((ref) => {
       const info = modelInfoMap.get(stripModelRefQualifier(ref));
       return info?.tags.includes(requiredTag);
     });
+    // Split each base model that declares quantizations into one selectable
+    // entry per variant (e.g. GLM 5.1 → GLM 5.1 fp8 + GLM 5.1 fp4). Models
+    // without a quantizations array are kept as a single entry.
+    return expandModelVariants(
+      filteredByTag,
+      (bareId) => modelInfoMap.get(bareId)?.quantizations,
+    );
   }, [supportedModels, modelInfoMap, requiredTag]);
 
   // Governance policies match on plain model ids; strip qualifiers before asking.
@@ -250,14 +265,27 @@ export function ModelSelector({ organizationId }: ModelSelectorProps) {
   const modelOptions = filteredModels.map((ref) => {
     const info = modelInfoMap.get(stripModelRefQualifier(ref));
     const providerSlug = getProviderSlug(ref);
+    const { quantization } = parseModelRef(ref);
+    const providerBadge = providerSlug ? (
+      <Badge variant="outline" className="text-[10px] font-normal">
+        {startCase(providerSlug)}
+      </Badge>
+    ) : null;
+    const variantBadge = quantization ? (
+      <Badge variant="outline" className="text-[10px] font-normal">
+        {getVariantBadgeLabel(quantization)}
+      </Badge>
+    ) : null;
     return {
       value: ref,
       label: getDisplayName(ref),
-      labelBadge: providerSlug ? (
-        <Badge variant="outline" className="text-[10px] font-normal">
-          {startCase(providerSlug)}
-        </Badge>
-      ) : undefined,
+      labelBadge:
+        providerBadge || variantBadge ? (
+          <>
+            {providerBadge}
+            {variantBadge}
+          </>
+        ) : undefined,
       description: info?.description,
     };
   });

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -21,8 +21,10 @@ import { useToast } from '@/app/hooks/use-toast';
 import { SUPPORTED_TEMPLATE_VARIABLES } from '@/convex/lib/agent_response/resolve_template_variables';
 import { STRUCTURED_RESPONSE_INSTRUCTIONS } from '@/convex/lib/agent_response/structured_response_instructions';
 import { useT } from '@/lib/i18n/client';
+import { getVariantBadgeLabel } from '@/lib/shared/utils/expand-model-variants';
 import { getOrganizationDefaultLocale } from '@/lib/shared/utils/get-organization-default-locale';
 import {
+  formatModelRef,
   parseModelRef,
   stripModelRefQualifier,
 } from '@/lib/shared/utils/model-ref';
@@ -173,22 +175,6 @@ function InstructionsTab() {
     return map;
   }, [providers]);
 
-  const modelTagsMap = useMemo(() => {
-    const map = new Map<string, string[]>();
-    for (const provider of providers) {
-      if (
-        !provider ||
-        !('models' in provider) ||
-        !Array.isArray(provider.models)
-      )
-        continue;
-      for (const model of provider.models) {
-        map.set(model.id, model.tags ?? []);
-      }
-    }
-    return map;
-  }, [providers]);
-
   // For unqualified refs, record every provider that defines each model id so
   // we can resolve (and hint about ambiguity) on display.
   const modelProvidersMap = useMemo(() => {
@@ -210,10 +196,16 @@ function InstructionsTab() {
   }, [providers]);
 
   const availableOptions = useMemo(() => {
-    const allModels: {
-      id: string;
+    // Each entry is a *concrete* selectable ref — for models with a
+    // `quantizations` array, that's one entry per declared variant. The base
+    // (unsplit) entry is intentionally dropped so users always pick a
+    // specific weight format, matching the chat selector's behavior.
+    const candidates: {
+      ref: string;
       displayName: string;
       providerName: string;
+      tags: string[];
+      quantization?: string;
     }[] = [];
     for (const provider of providers) {
       if (
@@ -224,41 +216,89 @@ function InstructionsTab() {
         continue;
       if (config.provider && provider.name !== config.provider) continue;
       for (const model of provider.models) {
-        allModels.push({
-          id: model.id,
-          displayName: model.displayName,
-          providerName: provider.name,
-        });
+        const variants = Array.isArray(model.quantizations)
+          ? model.quantizations
+          : undefined;
+        if (variants && variants.length > 0) {
+          for (const q of variants) {
+            candidates.push({
+              ref: formatModelRef({
+                providerName: provider.name,
+                modelId: model.id,
+                quantization: q,
+              }),
+              displayName: model.displayName,
+              providerName: provider.name,
+              tags: model.tags ?? [],
+              quantization: q,
+            });
+          }
+        } else {
+          candidates.push({
+            ref: formatModelRef({
+              providerName: provider.name,
+              modelId: model.id,
+            }),
+            displayName: model.displayName,
+            providerName: provider.name,
+            tags: model.tags ?? [],
+          });
+        }
       }
     }
-    const selected = new Set(selectedModels.map(stripModelRefQualifier));
-    return allModels
-      .filter((m) => !selected.has(m.id))
-      .map((m) => {
-        const tags = modelTagsMap.get(m.id) ?? [];
+    // Dedup against already-selected refs at the variant level so the user
+    // can add multiple variants of the same base model. Match both qualified
+    // and unqualified saved forms.
+    const selectedRefs = new Set(selectedModels);
+    const selectedBareIds = new Set(selectedModels.map(stripModelRefQualifier));
+    return candidates
+      .filter(
+        (c) =>
+          !selectedRefs.has(c.ref) &&
+          // also rule out a candidate whose unqualified form was saved
+          !selectedRefs.has(
+            c.quantization
+              ? `${stripModelRefQualifier(c.ref)}@${c.quantization}`
+              : stripModelRefQualifier(c.ref),
+          ) &&
+          // and don't suggest a model already saved without provider prefix
+          !(
+            !c.quantization &&
+            selectedBareIds.has(stripModelRefQualifier(c.ref))
+          ),
+      )
+      .map((c) => {
         const isEmbeddingOnly =
-          tags.includes('embedding') && !tags.includes('chat');
+          c.tags.includes('embedding') && !c.tags.includes('chat');
         const viaProvider = t('agents.form.viaProvider', {
-          provider: m.providerName,
-          defaultValue: `via ${m.providerName}`,
+          provider: c.providerName,
+          defaultValue: `via ${c.providerName}`,
         });
+        const variantSuffix = c.quantization
+          ? ` — ${getVariantBadgeLabel(c.quantization)}`
+          : '';
         const description = isEmbeddingOnly
-          ? `${viaProvider} — ${t('agents.form.embeddingModelWarning')}`
-          : viaProvider;
+          ? `${viaProvider}${variantSuffix} — ${t('agents.form.embeddingModelWarning')}`
+          : `${viaProvider}${variantSuffix}`;
         return {
           // Save in qualified form so routing is explicit even if multiple
-          // providers later define the same model id.
-          value: `${m.providerName}:${m.id}`,
-          label: m.displayName,
+          // providers later define the same model id; quantization variant
+          // is encoded as `@<quant>` per parseModelRef.
+          value: c.ref,
+          label: c.displayName,
           description,
         };
       });
-  }, [providers, selectedModels, config.provider, modelTagsMap, t]);
+  }, [providers, selectedModels, config.provider, t]);
 
   const getDisplayName = useCallback(
     (ref: string) => {
-      const plain = stripModelRefQualifier(ref);
-      return modelDisplayNames.get(plain) ?? plain.split('/').pop() ?? plain;
+      const { modelId, quantization } = parseModelRef(ref);
+      const base =
+        modelDisplayNames.get(modelId) ?? modelId.split('/').pop() ?? modelId;
+      return quantization
+        ? `${base} (${getVariantBadgeLabel(quantization)})`
+        : base;
     },
     [modelDisplayNames],
   );

--- a/services/platform/convex/agents/file_actions.ts
+++ b/services/platform/convex/agents/file_actions.ts
@@ -188,6 +188,7 @@ export const saveAgent = action({
     );
     const byProvider = new Map<string, Set<string>>();
     const modelTagLookup = new Map<string, string[]>();
+    const modelQuantsLookup = new Map<string, string[] | undefined>();
     for (const m of allModels) {
       let set = byProvider.get(m.providerName);
       if (!set) {
@@ -196,13 +197,14 @@ export const saveAgent = action({
       }
       set.add(m.id);
       modelTagLookup.set(`${m.providerName}:${m.id}`, m.tags);
+      modelQuantsLookup.set(`${m.providerName}:${m.id}`, m.quantizations);
     }
 
     const requireImageGenerationTag =
       config.primaryBehavior === 'image-generation';
     const warnings: string[] = [];
     for (const ref of config.supportedModels) {
-      const { providerName, modelId } = parseModelRef(ref);
+      const { providerName, modelId, quantization } = parseModelRef(ref);
       let resolvedProviderName = providerName;
       if (providerName) {
         const set = byProvider.get(providerName);
@@ -228,6 +230,19 @@ export const saveAgent = action({
           );
         }
         resolvedProviderName = matches[0];
+      }
+
+      if (quantization && resolvedProviderName) {
+        const declared = modelQuantsLookup.get(
+          `${resolvedProviderName}:${modelId}`,
+        );
+        if (!declared || !declared.includes(quantization)) {
+          const available = declared?.length ? declared.join(', ') : '(none)';
+          throw new ConvexError({
+            code: 'UNKNOWN_MODEL_VARIANT',
+            message: `Model "${modelId}" has no quantization "${quantization}". Available: ${available}`,
+          });
+        }
       }
 
       if (requireImageGenerationTag && resolvedProviderName) {

--- a/services/platform/convex/lib/provider_options.test.ts
+++ b/services/platform/convex/lib/provider_options.test.ts
@@ -4,6 +4,7 @@ import {
   buildCallProviderOptions,
   isPlainObject,
   mergeModelLevel,
+  pinQuantization,
   stripDenyListed,
 } from './provider_options';
 
@@ -169,6 +170,64 @@ describe('stripDenyListed', () => {
   });
 });
 
+describe('pinQuantization', () => {
+  it('rewrites a multi-element quantizations array to a single element', () => {
+    expect(
+      pinQuantization(
+        {
+          provider: { quantizations: ['fp8', 'fp4'], data_collection: 'deny' },
+        },
+        'fp4',
+      ),
+    ).toEqual({
+      provider: { quantizations: ['fp4'], data_collection: 'deny' },
+    });
+  });
+
+  it('creates the provider wrapper when input is undefined', () => {
+    expect(pinQuantization(undefined, 'fp4')).toEqual({
+      provider: { quantizations: ['fp4'] },
+    });
+  });
+
+  it('creates the provider wrapper when input has no provider key', () => {
+    expect(pinQuantization({ openrouter: { only: ['T'] } }, 'fp8')).toEqual({
+      openrouter: { only: ['T'] },
+      provider: { quantizations: ['fp8'] },
+    });
+  });
+
+  it('does not mutate its inputs', () => {
+    const input = {
+      provider: { quantizations: ['fp8', 'fp4'], data_collection: 'deny' },
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    pinQuantization(input, 'fp4');
+    expect(input).toEqual(snapshot);
+  });
+
+  it('replaces a non-object provider value with a fresh wrapper', () => {
+    expect(pinQuantization({ provider: 'forbidden' }, 'fp4')).toEqual({
+      provider: { quantizations: ['fp4'] },
+    });
+  });
+
+  it('preserves sibling provider fields and adds quantizations', () => {
+    expect(
+      pinQuantization(
+        { provider: { allow_fallbacks: false, only: ['Hyperbolic'] } },
+        'fp8',
+      ),
+    ).toEqual({
+      provider: {
+        allow_fallbacks: false,
+        only: ['Hyperbolic'],
+        quantizations: ['fp8'],
+      },
+    });
+  });
+});
+
 describe('buildCallProviderOptions', () => {
   it('returns undefined when no providerOptions are configured', () => {
     expect(
@@ -215,5 +274,59 @@ describe('buildCallProviderOptions', () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+});
+
+// End-to-end shape contract: the merge → pin → namespace pipeline must
+// produce exactly the body fields OpenRouter expects when a Tale model ref
+// like `openrouter:z-ai/glm-5.1@fp8` is resolved. The `@fp8` suffix lives
+// only inside Tale; on the wire the `model` field is bare and the variant
+// rides in `provider.quantizations` as a single-element array.
+describe('quantization wire-shape pipeline', () => {
+  it('produces the exact namespaced body fields OpenRouter expects', () => {
+    // Stand-in for the merge step in resolveModelData: provider-level
+    // defaults + model-level passthrough, post-merge.
+    const merged = mergeModelLevel(
+      { provider: { allow_fallbacks: false, data_collection: 'deny' } },
+      { provider: { quantizations: ['fp8', 'fp4'] } },
+    );
+
+    // resolveModelData pins the user-selected variant before returning.
+    const pinned = pinQuantization(merged, 'fp4');
+
+    // The call site spreads buildCallProviderOptions into streamText.
+    expect(
+      buildCallProviderOptions({
+        providerName: 'openrouter',
+        providerOptions: pinned,
+      }),
+    ).toEqual({
+      openrouter: {
+        provider: {
+          allow_fallbacks: false,
+          data_collection: 'deny',
+          quantizations: ['fp4'],
+        },
+      },
+    });
+  });
+
+  it('keeps non-`provider` namespaced sub-objects intact alongside the pin', () => {
+    const merged = mergeModelLevel(
+      { openrouter: { only: ['Hyperbolic'] } },
+      { provider: { quantizations: ['fp8'] } },
+    );
+    const pinned = pinQuantization(merged, 'fp8');
+    expect(
+      buildCallProviderOptions({
+        providerName: 'openrouter',
+        providerOptions: pinned,
+      }),
+    ).toEqual({
+      openrouter: {
+        openrouter: { only: ['Hyperbolic'] },
+        provider: { quantizations: ['fp8'] },
+      },
+    });
   });
 });

--- a/services/platform/convex/lib/provider_options.ts
+++ b/services/platform/convex/lib/provider_options.ts
@@ -79,6 +79,40 @@ function pruneEmpty(
 }
 
 /**
+ * Pin `providerOptions.provider.quantizations` to a single-element array
+ * containing only `quantization`. Used by the resolver when the user selected
+ * a specific variant via the `@<quant>` model-ref suffix — the merged options
+ * may carry the model's full `quantizations: ['fp8', 'fp4']` array, but the
+ * outgoing request must request exactly one weight format.
+ *
+ * Returns a new object — never mutates `options` or its top-level entries.
+ * The top-level wrapper is shallow-cloned and `provider` is shallow-cloned
+ * before its `quantizations` field is set, so non-`provider` siblings (e.g.
+ * `openrouter`) and other `provider` sub-fields (`data_collection`,
+ * `allow_fallbacks`) keep their original references — safe given that this
+ * only runs on JSON-derived data we then hand to the AI SDK without further
+ * mutation. If a caller later relied on deep independence of nested
+ * sub-trees, switch to `structuredClone`.
+ *
+ * If the input has a non-object `provider` value (a config bug), it's
+ * replaced with a fresh `{ quantizations: [quantization] }` object — the
+ * deny-list strip and parse layer already reject those shapes before they
+ * reach here, but staying defensive ensures we always emit a valid pinned
+ * variant rather than propagating a malformed value.
+ */
+export function pinQuantization(
+  options: Record<string, unknown> | undefined,
+  quantization: string,
+): Record<string, unknown> {
+  const base = options ? { ...options } : {};
+  const existing = base.provider;
+  const provider = isPlainObject(existing) ? { ...existing } : {};
+  provider.quantizations = [quantization];
+  base.provider = provider;
+  return base;
+}
+
+/**
  * Defensive belt-and-braces filter that removes any deny-listed key (SDK
  * reserved or body-overwrite) at the top level and one nested level. Logs a
  * `console.error` per stripped key — every entry point that produces a

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -17,6 +17,7 @@ import { ConvexError, v } from 'convex/values';
 
 import type { ProviderSecrets } from '../../lib/shared/schemas/providers';
 import { providerJsonSchema } from '../../lib/shared/schemas/providers';
+import { parseModelRef } from '../../lib/shared/utils/model-ref';
 import { internal } from '../_generated/api';
 import { action, internalAction, type ActionCtx } from '../_generated/server';
 import { resolveAgeRecipients } from '../lib/age_keygen';
@@ -27,7 +28,12 @@ import {
   sha256,
 } from '../lib/file_io';
 import { isPrivateIp, safeFetch, SafeFetchError } from '../lib/http/safe_fetch';
-import { mergeModelLevel, stripDenyListed } from '../lib/provider_options';
+import {
+  isPlainObject,
+  mergeModelLevel,
+  pinQuantization,
+  stripDenyListed,
+} from '../lib/provider_options';
 import {
   EncryptedFileWithoutKeyError,
   decryptSecretsFile,
@@ -67,6 +73,26 @@ import {
 function maskApiKey(key: string): string {
   if (key.length <= 6) return '••••••••••';
   return key.slice(0, 6) + '••••••';
+}
+
+/**
+ * Read a model's declared quantization variants from its `providerOptions`.
+ * Returns the array only when it's a non-empty list of strings; any other
+ * shape (missing, non-array, mixed types) is treated as "no variants" so the
+ * model behaves as a plain non-quantized entry. The schema accepts arbitrary
+ * passthrough under `providerOptions`, so this defensive read is required.
+ */
+function readQuantizations(
+  providerOptions: Record<string, unknown> | undefined,
+): string[] | undefined {
+  if (!providerOptions) return undefined;
+  const provider = providerOptions.provider;
+  if (!isPlainObject(provider)) return undefined;
+  const q = provider.quantizations;
+  if (!Array.isArray(q) || q.length === 0) return undefined;
+  if (!q.every((item) => typeof item === 'string' && item.length > 0))
+    return undefined;
+  return q;
 }
 
 /** True iff `err` is a Node ErrnoException with the given code. */
@@ -359,6 +385,10 @@ export const listProviders = action({
               tags: m.tags,
               hasBaseUrlOverride: m.baseUrl != null,
               hasApiKeyOverride: modelKeys?.[m.id] != null,
+              // Surface quantization variants so the UI selectors can split
+              // each model into one selectable entry per declared weight
+              // format. Models without a quantizations array stay single.
+              quantizations: readQuantizations(m.providerOptions),
             })),
             i18n: result.config.i18n,
           };
@@ -545,6 +575,11 @@ export const resolveModelData = internalAction({
       });
     }
 
+    // Split off any `@<quant>` suffix so the provider config lookup uses the
+    // bare model id from the JSON. The variant pins the
+    // `providerOptions.provider.quantizations` array further below.
+    const { modelId: bareModelId, quantization } = parseModelRef(args.modelId);
+
     let firstMatch:
       | {
           provider: (typeof candidates)[number];
@@ -554,7 +589,7 @@ export const resolveModelData = internalAction({
     const secondaryMatchProviders: string[] = [];
     for (const provider of candidates) {
       const definition = provider.config.models.find(
-        (m) => m.id === args.modelId,
+        (m) => m.id === bareModelId,
       );
       if (!definition) continue;
       if (!firstMatch) {
@@ -567,19 +602,42 @@ export const resolveModelData = internalAction({
     if (firstMatch) {
       if (!args.providerName && secondaryMatchProviders.length > 0) {
         console.warn(
-          `[resolveModelData] Unqualified model "${args.modelId}" matches multiple providers ` +
+          `[resolveModelData] Unqualified model "${bareModelId}" matches multiple providers ` +
             `(pinned: ${firstMatch.provider.name}; also in: ${secondaryMatchProviders.join(', ')}). ` +
-            `Qualify as "${firstMatch.provider.name}:${args.modelId}" to pin explicitly.`,
+            `Qualify as "${firstMatch.provider.name}:${bareModelId}" to pin explicitly.`,
         );
       }
       const { provider, definition } = firstMatch;
+      let providerOptions = mergeModelLevel(
+        provider.config.providerOptions,
+        definition.providerOptions,
+      );
+
+      // The user pinned a specific quantization via the `@<quant>` suffix.
+      // Validate it appears in the model's declared `quantizations` and
+      // narrow the merged passthrough to a single-element array so the
+      // upstream request asks for exactly that weight format.
+      if (quantization) {
+        const declared = readQuantizations(providerOptions);
+        if (!declared || !declared.includes(quantization)) {
+          const available = declared?.length ? declared.join(', ') : '(none)';
+          throw new ConvexError({
+            code: 'UNKNOWN_MODEL_VARIANT',
+            message: `Model "${bareModelId}" has no quantization "${quantization}". Available: ${available}`,
+          });
+        }
+        providerOptions = pinQuantization(providerOptions, quantization);
+      }
+
       return {
         providerName: provider.name,
         baseUrl: definition.baseUrl ?? provider.config.baseUrl,
         apiKey:
           provider.secrets.modelKeys?.[definition.id] ??
           provider.secrets.apiKey,
-        modelId: args.modelId,
+        // The wire-side request uses the bare config id; the variant lives
+        // only in providerOptions.provider.quantizations.
+        modelId: bareModelId,
         tags: [...definition.tags],
         dimensions: definition.dimensions,
         maxOutputTokens: definition.maxOutputTokens,
@@ -592,10 +650,7 @@ export const resolveModelData = internalAction({
         outputCentsPerMillion: definition.cost?.outputCentsPerMillion,
         imageCentsPerImage: definition.cost?.imageCentsPerImage,
         centsPerAudioMinute: definition.cost?.centsPerAudioMinute,
-        providerOptions: mergeModelLevel(
-          provider.config.providerOptions,
-          definition.providerOptions,
-        ),
+        providerOptions,
       };
     }
 
@@ -604,7 +659,7 @@ export const resolveModelData = internalAction({
     );
     throw new ConvexError({
       code: 'UNKNOWN_MODEL',
-      message: `Model "${args.modelId}" not found${args.providerName ? ` in provider "${args.providerName}"` : ' in any provider'}. Available: ${allModelIds.join(', ')}`,
+      message: `Model "${bareModelId}" not found${args.providerName ? ` in provider "${args.providerName}"` : ' in any provider'}. Available: ${allModelIds.join(', ')}`,
     });
   },
 });
@@ -743,6 +798,7 @@ export const getAllModelIds = internalAction({
       tags: v.array(v.string()),
       providerName: v.string(),
       displayName: v.optional(v.string()),
+      quantizations: v.optional(v.array(v.string())),
     }),
   ),
   handler: async (_ctx, args) => {
@@ -758,6 +814,7 @@ export const getAllModelIds = internalAction({
       tags: string[];
       providerName: string;
       displayName?: string;
+      quantizations?: string[];
     }> = [];
     for (const provider of providers) {
       for (const m of provider.config.models) {
@@ -766,6 +823,7 @@ export const getAllModelIds = internalAction({
           tags: [...m.tags],
           providerName: provider.name,
           displayName: m.displayName,
+          quantizations: readQuantizations(m.providerOptions),
         });
       }
     }
@@ -788,6 +846,7 @@ export const getAllConfiguredModelIds = internalAction({
       tags: v.array(v.string()),
       providerName: v.string(),
       displayName: v.optional(v.string()),
+      quantizations: v.optional(v.array(v.string())),
     }),
   ),
   handler: async (_ctx, args) => {
@@ -810,6 +869,7 @@ export const getAllConfiguredModelIds = internalAction({
       tags: string[];
       providerName: string;
       displayName?: string;
+      quantizations?: string[];
     }> = [];
     await Promise.all(
       jsonFiles.map(async (fileName) => {
@@ -823,6 +883,7 @@ export const getAllConfiguredModelIds = internalAction({
             tags: [...m.tags],
             providerName: name,
             displayName: m.displayName,
+            quantizations: readQuantizations(m.providerOptions),
           });
         }
       }),

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -95,6 +95,20 @@ function readQuantizations(
   return q;
 }
 
+/**
+ * Read the quantization variants that apply to a model after merging
+ * provider-level and model-level `providerOptions` (model wins on conflict),
+ * so the UI's variant expansion matches what `resolveModelData` would pin
+ * at request time. Reading model-level alone would silently ignore
+ * provider-wide defaults declared at the top of a provider JSON.
+ */
+function readEffectiveQuantizations(
+  providerLevel: Record<string, unknown> | undefined,
+  modelLevel: Record<string, unknown> | undefined,
+): string[] | undefined {
+  return readQuantizations(mergeModelLevel(providerLevel, modelLevel));
+}
+
 /** True iff `err` is a Node ErrnoException with the given code. */
 function isErrnoCode(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && err.code === code;
@@ -387,8 +401,12 @@ export const listProviders = action({
               hasApiKeyOverride: modelKeys?.[m.id] != null,
               // Surface quantization variants so the UI selectors can split
               // each model into one selectable entry per declared weight
-              // format. Models without a quantizations array stay single.
-              quantizations: readQuantizations(m.providerOptions),
+              // format. Read from merged provider+model providerOptions to
+              // match resolveModelData's runtime view.
+              quantizations: readEffectiveQuantizations(
+                result.config.providerOptions,
+                m.providerOptions,
+              ),
             })),
             i18n: result.config.i18n,
           };
@@ -563,22 +581,30 @@ export const resolveModelData = internalAction({
     const orgSlug = args.orgSlug ?? 'default';
     const providers = await loadAllProviders(orgSlug);
 
-    const candidates = args.providerName
-      ? providers.filter((p) => p.name === args.providerName)
-      : providers;
-
-    if (args.providerName && candidates.length === 0) {
-      const available = providers.map((p) => p.name);
-      throw new ConvexError({
-        code: 'UNKNOWN_PROVIDER',
-        message: `Provider "${args.providerName}" not found. Available: ${available.join(', ')}`,
-      });
-    }
-
     // Split off any `@<quant>` suffix so the provider config lookup uses the
     // bare model id from the JSON. The variant pins the
     // `providerOptions.provider.quantizations` array further below.
-    const { modelId: bareModelId, quantization } = parseModelRef(args.modelId);
+    // Fall back to the ref's parsed `provider:` qualifier when the caller
+    // didn't pass `args.providerName` separately, so a fully-qualified
+    // modelId pins the lookup without a redundant arg.
+    const {
+      providerName: parsedProviderName,
+      modelId: bareModelId,
+      quantization,
+    } = parseModelRef(args.modelId);
+    const effectiveProviderName = args.providerName ?? parsedProviderName;
+
+    const candidates = effectiveProviderName
+      ? providers.filter((p) => p.name === effectiveProviderName)
+      : providers;
+
+    if (effectiveProviderName && candidates.length === 0) {
+      const available = providers.map((p) => p.name);
+      throw new ConvexError({
+        code: 'UNKNOWN_PROVIDER',
+        message: `Provider "${effectiveProviderName}" not found. Available: ${available.join(', ')}`,
+      });
+    }
 
     let firstMatch:
       | {
@@ -600,7 +626,7 @@ export const resolveModelData = internalAction({
     }
 
     if (firstMatch) {
-      if (!args.providerName && secondaryMatchProviders.length > 0) {
+      if (!effectiveProviderName && secondaryMatchProviders.length > 0) {
         console.warn(
           `[resolveModelData] Unqualified model "${bareModelId}" matches multiple providers ` +
             `(pinned: ${firstMatch.provider.name}; also in: ${secondaryMatchProviders.join(', ')}). ` +
@@ -659,7 +685,7 @@ export const resolveModelData = internalAction({
     );
     throw new ConvexError({
       code: 'UNKNOWN_MODEL',
-      message: `Model "${bareModelId}" not found${args.providerName ? ` in provider "${args.providerName}"` : ' in any provider'}. Available: ${allModelIds.join(', ')}`,
+      message: `Model "${bareModelId}" not found${effectiveProviderName ? ` in provider "${effectiveProviderName}"` : ' in any provider'}. Available: ${allModelIds.join(', ')}`,
     });
   },
 });
@@ -823,7 +849,10 @@ export const getAllModelIds = internalAction({
           tags: [...m.tags],
           providerName: provider.name,
           displayName: m.displayName,
-          quantizations: readQuantizations(m.providerOptions),
+          quantizations: readEffectiveQuantizations(
+            provider.config.providerOptions,
+            m.providerOptions,
+          ),
         });
       }
     }
@@ -883,7 +912,10 @@ export const getAllConfiguredModelIds = internalAction({
             tags: [...m.tags],
             providerName: name,
             displayName: m.displayName,
-            quantizations: readQuantizations(m.providerOptions),
+            quantizations: readEffectiveQuantizations(
+              result.config.providerOptions,
+              m.providerOptions,
+            ),
           });
         }
       }),

--- a/services/platform/lib/shared/utils/__tests__/expand-model-variants.test.ts
+++ b/services/platform/lib/shared/utils/__tests__/expand-model-variants.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandModelVariants,
+  getVariantBadgeLabel,
+} from '../expand-model-variants';
+
+const QUANTS: Record<string, string[]> = {
+  'z-ai/glm-5.1': ['fp8', 'fp4'],
+  'deepseek/deepseek-v4-pro': ['fp8', 'fp4'],
+};
+const lookup = (id: string): string[] | undefined => QUANTS[id];
+
+describe('expandModelVariants', () => {
+  it('returns an empty array when given an empty input', () => {
+    expect(expandModelVariants([], lookup)).toEqual([]);
+  });
+
+  it('keeps a model with no quantizations unchanged', () => {
+    expect(
+      expandModelVariants(['openrouter:anthropic/claude-opus-4.6'], lookup),
+    ).toEqual(['openrouter:anthropic/claude-opus-4.6']);
+  });
+
+  it('expands a base ref into one entry per quantization in declared order', () => {
+    expect(expandModelVariants(['openrouter:z-ai/glm-5.1'], lookup)).toEqual([
+      'openrouter:z-ai/glm-5.1@fp8',
+      'openrouter:z-ai/glm-5.1@fp4',
+    ]);
+  });
+
+  it('keeps an already-pinned variant ref verbatim (no re-expansion)', () => {
+    expect(
+      expandModelVariants(['openrouter:z-ai/glm-5.1@fp4'], lookup),
+    ).toEqual(['openrouter:z-ai/glm-5.1@fp4']);
+  });
+
+  it('dedupes two identical pinned-variant refs', () => {
+    expect(
+      expandModelVariants(
+        ['openrouter:z-ai/glm-5.1@fp8', 'openrouter:z-ai/glm-5.1@fp8'],
+        lookup,
+      ),
+    ).toEqual(['openrouter:z-ai/glm-5.1@fp8']);
+  });
+
+  it('preserves order when two distinct pinned variants of the same base are given', () => {
+    expect(
+      expandModelVariants(
+        ['openrouter:z-ai/glm-5.1@fp4', 'openrouter:z-ai/glm-5.1@fp8'],
+        lookup,
+      ),
+    ).toEqual(['openrouter:z-ai/glm-5.1@fp4', 'openrouter:z-ai/glm-5.1@fp8']);
+  });
+
+  it('dedupes when input mixes a base ref with one of its variants', () => {
+    expect(
+      expandModelVariants(
+        ['openrouter:z-ai/glm-5.1@fp8', 'openrouter:z-ai/glm-5.1'],
+        lookup,
+      ),
+    ).toEqual(['openrouter:z-ai/glm-5.1@fp8', 'openrouter:z-ai/glm-5.1@fp4']);
+  });
+
+  it('dedupes duplicate base refs', () => {
+    expect(
+      expandModelVariants(
+        ['openrouter:z-ai/glm-5.1', 'openrouter:z-ai/glm-5.1'],
+        lookup,
+      ),
+    ).toEqual(['openrouter:z-ai/glm-5.1@fp8', 'openrouter:z-ai/glm-5.1@fp4']);
+  });
+
+  it('treats an empty quantizations array as no-variant', () => {
+    expect(
+      expandModelVariants(['openrouter:foo/bar'], (id) =>
+        id === 'foo/bar' ? [] : undefined,
+      ),
+    ).toEqual(['openrouter:foo/bar']);
+  });
+
+  it('preserves the missing provider prefix when expanding unqualified refs', () => {
+    expect(expandModelVariants(['z-ai/glm-5.1'], lookup)).toEqual([
+      'z-ai/glm-5.1@fp8',
+      'z-ai/glm-5.1@fp4',
+    ]);
+  });
+
+  it('keeps unknown bare ids as-is', () => {
+    expect(expandModelVariants(['openrouter:unknown/model'], lookup)).toEqual([
+      'openrouter:unknown/model',
+    ]);
+  });
+
+  it('handles multiple distinct models in one input list', () => {
+    expect(
+      expandModelVariants(
+        [
+          'openrouter:z-ai/glm-5.1',
+          'openrouter:anthropic/claude-opus-4.6',
+          'openrouter:deepseek/deepseek-v4-pro@fp4',
+        ],
+        lookup,
+      ),
+    ).toEqual([
+      'openrouter:z-ai/glm-5.1@fp8',
+      'openrouter:z-ai/glm-5.1@fp4',
+      'openrouter:anthropic/claude-opus-4.6',
+      'openrouter:deepseek/deepseek-v4-pro@fp4',
+    ]);
+  });
+});
+
+describe('getVariantBadgeLabel', () => {
+  it('uppercases the token', () => {
+    expect(getVariantBadgeLabel('fp8')).toBe('FP8');
+    expect(getVariantBadgeLabel('bf16')).toBe('BF16');
+    expect(getVariantBadgeLabel('int8')).toBe('INT8');
+  });
+});

--- a/services/platform/lib/shared/utils/__tests__/model-ref.test.ts
+++ b/services/platform/lib/shared/utils/__tests__/model-ref.test.ts
@@ -90,6 +90,99 @@ describe('parseModelRef', () => {
       modelId: `${longPrefix}:model`,
     });
   });
+
+  describe('quantization variants', () => {
+    it('extracts the @quantization suffix from a qualified ref', () => {
+      expect(parseModelRef('openrouter:z-ai/glm-5.1@fp8')).toEqual({
+        providerName: 'openrouter',
+        modelId: 'z-ai/glm-5.1',
+        quantization: 'fp8',
+      });
+    });
+
+    it('extracts the @quantization suffix from an unqualified ref', () => {
+      expect(parseModelRef('z-ai/glm-5.1@fp4')).toEqual({
+        modelId: 'z-ai/glm-5.1',
+        quantization: 'fp4',
+      });
+    });
+
+    it('omits quantization when not present', () => {
+      expect(parseModelRef('z-ai/glm-5.1')).toEqual({
+        modelId: 'z-ai/glm-5.1',
+      });
+    });
+
+    it('preserves bedrock-style ids with embedded colons (no @ → no variant)', () => {
+      const bedrockId = 'anthropic.claude-3-5-sonnet-20240620-v1:0';
+      expect(parseModelRef(`bedrock:${bedrockId}`)).toEqual({
+        providerName: 'bedrock',
+        modelId: bedrockId,
+      });
+    });
+
+    it('rejects uppercase variant tokens (kept as part of modelId)', () => {
+      expect(parseModelRef('z-ai/glm-5.1@FP8')).toEqual({
+        modelId: 'z-ai/glm-5.1@FP8',
+      });
+    });
+
+    it('rejects empty variant tokens (kept as part of modelId)', () => {
+      expect(parseModelRef('z-ai/glm-5.1@')).toEqual({
+        modelId: 'z-ai/glm-5.1@',
+      });
+    });
+
+    it('rejects variant tokens with punctuation (kept as part of modelId)', () => {
+      expect(parseModelRef('foo@bar-baz')).toEqual({ modelId: 'foo@bar-baz' });
+    });
+
+    it('splits on the LAST @ when multiple are present', () => {
+      expect(parseModelRef('foo@bar@fp8')).toEqual({
+        modelId: 'foo@bar',
+        quantization: 'fp8',
+      });
+    });
+
+    it('accepts multi-character lowercase alphanumeric tokens', () => {
+      expect(parseModelRef('m@bf16')).toEqual({
+        modelId: 'm',
+        quantization: 'bf16',
+      });
+      expect(parseModelRef('m@int8')).toEqual({
+        modelId: 'm',
+        quantization: 'int8',
+      });
+    });
+
+    it('accepts single-character variant tokens (letter or digit)', () => {
+      expect(parseModelRef('m@q')).toEqual({
+        modelId: 'm',
+        quantization: 'q',
+      });
+      expect(parseModelRef('m@8')).toEqual({
+        modelId: 'm',
+        quantization: '8',
+      });
+    });
+
+    it('rejects variant tokens longer than 16 chars (kept as part of modelId)', () => {
+      const longVariant = 'a'.repeat(17);
+      expect(parseModelRef(`m@${longVariant}`)).toEqual({
+        modelId: `m@${longVariant}`,
+      });
+    });
+
+    it('extracts a variant from a bedrock-style id with embedded colons', () => {
+      expect(
+        parseModelRef('bedrock:anthropic.claude-3-5-sonnet-20240620-v1:0@fp8'),
+      ).toEqual({
+        providerName: 'bedrock',
+        modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        quantization: 'fp8',
+      });
+    });
+  });
 });
 
 describe('formatModelRef', () => {
@@ -112,6 +205,27 @@ describe('formatModelRef', () => {
     const input = 'openrouter:anthropic/claude-opus-4.6';
     expect(formatModelRef(parseModelRef(input))).toBe(input);
   });
+
+  it('appends @quantization on a qualified ref', () => {
+    expect(
+      formatModelRef({
+        providerName: 'openrouter',
+        modelId: 'z-ai/glm-5.1',
+        quantization: 'fp8',
+      }),
+    ).toBe('openrouter:z-ai/glm-5.1@fp8');
+  });
+
+  it('appends @quantization on an unqualified ref', () => {
+    expect(
+      formatModelRef({ modelId: 'z-ai/glm-5.1', quantization: 'fp4' }),
+    ).toBe('z-ai/glm-5.1@fp4');
+  });
+
+  it('round-trips a variant ref through parse', () => {
+    const input = 'openrouter:z-ai/glm-5.1@fp8';
+    expect(formatModelRef(parseModelRef(input))).toBe(input);
+  });
 });
 
 describe('stripModelRefQualifier', () => {
@@ -126,6 +240,16 @@ describe('stripModelRefQualifier', () => {
       'anthropic/claude-opus-4.6',
     );
   });
+
+  it('strips both provider prefix and @quantization', () => {
+    expect(stripModelRefQualifier('openrouter:z-ai/glm-5.1@fp8')).toBe(
+      'z-ai/glm-5.1',
+    );
+  });
+
+  it('strips @quantization on an unqualified ref', () => {
+    expect(stripModelRefQualifier('z-ai/glm-5.1@fp4')).toBe('z-ai/glm-5.1');
+  });
 });
 
 describe('isValidModelRef', () => {
@@ -139,5 +263,10 @@ describe('isValidModelRef', () => {
     expect(isValidModelRef('   ')).toBe(false);
     expect(isValidModelRef(':foo')).toBe(false);
     expect(isValidModelRef('foo:')).toBe(false);
+  });
+
+  it('returns true for variant-qualified refs', () => {
+    expect(isValidModelRef('openrouter:z-ai/glm-5.1@fp8')).toBe(true);
+    expect(isValidModelRef('z-ai/glm-5.1@fp4')).toBe(true);
   });
 });

--- a/services/platform/lib/shared/utils/expand-model-variants.ts
+++ b/services/platform/lib/shared/utils/expand-model-variants.ts
@@ -1,0 +1,50 @@
+import { formatModelRef, parseModelRef } from './model-ref';
+
+/**
+ * Expands a list of model refs into per-quantization variants.
+ *
+ * For each ref:
+ * - If the ref already pins a quantization (e.g. `openrouter:z-ai/glm-5.1@fp8`),
+ *   it's kept as-is.
+ * - If the bare model has a non-empty `quantizations` array (looked up via
+ *   `getQuantizations(bareId)`), the ref is replaced by one variant ref per
+ *   quantization in declared order. The unsplit base entry is dropped — the
+ *   UX rule is "force an explicit variant pick when quantizations exist".
+ * - Otherwise, the ref is kept as-is.
+ *
+ * Output is deduplicated while preserving first-occurrence order.
+ */
+export function expandModelVariants(
+  refs: readonly string[],
+  getQuantizations: (bareModelId: string) => readonly string[] | undefined,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (ref: string): void => {
+    if (seen.has(ref)) return;
+    seen.add(ref);
+    out.push(ref);
+  };
+
+  for (const ref of refs) {
+    const parsed = parseModelRef(ref);
+    if (parsed.quantization) {
+      push(ref);
+      continue;
+    }
+    const variants = getQuantizations(parsed.modelId);
+    if (variants && variants.length > 0) {
+      for (const q of variants) {
+        push(formatModelRef({ ...parsed, quantization: q }));
+      }
+    } else {
+      push(ref);
+    }
+  }
+  return out;
+}
+
+/** Render a quantization token as a UI badge label, e.g. `'fp8'` → `'FP8'`. */
+export function getVariantBadgeLabel(quantization: string): string {
+  return quantization.toUpperCase();
+}


### PR DESCRIPTION
## Summary

- Each `providerOptions.provider.quantizations` entry becomes its own selectable model in the chat picker, arena picker, and agent `supportedModels` editor — e.g. **GLM 5.1** with an `FP8` badge and **GLM 5.1** with an `FP4` badge as separate entries.
- The chosen variant is encoded as `provider:base@quant` end-to-end; on the wire to OpenRouter the model id is bare and the variant rides in `provider.quantizations: [chosen]`.
- No JSON schema changes, no DB migrations, no new i18n keys. Existing agent JSONs referring to a bare base id still resolve at runtime (provider picks); they re-bind to a variant on the user's next selection.

## Approach

- **Encoding**: `provider:base-id@quant` (e.g. `openrouter:z-ai/glm-5.1@fp8`). Token regex `^[a-z0-9]{1,16}$` so `@` followed by uppercase / punctuation / empty stays part of the modelId — parser is predictable, never half-parses.
- **UI rule**: when a model declares `quantizations`, selectors render **only** the variant entries (no unsplit base option), forcing an explicit pick.
- **Runtime**: `resolveModelData` parses the suffix, validates it against the declared array, calls `pinQuantization` to narrow the merged passthrough to a single element, returns the bare modelId. `buildCallProviderOptions` namespaces the result; the AI SDK spreads it as top-level body fields. `governance.stripModelRefQualifier` continues returning the bare id, so policies stay variant-agnostic.

### Wire shape (verified by composed test)

For `openrouter:z-ai/glm-5.1@fp8`:

```json
{ "model": "z-ai/glm-5.1",
  "provider": { "quantizations": ["fp8"] } }
```

## Files

- `lib/shared/utils/model-ref.ts` — `parseModelRef`/`formatModelRef`/`stripModelRefQualifier` extended for `@quant`
- `lib/shared/utils/expand-model-variants.ts` *(new)* — pure expansion + badge label helper
- `convex/lib/provider_options.ts` — `pinQuantization` (shallow-clones, narrows to `[quant]`)
- `convex/providers/file_actions.ts` — `resolveModelData` parses + validates + pins; `listProviders`/`getAllModelIds`/`getAllConfiguredModelIds` expose `quantizations`
- `convex/agents/file_actions.ts` — `saveAgent` rejects bogus variants with `UNKNOWN_MODEL_VARIANT`
- `app/features/chat/components/{model-selector,arena/arena-model-selector}.tsx` — render variant entries with badges
- `app/routes/dashboard/$id/agents/$agentId/instructions.tsx` — agent editor offers per-variant entries; variant-aware dedup; variant in displayed name

## Test plan

- [x] `bun run check` — 38/38 turbo tasks green (5602 vitest, lint, typecheck, format-check)
- [x] `bunx knip` — clean
- [x] CodeRabbit review across 3 passes — addressed every actionable finding
- [x] Composed `merge → pinQuantization → buildCallProviderOptions` test asserts the exact OpenRouter body shape
- [ ] **Manual**: with `TALE_DEBUG_LLM_WIRE=1`, send a chat with GLM 5.1 (FP4); confirm wire body has `model: "z-ai/glm-5.1"` and `provider: { quantizations: ["fp4"] }`
- [ ] **Manual**: switch variant mid-conversation; confirm wire body updates
- [ ] **Manual**: try saving an agent JSON with a bogus variant (`@fp16`) → `UNKNOWN_MODEL_VARIANT` error
- [ ] **Manual**: existing agent with bare `openrouter:z-ai/glm-5.1` still runs; chat picker re-binds on next selection
- [ ] **Manual**: `anthropic/claude-opus-4.6` (no quantizations) still appears as a single entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model selectors now support quantization variants, enabling users to select specific model optimizations alongside standard models.
  * Model variant options are identified with descriptive badges in selection menus.
  * Agent instruction configurations can now reference specific model quantization variants.

* **Tests**
  * Added comprehensive test coverage for model variant expansion, reference parsing, and quantization handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1697)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->