### PR TITLE
feat(platform): assistant open button + overlay AI chat on automation editor

### DIFF
--- a/services/platform/app/features/automations/components/automation-ai-chat-panel.tsx
+++ b/services/platform/app/features/automations/components/automation-ai-chat-panel.tsx
@@ -20,6 +20,8 @@ interface AutomationAIChatPanelProps {
   onClose: () => void;
   panelWidth?: number;
   onPanelWidthChange?: (width: number) => void;
+  /** When true, the panel floats over the page content instead of taking layout space. */
+  overlay?: boolean;
 }
 
 export function AutomationAIChatPanel({
@@ -29,6 +31,7 @@ export function AutomationAIChatPanel({
   onClose,
   panelWidth,
   onPanelWidthChange,
+  overlay = false,
 }: AutomationAIChatPanelProps) {
   const { t } = useT('automations');
   const panelRef = useRef<HTMLDivElement>(null);
@@ -59,7 +62,12 @@ export function AutomationAIChatPanel({
       role="complementary"
       aria-label={t('sidePanel.aiAssistant')}
       style={{ '--panel-width': `${width}px` }}
-      className="bg-background border-border relative flex min-h-0 w-(--panel-width) flex-[0_0_auto] flex-col overflow-hidden border-l max-md:absolute max-md:inset-0 max-md:z-20 max-md:w-full"
+      className={cn(
+        'bg-background border-border flex min-h-0 w-(--panel-width) flex-col overflow-hidden border-l shadow-lg max-md:absolute max-md:inset-0 max-md:z-20 max-md:w-full max-md:shadow-none',
+        overlay
+          ? 'absolute top-0 right-0 bottom-0 z-20'
+          : 'relative flex-[0_0_auto] shadow-none',
+      )}
     >
       {/* Resize handle */}
       <div

--- a/services/platform/app/features/automations/components/automation-navigation.tsx
+++ b/services/platform/app/features/automations/components/automation-navigation.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@tale/ui/button';
 import { DropdownMenu, type DropdownMenuItem } from '@tale/ui/dropdown-menu';
-import { History } from 'lucide-react';
+import { History, Sparkles } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -31,6 +31,8 @@ interface AutomationNavigationProps {
   automationId?: string;
   workflowSlug: string;
   onRefetch: () => Promise<void>;
+  isAssistantOpen?: boolean;
+  onOpenAssistant?: () => void;
 }
 
 interface HistoryEntry {
@@ -43,6 +45,8 @@ export function AutomationNavigation({
   automationId,
   workflowSlug,
   onRefetch,
+  isAssistantOpen,
+  onOpenAssistant,
 }: AutomationNavigationProps) {
   const { t } = useT('automations');
   const { t: tCommon } = useT('common');
@@ -52,6 +56,8 @@ export function AutomationNavigation({
   // Surface dirty state to the page-level blocker so navigation away from
   // the editor with unsaved workflow edits triggers the unified confirm.
   useRegisterDirtySource(isDirty);
+
+  const showOpenAssistantButton = !!onOpenAssistant && !isAssistantOpen;
 
   const listHistoryAction = useConvexAction(
     api.workflows.file_actions.listHistory,
@@ -215,6 +221,36 @@ export function AutomationNavigation({
     return null;
   }
 
+  const assistantButton = showOpenAssistantButton ? (
+    <Button
+      variant="secondary"
+      size="icon"
+      className="size-8"
+      onClick={onOpenAssistant}
+      aria-label={t('navigation.openAssistant')}
+      title={t('navigation.openAssistant')}
+    >
+      <Sparkles className="size-3.5 text-purple-600" aria-hidden="true" />
+    </Button>
+  ) : null;
+
+  const historyMenu = (
+    <DropdownMenu
+      trigger={
+        <Button variant="secondary" size="sm" className="h-8 text-sm">
+          <History className="mr-1.5 size-3.5" aria-hidden="true" />
+          {t('navigation.history')}
+        </Button>
+      }
+      items={historyMenuItems}
+      align="end"
+      contentClassName="w-64"
+      onOpenChange={(open) => {
+        if (open) void handleLoadHistory();
+      }}
+    />
+  );
+
   return (
     <>
       <TabNavigation
@@ -223,22 +259,8 @@ export function AutomationNavigation({
         ariaLabel={tCommon('aria.automationsNavigation')}
       >
         <AutomationEditorActionsSlot
-          history={
-            <DropdownMenu
-              trigger={
-                <Button variant="secondary" size="sm" className="h-8 text-sm">
-                  <History className="mr-1.5 size-3.5" aria-hidden="true" />
-                  {t('navigation.history')}
-                </Button>
-              }
-              items={historyMenuItems}
-              align="end"
-              contentClassName="w-64"
-              onOpenChange={(open) => {
-                if (open) void handleLoadHistory();
-              }}
-            />
-          }
+          assistant={assistantButton}
+          history={historyMenu}
         />
       </TabNavigation>
 
@@ -264,19 +286,31 @@ export function AutomationNavigation({
  * the active editor null and only the History button shows.
  */
 function AutomationEditorActionsSlot({
+  assistant,
   history,
 }: {
+  assistant?: React.ReactNode;
   history: React.ReactNode;
 }) {
   const controller = useActiveEditor();
   if (!controller) {
-    return <div className="ml-auto flex items-center gap-2">{history}</div>;
+    return (
+      <div className="ml-auto flex items-center gap-2">
+        {assistant}
+        {history}
+      </div>
+    );
   }
   return (
     <EditorActions
       controller={controller}
       entityKind="automation"
-      history={history}
+      history={
+        <>
+          {assistant}
+          {history}
+        </>
+      }
     />
   );
 }

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -255,6 +255,10 @@ function AutomationDetailInner({
     setIsAIChatOpen(false);
   }, []);
 
+  const handleOpenAIChat = useCallback(() => {
+    setIsAIChatOpen(true);
+  }, []);
+
   useEffect(() => {
     const handler = () => void onRefetch();
     window.addEventListener('workflow-updated', handler);
@@ -305,12 +309,14 @@ function AutomationDetailInner({
             automationId={amId}
             workflowSlug={workflowSlug}
             onRefetch={onRefetch}
+            isAssistantOpen={isAIChatOpen}
+            onOpenAssistant={handleOpenAIChat}
           />
         </>
       }
       organizationId={organizationId}
     >
-      <div className="flex min-h-0 flex-1">
+      <div className="relative flex min-h-0 flex-1">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
           {isExactAutomationPage ? (
             <Suspense fallback={<AutomationStepsSkeleton />}>
@@ -321,6 +327,7 @@ function AutomationDetailInner({
                 steps={steps as Doc<'wfStepDefs'>[]}
                 organizationId={organizationId}
                 automationId={workflowSlug}
+                onOpenAIChat={handleOpenAIChat}
               />
             </Suspense>
           ) : (
@@ -336,6 +343,7 @@ function AutomationDetailInner({
             onClose={handleCloseAIChat}
             panelWidth={panelWidth}
             onPanelWidthChange={setPanelWidth}
+            overlay
           />
         )}
       </div>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -401,7 +401,8 @@
     "renameTitle": "Automatisierung umbenennen",
     "navigation": {
       "editor": "Editor",
-      "history": "Verlauf"
+      "history": "Verlauf",
+      "openAssistant": "KI-Assistent öffnen"
     },
     "history": {
       "empty": "Keine Verlaufseinträge",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -401,7 +401,8 @@
     "renameTitle": "Rename automation",
     "navigation": {
       "editor": "Editor",
-      "history": "History"
+      "history": "History",
+      "openAssistant": "Open AI assistant"
     },
     "history": {
       "empty": "No history entries",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -402,7 +402,8 @@
     "renameTitle": "Renommer l'automatisation",
     "navigation": {
       "editor": "Éditeur",
-      "history": "Historique"
+      "history": "Historique",
+      "openAssistant": "Ouvrir l'assistant IA"
     },
     "history": {
       "empty": "Aucune entrée d'historique",


### PR DESCRIPTION
## Summary
- Adds a Sparkles button to the automation tab strip that reopens the AI assistant when it's closed (hidden while open).
- Renders the AI chat panel as an overlay (`position: absolute`) above the editor when open, so toggling no longer reflows the workflow canvas.
- Adds `automations.navigation.openAssistant` label in en/de/fr.

## Test plan
- [ ] Open an automation; AI panel renders inline as before, no overlap with editor controls.
- [ ] Close the AI panel; Sparkles button appears in the tab strip header next to History.
- [ ] Click Sparkles; panel re-opens as an overlay on top of the canvas without shifting steps.
- [ ] Verify tooltip text in en/de/fr.
- [ ] Confirm Configuration tab's Save/Discard cluster still renders alongside History + assistant button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Open Assistant" button in the automation navigation interface, providing quick and convenient access to all AI chat features, capabilities, and assistance.
  * The AI chat panel now supports a floating overlay display mode, enabling flexible and non-intrusive workspace layouts as an alternative to the standard fixed positioning.
  * Extended full language support with new assistant feature labels and comprehensive translations available in English, German, and French languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->