### PR TITLE
fix(proxy): redesign maintenance page to match offline screen

### DIFF
--- a/services/proxy/maintenance.html
+++ b/services/proxy/maintenance.html
@@ -2,42 +2,101 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <meta http-equiv="refresh" content="2" />
-    <title>Tale - Updating...</title>
+    <title>Tale — updating…</title>
     <style>
-      * {
+      /* Inline copy of the platform's `:root` / `.dark` tokens (see
+         packages/ui/src/globals.css) so this static shell matches the app
+         shell — and the sibling offline.html — without a JS runtime. Brand
+         accent is the dark-zinc / off-white pair from `--color-accent-base`
+         / `--color-accent-fg`. */
+      :root {
+        --bg-base: #fcfcfc;
+        --bg-muted: #f4f4f5;
+        --fg-base: #09090b;
+        --fg-muted: #71717a;
+        --border: #e4e4e7;
+        --accent-base: #030712;
+        --accent-fg: #ffffff;
+        --destructive: hsl(0 84.2% 60.2%);
+        --success: hsl(155 92% 24%);
+        color-scheme: light;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg-base: #09090b;
+          --bg-muted: rgba(255, 255, 255, 0.06);
+          --fg-base: #fafafa;
+          --fg-muted: hsl(218 11% 65%);
+          --border: #27272a;
+          --accent-base: #ffffff;
+          --accent-fg: #030712;
+          --destructive: hsl(0 91% 71%);
+          --success: hsl(155 85% 35%);
+          color-scheme: dark;
+        }
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
         margin: 0;
         padding: 0;
-        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        height: 100%;
       }
 
       body {
         font-family:
-          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-          Cantarell, sans-serif;
-        min-height: 100vh;
+          'Inter',
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          Roboto,
+          sans-serif;
+        background: var(--bg-base);
+        color: var(--fg-base);
         display: flex;
         align-items: center;
         justify-content: center;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        color: #fff;
+        min-height: 100dvh;
+        padding: max(env(safe-area-inset-top, 0px) + 1.5rem, 2rem) 1.5rem
+          max(env(safe-area-inset-bottom, 0px) + 1.5rem, 2rem);
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
       .container {
         text-align: center;
-        padding: 2rem;
-        max-width: 400px;
+        max-width: 24rem;
+        width: 100%;
       }
 
-      .spinner {
-        width: 50px;
-        height: 50px;
-        border: 4px solid rgba(255, 255, 255, 0.3);
-        border-top-color: #fff;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
+      .icon-wrapper {
+        width: 4rem;
+        height: 4rem;
         margin: 0 auto 1.5rem;
+        border-radius: 9999px;
+        background: var(--bg-muted);
+        color: var(--fg-muted);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .icon-wrapper svg {
+        width: 2rem;
+        height: 2rem;
+        animation: spin 1s linear infinite;
       }
 
       @keyframes spin {
@@ -49,30 +108,85 @@
       h1 {
         font-size: 1.5rem;
         font-weight: 600;
+        letter-spacing: -0.025em;
+        line-height: 1.2;
         margin-bottom: 0.75rem;
       }
 
       p {
-        font-size: 0.95rem;
-        opacity: 0.9;
-        line-height: 1.5;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: var(--fg-muted);
+        margin-bottom: 1.5rem;
       }
 
-      /* Dark mode support */
-      @media (prefers-color-scheme: dark) {
-        body {
-          background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.375rem 0.875rem;
+        border-radius: 9999px;
+        background: var(--bg-muted);
+        color: var(--fg-muted);
+        font-size: 0.875rem;
+        line-height: 1.25;
+        font-weight: 500;
+      }
+
+      .status-indicator {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 9999px;
+        background: var(--accent-base);
+        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.4;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .icon-wrapper svg,
+        .status-indicator {
+          animation: none;
         }
       }
     </style>
   </head>
   <body>
-    <div class="container">
-      <div class="spinner"></div>
+    <main class="container">
+      <div class="icon-wrapper" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+          <path d="M21 3v5h-5" />
+          <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+          <path d="M8 16H3v5" />
+        </svg>
+      </div>
+
       <h1>Updating Tale</h1>
       <p>
         This usually takes a few seconds. The page will refresh automatically.
       </p>
-    </div>
+
+      <div class="status" role="status" aria-live="polite">
+        <span class="status-indicator" aria-hidden="true"></span>
+        <span>Updating…</span>
+      </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## What

Redesigns the proxy maintenance/update screen (`services/proxy/maintenance.html`) — shown while the platform is redeploying — to match the polished PWA offline screen (`services/platform/public/offline.html`).

Before: a purple gradient with a plain white spinner, sharing none of the app's visual language. After: the offline screen's design system — design-token CSS variables (light + dark via `prefers-color-scheme`), a centered `max-width: 24rem` container, an icon-in-muted-circle (a spinning refresh glyph), and a pulsing "Updating…" status badge.

Kept intact:
- `<meta http-equiv="refresh" content="2">` — this is a no-JS proxy shell, so it self-reloads (unlike offline.html's fetch-probe script).
- `prefers-reduced-motion: reduce` disables the spin + pulse animations.
- Copy unchanged: "Updating Tale" / "This usually takes a few seconds. The page will refresh automatically."

Verified by serving the file and screenshotting in light and dark — matches offline.html and still auto-refreshes.

## Pre-PR checklist

- [x] Ran `bun run check` — N/A beyond format: `@tale/proxy` is a Docker service with no lint/typecheck/test; `oxfmt --check` passes on the file.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no-runtime static proxy shell; copy is not part of the i18n layer, consistent with offline.html).
- [x] Updated `/docs/{en,de,fr}/` — N/A (infra page, no user-facing docs).
- [x] Docs pages opening/closing — N/A (no docs touched).
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated maintenance/offline page design to align with app styling with improved light and dark theme support.
  * Enhanced responsive layout with better spacing and safe-area support for notched devices.
  * Improved accessibility with status indicators and reduced-motion support for users with motion sensitivity preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->