### PR TITLE
refactor(ui): remove zoom scale animation from overlays

### DIFF
--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -239,7 +239,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
           </DropdownMenuPrimitive.SubTrigger>
           <DropdownMenuPrimitive.SubContent
             className={cn(
-              'bg-muted text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg',
+              'bg-muted text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg',
               item.contentClassName,
             )}
           >
@@ -343,7 +343,7 @@ export function DropdownMenu({
           align={align}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] overflow-y-auto overflow-x-hidden rounded-lg border bg-card p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none',
+            'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] overflow-y-auto overflow-x-hidden rounded-lg border bg-card p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none',
             contentClassName,
           )}
         >

--- a/packages/ui/src/components/overlays/popover.tsx
+++ b/packages/ui/src/components/overlays/popover.tsx
@@ -19,7 +19,7 @@ interface PopoverProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
 
 export function Popover({
   trigger,

--- a/packages/ui/src/components/overlays/tooltip.tsx
+++ b/packages/ui/src/components/overlays/tooltip.tsx
@@ -16,7 +16,7 @@ export const TooltipContent = forwardRef<
     sideOffset={sideOffset}
     className={cn(
       'z-50 overflow-hidden rounded-md bg-[color:var(--color-accent-base)] px-3 py-1.5 text-xs text-[color:var(--color-accent-fg)] shadow-md',
-      'animate-in fade-in-0 zoom-in-95 motion-reduce:animate-none',
+      'animate-in fade-in-0 motion-reduce:animate-none',
       className,
     )}
     {...props}

--- a/services/platform/app/components/organization-button.tsx
+++ b/services/platform/app/components/organization-button.tsx
@@ -90,7 +90,7 @@ export function OrganizationButton({
         <TooltipPrimitive.Content
           side="right"
           sideOffset={4}
-          className="bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
+          className="bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
         >
           {accessibleLabel}
         </TooltipPrimitive.Content>

--- a/services/platform/app/components/ui/dialog/dialog.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.tsx
@@ -34,7 +34,7 @@ const dialogContentVariants = cva(
     // (which sets BOTH left+right to auto) caused the inset shorthand to
     // overwrite the left positioning, anchoring the dialog at the viewport
     // edge instead of the centre.
-    'md:left-1/2 md:right-auto md:top-1/2 md:bottom-auto md:w-full md:-translate-x-1/2 md:-translate-y-1/2 md:max-h-[90dvh] md:p-6 md:pb-6 md:pt-5 md:rounded-2xl md:data-[state=open]:zoom-in-95 md:data-[state=closed]:zoom-out-95 md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=closed]:slide-out-to-bottom-0',
+    'md:left-1/2 md:right-auto md:top-1/2 md:bottom-auto md:w-full md:-translate-x-1/2 md:-translate-y-1/2 md:max-h-[90dvh] md:p-6 md:pb-6 md:pt-5 md:rounded-2xl md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=closed]:slide-out-to-bottom-0',
   {
     variants: {
       size: {

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -91,7 +91,7 @@ export interface SearchableSelectProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
 
 function defaultFilterFn(option: SearchableSelectOption, query: string) {
   const lower = query.toLowerCase();

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils/cn';
 import { Label } from './label';
 
 const selectContentVariants = cva(
-  'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-muted text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+  'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-muted text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   {
     variants: {
       position: {

--- a/services/platform/app/components/ui/navigation/navigation-menu.tsx
+++ b/services/platform/app/components/ui/navigation/navigation-menu.tsx
@@ -76,7 +76,7 @@ const NavigationMenuViewport = forwardRef<
   <div className={cn('absolute left-0 top-full z-50 flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-muted text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-(--radix-navigation-menu-viewport-width)',
+        'origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-muted text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out md:w-(--radix-navigation-menu-viewport-width)',
         className,
       )}
       ref={ref}

--- a/services/platform/app/components/ui/overlays/tooltip.tsx
+++ b/services/platform/app/components/ui/overlays/tooltip.tsx
@@ -37,7 +37,7 @@ export function Tooltip({
             side={side}
             sideOffset={sideOffset}
             className={cn(
-              'z-[60] overflow-hidden rounded-lg border bg-foreground p-2 py-1 text-xs text-background shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+              'z-[60] overflow-hidden rounded-lg border bg-foreground p-2 py-1 text-xs text-background shadow-md animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
               contentClassName,
             )}
           >

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -599,7 +599,7 @@ export function UserButton({
           <TooltipPrimitive.Content
             side="right"
             sideOffset={4}
-            className="bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
+            className="bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
           >
             {tooltipText ?? t('userButton.manageAccount')}
           </TooltipPrimitive.Content>


### PR DESCRIPTION
## What

Removes the shadcn/Radix `zoom-in-95` / `zoom-out-95` scale entrance from every overlay surface. On selectors (agent/model pickers), dropdowns, and menus the scale-on-open read as a distracting "pop." Now overlays still animate in via **fade + slide**, just without the zoom.

Touched surfaces:
- `@tale/ui`: popover, dropdown menu, tooltip
- `@tale/platform`: select, searchable select, navigation menu, dialog (desktop entrance), the account & org tooltips

The unrelated `cursor-zoom-in` (image-preview cursor in `editing-banner.tsx`) is intentionally left alone — it's a cursor, not an animation.

## Verification

- `@tale/ui` + `@tale/platform` typecheck + lint pass; overlay tests (18) pass; `oxfmt --check` clean.
- No test asserts on the removed classes.

## Pre-PR checklist

- [x] Ran `bun run check` — typecheck + lint + overlay tests + `oxfmt --check` pass.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no strings).
- [x] Updated `/docs/{en,de,fr}/` — N/A (animation only).
- [x] Docs opening/closing — N/A.
- [x] Ran `@tale/docs` lint/test — N/A.
- [x] Updated README files — N/A.