### PR TITLE
feat(platform): prompt categories scaffolding, member 2FA surfacing, settings polish

### DIFF
--- a/services/platform/app/components/ui/data-display/copyable-field.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-field.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy } from 'lucide-react';
 import * as React from 'react';
 
+import { Description } from '@/app/components/ui/forms/description';
 import { Label } from '@/app/components/ui/forms/label';
 import { HStack } from '@/app/components/ui/layout/layout';
 import { useCopyButton } from '@/app/hooks/use-copy';
@@ -14,6 +15,8 @@ interface CopyableFieldProps {
   value: string;
   /** Optional label for the field */
   label?: string;
+  /** Optional description rendered below the field */
+  description?: React.ReactNode;
   /** Whether to show the value in a monospace font */
   mono?: boolean;
   /** Additional className for the pill container */
@@ -37,6 +40,7 @@ interface CopyableFieldProps {
 export const CopyableField = React.memo(function CopyableField({
   value,
   label,
+  description,
   mono = true,
   inputClassName,
   className,
@@ -51,6 +55,7 @@ export const CopyableField = React.memo(function CopyableField({
   const valueId = `${reactId}-value`;
   const valueTextId = `${reactId}-value-text`;
   const statusId = `${reactId}-status`;
+  const descriptionId = `${reactId}-description`;
   const { copied, onClick } = useCopyButton(value, {
     copiedDuration,
     onSuccess: onCopy,
@@ -66,7 +71,11 @@ export const CopyableField = React.memo(function CopyableField({
         onClick={onClick}
         aria-labelledby={label ? `${labelId} ${valueTextId}` : valueTextId}
         aria-label={copyAriaLabel}
-        aria-describedby={copied ? statusId : undefined}
+        aria-describedby={
+          [description ? descriptionId : null, copied ? statusId : null]
+            .filter(Boolean)
+            .join(' ') || undefined
+        }
         className={cn(
           'ring-border bg-muted/40 hover:bg-muted/60',
           'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
@@ -96,6 +105,11 @@ export const CopyableField = React.memo(function CopyableField({
           />
         )}
       </button>
+      {description && (
+        <Description id={descriptionId} className="text-xs">
+          {description}
+        </Description>
+      )}
       <span id={statusId} className="sr-only" role="status" aria-live="polite">
         {copied ? tCommon('actions.copied') : ''}
       </span>

--- a/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
@@ -32,8 +32,18 @@ import { TagChipInput } from './tag-chip-input';
 type PromptScope = 'global' | 'team' | 'personal';
 
 // Radix Select reserves `value=""` for "unselected" and throws if an Item
-// is rendered with it, so the explicit "None" choice rides on a sentinel.
+// is rendered with it, so the explicit "None" choice rides on a sentinel and
+// user-supplied categories are namespaced with `cat:` to avoid any chance of
+// collision with that sentinel.
 const CATEGORY_NONE_VALUE = '__none__';
+const CATEGORY_VALUE_PREFIX = 'cat:';
+const encodeCategory = (c: string) => `${CATEGORY_VALUE_PREFIX}${c}`;
+const decodeCategory = (v: string) =>
+  v === CATEGORY_NONE_VALUE
+    ? ''
+    : v.startsWith(CATEGORY_VALUE_PREFIX)
+      ? v.slice(CATEGORY_VALUE_PREFIX.length)
+      : v;
 
 // Positional tag equality. Mirrors `metadataDiffers` on the server so a
 // reorder counts as an edit. Module-scope so it's a stable reference across
@@ -185,7 +195,10 @@ function PromptFormDialogContent({
   const categoryOptions = useMemo(
     () => [
       { value: CATEGORY_NONE_VALUE, label: t('form.categoryNone') },
-      ...existingCategories.map((c) => ({ value: c, label: c })),
+      ...existingCategories.map((c) => ({
+        value: encodeCategory(c),
+        label: c,
+      })),
     ],
     [existingCategories, t],
   );
@@ -433,8 +446,10 @@ function PromptFormDialogContent({
         </HStack>
         <Select
           options={categoryOptions}
-          value={category === '' ? CATEGORY_NONE_VALUE : category}
-          onValueChange={(v) => setCategory(v === CATEGORY_NONE_VALUE ? '' : v)}
+          value={
+            category === '' ? CATEGORY_NONE_VALUE : encodeCategory(category)
+          }
+          onValueChange={(v) => setCategory(decodeCategory(v))}
           placeholder={t('form.categoryPlaceholder')}
           aria-labelledby={categoryLabelId}
         />

--- a/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-form-dialog.tsx
@@ -15,7 +15,6 @@ import { Text } from '@/app/components/ui/typography/text';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import {
-  MAX_PROMPT_CATEGORY_LEN,
   MAX_PROMPT_CONTENT_BYTES,
   MAX_PROMPT_DESCRIPTION_LEN,
   MAX_PROMPT_TAG_LEN,
@@ -31,6 +30,10 @@ import { AddCategoryPopover } from './add-category-popover';
 import { TagChipInput } from './tag-chip-input';
 
 type PromptScope = 'global' | 'team' | 'personal';
+
+// Radix Select reserves `value=""` for "unselected" and throws if an Item
+// is rendered with it, so the explicit "None" choice rides on a sentinel.
+const CATEGORY_NONE_VALUE = '__none__';
 
 // Positional tag equality. Mirrors `metadataDiffers` on the server so a
 // reorder counts as an edit. Module-scope so it's a stable reference across
@@ -176,9 +179,15 @@ function PromptFormDialogContent({
     return merged.sort((a, b) => a.localeCompare(b));
   }, [prompts, localCategories]);
 
+  // Radix Select treats `value=""` as "no selection" and rejects an Item
+  // with that value, so we use a sentinel for the explicit "None" choice and
+  // map it back to '' (the schema's optional-empty form) on submit.
   const categoryOptions = useMemo(
-    () => existingCategories.map((c) => ({ value: c, label: c })),
-    [existingCategories],
+    () => [
+      { value: CATEGORY_NONE_VALUE, label: t('form.categoryNone') },
+      ...existingCategories.map((c) => ({ value: c, label: c })),
+    ],
+    [existingCategories, t],
   );
 
   const teamOptions = useMemo(
@@ -342,6 +351,13 @@ function PromptFormDialogContent({
         required
         aria-required
       />
+      <Input
+        label={t('form.descriptionLabel')}
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder={t('form.descriptionPlaceholder')}
+        maxLength={MAX_PROMPT_DESCRIPTION_LEN}
+      />
       <div className="flex flex-col gap-1">
         <Textarea
           id={contentId}
@@ -380,13 +396,6 @@ function PromptFormDialogContent({
           </Text>
         )}
       </div>
-      <Input
-        label={t('form.descriptionLabel')}
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        placeholder={t('form.descriptionPlaceholder')}
-        maxLength={MAX_PROMPT_DESCRIPTION_LEN}
-      />
       <div className="flex flex-col gap-2">
         <label id={scopeLabelId} className="text-sm font-medium">
           {t('form.scopeLabel')}
@@ -422,23 +431,13 @@ function PromptFormDialogContent({
             onAddCategory={handleAddCategory}
           />
         </HStack>
-        {categoryOptions.length > 0 ? (
-          <Select
-            options={categoryOptions}
-            value={category}
-            onValueChange={setCategory}
-            placeholder={t('form.categoryPlaceholder')}
-            aria-labelledby={categoryLabelId}
-          />
-        ) : (
-          <Input
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            placeholder={t('form.categoryPlaceholder')}
-            maxLength={MAX_PROMPT_CATEGORY_LEN}
-            aria-labelledby={categoryLabelId}
-          />
-        )}
+        <Select
+          options={categoryOptions}
+          value={category === '' ? CATEGORY_NONE_VALUE : category}
+          onValueChange={(v) => setCategory(v === CATEGORY_NONE_VALUE ? '' : v)}
+          placeholder={t('form.categoryPlaceholder')}
+          aria-labelledby={categoryLabelId}
+        />
       </div>
       <TagChipInput
         value={tags}

--- a/services/platform/app/features/prompts/components/save-prompt-dialog.tsx
+++ b/services/platform/app/features/prompts/components/save-prompt-dialog.tsx
@@ -62,12 +62,16 @@ function SavePromptDialogContent({
   const bytesErrorId = `${bytesId}-error`;
   const isPending = savePrompt.isPending;
 
-  const existingCategories = useMemo(() => {
+  const { existingCategories, persistedCategorySet } = useMemo(() => {
     const fromPrompts = prompts
       .map((p) => p.category)
       .filter((c): c is string => !!c);
+    const persisted = new Set(fromPrompts);
     const merged = [...new Set([...fromPrompts, ...localCategories])];
-    return merged.sort((a, b) => a.localeCompare(b));
+    return {
+      existingCategories: merged.sort((a, b) => a.localeCompare(b)),
+      persistedCategorySet: persisted,
+    };
   }, [prompts, localCategories]);
 
   const teamOptions = useMemo(
@@ -176,6 +180,11 @@ function SavePromptDialogContent({
     setCategory(newCategory);
   }, []);
 
+  const handleRemoveLocalCategory = useCallback((cat: string) => {
+    setLocalCategories((prev) => prev.filter((c) => c !== cat));
+    setCategory((prev) => (prev === cat ? '' : prev));
+  }, []);
+
   return (
     <FormDialog
       open={open}
@@ -259,21 +268,46 @@ function SavePromptDialogContent({
         >
           {existingCategories.map((cat) => {
             const selected = category === cat;
+            const isLocalOnly = !persistedCategorySet.has(cat);
             return (
-              <button
+              <span
                 key={cat}
-                type="button"
-                aria-pressed={selected}
-                onClick={() => setCategory((prev) => (prev === cat ? '' : cat))}
                 className={cn(
-                  'rounded-full px-2.5 py-1.5 text-[13px] font-medium transition-colors',
+                  'inline-flex items-center rounded-full text-[13px] font-medium transition-colors',
                   selected
                     ? 'bg-primary text-primary-foreground'
-                    : 'bg-muted text-muted-foreground hover:bg-accent',
+                    : 'bg-muted text-muted-foreground',
                 )}
               >
-                {cat}
-              </button>
+                <button
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() =>
+                    setCategory((prev) => (prev === cat ? '' : cat))
+                  }
+                  className={cn(
+                    'rounded-full px-2.5 py-1.5',
+                    !selected && 'hover:bg-accent',
+                  )}
+                >
+                  {cat}
+                </button>
+                {isLocalOnly && (
+                  <button
+                    type="button"
+                    aria-label={t('addCategory.remove', { category: cat })}
+                    onClick={() => handleRemoveLocalCategory(cat)}
+                    className={cn(
+                      'rounded-full px-1.5 py-1.5 opacity-70 hover:opacity-100',
+                      selected
+                        ? 'hover:bg-primary-foreground/15'
+                        : 'hover:bg-accent',
+                    )}
+                  >
+                    ×
+                  </button>
+                )}
+              </span>
             );
           })}
           <AddCategoryPopover

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
@@ -186,25 +186,6 @@ export function AddMemberDialog({
           errorMessage={formState.errors.email?.message}
         />
 
-        <FormSection>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            label={tSettings('form.password')}
-            placeholder={tSettings('form.passwordPlaceholder')}
-            description={tSettings('form.forgotPassword')}
-            {...register('password')}
-            className="w-full"
-          />
-          {password && (
-            <ValidationCheckList
-              items={passwordValidationItems}
-              className="text-xs"
-            />
-          )}
-        </FormSection>
-
         <Select
           value={selectedRole}
           onValueChange={(value) => {
@@ -230,6 +211,25 @@ export function AddMemberDialog({
             { value: 'disabled', label: tSettings('roles.disabled') },
           ]}
         />
+
+        <FormSection>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            label={tSettings('form.password')}
+            placeholder={tSettings('form.passwordPlaceholder')}
+            description={tSettings('form.forgotPassword')}
+            {...register('password')}
+            className="w-full"
+          />
+          {password && (
+            <ValidationCheckList
+              items={passwordValidationItems}
+              className="text-xs"
+            />
+          )}
+        </FormSection>
       </FormDialog>
 
       <ViewDialog

--- a/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
@@ -47,6 +47,7 @@ type MemberLite = {
   displayName?: string;
   role?: string;
   email?: string;
+  twoFactorEnabled?: boolean;
 };
 
 interface EditMemberDialogProps {
@@ -295,7 +296,7 @@ export function EditMemberDialog({
         )}
       </FormSection>
 
-      {!isEditingSelf && member && (
+      {!isEditingSelf && member && member.twoFactorEnabled && (
         <TwoFactorResetControl
           memberId={member._id}
           memberName={member.displayName ?? member.email ?? ''}
@@ -346,9 +347,6 @@ function TwoFactorResetControl({
   const { t } = useT('twoFactor');
   return (
     <FormSection className="border-t pt-4">
-      <Text variant="caption" className="mb-2">
-        {t('enrollment.title')}
-      </Text>
       <Button
         type="button"
         variant="secondary"

--- a/services/platform/app/features/settings/organization/components/member-row-actions.tsx
+++ b/services/platform/app/features/settings/organization/components/member-row-actions.tsx
@@ -21,6 +21,7 @@ type MemberItem = {
   email?: string;
   role?: string;
   displayName?: string;
+  twoFactorEnabled?: boolean;
 };
 
 interface MemberRowActionsProps {

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -168,59 +168,56 @@ export function OrganizationSettings({
 
   return (
     <Stack>
-      <Form onSubmit={handleSubmit(onSubmit)} className="space-y-0">
-        <HStack
-          gap={3}
-          align="end"
-          justify="between"
-          className="sticky bottom-0 z-40"
-        >
-          <Input
-            id="org-name"
-            label={tSettings('organization.title')}
-            {...register('name')}
-            wrapperClassName="max-w-sm flex-1"
-          />
-          {isDirty && (
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? tCommon('actions.saving')
-                : tCommon('actions.saveChanges')}
-            </Button>
-          )}
-        </HStack>
+      <PageSection
+        title={tSettings('organization.detailsTitle')}
+        description={tSettings('organization.detailsDescription')}
+      >
+        <Form onSubmit={handleSubmit(onSubmit)} className="space-y-0">
+          <HStack
+            gap={3}
+            align="end"
+            justify="between"
+            className="sticky bottom-0 z-40"
+          >
+            <Input
+              id="org-name"
+              label={tSettings('organization.title')}
+              {...register('name')}
+              wrapperClassName="max-w-sm flex-1"
+            />
+            {isDirty && (
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? tCommon('actions.saving')
+                  : tCommon('actions.saveChanges')}
+              </Button>
+            )}
+          </HStack>
 
-        <div className="mt-4 max-w-sm">
-          <Select
-            id="default-locale"
-            label={tSettings('organization.defaultLocale')}
-            description={tSettings('organization.defaultLocaleHelp')}
-            value={defaultLocale}
-            onValueChange={(value) =>
-              setValue('defaultLocale', value, { shouldDirty: true })
-            }
-            disabled={isSubmitting}
-            options={localeOptions}
-          />
-        </div>
-      </Form>
+          <div className="mt-4 max-w-sm">
+            <Select
+              id="default-locale"
+              label={tSettings('organization.defaultLocale')}
+              value={defaultLocale}
+              onValueChange={(value) =>
+                setValue('defaultLocale', value, { shouldDirty: true })
+              }
+              disabled={isSubmitting}
+              options={localeOptions}
+            />
 
-      {organization && (
-        <div className="mt-4 max-w-sm space-y-2">
-          <Stack gap={1}>
-            <span className="text-foreground text-sm font-medium">
-              {tSettings('organization.organizationId')}
-            </span>
-            <span className="text-muted-foreground text-xs">
-              {tSettings('organization.organizationIdHelp')}
-            </span>
-          </Stack>
-          <CopyableField
-            value={organization._id}
-            copyAriaLabel={tSettings('organization.copyOrganizationId')}
-          />
-        </div>
-      )}
+            {organization && (
+              <div className="mt-4 max-w-sm">
+                <CopyableField
+                  value={organization._id}
+                  label={tSettings('organization.organizationId')}
+                  copyAriaLabel={tSettings('organization.copyOrganizationId')}
+                />
+              </div>
+            )}
+          </div>
+        </Form>
+      </PageSection>
 
       <PageSection
         title={tSettings('organization.membersTitle')}

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -207,7 +207,7 @@ export function OrganizationSettings({
             />
 
             {organization && (
-              <div className="mt-4 max-w-sm">
+              <div className="mt-4">
                 <CopyableField
                   value={organization._id}
                   label={tSettings('organization.organizationId')}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -656,6 +656,8 @@ import type * as products_update_products from "../products/update_products.js";
 import type * as products_upsert_product_translation from "../products/upsert_product_translation.js";
 import type * as products_validators from "../products/validators.js";
 import type * as prompts_actions from "../prompts/actions.js";
+import type * as prompts_categories from "../prompts/categories.js";
+import type * as prompts_category_access from "../prompts/category_access.js";
 import type * as prompts_constants from "../prompts/constants.js";
 import type * as prompts_generate_title from "../prompts/generate_title.js";
 import type * as prompts_mutations from "../prompts/mutations.js";
@@ -1714,6 +1716,8 @@ declare const fullApi: ApiFromModules<{
   "products/upsert_product_translation": typeof products_upsert_product_translation;
   "products/validators": typeof products_validators;
   "prompts/actions": typeof prompts_actions;
+  "prompts/categories": typeof prompts_categories;
+  "prompts/category_access": typeof prompts_category_access;
   "prompts/constants": typeof prompts_constants;
   "prompts/generate_title": typeof prompts_generate_title;
   "prompts/mutations": typeof prompts_mutations;

--- a/services/platform/convex/members/queries.test.ts
+++ b/services/platform/convex/members/queries.test.ts
@@ -478,6 +478,7 @@ describe('listByOrganizationHandler', () => {
         createdAt: 1000,
         displayName: 'Alice',
         email: 'alice@example.com',
+        twoFactorEnabled: false,
       },
     ]);
   });
@@ -529,6 +530,7 @@ describe('listByOrganizationHandler', () => {
         createdAt: 1000,
         displayName: undefined,
         email: undefined,
+        twoFactorEnabled: false,
       },
       {
         _id: 'm_2',
@@ -538,6 +540,7 @@ describe('listByOrganizationHandler', () => {
         createdAt: 2000,
         displayName: 'Bob',
         email: 'bob@example.com',
+        twoFactorEnabled: false,
       },
     ]);
   });

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -148,6 +148,7 @@ export async function listByOrganizationHandler(
     result.page.map(async (member) => {
       let displayName: string | undefined;
       let email: string | undefined;
+      let twoFactorEnabled = false;
       try {
         const userResult = await ctx.runQuery(
           components.betterAuth.adapter.findOne,
@@ -158,6 +159,7 @@ export async function listByOrganizationHandler(
         );
         displayName = userResult?.name;
         email = userResult?.email;
+        twoFactorEnabled = userResult?.twoFactorEnabled === true;
       } catch (error) {
         console.warn(
           '[Members] Failed to fetch user details',
@@ -178,6 +180,7 @@ export async function listByOrganizationHandler(
         createdAt: member.createdAt,
         displayName,
         email,
+        twoFactorEnabled,
       };
     }),
   );
@@ -194,6 +197,7 @@ export const listByOrganization = query({
       createdAt: v.number(),
       displayName: v.optional(v.string()),
       email: v.optional(v.string()),
+      twoFactorEnabled: v.boolean(),
     }),
   ),
   handler: listByOrganizationHandler,

--- a/services/platform/convex/members/types.ts
+++ b/services/platform/convex/members/types.ts
@@ -17,6 +17,7 @@ export interface BetterAuthUser {
   createdAt: number;
   updatedAt: number;
   userId?: string | null;
+  twoFactorEnabled?: boolean | null;
 }
 
 /**

--- a/services/platform/convex/prompts/categories.ts
+++ b/services/platform/convex/prompts/categories.ts
@@ -112,16 +112,13 @@ export async function findCategoryInBucket(
     nameLower: string;
   },
 ): Promise<Doc<'promptCategories'> | null> {
-  const candidates = await ctx.db
+  for await (const c of ctx.db
     .query('promptCategories')
     .withIndex('by_organizationId_and_nameLower', (q) =>
       q
         .eq('organizationId', args.organizationId)
         .eq('nameLower', args.nameLower),
-    )
-    .collect();
-
-  for (const c of candidates) {
+    )) {
     if (c.scope !== args.scope) continue;
     if (args.scope === 'team' && c.teamId !== args.teamId) continue;
     if (args.scope === 'personal' && c.createdBy !== args.createdBy) continue;

--- a/services/platform/convex/prompts/categories.ts
+++ b/services/platform/convex/prompts/categories.ts
@@ -1,0 +1,443 @@
+/**
+ * `promptCategories` queries and mutations.
+ *
+ * The table itself is additive in this slice: prompts still carry the
+ * legacy `category: string` field. The lazy migration that translates
+ * legacy strings into `categoryId` rows lives with the prompt
+ * create/update mutations (slice 2). This module only owns the lifecycle
+ * of the category rows themselves.
+ *
+ * Access rules (see `category_access.ts`):
+ *  - Personal: any member can create their own; only the creator
+ *    manages (rename/delete) — admin status does NOT override.
+ *  - Team / global: admins only, end to end.
+ *
+ * The "delete clears `categoryId` on linked prompts" fan-out is wired
+ * defensively even though no prompt row references `categoryId` yet —
+ * once slice 2 lands, delete will already do the right thing without a
+ * follow-up edit here.
+ */
+
+import { ConvexError, v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Doc } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { getUserTeamIds } from '../lib/get_user_teams';
+import { requireAuthenticatedUser } from '../lib/rls/auth/require_authenticated_user';
+import { mutationWithRLS } from '../lib/rls/helpers/mutation_with_rls';
+import { queryWithRLS } from '../lib/rls/helpers/query_with_rls';
+import { validateOrganizationAccess } from '../lib/rls/organization/validate_organization_access';
+import type { RLSContext } from '../lib/rls/types';
+import {
+  canCreateCategoryInScope,
+  canManageCategory,
+  toCategoryAccessShape,
+} from './category_access';
+import { MAX_PROMPT_CATEGORY_LEN } from './constants';
+import {
+  listCategoriesResultValidator,
+  promptCategoryValidator,
+  promptScopeValidator,
+} from './validators';
+
+/**
+ * Audit emitter for category lifecycle. Mirrors `emitPromptAudit` in
+ * `mutations.ts` — routed through an internal mutation because the RLS
+ * wrapper denies non-admin direct writes to `auditLogs`.
+ */
+async function emitCategoryAudit(
+  ctx: MutationCtx,
+  rlsContext: RLSContext,
+  action: string,
+  resourceId: string,
+  resourceName: string,
+  newState?: Record<string, unknown>,
+): Promise<void> {
+  await ctx.runMutation(internal.audit_logs.internal_mutations.createAuditLog, {
+    organizationId: rlsContext.organizationId,
+    actorId: rlsContext.user.userId,
+    actorEmail: rlsContext.user.email,
+    actorRole: rlsContext.role,
+    actorType: 'user',
+    action,
+    category: 'data',
+    resourceType: 'prompt_category',
+    resourceId,
+    resourceName,
+    newState,
+    status: 'success',
+  });
+}
+
+function normalizeName(name: string): { name: string; nameLower: string } {
+  const trimmed = name.trim();
+  return { name: trimmed, nameLower: trimmed.toLowerCase() };
+}
+
+function assertNameValid(name: string): void {
+  if (name.length === 0) {
+    throw new ConvexError({
+      code: 'invalid_argument',
+      message: 'Category name cannot be empty',
+    });
+  }
+  if (name.length > MAX_PROMPT_CATEGORY_LEN) {
+    throw new ConvexError({
+      code: 'too_large',
+      message: `Category name exceeds ${MAX_PROMPT_CATEGORY_LEN} characters`,
+    });
+  }
+}
+
+/**
+ * Find an existing category in the same "uniqueness bucket" as the
+ * candidate — used both by `createCategory` (reject) and the future lazy-
+ * migration code path (find-or-create). Buckets:
+ *  - personal: same (org, scope, createdBy, nameLower)
+ *  - team:     same (org, scope, teamId, nameLower)
+ *  - global:   same (org, scope, nameLower)
+ *
+ * Uses the `by_organizationId_and_nameLower` index to scope the scan to
+ * matching-name rows in the org; bucket filtering happens in memory on
+ * what is expected to be a tiny result set (collisions only).
+ */
+export async function findCategoryInBucket(
+  ctx: { db: MutationCtx['db'] },
+  args: {
+    organizationId: string;
+    scope: 'global' | 'team' | 'personal';
+    teamId?: string;
+    createdBy: string;
+    nameLower: string;
+  },
+): Promise<Doc<'promptCategories'> | null> {
+  const candidates = await ctx.db
+    .query('promptCategories')
+    .withIndex('by_organizationId_and_nameLower', (q) =>
+      q
+        .eq('organizationId', args.organizationId)
+        .eq('nameLower', args.nameLower),
+    )
+    .collect();
+
+  for (const c of candidates) {
+    if (c.scope !== args.scope) continue;
+    if (args.scope === 'team' && c.teamId !== args.teamId) continue;
+    if (args.scope === 'personal' && c.createdBy !== args.createdBy) continue;
+    return c;
+  }
+  return null;
+}
+
+/**
+ * Categories the caller can see, bucketed by scope. Drives the picker.
+ *
+ * Visibility:
+ *  - personal: rows the caller created.
+ *  - team:     rows for teams the caller is a member of.
+ *  - global:   all rows in the org.
+ *
+ * The picker on the form filters further by the form's current scope
+ * (and selected teamId for team-scope prompts) — we return all three
+ * buckets at once so toggling scope doesn't trigger a new round-trip.
+ */
+export const listCategories = queryWithRLS({
+  args: {
+    organizationId: v.string(),
+  },
+  returns: listCategoriesResultValidator,
+  handler: async (ctx, args) => {
+    const user = await requireAuthenticatedUser(ctx);
+    // Org membership gate — non-members get an empty result rather than
+    // an error so the picker degrades gracefully when the user is in the
+    // middle of an org switch.
+    await validateOrganizationAccess(ctx, args.organizationId, undefined, user);
+
+    const userTeamIds = await getUserTeamIds(ctx, user.userId);
+    const userTeamSet = new Set(userTeamIds);
+
+    const personal: Doc<'promptCategories'>[] = [];
+    const team: Doc<'promptCategories'>[] = [];
+    const global: Doc<'promptCategories'>[] = [];
+
+    for await (const row of ctx.db
+      .query('promptCategories')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )) {
+      if (row.scope === 'global') {
+        global.push(row);
+      } else if (row.scope === 'team') {
+        if (row.teamId && userTeamSet.has(row.teamId)) team.push(row);
+      } else if (row.scope === 'personal') {
+        if (row.createdBy === user.userId) personal.push(row);
+      }
+    }
+
+    const byName = (a: Doc<'promptCategories'>, b: Doc<'promptCategories'>) =>
+      a.nameLower.localeCompare(b.nameLower);
+    personal.sort(byName);
+    team.sort(byName);
+    global.sort(byName);
+
+    return { personal, team, global };
+  },
+});
+
+/**
+ * Create a category at the requested scope. Personal: any member.
+ * Team / global: admins only. Duplicate-name (case-insensitive) in the
+ * same uniqueness bucket is rejected.
+ *
+ * Team-scope creates do NOT also assert that the actor is a member of
+ * the team — admins manage team categories whether they belong to the
+ * team or not. (The prompt-side write invariant still keeps non-members
+ * from attaching to prompts they can't read.)
+ */
+export const createCategory = mutationWithRLS({
+  args: {
+    organizationId: v.string(),
+    scope: promptScopeValidator,
+    teamId: v.optional(v.string()),
+    name: v.string(),
+  },
+  returns: promptCategoryValidator,
+  handler: async (ctx, args) => {
+    const user = await requireAuthenticatedUser(ctx);
+    const rlsContext = await validateOrganizationAccess(
+      ctx,
+      args.organizationId,
+      undefined,
+      user,
+    );
+
+    if (
+      !canCreateCategoryInScope({
+        scope: args.scope,
+        isOrgAdmin: rlsContext.isAdmin,
+      })
+    ) {
+      throw new ConvexError({
+        code: 'forbidden',
+        message: `Only admins can create ${args.scope} categories`,
+      });
+    }
+
+    if (args.scope === 'team' && !args.teamId) {
+      throw new ConvexError({
+        code: 'invalid_argument',
+        message: 'Team-scope categories must specify a teamId',
+      });
+    }
+    // Ignore caller-supplied teamId for non-team scopes so a stray value
+    // can't leak into a personal/global row and confuse the dedup check.
+    const teamId = args.scope === 'team' ? args.teamId : undefined;
+
+    const { name, nameLower } = normalizeName(args.name);
+    assertNameValid(name);
+
+    const duplicate = await findCategoryInBucket(ctx, {
+      organizationId: args.organizationId,
+      scope: args.scope,
+      teamId,
+      createdBy: user.userId,
+      nameLower,
+    });
+    if (duplicate) {
+      throw new ConvexError({
+        code: 'duplicate_category',
+        message: `A ${args.scope} category named "${duplicate.name}" already exists`,
+      });
+    }
+
+    const id = await ctx.db.insert('promptCategories', {
+      organizationId: args.organizationId,
+      scope: args.scope,
+      teamId,
+      createdBy: user.userId,
+      name,
+      nameLower,
+    });
+
+    const row = await ctx.db.get(id);
+    if (!row) {
+      throw new ConvexError({
+        code: 'internal_error',
+        message: 'Failed to read category after insert',
+      });
+    }
+
+    await emitCategoryAudit(
+      ctx,
+      rlsContext,
+      'prompt_category.created',
+      id,
+      name,
+      { scope: args.scope, teamId },
+    );
+
+    return row;
+  },
+});
+
+/**
+ * Rename a category. Manageability follows scope:
+ *  - personal: creator only (admin status does NOT override).
+ *  - team / global: admins only.
+ *
+ * The new name must be unique in the same uniqueness bucket.
+ */
+export const renameCategory = mutationWithRLS({
+  args: {
+    categoryId: v.id('promptCategories'),
+    name: v.string(),
+  },
+  returns: promptCategoryValidator,
+  handler: async (ctx, args) => {
+    const user = await requireAuthenticatedUser(ctx);
+    const existing = await ctx.db.get(args.categoryId);
+    if (!existing) {
+      throw new ConvexError({
+        code: 'not_found',
+        message: 'Category not found',
+      });
+    }
+    const rlsContext = await validateOrganizationAccess(
+      ctx,
+      existing.organizationId,
+      undefined,
+      user,
+    );
+
+    if (
+      !canManageCategory({
+        category: toCategoryAccessShape(existing),
+        userId: user.userId,
+        isOrgAdmin: rlsContext.isAdmin,
+      })
+    ) {
+      throw new ConvexError({
+        code: 'forbidden',
+        message: 'You cannot manage this category',
+      });
+    }
+
+    const { name, nameLower } = normalizeName(args.name);
+    assertNameValid(name);
+
+    if (nameLower !== existing.nameLower) {
+      const duplicate = await findCategoryInBucket(ctx, {
+        organizationId: existing.organizationId,
+        scope: existing.scope,
+        teamId: existing.teamId,
+        createdBy: existing.createdBy,
+        nameLower,
+      });
+      if (duplicate && duplicate._id !== existing._id) {
+        throw new ConvexError({
+          code: 'duplicate_category',
+          message: `A ${existing.scope} category named "${duplicate.name}" already exists`,
+        });
+      }
+    }
+
+    await ctx.db.patch(args.categoryId, { name, nameLower });
+
+    const updated = await ctx.db.get(args.categoryId);
+    if (!updated) {
+      throw new ConvexError({
+        code: 'internal_error',
+        message: 'Failed to read category after rename',
+      });
+    }
+
+    await emitCategoryAudit(
+      ctx,
+      rlsContext,
+      'prompt_category.renamed',
+      args.categoryId,
+      name,
+      { previousName: existing.name },
+    );
+
+    return updated;
+  },
+});
+
+/**
+ * Delete a category. Sets `categoryId` to undefined on every linked prompt
+ * in the same transaction so the fan-out is atomic with the row removal.
+ * Version-history snapshots keep their (now-dangling) id — slice 2's
+ * display path tolerates this and falls back to the snapshot's legacy
+ * `category` string or a "(deleted)" label.
+ *
+ * No dedicated `by_organizationId_and_categoryId` index yet; we scan via
+ * the existing org index. Deletes are rare; if scan cost becomes an issue
+ * after slice 2 wires up `categoryId`, add the index without changing
+ * this code.
+ */
+export const deleteCategory = mutationWithRLS({
+  args: {
+    categoryId: v.id('promptCategories'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const user = await requireAuthenticatedUser(ctx);
+    const existing = await ctx.db.get(args.categoryId);
+    if (!existing) {
+      throw new ConvexError({
+        code: 'not_found',
+        message: 'Category not found',
+      });
+    }
+    const rlsContext = await validateOrganizationAccess(
+      ctx,
+      existing.organizationId,
+      undefined,
+      user,
+    );
+
+    if (
+      !canManageCategory({
+        category: toCategoryAccessShape(existing),
+        userId: user.userId,
+        isOrgAdmin: rlsContext.isAdmin,
+      })
+    ) {
+      throw new ConvexError({
+        code: 'forbidden',
+        message: 'You cannot manage this category',
+      });
+    }
+
+    // Fan-out: clear `categoryId` on every prompt row that referenced this
+    // category. Slice 2 stamps `categoryId`; until then this loop is a
+    // no-op fast path because the field is never set, but wiring it now
+    // means the contract is in place from day one.
+    let clearedCount = 0;
+    for await (const prompt of ctx.db
+      .query('promptTemplates')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', existing.organizationId),
+      )) {
+      if (prompt.categoryId === args.categoryId) {
+        await ctx.db.patch(prompt._id, { categoryId: undefined });
+        clearedCount++;
+      }
+    }
+
+    await ctx.db.delete(args.categoryId);
+
+    await emitCategoryAudit(
+      ctx,
+      rlsContext,
+      'prompt_category.deleted',
+      args.categoryId,
+      existing.name,
+      { scope: existing.scope, teamId: existing.teamId, clearedCount },
+    );
+
+    return null;
+  },
+});

--- a/services/platform/convex/prompts/category_access.test.ts
+++ b/services/platform/convex/prompts/category_access.test.ts
@@ -1,0 +1,318 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CategoryAccessShape,
+  type PromptScope,
+  assertCategoryScopeMatchesPromptScope,
+  canCreateCategoryInScope,
+  canManageCategory,
+} from './category_access';
+
+function makeCategory(
+  overrides: Partial<CategoryAccessShape> = {},
+): CategoryAccessShape {
+  return { scope: 'personal', createdBy: 'user_a', ...overrides };
+}
+
+describe('canCreateCategoryInScope', () => {
+  it.each<[PromptScope, boolean]>([
+    ['personal', true],
+    ['team', false],
+    ['global', false],
+  ])('non-admin can create personal only (%s → %s)', (scope, expected) => {
+    expect(canCreateCategoryInScope({ scope, isOrgAdmin: false })).toBe(
+      expected,
+    );
+  });
+
+  it.each<PromptScope>(['personal', 'team', 'global'])(
+    'admin can create at every scope (%s)',
+    (scope) => {
+      expect(canCreateCategoryInScope({ scope, isOrgAdmin: true })).toBe(true);
+    },
+  );
+});
+
+describe('canManageCategory', () => {
+  describe('personal scope', () => {
+    it('creator can manage their own personal category', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+          userId: 'user_a',
+          isOrgAdmin: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('non-creator non-admin cannot manage', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+          userId: 'user_b',
+          isOrgAdmin: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('non-creator admin cannot manage — personal stays personal', () => {
+      // This is the load-bearing case: admin status does NOT override the
+      // personal-scope creator gate. A personal category created by user_a
+      // remains exclusively user_a's to rename/delete, even if user_b is
+      // an org admin.
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+          userId: 'user_b',
+          isOrgAdmin: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('creator admin can manage (because they are creator, not because admin)', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+          userId: 'user_a',
+          isOrgAdmin: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('team scope', () => {
+    it('admin can manage even when not the creator', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'team', createdBy: 'user_a' }),
+          userId: 'user_b',
+          isOrgAdmin: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('non-admin cannot manage even if they created it', () => {
+      // Non-admins can't create team categories in the first place, but if
+      // legacy data exists or roles were revoked, the rule still holds.
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'team', createdBy: 'user_a' }),
+          userId: 'user_a',
+          isOrgAdmin: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('global scope', () => {
+    it('admin can manage', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'global', createdBy: 'user_a' }),
+          userId: 'user_b',
+          isOrgAdmin: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('non-admin cannot manage', () => {
+      expect(
+        canManageCategory({
+          category: makeCategory({ scope: 'global', createdBy: 'user_a' }),
+          userId: 'user_a',
+          isOrgAdmin: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});
+
+describe('assertCategoryScopeMatchesPromptScope', () => {
+  const callArgs = (
+    overrides: Partial<
+      Parameters<typeof assertCategoryScopeMatchesPromptScope>[0]
+    >,
+  ): Parameters<typeof assertCategoryScopeMatchesPromptScope>[0] => ({
+    promptScope: 'personal',
+    category: makeCategory(),
+    userId: 'user_a',
+    userTeamIds: [],
+    ...overrides,
+  });
+
+  // ---- global category: always allowed ----
+  it.each<PromptScope>(['personal', 'team', 'global'])(
+    'global category works on a %s prompt',
+    (promptScope) => {
+      expect(() =>
+        assertCategoryScopeMatchesPromptScope(
+          callArgs({
+            promptScope,
+            promptTeamId: promptScope === 'team' ? 'team_1' : undefined,
+            category: makeCategory({ scope: 'global', createdBy: 'admin_x' }),
+          }),
+        ),
+      ).not.toThrow();
+    },
+  );
+
+  // ---- global prompt: only global category ----
+  it('global prompt rejects a personal category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'global',
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  it('global prompt rejects a team category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'global',
+          category: makeCategory({
+            scope: 'team',
+            teamId: 'team_1',
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  // ---- team prompt: global, or own-team team-category ----
+  it('team prompt accepts a matching-team team category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'team',
+          promptTeamId: 'team_1',
+          category: makeCategory({
+            scope: 'team',
+            teamId: 'team_1',
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('team prompt rejects a different-team team category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'team',
+          promptTeamId: 'team_1',
+          category: makeCategory({
+            scope: 'team',
+            teamId: 'team_2',
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  it('team prompt rejects a personal category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'team',
+          promptTeamId: 'team_1',
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  it('team prompt rejects a team category whose teamId is missing (defensive)', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'team',
+          promptTeamId: 'team_1',
+          category: makeCategory({
+            scope: 'team',
+            teamId: undefined,
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  // ---- personal prompt: own-personal, own-team, or global ----
+  it('personal prompt accepts the caller’s own personal category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'personal',
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('personal prompt rejects another user’s personal category', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'personal',
+          category: makeCategory({ scope: 'personal', createdBy: 'user_b' }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  it('personal prompt accepts a team category for a team the user is in', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'personal',
+          userTeamIds: ['team_1', 'team_2'],
+          category: makeCategory({
+            scope: 'team',
+            teamId: 'team_2',
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('personal prompt rejects a team category for a team the user is not in', () => {
+    expect(() =>
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'personal',
+          userTeamIds: ['team_1'],
+          category: makeCategory({
+            scope: 'team',
+            teamId: 'team_99',
+            createdBy: 'admin_x',
+          }),
+        }),
+      ),
+    ).toThrow(ConvexError);
+  });
+
+  it('throws ConvexError with code "forbidden" on violation', () => {
+    try {
+      assertCategoryScopeMatchesPromptScope(
+        callArgs({
+          promptScope: 'global',
+          category: makeCategory({ scope: 'personal', createdBy: 'user_a' }),
+        }),
+      );
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConvexError);
+      const data = (err as ConvexError<{ code: string }>).data;
+      expect(data.code).toBe('forbidden');
+    }
+  });
+});

--- a/services/platform/convex/prompts/category_access.test.ts
+++ b/services/platform/convex/prompts/category_access.test.ts
@@ -311,8 +311,8 @@ describe('assertCategoryScopeMatchesPromptScope', () => {
       throw new Error('expected throw');
     } catch (err) {
       expect(err).toBeInstanceOf(ConvexError);
-      const data = (err as ConvexError<{ code: string }>).data;
-      expect(data.code).toBe('forbidden');
+      if (!(err instanceof ConvexError)) throw err;
+      expect((err.data as { code: string }).code).toBe('forbidden');
     }
   });
 });

--- a/services/platform/convex/prompts/category_access.ts
+++ b/services/platform/convex/prompts/category_access.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure-function access rules for `promptCategories`.
+ *
+ * Kept ctx-free so the rules can be unit-tested in isolation and reused
+ * verbatim by the picker on the client. Three rules:
+ *
+ *  - `canCreateCategoryInScope`: who is allowed to create a category at
+ *    each scope.
+ *  - `canManageCategory`: who is allowed to rename/delete an existing
+ *    category. Personal stays personal even when the creator is an admin —
+ *    only the creator manages a personal-scope row.
+ *  - `assertCategoryScopeMatchesPromptScope`: the write-side invariant that
+ *    keeps a prompt's category readable by every viewer of the prompt. A
+ *    prompt at scope X can only reference a category whose scope is at
+ *    least as permissive as X (and, where relevant, owned by/visible to
+ *    the caller). This is what lets every reader resolve the category name
+ *    without per-viewer hiding.
+ */
+
+import { ConvexError } from 'convex/values';
+
+import type { Doc } from '../_generated/dataModel';
+
+export type PromptScope = 'global' | 'team' | 'personal';
+
+/**
+ * Subset of a `promptCategories` row needed by the rule checks. Stays
+ * structural so client callers can pass their own typed shape without
+ * importing Convex's `Doc<>` helper.
+ */
+export interface CategoryAccessShape {
+  scope: PromptScope;
+  teamId?: string;
+  createdBy: string;
+}
+
+/**
+ * Who can create a category at `scope`. Team and global are admin-only,
+ * matching the prompt-scope creation rules. Personal is open to any member
+ * (they're creating it for themselves).
+ */
+export function canCreateCategoryInScope(args: {
+  scope: PromptScope;
+  isOrgAdmin: boolean;
+}): boolean {
+  if (args.scope === 'personal') return true;
+  return args.isOrgAdmin;
+}
+
+/**
+ * Who can rename or delete an existing category.
+ *
+ * Personal categories are creator-only — they remain personal even when
+ * the creator happens to be an admin. Team and global categories are
+ * managed by org admins regardless of which admin created the row.
+ */
+export function canManageCategory(args: {
+  category: CategoryAccessShape;
+  userId: string;
+  isOrgAdmin: boolean;
+}): boolean {
+  const { category, userId, isOrgAdmin } = args;
+  if (category.scope === 'personal') return category.createdBy === userId;
+  return isOrgAdmin;
+}
+
+/**
+ * Write-side invariant: a prompt at `promptScope` can only carry a
+ * category whose scope is readable by every viewer of the prompt.
+ *
+ * | Prompt scope | Allowed category scopes                                  |
+ * |--------------|----------------------------------------------------------|
+ * | global       | global only                                              |
+ * | team         | global, OR team-scope category matching the prompt team  |
+ * | personal     | global, your-own-personal, OR a team you are a member of |
+ *
+ * Throws `ConvexError({ code: 'forbidden', ... })` on violation so callers
+ * surface the error without leaking which combination was attempted.
+ */
+export function assertCategoryScopeMatchesPromptScope(args: {
+  promptScope: PromptScope;
+  /** Required iff `promptScope === 'team'`. */
+  promptTeamId?: string;
+  category: CategoryAccessShape;
+  userId: string;
+  userTeamIds: readonly string[];
+}): void {
+  const { promptScope, promptTeamId, category, userId, userTeamIds } = args;
+
+  // Global categories are universally readable — always allowed.
+  if (category.scope === 'global') return;
+
+  if (promptScope === 'global') {
+    throw new ConvexError({
+      code: 'forbidden',
+      message: 'Global prompts can only carry global categories',
+    });
+  }
+
+  if (promptScope === 'team') {
+    if (
+      category.scope === 'team' &&
+      category.teamId !== undefined &&
+      category.teamId === promptTeamId
+    ) {
+      return;
+    }
+    throw new ConvexError({
+      code: 'forbidden',
+      message:
+        "Team prompts can only carry global categories or the team's own categories",
+    });
+  }
+
+  // promptScope === 'personal'
+  if (category.scope === 'personal' && category.createdBy === userId) return;
+  if (
+    category.scope === 'team' &&
+    category.teamId !== undefined &&
+    userTeamIds.includes(category.teamId)
+  ) {
+    return;
+  }
+  throw new ConvexError({
+    code: 'forbidden',
+    message:
+      'Personal prompts can only carry your own personal, your-team, or global categories',
+  });
+}
+
+/**
+ * Narrowing helper for callers that hand us a full `Doc<'promptCategories'>`.
+ * Keeps call sites readable when we already loaded the row from the db.
+ */
+export function toCategoryAccessShape(
+  doc: Doc<'promptCategories'>,
+): CategoryAccessShape {
+  return {
+    scope: doc.scope,
+    teamId: doc.teamId,
+    createdBy: doc.createdBy,
+  };
+}

--- a/services/platform/convex/prompts/schema.ts
+++ b/services/platform/convex/prompts/schema.ts
@@ -13,7 +13,18 @@ export const promptTemplatesTable = defineTable({
   description: v.optional(v.string()),
   scope: promptScopeValidator,
   teamId: v.optional(v.string()),
+  /**
+   * Legacy free-form category string. Coexists with `categoryId` during the
+   * `promptCategories` transition: writes prefer `categoryId`, reads fall
+   * back to this string when no id is set. A future cleanup migration will
+   * sweep remaining string-only rows once usage drops to near-zero.
+   */
   category: v.optional(v.string()),
+  /**
+   * Reference to the structured `promptCategories` row. Optional during the
+   * transition window — slice 2 wires lazy migration on any prompt mutation.
+   */
+  categoryId: v.optional(v.id('promptCategories')),
   tags: v.optional(v.array(v.string())),
   usageCount: v.number(),
   /** The message ID this prompt was saved from, if any. */
@@ -54,6 +65,8 @@ export const promptTemplatesTable = defineTable({
         title: v.string(),
         description: v.optional(v.string()),
         category: v.optional(v.string()),
+        /** See `promptTemplatesTable.categoryId` — same transition rules. */
+        categoryId: v.optional(v.id('promptCategories')),
         tags: v.optional(v.array(v.string())),
         scope: promptScopeValidator,
         teamId: v.optional(v.string()),
@@ -83,3 +96,47 @@ export const promptTemplatesTable = defineTable({
     'organizationId',
     'lifecycleStatus',
   ]);
+
+/**
+ * Named categories that prompts attach to via `promptTemplates.categoryId`.
+ *
+ * Scope semantics:
+ *  - `personal` — visible to (and manageable by) `createdBy` only.
+ *  - `team`     — visible to members of `teamId`; manageable by org admins.
+ *  - `global`   — visible to the whole org; manageable by org admins.
+ *
+ * The write-side invariant (see `assertCategoryScopeMatchesPromptScope`)
+ * keeps a prompt's category scope at least as permissive as the prompt's
+ * own scope, so any viewer who can read the prompt can also read the
+ * category — there is no per-viewer rendering path.
+ *
+ * Categories with the same `name` may legitimately coexist within an org
+ * (e.g. one user's personal "Drafts" and a team's "Drafts"). Uniqueness is
+ * enforced within a bucket — `(organizationId, scope, teamId, createdBy)`
+ * for personal; `(organizationId, scope, teamId)` for team; `(organizationId,
+ * scope)` for global. `nameLower` exists so that find-or-create on the
+ * lazy-migration path can do case-insensitive lookups without a full scan.
+ */
+export const promptCategoriesTable = defineTable({
+  organizationId: v.string(),
+  scope: promptScopeValidator,
+  /** Required iff `scope === 'team'`. */
+  teamId: v.optional(v.string()),
+  createdBy: v.string(),
+  name: v.string(),
+  /** `name.trim().toLowerCase()` — for case-insensitive dedup scans. */
+  nameLower: v.string(),
+})
+  .index('by_organizationId', ['organizationId'])
+  .index('by_organizationId_and_scope', ['organizationId', 'scope'])
+  .index('by_organizationId_and_scope_and_teamId', [
+    'organizationId',
+    'scope',
+    'teamId',
+  ])
+  .index('by_organizationId_and_scope_and_createdBy', [
+    'organizationId',
+    'scope',
+    'createdBy',
+  ])
+  .index('by_organizationId_and_nameLower', ['organizationId', 'nameLower']);

--- a/services/platform/convex/prompts/validators.ts
+++ b/services/platform/convex/prompts/validators.ts
@@ -26,6 +26,7 @@ const promptVersionEntryStoredValidator = v.object({
   title: v.string(),
   description: v.optional(v.string()),
   category: v.optional(v.string()),
+  categoryId: v.optional(v.id('promptCategories')),
   tags: v.optional(v.array(v.string())),
   scope: promptScopeValidator,
   teamId: v.optional(v.string()),
@@ -47,6 +48,7 @@ const promptVersionEntryValidator = v.object({
   title: v.string(),
   description: v.optional(v.string()),
   category: v.optional(v.string()),
+  categoryId: v.optional(v.id('promptCategories')),
   tags: v.optional(v.array(v.string())),
   scope: promptScopeValidator,
   teamId: v.optional(v.string()),
@@ -69,6 +71,7 @@ const promptTemplateBaseFields = {
   scope: promptScopeValidator,
   teamId: v.optional(v.string()),
   category: v.optional(v.string()),
+  categoryId: v.optional(v.id('promptCategories')),
   tags: v.optional(v.array(v.string())),
   usageCount: v.number(),
   sourceMessageId: v.optional(v.string()),
@@ -93,4 +96,31 @@ export const promptHistoryResultValidator = v.object({
   current: promptVersionEntryValidator,
   history: v.array(promptVersionEntryValidator),
   totalCount: v.number(),
+});
+
+/**
+ * Row shape returned by category queries/mutations. Mirrors the
+ * `promptCategoriesTable` definition exactly so `ctx.db.get(...)` round-trips
+ * cleanly through Convex's return-validator check.
+ */
+export const promptCategoryValidator = v.object({
+  _id: v.id('promptCategories'),
+  _creationTime: v.number(),
+  organizationId: v.string(),
+  scope: promptScopeValidator,
+  teamId: v.optional(v.string()),
+  createdBy: v.string(),
+  name: v.string(),
+  nameLower: v.string(),
+});
+
+/**
+ * Grouped result for `listCategories`: the picker uses the buckets directly
+ * to scope the dropdown by the form's current scope/teamId selection without
+ * a second pass on the client.
+ */
+export const listCategoriesResultValidator = v.object({
+  personal: v.array(promptCategoryValidator),
+  team: v.array(promptCategoryValidator),
+  global: v.array(promptCategoryValidator),
 });

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -53,7 +53,7 @@ import { mcpServersTable } from './mcp_servers/schema';
 import { notificationsTable } from './notifications/schema';
 import { onedriveSyncConfigsTable } from './onedrive/schema';
 import { productsTable } from './products/schema';
-import { promptTemplatesTable } from './prompts/schema';
+import { promptCategoriesTable, promptTemplatesTable } from './prompts/schema';
 import { ssoProvidersTable } from './sso_providers/schema';
 import { messageMetadataTable } from './streaming/schema';
 import { threadTodosTable } from './thread_todos/schema';
@@ -108,6 +108,7 @@ export default defineSchema({
   chatFilterEvents: chatFilterEventsTable,
   usageLedger: usageLedgerTable,
   promptTemplates: promptTemplatesTable,
+  promptCategories: promptCategoriesTable,
   messageFeedback: messageFeedbackTable,
   mcpServers: mcpServersTable,
   brandingBindings: brandingBindingsTable,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -489,14 +489,14 @@
     },
     "organization": {
       "title": "Organisation (optional)",
+      "detailsTitle": "Organisationsdetails",
+      "detailsDescription": "Grundlegende Informationen zu Ihrer Organisation.",
       "organizationId": "Organisations-ID",
-      "organizationIdHelp": "Wird für API-Integrationen verwendet",
       "copyOrganizationId": "Organisations-ID kopieren",
       "membersTitle": "Organisationsmitglieder",
       "membersEntityLabel": "Mitglieder",
       "manageAccess": "Zugriff auf die Organisation verwalten",
-      "defaultLocale": "Antwortsprache der Agenten",
-      "defaultLocaleHelp": "Gilt für die Agentenausgabe. Die Sprache der Benutzeroberfläche richtet sich nach der individuellen Einstellung jedes Nutzers.",
+      "defaultLocale": "Standardsprache (für Agenten)",
       "searchMember": "Mitglied suchen",
       "addMember": "Mitglied hinzufügen",
       "createOrganization": "Organisation erstellen",
@@ -4390,6 +4390,7 @@
       "teamPlaceholder": "Team auswählen...",
       "categoryLabel": "Kategorie",
       "categoryPlaceholder": "z.B. Schreiben, Analyse, Programmierung",
+      "categoryNone": "— Keine —",
       "tagsLabel": "Tags",
       "tagsPlaceholder": "Kommagetrennte Tags...",
       "save": "Speichern",
@@ -4472,7 +4473,8 @@
     "addCategory": {
       "inputPlaceholder": "Kategoriename",
       "cancel": "Abbrechen",
-      "add": "Hinzufügen"
+      "add": "Hinzufügen",
+      "remove": "{category} entfernen"
     },
     "sidebar": {
       "sectionTitle": "Prompt-Bibliothek"

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -490,7 +490,7 @@
     "organization": {
       "title": "Organisation (optional)",
       "detailsTitle": "Organisationsdetails",
-      "detailsDescription": "Grundlegende Informationen zu Ihrer Organisation.",
+      "detailsDescription": "Grundlegende Informationen zu deiner Organisation.",
       "organizationId": "Organisations-ID",
       "copyOrganizationId": "Organisations-ID kopieren",
       "membersTitle": "Organisationsmitglieder",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -488,15 +488,15 @@
       }
     },
     "organization": {
-      "title": "Organization (optional)",
+      "title": "Organization name",
+      "detailsTitle": "Organization details",
+      "detailsDescription": "Basic information about your organization.",
       "organizationId": "Organization ID",
-      "organizationIdHelp": "Used for API integrations",
       "copyOrganizationId": "Copy organization ID",
       "membersTitle": "Organization members",
       "membersEntityLabel": "members",
       "manageAccess": "Manage access to the organization",
-      "defaultLocale": "Agent response language",
-      "defaultLocaleHelp": "Applies to agent output. User interface language follows each user's own setting.",
+      "defaultLocale": "Default language (for Agents)",
       "searchMember": "Search member",
       "addMember": "Add member",
       "createOrganization": "Create organization",
@@ -4390,6 +4390,7 @@
       "teamPlaceholder": "Select a team...",
       "categoryLabel": "Category",
       "categoryPlaceholder": "e.g., writing, analysis, coding",
+      "categoryNone": "— None —",
       "tagsLabel": "Tags",
       "tagsPlaceholder": "Comma-separated tags...",
       "save": "Save",
@@ -4472,7 +4473,8 @@
     "addCategory": {
       "inputPlaceholder": "Category name",
       "cancel": "Cancel",
-      "add": "Add"
+      "add": "Add",
+      "remove": "Remove {category}"
     },
     "sidebar": {
       "sectionTitle": "Prompt library"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -496,7 +496,7 @@
       "membersTitle": "Organization members",
       "membersEntityLabel": "members",
       "manageAccess": "Manage access to the organization",
-      "defaultLocale": "Default language (for Agents)",
+      "defaultLocale": "Default language (for agents)",
       "searchMember": "Search member",
       "addMember": "Add member",
       "createOrganization": "Create organization",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -490,7 +490,7 @@
     "organization": {
       "title": "Organisation (facultatif)",
       "detailsTitle": "Détails de l'organisation",
-      "detailsDescription": "Informations de base sur votre organisation.",
+      "detailsDescription": "Informations de base sur ton organisation.",
       "organizationId": "ID de l'organisation",
       "copyOrganizationId": "Copier l'ID de l'organisation",
       "membersTitle": "Membres de l'organisation",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -489,14 +489,14 @@
     },
     "organization": {
       "title": "Organisation (facultatif)",
+      "detailsTitle": "Détails de l'organisation",
+      "detailsDescription": "Informations de base sur votre organisation.",
       "organizationId": "ID de l'organisation",
-      "organizationIdHelp": "Utilisé pour les intégrations API",
       "copyOrganizationId": "Copier l'ID de l'organisation",
       "membersTitle": "Membres de l'organisation",
       "membersEntityLabel": "membres",
       "manageAccess": "Gérer l'accès à l'organisation",
-      "defaultLocale": "Langue de réponse des agents",
-      "defaultLocaleHelp": "S'applique à la sortie de l'agent. La langue de l'interface suit les préférences de chaque utilisateur.",
+      "defaultLocale": "Langue par défaut (pour les agents)",
       "searchMember": "Rechercher un membre",
       "addMember": "Ajouter un membre",
       "createOrganization": "Créer une organisation",
@@ -4315,6 +4315,7 @@
       "teamPlaceholder": "Sélectionner une équipe...",
       "categoryLabel": "Catégorie",
       "categoryPlaceholder": "ex. rédaction, analyse, programmation",
+      "categoryNone": "— Aucune —",
       "tagsLabel": "Étiquettes",
       "tagsPlaceholder": "Étiquettes séparées par des virgules...",
       "save": "Enregistrer",
@@ -4397,7 +4398,8 @@
     "addCategory": {
       "inputPlaceholder": "Nom de la catégorie",
       "cancel": "Annuler",
-      "add": "Ajouter"
+      "add": "Ajouter",
+      "remove": "Supprimer {category}"
     },
     "sidebar": {
       "sectionTitle": "Bibliothèque de prompts"


### PR DESCRIPTION
## Summary

Three coordinated platform changes:

- **Prompts — categories scaffolding.** New `promptCategories` table plus queries, mutations, and access rules in `convex/prompts/categories.ts` and `convex/prompts/category_access.ts`. Additive only: prompts still carry the legacy `category: string`, and `categoryId` rides alongside as optional. The lazy-migration that translates legacy strings → category rows lands in a follow-up slice (slice 2). Access split: personal categories are creator-managed (admin status does not override); team and global are admin-only.
- **Prompts — form UX.** `PromptFormDialog` swaps the conditional Input/Select for a single `Select` with an explicit "— None —" sentinel (Radix rejects `value=""` items). `SavePromptDialog` separates persisted-vs-local categories and exposes a remove (×) affordance on local-only chips.
- **Members — 2FA status surfacing.** `listByOrganization` now returns `twoFactorEnabled` from the Better Auth user record. `EditMemberDialog` only renders the 2FA reset control for members that actually have it enabled, and the redundant "Two-factor authentication" caption is dropped.
- **Settings — Organization page polish.** Org details wrap in a `PageSection` with a real title/description, the `defaultLocaleHelp` and `organizationIdHelp` micro-copy is removed in favour of a single section description, and the Organization ID block collapses to a single `CopyableField` (which now accepts a `description` prop).

## Pre-PR checklist

- [ ] Ran `bun run check` — partial. Platform `lint` (`lib/seo/integration.test.ts:15:19` `require-array-sort-compare`) and `@tale/seo` tests (CJS/ESM `html-encoding-sniffer` resolution) fail on `origin/main` before this branch. Platform tests pass; platform typecheck passes.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — `addCategory.remove`, `form.categoryNone`, org-details title/description, removed obsolete `defaultLocaleHelp` / `organizationIdHelp`.
- [ ] Updated `/docs/{en,de,fr}/` — N/A (no user-visible doc surface changed; categories backend is additive and not yet wired into prose).
- [ ] Every touched docs page has a real opening and closing — N/A.
- [ ] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — N/A.
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.

## Test plan

- [ ] Open a prompt, change its category via the Select, confirm "— None —" clears the field on submit.
- [ ] In Save Prompt, type a new category, confirm a × appears only on the just-added chip and clicking it removes the chip + clears selection if it was active.
- [ ] As an org admin, edit a member who has 2FA enabled — reset control appears; edit one without 2FA — control is hidden.
- [ ] Visit Organization Settings, confirm details now sit in a titled section and the Organization ID copies cleanly with its label/description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two-Factor Authentication support for member tracking and reset functionality
  * Prompt category management system with personal, team, and global scopes
  * Ability to remove locally-created categories from selections

* **Improvements**
  * Enhanced organization settings interface with improved layout
  * Improved accessibility with description support in copyable fields
  * Character length limits enforced for prompt descriptions
  * Optimized form field ordering in member dialogs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->