### PR TITLE
fix(platform): make document search cover all pages

### DIFF
--- a/services/platform/app/features/documents/components/documents-table.test.tsx
+++ b/services/platform/app/features/documents/components/documents-table.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
 import { render } from '@/test/utils/render';
@@ -49,14 +49,19 @@ vi.mock('@/app/features/settings/teams/hooks/queries', () => ({
   useTeams: () => ({ teams: [], isLoading: false }),
 }));
 
+const paginatedMock = vi.hoisted(() => ({
+  loadMore: vi.fn(),
+  status: 'CanLoadMore' as string,
+}));
+
 vi.mock('../hooks/queries', () => ({
   useApproxDocumentCount: () => ({ data: 0 }),
   useFolder: () => ({ data: null }),
   useFolders: () => ({ data: [] }),
   useListDocumentsPaginated: () => ({
     results: [],
-    status: 'success',
-    loadMore: vi.fn(),
+    status: paginatedMock.status,
+    loadMore: paginatedMock.loadMore,
     isLoading: false,
   }),
 }));
@@ -85,6 +90,35 @@ vi.mock('./breadcrumb-navigation', () => ({
 import { DocumentsTable } from './documents-table';
 
 describe('DocumentsTable', () => {
+  beforeEach(() => {
+    paginatedMock.loadMore.mockClear();
+    paginatedMock.status = 'CanLoadMore';
+  });
+
+  // Search/filters run client-side over loaded pages only; without this the
+  // first matching document past page 1 reads as "no results".
+  describe('eager pagination while searching', () => {
+    it('loads remaining pages when a search query is active', () => {
+      render(
+        <DocumentsTable organizationId="test-org-id" searchQuery="contract" />,
+      );
+      expect(paginatedMock.loadMore).toHaveBeenCalled();
+    });
+
+    it('does not force-load pages without a search or filter', () => {
+      render(<DocumentsTable organizationId="test-org-id" />);
+      expect(paginatedMock.loadMore).not.toHaveBeenCalled();
+    });
+
+    it('stops loading once pages are exhausted', () => {
+      paginatedMock.status = 'Exhausted';
+      render(
+        <DocumentsTable organizationId="test-org-id" searchQuery="contract" />,
+      );
+      expect(paginatedMock.loadMore).not.toHaveBeenCalled();
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(

--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -3,7 +3,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { type Row } from '@tanstack/react-table';
 import { FileText } from 'lucide-react';
-import { useMemo, useState, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import type { FilterConfig } from '@/app/components/ui/data-table/data-table-filters';
@@ -69,6 +69,24 @@ export function DocumentsTable({
     folderId: currentFolderId,
     initialNumItems: 20,
   });
+
+  // Search and filters run client-side over `paginatedResult.results`, which
+  // only holds loaded pages. The default infinite-scroll list has nothing to
+  // scroll while a query is active, so further pages never load and any match
+  // beyond the first page reads as "no results". Eagerly pull every page while
+  // a search/filter is active so the client-side filter sees the full set.
+  const hasActiveQuery =
+    debouncedQuery.trim().length > 0 ||
+    selectedRagStatuses.length > 0 ||
+    selectedSources.length > 0 ||
+    selectedTeamIds.length > 0;
+
+  const { status: pageStatus, loadMore: loadMorePage } = paginatedResult;
+  useEffect(() => {
+    if (hasActiveQuery && pageStatus === 'CanLoadMore') {
+      loadMorePage(200);
+    }
+  }, [hasActiveQuery, pageStatus, loadMorePage]);
 
   const { data: currentFolder } = useFolder(currentFolderId);
   const parentFolderTeamId = currentFolder?.teamId ?? undefined;


### PR DESCRIPTION
## What

Document search returned **no results** for anything not on the first page of the table.

Root cause: the documents table loads documents with `useListDocumentsPaginated` (20 newest at a time) and runs search/filters client-side over `paginatedResult.results` — i.e. only the *loaded* pages. In the default infinite-scroll list there's nothing to scroll while a query is active, so additional pages never load. A search for a document outside the first page matched nothing and read as "no results at all". (Chat search works because it loads *all* threads, then filters.)

Fix: while a search query or any in-table filter (RAG status / source / team) is active, eagerly pull the remaining pages so the client-side filter sees the full document set.

```tsx
const hasActiveQuery =
  debouncedQuery.trim().length > 0 ||
  selectedRagStatuses.length > 0 ||
  selectedSources.length > 0 ||
  selectedTeamIds.length > 0;

const { status: pageStatus, loadMore: loadMorePage } = paginatedResult;
useEffect(() => {
  if (hasActiveQuery && pageStatus === 'CanLoadMore') loadMorePage(200);
}, [hasActiveQuery, pageStatus, loadMorePage]);
```

The effect re-runs as the Convex pagination status cycles (`CanLoadMore → LoadingMore → … → Exhausted`), so loading stops automatically once exhausted, and never triggers when no query is active (unchanged behavior for plain browsing).

## Tests

Added three regression tests to `documents-table.test.tsx`: loads pages while a query is active, does not load without a query, and stops once exhausted.

## Notes

- This is the scoped minimal fix. A `useEffect` is used deliberately: the load must continue across asynchronous pagination-status transitions, which no single user event can express — this is external-store synchronization, not an event handler standing in for a click.

## Pre-PR checklist

- [x] Ran `bun run check` — `@tale/platform` typecheck + lint pass; documents test suite (104 tests incl. 3 new) passes; `oxfmt --check` clean.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no copy changes).
- [x] Updated `/docs/{en,de,fr}/` — N/A (bug fix, no user-visible feature/wording change).
- [x] Docs pages opening/closing — N/A.
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced document search and filtering: When search or filter criteria are active, the system now automatically loads additional result pages in the background. This ensures filtering operations have access to a more complete dataset, allowing for more comprehensive filtering across available document results before pagination becomes fully exhausted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->