### PR TITLE
feat(platform): show Get app on iOS with Add to Home Screen sheet

### DIFF
--- a/packages/ui/src/pwa/use-install-prompt.ts
+++ b/packages/ui/src/pwa/use-install-prompt.ts
@@ -27,6 +27,14 @@ function readIosStandalone(navigator: Navigator): boolean {
   return value === true;
 }
 
+// iOS never fires `beforeinstallprompt`, so install there is the manual
+// "Add to Home Screen" flow. Detect iPhone/iPad/iPod directly, plus iPadOS
+// 13+ which masquerades as "MacIntel" but reports multiple touch points.
+function isIosDevice(navigator: Navigator): boolean {
+  if (/iPhone|iPad|iPod/.test(navigator.userAgent)) return true;
+  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+}
+
 export interface InstallPromptState {
   /**
    * True when the browser has fired `beforeinstallprompt` (meaning the PWA
@@ -34,6 +42,13 @@ export interface InstallPromptState {
    * False on iOS Safari, Firefox, and when running as an installed PWA.
    */
   canInstall: boolean;
+  /**
+   * True on an iOS device that isn't already installed. iOS can't install
+   * programmatically (no `beforeinstallprompt`), so a button gated on this
+   * should open manual "Add to Home Screen" instructions rather than calling
+   * `promptInstall`.
+   */
+  isIOS: boolean;
   /**
    * True when the app is running as an installed PWA — i.e. in standalone
    * display mode (Chromium/Android) or via the legacy `navigator.standalone`
@@ -61,9 +76,12 @@ export function useInstallPrompt(): InstallPromptState {
     null,
   );
   const [isInstalled, setIsInstalled] = useState(false);
+  const [isIosDeviceFlag, setIsIosDeviceFlag] = useState(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
+
+    setIsIosDeviceFlag(isIosDevice(window.navigator));
 
     const standaloneQuery = window.matchMedia('(display-mode: standalone)');
     setIsInstalled(
@@ -117,6 +135,7 @@ export function useInstallPrompt(): InstallPromptState {
 
   return {
     canInstall: deferred !== null && !isInstalled,
+    isIOS: isIosDeviceFlag && !isInstalled,
     isInstalled,
     promptInstall,
   };

--- a/services/platform/app/components/pwa/ios-install-sheet.tsx
+++ b/services/platform/app/components/pwa/ios-install-sheet.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { Text } from '@tale/ui/text';
+import { Share, SquarePlus } from 'lucide-react';
+
+import { Dialog } from '@/app/components/ui/dialog/dialog';
+import { useT } from '@/lib/i18n/client';
+
+export interface IosInstallSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * "Add to Home Screen" instructions for iOS, where the browser never fires
+ * `beforeinstallprompt` so there's no programmatic install. Rendered as a
+ * bottom sheet on mobile (via the shared Dialog) — the only place this is
+ * reachable, since the trigger is gated on `useInstallPrompt().isIOS`.
+ */
+export function IosInstallSheet({ open, onOpenChange }: IosInstallSheetProps) {
+  const { t } = useT('auth');
+
+  const steps: { icon: typeof Share; text: string }[] = [
+    { icon: Share, text: t('userButton.iosInstall.step1') },
+    { icon: SquarePlus, text: t('userButton.iosInstall.step2') },
+  ];
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('userButton.iosInstall.title')}
+      description={t('userButton.iosInstall.description')}
+      footer={
+        <Button type="button" onClick={() => onOpenChange(false)}>
+          {t('userButton.iosInstall.done')}
+        </Button>
+      }
+    >
+      <ol className="mt-2 flex flex-col gap-3">
+        {steps.map((step, index) => {
+          const StepIcon = step.icon;
+          return (
+            <li key={index} className="flex items-center gap-3">
+              <span
+                aria-hidden="true"
+                className="bg-muted text-foreground flex size-9 shrink-0 items-center justify-center rounded-xl"
+              >
+                <StepIcon className="size-4" />
+              </span>
+              <Text as="span" className="text-sm">
+                {step.text}
+              </Text>
+            </li>
+          );
+        })}
+      </ol>
+    </Dialog>
+  );
+}

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
+import { IosInstallSheet } from '@/app/components/pwa/ios-install-sheet';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { NotificationListPanel } from '@/app/features/notifications/components/notification-list-panel';
@@ -91,14 +92,21 @@ export function UserButton({
     organizationId ?? '',
   );
   const unreadCount = notificationsUnread ?? 0;
-  // PWA install — `canInstall` is only true on browsers that fired
-  // `beforeinstallprompt` AND when the app isn't already installed, so the
-  // "Get app" row stays hidden everywhere else (iOS Safari, Firefox, etc.).
-  const { canInstall, promptInstall } = useInstallPrompt();
+  // PWA install — `canInstall` is true on browsers that fired
+  // `beforeinstallprompt` (Chromium/Android), where we can prompt directly.
+  // iOS can't install programmatically, so `isIOS` instead opens manual
+  // "Add to Home Screen" instructions. Both stay hidden once installed and
+  // on browsers with no install path (Firefox, desktop Safari).
+  const { canInstall, isIOS, promptInstall } = useInstallPrompt();
+  const [iosSheetOpen, setIosSheetOpen] = useState(false);
 
   const handleInstallApp = useCallback(() => {
-    void promptInstall();
-  }, [promptInstall]);
+    if (canInstall) {
+      void promptInstall();
+      return;
+    }
+    setIosSheetOpen(true);
+  }, [canInstall, promptInstall]);
 
   // Used to display the current org name in the dropdown trigger row.
   const { organizations: userOrgs } = useUserOrganizationsWithDetails();
@@ -451,7 +459,7 @@ export function UserButton({
     ]);
 
     const helpGroup: DropdownMenuGroup = [];
-    if (canInstall) {
+    if (canInstall || isIOS) {
       helpGroup.push({
         type: 'item',
         label: t('userButton.getApp'),
@@ -505,6 +513,7 @@ export function UserButton({
     handleBackToProfile,
     handleInstallApp,
     canInstall,
+    isIOS,
     unreadCount,
     currentVersion,
     lastSeenVersion,
@@ -555,6 +564,13 @@ export function UserButton({
     />
   );
 
+  const overlays = (
+    <>
+      {signOutConfirmDialog}
+      <IosInstallSheet open={iosSheetOpen} onOpenChange={setIosSheetOpen} />
+    </>
+  );
+
   // Width transitions between the compact profile view and the wider
   // notifications view so the side-extension swap feels continuous.
   // `max-w-[calc(100vw-2rem)]` keeps the wider variant inside the viewport
@@ -575,7 +591,7 @@ export function UserButton({
           onOpenChange={handleOpenChange}
           contentClassName={contentClassName}
         />
-        {signOutConfirmDialog}
+        {overlays}
       </>
     );
   }
@@ -605,7 +621,7 @@ export function UserButton({
           </TooltipPrimitive.Content>
         </TooltipPrimitive.Root>
       </TooltipPrimitive.Provider>
-      {signOutConfirmDialog}
+      {overlays}
     </>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -278,6 +278,13 @@
       "defaultName": "Benutzer",
       "manageAccount": "Konto verwalten",
       "getApp": "App installieren",
+      "iosInstall": {
+        "title": "Tale installieren",
+        "description": "Füge Tale zu deinem Home-Bildschirm hinzu, damit es im Vollbild wie eine App läuft.",
+        "step1": "Tippe in der Symbolleiste deines Browsers auf „Teilen“.",
+        "step2": "Wähle „Zum Home-Bildschirm“ und tippe dann auf „Hinzufügen“.",
+        "done": "Verstanden"
+      },
       "helpFeedback": "Hilfe & Feedback",
       "currentVersion": "Aktuelle Version: v{version}",
       "whatsNew": "Neuigkeiten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -278,6 +278,13 @@
       "defaultName": "User",
       "manageAccount": "Manage account",
       "getApp": "Get app",
+      "iosInstall": {
+        "title": "Install Tale",
+        "description": "Add Tale to your home screen for a full-screen, app-like experience.",
+        "step1": "Tap the Share button in your browser's toolbar.",
+        "step2": "Choose \"Add to Home Screen\", then tap \"Add\".",
+        "done": "Got it"
+      },
       "helpFeedback": "Help & feedback",
       "currentVersion": "Current version: v{version}",
       "whatsNew": "What's new",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -279,6 +279,13 @@
       "defaultName": "Utilisateur",
       "manageAccount": "Gérer le compte",
       "getApp": "Installer l'app",
+      "iosInstall": {
+        "title": "Installer Tale",
+        "description": "Ajoute Tale à ton écran d'accueil pour l'ouvrir en plein écran, comme une app.",
+        "step1": "Appuie sur « Partager » dans la barre d'outils de ton navigateur.",
+        "step2": "Choisis « Sur l'écran d'accueil », puis appuie sur « Ajouter ».",
+        "done": "Compris"
+      },
       "helpFeedback": "Aide et retours",
       "currentVersion": "Version actuelle : v{version}",
       "whatsNew": "Nouveautés",


### PR DESCRIPTION
## What

The account menu's "Get app" row was gated on `useInstallPrompt().canInstall`, which is only ever true on Chromium/Android (browsers that fire `beforeinstallprompt`). On **iOS Safari** that event never fires, so the row was permanently hidden — users on iOS had no way to install the PWA from the menu.

This adds iOS support:
- `useInstallPrompt` now also reports `isIOS` (iOS device — incl. iPadOS-on-Mac — and not already installed).
- The "Get app" row shows when `canInstall || isIOS`.
- On Chromium/Android it still calls `promptInstall()` (native prompt, unchanged). On iOS it opens a small **"Add to Home Screen"** instructions sheet (`IosInstallSheet`) built on the shared `Dialog` (bottom sheet on mobile), with two illustrated steps: tap Share → choose "Add to Home Screen".
- New i18n keys `auth.userButton.iosInstall.*` in en/de/fr.

## Why

iOS can't install a PWA programmatically — it's a manual Share → Add to Home Screen flow. Surfacing the same "Get app" entry with platform-appropriate guidance closes the gap without changing the Android/Chromium path.

## Notes

- Static verification done: typecheck, lint, i18n parity + terminology tests, react-doctor (99/100). The remaining react-doctor finding (`UserButton` length) is pre-existing.
- A final visual check on a real iOS Safari device is recommended (the iOS install flow can't be exercised on desktop).

## Pre-PR checklist

- [x] Ran `bun run check` — typecheck + lint (`@tale/platform`, `@tale/ui`), `lib/i18n` tests, centralized i18n checks, `oxfmt --check` all pass.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — added `auth.userButton.iosInstall.*` to all three locales.
- [x] Updated `/docs/{en,de,fr}/` — N/A (no documented install/PWA page; this is a small in-app affordance, the existing "Get app" entry was already undocumented).
- [x] Docs pages opening/closing — N/A.
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.