### PR TITLE
fix(platform): settings Save/Discard on mobile + stop double unsaved-changes prompt

### DIFF
--- a/services/platform/app/components/ui/editor/dirty-blocker-provider.tsx
+++ b/services/platform/app/components/ui/editor/dirty-blocker-provider.tsx
@@ -104,6 +104,12 @@ export function DirtyBlockerProvider({
   }, [blocker]);
 
   const handleDiscardAndLeave = useCallback(() => {
+    // Drop every registered dirty flag before proceeding. The user chose to
+    // discard, so this can't lose work — and it makes `anyDirty` false
+    // immediately, so a re-evaluation of `shouldBlockFn` during the in-flight
+    // navigation can't re-arm the blocker and prompt a second time. A later
+    // edit re-registers the source via its own effect.
+    setSources((prev) => (prev.size === 0 ? prev : new Map()));
     blocker.proceed?.();
   }, [blocker]);
 

--- a/services/platform/app/routes/dashboard/$id/settings.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings.tsx
@@ -12,7 +12,11 @@ import {
 } from '@/app/components/layout/adaptive-header';
 import { ContentArea } from '@/app/components/layout/content-area';
 import { PageLayout } from '@/app/components/layout/page-layout';
-import { ActiveEditorProvider } from '@/app/components/ui/editor';
+import {
+  ActiveEditorProvider,
+  EditorActions,
+  useActiveEditor,
+} from '@/app/components/ui/editor';
 import { SettingsNavigation } from '@/app/features/settings/components/settings-navigation';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
@@ -27,7 +31,6 @@ export const Route = createFileRoute('/dashboard/$id/settings')({
 function SettingsLayout() {
   const { id: organizationId } = Route.useParams();
   const { t: tNav } = useT('navigation');
-  const { t: tCommon } = useT('common');
   const location = useLocation();
 
   const settingsRoot = `/dashboard/${organizationId}/settings`;
@@ -65,24 +68,63 @@ function SettingsLayout() {
           </>
         }
       >
-        {!isAtIndex && isDirectChild && (
-          <Link
-            to={
-              isUserScope
-                ? '/dashboard/$id/settings/personal'
-                : '/dashboard/$id/settings'
-            }
-            params={{ id: organizationId }}
-            className="text-muted-foreground hover:text-foreground border-border flex items-center gap-1.5 border-b px-4 py-2.5 text-sm font-medium md:hidden"
-          >
-            <ChevronLeft aria-hidden="true" className="size-4" />
-            {tCommon('actions.back')}
-          </Link>
-        )}
+        <SettingsMobileActionBar
+          showBack={!isAtIndex && isDirectChild}
+          isUserScope={isUserScope}
+          organizationId={organizationId}
+        />
         <ContentArea className="min-h-0 flex-1" variant="page" gap={6}>
           <Outlet />
         </ContentArea>
       </PageLayout>
     </ActiveEditorProvider>
+  );
+}
+
+interface SettingsMobileActionBarProps {
+  showBack: boolean;
+  isUserScope: boolean;
+  organizationId: string;
+}
+
+/**
+ * Mobile-only bar holding the back link and the active settings page's
+ * Save/Discard cluster. The desktop equivalent lives in the settings tab
+ * strip (`SettingsNavigation`), which is `hidden md:block` — so on small
+ * screens the Save/Discard buttons were unreachable. Reads the active editor
+ * (set by each form page) and renders the cluster only when one is present.
+ */
+function SettingsMobileActionBar({
+  showBack,
+  isUserScope,
+  organizationId,
+}: SettingsMobileActionBarProps) {
+  const { t: tCommon } = useT('common');
+  const controller = useActiveEditor();
+
+  if (!showBack && !controller) return null;
+
+  return (
+    <div className="border-border flex items-center justify-between gap-2 border-b px-4 py-2 md:hidden">
+      {showBack ? (
+        <Link
+          to={
+            isUserScope
+              ? '/dashboard/$id/settings/personal'
+              : '/dashboard/$id/settings'
+          }
+          params={{ id: organizationId }}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm font-medium"
+        >
+          <ChevronLeft aria-hidden="true" className="size-4" />
+          {tCommon('actions.back')}
+        </Link>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {controller && (
+        <EditorActions controller={controller} entityKind="settings" />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## What

Two related settings/editor fixes.

### Save/Discard invisible on mobile
The settings Save/Discard cluster is rendered by `SettingsEditorActionsSlot` **inside `SettingsNavigation`**, which the settings layout wraps in `hidden md:block`. So on small screens the whole tab strip — including Save/Discard — was hidden, leaving only the back link. Users couldn't save or discard a settings form on mobile.

Fix: add a mobile-only (`md:hidden`) action bar to the settings layout that pairs the back link with the active editor's Save/Discard cluster (read via `useActiveEditor`, the same source the desktop strip uses). It renders only when there's a back link or an active editor, so index pages stay clean.

### Double unsaved-changes prompt
Hardened the shared `DirtyBlockerProvider`: when the user picks **Discard and leave**, clear all registered dirty sources *before* `blocker.proceed()`. This makes `anyDirty` false immediately, so if TanStack re-evaluates `shouldBlockFn` while the navigation is in flight it can't re-arm the blocker and prompt a second time. It's loss-safe (the user chose to discard) and a later edit re-registers the source via its existing effect.

## Verification

- `@tale/platform` typecheck + lint pass; settings + editor tests pass.
- The mobile bar is structural (renders the existing `EditorActions` on mobile); a quick on-device check of a dirty personal/org settings form is worthwhile. I could not fully reproduce the double-prompt in isolation, so the blocker change is a safe hardening targeting the most plausible cause rather than a confirmed repro.

## Pre-PR checklist

- [x] Ran `bun run check` — `@tale/platform` typecheck + lint + settings/editor tests pass; `oxfmt --check` clean.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (reuses existing `common.actions.*` / editor strings).
- [x] Updated `/docs/{en,de,fr}/` — N/A (no feature/wording change).
- [x] Docs opening/closing — N/A.
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the confirmation dialog would reappear after selecting "Discard and Leave".

* **UI Improvements**
  * Enhanced mobile settings experience with a dedicated mobile action bar displaying navigation and save/discard options when editing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->