### PR TITLE
fix(platform): redirect to create-organization instead of auto-creating Default org

### DIFF
--- a/services/platform/app/features/settings/integrations/components/__tests__/integration-card.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/__tests__/integration-card.test.tsx
@@ -46,6 +46,26 @@ describe('IntegrationCard', () => {
     expect(screen.getByText('integrations.badge.connect')).toBeInTheDocument();
   });
 
+  it('shows "Reconnect needed" badge when status is "error", overriding isActive', () => {
+    render(
+      <IntegrationCard
+        title="Google Drive"
+        description="Access Google Drive."
+        isActive
+        status="error"
+      />,
+    );
+    expect(
+      screen.getByText('integrations.badge.reconnectNeeded'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('integrations.badge.connected'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('integrations.badge.connect'),
+    ).not.toBeInTheDocument();
+  });
+
   it('calls onClick when clicked', async () => {
     const user = userEvent.setup();
     const handleClick = vi.fn();

--- a/services/platform/app/features/settings/integrations/components/integration-card.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-card.tsx
@@ -14,6 +14,7 @@ interface IntegrationCardProps {
   title: string;
   description?: string;
   isActive?: boolean;
+  status?: string;
   disabled?: boolean;
   iconUrl?: string;
   icon?: LucideIcon;
@@ -24,6 +25,7 @@ export function IntegrationCard({
   title,
   description,
   isActive,
+  status,
   disabled,
   iconUrl,
   icon: Icon = Puzzle,
@@ -55,7 +57,11 @@ export function IntegrationCard({
                 <Icon className="size-6" />
               )}
             </Center>
-            {isActive ? (
+            {status === 'error' ? (
+              <Badge variant="destructive" dot>
+                {t('integrations.badge.reconnectNeeded')}
+              </Badge>
+            ) : isActive ? (
               <Badge variant="green" dot>
                 {t('integrations.badge.connected')}
               </Badge>

--- a/services/platform/app/features/settings/integrations/components/integration-manage/integration-icon-upload.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-manage/integration-icon-upload.tsx
@@ -13,6 +13,7 @@ interface IntegrationIconUploadProps {
   title: string;
   isUploadingIcon: boolean;
   isActive: boolean;
+  status?: string;
   isSql: boolean;
   authMethod: string;
   operationCount: number;
@@ -25,6 +26,7 @@ export function IntegrationIconUpload({
   title,
   isUploadingIcon,
   isActive,
+  status,
   isSql,
   authMethod,
   operationCount,
@@ -67,10 +69,16 @@ export function IntegrationIconUpload({
         onChange={onIconUpload}
         aria-label={t('integrations.upload.changeIcon')}
       />
-      <StatusIndicator variant={isActive ? 'success' : 'warning'}>
-        {isActive
-          ? t('integrations.upload.active')
-          : t('integrations.upload.inactive')}
+      <StatusIndicator
+        variant={
+          status === 'error' ? 'error' : isActive ? 'success' : 'warning'
+        }
+      >
+        {status === 'error'
+          ? t('integrations.upload.reconnectNeeded')
+          : isActive
+            ? t('integrations.upload.active')
+            : t('integrations.upload.inactive')}
       </StatusIndicator>
       {operationCount > 0 && (
         <HStack gap={2} className="ml-auto flex-wrap">

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -134,6 +134,11 @@ export function IntegrationPanel({
               title={integration.title}
               isUploadingIcon={manage.isUploadingIcon}
               isActive={isDetailsMode}
+              status={
+                typeof integration.status === 'string'
+                  ? integration.status
+                  : undefined
+              }
               isSql={manage.isSql}
               authMethod={integration.authMethod ?? ''}
               operationCount={manage.operationCount}

--- a/services/platform/app/features/settings/integrations/components/integrations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integrations.tsx
@@ -161,6 +161,11 @@ export function Integrations({
               title={integration.title}
               description={integration.description}
               isActive={integration.isActive === true}
+              status={
+                typeof integration.status === 'string'
+                  ? integration.status
+                  : undefined
+              }
               iconUrl={
                 typeof integration.iconUrl === 'string'
                   ? integration.iconUrl

--- a/services/platform/app/features/settings/integrations/hooks/queries.ts
+++ b/services/platform/app/features/settings/integrations/hooks/queries.ts
@@ -9,10 +9,15 @@ import { api } from '@/convex/_generated/api';
 // ---------------------------------------------------------------------------
 
 export function useIntegrations(orgSlug: string) {
+  // Skip the action while the caller is still resolving the org's slug
+  // (e.g. /dashboard/$id/settings/integrations on first render before
+  // useOrganization resolves). Firing with orgSlug='' would throw
+  // "Invalid org slug:" on the server — noise only, but pollutes logs.
   const { data, isLoading, error, refetch } = useActionQuery(
     configKeys.list('integrations', orgSlug),
     api.integrations.file_actions.listIntegrations,
     { orgSlug, filter: 'all' },
+    { enabled: orgSlug !== '' },
   );
   return { integrations: data ?? [], isLoading, error, refetch };
 }

--- a/services/platform/app/routes/dashboard/index.tsx
+++ b/services/platform/app/routes/dashboard/index.tsx
@@ -2,7 +2,7 @@ import { convexQuery } from '@convex-dev/react-query';
 import { Spinner } from '@tale/ui/spinner';
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
-import { useAction, useMutation } from 'convex/react';
+import { useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
 import { FullPageCenter } from '@/app/components/ui/layout/full-page-center';
@@ -29,9 +29,6 @@ export const Route = createFileRoute('/dashboard/')({
 function DashboardIndex() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const initializeWorkflows = useAction(
-    api.organizations.actions.initializeDefaultWorkflows,
-  );
   const recordOrgSwitch = useMutation(
     api.organizations.record_org_switch.recordOrgSwitch,
   );
@@ -53,7 +50,7 @@ function DashboardIndex() {
 
     if (organizations.length === 0) {
       resolvedRef.current = true;
-      void createDefaultOrganization();
+      void navigate({ to: '/dashboard/create-organization' });
       return;
     }
 
@@ -107,39 +104,12 @@ function DashboardIndex() {
         resolvedRef.current = false;
       }
     })();
-
-    async function createDefaultOrganization() {
-      try {
-        const result = await authClient.organization.create({
-          name: 'Default',
-          slug: 'default',
-        });
-        const orgId = result.data?.id;
-        if (!orgId) throw new Error('Failed to create organization');
-
-        await authClient.organization.setActive({ organizationId: orgId });
-        await queryClient.invalidateQueries({ queryKey: ['auth', 'session'] });
-        await initializeWorkflows({ organizationId: orgId });
-
-        try {
-          await recordOrgSwitch({ organizationId: orgId });
-        } catch (err) {
-          console.warn('Failed to record org switch audit entry:', err);
-        }
-
-        void navigate({ to: '/dashboard/$id', params: { id: orgId } });
-      } catch (error) {
-        console.error('Failed to create default organization:', error);
-        void navigate({ to: '/dashboard/create-organization' });
-      }
-    }
   }, [
     isOrgsLoading,
     isLastActiveLoading,
     organizations,
     lastActiveOrgId,
     navigate,
-    initializeWorkflows,
     queryClient,
     recordOrgSwitch,
   ]);

--- a/services/platform/convex/integrations/decrypt_and_refresh_oauth2.ts
+++ b/services/platform/convex/integrations/decrypt_and_refresh_oauth2.ts
@@ -6,6 +6,7 @@
  */
 
 import { fetchJson } from '../../lib/utils/type-cast-helpers';
+import { isRecord } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { ActionCtx } from '../_generated/server';
@@ -21,6 +22,33 @@ interface TokenRefreshResponse {
   token_type: string;
   expires_in?: number;
   scope?: string;
+}
+
+// Parses a token-endpoint OAuth2 error body into its standard `error` /
+// `error_description` fields (RFC 6749 §5.2). Returns null for non-JSON or
+// non-conforming bodies so callers fall back to a generic message.
+function parseOAuthError(
+  errorText: string,
+): { code: string; description?: string } | null {
+  try {
+    const parsed: unknown = JSON.parse(errorText);
+    if (isRecord(parsed) && typeof parsed.error === 'string') {
+      return {
+        code: parsed.error,
+        description:
+          typeof parsed.error_description === 'string'
+            ? parsed.error_description
+            : undefined,
+      };
+    }
+    return null;
+  } catch (err) {
+    console.warn(
+      '[Integration OAuth2] Token endpoint returned non-JSON error body:',
+      err,
+    );
+    return null;
+  }
 }
 
 export async function decryptAndRefreshIntegrationOAuth2(
@@ -74,6 +102,17 @@ export async function decryptAndRefreshIntegrationOAuth2(
       `[Integration OAuth2] Token expired for ${integration._id} but cannot refresh: ` +
         `missing ${missingPrerequisites.join(', ')}`,
     );
+    if (credentialId) {
+      await ctx.runMutation(
+        internal.integrations.credential_mutations.updateCredentialsInternal,
+        {
+          credentialId,
+          status: 'error',
+          errorMessage: `OAuth2 refresh prerequisites missing: ${missingPrerequisites.join(', ')}`,
+          lastErrorAt: Date.now(),
+        },
+      );
+    }
     throw new Error(
       `OAuth2 access token has expired but cannot refresh: missing ${missingPrerequisites.join(', ')}. ` +
         'Please re-authorize the integration.',
@@ -113,13 +152,28 @@ export async function decryptAndRefreshIntegrationOAuth2(
 
   if (!response.ok) {
     const errorText = await response.text();
+    const parsed = parseOAuthError(errorText);
+    const detail = parsed
+      ? ` (${parsed.code}${parsed.description ? `: ${parsed.description}` : ''})`
+      : '';
     console.error(
       `[Integration OAuth2] Token refresh failed for ${integration._id} ` +
         `(status ${response.status}):`,
       errorText,
     );
+    if (credentialId) {
+      await ctx.runMutation(
+        internal.integrations.credential_mutations.updateCredentialsInternal,
+        {
+          credentialId,
+          status: 'error',
+          errorMessage: `OAuth2 refresh failed${detail}`,
+          lastErrorAt: Date.now(),
+        },
+      );
+    }
     throw new Error(
-      'Failed to refresh OAuth2 token. Please re-authorize the integration.',
+      `Failed to refresh OAuth2 token${detail}. Please re-authorize the integration.`,
     );
   }
 
@@ -129,6 +183,18 @@ export async function decryptAndRefreshIntegrationOAuth2(
     console.error(
       `[Integration OAuth2] Token refresh response missing access_token for ${integration._id}`,
     );
+    if (credentialId) {
+      await ctx.runMutation(
+        internal.integrations.credential_mutations.updateCredentialsInternal,
+        {
+          credentialId,
+          status: 'error',
+          errorMessage:
+            'OAuth2 token refresh returned an invalid response (no access_token)',
+          lastErrorAt: Date.now(),
+        },
+      );
+    }
     throw new Error(
       'OAuth2 token refresh returned an invalid response. Please re-authorize the integration.',
     );
@@ -153,7 +219,12 @@ export async function decryptAndRefreshIntegrationOAuth2(
   if (credentialId) {
     await ctx.runMutation(
       internal.integrations.credential_mutations.updateCredentialsInternal,
-      { credentialId, oauth2Auth: updatedOAuth2Auth },
+      {
+        credentialId,
+        oauth2Auth: updatedOAuth2Auth,
+        status: 'active',
+        lastSuccessAt: Date.now(),
+      },
     );
   }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -817,7 +817,8 @@
       "searchPlaceholder": "Integrationen suchen...",
       "badge": {
         "connected": "Verbunden",
-        "connect": "Verbinden"
+        "connect": "Verbinden",
+        "reconnectNeeded": "Erneut verbinden"
       },
       "empty": {
         "connectedTitle": "Keine verbundenen Integrationen",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -872,6 +872,7 @@
         "configureCredentialsHint": "Konfiguriere die Zugangsdaten in den Integrationseinstellungen, um sie zu aktivieren.",
         "active": "Aktiv",
         "inactive": "Inaktiv",
+        "reconnectNeeded": "Erneut verbinden",
         "changeIcon": "Symbol ändern",
         "iconTooLarge": "Symbol muss unter 256 KB sein",
         "invalidIconFormat": "Symbol muss PNG, SVG, JPG oder WebP sein"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -872,6 +872,7 @@
         "configureCredentialsHint": "Configure credentials in the integration settings to activate it.",
         "active": "Active",
         "inactive": "Inactive",
+        "reconnectNeeded": "Reconnect needed",
         "changeIcon": "Change icon",
         "iconTooLarge": "Icon must be under 256KB",
         "invalidIconFormat": "Icon must be PNG, SVG, JPG, or WebP"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -817,7 +817,8 @@
       "searchPlaceholder": "Search integrations...",
       "badge": {
         "connected": "Connected",
-        "connect": "Connect"
+        "connect": "Connect",
+        "reconnectNeeded": "Reconnect needed"
       },
       "empty": {
         "connectedTitle": "No connected integrations",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -817,7 +817,8 @@
       "searchPlaceholder": "Rechercher des intégrations...",
       "badge": {
         "connected": "Connectée",
-        "connect": "Connecter"
+        "connect": "Connecter",
+        "reconnectNeeded": "Reconnexion requise"
       },
       "empty": {
         "connectedTitle": "Aucune intégration connectée",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -872,6 +872,7 @@
         "configureCredentialsHint": "Configure les identifiants dans les paramètres de l'intégration pour l'activer.",
         "active": "Actif",
         "inactive": "Inactif",
+        "reconnectNeeded": "Reconnexion requise",
         "changeIcon": "Changer l'icône",
         "iconTooLarge": "L'icône doit faire moins de 256 Ko",
         "invalidIconFormat": "L'icône doit être au format PNG, SVG, JPG ou WebP"


### PR DESCRIPTION
## Summary
- When a signed-in user has no organizations, route them to `/dashboard/create-organization` instead of silently creating a `Default` org and initializing workflows.
- Removes the unused `initializeDefaultWorkflows` action call and the inline `createDefaultOrganization` helper from the dashboard index route.

## Test plan
- [ ] Sign in as a user with zero organizations → lands on `/dashboard/create-organization` (no `Default` org auto-created).
- [ ] Sign in as a user with one or more organizations → still resolves to the last-active org as before.
- [ ] `bun run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now directs users to create an organization when none exists, replacing the previous automatic organization setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1698)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->