### PR TITLE
fix(cli): stop prompting OpenRouter key on partial env upgrade

### DIFF
--- a/tools/cli/src/lib/config/ensure-env.ts
+++ b/tools/cli/src/lib/config/ensure-env.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { getProjectId } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
@@ -124,13 +124,13 @@ export async function ensureEnv(
     const missingUser = requiredUserVars.filter((v) => !existing[v]);
     const missingAuto = requiredAutoVars.filter((v) => !existing[v]);
 
+    let result: EnvSetupResult;
+
     if (missingUser.length === 0 && missingAuto.length === 0) {
       // All required vars present — derive public key for caller
       const agePublicKey = deriveAgePublicKey(existing.SOPS_AGE_KEY);
-      return { success: true, agePublicKey };
-    }
-
-    if (!isTTY) {
+      result = { success: true, agePublicKey };
+    } else if (!isTTY) {
       // Headless: refuse only when user-supplied vars are missing (we
       // can't synthesize a domain or TLS choice). Otherwise auto-generate
       // the missing secrets and continue so CI/CD upgrades stay green.
@@ -141,14 +141,23 @@ export async function ensureEnv(
         logger.info('Run the CLI interactively to complete environment setup.');
         return { success: false };
       }
-      return await runHeadlessAutoSecretFill(envPath, existing, missingAuto);
+      result = await runHeadlessAutoSecretFill(envPath, existing, missingAuto);
+    } else {
+      // Fill in only the missing variables
+      result = await runPartialEnvSetup(envPath, existing, [
+        ...missingUser,
+        ...missingAuto,
+      ]);
     }
 
-    // Fill in only the missing variables
-    return await runPartialEnvSetup(envPath, existing, [
-      ...missingUser,
-      ...missingAuto,
-    ]);
+    // .env-already-exists path → onboarding for OpenRouter happens elsewhere
+    // (`tale init` or the platform's Settings → AI providers UI). Avoid
+    // hijacking deploy/upgrade with an interactive prompt that was only
+    // supposed to fire on first install.
+    if (result.success) {
+      warnIfOpenrouterSecretMissing(options.deployDir);
+    }
+    return result;
   }
 
   if (!isTTY) {
@@ -242,7 +251,7 @@ async function runPartialEnvSetup(
   existing: Record<string, string>,
   missing: string[],
 ): Promise<EnvSetupResult> {
-  const { input, password, select } = await import('@inquirer/prompts');
+  const { input, select } = await import('@inquirer/prompts');
 
   logger.blank();
   logger.header('Environment Setup (partial)');
@@ -250,7 +259,6 @@ async function runPartialEnvSetup(
   logger.blank();
 
   const updates: Record<string, string> = {};
-  let openrouterKey: string | undefined;
 
   // Domain configuration
   if (missing.includes('HOST')) {
@@ -333,30 +341,6 @@ async function runPartialEnvSetup(
     logger.info('Generated age encryption keypair for provider secrets.');
   }
 
-  // OpenRouter API key (prompt if no secrets file exists)
-  const secretsPath = join(
-    dirname(envPath),
-    'providers',
-    'openrouter.secrets.json',
-  );
-  if (!existsSync(secretsPath)) {
-    logger.blank();
-    logger.header('API Configuration');
-    openrouterKey = await password({
-      message: 'Enter your OpenRouter API key (from https://openrouter.ai):',
-      mask: '*',
-      validate: (v) => {
-        if (!v.trim()) return 'OpenRouter API key is required';
-        return true;
-      },
-    });
-    const shouldContinue = await warnIfInvalidKeyFormat(openrouterKey);
-    if (!shouldContinue) {
-      logger.info('Aborted. Please re-run with a valid API key.');
-      return { success: false };
-    }
-  }
-
   // Surgically append missing variables to the existing .env (preserves all original content)
   const existingContent = await readFile(envPath, 'utf-8');
   const appendLines: string[] = [];
@@ -377,7 +361,26 @@ async function runPartialEnvSetup(
   logger.blank();
 
   const agePublicKey = deriveAgePublicKey(sopsAgeKey);
-  return { success: true, agePublicKey, openrouterKey };
+  return { success: true, agePublicKey };
+}
+
+/**
+ * Emit a one-line warning when the local OpenRouter secrets file is missing
+ * on the `.env`-already-exists path. Intentionally non-fatal: the operator
+ * may have configured OpenRouter through Settings → AI providers (which
+ * writes to the platform DB, not this file), or be using a different
+ * provider altogether. Re-prompting on every deploy/upgrade for users who
+ * legitimately have no local file is the bug we're avoiding.
+ */
+function warnIfOpenrouterSecretMissing(deployDir: string): void {
+  const secretsPath = join(deployDir, 'providers', 'openrouter.secrets.json');
+  if (existsSync(secretsPath)) return;
+  logger.warn(
+    'providers/openrouter.secrets.json not found. ' +
+      'If OpenRouter is already configured via Settings → AI providers or ' +
+      'another provider is in use, ignore this. ' +
+      "Otherwise run 'tale init' to provision a key.",
+  );
 }
 
 async function runEnvSetup(envPath: string): Promise<EnvSetupResult> {


### PR DESCRIPTION
## Summary

`tale deploy` started re-asking for an OpenRouter API key on upgrade to v0.2.73 (reproduced from v0.2.72 → v0.2.73), even though the user's existing key had not changed. Root cause:

- PR #1727 added `SANDBOX_TOKEN` to `requiredAutoVars` in [`ensure-env.ts`](tools/cli/src/lib/config/ensure-env.ts).
- For any `.env` minted pre-#1727, `ensureEnv` now drops into `runPartialEnvSetup` to fill in the new secret.
- `runPartialEnvSetup` then unconditionally checked `providers/openrouter.secrets.json` and prompted on miss — completely independent of which env var was actually missing.
- Operators who'd configured OpenRouter via Settings → AI providers (DB-backed, not the local file) got blocked on every deploy.

`--fresh` is a red herring; it only sets `FORCE_SEED=true` and doesn't touch `providers/`.

## Changes

- Drop the OpenRouter prompt block from `runPartialEnvSetup` entirely. The function returns to its declared job: filling in missing env vars.
- Replace it with a single non-fatal warning in `ensureEnv` (new helper `warnIfOpenrouterSecretMissing`) that fires once on the `.env`-already-exists path when the local secrets file is absent — guiding the operator to `tale init` or Settings → AI providers, but never blocking.
- `runEnvSetup` (true-first-install path, no `.env`) is unchanged; it still prompts for the key, since that's the only path where the CLI is the sole place onboarding can happen.
- Verified `openrouterKey` from `runPartialEnvSetup`'s return is unused — only `tale init` consumes it, and it only ever hits `runEnvSetup` on fresh dirs. Deploy/start/rollback/reset only read `success`.

## Test plan

- [ ] **Main bug regression**: Pre-#1727-style `.env` (missing `SANDBOX_TOKEN`), no `providers/openrouter.secrets.json` locally — `tale deploy` shows `Generated 1 missing secret(s)` + the new warning, then proceeds to docker stage without any prompt.
- [ ] **File-present upgrade**: Same as above but with `providers/openrouter.secrets.json` present — no warning, no prompt, clean.
- [ ] **Fresh install**: Empty dir → `tale init` → confirm `runEnvSetup` still prompts for OpenRouter, writes encrypted `providers/openrouter.secrets.json`.
- [ ] **Headless upgrade**: `CI=1 tale deploy` against pre-#1727 `.env` — `runHeadlessAutoSecretFill` fills `SANDBOX_TOKEN`, warning still emitted, no prompt.
- [ ] **Post-deploy sanity**: After the regression-test deploy, OpenRouter is still callable from the platform (proving the DB-backed config wasn't relying on this CLI side effect).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed OpenRouter API key prompt from partial environment setup flow.
  * Added a warning notification when OpenRouter secrets file is missing after successful setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->