### PR TITLE
fix(platform): eliminate chat + dashboard layout flicker on load

### DIFF
--- a/services/platform/app/features/chat/components/agent-selector.test.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.test.tsx
@@ -60,9 +60,13 @@ let mockEffectiveAgent: { name: string; displayName: string } | null = {
   name: 'chat-agent',
   displayName: 'Default Chat',
 };
+let mockEffectiveAgentLoading = false;
 
 vi.mock('../hooks/use-effective-agent', () => ({
-  useEffectiveAgent: () => ({ agent: mockEffectiveAgent, isLoading: false }),
+  useEffectiveAgent: () => ({
+    agent: mockEffectiveAgent,
+    isLoading: mockEffectiveAgentLoading,
+  }),
 }));
 
 let mockCanWrite = true;
@@ -123,6 +127,7 @@ beforeEach(() => {
   mockDialogIsOpen = false;
   mockAgents = defaultAgents;
   mockEffectiveAgent = { name: 'chat-agent', displayName: 'Default Chat' };
+  mockEffectiveAgentLoading = false;
 });
 
 describe('AgentSelector', () => {
@@ -140,6 +145,20 @@ describe('AgentSelector', () => {
     mockEffectiveAgent = null;
     render(<AgentSelector organizationId="org-1" />);
     expect(screen.getByText('Default agent')).toBeInTheDocument();
+  });
+
+  it('renders a skeleton inside the trigger while the effective agent is loading', () => {
+    mockEffectiveAgent = null;
+    mockEffectiveAgentLoading = true;
+    render(<AgentSelector organizationId="org-1" />);
+
+    // No "Assistant" / "Default agent" flash while we wait. Trigger button
+    // stays mounted (no layout shift) but disabled, with a skeleton in place
+    // of the label.
+    expect(screen.queryByText('Default agent')).not.toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: 'Select agent' });
+    expect(trigger).toBeDisabled();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('shows "Add agent" button when user has write permission', async () => {

--- a/services/platform/app/features/chat/components/agent-selector.test.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup } from '@testing-library/react';
+import { cleanup, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
@@ -153,12 +153,20 @@ describe('AgentSelector', () => {
     render(<AgentSelector organizationId="org-1" />);
 
     // No "Assistant" / "Default agent" flash while we wait. Trigger button
-    // stays mounted (no layout shift) but disabled, with a skeleton in place
-    // of the label.
+    // stays mounted but disabled, with a skeleton in place of the label.
     expect(screen.queryByText('Default agent')).not.toBeInTheDocument();
     const trigger = screen.getByRole('button', { name: 'Select agent' });
     expect(trigger).toBeDisabled();
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    // Trigger keeps its leading + trailing icons so the width footprint is
+    // stable across loading and loaded states.
+    expect(trigger.querySelectorAll('svg')).toHaveLength(2);
+    // Skeleton renders in place of the label, with dimensions matching the
+    // actual label height to avoid vertical jitter on resolve.
+    const skeleton = within(trigger).getByRole('status');
+    expect(skeleton).toHaveClass('h-3.5', 'w-20');
+    // Trigger has a min-width pin so loading→loaded never reflows for the
+    // common label range.
+    expect(trigger).toHaveClass('min-w-40');
   });
 
   it('shows "Add agent" button when user has write permission', async () => {

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -115,11 +115,13 @@ export function AgentSelector({ organizationId }: AgentSelectorProps) {
         searchPlaceholder={t('agentSelector.searchPlaceholder')}
         emptyText={t('agentSelector.noResults')}
         aria-label={t('agentSelector.label')}
-        disabled={isAgentLoading}
         trigger={
+          // min-w-40 (160 px) pins the trigger so the loading→loaded swap
+          // doesn't reflow for common labels. Names longer than ~160 px
+          // (rare, e.g. "Research Agent") still grow on resolve.
           <Button
             type="button"
-            className="gap-2"
+            className="min-w-40 gap-2"
             size="icon"
             variant="ghost"
             aria-label={t('agentSelector.label')}
@@ -127,7 +129,7 @@ export function AgentSelector({ organizationId }: AgentSelectorProps) {
           >
             <Bot className="size-3.5" aria-hidden="true" />
             {isAgentLoading ? (
-              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-3.5 w-20" />
             ) : (
               <span>{currentLabel}</span>
             )}

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
+import { Skeleton } from '@tale/ui/skeleton';
 import { useNavigate } from '@tanstack/react-router';
 import { Bot, ChevronDown, Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -29,7 +30,8 @@ export function AgentSelector({ organizationId }: AgentSelectorProps) {
   const navigate = useNavigate();
   const ability = useAbility();
   const { setSelectedAgent } = useChatLayout();
-  const { agent: effectiveAgent } = useEffectiveAgent(organizationId);
+  const { agent: effectiveAgent, isLoading: isAgentLoading } =
+    useEffectiveAgent(organizationId);
   const { agents: allAgents } = useChatAgents(organizationId);
   const readiness = useIntegrationReadiness(organizationId);
   const canManageAgents = ability.can('write', 'agents');
@@ -113,6 +115,7 @@ export function AgentSelector({ organizationId }: AgentSelectorProps) {
         searchPlaceholder={t('agentSelector.searchPlaceholder')}
         emptyText={t('agentSelector.noResults')}
         aria-label={t('agentSelector.label')}
+        disabled={isAgentLoading}
         trigger={
           <Button
             type="button"
@@ -120,9 +123,14 @@ export function AgentSelector({ organizationId }: AgentSelectorProps) {
             size="icon"
             variant="ghost"
             aria-label={t('agentSelector.label')}
+            disabled={isAgentLoading}
           >
             <Bot className="size-3.5" aria-hidden="true" />
-            <span>{currentLabel}</span>
+            {isAgentLoading ? (
+              <Skeleton className="h-4 w-20" />
+            ) : (
+              <span>{currentLabel}</span>
+            )}
             <ChevronDown className="size-3" aria-hidden="true" />
           </Button>
         }

--- a/services/platform/app/features/chat/hooks/use-effective-agent.test.ts
+++ b/services/platform/app/features/chat/hooks/use-effective-agent.test.ts
@@ -47,6 +47,18 @@ vi.mock('./queries', () => ({
   }),
 }));
 
+let mockIsAuthLoading = false;
+
+vi.mock('@/app/hooks/use-convex-auth', () => ({
+  useAuth: () => ({
+    user: mockIsAuthLoading ? undefined : { userId: 'user-1' },
+    isLoading: mockIsAuthLoading,
+    isAuthenticated: !mockIsAuthLoading,
+    signIn: async () => {},
+    signOut: async () => {},
+  }),
+}));
+
 // Import after mocks are set up
 const { useEffectiveAgent } = await import('./use-effective-agent');
 
@@ -69,10 +81,27 @@ beforeEach(() => {
   mockSelectedAgent = null;
   mockAgents = undefined;
   mockIsLoading = false;
+  mockIsAuthLoading = false;
   mockLocale = 'en';
 });
 
 describe('useEffectiveAgent', () => {
+  describe('when auth is loading', () => {
+    it('returns null agent with isLoading true even when agents have loaded', () => {
+      // The agent localStorage key is keyed on user.userId; while auth is in
+      // flight the wrong key is in use, so selectedAgent would be null and
+      // we'd render the chat-agent fallback for one frame. The hook must
+      // suppress that fallback until auth resolves.
+      mockIsAuthLoading = true;
+      mockAgents = AGENTS;
+      mockSelectedAgent = null;
+
+      const { result } = renderHook(() => useEffectiveAgent(ORG_ID));
+
+      expect(result.current).toEqual({ agent: null, isLoading: true });
+    });
+  });
+
   describe('when agents are loading', () => {
     it('returns null agent with isLoading true when no selected agent', () => {
       mockAgents = undefined;

--- a/services/platform/app/features/chat/hooks/use-effective-agent.test.ts
+++ b/services/platform/app/features/chat/hooks/use-effective-agent.test.ts
@@ -100,6 +100,26 @@ describe('useEffectiveAgent', () => {
 
       expect(result.current).toEqual({ agent: null, isLoading: true });
     });
+
+    it('resolves to chat-agent fallback when auth completes', () => {
+      // This is the transition the flicker fix actually targets: when auth
+      // resolves we must transition cleanly from `null/loading` to the real
+      // agent without an intermediate "Default Chat" flash.
+      mockIsAuthLoading = true;
+      mockAgents = AGENTS;
+      mockSelectedAgent = null;
+
+      const { result, rerender } = renderHook(() => useEffectiveAgent(ORG_ID));
+      expect(result.current).toEqual({ agent: null, isLoading: true });
+
+      mockIsAuthLoading = false;
+      rerender();
+
+      expect(result.current).toEqual({
+        agent: { name: 'chat-agent', displayName: 'Default Chat' },
+        isLoading: false,
+      });
+    });
   });
 
   describe('when agents are loading', () => {

--- a/services/platform/app/features/chat/hooks/use-effective-agent.ts
+++ b/services/platform/app/features/chat/hooks/use-effective-agent.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAuth } from '@/app/hooks/use-convex-auth';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 
 import type { SelectedAgent } from '../context/chat-layout-context';
@@ -30,6 +31,7 @@ export function useEffectiveAgent(organizationId: string): {
 } {
   const { selectedAgent } = useChatLayout();
   const { agents, isLoading } = useChatAgents(organizationId);
+  const { isLoading: isAuthLoading } = useAuth();
   const { i18n } = useTranslation();
 
   const locale = i18n.language;
@@ -60,6 +62,14 @@ export function useEffectiveAgent(organizationId: string): {
 
     return resolve(firstAgent);
   }, [selectedAgent, agents, locale]);
+
+  // While auth is loading, the localStorage key (which embeds user.userId) is
+  // org-scoped and won't match the real user-scoped entry — so `selectedAgent`
+  // would falsely look null and we'd render the chat-agent fallback for one
+  // frame. Treat that window as "agent not yet known" instead.
+  if (isAuthLoading) {
+    return { agent: null, isLoading: true };
+  }
 
   return { agent, isLoading };
 }

--- a/services/platform/app/hooks/use-persisted-state.test.ts
+++ b/services/platform/app/hooks/use-persisted-state.test.ts
@@ -107,6 +107,22 @@ describe('usePersistedState', () => {
       expect(result.current[0]).toBe('default');
     });
 
+    it('does not write to the new key on key change when no stored value exists', () => {
+      const { rerender } = renderHook(
+        ({ key }) => usePersistedState(key, 'default'),
+        { initialProps: { key: 'key-a' } },
+      );
+
+      expect(localStorage.getItem('key-b')).toBeNull();
+
+      rerender({ key: 'key-b' });
+
+      // Key swap should NOT echo 'default' back to storage at 'key-b' —
+      // a never-written key must stay un-written so callers can distinguish
+      // "user has set nothing" from "user set the value to default".
+      expect(localStorage.getItem('key-b')).toBeNull();
+    });
+
     it('preserves value written to a key after switching away and back', () => {
       const { result, rerender } = renderHook(
         ({ key }) => usePersistedState(key, ''),

--- a/services/platform/app/hooks/use-persisted-state.test.ts
+++ b/services/platform/app/hooks/use-persisted-state.test.ts
@@ -14,15 +14,25 @@ describe('usePersistedState', () => {
     expect(result.current[0]).toBe('hello');
   });
 
-  it('hydrates from localStorage after mount', () => {
+  it('reads from localStorage synchronously on first render', () => {
     localStorage.setItem('test-key', JSON.stringify('stored-value'));
 
     const { result } = renderHook(() =>
       usePersistedState('test-key', 'default'),
     );
 
-    // After hydration effect runs
+    // Lazy useState initializer reads localStorage during initial render —
+    // no post-mount hydration step, so consumers never observe the default.
     expect(result.current[0]).toBe('stored-value');
+  });
+
+  it('does not write the initial value back to localStorage on mount', () => {
+    renderHook(() => usePersistedState('test-key', 'default'));
+
+    // First-mount persist must be a no-op: a hook that's never been written
+    // to should not echo its initial value to storage (would otherwise
+    // pollute the key and trigger spurious storage events).
+    expect(localStorage.getItem('test-key')).toBeNull();
   });
 
   it('persists value changes to localStorage', () => {

--- a/services/platform/app/hooks/use-persisted-state.ts
+++ b/services/platform/app/hooks/use-persisted-state.ts
@@ -38,22 +38,18 @@ function isValidType<T>(value: unknown, initialValue: T): value is T {
 }
 
 export function usePersistedState<T>(key: string, initialValue: T) {
-  const [value, setValue] = useState(initialValue);
-  const [isHydrated, setIsHydrated] = useState(false);
+  // Lazy init: read localStorage synchronously during the first render so
+  // consumers never see the static initialValue when a stored value exists.
+  // SPA-only app (no SSR) — `window` is always defined here.
+  const [value, setValue] = useState<T>(() => {
+    const item = getItem<T>(key);
+    return item !== undefined && isValidType(item, initialValue)
+      ? item
+      : initialValue;
+  });
   const prevKeyRef = useRef(key);
   const clearedRef = useRef(false);
-
-  // On mount: hydrate from localStorage
-  useEffect(() => {
-    setIsHydrated(true);
-
-    const item = getItem<T>(key);
-    if (item !== undefined && isValidType(item, initialValue)) {
-      setValue(item);
-    }
-    // Only runs on mount (key/initialValue are stable on first render)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const didMountRef = useRef(false);
 
   // On key change: read the new key's value synchronously during render
   // so the persist effect sees the correct value
@@ -68,15 +64,20 @@ export function usePersistedState<T>(key: string, initialValue: T) {
     }
   }
 
-  // Persist value changes to localStorage
+  // Persist value changes to localStorage. Skip the first mount so a hook
+  // that's never been written-to doesn't echo its initial value back to
+  // storage.
   useEffect(() => {
-    if (!isHydrated) return;
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     if (clearedRef.current) {
       clearedRef.current = false;
       return;
     }
     setItem(key, value);
-  }, [key, value, isHydrated]);
+  }, [key, value]);
 
   const clear = useCallback(() => {
     clearedRef.current = true;

--- a/services/platform/app/hooks/use-persisted-state.ts
+++ b/services/platform/app/hooks/use-persisted-state.ts
@@ -50,11 +50,16 @@ export function usePersistedState<T>(key: string, initialValue: T) {
   const prevKeyRef = useRef(key);
   const clearedRef = useRef(false);
   const didMountRef = useRef(false);
+  const skipNextPersistRef = useRef(false);
 
   // On key change: read the new key's value synchronously during render
   // so the persist effect sees the correct value
   if (prevKeyRef.current !== key) {
     prevKeyRef.current = key;
+    // The value we're about to set comes from (or falls back from) the new
+    // key's stored entry — persisting it would be a no-op write at best,
+    // or pollute a never-written key with the initial value at worst.
+    skipNextPersistRef.current = true;
 
     const item = getItem<T>(key);
     if (item !== undefined && isValidType(item, initialValue)) {
@@ -74,6 +79,10 @@ export function usePersistedState<T>(key: string, initialValue: T) {
     }
     if (clearedRef.current) {
       clearedRef.current = false;
+      return;
+    }
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false;
       return;
     }
     setItem(key, value);

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -26,6 +26,7 @@ import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { TeamFilterProvider } from '@/app/hooks/use-team-filter';
 import { toast } from '@/app/hooks/use-toast';
+import { DashboardShellSkeleton } from '@/app/routes/dashboard/dashboard-shell-skeleton';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
@@ -169,11 +170,7 @@ function DashboardLayout() {
         </FullPageCenter>
       );
     }
-    return (
-      <FullPageCenter>
-        <Spinner size="lg" />
-      </FullPageCenter>
-    );
+    return <DashboardShellSkeleton />;
   }
 
   return (

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -85,7 +85,7 @@ function ChatSkeleton() {
 function ThreadLoadingSkeleton() {
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="flex flex-col p-4 sm:p-6">
+      <div className="flex flex-1 flex-col p-4 sm:p-6">
         <MessagesSkeleton />
       </div>
       <ChatInputSkeleton />

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -18,6 +18,7 @@ import {
 import { ChatHeader } from '@/app/features/chat/components/chat-header';
 import { ChatHistorySidebar } from '@/app/features/chat/components/chat-history-sidebar';
 import { ChatInterface } from '@/app/features/chat/components/chat-interface';
+import { MessagesSkeleton } from '@/app/features/chat/components/messages-skeleton';
 import { SharedChatView } from '@/app/features/chat/components/shared-chat-view';
 import { WelcomeContentSkeleton } from '@/app/features/chat/components/welcome-content-skeleton';
 import {
@@ -78,6 +79,20 @@ function ChatSkeleton() {
   );
 }
 
+// Loading placeholder for the existing-thread path. Mirrors ChatSkeleton's
+// outer chrome but shows a messages-list skeleton — an existing thread
+// always has history, so the centered welcome placeholder is misleading.
+function ThreadLoadingSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-col p-4 sm:p-6">
+        <MessagesSkeleton />
+      </div>
+      <ChatInputSkeleton />
+    </div>
+  );
+}
+
 /**
  * Gates ChatInterface behind a thread ownership check.
  * When a threadId is present, waits for getThreadStatus to resolve:
@@ -126,7 +141,7 @@ function ThreadGate({
 
   // Still loading
   if (threadStatus === undefined) {
-    return <ChatSkeleton />;
+    return <ThreadLoadingSkeleton />;
   }
 
   // Loaded but thread not found / not authorized

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -55,9 +55,12 @@ export const Route = createFileRoute('/dashboard/$id/chat')({
 
 function ChatInputSkeleton() {
   return (
-    <PanelFooter>
+    // mt-auto mirrors ChatInterface's PanelFooter pinning so the composer
+    // sits at the bottom without relying on a flex-1 sibling. Harmless
+    // inside ChatSkeleton where the sibling already consumes all space.
+    <PanelFooter className="mt-auto">
       <div className="mx-auto w-full max-w-(--chat-max-width)">
-        <div className="bg-background border-muted-foreground/50 relative flex flex-col gap-2 rounded-t-2xl border border-b-0 px-5 pt-4">
+        <div className="bg-background border-muted-foreground/50 relative mb-2 flex flex-col gap-2 rounded-2xl border px-5 pt-4">
           <Skeleton className="h-[100px] w-full bg-transparent" />
           <div className="flex items-center pb-3">
             <Skeleton className="h-5 w-5 rounded" />
@@ -79,13 +82,13 @@ function ChatSkeleton() {
   );
 }
 
-// Loading placeholder for the existing-thread path. Mirrors ChatSkeleton's
-// outer chrome but shows a messages-list skeleton — an existing thread
-// always has history, so the centered welcome placeholder is misleading.
+// Loading placeholder for the existing-thread path. Mirrors ChatInterface's
+// wrapper for the messages-list render (chat-interface.tsx) — content div
+// is natural-height, ChatInputSkeleton pins to bottom via `mt-auto`.
 function ThreadLoadingSkeleton() {
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="flex flex-1 flex-col p-4 sm:p-6">
+      <div className="flex flex-col overflow-y-visible p-4 sm:p-6">
         <MessagesSkeleton />
       </div>
       <ChatInputSkeleton />

--- a/services/platform/app/routes/dashboard/create-organization.tsx
+++ b/services/platform/app/routes/dashboard/create-organization.tsx
@@ -1,10 +1,9 @@
-import { Spinner } from '@tale/ui/spinner';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
 
-import { FullPageCenter } from '@/app/components/ui/layout/full-page-center';
 import { OrganizationForm } from '@/app/features/organization/components/organization-form';
 import { useUserOrganizations } from '@/app/features/organization/hooks/queries';
+import { DashboardShellSkeleton } from '@/app/routes/dashboard/dashboard-shell-skeleton';
 import { seo } from '@/lib/utils/seo';
 
 export const Route = createFileRoute('/dashboard/create-organization')({
@@ -31,11 +30,7 @@ function CreateOrganizationPage() {
   }, [isAuthLoading, isAuthenticated, navigate]);
 
   if (isAuthLoading || isOrgsLoading) {
-    return (
-      <FullPageCenter>
-        <Spinner size="lg" />
-      </FullPageCenter>
-    );
+    return <DashboardShellSkeleton />;
   }
 
   return <OrganizationForm />;

--- a/services/platform/app/routes/dashboard/dashboard-layout.test.tsx
+++ b/services/platform/app/routes/dashboard/dashboard-layout.test.tsx
@@ -141,7 +141,7 @@ afterEach(() => {
 });
 
 describe('DashboardLayout', () => {
-  it('shows spinner (not outlet) while Convex auth is loading', () => {
+  it('shows skeleton (not outlet) while Convex auth is loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: true,
       isAuthenticated: false,
@@ -157,10 +157,10 @@ describe('DashboardLayout', () => {
     // Outlet must not render until access is confirmed — child routes mount
     // org-scoped Convex subscriptions that throw on UnauthorizedError.
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
   });
 
-  it('shows spinner (not outlet) while member context query is loading', () => {
+  it('shows skeleton (not outlet) while member context query is loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -174,10 +174,10 @@ describe('DashboardLayout', () => {
     render(<DashboardLayout />);
 
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
   });
 
-  it('shows spinner when both auth and query are loading', () => {
+  it('shows skeleton when both auth and query are loading', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: true,
       isAuthenticated: false,
@@ -191,7 +191,7 @@ describe('DashboardLayout', () => {
     render(<DashboardLayout />);
 
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
   });
 
   it('renders child routes when auth complete and member has role', () => {
@@ -327,7 +327,7 @@ describe('DashboardLayout', () => {
     expect(mockUseCurrentMemberContext.mock.calls[0]?.[1]).toBe(false);
   });
 
-  it('shows spinner (not outlet) when query errors without prior data', () => {
+  it('shows skeleton (not outlet) when query errors without prior data', () => {
     mockUseConvexAuth.mockReturnValue({
       isLoading: false,
       isAuthenticated: true,
@@ -341,14 +341,14 @@ describe('DashboardLayout', () => {
     render(<DashboardLayout />);
 
     // Without resolved memberContext we can't confirm access — fall through
-    // to the loading spinner rather than rendering Outlet (which would mount
+    // to the loading skeleton rather than rendering Outlet (which would mount
     // org-scoped subscriptions) or AccessDenied (which would be misleading
     // for a transient error).
     expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
     expect(
       screen.queryByText('accessDenied.noMembership'),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
   });
 
   it('keeps outlet visible when query errors but has previous data', () => {

--- a/services/platform/app/routes/dashboard/dashboard-shell-skeleton.tsx
+++ b/services/platform/app/routes/dashboard/dashboard-shell-skeleton.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from '@tale/ui/skeleton';
+
+// Mirrors the wrapper structure of DashboardLayout's resolved render
+// (services/platform/app/routes/dashboard/$id.tsx) so that when auth +
+// member context resolve, the real chrome slots in without reflow —
+// only the inner placeholders swap to real content.
+export function DashboardShellSkeleton() {
+  return (
+    <div className="flex size-full flex-col overflow-hidden md:flex-row">
+      {/* Mobile top bar */}
+      <div className="bg-background flex h-[--nav-size] items-center gap-2 p-2 md:hidden">
+        <Skeleton className="size-8 rounded-md" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+
+      {/* Desktop side nav */}
+      <div className="bg-background hidden h-full px-2 py-3 md:flex md:flex-[0_0_var(--nav-size)] md:flex-col md:items-center md:justify-between">
+        <div className="flex flex-col items-center gap-3">
+          <Skeleton className="size-8 rounded-md" />
+          <div className="flex flex-col items-center gap-2 pt-4">
+            {Array.from({ length: 5 }, (_, i) => (
+              <Skeleton key={i} className="size-8 rounded-md" />
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Skeleton className="size-8 rounded-full" />
+          <Skeleton className="size-8 rounded-full" />
+          <Skeleton className="size-8 rounded-full" />
+        </div>
+      </div>
+
+      <main className="border-border bg-background flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden md:border-l" />
+    </div>
+  );
+}

--- a/services/platform/app/routes/dashboard/dashboard-shell-skeleton.tsx
+++ b/services/platform/app/routes/dashboard/dashboard-shell-skeleton.tsx
@@ -4,6 +4,14 @@ import { Skeleton } from '@tale/ui/skeleton';
 // (services/platform/app/routes/dashboard/$id.tsx) so that when auth +
 // member context resolve, the real chrome slots in without reflow —
 // only the inner placeholders swap to real content.
+//
+// Side-nav structure mirrors `Navigation`
+// (services/platform/app/components/ui/navigation/navigation.tsx): outer
+// is plain `px-2`, inner column owns the `py-3` rows. Middle is an empty
+// `flex-1` spacer rather than a fixed item count, because the real item
+// count is CASL-gated (4–6 depending on role) and not known until auth
+// resolves — any hardcoded count would shift on resolve for at least one
+// role.
 export function DashboardShellSkeleton() {
   return (
     <div className="flex size-full flex-col overflow-hidden md:flex-row">
@@ -13,20 +21,18 @@ export function DashboardShellSkeleton() {
         <Skeleton className="h-4 w-32" />
       </div>
 
-      {/* Desktop side nav */}
-      <div className="bg-background hidden h-full px-2 py-3 md:flex md:flex-[0_0_var(--nav-size)] md:flex-col md:items-center md:justify-between">
-        <div className="flex flex-col items-center gap-3">
-          <Skeleton className="size-8 rounded-md" />
-          <div className="flex flex-col items-center gap-2 pt-4">
-            {Array.from({ length: 5 }, (_, i) => (
-              <Skeleton key={i} className="size-8 rounded-md" />
-            ))}
+      {/* Desktop side nav — outer matches $id.tsx exactly */}
+      <div className="bg-background hidden h-full px-2 md:flex md:flex-[0_0_var(--nav-size)]">
+        <div className="border-border flex h-full flex-col">
+          <div className="flex flex-shrink-0 items-center justify-center py-3">
+            <Skeleton className="size-8 rounded-md" />
           </div>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <Skeleton className="size-8 rounded-full" />
-          <Skeleton className="size-8 rounded-full" />
-          <Skeleton className="size-8 rounded-full" />
+          <div className="mx-1 min-h-0 flex-1 overflow-y-auto py-4" />
+          <div className="flex flex-shrink-0 flex-col items-center gap-2 py-3">
+            <Skeleton className="size-9 rounded-full" />
+            <Skeleton className="size-9 rounded-full" />
+            <Skeleton className="size-9 rounded-full" />
+          </div>
         </div>
       </div>
 

--- a/services/platform/app/routes/dashboard/index.tsx
+++ b/services/platform/app/routes/dashboard/index.tsx
@@ -1,12 +1,11 @@
 import { convexQuery } from '@convex-dev/react-query';
-import { Spinner } from '@tale/ui/spinner';
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useAction, useMutation } from 'convex/react';
 import { useEffect, useRef } from 'react';
 
-import { FullPageCenter } from '@/app/components/ui/layout/full-page-center';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { DashboardShellSkeleton } from '@/app/routes/dashboard/dashboard-shell-skeleton';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 
@@ -174,9 +173,5 @@ function DashboardIndex() {
     initializeWorkflows,
   ]);
 
-  return (
-    <FullPageCenter>
-      <Spinner size="lg" />
-    </FullPageCenter>
-  );
+  return <DashboardShellSkeleton />;
 }


### PR DESCRIPTION
## Summary

Closes a cluster of visible flickers on the chat and dashboard pages where the wrong UI rendered for one frame during async resolution.

- **Refresh-page agent flash.** When a non-default agent was selected and the user refreshed, the chat header rendered the chat-agent (\"Assistant\") label for one frame before flipping to the real agent. `usePersistedState` now reads localStorage synchronously via a lazy `useState` initializer; `useEffectiveAgent` treats `useAuth().isLoading` as \"agent not yet known\" (the agent key is user-scoped, so even with lazy init the first render uses the wrong key while auth is in flight); `AgentSelector` renders a `Skeleton` inside the trigger instead of falling back to the default-agent label.
- **Thread-switch wrong skeleton.** `ThreadGate` showed the empty-welcome placeholder while `getThreadStatus` was loading for an existing thread. Added `ThreadLoadingSkeleton` (uses `MessagesSkeleton` + a pinned input skeleton) for the existing-thread path; `ChatSkeleton` stays for new-chat / Suspense paths.
- **Dashboard cold-boot pop.** `DashboardLayout`, `dashboard/index.tsx`, and `create-organization.tsx` showed a centered spinner while auth + member context resolved, then the whole layout chrome popped in around it. Replaced with `DashboardShellSkeleton` that mirrors the resolved layout's outer structure (matches `Navigation`'s `px-2` outer + `py-3` inner rows + `size-9` footer circles) so chrome slots in without reflow.
- **Residual reflow + no-op-write fixes.** `AgentSelector` trigger pinned to `min-w-40` with a `h-3.5` skeleton to kill horizontal and -2px vertical jitter on resolve. `usePersistedState` skips persisting on key change so a re-read doesn't echo `initialValue` back to a never-written key. Nav-item count in `DashboardShellSkeleton` is a flex spacer rather than a hardcoded 5, since the real count is CASL-gated (4–6 by role) and not knowable pre-auth.

## Test plan

- [ ] Refresh chat page with a non-default agent selected — no \"Assistant\" flash; skeleton in the agent selector trigger resolves directly to the real agent label.
- [ ] Switch between existing chat threads — messages skeleton (not the welcome placeholder) is shown while loading; input skeleton stays pinned to the bottom.
- [ ] Cold boot at `/dashboard` — shell skeleton renders immediately, chrome slots in without reflow when auth resolves.
- [ ] Cold boot at `/dashboard/create-organization` — same shell skeleton, no centered-spinner flash.
- [ ] Open `/dashboard/$id` while signed out / signed in — auth-loading path renders the shell skeleton, not a spinner; access-denied + org-switching paths still render their respective UI.
- [ ] `bun run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flash of default agent name while authentication is loading; agent selector now remains disabled until ready.

* **User Experience**
  * Improved loading states across dashboard and chat routes to use skeleton placeholders instead of generic spinners for a more consistent visual experience.
  * Updated agent selector trigger button to show a skeleton while loading and prevent layout shifts during state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->