### PR TITLE
feat(web): marketing site polish + llms.txt across services

### DIFF
--- a/designs/web/frontpages.pen
+++ b/designs/web/frontpages.pen
@@ -140,7 +140,7 @@
                       "fill": "#4b5563ff",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "An AI chat interface trained on your company’s data, history, and documents.\n\nAsk questions, search across systems, and get instant, accurate answers without digging through dashboards or files.",
+                      "content": "An AI chat interface trained on your company's data, history, and documents — ask questions, search across systems, and get instant, accurate answers.",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 16,
@@ -284,7 +284,7 @@
                       "fill": "#1f2937ff",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "Workflows",
+                      "content": "Automations",
                       "lineHeight": 1.1666666666666667,
                       "fontFamily": "Inter",
                       "fontSize": 24,
@@ -772,7 +772,7 @@
                       "fill": "#1f2937ff",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "Workflows",
+                      "content": "Automations",
                       "lineHeight": 1.1666666666666667,
                       "fontFamily": "Inter",
                       "fontSize": 24,
@@ -1212,7 +1212,7 @@
                           "fill": "#1f2937ff",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
-                          "content": "Workflows",
+                          "content": "Automations",
                           "lineHeight": 1.1666666666666667,
                           "fontFamily": "Inter",
                           "fontSize": 24,
@@ -1656,7 +1656,7 @@
                       "fill": "#1f2937ff",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "Workflows",
+                      "content": "Automations",
                       "lineHeight": 1.1666666666666667,
                       "fontFamily": "Inter",
                       "fontSize": 24,
@@ -3331,7 +3331,7 @@
                   "fill": "#1f2937",
                   "textGrowth": "fixed-width",
                   "width": "fill_container",
-                  "content": "Workflows",
+                  "content": "Automations",
                   "lineHeight": 1.1666666666666667,
                   "fontFamily": "Inter",
                   "fontSize": 24,
@@ -38924,7 +38924,7 @@
                               "fill": "#4b5563ff",
                               "textGrowth": "fixed-width",
                               "width": "fill_container",
-                              "content": "An AI chat interface trained on your company’s data, history, and documents.\n\nAsk questions, search across systems, and get instant, accurate answers without digging through dashboards or files.",
+                              "content": "An AI chat interface trained on your company's data, history, and documents — ask questions, search across systems, and get instant, accurate answers.",
                               "lineHeight": 1.5,
                               "fontFamily": "Inter",
                               "fontSize": 16,
@@ -39068,7 +39068,7 @@
                               "fill": "#1f2937ff",
                               "textGrowth": "fixed-width",
                               "width": "fill_container",
-                              "content": "Workflows",
+                              "content": "Automations",
                               "lineHeight": 1.1666666666666667,
                               "fontFamily": "Inter",
                               "fontSize": 24,
@@ -46367,10 +46367,10 @@
                           "name": "acc5",
                           "descendants": {
                             "WMQpa": {
-                              "content": "Is there any usage-based or seat-based pricing?"
+                              "content": "How does Enterprise pricing work?"
                             },
                             "lMDiq": {
-                              "content": "No. We don't charge per user or per seat — the plan price stays the same."
+                              "content": "Enterprise is billed per user/month, with two months free when paying yearly. Storage beyond the included quota is billed per TB/month. The Community edition stays free for self-hosted use."
                             }
                           }
                         },
@@ -46385,7 +46385,7 @@
                               "content": "Are there additional features in the Enterprise plan?"
                             },
                             "lMDiq": {
-                              "content": "No. All product features are available in the open source version too. Pro and Enterprise add extended support and services."
+                              "content": "No. All product features are available in the open source version too. Enterprise adds extended support and services."
                             }
                           }
                         },
@@ -49102,7 +49102,7 @@
               "type": "ref",
               "ref": "JeAEC",
               "x": 0,
-              "y": 6468,
+              "y": 6516,
               "width": "fill_container"
             }
           ]
@@ -56766,13 +56766,13 @@
                           "gap": 12
                         },
                         "WMQpa": {
-                          "content": "Is there any usage-based or seat-based pricing?",
+                          "content": "How does Enterprise pricing work?",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
                           "fontSize": 18
                         },
                         "lMDiq": {
-                          "content": "No. We don't charge per user or per seat — the plan price stays the same.",
+                          "content": "Enterprise is billed per user/month, with two months free when paying yearly. Storage beyond the included quota is billed per TB/month. The Community edition stays free for self-hosted use.",
                           "width": "fill_container",
                           "fontSize": 15
                         }
@@ -56799,7 +56799,7 @@
                           "fontSize": 18
                         },
                         "lMDiq": {
-                          "content": "No. All product features are available in the open source version too. Pro and Enterprise add extended support and services.",
+                          "content": "No. All product features are available in the open source version too. Enterprise adds extended support and services.",
                           "width": "fill_container",
                           "fontSize": 15
                         }
@@ -59899,7 +59899,8 @@
                               "fill": "#4B5563",
                               "content": "I confirm that I have read the",
                               "fontFamily": "Inter",
-                              "fontSize": 14
+                              "fontSize": 14,
+                              "fontWeight": "normal"
                             },
                             {
                               "type": "frame",
@@ -60146,7 +60147,7 @@
                                   "id": "w7iRR",
                                   "name": "cb1Lbl",
                                   "fill": "#374151",
-                                  "content": "Pro/Enterprise solutions",
+                                  "content": "Enterprise solutions",
                                   "fontFamily": "Inter",
                                   "fontSize": 14,
                                   "fontWeight": "500"
@@ -60273,7 +60274,8 @@
                       "fill": "#4B5563",
                       "content": "I confirm that I have read the",
                       "fontFamily": "Inter",
-                      "fontSize": 14
+                      "fontSize": 14,
+                      "fontWeight": "normal"
                     },
                     {
                       "type": "frame",
@@ -60544,7 +60546,8 @@
                               "fill": "#4B5563",
                               "content": "I confirm that I have read the",
                               "fontFamily": "Inter",
-                              "fontSize": 14
+                              "fontSize": 14,
+                              "fontWeight": "normal"
                             },
                             {
                               "type": "frame",
@@ -60769,7 +60772,8 @@
                       "fill": "#4B5563",
                       "content": "I confirm that I have read the",
                       "fontFamily": "Inter",
-                      "fontSize": 14
+                      "fontSize": 14,
+                      "fontWeight": "normal"
                     },
                     {
                       "type": "frame",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./button": "./src/components/primitives/button.tsx",
     "./icon-button": "./src/components/primitives/icon-button.tsx",
+    "./image": "./src/components/primitives/image.tsx",
     "./input": "./src/components/forms/input.tsx",
     "./textarea": "./src/components/forms/textarea.tsx",
     "./label": "./src/components/forms/label.tsx",

--- a/packages/ui/src/components/feedback/accordion.tsx
+++ b/packages/ui/src/components/feedback/accordion.tsx
@@ -69,7 +69,12 @@ export interface AccordionItemProps {
   id?: string;
   question: ReactNode;
   children: ReactNode;
+  /** Wrapper class applied to the outer item container. */
   className?: string;
+  /** Class applied to the trigger button — overrides the default typography. */
+  triggerClassName?: string;
+  /** Class applied to the expanded content. */
+  contentClassName?: string;
 }
 
 export function AccordionItem({
@@ -77,6 +82,8 @@ export function AccordionItem({
   question,
   children,
   className,
+  triggerClassName,
+  contentClassName,
 }: AccordionItemProps) {
   const ctx = useContext(AccordionContext);
   if (!ctx) throw new Error('AccordionItem must be used inside Accordion');
@@ -92,12 +99,11 @@ export function AccordionItem({
         onClick={() => ctx.toggle(itemId)}
         aria-expanded={isOpen}
         aria-controls={`${itemId}-content`}
-        className="flex w-full items-center justify-between gap-4 text-left font-medium text-[color:var(--color-fg-base)] transition-colors hover:text-[color:var(--color-accent-base)]"
-        style={{
-          fontSize: '1.25rem',
-          letterSpacing: '-0.2px',
-          lineHeight: 1.4,
-        }}
+        className={cn(
+          'flex w-full items-center justify-between gap-4 text-left text-xl font-medium text-[color:var(--color-fg-base)] transition-colors hover:text-[color:var(--color-accent-base)]',
+          triggerClassName,
+        )}
+        style={{ letterSpacing: '-0.2px', lineHeight: 1.4 }}
       >
         <span>{question}</span>
         <ChevronDown
@@ -128,12 +134,11 @@ export function AccordionItem({
             className="overflow-hidden"
           >
             <div
-              className="text-fg-muted max-w-xl pt-3"
-              style={{
-                fontSize: '1rem',
-                letterSpacing: '-0.0072em',
-                lineHeight: 1.5,
-              }}
+              className={cn(
+                'text-fg-muted max-w-xl pt-3 text-base',
+                contentClassName,
+              )}
+              style={{ letterSpacing: '-0.0072em', lineHeight: 1.5 }}
             >
               {children}
             </div>

--- a/packages/ui/src/components/feedback/accordion.tsx
+++ b/packages/ui/src/components/feedback/accordion.tsx
@@ -60,14 +60,7 @@ export function Accordion({
   );
   return (
     <AccordionContext.Provider value={value}>
-      <div
-        className={cn(
-          'flex flex-col divide-y divide-[color:var(--color-border-base)]',
-          className,
-        )}
-      >
-        {children}
-      </div>
+      <div className={cn('flex flex-col', className)}>{children}</div>
     </AccordionContext.Provider>
   );
 }
@@ -93,25 +86,26 @@ export function AccordionItem({
   const reduceMotion = useReducedMotion();
 
   return (
-    <div className={cn('px-5 py-5', className)}>
+    <div className={cn('border-border-base border-b px-5 py-5', className)}>
       <button
         type="button"
         onClick={() => ctx.toggle(itemId)}
         aria-expanded={isOpen}
         aria-controls={`${itemId}-content`}
-        className="flex w-full items-center justify-between gap-4 text-left font-semibold text-[color:var(--color-fg-base)] transition-colors hover:text-[color:var(--color-accent-base)]"
+        className="flex w-full items-center justify-between gap-4 text-left font-medium text-[color:var(--color-fg-base)] transition-colors hover:text-[color:var(--color-accent-base)]"
         style={{
-          fontSize: '1.125rem',
-          letterSpacing: '-0.27px',
+          fontSize: '1.25rem',
+          letterSpacing: '-0.2px',
           lineHeight: 1.4,
         }}
       >
         <span>{question}</span>
         <ChevronDown
           aria-hidden
+          strokeWidth={2}
           className={cn(
-            'h-5 w-5 shrink-0 text-[color:var(--color-fg-muted)] motion-safe:transition-transform motion-safe:duration-300 motion-reduce:transition-none',
-            isOpen && 'rotate-180',
+            'h-6 w-6 shrink-0 text-[color:var(--color-fg-muted)] motion-safe:transition-transform motion-safe:duration-300 motion-reduce:transition-none',
+            isOpen ? 'rotate-180' : '',
           )}
         />
       </button>
@@ -134,11 +128,11 @@ export function AccordionItem({
             className="overflow-hidden"
           >
             <div
-              className="pt-3 text-[color:var(--color-fg-muted)]"
+              className="text-fg-muted max-w-xl pt-3"
               style={{
-                fontSize: '0.9375rem',
-                letterSpacing: '-0.084px',
-                lineHeight: 1.6,
+                fontSize: '1rem',
+                letterSpacing: '-0.0072em',
+                lineHeight: 1.5,
               }}
             >
               {children}

--- a/packages/ui/src/components/primitives/image.tsx
+++ b/packages/ui/src/components/primitives/image.tsx
@@ -1,0 +1,68 @@
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  useEffect,
+  useState,
+} from 'react';
+
+import { cn } from '../../lib/cn';
+
+const DEFAULT_PLACEHOLDER = '/assets/placeholder-image.png';
+
+interface ImageProps extends Omit<ComponentPropsWithoutRef<'img'>, 'onError'> {
+  /**
+   * Fallback image URL used when the primary image fails to load.
+   * Defaults to `/assets/placeholder-image.png`.
+   */
+  fallbackSrc?: string;
+  /**
+   * When true, disables lazy loading (uses `loading="eager"`).
+   * Use for above-the-fold images.
+   */
+  priority?: boolean;
+}
+
+/**
+ * Custom Image component built on the native `<img>` element.
+ *
+ * Features:
+ * - Automatic fallback on error
+ * - Lazy loading by default (disable with `priority`)
+ * - Full control over styling
+ */
+export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
+  {
+    src,
+    alt,
+    className,
+    fallbackSrc = DEFAULT_PLACEHOLDER,
+    priority = false,
+    loading,
+    ...props
+  },
+  ref,
+) {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const currentSrc = failedSrc === src ? fallbackSrc : src || fallbackSrc;
+
+  useEffect(() => {
+    setFailedSrc(null);
+  }, [src]);
+
+  const handleError = () => {
+    setFailedSrc(src ?? null);
+  };
+
+  return (
+    <img
+      key={src}
+      ref={ref}
+      src={currentSrc}
+      alt={alt}
+      className={cn(className)}
+      loading={loading ?? (priority ? 'eager' : 'lazy')}
+      onError={handleError}
+      {...props}
+    />
+  );
+});

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -34,9 +34,9 @@
   --color-bg-muted: #f3f4f6;
   --color-bg-overlay: rgba(0, 0, 0, 0.4);
 
-  --color-fg-base: #111827;
-  --color-fg-muted: #6b7280;
-  --color-fg-subtle: #9ca3af;
+  --color-fg-base: #030712;
+  --color-fg-muted: #4b5563;
+  --color-fg-subtle: #6b7280;
   --color-fg-inverse: #ffffff;
 
   --color-border-base: #e5e7eb;

--- a/packages/webui/src/layout/site-container.tsx
+++ b/packages/webui/src/layout/site-container.tsx
@@ -3,7 +3,8 @@ import type { HTMLAttributes } from 'react';
 
 /**
  * Marketing-page content width: design uses 1280px frame with 80px L/R
- * padding, yielding a 1120px content area. Mobile relaxes to 20px.
+ * padding, yielding a 1120px content area. Mobile uses 24px to match
+ * Pencil section padding.
  */
 export function SiteContainer({
   className,
@@ -11,7 +12,7 @@ export function SiteContainer({
 }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('mx-auto w-full max-w-[1280px] px-5 md:px-20', className)}
+      className={cn('mx-auto w-full max-w-[1280px] px-6 md:px-20', className)}
       {...props}
     />
   );

--- a/packages/webui/src/layout/site-footer.tsx
+++ b/packages/webui/src/layout/site-footer.tsx
@@ -79,10 +79,10 @@ export function SiteFooter({
   const compact = columnCount === 0;
   const gridCols =
     columnCount === 1
-      ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-[minmax(220px,1fr)_minmax(0,1fr)]'
+      ? 'grid-cols-1 sm:grid-cols-2 md:grid-cols-[minmax(180px,1fr)_minmax(0,1fr)] lg:grid-cols-[minmax(220px,1fr)_minmax(0,1fr)]'
       : columnCount === 2
-        ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-[minmax(220px,1fr)_repeat(2,minmax(0,1fr))]'
-        : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-[minmax(220px,1fr)_repeat(3,minmax(0,1fr))]';
+        ? 'grid-cols-1 sm:grid-cols-2 md:grid-cols-[minmax(180px,1fr)_repeat(2,minmax(0,1fr))] lg:grid-cols-[minmax(220px,1fr)_repeat(2,minmax(0,1fr))]'
+        : 'grid-cols-1 sm:grid-cols-2 md:grid-cols-[minmax(180px,1fr)_repeat(3,minmax(0,1fr))] lg:grid-cols-[minmax(220px,1fr)_repeat(3,minmax(0,1fr))]';
 
   const llmLinkClass =
     'text-fg-muted hover:text-fg-base focus-visible:ring-fg-base/60 focus-visible:ring-offset-bg-base rounded-sm px-2 py-1 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none';
@@ -125,8 +125,10 @@ export function SiteFooter({
           </div>
         ) : (
           <>
-            <div className={cn('grid gap-12 py-16', gridCols)}>
-              <div className="text-fg-muted flex flex-col gap-4 text-sm sm:col-span-2 lg:col-span-1">
+            <div
+              className={cn('grid gap-8 py-10 md:gap-12 md:py-16', gridCols)}
+            >
+              <div className="text-fg-muted flex flex-col gap-4 text-sm sm:col-span-2 md:col-span-1">
                 {logo}
                 {address}
               </div>
@@ -135,12 +137,15 @@ export function SiteFooter({
                 <nav
                   key={col.heading}
                   aria-label={col.heading}
-                  className="flex flex-col gap-3"
+                  className="flex flex-col gap-4"
                 >
-                  <h3 className="text-fg-base text-sm font-semibold">
+                  <h3
+                    className="text-fg-base text-base font-medium"
+                    style={{ letterSpacing: '-0.16px' }}
+                  >
                     {col.heading}
                   </h3>
-                  <ul role="list" className="flex flex-col gap-2">
+                  <ul role="list" className="flex flex-col gap-[14px]">
                     {col.links.map((link, i) => (
                       // oxlint-disable-next-line react/no-array-index-key -- link order is stable
                       <li key={i}>{link}</li>

--- a/packages/webui/src/layout/site-header.tsx
+++ b/packages/webui/src/layout/site-header.tsx
@@ -23,39 +23,39 @@ function BurgerIcon({
   const transition = { duration, ease: easeOut };
   return (
     <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.75"
+      strokeWidth="2"
       strokeLinecap="round"
       aria-hidden
     >
       <motion.line
-        initial={{ x1: 3, y1: 6, x2: 17, y2: 6 }}
+        initial={{ x1: 4, y1: 8, x2: 20, y2: 8 }}
         animate={
           open
-            ? { x1: 4.5, y1: 4.5, x2: 15.5, y2: 15.5 }
-            : { x1: 3, y1: 6, x2: 17, y2: 6 }
+            ? { x1: 6, y1: 6, x2: 18, y2: 18 }
+            : { x1: 4, y1: 8, x2: 20, y2: 8 }
         }
         transition={transition}
       />
       <motion.line
-        initial={{ x1: 3, y1: 10, x2: 17, y2: 10, opacity: 1 }}
+        initial={{ x1: 4, y1: 12, x2: 20, y2: 12, opacity: 1 }}
         animate={
           open
-            ? { x1: 3, y1: 10, x2: 17, y2: 10, opacity: 0 }
-            : { x1: 3, y1: 10, x2: 17, y2: 10, opacity: 1 }
+            ? { x1: 4, y1: 12, x2: 20, y2: 12, opacity: 0 }
+            : { x1: 4, y1: 12, x2: 20, y2: 12, opacity: 1 }
         }
         transition={transition}
       />
       <motion.line
-        initial={{ x1: 3, y1: 14, x2: 17, y2: 14 }}
+        initial={{ x1: 4, y1: 16, x2: 20, y2: 16 }}
         animate={
           open
-            ? { x1: 4.5, y1: 15.5, x2: 15.5, y2: 4.5 }
-            : { x1: 3, y1: 14, x2: 17, y2: 14 }
+            ? { x1: 6, y1: 18, x2: 18, y2: 6 }
+            : { x1: 4, y1: 16, x2: 20, y2: 16 }
         }
         transition={transition}
       />
@@ -179,7 +179,7 @@ export function SiteHeader({
               aria-label={open ? closeMenuLabel : openMenuLabel}
               aria-expanded={open}
               aria-controls={mobileNavId}
-              className="text-fg-base hover:bg-bg-muted inline-flex h-11 w-11 items-center justify-center rounded-lg transition-colors lg:hidden"
+              className="text-fg-muted hover:text-fg-base -mr-2.5 inline-flex h-11 w-11 items-center justify-center rounded-lg transition-colors lg:hidden"
               onClick={() => setOpen((prev) => !prev)}
             >
               <BurgerIcon open={open} reduceMotion={reduceMotion} />

--- a/services/docs/app/components/docs/docs-footer.tsx
+++ b/services/docs/app/components/docs/docs-footer.tsx
@@ -22,6 +22,8 @@ export function DocsFooter() {
       ]}
       llmsTxtUrl={`${import.meta.env.BASE_URL}llms.txt`}
       llmsTxtLabel={t('llmsTxtLabel')}
+      llmsFullTxtUrl={`${import.meta.env.BASE_URL}llms-full.txt`}
+      llmsFullTxtLabel={t('llmsFullTxtLabel')}
       bottomTrailing={
         <a
           href="https://github.com/tale-project/tale"

--- a/services/docs/index.html
+++ b/services/docs/index.html
@@ -53,9 +53,15 @@
     />
     <link
       rel="alternate"
-      type="application/rss+xml"
+      type="text/plain"
       href="%BASE_URL%llms.txt"
       title="llms.txt"
+    />
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="%BASE_URL%llms-full.txt"
+      title="llms-full.txt"
     />
   </head>
   <body>

--- a/services/docs/messages/de.json
+++ b/services/docs/messages/de.json
@@ -96,6 +96,7 @@
     "homeAriaLabel": "Tale Startseite",
     "githubAriaLabel": "GitHub",
     "llmsTxtLabel": "llms.txt",
+    "llmsFullTxtLabel": "llms-full.txt",
     "address": {
       "company": "Ruler GmbH",
       "street": "Seestraße 4",

--- a/services/docs/messages/en.json
+++ b/services/docs/messages/en.json
@@ -96,6 +96,7 @@
     "homeAriaLabel": "Tale home",
     "githubAriaLabel": "GitHub",
     "llmsTxtLabel": "llms.txt",
+    "llmsFullTxtLabel": "llms-full.txt",
     "address": {
       "company": "Ruler GmbH",
       "street": "Seestrasse 4",

--- a/services/docs/messages/fr.json
+++ b/services/docs/messages/fr.json
@@ -96,6 +96,7 @@
     "homeAriaLabel": "Accueil Tale",
     "githubAriaLabel": "GitHub",
     "llmsTxtLabel": "llms.txt",
+    "llmsFullTxtLabel": "llms-full.txt",
     "address": {
       "company": "Ruler GmbH",
       "street": "Seestrasse 4",

--- a/services/platform/app/components/ui/data-display/image.tsx
+++ b/services/platform/app/components/ui/data-display/image.tsx
@@ -1,70 +1,23 @@
 'use client';
 
-import {
-  ComponentPropsWithoutRef,
-  forwardRef,
-  useEffect,
-  useState,
-} from 'react';
+import { Image as BaseImage } from '@tale/ui/image';
+import { type ComponentPropsWithoutRef, forwardRef } from 'react';
 
 import { getEnv } from '@/lib/env';
-import { cn } from '@/lib/utils/cn';
 
-const PLACEHOLDER_IMAGE = `${getEnv('BASE_PATH')}/assets/placeholder-image.png`;
-
-interface ImageProps extends Omit<ComponentPropsWithoutRef<'img'>, 'onError'> {
-  /**
-   * Fallback image URL to use when the primary image fails to load.
-   * Defaults to '/assets/placeholder-image.png'.
-   */
-  fallbackSrc?: string;
-  /**
-   * When true, disables lazy loading (uses loading="eager").
-   * Use for above-the-fold images.
-   */
-  priority?: boolean;
-}
+type BaseImageProps = ComponentPropsWithoutRef<typeof BaseImage>;
 
 /**
- * Custom Image component that uses native img element.
+ * Platform-flavored Image component.
  *
- * Features:
- * - Automatic fallback on error
- * - Lazy loading by default (disable with priority prop)
- * - Full control over styling
+ * Wraps the shared `@tale/ui/image` primitive and prefixes the default
+ * placeholder fallback with `BASE_PATH` so subpath deployments resolve the
+ * placeholder asset correctly.
  */
-export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
-  {
-    src,
-    alt,
-    className,
-    fallbackSrc = PLACEHOLDER_IMAGE,
-    priority = false,
-    ...props
+export const Image = forwardRef<HTMLImageElement, BaseImageProps>(
+  function Image({ fallbackSrc, ...props }, ref) {
+    const resolvedFallback =
+      fallbackSrc ?? `${getEnv('BASE_PATH')}/assets/placeholder-image.png`;
+    return <BaseImage ref={ref} fallbackSrc={resolvedFallback} {...props} />;
   },
-  ref,
-) {
-  const [failedSrc, setFailedSrc] = useState<string | null>(null);
-  const currentSrc = failedSrc === src ? fallbackSrc : src || fallbackSrc;
-
-  useEffect(() => {
-    setFailedSrc(null);
-  }, [src]);
-
-  const handleError = () => {
-    setFailedSrc(src ?? null);
-  };
-
-  return (
-    <img
-      key={src}
-      ref={ref}
-      src={currentSrc}
-      alt={alt}
-      className={cn(className)}
-      loading={priority ? 'eager' : 'lazy'}
-      onError={handleError}
-      {...props}
-    />
-  );
-});
+);

--- a/services/platform/index.html
+++ b/services/platform/index.html
@@ -36,6 +36,13 @@
       media="(prefers-color-scheme: dark)"
     />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt" />
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="/llms-full.txt"
+      title="llms-full.txt"
+    />
     <!--
       Inter webfont is bundled via @fontsource/inter (see app/globals.css).
       Do NOT add third-party font/style CDNs here: self-deployed operators

--- a/services/platform/public/llms-full.txt
+++ b/services/platform/public/llms-full.txt
@@ -1,0 +1,15 @@
+# Tale Platform
+
+> Tale Platform — the self-hosted application for sovereign AI. Chat, custom agents, automations, and workspace tools running on your own infrastructure.
+
+The platform is the authenticated product surface: chat with local AI models, build and version custom agents, automate workflows, manage a shared knowledge base, and administer members, teams, and providers. It is a single-page application — there is no public-facing content to index here.
+
+For LLM-readable documentation of the platform's capabilities, see:
+
+- https://docs.tale.dev/llms.txt — index of all documentation pages
+- https://docs.tale.dev/llms-full.txt — full documentation content
+
+For information about Tale as a product (pricing, hardware, contact), see:
+
+- https://tale.dev/llms.txt
+- https://tale.dev/llms-full.txt

--- a/services/platform/public/llms.txt
+++ b/services/platform/public/llms.txt
@@ -1,0 +1,9 @@
+# Tale Platform
+
+> Tale Platform — the self-hosted application for sovereign AI. Chat, custom agents, automations, and workspace tools running on your own infrastructure. This surface is the authenticated product; user-facing documentation lives on the docs site.
+
+## Optional
+
+- [Documentation](https://docs.tale.dev/llms.txt)
+- [Marketing site](https://tale.dev/llms.txt)
+- [GitHub](https://github.com/tale-project/tale)

--- a/services/web/app/components/blocks/compliance-trust.tsx
+++ b/services/web/app/components/blocks/compliance-trust.tsx
@@ -1,3 +1,4 @@
+import { Image } from '@tale/ui/image';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Layers, Shield } from 'lucide-react';
 
@@ -60,10 +61,9 @@ export function ComplianceTrust() {
               {t('compliance.independent.description')}
             </p>
             <div className="pointer-events-none mt-auto flex aspect-16/10 w-full items-end justify-center overflow-hidden pt-6 md:pt-12">
-              <img
+              <Image
                 src="/marketing/trust-blocks.png"
                 alt=""
-                aria-hidden
                 draggable={false}
                 className="block h-auto w-auto max-w-84.5 object-contain"
               />
@@ -101,10 +101,9 @@ export function ComplianceTrust() {
               {t('compliance.certified.description')}
             </p>
             <div className="pointer-events-none mt-auto flex aspect-16/10 w-full items-end justify-center overflow-hidden pt-6 md:pt-12">
-              <img
+              <Image
                 src="/marketing/trust-network.png"
                 alt=""
-                aria-hidden
                 draggable={false}
                 className="block h-auto w-full object-contain"
               />

--- a/services/web/app/components/blocks/compliance-trust.tsx
+++ b/services/web/app/components/blocks/compliance-trust.tsx
@@ -11,8 +11,8 @@ export function ComplianceTrust() {
   const reduceMotion = useReducedMotion();
 
   return (
-    <section className="border-border-base border-b py-12">
-      <SiteContainer>
+    <section className="border-border-base border-b py-0 md:py-12">
+      <SiteContainer className="px-0 md:px-20">
         <motion.header
           initial={reduceMotion ? false : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -23,14 +23,14 @@ export function ComplianceTrust() {
           className="mx-auto max-w-[1120px]"
         >
           <h2
-            className="text-fg-base text-3xl font-medium md:text-[52px]"
+            className="text-fg-base sr-only text-3xl font-medium md:not-sr-only md:text-[52px]"
             style={{ letterSpacing: '-2.14px', lineHeight: 1.077 }}
           >
             {t('compliance.title')}
           </h2>
         </motion.header>
 
-        <div className="border-border-base mx-auto mt-12 grid max-w-[1120px] grid-cols-1 overflow-hidden border md:grid-cols-2">
+        <div className="border-border-base mx-auto grid max-w-[1120px] grid-cols-1 overflow-hidden md:mt-12 md:grid-cols-2 md:border">
           <motion.div
             initial={reduceMotion ? false : { opacity: 0, y: 24 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -38,7 +38,7 @@ export function ComplianceTrust() {
             transition={
               reduceMotion ? { duration: 0 } : { duration: 0.6, ease: easeOut }
             }
-            className="border-border-base relative flex flex-col gap-4 border-b p-10 md:border-r md:border-b-0"
+            className="border-border-base relative flex h-125 flex-col gap-4 border-x border-t p-6 md:h-auto md:border-x-0 md:border-t-0 md:border-r md:border-b-0 md:p-10"
           >
             <div className="flex items-center gap-2">
               <Layers
@@ -59,13 +59,13 @@ export function ComplianceTrust() {
             >
               {t('compliance.independent.description')}
             </p>
-            <div className="mt-auto flex aspect-[16/10] w-full items-center justify-center overflow-hidden pt-12">
+            <div className="pointer-events-none mt-auto flex aspect-16/10 w-full items-end justify-center overflow-hidden pt-6 md:pt-12">
               <img
-                src="/marketing/svg/mock-blocks.svg"
+                src="/marketing/trust-blocks.png"
                 alt=""
                 aria-hidden
                 draggable={false}
-                className="block max-h-full w-auto max-w-[360px] object-contain"
+                className="block h-auto w-auto max-w-84.5 object-contain"
               />
             </div>
           </motion.div>
@@ -79,7 +79,7 @@ export function ComplianceTrust() {
                 ? { duration: 0 }
                 : { delay: 0.08, duration: 0.6, ease: easeOut }
             }
-            className="relative flex flex-col gap-4 p-10"
+            className="border-border-base relative flex h-125 flex-col gap-4 overflow-hidden border p-6 md:h-auto md:border-0 md:p-10"
           >
             <div className="flex items-center gap-2">
               <Shield
@@ -100,13 +100,13 @@ export function ComplianceTrust() {
             >
               {t('compliance.certified.description')}
             </p>
-            <div className="mt-auto flex aspect-[16/10] w-full items-center justify-center overflow-hidden pt-12">
+            <div className="pointer-events-none mt-auto flex aspect-16/10 w-full items-end justify-center overflow-hidden pt-6 md:pt-12">
               <img
-                src="/marketing/svg/mock-compliance-columns.svg"
+                src="/marketing/trust-network.png"
                 alt=""
                 aria-hidden
                 draggable={false}
-                className="block max-h-full w-auto max-w-[360px] object-contain"
+                className="block h-auto w-full object-contain"
               />
             </div>
           </motion.div>

--- a/services/web/app/components/blocks/cta-deploy.tsx
+++ b/services/web/app/components/blocks/cta-deploy.tsx
@@ -12,13 +12,13 @@ export function CtaDeploy() {
   const reduceMotion = useReducedMotion();
 
   return (
-    <section className="bg-bg-base relative overflow-hidden py-24">
+    <section className="bg-bg-base border-border-strong relative overflow-hidden border-b pt-10 pb-24 md:py-24">
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 opacity-20"
         style={{
           backgroundImage:
-            'repeating-linear-gradient(135deg, var(--color-border-strong) 0, var(--color-border-strong) 1px, transparent 1px, transparent 8px)',
+            'repeating-linear-gradient(45deg, var(--color-border-strong) 0, var(--color-border-strong) 2px, transparent 2px, transparent 7px)',
         }}
       />
       <SiteContainer className="relative">
@@ -29,15 +29,15 @@ export function CtaDeploy() {
           transition={
             reduceMotion ? { duration: 0 } : { duration: 0.6, ease: easeOut }
           }
-          className="mx-auto flex max-w-[500px] flex-col items-center gap-10 text-center"
+          className="mx-auto flex max-w-[500px] flex-col items-center gap-8 text-center md:gap-10"
         >
           <h2
-            className="text-fg-base text-4xl font-medium md:text-[56px]"
-            style={{ letterSpacing: '-2.14px', lineHeight: 1.071 }}
+            className="text-accent-base text-[32px] font-medium tracking-[-0.044em] md:text-[56px] md:tracking-[-0.038em]"
+            style={{ lineHeight: 1.071 }}
           >
             {t('cta.title')}
           </h2>
-          <Button asChild>
+          <Button asChild className="text-base">
             <LocalizedLink to="/request-demo">{t('cta.primary')}</LocalizedLink>
           </Button>
         </motion.div>

--- a/services/web/app/components/blocks/faq-accordion.tsx
+++ b/services/web/app/components/blocks/faq-accordion.tsx
@@ -21,9 +21,9 @@ export function FaqAccordion() {
   const reduceMotion = useReducedMotion();
 
   return (
-    <section className="border-border-base border-b py-20">
+    <section className="border-border-base border-b py-12 lg:py-20">
       <SiteContainer>
-        <div className="mx-auto grid max-w-[1120px] grid-cols-1 gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,640px)] lg:gap-12">
+        <div className="mx-auto grid max-w-[1120px] grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,640px)] lg:gap-10">
           <motion.div
             initial={reduceMotion ? false : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -34,8 +34,8 @@ export function FaqAccordion() {
             className="lg:pl-10"
           >
             <h2
-              className="text-fg-base text-3xl font-medium md:text-[48px]"
-              style={{ letterSpacing: '-2.14px', lineHeight: 1.083 }}
+              className="text-fg-base text-[28px] font-medium tracking-[-0.05em] md:text-[48px] md:tracking-[-0.0446em]"
+              style={{ lineHeight: 1.1 }}
             >
               {t('faq.title')}
             </h2>
@@ -51,9 +51,17 @@ export function FaqAccordion() {
                 : { delay: 0.08, duration: 0.6, ease: easeOut }
             }
           >
-            <Accordion type="multiple">
+            <Accordion
+              type="multiple"
+              className="[&_[id$='-content']_div]:!text-[15px] lg:[&_[id$='-content']_div]:!text-[16px] [&_button]:!text-[18px] lg:[&_button]:!text-[20px] [&_button>span]:!text-[18px] lg:[&_button>span]:!text-[20px]"
+            >
               {FAQ_KEYS.map((key) => (
-                <AccordionItem key={key} id={key} question={t(`faq.${key}.q`)}>
+                <AccordionItem
+                  key={key}
+                  id={key}
+                  question={t(`faq.${key}.q`)}
+                  className="px-0 py-8 lg:px-5 lg:py-5"
+                >
                   {t(`faq.${key}.a`)}
                 </AccordionItem>
               ))}

--- a/services/web/app/components/blocks/faq-accordion.tsx
+++ b/services/web/app/components/blocks/faq-accordion.tsx
@@ -51,16 +51,15 @@ export function FaqAccordion() {
                 : { delay: 0.08, duration: 0.6, ease: easeOut }
             }
           >
-            <Accordion
-              type="multiple"
-              className="[&_[id$='-content']_div]:!text-[15px] lg:[&_[id$='-content']_div]:!text-[16px] [&_button]:!text-[18px] lg:[&_button]:!text-[20px] [&_button>span]:!text-[18px] lg:[&_button>span]:!text-[20px]"
-            >
+            <Accordion type="multiple">
               {FAQ_KEYS.map((key) => (
                 <AccordionItem
                   key={key}
                   id={key}
                   question={t(`faq.${key}.q`)}
                   className="px-0 py-8 lg:px-5 lg:py-5"
+                  triggerClassName="text-[18px] lg:text-[20px]"
+                  contentClassName="text-[15px] lg:text-[16px]"
                 >
                   {t(`faq.${key}.a`)}
                 </AccordionItem>

--- a/services/web/app/components/blocks/feature-grid.tsx
+++ b/services/web/app/components/blocks/feature-grid.tsx
@@ -35,16 +35,13 @@ export function FeatureGrid({ title, description, items }: FeatureGridProps) {
           className="mx-auto flex max-w-[720px] flex-col items-center gap-3 text-center"
         >
           <h2
-            className="text-fg-base text-3xl font-medium md:text-[52px]"
-            style={{ letterSpacing: '-2.14px', lineHeight: 1.077 }}
+            className="text-fg-base text-[32px] font-medium tracking-[-1.4px] md:text-[52px] md:tracking-[-2.14px]"
+            style={{ lineHeight: 1.08 }}
           >
             {title}
           </h2>
           {description ? (
-            <p
-              className="text-fg-muted max-w-[528px] text-base md:text-lg"
-              style={{ letterSpacing: '-0.27px', lineHeight: 1.556 }}
-            >
+            <p className="text-fg-muted max-w-[528px] text-[15px] leading-[1.55] tracking-[-0.1px] md:text-lg md:leading-[1.556] md:tracking-[-0.108px]">
               {description}
             </p>
           ) : null}
@@ -52,7 +49,7 @@ export function FeatureGrid({ title, description, items }: FeatureGridProps) {
 
         <div
           role="list"
-          className="border-border-base mx-auto mt-16 grid max-w-[1120px] grid-cols-1 overflow-hidden border md:grid-cols-2"
+          className="border-border-base mx-auto mt-12 grid max-w-[1120px] grid-cols-1 overflow-hidden border md:grid-cols-2"
         >
           {items.map((item, idx) => (
             <motion.div
@@ -66,13 +63,13 @@ export function FeatureGrid({ title, description, items }: FeatureGridProps) {
                   ? { duration: 0 }
                   : { duration: 0.5, delay: idx * 0.06, ease: easeOut }
               }
-              className="border-border-base flex flex-col border-t first:border-t-0 even:md:border-l md:[&:nth-child(2)]:border-t-0"
+              className="border-border-base flex flex-col border-t first:border-t-0 md:min-h-[532px] even:md:border-l md:[&:nth-child(2)]:border-t-0"
             >
-              <div className="flex flex-col gap-4 px-10 pt-10">
+              <div className="flex flex-col gap-4 px-6 pt-6 md:px-10 md:pt-10">
                 <div className="flex items-center gap-2">
                   <item.icon
                     className="text-fg-base h-6 w-6 shrink-0"
-                    strokeWidth={1.75}
+                    strokeWidth={2}
                     stroke="currentColor"
                     fill="none"
                     aria-hidden
@@ -92,7 +89,7 @@ export function FeatureGrid({ title, description, items }: FeatureGridProps) {
                 </p>
               </div>
               {item.illustration ? (
-                <div className="mt-auto flex aspect-[16/10] w-full items-end justify-center overflow-hidden pt-10">
+                <div className="mt-auto flex aspect-[16/10] w-full items-end justify-center overflow-hidden pt-6 md:pt-10">
                   <img
                     src={item.illustration}
                     alt=""

--- a/services/web/app/components/blocks/feature-grid.tsx
+++ b/services/web/app/components/blocks/feature-grid.tsx
@@ -1,3 +1,4 @@
+import { Image } from '@tale/ui/image';
 import { motion, useReducedMotion } from 'framer-motion';
 import type { ComponentType, SVGProps } from 'react';
 
@@ -90,10 +91,9 @@ export function FeatureGrid({ title, description, items }: FeatureGridProps) {
               </div>
               {item.illustration ? (
                 <div className="mt-auto flex aspect-[16/10] w-full items-end justify-center overflow-hidden pt-6 md:pt-10">
-                  <img
+                  <Image
                     src={item.illustration}
                     alt=""
-                    aria-hidden
                     draggable={false}
                     className="block h-full max-h-full w-full object-contain object-bottom"
                   />

--- a/services/web/app/components/blocks/feature-sectors.tsx
+++ b/services/web/app/components/blocks/feature-sectors.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@tale/ui/button';
+import { Image } from '@tale/ui/image';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { CircleDollarSign, Hotel, Scale, type LucideIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -154,12 +155,8 @@ export function FeatureSectors() {
             </div>
             <div className="border-border-base bg-bg-base relative h-125 overflow-hidden border-t lg:h-auto lg:border-t-0 lg:border-l">
               <AnimatePresence mode="wait" initial={false}>
-                <motion.img
+                <motion.div
                   key={active}
-                  src={ILLUSTRATIONS[active]}
-                  alt=""
-                  aria-hidden
-                  draggable={false}
                   initial={reduceMotion ? false : { opacity: 0, scale: 1.02 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={
@@ -170,8 +167,15 @@ export function FeatureSectors() {
                       ? { duration: 0 }
                       : { duration: 0.4, ease: easeOut }
                   }
-                  className="absolute inset-8 m-auto block max-h-[calc(100%-4rem)] max-w-[calc(100%-4rem)] object-contain"
-                />
+                  className="absolute inset-0"
+                >
+                  <Image
+                    src={ILLUSTRATIONS[active]}
+                    alt=""
+                    draggable={false}
+                    className="absolute inset-8 m-auto block max-h-[calc(100%-4rem)] max-w-[calc(100%-4rem)] object-contain"
+                  />
+                </motion.div>
               </AnimatePresence>
             </div>
           </div>

--- a/services/web/app/components/blocks/feature-sectors.tsx
+++ b/services/web/app/components/blocks/feature-sectors.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@tale/ui/button';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { CircleDollarSign, Hotel, Scale, type LucideIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import { LocalizedLink } from '@/app/components/layout/localized-link';
@@ -16,16 +17,34 @@ const ILLUSTRATIONS: Record<SectorKey, string> = {
   finance: '/marketing/svg/mock-document-card.svg',
 };
 
+const ICONS: Record<SectorKey, LucideIcon> = {
+  hospitality: Hotel,
+  legal: Scale,
+  finance: CircleDollarSign,
+};
+
 export function FeatureSectors() {
   const { t } = useT('home');
   const reduceMotion = useReducedMotion();
   const fadeInitial = reduceMotion ? false : { opacity: 0, y: 24 };
   const [active, setActive] = useState<SectorKey>('hospitality');
 
-  const sectors: { key: SectorKey; label: string }[] = [
-    { key: 'hospitality', label: t('featureSectors.hospitality.label') },
-    { key: 'legal', label: t('featureSectors.legal.label') },
-    { key: 'finance', label: t('featureSectors.finance.label') },
+  const sectors: { key: SectorKey; label: string; icon: LucideIcon }[] = [
+    {
+      key: 'hospitality',
+      label: t('featureSectors.hospitality.label'),
+      icon: ICONS.hospitality,
+    },
+    {
+      key: 'legal',
+      label: t('featureSectors.legal.label'),
+      icon: ICONS.legal,
+    },
+    {
+      key: 'finance',
+      label: t('featureSectors.finance.label'),
+      icon: ICONS.finance,
+    },
   ];
 
   return (
@@ -65,13 +84,14 @@ export function FeatureSectors() {
               ? { duration: 0 }
               : { delay: 0.1, duration: 0.7, ease: easeOut }
           }
-          className="border-border-base bg-bg-base mx-auto mt-16 max-w-[1120px] overflow-hidden border"
+          className="border-border-base bg-bg-base mx-auto mt-15 max-w-[1120px] overflow-hidden border"
           role="tablist"
           aria-label={t('featureSectors.title')}
         >
           <div className="border-border-base relative grid grid-cols-3 border-b">
             {sectors.map((s) => {
               const isActive = active === s.key;
+              const Icon = s.icon;
               return (
                 <button
                   key={s.key}
@@ -79,24 +99,19 @@ export function FeatureSectors() {
                   role="tab"
                   aria-selected={isActive}
                   onClick={() => setActive(s.key)}
-                  className={`text-fg-base border-border-base relative flex items-center justify-center gap-2 border-r px-6 py-4 text-sm font-medium transition-colors last:border-r-0 ${
+                  className={`border-border-base relative flex items-center justify-center gap-2 border-r px-3 py-4 text-base font-medium transition-colors last:border-r-0 ${
                     isActive
-                      ? 'bg-bg-base'
-                      : 'bg-bg-muted hover:bg-bg-elevated cursor-pointer'
+                      ? 'text-fg-base bg-bg-base'
+                      : 'text-fg-subtle bg-bg-muted hover:bg-bg-elevated cursor-pointer'
                   }`}
+                  style={{ letterSpacing: '-0.096px' }}
                 >
+                  <Icon
+                    aria-hidden="true"
+                    className="h-3.5 w-3.5 shrink-0"
+                    strokeWidth={1.75}
+                  />
                   {s.label}
-                  {isActive ? (
-                    <motion.span
-                      layoutId="sector-tab-underline"
-                      className="bg-fg-base absolute right-0 bottom-0 left-0 h-px"
-                      transition={
-                        reduceMotion
-                          ? { duration: 0 }
-                          : { type: 'spring', stiffness: 380, damping: 32 }
-                      }
-                    />
-                  ) : null}
                 </button>
               );
             })}
@@ -124,8 +139,8 @@ export function FeatureSectors() {
                     {t(`featureSectors.${active}.label`)}
                   </h3>
                   <p
-                    className="text-fg-muted text-base"
-                    style={{ letterSpacing: '-0.24px', lineHeight: 1.5 }}
+                    className="text-fg-muted text-lg"
+                    style={{ letterSpacing: '-0.27px', lineHeight: 1.778 }}
                   >
                     {t(`featureSectors.${active}.description`)}
                   </p>
@@ -137,7 +152,7 @@ export function FeatureSectors() {
                 </motion.div>
               </AnimatePresence>
             </div>
-            <div className="border-border-base bg-bg-elevated relative overflow-hidden border-t lg:border-t-0 lg:border-l">
+            <div className="border-border-base bg-bg-base relative h-125 overflow-hidden border-t lg:h-auto lg:border-t-0 lg:border-l">
               <AnimatePresence mode="wait" initial={false}>
                 <motion.img
                   key={active}

--- a/services/web/app/components/blocks/feature-secure.tsx
+++ b/services/web/app/components/blocks/feature-secure.tsx
@@ -41,11 +41,24 @@ const panelGradient = cva('absolute inset-0', {
   },
 });
 
-// Inner stage that holds the SVG mockup centered over the gradient.
-// `inset-X` keeps a comfortable margin on every side so the illustration
-// never bleeds to the panel edge regardless of its intrinsic aspect ratio.
+// Frosted glass inner card overlaying the gradient panel. Mirrors the
+// Pencil spec: flush-left, ~6% right margin, ~10% top inset, extends past
+// the bottom edge so it's clipped by the parent. Rounded only at the
+// top-right corner with a subtle gradient stroke (white/20 → white).
+const panelGlassCard =
+  'pointer-events-none absolute top-[10.4%] right-[6%] bottom-[-3.3%] left-0 overflow-hidden rounded-tr-3xl bg-white/10 backdrop-blur-md';
+
+// Gradient stroke for the glass card — top is fainter, bottom edge near
+// fully opaque white. Implemented as a separate absolute ring so it sits
+// on top of the backdrop-blurred surface.
+const panelGlassStroke =
+  'pointer-events-none absolute inset-0 rounded-tr-3xl [mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [mask-composite:exclude] p-px [background:linear-gradient(180deg,rgba(255,255,255,0.2)_0%,rgba(255,255,255,1)_100%)]';
+
+// Inner stage that holds the SVG mockup centered inside the glass card.
+// `inset-X` keeps a comfortable margin so the illustration never bleeds
+// to the card edge regardless of its intrinsic aspect ratio.
 const panelStage =
-  'absolute inset-6 flex items-center justify-center sm:inset-10';
+  'absolute inset-4 flex items-center justify-center sm:inset-8';
 
 // SVGs are vector — clamp to 100% on both axes and use `object-contain`
 // so they keep their aspect ratio and never blow up beyond the stage.
@@ -90,21 +103,27 @@ export function FeatureSecure() {
 
   const activeItem = items.find((item) => item.key === active) ?? items[0];
 
+  const tabId = (key: RailKey) => `feature-secure-tab-${key}`;
+
   const renderPanel = (item: RailItem) => (
     <div
       role="tabpanel"
-      className="relative aspect-[671/559] w-full overflow-hidden"
+      aria-labelledby={tabId(item.key)}
+      className="relative aspect-square w-full overflow-hidden lg:aspect-671/559"
     >
       <div aria-hidden className={panelGradient({ tab: item.key })} />
-      <div className={panelStage}>
-        <img
-          src={item.illustration}
-          alt=""
-          aria-hidden
-          draggable={false}
-          loading="lazy"
-          className={panelImage}
-        />
+      <div aria-hidden className={panelGlassCard}>
+        <div className={panelStage}>
+          <img
+            src={item.illustration}
+            alt=""
+            aria-hidden
+            draggable={false}
+            loading="lazy"
+            className={panelImage}
+          />
+        </div>
+        <div aria-hidden className={panelGlassStroke} />
       </div>
     </div>
   );
@@ -112,7 +131,7 @@ export function FeatureSecure() {
   return (
     <section
       id="features"
-      className="border-border-base scroll-mt-16 border-b py-20"
+      className="border-border-base scroll-mt-16 border-b py-12 md:py-20"
     >
       <SiteContainer>
         <motion.div
@@ -124,16 +143,10 @@ export function FeatureSecure() {
           }
           className="mx-auto flex max-w-[678px] flex-col items-center gap-3 text-center"
         >
-          <h2
-            className="text-fg-base text-3xl font-medium md:text-[52px]"
-            style={{ letterSpacing: '-2.14px', lineHeight: 1.077 }}
-          >
+          <h2 className="text-fg-base text-[32px] leading-[1.08] font-medium tracking-[-1.4px] md:text-[52px] md:leading-[1.077] md:tracking-[-2.14px]">
             {t('featureSecure.title')}
           </h2>
-          <p
-            className="text-fg-muted max-w-[528px] text-base md:text-lg"
-            style={{ letterSpacing: '-0.27px', lineHeight: 1.556 }}
-          >
+          <p className="text-fg-muted max-w-[528px] text-[15px] leading-[1.55] tracking-[-0.22px] md:text-lg md:leading-[1.556] md:tracking-[-0.27px]">
             {t('featureSecure.description')}
           </p>
         </motion.div>
@@ -149,7 +162,7 @@ export function FeatureSecure() {
               ? { duration: 0 }
               : { delay: 0.1, duration: 0.7, ease: easeOut }
           }
-          className="border-border-base mx-auto mt-16 grid max-w-[1120px] overflow-hidden border lg:grid-cols-[400px_1fr]"
+          className="border-border-base mx-auto mt-8 grid max-w-[1120px] overflow-hidden border md:mt-16 lg:grid-cols-[400px_1fr]"
         >
           <ul
             role="tablist"
@@ -164,33 +177,23 @@ export function FeatureSecure() {
                   key={key}
                   className={`relative ${isActive ? 'flex-1' : ''}`}
                 >
-                  <motion.span
-                    aria-hidden
-                    className="bg-fg-base absolute top-0 bottom-0 left-0 w-px origin-top"
-                    initial={false}
-                    animate={{ scaleY: isActive ? 1 : 0 }}
-                    transition={
-                      reduceMotion
-                        ? { duration: 0 }
-                        : { duration: 0.4, ease: easeOut }
-                    }
-                  />
                   <button
                     type="button"
                     role="tab"
+                    id={tabId(key)}
                     aria-selected={isActive}
                     aria-controls="feature-secure-panel"
                     onClick={() => setActive(key)}
-                    className={`flex w-full items-start gap-3 px-6 py-9 text-left transition-colors ${
+                    className={`focus-visible:ring-fg-base/60 focus-visible:ring-offset-bg-base flex w-full items-start gap-3 px-6 py-6 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none lg:py-9 ${
                       isActive
                         ? 'bg-bg-base'
                         : 'bg-bg-base hover:bg-bg-elevated cursor-pointer'
                     }`}
                   >
                     <Icon
-                      className="text-fg-base mt-1 h-6 w-6 shrink-0"
+                      className="text-fg-base h-6 w-6 shrink-0"
                       aria-hidden
-                      strokeWidth={1.75}
+                      strokeWidth={2}
                       stroke="currentColor"
                       fill="none"
                     />
@@ -225,7 +228,7 @@ export function FeatureSecure() {
                                 ? { duration: 0 }
                                 : { duration: 0.35, ease: easeOut }
                             }
-                            className="text-fg-muted overflow-hidden text-base whitespace-pre-line"
+                            className="text-fg-muted overflow-hidden text-base font-medium whitespace-pre-line"
                             style={{
                               letterSpacing: '-0.24px',
                               lineHeight: 1.5,

--- a/services/web/app/components/blocks/feature-secure.tsx
+++ b/services/web/app/components/blocks/feature-secure.tsx
@@ -1,3 +1,4 @@
+import { Image } from '@tale/ui/image';
 import { cva } from 'class-variance-authority';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { type ComponentType, type SVGProps, useState } from 'react';
@@ -114,12 +115,10 @@ export function FeatureSecure() {
       <div aria-hidden className={panelGradient({ tab: item.key })} />
       <div aria-hidden className={panelGlassCard}>
         <div className={panelStage}>
-          <img
+          <Image
             src={item.illustration}
             alt=""
-            aria-hidden
             draggable={false}
-            loading="lazy"
             className={panelImage}
           />
         </div>

--- a/services/web/app/components/blocks/form-card.tsx
+++ b/services/web/app/components/blocks/form-card.tsx
@@ -85,25 +85,25 @@ export function FormCard({
   return (
     <Section spacing="md">
       <Container size="lg">
-        <div className="grid gap-12 md:grid-cols-2 md:gap-16">
+        <div className="grid gap-10 md:grid-cols-2 md:gap-20">
           <motion.div
             initial={reduceMotion ? false : { opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={
               reduceMotion ? { duration: 0 } : { duration: 0.5, ease: easeOut }
             }
-            className="flex flex-col gap-5"
+            className="flex flex-col gap-6"
           >
             {eyebrow ? (
               <p className="text-xs font-semibold tracking-wider text-[color:var(--color-fg-muted)] uppercase">
                 {eyebrow}
               </p>
             ) : null}
-            <h1 className="text-4xl font-semibold tracking-tight text-[color:var(--color-fg-base)] md:text-5xl">
+            <h1 className="text-accent-base text-[2rem] font-medium tracking-tight md:text-5xl md:tracking-[-0.02em]">
               {title}
             </h1>
             {description ? (
-              <div className="text-base leading-relaxed text-[color:var(--color-fg-muted)] md:text-lg">
+              <div className="text-fg-muted text-base leading-[1.55] md:text-lg md:tracking-[-0.015em]">
                 {description}
               </div>
             ) : null}
@@ -146,7 +146,7 @@ export function FormCard({
               <FormProvider {...form}>
                 <form
                   onSubmit={onSubmit}
-                  className="flex flex-col gap-5"
+                  className="flex flex-col gap-8"
                   noValidate
                 >
                   {/* Honeypot field — hidden from real users. */}
@@ -162,7 +162,7 @@ export function FormCard({
                     </label>
                   </div>
 
-                  {children}
+                  <div className="flex flex-col gap-6">{children}</div>
 
                   <Field
                     error={
@@ -171,7 +171,7 @@ export function FormCard({
                         : undefined
                     }
                   >
-                    <label className="flex items-start gap-3 text-sm text-[color:var(--color-fg-base)]">
+                    <label className="text-fg-muted flex items-center gap-2 text-sm">
                       <Checkbox
                         checked={Boolean(form.watch('privacy'))}
                         onCheckedChange={(checked) =>
@@ -185,7 +185,7 @@ export function FormCard({
                         {t('privacyPrefix')}{' '}
                         <a
                           href="/legal/privacy-policy"
-                          className="font-medium text-[color:var(--color-fg-base)] underline underline-offset-4"
+                          className="text-fg-muted font-semibold underline underline-offset-4"
                         >
                           {t('privacyLink')}
                         </a>

--- a/services/web/app/components/blocks/hero-headline.tsx
+++ b/services/web/app/components/blocks/hero-headline.tsx
@@ -13,9 +13,9 @@ export function HeroHeadline() {
   const fadeUpInitial = reduceMotion ? false : { opacity: 0, y: 20 };
 
   return (
-    <section className="border-border-base relative overflow-hidden border-b pt-[60px] pb-4">
+    <section className="border-border-base relative overflow-hidden border-b pt-[60px] pb-10 md:pb-4">
       <SiteContainer>
-        <div className="mx-auto flex max-w-[700px] flex-col items-center gap-9 text-center">
+        <div className="mx-auto flex max-w-[700px] flex-col items-center gap-7 text-center md:gap-9">
           <motion.div
             initial={fadeUpInitial}
             animate={{ opacity: 1, y: 0 }}
@@ -25,13 +25,13 @@ export function HeroHeadline() {
             className="flex flex-col items-center gap-3"
           >
             <h1
-              className="text-fg-base text-5xl font-medium md:text-[68px]"
+              className="text-fg-base text-[36px] font-medium md:text-[68px]"
               style={{ letterSpacing: '-2.94px', lineHeight: 1.1176 }}
             >
               {t('hero.title')}
             </h1>
             <p
-              className="text-fg-muted max-w-[548px] text-base md:text-xl"
+              className="text-fg-muted max-w-137 text-base md:text-xl"
               style={{ letterSpacing: '-0.3px', lineHeight: 1.6 }}
             >
               {t('hero.subtitle')}
@@ -46,7 +46,7 @@ export function HeroHeadline() {
                 : { delay: 0.15, duration: 0.6, ease: easeOut }
             }
           >
-            <Button asChild>
+            <Button asChild className="text-base">
               <LocalizedLink to="/request-demo">
                 {t('hero.ctaPrimary')}
               </LocalizedLink>
@@ -62,7 +62,7 @@ export function HeroHeadline() {
             ? { duration: 0 }
             : { delay: 0.35, duration: 0.8, ease: easeOut }
         }
-        className="mx-auto mt-[120px] w-full max-w-[1200px] px-5 md:px-10"
+        className="mx-auto mt-14.25 w-full max-w-[1200px] px-5 md:mt-24.75 md:px-10"
       >
         <img
           src="/marketing/hero-chat.png"

--- a/services/web/app/components/blocks/logo-wall.tsx
+++ b/services/web/app/components/blocks/logo-wall.tsx
@@ -8,14 +8,14 @@ export function LogoWall() {
   const { t } = useT('home');
 
   return (
-    <section className="border-border-base border-b py-12">
+    <section className="border-border-base border-b py-6 md:py-12">
       <SiteContainer>
         <p
-          className="text-fg-muted flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center text-base"
+          className="text-fg-muted flex flex-col items-center justify-center gap-3 text-center text-sm md:flex-row md:flex-wrap md:gap-x-4 md:gap-y-2 md:text-base"
           style={{ letterSpacing: '-0.24px' }}
         >
           <span>{t('logoWall.prefix')}</span>
-          <span className="inline-flex items-center gap-4">
+          <span className="inline-flex items-center gap-6">
             <MicrosoftIcon className="h-6 w-6" />
             <GoogleIcon className="h-6 w-6" />
             <AtlassianIcon className="h-6 w-6" />

--- a/services/web/app/components/blocks/logo-wall.tsx
+++ b/services/web/app/components/blocks/logo-wall.tsx
@@ -16,9 +16,9 @@ export function LogoWall() {
         >
           <span>{t('logoWall.prefix')}</span>
           <span className="inline-flex items-center gap-6">
-            <MicrosoftIcon className="h-6 w-6" />
-            <GoogleIcon className="h-6 w-6" />
-            <AtlassianIcon className="h-6 w-6" />
+            <MicrosoftIcon className="h-6 w-6" aria-hidden="true" />
+            <GoogleIcon className="h-6 w-6" aria-hidden="true" />
+            <AtlassianIcon className="h-6 w-6" aria-hidden="true" />
           </span>
           <span>{t('logoWall.suffix')}</span>
         </p>

--- a/services/web/app/components/blocks/pricing-compare.tsx
+++ b/services/web/app/components/blocks/pricing-compare.tsx
@@ -48,6 +48,36 @@ interface SectionRow {
 
 type Row = DataRow | SpanRow | SectionRow;
 
+function LabelWithInfo({
+  label,
+  info,
+}: {
+  label: string;
+  info: string;
+}): ReactNode {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {label}
+      <TooltipProvider delayDuration={150}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={info}
+              className="text-fg-muted hover:text-fg-base focus-visible:ring-accent-base/30 inline-flex h-4 w-4 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
+            >
+              <HelpCircle className="h-3.5 w-3.5" strokeWidth={2} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-xs text-center">
+            {info}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </span>
+  );
+}
+
 function renderCell(cell: Cell, yesLabel: string, noLabel: string): ReactNode {
   if (cell.kind === 'check') {
     return (
@@ -130,25 +160,10 @@ export function PricingCompare({ region }: PricingCompareProps) {
       kind: 'data',
       rowKey: 'customDpa',
       label: (
-        <span className="inline-flex items-center gap-1.5">
-          {t('compare.rows.customDpa')}
-          <TooltipProvider delayDuration={150}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={t('compare.rows.customDpaInfo')}
-                  className="text-fg-muted hover:text-fg-base focus-visible:ring-accent-base/30 inline-flex h-4 w-4 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
-                >
-                  <HelpCircle className="h-3.5 w-3.5" strokeWidth={2} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="max-w-xs text-center">
-                {t('compare.rows.customDpaInfo')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </span>
+        <LabelWithInfo
+          label={t('compare.rows.customDpa')}
+          info={t('compare.rows.customDpaInfo')}
+        />
       ),
       cells: { community: dash, enterprise: check },
     },
@@ -156,17 +171,32 @@ export function PricingCompare({ region }: PricingCompareProps) {
     { kind: 'section', label: t('compare.categories.support') },
     {
       kind: 'data',
-      label: t('compare.rows.emailSupport'),
+      label: (
+        <LabelWithInfo
+          label={t('compare.rows.emailSupport')}
+          info={t('compare.rows.emailSupportInfo')}
+        />
+      ),
       cells: { community: dash, enterprise: check },
     },
     {
       kind: 'data',
-      label: t('compare.rows.phoneSupport'),
+      label: (
+        <LabelWithInfo
+          label={t('compare.rows.phoneSupport')}
+          info={t('compare.rows.phoneSupportInfo')}
+        />
+      ),
       cells: { community: dash, enterprise: check },
     },
     {
       kind: 'data',
-      label: t('compare.rows.remoteSupport'),
+      label: (
+        <LabelWithInfo
+          label={t('compare.rows.remoteSupport')}
+          info={t('compare.rows.remoteSupportInfo')}
+        />
+      ),
       cells: { community: dash, enterprise: check },
     },
 

--- a/services/web/app/components/icons/atlassian-icon.tsx
+++ b/services/web/app/components/icons/atlassian-icon.tsx
@@ -1,12 +1,15 @@
 import { cn } from '@tale/ui/cn';
+import type { SVGProps } from 'react';
 
-export const AtlassianIcon = ({ className }: { className?: string }) => (
+export const AtlassianIcon = ({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>) => (
   <svg
     className={cn('size-full', className)}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
-    aria-label="Atlassian"
-    role="img"
+    {...props}
   >
     <defs>
       <linearGradient

--- a/services/web/app/components/icons/google-icon.tsx
+++ b/services/web/app/components/icons/google-icon.tsx
@@ -1,12 +1,15 @@
 import { cn } from '@tale/ui/cn';
+import type { SVGProps } from 'react';
 
-export const GoogleIcon = ({ className }: { className?: string }) => (
+export const GoogleIcon = ({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>) => (
   <svg
     className={cn('size-full', className)}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
-    aria-label="Google"
-    role="img"
+    {...props}
   >
     <path
       fill="#4285F4"

--- a/services/web/app/components/icons/marketing-icons.tsx
+++ b/services/web/app/components/icons/marketing-icons.tsx
@@ -41,35 +41,3 @@ export function ApprovalsIcon(props: IconProps) {
     </svg>
   );
 }
-
-export function IndependentIcon(props: IconProps) {
-  return (
-    <svg viewBox="-1 -1 20 14" aria-hidden {...baseStrokeProps} {...props}>
-      <path d="M8 6H0M13 0H0M13 12H0M18 6H12" />
-    </svg>
-  );
-}
-
-export function StackIcon(props: IconProps) {
-  return (
-    <svg viewBox="-1 -1 22 18" aria-hidden {...baseStrokeProps} {...props}>
-      <path d="M10 4V0H6M0 10H2M18 10H20M13 9V11M7 9V11M4 4H16C17.1046 4 18 4.89543 18 6V14C18 15.1046 17.1046 16 16 16H4C2.89543 16 2 15.1046 2 14V6C2 4.89543 2.89543 4 4 4Z" />
-    </svg>
-  );
-}
-
-export function SecureIcon(props: IconProps) {
-  return (
-    <svg viewBox="-1 -1 20 22" aria-hidden {...baseStrokeProps} {...props}>
-      <path d="M4 9V5C4 3.67392 4.52678 2.40215 5.46447 1.46447C6.40215 0.526784 7.67392 0 9 0C10.3261 0 11.5979 0.526784 12.5355 1.46447C13.4732 2.40215 14 3.67392 14 5V9M2 9H16C17.1046 9 18 9.89543 18 11V18C18 19.1046 17.1046 20 16 20H2C0.89543 20 0 19.1046 0 18V11C0 9.89543 0.89543 9 2 9Z" />
-    </svg>
-  );
-}
-
-export function BuiltForYouIcon(props: IconProps) {
-  return (
-    <svg viewBox="-1 -1 22 18" aria-hidden {...baseStrokeProps} {...props}>
-      <path d="M0 16H20M3 0H17C18.1046 0 19 0.89543 19 2V10C19 11.1046 18.1046 12 17 12H3C1.89543 12 1 11.1046 1 10V2C1 0.89543 1.89543 0 3 0Z" />
-    </svg>
-  );
-}

--- a/services/web/app/components/icons/microsoft-icon.tsx
+++ b/services/web/app/components/icons/microsoft-icon.tsx
@@ -1,12 +1,15 @@
 import { cn } from '@tale/ui/cn';
+import type { SVGProps } from 'react';
 
-export const MicrosoftIcon = ({ className }: { className?: string }) => (
+export const MicrosoftIcon = ({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>) => (
   <svg
     className={cn('size-full', className)}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
-    aria-label="Microsoft"
-    role="img"
+    {...props}
   >
     <path d="M11.4 2H2v9.4h9.4V2z" fill="#F25022" />
     <path d="M22 2h-9.4v9.4H22V2z" fill="#7FBA00" />

--- a/services/web/app/components/layout/site-footer.tsx
+++ b/services/web/app/components/layout/site-footer.tsx
@@ -142,7 +142,10 @@ export function SiteFooter() {
         </LocalizedLink>
       }
       address={
-        <address className="leading-relaxed not-italic">
+        <address
+          className="not-italic"
+          style={{ lineHeight: 1.4286, letterSpacing: '-0.14px' }}
+        >
           {t('address.company')}
           <br />
           {t('address.street')}
@@ -174,9 +177,9 @@ export function SiteFooter() {
           target="_blank"
           rel="noopener noreferrer"
           aria-label={t('githubAriaLabel')}
-          className="text-fg-muted hover:bg-bg-muted hover:text-fg-base inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors"
+          className="text-fg-muted hover:text-fg-base focus-visible:ring-fg-base/60 focus-visible:ring-offset-bg-base sm:hover:bg-bg-muted inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:h-10 sm:w-10 sm:rounded-md"
         >
-          <GithubIcon className="h-5 w-5" />
+          <GithubIcon className="h-6 w-6 sm:h-5 sm:w-5" />
         </a>
       }
     />

--- a/services/web/app/components/layout/site-header.tsx
+++ b/services/web/app/components/layout/site-header.tsx
@@ -51,40 +51,43 @@ export function SiteHeader() {
 
   const desktopActions = (
     <>
-      <Button asChild variant="secondary" size="sm">
+      <Button
+        asChild
+        variant="secondary"
+        size="sm"
+        className="text-fg-muted hover:text-fg-base text-sm"
+      >
         <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
           {t('readDocs')}
         </a>
       </Button>
-      <Button asChild size="sm">
+      <Button asChild size="sm" className="text-sm">
         <LocalizedLink to="/request-demo">{t('requestDemo')}</LocalizedLink>
       </Button>
     </>
   );
 
   const mobileNav = (
-    <>
+    <div className="flex flex-col gap-6">
       {NAV_ITEMS.map((item) => (
         <LocalizedLink
           key={item.key}
           to={item.to}
           hash={item.hash}
-          className="text-fg-base hover:bg-bg-muted rounded-md px-3 py-3 text-base font-medium transition-colors"
+          className="text-fg-base text-2xl font-semibold tracking-tight transition-colors"
         >
           {t(item.key)}
         </LocalizedLink>
       ))}
-      <div className="mt-2 flex flex-col gap-2">
-        <Button asChild variant="secondary" fullWidth>
-          <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
-            {t('readDocs')}
-          </a>
-        </Button>
-        <Button asChild fullWidth>
-          <LocalizedLink to="/request-demo">{t('requestDemo')}</LocalizedLink>
-        </Button>
-      </div>
-    </>
+      <Button asChild variant="secondary" fullWidth>
+        <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
+          {t('readDocs')}
+        </a>
+      </Button>
+      <Button asChild fullWidth>
+        <LocalizedLink to="/request-demo">{t('requestDemo')}</LocalizedLink>
+      </Button>
+    </div>
   );
 
   return (

--- a/services/web/app/pages/home-page.tsx
+++ b/services/web/app/pages/home-page.tsx
@@ -1,3 +1,5 @@
+import { Bot, LaptopMinimal, ListMinus, Lock } from 'lucide-react';
+
 import { ComplianceTrust } from '@/app/components/blocks/compliance-trust';
 import { CtaDeploy } from '@/app/components/blocks/cta-deploy';
 import { FaqAccordion } from '@/app/components/blocks/faq-accordion';
@@ -6,12 +8,6 @@ import { FeatureSectors } from '@/app/components/blocks/feature-sectors';
 import { FeatureSecure } from '@/app/components/blocks/feature-secure';
 import { HeroHeadline } from '@/app/components/blocks/hero-headline';
 import { LogoWall } from '@/app/components/blocks/logo-wall';
-import {
-  BuiltForYouIcon,
-  IndependentIcon,
-  SecureIcon,
-  StackIcon,
-} from '@/app/components/icons/marketing-icons';
 import { useT } from '@/lib/i18n/client';
 import { localizedPath } from '@/lib/i18n/locales';
 import { useCurrentLocale } from '@/lib/i18n/use-current-locale';
@@ -44,25 +40,25 @@ export function HomePage() {
         description={t('featureGrid.description')}
         items={[
           {
-            icon: IndependentIcon,
+            icon: ListMinus,
             title: t('featureGrid.independent.title'),
             description: t('featureGrid.independent.description'),
             illustration: '/marketing/security-1-independent.png',
           },
           {
-            icon: StackIcon,
+            icon: Bot,
             title: t('featureGrid.stack.title'),
             description: t('featureGrid.stack.description'),
             illustration: '/marketing/svg/mock-integrations-stack.svg',
           },
           {
-            icon: SecureIcon,
+            icon: Lock,
             title: t('featureGrid.proven.title'),
             description: t('featureGrid.proven.description'),
             illustration: '/marketing/svg/mock-compliance-columns.svg',
           },
           {
-            icon: BuiltForYouIcon,
+            icon: LaptopMinimal,
             title: t('featureGrid.needs.title'),
             description: t('featureGrid.needs.description'),
             illustration: '/marketing/security-4-needs.png',

--- a/services/web/app/pages/request-demo-page.tsx
+++ b/services/web/app/pages/request-demo-page.tsx
@@ -71,7 +71,7 @@ export function RequestDemoPage() {
       description={
         <>
           <p>{t('paragraph1')}</p>
-          <p className="mt-3">{t('paragraph2')}</p>
+          <p className="mt-6">{t('paragraph2')}</p>
         </>
       }
       // oxlint-disable-next-line typescript/no-explicit-any -- FormCard expects a base shape; runtime payload is shape-compatible
@@ -144,10 +144,10 @@ export function RequestDemoPage() {
         label={t('fieldInterests')}
         error={errors.interests?.message as string | undefined}
       >
-        <ul role="list" className="flex flex-col gap-2">
+        <ul role="list" className="flex flex-col gap-4">
           {REQUEST_DEMO_INTERESTS.map((key) => (
             <li key={key}>
-              <label className="flex items-center gap-3 text-sm text-[color:var(--color-fg-base)]">
+              <label className="flex items-center gap-2 text-sm text-[color:var(--color-fg-base)]">
                 <Checkbox
                   checked={interests.includes(key)}
                   onCheckedChange={() => toggleInterest(key)}
@@ -162,7 +162,6 @@ export function RequestDemoPage() {
       <Field
         label={t('fieldMessage')}
         htmlFor="rd-message"
-        description={t('messageHelp')}
         error={errors.message?.message}
       >
         <Textarea

--- a/services/web/index.html
+++ b/services/web/index.html
@@ -40,6 +40,14 @@
       name="twitter:description"
       content="Self-hosted AI platform for data-sensitive organizations. ISO 27001 & SOC 2 certified."
     />
+
+    <link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt" />
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="/llms-full.txt"
+      title="llms-full.txt"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/services/web/messages/de.json
+++ b/services/web/messages/de.json
@@ -287,8 +287,11 @@
         "customDpa": "Individueller AVV",
         "customDpaInfo": "Wir akzeptieren auch individuelle Auftragsverarbeitungsverträge mit unseren Kunden.",
         "emailSupport": "E-Mail-Support",
+        "emailSupportInfo": "Antworten innerhalb Geschäftszeiten: Mo–Fr, 08:00–17:00 (MEZ/MESZ).",
         "phoneSupport": "Telefon-Support",
-        "remoteSupport": "Remote-Support"
+        "phoneSupportInfo": "Verfügbar innerhalb Geschäftszeiten: Mo–Fr, 08:00–17:00 (MEZ/MESZ).",
+        "remoteSupport": "Remote-Support",
+        "remoteSupportInfo": "Verfügbar innerhalb Geschäftszeiten: Mo–Fr, 08:00–17:00 (MEZ/MESZ)."
       },
       "cellLabels": {
         "yes": "Enthalten",
@@ -440,7 +443,6 @@
       "customAiTraining": "Individuelles KI-Modelltraining",
       "aiHardware": "KI-Hardware"
     },
-    "messageHelp": "Alle geteilten Projektdetails behandeln wir vertraulich.",
     "submit": "Kontakt aufnehmen"
   },
   "contact": {

--- a/services/web/messages/en.json
+++ b/services/web/messages/en.json
@@ -287,8 +287,11 @@
         "customDpa": "Custom DPA",
         "customDpaInfo": "We also accept custom Data Processing Agreements with our customers.",
         "emailSupport": "Email support",
+        "emailSupportInfo": "Replies during business hours: Mon–Fri, 08:00–17:00 (CET/CEST).",
         "phoneSupport": "Phone support",
-        "remoteSupport": "Remote support"
+        "phoneSupportInfo": "Available during business hours: Mon–Fri, 08:00–17:00 (CET/CEST).",
+        "remoteSupport": "Remote support",
+        "remoteSupportInfo": "Available during business hours: Mon–Fri, 08:00–17:00 (CET/CEST)."
       },
       "cellLabels": {
         "yes": "Included",
@@ -440,7 +443,6 @@
       "customAiTraining": "Custom AI model training",
       "aiHardware": "AI hardware"
     },
-    "messageHelp": "All project details shared with us are kept confidential.",
     "submit": "Get in touch"
   },
   "contact": {

--- a/services/web/messages/fr.json
+++ b/services/web/messages/fr.json
@@ -287,8 +287,11 @@
         "customDpa": "DPA personnalisé",
         "customDpaInfo": "Nous acceptons également des accords de traitement des données personnalisés avec nos clients.",
         "emailSupport": "Support par email",
+        "emailSupportInfo": "Réponses durant les heures ouvrables : lun.–ven., 08h00–17h00 (CET/CEST).",
         "phoneSupport": "Support téléphone",
-        "remoteSupport": "Support à distance"
+        "phoneSupportInfo": "Disponible durant les heures ouvrables : lun.–ven., 08h00–17h00 (CET/CEST).",
+        "remoteSupport": "Support à distance",
+        "remoteSupportInfo": "Disponible durant les heures ouvrables : lun.–ven., 08h00–17h00 (CET/CEST)."
       },
       "cellLabels": {
         "yes": "Inclus",
@@ -440,7 +443,6 @@
       "customAiTraining": "Entraînement de modèle IA sur mesure",
       "aiHardware": "Matériel IA"
     },
-    "messageHelp": "Tous les détails partagés restent confidentiels.",
     "submit": "Prendre contact"
   },
   "contact": {

--- a/tools/plop/generators/react-service.ts
+++ b/tools/plop/generators/react-service.ts
@@ -96,6 +96,8 @@ const files = [
   'messages/global.json',
   'public/manifest.webmanifest.hbs',
   'public/robots.txt',
+  'public/llms.txt.hbs',
+  'public/llms-full.txt.hbs',
   'public/favicon.ico',
   'types/.gitkeep',
 ];

--- a/tools/plop/templates/react-service/index.html.hbs
+++ b/tools/plop/templates/react-service/index.html.hbs
@@ -17,6 +17,18 @@
       href="/favicon-dark.png"
       media="(prefers-color-scheme: dark)"
     />
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="/llms.txt"
+      title="llms.txt"
+    />
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="/llms-full.txt"
+      title="llms-full.txt"
+    />
     <title>Tale</title>
   </head>
   <body>

--- a/tools/plop/templates/react-service/public/llms-full.txt.hbs
+++ b/tools/plop/templates/react-service/public/llms-full.txt.hbs
@@ -1,0 +1,10 @@
+# Tale {{titleCase name}}
+
+> {{description}}
+
+This service ships an `llms.txt` index and this `llms-full.txt` body so LLM tooling can discover and ingest its public surface. Replace the contents of these files with meaningful, LLM-readable summaries of the pages this service serves.
+
+For documentation about the wider Tale platform, see:
+
+- https://docs.tale.dev/llms.txt
+- https://docs.tale.dev/llms-full.txt

--- a/tools/plop/templates/react-service/public/llms.txt.hbs
+++ b/tools/plop/templates/react-service/public/llms.txt.hbs
@@ -1,0 +1,8 @@
+# Tale {{titleCase name}}
+
+> {{description}}
+
+## Optional
+
+- [Documentation](https://docs.tale.dev/llms.txt)
+- [GitHub](https://github.com/tale-project/tale)


### PR DESCRIPTION
## Summary

- **Marketing site** (`services/web`): hero, FAQ, feature blocks, sector tabs with lucide icons, compliance trust panels with new artwork, pricing tooltips with support-hours info, form/CTA polish — tracks the updated Pencil spec in `designs/web/frontpages.pen`
- **Shared webui layout** (`packages/webui`): tighter footer grid for mid-widths, bigger burger icon on mobile, container mobile padding bumped to 24px to match Pencil section padding
- **UI primitives** (`packages/ui`): accordion typography + border treatment refresh; darker fg tokens in `globals.css` for better AA contrast
- **llms.txt infrastructure**: new `public/llms.txt` + `llms-full.txt` for the platform service, `<link rel="alternate" type="text/plain">` tags wired into web/docs/platform `index.html`, matching templates baked into the `tools/plop` react-service generator so future services get them by default
- **i18n**: support-hours tooltip copy + `llmsFullTxtLabel` added to en/de/fr; unused `messageHelp` key removed

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no platform message changes; web/docs message files updated in all three locales).
- [ ] Updated `/docs/{en,de,fr}/` for every user-visible change — N/A (marketing-site / shared-UI polish, no docs-site behavior change).
- [ ] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — N/A (covered by `bun run check`).
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.

## Test plan

- [ ] `bun run --filter @tale/web dev` — verify hero, logo wall, feature grid, sector tabs, compliance panels, FAQ, pricing tooltips, CTA, request-demo form across mobile + desktop breakpoints
- [ ] `bun run --filter @tale/docs dev` — confirm footer renders both `llms.txt` and `llms-full.txt` links
- [ ] Hit `/llms.txt` and `/llms-full.txt` on the platform service in dev and confirm they serve text/plain content
- [ ] `prefers-reduced-motion: reduce` — verify accordion + animated panels stay legible
- [ ] Keyboard navigation through pricing tooltips and FAQ accordion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Automations" terminology throughout the platform
  * Enhanced request demo form with new interest options (custom AI training, AI hardware)
  * Added LLM integration discovery resources
  * Sector navigation now displays icons

* **UI/Visual Improvements**
  * Refined color palette for improved readability
  * Enhanced visual effects with frosted glass overlays
  * Improved spacing and layout across components
  * Updated mobile navigation and footer design

* **Localization**
  * Added multi-language support for enterprise pricing and support details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1707)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->