### PR TITLE
feat(platform): public /status page with per-component health

### DIFF
--- a/docs/de-CH/develop/api-reference.md
+++ b/docs/de-CH/develop/api-reference.md
@@ -293,3 +293,37 @@ Liste der verfügbaren Agents (Modelle).
   ]
 }
 ```
+
+## Status-Endpoints
+
+Zwei öffentliche, nicht authentifizierte Endpoints geben den Gesamt-Up/Down-Status der Plattform aus. Sie teilen sich denselben Probe (5-Sekunden-In-Memory-Cache) und unterscheiden sich nur in der Darstellung:
+
+| Endpoint       | Verwendung                                                                                                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `/status`      | Lesbare HTML-Statusseite. Wählt Englisch, Deutsch oder Französisch anhand von `Accept-Language`.                            |
+| `/status.json` | Maschinenlesbarer Feed für externe Monitore (BetterStack, UptimeRobot, Atlassian Statuspage, Datadog Synthetics und andere) |
+
+Beide Endpoints antworten immer mit `200 OK` und `Cache-Control: public, max-age=5`. Die Plattform selbst ist die Quelle der Wahrheit — wenn dein Monitor `/status.json` überhaupt nicht erreicht, ist der Plattformprozess nicht erreichbar, und das Timeout des Monitors ist das Signal.
+
+### Wire-Format (`/status.json`)
+
+```json
+{
+  "status": "operational",
+  "checkedAt": "2026-05-11T13:45:07.123Z",
+  "components": [
+    { "id": "convex", "status": "operational" },
+    { "id": "rag", "status": "operational" },
+    { "id": "crawler", "status": "outage" }
+  ]
+}
+```
+
+| Feld                  | Typ    | Werte                                                                                |
+| --------------------- | ------ | ------------------------------------------------------------------------------------ |
+| `status`              | string | `operational`, `degraded` (einige Komponenten ausgefallen) oder `outage` (alle aus). |
+| `checkedAt`           | string | ISO-8601-Zeitstempel der letzten Probe-Runde.                                        |
+| `components[].id`     | string | Stabile Komponenten-Kennung: `convex`, `rag` oder `crawler`.                         |
+| `components[].status` | string | `operational` oder `outage` pro Komponente.                                          |
+
+Keyword-basierte Uptime-Monitore können auf den gross-/kleinschreibungssensitiven Substring `"status":"outage"` reagieren.

--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -293,3 +293,37 @@ Liste der verfügbaren Agents (Modelle).
   ]
 }
 ```
+
+## Status-Endpoints
+
+Zwei öffentliche, nicht authentifizierte Endpoints geben den Gesamt-Up/Down-Status der Plattform aus. Sie teilen sich denselben Probe (5-Sekunden-In-Memory-Cache) und unterscheiden sich nur in der Darstellung:
+
+| Endpoint       | Verwendung                                                                                                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `/status`      | Lesbare HTML-Statusseite. Wählt Englisch, Deutsch oder Französisch anhand von `Accept-Language`.                            |
+| `/status.json` | Maschinenlesbarer Feed für externe Monitore (BetterStack, UptimeRobot, Atlassian Statuspage, Datadog Synthetics und andere) |
+
+Beide Endpoints antworten immer mit `200 OK` und `Cache-Control: public, max-age=5`. Die Plattform selbst ist die Quelle der Wahrheit — wenn dein Monitor `/status.json` überhaupt nicht erreicht, ist der Plattformprozess nicht erreichbar, und das Timeout des Monitors ist das Signal.
+
+### Wire-Format (`/status.json`)
+
+```json
+{
+  "status": "operational",
+  "checkedAt": "2026-05-11T13:45:07.123Z",
+  "components": [
+    { "id": "convex", "status": "operational" },
+    { "id": "rag", "status": "operational" },
+    { "id": "crawler", "status": "outage" }
+  ]
+}
+```
+
+| Feld                  | Typ    | Werte                                                                                |
+| --------------------- | ------ | ------------------------------------------------------------------------------------ |
+| `status`              | string | `operational`, `degraded` (einige Komponenten ausgefallen) oder `outage` (alle aus). |
+| `checkedAt`           | string | ISO-8601-Zeitstempel der letzten Probe-Runde.                                        |
+| `components[].id`     | string | Stabile Komponenten-Kennung: `convex`, `rag` oder `crawler`.                         |
+| `components[].status` | string | `operational` oder `outage` pro Komponente.                                          |
+
+Keyword-basierte Uptime-Monitore können auf den groß-/kleinschreibungssensitiven Substring `"status":"outage"` reagieren.

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -293,3 +293,37 @@ List available agents (models).
   ]
 }
 ```
+
+## Status endpoints
+
+Two public, unauthenticated endpoints expose the platform's overall up/down state. They share the same probe (5-second in-memory cache) and only differ in representation:
+
+| Endpoint       | Use                                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `/status`      | Human-readable HTML status page. Picks English, German, or French from `Accept-Language`.                              |
+| `/status.json` | Machine-readable feed for external monitors (BetterStack, UptimeRobot, Atlassian Statuspage, Datadog Synthetics, etc.) |
+
+Both endpoints always respond with `200 OK` and `Cache-Control: public, max-age=5`. The platform itself is the source of truth — if your monitor cannot reach `/status.json` at all, the platform process is unreachable, and the monitor's own timeout is the signal.
+
+### Wire shape (`/status.json`)
+
+```json
+{
+  "status": "operational",
+  "checkedAt": "2026-05-11T13:45:07.123Z",
+  "components": [
+    { "id": "convex", "status": "operational" },
+    { "id": "rag", "status": "operational" },
+    { "id": "crawler", "status": "outage" }
+  ]
+}
+```
+
+| Field                 | Type   | Values                                                                    |
+| --------------------- | ------ | ------------------------------------------------------------------------- |
+| `status`              | string | `operational`, `degraded` (some components down), or `outage` (all down). |
+| `checkedAt`           | string | ISO 8601 timestamp of the most recent probe round.                        |
+| `components[].id`     | string | Stable component identifier: `convex`, `rag`, or `crawler`.               |
+| `components[].status` | string | `operational` or `outage` per component.                                  |
+
+Keyword-based uptime monitors can alert on the case-sensitive substring `"status":"outage"`.

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -293,3 +293,37 @@ Liste les agents disponibles (modèles).
   ]
 }
 ```
+
+## Endpoints d'état
+
+Deux endpoints publics et non authentifiés exposent l'état global up/down de la plateforme. Ils partagent la même sonde (cache en mémoire de 5 secondes) et ne diffèrent que par la représentation :
+
+| Endpoint       | Utilisation                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `/status`      | Page d'état HTML lisible. Choisit l'anglais, l'allemand ou le français selon `Accept-Language`.                                   |
+| `/status.json` | Flux lisible par machine pour les services de surveillance externes (BetterStack, UptimeRobot, Atlassian Statuspage, Datadog, …). |
+
+Les deux endpoints répondent toujours avec `200 OK` et `Cache-Control: public, max-age=5`. La plateforme elle-même est la source de vérité — si ton service de surveillance n'atteint pas du tout `/status.json`, c'est que le processus de la plateforme est injoignable, et le timeout du service de surveillance est alors le signal.
+
+### Format de la réponse (`/status.json`)
+
+```json
+{
+  "status": "operational",
+  "checkedAt": "2026-05-11T13:45:07.123Z",
+  "components": [
+    { "id": "convex", "status": "operational" },
+    { "id": "rag", "status": "operational" },
+    { "id": "crawler", "status": "outage" }
+  ]
+}
+```
+
+| Champ                 | Type   | Valeurs                                                                               |
+| --------------------- | ------ | ------------------------------------------------------------------------------------- |
+| `status`              | string | `operational`, `degraded` (certains composants en panne) ou `outage` (tous en panne). |
+| `checkedAt`           | string | Horodatage ISO 8601 de la dernière sonde.                                             |
+| `components[].id`     | string | Identifiant stable du composant : `convex`, `rag` ou `crawler`.                       |
+| `components[].status` | string | `operational` ou `outage` par composant.                                              |
+
+Les services de surveillance par mots-clés peuvent déclencher une alerte sur la sous-chaîne sensible à la casse `"status":"outage"`.

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -86,6 +86,12 @@ COPY services/platform/docker-entrypoint.sh \
      services/platform/env.sh \
      ./services/platform/
 
+# status-probe.ts is imported by vite-plugins/serve-status.ts (loaded via
+# vite.config.ts) so it must be present before `vite build` for rolldown
+# to resolve the static import, even though the plugin itself is dev-only.
+# server.ts also imports it for the production /status handler.
+COPY services/platform/status-probe.ts ./services/platform/
+
 ENV NODE_ENV=production
 
 RUN cd services/platform && bun --bun vite build
@@ -215,6 +221,7 @@ COPY --from=pruner --chown=app:app \
      /app/services/platform/server.ts \
      /app/services/platform/telemetry.ts \
      /app/services/platform/convex-metrics.ts \
+     /app/services/platform/status-probe.ts \
      ./
 COPY --from=pruner --chown=app:app /app/services/platform/convex ./convex
 COPY --from=pruner --chown=app:app /app/services/platform/lib ./lib

--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -332,6 +332,33 @@ describe('canvas-preview storage shim', () => {
   });
 });
 
+describe('GET /status.json', () => {
+  test('responds with the canonical StatusFeed shape as JSON', async () => {
+    const app = createApp(baseEnv);
+    const res = await app.fetch(new Request('http://localhost/status.json'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=5');
+
+    // No upstreams are running in test; probes fail (ECONNREFUSED) and the
+    // feed reports `outage`. The point of this test is the wire shape and
+    // headers — not the upstream verdict — so assertions stay on structure.
+    const body = JSON.parse(await res.text());
+    expect(body).toMatchObject({
+      status: expect.stringMatching(/^(operational|degraded|outage)$/),
+      checkedAt: expect.any(String),
+      components: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'convex',
+          status: expect.stringMatching(/^(operational|outage)$/),
+        }),
+        expect.objectContaining({ id: 'rag' }),
+        expect.objectContaining({ id: 'crawler' }),
+      ]),
+    });
+  });
+});
+
 describe('SSE /events/file', () => {
   test('preserves text/event-stream content type and no-cache', async () => {
     const app = createApp(baseEnv);

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -11,7 +11,12 @@ import {
   wrapCanvasPreviewHtml,
 } from './lib/canvas-preview-shell';
 import { createConfigWatcher } from './lib/config-watcher';
-import { probeServices, renderStatusPage } from './status-probe';
+import {
+  buildStatusFeed,
+  probeServices,
+  renderStatusJson,
+  renderStatusPage,
+} from './status-probe';
 import { initTelemetry, metricsResponse } from './telemetry';
 
 // Platform graceful shutdown marker (written by docker-entrypoint.sh trap).
@@ -269,17 +274,26 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
 
   // Public, unauthenticated overall up/down. Hono catches this before the
   // SPA `*` fallback below, so it bypasses the TanStack Router shell. Caddy
-  // forwards `/status` to this handler via the default `reverse_proxy
-  // platform:3000` (no `/api/*` collision with the Convex-bound block).
+  // forwards `/status` and `/status.json` to this handler via the default
+  // `reverse_proxy platform:3000` (no `/api/*` collision with the
+  // Convex-bound block). Both routes project from the same `StatusFeed`
+  // so the human and machine views cannot drift.
   app.get('/status', async (c) => {
-    const result = await probeServices();
-    const html = renderStatusPage(
-      result,
-      c.req.header('accept-language') ?? '',
-    );
+    const feed = buildStatusFeed(await probeServices());
+    const html = renderStatusPage(feed, c.req.header('accept-language') ?? '');
     return new Response(html, {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=5',
+      },
+    });
+  });
+
+  app.get('/status.json', async () => {
+    const feed = buildStatusFeed(await probeServices());
+    return new Response(renderStatusJson(feed), {
+      headers: {
+        'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=5',
       },
     });

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -11,6 +11,7 @@ import {
   wrapCanvasPreviewHtml,
 } from './lib/canvas-preview-shell';
 import { createConfigWatcher } from './lib/config-watcher';
+import { probeServices, renderStatusPage } from './status-probe';
 import { initTelemetry, metricsResponse } from './telemetry';
 
 // Platform graceful shutdown marker (written by docker-entrypoint.sh trap).
@@ -264,6 +265,24 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
       return c.json({ status: 'shutting_down' }, 503);
     }
     return c.json({ status: 'ok' });
+  });
+
+  // Public, unauthenticated overall up/down. Hono catches this before the
+  // SPA `*` fallback below, so it bypasses the TanStack Router shell. Caddy
+  // forwards `/status` to this handler via the default `reverse_proxy
+  // platform:3000` (no `/api/*` collision with the Convex-bound block).
+  app.get('/status', async (c) => {
+    const result = await probeServices();
+    const html = renderStatusPage(
+      result,
+      c.req.header('accept-language') ?? '',
+    );
+    return new Response(html, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=5',
+      },
+    });
   });
 
   app.get('/events/file', (c) => {

--- a/services/platform/status-probe.test.ts
+++ b/services/platform/status-probe.test.ts
@@ -2,9 +2,13 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   _resetStatusProbeCache,
+  buildStatusFeed,
   type ComponentResult,
   probeServices,
+  renderStatusJson,
   renderStatusPage,
+  type StatusFeed,
+  type StatusFeedComponent,
   type StatusResult,
 } from './status-probe';
 
@@ -21,6 +25,14 @@ function allUpComponents(): ComponentResult[] {
     { id: 'convex', up: true },
     { id: 'rag', up: true },
     { id: 'crawler', up: true },
+  ];
+}
+
+function allOperationalFeedComponents(): StatusFeedComponent[] {
+  return [
+    { id: 'convex', status: 'operational' },
+    { id: 'rag', status: 'operational' },
+    { id: 'crawler', status: 'operational' },
   ];
 }
 
@@ -155,36 +167,136 @@ describe('probeServices', () => {
   });
 });
 
+describe('buildStatusFeed', () => {
+  const checkedAt = '2026-05-11T13:45:07.123Z';
+
+  test('all up → operational, each component operational', () => {
+    const raw: StatusResult = {
+      overall: 'operational',
+      components: allUpComponents(),
+      checkedAt,
+    };
+    expect(buildStatusFeed(raw)).toEqual({
+      status: 'operational',
+      checkedAt,
+      components: allOperationalFeedComponents(),
+    });
+  });
+
+  test('one down → degraded overall, that component outage', () => {
+    const raw: StatusResult = {
+      overall: 'degraded',
+      components: [
+        { id: 'convex', up: true },
+        { id: 'rag', up: false },
+        { id: 'crawler', up: true },
+      ],
+      checkedAt,
+    };
+    const feed = buildStatusFeed(raw);
+    expect(feed.status).toBe('degraded');
+    expect(feed.components.find((c) => c.id === 'rag')?.status).toBe('outage');
+    expect(feed.components.find((c) => c.id === 'convex')?.status).toBe(
+      'operational',
+    );
+  });
+
+  test('all down → outage overall, every component outage', () => {
+    const raw: StatusResult = {
+      overall: 'outage',
+      components: [
+        { id: 'convex', up: false },
+        { id: 'rag', up: false },
+        { id: 'crawler', up: false },
+      ],
+      checkedAt,
+    };
+    const feed = buildStatusFeed(raw);
+    expect(feed.status).toBe('outage');
+    expect(feed.components.every((c) => c.status === 'outage')).toBe(true);
+  });
+});
+
+describe('renderStatusJson', () => {
+  const checkedAt = '2026-05-11T13:45:07.123Z';
+
+  test('serialises an operational feed', () => {
+    const feed: StatusFeed = {
+      status: 'operational',
+      checkedAt,
+      components: allOperationalFeedComponents(),
+    };
+    const raw = renderStatusJson(feed);
+    expect(JSON.parse(raw)).toEqual(feed);
+    // Stable substring keyword-monitor contract — BetterStack / UptimeRobot
+    // and friends match on this literal. Don't quietly change the casing or
+    // shape without updating this test.
+    expect(raw).toContain('"status":"operational"');
+  });
+
+  test('serialises a degraded feed with mixed component statuses', () => {
+    const feed: StatusFeed = {
+      status: 'degraded',
+      checkedAt,
+      components: [
+        { id: 'convex', status: 'operational' },
+        { id: 'rag', status: 'outage' },
+        { id: 'crawler', status: 'operational' },
+      ],
+    };
+    const raw = renderStatusJson(feed);
+    expect(JSON.parse(raw)).toEqual(feed);
+    expect(raw).toContain('"status":"degraded"');
+    expect(raw).toContain('"status":"outage"');
+  });
+
+  test('serialises a full outage feed', () => {
+    const feed: StatusFeed = {
+      status: 'outage',
+      checkedAt,
+      components: [
+        { id: 'convex', status: 'outage' },
+        { id: 'rag', status: 'outage' },
+        { id: 'crawler', status: 'outage' },
+      ],
+    };
+    const raw = renderStatusJson(feed);
+    expect(JSON.parse(raw)).toEqual(feed);
+    expect(raw).toContain('"status":"outage"');
+    expect(raw).not.toContain('"status":"operational"');
+  });
+});
+
 describe('renderStatusPage', () => {
-  const baseResult: StatusResult = {
-    overall: 'operational',
-    components: allUpComponents(),
+  const baseFeed: StatusFeed = {
+    status: 'operational',
+    components: allOperationalFeedComponents(),
     checkedAt: '2026-05-11T13:45:07.123Z',
   };
 
   test('renders English by default', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     expect(html).toContain('<html lang="en">');
     expect(html).toContain('All systems operational');
     expect(html).toContain('Last checked');
   });
 
   test('renders German when Accept-Language starts with de', () => {
-    const html = renderStatusPage(baseResult, 'de-DE,en;q=0.5');
+    const html = renderStatusPage(baseFeed, 'de-DE,en;q=0.5');
     expect(html).toContain('<html lang="de">');
     expect(html).toContain('Alle Systeme verfügbar');
     expect(html).toContain('Zuletzt geprüft');
   });
 
   test('renders French when Accept-Language starts with fr', () => {
-    const html = renderStatusPage(baseResult, 'fr-FR,en;q=0.5');
+    const html = renderStatusPage(baseFeed, 'fr-FR,en;q=0.5');
     expect(html).toContain('<html lang="fr">');
     expect(html).toContain('Tous les systèmes opérationnels');
     expect(html).toContain('Dernière vérification');
   });
 
   test('respects first listed language, not later ones', () => {
-    const html = renderStatusPage(baseResult, 'en-US,de;q=0.9');
+    const html = renderStatusPage(baseFeed, 'en-US,de;q=0.9');
     expect(html).toContain('<html lang="en">');
     expect(html).not.toContain('Alle Systeme');
   });
@@ -192,13 +304,13 @@ describe('renderStatusPage', () => {
   test('renders degraded copy + amber banner', () => {
     const html = renderStatusPage(
       {
-        overall: 'degraded',
+        status: 'degraded',
         components: [
-          { id: 'convex', up: true },
-          { id: 'rag', up: false },
-          { id: 'crawler', up: true },
+          { id: 'convex', status: 'operational' },
+          { id: 'rag', status: 'outage' },
+          { id: 'crawler', status: 'operational' },
         ],
-        checkedAt: baseResult.checkedAt,
+        checkedAt: baseFeed.checkedAt,
       },
       '',
     );
@@ -209,13 +321,13 @@ describe('renderStatusPage', () => {
   test('renders outage copy + red banner', () => {
     const html = renderStatusPage(
       {
-        overall: 'outage',
+        status: 'outage',
         components: [
-          { id: 'convex', up: false },
-          { id: 'rag', up: false },
-          { id: 'crawler', up: false },
+          { id: 'convex', status: 'outage' },
+          { id: 'rag', status: 'outage' },
+          { id: 'crawler', status: 'outage' },
         ],
-        checkedAt: baseResult.checkedAt,
+        checkedAt: baseFeed.checkedAt,
       },
       '',
     );
@@ -224,23 +336,23 @@ describe('renderStatusPage', () => {
   });
 
   test('formats checked timestamp as HH:MM:SS UTC', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     expect(html).toContain('13:45:07 UTC');
     expect(html).toContain('datetime="2026-05-11T13:45:07.123Z"');
   });
 
   test('marks the banner with role=status for screen readers', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     expect(html).toMatch(/<h1 role="status">/);
   });
 
   test('opts out of search-engine indexing', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     expect(html).toContain('<meta name="robots" content="noindex">');
   });
 
   test('renders neutral English component labels — no stack names leaked', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     expect(html).toContain('Application');
     expect(html).toContain('Knowledge base');
     expect(html).toContain('Web &amp; document services');
@@ -250,14 +362,14 @@ describe('renderStatusPage', () => {
   });
 
   test('renders German component labels for de locale', () => {
-    const html = renderStatusPage(baseResult, 'de');
+    const html = renderStatusPage(baseFeed, 'de');
     expect(html).toContain('Anwendung');
     expect(html).toContain('Wissensdatenbank');
     expect(html).toContain('Web- &amp; Dokumentendienste');
   });
 
   test('renders French component labels for fr locale', () => {
-    const html = renderStatusPage(baseResult, 'fr');
+    const html = renderStatusPage(baseFeed, 'fr');
     expect(html).toContain('Base de connaissances');
     expect(html).toContain('Services web et documents');
   });
@@ -265,13 +377,13 @@ describe('renderStatusPage', () => {
   test('shows status word per component (not color alone)', () => {
     const html = renderStatusPage(
       {
-        overall: 'degraded',
+        status: 'degraded',
         components: [
-          { id: 'convex', up: true },
-          { id: 'rag', up: false },
-          { id: 'crawler', up: true },
+          { id: 'convex', status: 'operational' },
+          { id: 'rag', status: 'outage' },
+          { id: 'crawler', status: 'operational' },
         ],
-        checkedAt: baseResult.checkedAt,
+        checkedAt: baseFeed.checkedAt,
       },
       '',
     );
@@ -284,13 +396,13 @@ describe('renderStatusPage', () => {
   test('uses German status words for de locale', () => {
     const html = renderStatusPage(
       {
-        overall: 'degraded',
+        status: 'degraded',
         components: [
-          { id: 'convex', up: true },
-          { id: 'rag', up: false },
-          { id: 'crawler', up: true },
+          { id: 'convex', status: 'operational' },
+          { id: 'rag', status: 'outage' },
+          { id: 'crawler', status: 'operational' },
         ],
-        checkedAt: baseResult.checkedAt,
+        checkedAt: baseFeed.checkedAt,
       },
       'de-DE',
     );
@@ -301,13 +413,13 @@ describe('renderStatusPage', () => {
   test('uses French status words for fr locale', () => {
     const html = renderStatusPage(
       {
-        overall: 'degraded',
+        status: 'degraded',
         components: [
-          { id: 'convex', up: true },
-          { id: 'rag', up: false },
-          { id: 'crawler', up: true },
+          { id: 'convex', status: 'operational' },
+          { id: 'rag', status: 'outage' },
+          { id: 'crawler', status: 'operational' },
         ],
-        checkedAt: baseResult.checkedAt,
+        checkedAt: baseFeed.checkedAt,
       },
       'fr-FR',
     );
@@ -316,7 +428,7 @@ describe('renderStatusPage', () => {
   });
 
   test('marks status dots aria-hidden so screen readers rely on the text label', () => {
-    const html = renderStatusPage(baseResult, '');
+    const html = renderStatusPage(baseFeed, '');
     // Every dot element carries aria-hidden so the visible status text is
     // the canonical signal for assistive tech.
     const dots = html.match(/<span class="dot"[^>]*>/g) ?? [];

--- a/services/platform/status-probe.test.ts
+++ b/services/platform/status-probe.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  _resetStatusProbeCache,
+  type ComponentResult,
+  probeServices,
+  renderStatusPage,
+  type StatusResult,
+} from './status-probe';
+
+function okResponse() {
+  return new Response('ok', { status: 200 });
+}
+
+function downResponse() {
+  return new Response('boom', { status: 503 });
+}
+
+function allUpComponents(): ComponentResult[] {
+  return [
+    { id: 'convex', up: true },
+    { id: 'rag', up: true },
+    { id: 'crawler', up: true },
+  ];
+}
+
+afterEach(() => {
+  _resetStatusProbeCache();
+  vi.restoreAllMocks();
+});
+
+describe('probeServices', () => {
+  test('returns operational with all components up when every probe returns 2xx', async () => {
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.overall).toBe('operational');
+    expect(result.components.map((c) => c.id)).toEqual([
+      'convex',
+      'rag',
+      'crawler',
+    ]);
+    expect(result.components.every((c) => c.up)).toBe(true);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('returns degraded with the failing component marked down', async () => {
+    // Match RAG by port (8001) rather than substring — RAG_URL defaults to
+    // http://localhost:8001 in dev, which has no 'rag' substring.
+    const doFetch = vi.fn((url: string) =>
+      Promise.resolve(url.includes(':8001') ? downResponse() : okResponse()),
+    );
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.overall).toBe('degraded');
+    expect(result.components.find((c) => c.id === 'rag')?.up).toBe(false);
+    expect(result.components.find((c) => c.id === 'convex')?.up).toBe(true);
+    expect(result.components.find((c) => c.id === 'crawler')?.up).toBe(true);
+  });
+
+  test('returns outage with every component marked down when every probe fails', async () => {
+    const doFetch = vi.fn(() => Promise.resolve(downResponse()));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.overall).toBe('outage');
+    expect(result.components.every((c) => !c.up)).toBe(true);
+  });
+
+  test('treats fetch rejection (timeout, ECONNREFUSED) as down', async () => {
+    const doFetch = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+    const result = await probeServices(doFetch as unknown as typeof fetch);
+    expect(result.overall).toBe('outage');
+    expect(result.components.every((c) => !c.up)).toBe(true);
+  });
+
+  test('discards response body to avoid memory pressure from upstream', async () => {
+    const cancel = vi.fn(() => Promise.resolve());
+    const body = { cancel } as unknown as ReadableStream;
+    const res = new Response('ignored', { status: 200 });
+    Object.defineProperty(res, 'body', { value: body });
+
+    const doFetch = vi.fn(() => Promise.resolve(res));
+    await probeServices(doFetch as unknown as typeof fetch);
+
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  test('serves from cache within TTL without re-probing', async () => {
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    let now = 1000;
+    const clock = () => now;
+
+    await probeServices(doFetch as unknown as typeof fetch, clock);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+
+    now = 2000; // 1s later — still inside the 5s TTL
+    await probeServices(doFetch as unknown as typeof fetch, clock);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('re-probes after TTL expires', async () => {
+    const doFetch = vi.fn(() => Promise.resolve(okResponse()));
+    let now = 1000;
+    const clock = () => now;
+
+    await probeServices(doFetch as unknown as typeof fetch, clock);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+
+    now = 7000; // 6s later — past the 5s TTL
+    await probeServices(doFetch as unknown as typeof fetch, clock);
+    expect(doFetch).toHaveBeenCalledTimes(6);
+  });
+
+  test('caches success and failure independently — recovery after TTL', async () => {
+    let downNow = true;
+    const doFetch = vi.fn(() =>
+      Promise.resolve(downNow ? downResponse() : okResponse()),
+    );
+    let now = 1000;
+    const clock = () => now;
+
+    const first = await probeServices(
+      doFetch as unknown as typeof fetch,
+      clock,
+    );
+    expect(first.overall).toBe('outage');
+
+    downNow = false;
+    now = 7000;
+    const second = await probeServices(
+      doFetch as unknown as typeof fetch,
+      clock,
+    );
+    expect(second.overall).toBe('operational');
+  });
+
+  test('single-flight: concurrent callers share one in-flight probe round', async () => {
+    const resolvers: Array<(res: Response) => void> = [];
+    const doFetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const a = probeServices(doFetch as unknown as typeof fetch);
+    const b = probeServices(doFetch as unknown as typeof fetch);
+    const c = probeServices(doFetch as unknown as typeof fetch);
+
+    // All three callers should be waiting on the same probe round —
+    // exactly 3 fetches (one per backend), not 9.
+    expect(doFetch).toHaveBeenCalledTimes(3);
+
+    for (const r of resolvers) r(okResponse());
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+    expect(ra).toBe(rb);
+    expect(rb).toBe(rc);
+  });
+});
+
+describe('renderStatusPage', () => {
+  const baseResult: StatusResult = {
+    overall: 'operational',
+    components: allUpComponents(),
+    checkedAt: '2026-05-11T13:45:07.123Z',
+  };
+
+  test('renders English by default', () => {
+    const html = renderStatusPage(baseResult, '');
+    expect(html).toContain('<html lang="en">');
+    expect(html).toContain('All systems operational');
+    expect(html).toContain('Last checked');
+  });
+
+  test('renders German when Accept-Language starts with de', () => {
+    const html = renderStatusPage(baseResult, 'de-DE,en;q=0.5');
+    expect(html).toContain('<html lang="de">');
+    expect(html).toContain('Alle Systeme verfügbar');
+    expect(html).toContain('Zuletzt geprüft');
+  });
+
+  test('renders French when Accept-Language starts with fr', () => {
+    const html = renderStatusPage(baseResult, 'fr-FR,en;q=0.5');
+    expect(html).toContain('<html lang="fr">');
+    expect(html).toContain('Tous les systèmes opérationnels');
+    expect(html).toContain('Dernière vérification');
+  });
+
+  test('respects first listed language, not later ones', () => {
+    const html = renderStatusPage(baseResult, 'en-US,de;q=0.9');
+    expect(html).toContain('<html lang="en">');
+    expect(html).not.toContain('Alle Systeme');
+  });
+
+  test('renders degraded copy + amber banner', () => {
+    const html = renderStatusPage(
+      {
+        overall: 'degraded',
+        components: [
+          { id: 'convex', up: true },
+          { id: 'rag', up: false },
+          { id: 'crawler', up: true },
+        ],
+        checkedAt: baseResult.checkedAt,
+      },
+      '',
+    );
+    expect(html).toContain('Partial degradation');
+    expect(html).toContain('#fef3c7');
+  });
+
+  test('renders outage copy + red banner', () => {
+    const html = renderStatusPage(
+      {
+        overall: 'outage',
+        components: [
+          { id: 'convex', up: false },
+          { id: 'rag', up: false },
+          { id: 'crawler', up: false },
+        ],
+        checkedAt: baseResult.checkedAt,
+      },
+      '',
+    );
+    expect(html).toContain('Service outage');
+    expect(html).toContain('#fee2e2');
+  });
+
+  test('formats checked timestamp as HH:MM:SS UTC', () => {
+    const html = renderStatusPage(baseResult, '');
+    expect(html).toContain('13:45:07 UTC');
+    expect(html).toContain('datetime="2026-05-11T13:45:07.123Z"');
+  });
+
+  test('marks the banner with role=status for screen readers', () => {
+    const html = renderStatusPage(baseResult, '');
+    expect(html).toMatch(/<h1 role="status">/);
+  });
+
+  test('opts out of search-engine indexing', () => {
+    const html = renderStatusPage(baseResult, '');
+    expect(html).toContain('<meta name="robots" content="noindex">');
+  });
+
+  test('renders neutral English component labels — no stack names leaked', () => {
+    const html = renderStatusPage(baseResult, '');
+    expect(html).toContain('Application');
+    expect(html).toContain('Knowledge base');
+    expect(html).toContain('Web &amp; document services');
+    expect(html).not.toContain('Convex');
+    expect(html).not.toContain('RAG');
+    expect(html).not.toContain('Crawler');
+  });
+
+  test('renders German component labels for de locale', () => {
+    const html = renderStatusPage(baseResult, 'de');
+    expect(html).toContain('Anwendung');
+    expect(html).toContain('Wissensdatenbank');
+    expect(html).toContain('Web- &amp; Dokumentendienste');
+  });
+
+  test('renders French component labels for fr locale', () => {
+    const html = renderStatusPage(baseResult, 'fr');
+    expect(html).toContain('Base de connaissances');
+    expect(html).toContain('Services web et documents');
+  });
+
+  test('shows status word per component (not color alone)', () => {
+    const html = renderStatusPage(
+      {
+        overall: 'degraded',
+        components: [
+          { id: 'convex', up: true },
+          { id: 'rag', up: false },
+          { id: 'crawler', up: true },
+        ],
+        checkedAt: baseResult.checkedAt,
+      },
+      '',
+    );
+    // Two operational, one unavailable.
+    const operationalMatches = html.match(/>Operational</g) ?? [];
+    expect(operationalMatches.length).toBe(2);
+    expect(html).toContain('>Unavailable<');
+  });
+
+  test('uses German status words for de locale', () => {
+    const html = renderStatusPage(
+      {
+        overall: 'degraded',
+        components: [
+          { id: 'convex', up: true },
+          { id: 'rag', up: false },
+          { id: 'crawler', up: true },
+        ],
+        checkedAt: baseResult.checkedAt,
+      },
+      'de-DE',
+    );
+    expect(html).toContain('>Verfügbar<');
+    expect(html).toContain('>Nicht verfügbar<');
+  });
+
+  test('uses French status words for fr locale', () => {
+    const html = renderStatusPage(
+      {
+        overall: 'degraded',
+        components: [
+          { id: 'convex', up: true },
+          { id: 'rag', up: false },
+          { id: 'crawler', up: true },
+        ],
+        checkedAt: baseResult.checkedAt,
+      },
+      'fr-FR',
+    );
+    expect(html).toContain('>Opérationnel<');
+    expect(html).toContain('>Indisponible<');
+  });
+
+  test('marks status dots aria-hidden so screen readers rely on the text label', () => {
+    const html = renderStatusPage(baseResult, '');
+    // Every dot element carries aria-hidden so the visible status text is
+    // the canonical signal for assistive tech.
+    const dots = html.match(/<span class="dot"[^>]*>/g) ?? [];
+    expect(dots.length).toBe(3);
+    for (const dot of dots) expect(dot).toContain('aria-hidden="true"');
+  });
+});

--- a/services/platform/status-probe.ts
+++ b/services/platform/status-probe.ts
@@ -27,6 +27,11 @@ const CRAWLER_URL = process.env.CRAWLER_URL || 'http://localhost:8002';
 export type OverallStatus = 'operational' | 'degraded' | 'outage';
 export type ComponentId = 'convex' | 'rag' | 'crawler';
 
+// Binary today because each probe is just `fetch.ok`. The wider
+// `OverallStatus` vocabulary leaves room for a future `'degraded'`
+// per-component value (e.g. latency-based) without breaking consumers.
+export type ComponentStatus = 'operational' | 'outage';
+
 export interface ComponentResult {
   id: ComponentId;
   up: boolean;
@@ -36,6 +41,17 @@ export interface StatusResult {
   overall: OverallStatus;
   components: ComponentResult[];
   checkedAt: string;
+}
+
+export interface StatusFeedComponent {
+  id: ComponentId;
+  status: ComponentStatus;
+}
+
+export interface StatusFeed {
+  status: OverallStatus;
+  checkedAt: string;
+  components: StatusFeedComponent[];
 }
 
 interface Probe {
@@ -124,6 +140,30 @@ export async function probeServices(
 export function _resetStatusProbeCache(): void {
   cache = null;
   inflight = null;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical public-facing model
+//
+// `StatusFeed` is the single shape every consumer (HTML page, JSON feed,
+// future RSS / webhook) reads. `buildStatusFeed` is the only place that
+// interprets raw probe output (`up: boolean`) as a public status string,
+// so the human view and the machine view cannot drift.
+// ---------------------------------------------------------------------------
+
+export function buildStatusFeed(result: StatusResult): StatusFeed {
+  return {
+    status: result.overall,
+    checkedAt: result.checkedAt,
+    components: result.components.map((c) => ({
+      id: c.id,
+      status: c.up ? 'operational' : 'outage',
+    })),
+  };
+}
+
+export function renderStatusJson(feed: StatusFeed): string {
+  return JSON.stringify(feed);
 }
 
 // ---------------------------------------------------------------------------
@@ -227,22 +267,23 @@ function escapeHtml(s: string): string {
 }
 
 export function renderStatusPage(
-  result: StatusResult,
+  feed: StatusFeed,
   acceptLanguage: string,
 ): string {
   const t = STRINGS[pickLocale(acceptLanguage)];
-  const banner = COLORS[result.overall];
-  const headline = t[result.overall];
+  const banner = COLORS[feed.status];
+  const headline = t[feed.status];
 
-  const rows = result.components
+  const rows = feed.components
     .map((c) => {
+      const up = c.status === 'operational';
       const label = escapeHtml(t.components[c.id]);
-      const statusWord = escapeHtml(c.up ? t.statusUp : t.statusDown);
-      const dotColor = c.up ? DOT.up : DOT.down;
+      const statusWord = escapeHtml(up ? t.statusUp : t.statusDown);
+      const dotColor = up ? DOT.up : DOT.down;
       return `    <li>
       <span class="dot" style="background:${dotColor}" aria-hidden="true"></span>
       <span class="label">${label}</span>
-      <span class="state state-${c.up ? 'up' : 'down'}">${statusWord}</span>
+      <span class="state state-${up ? 'up' : 'down'}">${statusWord}</span>
     </li>`;
     })
     .join('\n');
@@ -331,7 +372,7 @@ export function renderStatusPage(
   <ul>
 ${rows}
   </ul>
-  <p class="checked">${escapeHtml(t.checkedAt)}: <time datetime="${result.checkedAt}">${formatChecked(result.checkedAt)}</time></p>
+  <p class="checked">${escapeHtml(t.checkedAt)}: <time datetime="${feed.checkedAt}">${formatChecked(feed.checkedAt)}</time></p>
 </main>
 </body>
 </html>

--- a/services/platform/status-probe.ts
+++ b/services/platform/status-probe.ts
@@ -1,0 +1,339 @@
+/**
+ * Probes for the public `/status` page.
+ *
+ * Hits the per-service health endpoints on the Docker network and aggregates
+ * to a single overall up/down state. A single-flight in-memory cache bounds
+ * upstream probe load: an unauthenticated `/status` route cannot afford to
+ * pay for fan-out probes on every request.
+ *
+ * Only HTTP status is inspected — response bodies are discarded — so a
+ * misbehaving (or compromised) upstream cannot push arbitrary bytes into
+ * the public response or this process's memory.
+ */
+
+const CACHE_TTL_MS = 5000;
+const PROBE_TIMEOUT_MS = 2000;
+
+// Default to loopback so `bun run dev` works without env overrides when the
+// developer runs RAG / Crawler on the standard ports. Docker compose sets
+// the env vars to the in-network DNS names (rag / crawler / convex), which
+// take precedence. Matches the convention in vite.config.ts, dev.ts,
+// convex/lib/helpers/rag_config.ts, convex/agent_tools/web/helpers/
+// get_crawler_service_url.ts.
+const CONVEX_URL = process.env.CONVEX_URL || 'http://127.0.0.1:3210';
+const RAG_URL = process.env.RAG_URL || 'http://localhost:8001';
+const CRAWLER_URL = process.env.CRAWLER_URL || 'http://localhost:8002';
+
+export type OverallStatus = 'operational' | 'degraded' | 'outage';
+export type ComponentId = 'convex' | 'rag' | 'crawler';
+
+export interface ComponentResult {
+  id: ComponentId;
+  up: boolean;
+}
+
+export interface StatusResult {
+  overall: OverallStatus;
+  components: ComponentResult[];
+  checkedAt: string;
+}
+
+interface Probe {
+  id: ComponentId;
+  url: string;
+}
+
+// Convex has no `/health`; `/version` is the established liveness probe
+// (already used by services/platform/docker-entrypoint.sh and the Convex
+// container's own healthcheck). Body is plain text — do NOT call .json().
+const PROBES: readonly Probe[] = [
+  { id: 'convex', url: `${CONVEX_URL}/version` },
+  { id: 'rag', url: `${RAG_URL}/health` },
+  { id: 'crawler', url: `${CRAWLER_URL}/health` },
+];
+
+let cache: { at: number; result: StatusResult } | null = null;
+let inflight: Promise<StatusResult> | null = null;
+
+async function probeOne(url: string, doFetch: typeof fetch): Promise<boolean> {
+  try {
+    const res = await doFetch(url, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      redirect: 'error',
+    });
+    // Drop the body unread — we only care about reachability + 2xx, and
+    // an upstream returning a huge or hostile body must not affect us.
+    res.body?.cancel().catch(() => {});
+    return res.ok;
+  } catch {
+    // Timeout, connection refused, DNS failure, redirect, or any other
+    // transport error all count as "down". No upstream string is ever
+    // surfaced to the public response.
+    return false;
+  }
+}
+
+async function runProbes(doFetch: typeof fetch): Promise<StatusResult> {
+  const ups = await Promise.all(PROBES.map((p) => probeOne(p.url, doFetch)));
+  const components: ComponentResult[] = PROBES.map((p, i) => ({
+    id: p.id,
+    up: ups[i] ?? false,
+  }));
+
+  const allUp = components.every((c) => c.up);
+  const allDown = components.every((c) => !c.up);
+
+  // Platform liveness is implicit — if this code is running, /status is
+  // responding, so the platform is at least reachable. "outage" therefore
+  // means every backend probe failed, which is what users effectively see.
+  let overall: OverallStatus;
+  if (allUp) overall = 'operational';
+  else if (allDown) overall = 'outage';
+  else overall = 'degraded';
+
+  return {
+    overall,
+    components,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+export async function probeServices(
+  doFetch: typeof fetch = fetch,
+  now: () => number = Date.now,
+): Promise<StatusResult> {
+  const t = now();
+  if (cache && t - cache.at < CACHE_TTL_MS) {
+    return cache.result;
+  }
+  if (inflight) return inflight;
+
+  const pending = runProbes(doFetch)
+    .then((result) => {
+      cache = { at: now(), result };
+      return result;
+    })
+    .finally(() => {
+      if (inflight === pending) inflight = null;
+    });
+  inflight = pending;
+  return pending;
+}
+
+/** Reset module state. Test-only. */
+export function _resetStatusProbeCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public page rendering
+//
+// Server-rendered HTML for `/status` — no JavaScript, no React shell, no
+// auto-refresh. The user reloads if they want a fresh state. Component
+// labels are deliberately nouns ("Application" / "Knowledge base" / "Web
+// & document services") rather than action verbs, so each label covers
+// every failure mode of that subsystem (e.g. "Knowledge base" covers both
+// indexing new docs and querying existing ones — neither aspect needs its
+// own line). This also keeps the public surface free of stack names
+// (Convex / RAG / Crawler).
+// Locale picked from Accept-Language prefix: de → German, fr → French,
+// else English. Matches the locale bundles already shipped at
+// services/platform/messages/{en,de,fr}.json.
+// ---------------------------------------------------------------------------
+
+const STRINGS = {
+  en: {
+    htmlLang: 'en',
+    title: 'System status',
+    operational: 'All systems operational',
+    degraded: 'Partial degradation',
+    outage: 'Service outage',
+    checkedAt: 'Last checked',
+    statusUp: 'Operational',
+    statusDown: 'Unavailable',
+    components: {
+      convex: 'Application',
+      rag: 'Knowledge base',
+      crawler: 'Web & document services',
+    },
+  },
+  de: {
+    htmlLang: 'de',
+    title: 'Systemstatus',
+    operational: 'Alle Systeme verfügbar',
+    degraded: 'Teilweise eingeschränkt',
+    outage: 'Schwerwiegende Störung',
+    checkedAt: 'Zuletzt geprüft',
+    statusUp: 'Verfügbar',
+    statusDown: 'Nicht verfügbar',
+    components: {
+      convex: 'Anwendung',
+      rag: 'Wissensdatenbank',
+      crawler: 'Web- & Dokumentendienste',
+    },
+  },
+  fr: {
+    htmlLang: 'fr',
+    title: 'État du système',
+    operational: 'Tous les systèmes opérationnels',
+    degraded: 'Dégradation partielle',
+    outage: 'Panne de service',
+    checkedAt: 'Dernière vérification',
+    statusUp: 'Opérationnel',
+    statusDown: 'Indisponible',
+    components: {
+      convex: 'Application',
+      rag: 'Base de connaissances',
+      crawler: 'Services web et documents',
+    },
+  },
+} as const;
+
+const COLORS: Record<OverallStatus, { bg: string; fg: string }> = {
+  operational: { bg: '#dcfce7', fg: '#166534' },
+  degraded: { bg: '#fef3c7', fg: '#92400e' },
+  outage: { bg: '#fee2e2', fg: '#991b1b' },
+};
+
+const DOT = {
+  up: '#16a34a',
+  down: '#dc2626',
+};
+
+function pickLocale(acceptLanguage: string): 'en' | 'de' | 'fr' {
+  // First listed language wins. "en-US,de;q=0.9" → "en-us".
+  const first = (acceptLanguage.split(',')[0] ?? '')
+    .split(';')[0]
+    ?.trim()
+    .toLowerCase();
+  if (first?.startsWith('de')) return 'de';
+  if (first?.startsWith('fr')) return 'fr';
+  return 'en';
+}
+
+function formatChecked(iso: string): string {
+  // HH:MM:SS UTC — short, locale-independent, no JS needed.
+  return `${iso.slice(11, 19)} UTC`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function renderStatusPage(
+  result: StatusResult,
+  acceptLanguage: string,
+): string {
+  const t = STRINGS[pickLocale(acceptLanguage)];
+  const banner = COLORS[result.overall];
+  const headline = t[result.overall];
+
+  const rows = result.components
+    .map((c) => {
+      const label = escapeHtml(t.components[c.id]);
+      const statusWord = escapeHtml(c.up ? t.statusUp : t.statusDown);
+      const dotColor = c.up ? DOT.up : DOT.down;
+      return `    <li>
+      <span class="dot" style="background:${dotColor}" aria-hidden="true"></span>
+      <span class="label">${label}</span>
+      <span class="state state-${c.up ? 'up' : 'down'}">${statusWord}</span>
+    </li>`;
+    })
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="${t.htmlLang}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>${escapeHtml(t.title)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    color: #0f172a;
+    background: #f8fafc;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+  }
+  main { width: 100%; max-width: 32rem; }
+  h1 {
+    margin: 0;
+    padding: 1.75rem 1.5rem;
+    font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+    font-weight: 600;
+    line-height: 1.3;
+    text-align: center;
+    border-radius: 0.75rem;
+    background: ${banner.bg};
+    color: ${banner.fg};
+  }
+  ul {
+    list-style: none;
+    margin: 1.5rem 0 0;
+    padding: 0;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    background: #ffffff;
+    overflow: hidden;
+  }
+  li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1.25rem;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 0.95rem;
+  }
+  li:last-child { border-bottom: 0; }
+  .dot {
+    display: inline-block;
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 50%;
+  }
+  .label { color: #0f172a; font-weight: 500; }
+  .state { font-size: 0.825rem; color: #475569; font-variant-numeric: tabular-nums; }
+  .state-down { color: #b91c1c; font-weight: 600; }
+  p.checked {
+    margin: 1.25rem 0 0;
+    font-size: 0.825rem;
+    color: #64748b;
+    text-align: center;
+  }
+  time { font-variant-numeric: tabular-nums; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e2e8f0; background: #0f172a; }
+    ul { background: #1e293b; border-color: #334155; }
+    li { border-bottom-color: #334155; }
+    .label { color: #e2e8f0; }
+    .state { color: #94a3b8; }
+    .state-down { color: #fca5a5; }
+    p.checked { color: #94a3b8; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <h1 role="status">${escapeHtml(headline)}</h1>
+  <ul>
+${rows}
+  </ul>
+  <p class="checked">${escapeHtml(t.checkedAt)}: <time datetime="${result.checkedAt}">${formatChecked(result.checkedAt)}</time></p>
+</main>
+</body>
+</html>
+`;
+}

--- a/services/platform/vite-plugins/serve-status.ts
+++ b/services/platform/vite-plugins/serve-status.ts
@@ -2,13 +2,19 @@ import type { ServerResponse } from 'node:http';
 
 import { type Plugin } from 'vite';
 
-import { probeServices, renderStatusPage } from '../status-probe';
+import {
+  buildStatusFeed,
+  probeServices,
+  renderStatusJson,
+  renderStatusPage,
+} from '../status-probe';
 
 // In dev, Vite (not Hono) sits in front of the SPA. The production
-// `app.get('/status', ...)` handler in server.ts is therefore not in the
-// request path, and /status falls through to Vite's SPA index, which
-// returns 404 for unknown routes. This middleware mirrors the production
-// handler so the same response is served during `bun run dev`.
+// `app.get('/status', ...)` and `app.get('/status.json', ...)` handlers
+// in server.ts are therefore not in the request path, and these routes
+// fall through to Vite's SPA index, which returns 404 for unknown
+// routes. This middleware mirrors the production handlers so the same
+// responses are served during `bun run dev`.
 //
 // Pattern: same as serve-canvas-preview.ts / serve-branding-images.ts —
 // both Hono routes need a Vite dev shim because Vite owns request handling
@@ -22,7 +28,7 @@ export function serveStatus(): Plugin {
         if (req.method !== 'GET' && req.method !== 'HEAD') return next();
         if (!req.url) return next();
         const path = req.url.split('?')[0];
-        if (path !== '/status') return next();
+        if (path !== '/status' && path !== '/status.json') return next();
 
         const acceptLanguage =
           (Array.isArray(req.headers['accept-language'])
@@ -31,7 +37,7 @@ export function serveStatus(): Plugin {
         // Fire-and-forget — handler always terminates the response and
         // never delegates to `next()`, so this can't double-respond.
         // Errors are caught and rendered as 500.
-        void handleStatus(res, acceptLanguage, req.method);
+        void handleStatus(res, path, acceptLanguage, req.method);
       });
     },
   };
@@ -39,19 +45,26 @@ export function serveStatus(): Plugin {
 
 async function handleStatus(
   res: ServerResponse,
+  path: '/status' | '/status.json',
   acceptLanguage: string,
   method: string | undefined,
 ): Promise<void> {
   try {
-    const result = await probeServices();
-    const html = renderStatusPage(result, acceptLanguage);
-    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    const feed = buildStatusFeed(await probeServices());
+    const isJson = path === '/status.json';
+    const body = isJson
+      ? renderStatusJson(feed)
+      : renderStatusPage(feed, acceptLanguage);
+    res.setHeader(
+      'Content-Type',
+      isJson ? 'application/json' : 'text/html; charset=utf-8',
+    );
     res.setHeader('Cache-Control', 'public, max-age=5');
     if (method === 'HEAD') {
       res.end();
       return;
     }
-    res.end(html);
+    res.end(body);
   } catch (err) {
     console.warn('[serve-status] probe failed', err);
     res.statusCode = 500;

--- a/services/platform/vite-plugins/serve-status.ts
+++ b/services/platform/vite-plugins/serve-status.ts
@@ -1,0 +1,60 @@
+import type { ServerResponse } from 'node:http';
+
+import { type Plugin } from 'vite';
+
+import { probeServices, renderStatusPage } from '../status-probe';
+
+// In dev, Vite (not Hono) sits in front of the SPA. The production
+// `app.get('/status', ...)` handler in server.ts is therefore not in the
+// request path, and /status falls through to Vite's SPA index, which
+// returns 404 for unknown routes. This middleware mirrors the production
+// handler so the same response is served during `bun run dev`.
+//
+// Pattern: same as serve-canvas-preview.ts / serve-branding-images.ts —
+// both Hono routes need a Vite dev shim because Vite owns request handling
+// in dev.
+export function serveStatus(): Plugin {
+  return {
+    name: 'serve-status',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+        if (!req.url) return next();
+        const path = req.url.split('?')[0];
+        if (path !== '/status') return next();
+
+        const acceptLanguage =
+          (Array.isArray(req.headers['accept-language'])
+            ? req.headers['accept-language'][0]
+            : req.headers['accept-language']) ?? '';
+        // Fire-and-forget — handler always terminates the response and
+        // never delegates to `next()`, so this can't double-respond.
+        // Errors are caught and rendered as 500.
+        void handleStatus(res, acceptLanguage, req.method);
+      });
+    },
+  };
+}
+
+async function handleStatus(
+  res: ServerResponse,
+  acceptLanguage: string,
+  method: string | undefined,
+): Promise<void> {
+  try {
+    const result = await probeServices();
+    const html = renderStatusPage(result, acceptLanguage);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, max-age=5');
+    if (method === 'HEAD') {
+      res.end();
+      return;
+    }
+    res.end(html);
+  } catch (err) {
+    console.warn('[serve-status] probe failed', err);
+    res.statusCode = 500;
+    res.end();
+  }
+}

--- a/services/platform/vite.config.ts
+++ b/services/platform/vite.config.ts
@@ -6,6 +6,7 @@ import { injectAcceptLanguage } from './vite-plugins/inject-accept-language';
 import { injectEnv } from './vite-plugins/inject-env';
 import { serveBrandingImages } from './vite-plugins/serve-branding-images';
 import { serveCanvasPreview } from './vite-plugins/serve-canvas-preview';
+import { serveStatus } from './vite-plugins/serve-status';
 import { stubSSRImports } from './vite-plugins/stub-ssr';
 import { watchExamples } from './vite-plugins/watch-examples';
 
@@ -145,5 +146,6 @@ export default defineConfig({
     watchExamples(),
     serveBrandingImages(),
     serveCanvasPreview(),
+    serveStatus(),
   ],
 });


### PR DESCRIPTION
## Summary

Adds an unauthenticated `/status` page showing overall up/down plus a per-component breakdown using neutral product vocabulary (no stack names leaked).

- Server-rendered HTML, no JS, no auto-refresh
- 5s single-flight probe cache bounds upstream load on a public surface
- Probes Convex `/version` (status-only — body is plain text), RAG/Crawler `/health` (lenient 2xx)
- Response bodies discarded — a misbehaving upstream can't push bytes into the public response
- `en` / `de` / `fr` copy via `Accept-Language` prefix
- Component labels are nouns (Application / Knowledge base / Web & document services) so each label covers all failure modes of that subsystem without exposing Convex / RAG / Crawler publicly
- A11y: status conveyed by text + colour (status dots are `aria-hidden`)

## How it routes

- Caddy: `/status` falls through to the default `reverse_proxy platform:3000` — no Caddyfile change needed (avoids the `/api/*` → Convex collision)
- Production: `app.get('/status', ...)` in `server.ts`, before the SPA catch-all
- Dev: matching `vite-plugins/serve-status.ts` mirrors the Hono route (the same pattern used by `serve-canvas-preview.ts` / `serve-branding-images.ts`)

Defaults align with the platform's localhost convention (`rag_config.ts`, `get_crawler_service_url.ts`, `vite.config.ts`); Docker compose env vars override to in-network DNS.

## Test plan

- [ ] `bun run check` — green
- [ ] `bun run dev` → open `http://localhost:3000/status` → shows the page (likely "Partial degradation" since RAG/Crawler aren't running locally by default)
- [ ] `curl -s -H 'Accept-Language: de-DE' http://localhost:3000/status | grep '<title>'` → German title
- [ ] `curl -s -H 'Accept-Language: fr-FR' http://localhost:3000/status | grep '<title>'` → French title
- [ ] `curl -I http://localhost:3000/status` → `Cache-Control: public, max-age=5`, `Content-Type: text/html`
- [ ] Full Docker stack (`tale start`) → `$SITE_ORIGIN/status` works through Caddy
- [ ] Stop one backend service → banner flips to "Partial degradation" within 5s
- [ ] Stop all three → banner flips to "Service outage"

## Out of scope (filed for follow-up)

- Per-user usage metric labelling — `requestCount` is model invocations, not user prompts
- Org-level "aggregate-only" usage mode (Betriebsrat / § 87 BetrVG)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published a public `/status` endpoint that monitors platform health in real-time, displaying the status of core services. The status page offers multilingual support (English, German, French) and includes intelligent caching to optimize performance and reduce backend load.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1699)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->