### PR TITLE
fix(platform): allow audit-log chain writes through RLS

### DIFF
--- a/services/platform/convex/lib/rls/helpers/rls_rules.ts
+++ b/services/platform/convex/lib/rls/helpers/rls_rules.ts
@@ -596,6 +596,25 @@ export async function rlsRules(
       },
     },
 
+    // Audit Log Chain Genesis - internal per-org serialization sentinel for
+    // the audit hash chain (see audit_logs/schema.ts). Carries no user data;
+    // any org member who can produce an audit-logged write must be able to
+    // upsert and patch this row, so gate purely on org membership.
+    auditLogChainGenesis: {
+      read: async (_, row) => {
+        if (!user) return false;
+        return userOrgIds.has(row.organizationId);
+      },
+      insert: async ({ user: ruleUser }, row) => {
+        if (!ruleUser) return false;
+        return userOrgIds.has(row.organizationId);
+      },
+      modify: async (_, row) => {
+        if (!user) return false;
+        return userOrgIds.has(row.organizationId);
+      },
+    },
+
     // Audit Logs - organization-scoped, allow inserts for org members
     auditLogs: {
       read: async (_, log) => {
@@ -606,7 +625,17 @@ export async function rlsRules(
         );
         return authorizeRls(membership?.role, 'auditLogs', 'read');
       },
-      modify: async () => false, // Audit logs are immutable
+      // Audit-log row content is immutable; the chain hash + verifyIntegrity
+      // job enforce that. Convex-helpers RLS only sees the document, not the
+      // patch diff, so we cannot block "edit field X" while allowing the
+      // forward-chain link patch (chainSuccessor) that createAuditLog must
+      // perform on the predecessor row to serialize concurrent writers via
+      // OCC. Gate modify on org membership; any tampering with other fields
+      // is caught by the next write's self-check against the recomputed hash.
+      modify: async (_, log) => {
+        if (!user) return false;
+        return userOrgIds.has(log.organizationId);
+      },
       insert: async ({ user: ruleUser }, log) => {
         if (!ruleUser) return false;
         if (!userOrgIds.has(log.organizationId)) return false;


### PR DESCRIPTION
## Summary

- Adds RLS rule for `auditLogChainGenesis` (org-membership gated read/insert/modify) so the per-org chain-genesis sentinel can be upserted.
- Relaxes `auditLogs.modify` from blanket-deny to org-membership gating so `createAuditLog` can patch the predecessor row's `chainSuccessor` (the OCC anti-fork mechanism).
- Audit-log content immutability remains enforced by the chain `integrityHash` + `verifyIntegrity` self-check — not by the RLS modify rule, which has no visibility into the patch diff.

## Why

`mutationWithRLS` runs with `defaultPolicy: 'deny'`. After the audit-chain anti-fork landed (PR #1676 hardening series), `createAuditLog` started doing two writes that RLS blocked:

1. Upsert of `auditLogChainGenesis` — no RLS rule existed, default-denied.
2. Patch of the predecessor `auditLogs` row's `chainSuccessor` field — blocked by the previous \`modify: () => false\` rule.

Every audit-logged mutation in a user-facing context was failing. User-visible symptom: navigating conversation items threw \`Failed to mark conversation as read: [CONVEX M(conversations/mutations:markConversationAsRead)] [...] insert access not allowed\`, then after fixing the first hop, \`write access not allowed\` from the predecessor patch.

## Test plan

- [x] All 70 tests in `convex/audit_logs`, `convex/lib/rls`, `convex/conversations` pass.
- [ ] Verify in the running app: navigate between conversation items → no console error, `unread_count` clears, audit log row is written.
- [ ] Verify hash chain integrity: run `verifyIntegrity` against a newly created org's audit log and confirm the chain validates end-to-end with `chainSuccessor` populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced audit log access controls to allow organization members to modify logs when appropriate.
  * Improved audit log integrity verification through cryptographic validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->