### PR TITLE
fix(platform): disable search indexes to unblock stuck deploys

### DIFF
--- a/services/platform/convex/customers/schema.ts
+++ b/services/platform/convex/customers/schema.ts
@@ -37,8 +37,4 @@ export const customersTable = defineTable({
   .index('by_organizationId_and_externalId', ['organizationId', 'externalId'])
   .index('by_organizationId_and_status', ['organizationId', 'status'])
   .index('by_organizationId_and_source', ['organizationId', 'source'])
-  .index('by_organizationId_and_locale', ['organizationId', 'locale'])
-  .searchIndex('search_customers', {
-    searchField: 'name',
-    filterFields: ['organizationId', 'status'],
-  });
+  .index('by_organizationId_and_locale', ['organizationId', 'locale']);

--- a/services/platform/convex/customers/search_customers.ts
+++ b/services/platform/convex/customers/search_customers.ts
@@ -40,16 +40,30 @@ export async function searchCustomers(
 
   const searchAsNumber = Number(searchTerm);
 
+  // TODO(search-index-disabled): search_customers .searchIndex was dropped
+  // to unblock deploy past SearchIndexBootstrapWorker crash loop. Re-enable
+  // once the bootstrap is fixed; until then fall back to a scoped scan.
+  const collectNameMatches = async (): Promise<Array<Doc<'customers'>>> => {
+    const matches: Array<Doc<'customers'>> = [];
+    const nameQuery = ctx.db
+      .query('customers')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', organizationId),
+      );
+    for await (const customer of nameQuery) {
+      if (customer.name?.toLowerCase().includes(searchLower)) {
+        matches.push(customer);
+        if (matches.length >= resultLimit) break;
+      }
+    }
+    return matches;
+  };
+
   // Run all independent searches in parallel
   const [nameResults, emailMatches, externalIdExact, externalIdNumeric] =
     await Promise.all([
-      // 1. Search by name using full-text search index
-      ctx.db
-        .query('customers')
-        .withSearchIndex('search_customers', (q) =>
-          q.search('name', searchTerm).eq('organizationId', organizationId),
-        )
-        .take(resultLimit),
+      // 1. Search by name via scoped scan (search index disabled, see above)
+      collectNameMatches(),
 
       // 2. Search by email using the email index
       collectEmailMatches(),

--- a/services/platform/convex/products/schema.ts
+++ b/services/platform/convex/products/schema.ts
@@ -48,8 +48,4 @@ export const productsTable = defineTable({
     'status',
     'lastUpdated',
   ])
-  .index('by_org_lastUpdated', ['organizationId', 'lastUpdated'])
-  .searchIndex('search_products', {
-    searchField: 'name',
-    filterFields: ['organizationId', 'status', 'category'],
-  });
+  .index('by_org_lastUpdated', ['organizationId', 'lastUpdated']);

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -413,17 +413,23 @@ export const searchProjects = query({
     const auth = await getAuthContext(ctx, args.organizationId);
     const limit = Math.min(Math.max(args.limit ?? 20, 1), 50);
 
-    const rows = await ctx.db
+    // TODO(search-index-disabled): search_projects .searchIndex was dropped
+    // to unblock deploy past SearchIndexBootstrapWorker crash loop. Re-enable
+    // once the bootstrap is fixed; until then fall back to a scoped scan
+    // of non-archived projects in the org, filtering by name substring.
+    const searchLower = args.query.toLowerCase();
+    const rows: Array<Doc<'projects'>> = [];
+    const scan = ctx.db
       .query('projects')
-      .withSearchIndex('search_projects', (q) =>
-        q
-          .search('name', args.query)
-          .eq('organizationId', args.organizationId)
-          // archivedAt is `optional(number)`; the search index allows
-          // querying for "not archived" via .eq(undefined).
-          .eq('archivedAt', undefined),
-      )
-      .take(limit * 2);
+      .withIndex('by_organization_archived', (q) =>
+        q.eq('organizationId', args.organizationId).eq('archivedAt', undefined),
+      );
+    for await (const row of scan) {
+      if (row.name.toLowerCase().includes(searchLower)) {
+        rows.push(row);
+        if (rows.length >= limit * 2) break;
+      }
+    }
 
     return rows
       .filter((row) => hasProjectAccess(row, auth.teamIds, auth.role))

--- a/services/platform/convex/projects/schema.ts
+++ b/services/platform/convex/projects/schema.ts
@@ -74,8 +74,4 @@ export const projectsTable = defineTable({
 })
   .index('by_organization', ['organizationId'])
   .index('by_organization_archived', ['organizationId', 'archivedAt'])
-  .index('by_organization_updatedAt', ['organizationId', 'updatedAt'])
-  .searchIndex('search_projects', {
-    searchField: 'name',
-    filterFields: ['organizationId', 'archivedAt'],
-  });
+  .index('by_organization_updatedAt', ['organizationId', 'updatedAt']);


### PR DESCRIPTION
## Summary

- The convex backend's `SearchIndexBootstrapWorker` is crash-looping (`num_failures` > 150). `convex deploy` stalls at `Backfilling indexes (412/413 ready)` until the 300s timeout trips and the platform color fails to come up.
- The actual worker error is swallowed by `common::errors=off` in `services/convex/docker-entrypoint.sh:494`, so we can't yet root-cause the crash. This PR is the unblock; the bootstrap bug remains open.
- Drops the three `.searchIndex(...)` declarations (`search_products`, `search_customers`, `search_projects`) from the schemas so the index diff no longer waits on them — `wait_for_schema` then completes and the deploy commits.

## Caller fallbacks

- `customers/search_customers.ts` — name search switches from `withSearchIndex('search_customers', …)` to a scoped scan via the existing `by_organizationId` index, filtering by name substring. Email + externalId branches untouched.
- `projects/queries.ts` — `searchProjects` switches from `withSearchIndex('search_projects', …)` to a scoped scan via the existing `by_organization_archived` index, filtering by name substring. Access filter / slice / mapping tail unchanged.
- `search_products` had no caller — schema entry dropped, no other code touched.
- Both fallbacks carry a `TODO(search-index-disabled)` comment naming the rationale and the follow-up.

## Follow-ups (not in this PR)

- Restart convex with `RUST_LOG=info,common::errors=trace,database::search_index_bootstrap=trace` to capture the actual bootstrap error, then fix the root cause (likely a corrupt segment under `/app/data/convex/search/`).
- Once the bootstrap is healthy, restore the three `.searchIndex(...)` blocks one commit at a time and revert the two caller scans back to `withSearchIndex`.
- The `InvalidModules` error from the very first deploy attempt was a separate, transient hash-mismatch issue that self-healed on retry; no action needed.

## Test plan

- [x] `npx tsc --noEmit` from `services/platform/` — clean
- [x] `npm run lint --workspace=@tale/platform` — 0 warnings, 0 errors
- [ ] Deploy this branch to the affected host and confirm `Backfilling indexes` count drops from 413 → 412 (or lower) and the deploy completes in well under the 300s timeout
- [ ] Customers UI: search by email/externalId works as before; name search returns results via scan fallback
- [ ] Projects UI: `searchProjects` returns matching projects via scan fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized search implementation for customers, products, and projects with improved query processing. Search functionality remains unchanged for end-users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->