### PR TITLE
fix(platform): auto-create default org only on truly fresh instances

### DIFF
--- a/services/platform/app/routes/dashboard/index.tsx
+++ b/services/platform/app/routes/dashboard/index.tsx
@@ -2,7 +2,7 @@ import { convexQuery } from '@convex-dev/react-query';
 import { Spinner } from '@tale/ui/spinner';
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
-import { useMutation } from 'convex/react';
+import { useAction, useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
 import { FullPageCenter } from '@/app/components/ui/layout/full-page-center';
@@ -32,23 +32,80 @@ function DashboardIndex() {
   const recordOrgSwitch = useMutation(
     api.organizations.record_org_switch.recordOrgSwitch,
   );
+  const initializeWorkflows = useAction(
+    api.organizations.actions.initializeDefaultWorkflows,
+  );
   const resolvedRef = useRef(false);
   const { data: organizations, isLoading: isOrgsLoading } = useConvexQuery(
     api.members.queries.getUserOrganizationsWithDetails,
   );
   const { data: lastActiveOrgId, isLoading: isLastActiveLoading } =
     useConvexQuery(api.users.get_last_active_org.getLastActiveOrganizationId);
+  const { data: instanceHasAnyOrg, isLoading: isInstanceCheckLoading } =
+    useConvexQuery(api.organizations.queries.instanceHasAnyOrganization);
 
   useEffect(() => {
     if (
       isOrgsLoading ||
       isLastActiveLoading ||
+      isInstanceCheckLoading ||
       !organizations ||
+      instanceHasAnyOrg === undefined ||
       resolvedRef.current
     )
       return;
 
     if (organizations.length === 0) {
+      // Fresh instance (no orgs anywhere): seed the `default` org so the
+      // many hardcoded `orgSlug: 'default'` callsites have something to
+      // resolve against. If the instance already has orgs and this user
+      // simply isn't a member, route to the create-organization form so
+      // they pick their own non-`default` slug (multi-org deployment).
+      if (!instanceHasAnyOrg) {
+        resolvedRef.current = true;
+        void (async () => {
+          try {
+            const result = await authClient.organization.create({
+              name: 'Default',
+              slug: 'default',
+            });
+            const orgId = result.data?.id;
+            if (!orgId) throw new Error('Failed to create organization');
+
+            await authClient.organization.setActive({ organizationId: orgId });
+            await queryClient.invalidateQueries({
+              queryKey: ['auth', 'session'],
+            });
+            await initializeWorkflows({ organizationId: orgId });
+
+            try {
+              await recordOrgSwitch({ organizationId: orgId });
+            } catch (err) {
+              console.warn('Failed to record org switch audit entry:', err);
+            }
+
+            void navigate({ to: '/dashboard/$id', params: { id: orgId } });
+          } catch (error) {
+            // Likely a slug-conflict race (another tab/user beat us to
+            // creating `default`). Drop the resolved guard and invalidate
+            // the cached instance-org existence so the effect re-runs and
+            // routes us through the form branch below.
+            console.warn(
+              'Auto-create of default organization failed; falling back to create-organization form:',
+              error,
+            );
+            await queryClient.invalidateQueries(
+              convexQuery(
+                api.organizations.queries.instanceHasAnyOrganization,
+                {},
+              ),
+            );
+            resolvedRef.current = false;
+          }
+        })();
+        return;
+      }
+
       resolvedRef.current = true;
       void navigate({ to: '/dashboard/create-organization' });
       return;
@@ -107,11 +164,14 @@ function DashboardIndex() {
   }, [
     isOrgsLoading,
     isLastActiveLoading,
+    isInstanceCheckLoading,
     organizations,
     lastActiveOrgId,
+    instanceHasAnyOrg,
     navigate,
     queryClient,
     recordOrgSwitch,
+    initializeWorkflows,
   ]);
 
   return (

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -624,6 +624,7 @@ import type * as organizations_delete_cleanup from "../organizations/delete_clea
 import type * as organizations_delete_organization from "../organizations/delete_organization.js";
 import type * as organizations_delete_organization_logo from "../organizations/delete_organization_logo.js";
 import type * as organizations_get_organization from "../organizations/get_organization.js";
+import type * as organizations_has_any_organization from "../organizations/has_any_organization.js";
 import type * as organizations_helpers from "../organizations/helpers.js";
 import type * as organizations_internal_queries from "../organizations/internal_queries.js";
 import type * as organizations_queries from "../organizations/queries.js";
@@ -1676,6 +1677,7 @@ declare const fullApi: ApiFromModules<{
   "organizations/delete_organization": typeof organizations_delete_organization;
   "organizations/delete_organization_logo": typeof organizations_delete_organization_logo;
   "organizations/get_organization": typeof organizations_get_organization;
+  "organizations/has_any_organization": typeof organizations_has_any_organization;
   "organizations/helpers": typeof organizations_helpers;
   "organizations/internal_queries": typeof organizations_internal_queries;
   "organizations/queries": typeof organizations_queries;

--- a/services/platform/convex/organizations/has_any_organization.ts
+++ b/services/platform/convex/organizations/has_any_organization.ts
@@ -1,0 +1,25 @@
+/**
+ * Check if any organizations exist in the Better Auth `organization` table.
+ *
+ * Used by the dashboard to decide whether to auto-create the seeded
+ * `default` org (fresh-instance case) or redirect the user to the
+ * create-organization form (multi-org instance with an uninvited user).
+ *
+ * Performance: numItems=1 short-circuits — we only need existence.
+ */
+
+import { components } from '../_generated/api';
+import { QueryCtx } from '../_generated/server';
+
+export async function hasAnyOrganization(ctx: QueryCtx): Promise<boolean> {
+  const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'organization',
+    paginationOpts: {
+      cursor: null,
+      numItems: 1,
+    },
+    where: [],
+  });
+
+  return result && result.page.length > 0;
+}

--- a/services/platform/convex/organizations/queries.ts
+++ b/services/platform/convex/organizations/queries.ts
@@ -1,7 +1,9 @@
 import { v } from 'convex/values';
 
 import { query } from '../_generated/server';
+import { authComponent } from '../auth';
 import { getOrganization as getOrganizationHelper } from './get_organization';
+import { hasAnyOrganization as hasAnyOrganizationHelper } from './has_any_organization';
 
 export const getOrganization = query({
   args: { id: v.string() },
@@ -19,5 +21,29 @@ export const getOrganization = query({
   ),
   handler: async (ctx, args) => {
     return await getOrganizationHelper(ctx, args.id);
+  },
+});
+
+/**
+ * Whether the instance has any organization at all.
+ *
+ * The dashboard uses this to gate the auto-create of the seeded `default`
+ * org: when the instance has zero orgs, the first authenticated user
+ * triggers the seed; otherwise they are routed to the create-organization
+ * form so they create their own non-`default` org.
+ *
+ * Auth-gated to avoid leaking instance provisioning state to anonymous
+ * probes — unlike `hasAnyUsers` which is intentionally public for the
+ * sign-up onboarding flow.
+ */
+export const instanceHasAnyOrganization = query({
+  args: {},
+  returns: v.boolean(),
+  handler: async (ctx): Promise<boolean> => {
+    const authUser = await authComponent.getAuthUser(ctx);
+    if (!authUser) {
+      throw new Error('Unauthenticated');
+    }
+    return await hasAnyOrganizationHelper(ctx);
   },
 });


### PR DESCRIPTION
## Summary

Commit 9b923960 replaced the dashboard's auto-create-`default`-org flow with an unconditional redirect to the create-organization form. That broke the invariant relied on by many hardcoded `orgSlug: 'default'` callsites (agents, chat, integrations, providers, login policy, etc.): on a fresh instance, the first user picked a free-form name, ended up with a non-`default` slug, and every hardcoded reference misfired. This PR restores the auto-create, but only when the instance has zero organizations; multi-org deployments and uninvited users still get the form.

### Branching

| Scenario | Instance orgs | User memberships | Behavior |
| --- | --- | --- | --- |
| A. Fresh instance | 0 | 0 | Auto-seed `default`, set active, init workflows, record switch, navigate to `/dashboard/$id` |
| B. Multi-org instance, uninvited user | ≥1 | 0 | Redirect to `/dashboard/create-organization` (current 9b923960 behavior) |
| C. Existing user | ≥1 | ≥1 | Unchanged — last-active routing |

### Implementation

- New `instanceHasAnyOrganization` query (auth-gated, mirrors the existing `hasAnyUsers` helper pattern; one-row `findMany` for fast existence check).
- Dashboard's 0-membership branch now gates on `instanceHasAnyOrg`. On auto-create failure (e.g. slug-conflict race against another tab/user), the cached existence query is invalidated and `resolvedRef` is reset so the effect re-runs and routes the loser through the form branch — no orphan state.

### Known follow-up (out of scope)

In scenario B, if the user types "Default" / "default" into the form, the server-side `beforeCreateOrganization` already rejects with `Organization slug "default" is already taken.`, but the form's generic error toast obscures it. Surfacing the server message verbatim is a separate UX polish.

## Pre-merge checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — all 38 tasks succeeded, 3377 tests passed, 0 lint errors.
- [x] Updated `services/platform/messages/{en,de,fr}.json` for any new/renamed/removed keys — **N/A** (no user-facing strings changed).
- [x] Updated `docs/`, `docs/de/`, and `docs/fr/` for every user-visible change — **N/A** (internal redirect-branch logic; the user-facing form and dashboard surfaces are unchanged).
- [x] Ran `bun run --filter @tale/docs lint` (broken links + oxlint) — **N/A** (no docs touched).
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` if the change affects what they document — **N/A**.

## Test plan

- [ ] **Scenario A (fresh instance auto-create):** wipe the Convex DB, sign up the first user → lands on `/dashboard/<orgId>` with `slug=default`. Open a feature that hardcodes `'default'` (e.g. integrations or chat) and confirm it works.
- [ ] **Scenario B (multi-org instance, uninvited new user):** with `default` already present, sign up a brand-new user → redirected to `/dashboard/create-organization`. Submit name "Acme" → `acme` org created, lands on its dashboard. Try name "Default" → friendly server error toast.
- [ ] **Scenario C (existing user):** sign in as a user who already has orgs → unchanged last-active routing.
- [ ] **Race condition:** in two private windows, sign up two users on a fresh instance and click submit near-simultaneously → one lands on a dashboard; the other lands on `/dashboard/create-organization` with no orphan state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-seeding of a default organization with initialized workflows when a new user accesses the dashboard on an empty instance, streamlining initial onboarding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1702)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->