### PR TITLE
feat(ui): collapse button-bar labels to icons on mobile

### DIFF
--- a/packages/ui/src/components/primitives/button.stories.tsx
+++ b/packages/ui/src/components/primitives/button.stories.tsx
@@ -66,6 +66,11 @@ import { Button } from '@/app/components/ui/primitives';
       control: 'boolean',
       description: 'Disables the button',
     },
+    collapseLabel: {
+      control: 'boolean',
+      description:
+        'Collapse the label to an icon below the sm breakpoint (label stays in the a11y tree)',
+    },
   },
   args: {
     onClick: fn(),
@@ -159,6 +164,27 @@ export const AsLink: Story = {
     docs: {
       description: {
         story: 'Use `LinkButton` for navigation that looks like a button.',
+      },
+    },
+  },
+};
+
+export const CollapseLabel: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button icon={Check} variant="secondary" collapseLabel>
+        Save
+      </Button>
+      <Button icon={Trash2} variant="destructive" collapseLabel>
+        Delete
+      </Button>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `collapseLabel`, the text hides below the `sm` breakpoint (icon-only) and reappears from `sm` up — useful in crowded toolbars. The label stays in the accessibility tree, so the button keeps its name on mobile. Resize the preview to see it switch.',
       },
     },
   },

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -131,6 +131,37 @@ describe('Button', () => {
     });
   });
 
+  describe('collapseLabel', () => {
+    it('keeps an accessible name when the label is collapsed', () => {
+      render(
+        <Button icon={Mail} collapseLabel>
+          Send
+        </Button>,
+      );
+      // Label is visually hidden on mobile (sr-only) but stays the a11y name.
+      expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+    });
+
+    it('wraps the label so it is hidden below sm and shown from sm', () => {
+      render(
+        <Button icon={Mail} collapseLabel>
+          Send
+        </Button>,
+      );
+      const label = screen.getByText('Send');
+      expect(label).toHaveClass('sr-only', 'sm:not-sr-only');
+    });
+
+    it('passes axe audit when collapsed', async () => {
+      const { container } = render(
+        <Button icon={Mail} collapseLabel>
+          Send
+        </Button>,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<Button>Accessible Button</Button>);

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -48,6 +48,14 @@ export interface ButtonProps
   iconClassName?: string;
   /** Make button full width */
   fullWidth?: boolean;
+  /**
+   * Collapse the text label to an icon-only button below the `sm` breakpoint.
+   * The label stays in the accessibility tree (visually hidden), so the button
+   * keeps its accessible name on mobile, then becomes visible from `sm` up.
+   * Pair with an `icon` so there's something to show. Use in crowded toolbars
+   * and action rows where labels would otherwise overlap on mobile.
+   */
+  collapseLabel?: boolean;
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -61,13 +69,27 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       icon: Icon,
       iconClassName,
       fullWidth = false,
+      collapseLabel = false,
       children,
       ...props
     },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button';
-    const iconClass = cn('size-4', children && 'mr-2', iconClassName);
+    const iconClass = cn(
+      'size-4',
+      children && (collapseLabel ? 'sm:mr-2' : 'mr-2'),
+      iconClassName,
+    );
+
+    // When collapsed, keep the label in the a11y tree (sr-only) so the button
+    // still has an accessible name on mobile, revealing it from `sm` up.
+    const label =
+      collapseLabel && children ? (
+        <span className="sr-only sm:not-sr-only">{children}</span>
+      ) : (
+        children
+      );
 
     const content =
       asChild && !isLoading && !Icon ? (
@@ -78,12 +100,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             className={cn(iconClass, 'animate-spin motion-reduce:animate-none')}
             aria-hidden="true"
           />
-          {children}
+          {label}
         </>
       ) : (
         <>
           {Icon ? <Icon className={iconClass} aria-hidden="true" /> : null}
-          {children}
+          {label}
         </>
       );
 
@@ -121,6 +143,12 @@ export interface LinkButtonProps extends VariantProps<typeof buttonVariants> {
   children?: React.ReactNode;
   /** Prefetch the route */
   prefetch?: boolean;
+  /**
+   * Collapse the text label to an icon-only link below the `sm` breakpoint.
+   * The label stays in the accessibility tree (visually hidden) so the link
+   * keeps its accessible name on mobile, then becomes visible from `sm` up.
+   */
+  collapseLabel?: boolean;
 }
 
 /**
@@ -135,6 +163,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
       size,
       icon: Icon,
       iconClassName,
+      collapseLabel = false,
       children,
       href,
       params,
@@ -142,7 +171,11 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
     },
     ref,
   ) => {
-    const iconClass = cn('size-4', children && 'mr-2', iconClassName);
+    const iconClass = cn(
+      'size-4',
+      children && (collapseLabel ? 'sm:mr-2' : 'mr-2'),
+      iconClassName,
+    );
 
     return (
       <Link
@@ -153,7 +186,11 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
         preload={prefetch ? 'intent' : false}
       >
         {Icon && <Icon className={iconClass} aria-hidden="true" />}
-        {children}
+        {collapseLabel && children ? (
+          <span className="sr-only sm:not-sr-only">{children}</span>
+        ) : (
+          children
+        )}
       </Link>
     );
   },

--- a/services/platform/app/components/ui/editor/editor-actions.tsx
+++ b/services/platform/app/components/ui/editor/editor-actions.tsx
@@ -155,10 +155,12 @@ export function EditorActions({
         onClick={handleDiscard}
         variant="secondary"
         size="sm"
+        icon={Undo2}
+        iconClassName="size-3.5"
+        collapseLabel
         disabled={discardDisabled}
         aria-disabled={discardDisabled ? 'true' : undefined}
       >
-        <Undo2 className="mr-1.5 size-3.5" aria-hidden="true" />
         {t('actions.discard')}
       </Button>
       <Button
@@ -171,19 +173,24 @@ export function EditorActions({
       >
         {controller.isSaving ? (
           <Loader2
-            className="mr-1.5 size-3.5 animate-spin"
+            className="size-3.5 animate-spin sm:mr-1.5"
             aria-hidden="true"
           />
         ) : flashSaved ? (
-          <Check className="mr-1.5 size-3.5" aria-hidden="true" />
+          <Check className="size-3.5 sm:mr-1.5" aria-hidden="true" />
         ) : (
-          <Save className="mr-1.5 size-3.5" aria-hidden="true" />
+          <Save className="size-3.5 sm:mr-1.5" aria-hidden="true" />
         )}
-        {controller.isSaving
-          ? t('actions.saving')
-          : flashSaved
-            ? t('actions.saved')
-            : t('actions.save')}
+        {/* Collapse the label to an icon on mobile (still in the a11y tree)
+            to match `collapseLabel`; the icon here is dynamic, so the pattern
+            is applied inline rather than via the Button prop. */}
+        <span className="sr-only sm:not-sr-only">
+          {controller.isSaving
+            ? t('actions.saving')
+            : flashSaved
+              ? t('actions.saved')
+              : t('actions.save')}
+        </span>
       </Button>
     </div>
   );

--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -402,8 +402,14 @@ export function AgentNavigation({
           history={
             <DropdownMenu
               trigger={
-                <Button variant="secondary" size="sm" className="h-8 text-sm">
-                  <History className="mr-1.5 size-3.5" aria-hidden="true" />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-8 text-sm"
+                  icon={History}
+                  iconClassName="size-3.5"
+                  collapseLabel
+                >
                   {t('agents.navigation.history')}
                 </Button>
               }

--- a/services/platform/app/features/automations/components/automation-navigation.tsx
+++ b/services/platform/app/features/automations/components/automation-navigation.tsx
@@ -237,8 +237,14 @@ export function AutomationNavigation({
   const historyMenu = (
     <DropdownMenu
       trigger={
-        <Button variant="secondary" size="sm" className="h-8 text-sm">
-          <History className="mr-1.5 size-3.5" aria-hidden="true" />
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-8 text-sm"
+          icon={History}
+          iconClassName="size-3.5"
+          collapseLabel
+        >
           {t('navigation.history')}
         </Button>
       }


### PR DESCRIPTION
## What

On mobile, multi-button toolbars rendered full icon+text buttons that crowded and overlapped neighbouring elements. This adds a reusable way to collapse a button's label to an icon on small screens, and applies it across the app's button bars.

**Shared capability** (`@tale/ui`)
- New opt-in `collapseLabel` prop on `Button` and `LinkButton`. When set, the label is wrapped in `sr-only sm:not-sr-only` — visually hidden below `sm` but **kept in the accessibility tree** (the button keeps its name on mobile) — and the icon's right margin becomes responsive (`sm:mr-2`). From `sm` up the label reappears. Storybook story + tests added.

**Applied broadly** (`@tale/platform`)
- **`EditorActions` (Save / Discard)** — this shared cluster is consumed by **13 surfaces**: agents, automations, projects (×2), and every settings/governance editor (organization, account, branding, personalization, system-prompt, login/password/upload policies). One change collapses the Save/Discard labels everywhere they appear.
- **Agent editor History** button → icon-only on mobile.
- **Automation editor History** button → icon-only on mobile.

| | Mobile (< sm) | Desktop (≥ sm) |
|---|---|---|
| Editor toolbar | `[↩] [↗] [▣]` | `[↩ History] [↗ Discard] [▣ Save]` |

## Audit — where it was *not* applied (and why)

I swept the other multi-button groups; most already handle mobile or shouldn't collapse:
- **Chat header / chat list actions** — already icon-only on mobile (separate `md`-gated blocks / `size="icon"`).
- **Approval cards** (workflow / document-write / integration approvals) — Approve/Reject labels are safety-critical and must stay.
- **Settings/governance multi-button editors** — their Save/Discard already flow through `EditorActions` (covered); remaining buttons sit in roomy desktop panels/dialogs.
- The assistant button in the automation toolbar is already `size="icon"`.

## Accessibility

Uses `sr-only sm:not-sr-only` (not `hidden`), so the label text stays in the a11y tree on mobile — the button keeps its accessible name without a separate `aria-label`. Verified by axe + name-query tests.

## Verification

- Typecheck + lint (`@tale/ui`, `@tale/platform`), Button tests (34, incl. 3 new), agent-navigation test, `oxfmt --check` — all pass.
- Visual check in an isolated Tailwind harness confirmed icon-only at 375px and icon+label at 800px.

## Pre-PR checklist

- [x] Ran `bun run check` — typecheck + lint + Button/agent tests + `oxfmt --check` pass.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no new/changed strings; existing labels reused).
- [x] Updated `/docs/{en,de,fr}/` — N/A (responsive presentation only).
- [x] Docs opening/closing — N/A.
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.