### PR TITLE
fix(platform): seed new orgs from builtin catalog, not default workspace

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -71,7 +71,6 @@ tale init [directory]              # Neues Projekt mit Beispiel-Configs anlegen
 tale start                         # Alle Dienste lokal starten
 tale start --detach                # Im Hintergrund starten
 tale start --port 8443             # Eigenen HTTPS-Port nutzen
-tale start --fresh                 # Builtin-Configs neu seeden
 tale upgrade                       # CLI upgraden und Projektdateien synchronisieren
 tale convex admin                  # Convex-Dashboard-Admin-Key generieren
 tale config                        # CLI-Konfiguration verwalten

--- a/README.fr.md
+++ b/README.fr.md
@@ -71,7 +71,6 @@ tale init [directory]              # Créer un nouveau projet avec des configs d
 tale start                         # Démarrer tous les services localement
 tale start --detach                # Démarrer en arrière-plan
 tale start --port 8443             # Utiliser un port HTTPS personnalisé
-tale start --fresh                 # Re-seeder les configs intégrées
 tale upgrade                       # Mettre à jour le CLI et synchroniser les fichiers du projet
 tale convex admin                  # Générer une clé admin du Convex Dashboard
 tale config                        # Gérer la configuration du CLI

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ tale init [directory]              # Create a new project with example configs
 tale start                         # Start all services locally
 tale start --detach                # Start in background
 tale start --port 8443             # Use a custom HTTPS port
-tale start --fresh                 # Re-seed builtin configs
 tale upgrade                       # Upgrade CLI and sync project files
 tale convex admin                  # Generate Convex dashboard admin key
 tale config                        # Manage CLI configuration

--- a/services/convex/Dockerfile
+++ b/services/convex/Dockerfile
@@ -107,8 +107,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && mkdir -p /home/app && chown app:app /home/app && chmod 755 /home/app \
     && mkdir -p /app/data/convex /app/data/agents /app/data/workflows /app/data/integrations /app/data/providers /app/data/branding /app/data/retention /app/data/skills \
                 /dashboard \
-                /app/agents-builtin /app/workflows-builtin /app/integrations-builtin /app/providers-builtin /app/branding-builtin /app/retention-builtin /app/skills-builtin \
-    && chown -R app:app /app/data /dashboard /app/agents-builtin /app/workflows-builtin /app/integrations-builtin /app/providers-builtin /app/branding-builtin /app/retention-builtin /app/skills-builtin \
+                /app/builtin/agents /app/builtin/workflows /app/builtin/integrations /app/builtin/providers /app/builtin/branding /app/builtin/retention /app/builtin/skills \
+    && chown -R app:app /app/data /dashboard /app/builtin \
     # Strip system bloat from Convex backend base (~155 MB)
     && ARCH_LIB="/usr/lib/$(dpkg --print-architecture | sed 's/amd64/x86_64-linux-gnu/;s/arm64/aarch64-linux-gnu/')" \
     && rm -rf "${ARCH_LIB}"/libLLVM* "${ARCH_LIB}"/libclang* \
@@ -173,13 +173,13 @@ COPY --from=convex-dashboard --chown=app:app /app /dashboard
 # Builtin seed assets (one-time copy on fresh volume; .history/ preserves user edits).
 # Sources come from repo-root examples/ (same as platform Dockerfile).
 # ----------------------------------------------------------------------------
-COPY --chown=app:app examples/agents/       /app/agents-builtin/
-COPY --chown=app:app examples/workflows/    /app/workflows-builtin/
-COPY --chown=app:app examples/integrations/ /app/integrations-builtin/
-COPY --chown=app:app examples/providers/    /app/providers-builtin/
-COPY --chown=app:app examples/branding/     /app/branding-builtin/
-COPY --chown=app:app examples/retention/    /app/retention-builtin/
-COPY --chown=app:app examples/skills/       /app/skills-builtin/
+COPY --chown=app:app examples/agents/       /app/builtin/agents/
+COPY --chown=app:app examples/workflows/    /app/builtin/workflows/
+COPY --chown=app:app examples/integrations/ /app/builtin/integrations/
+COPY --chown=app:app examples/providers/    /app/builtin/providers/
+COPY --chown=app:app examples/branding/     /app/builtin/branding/
+COPY --chown=app:app examples/retention/    /app/builtin/retention/
+COPY --chown=app:app examples/skills/       /app/builtin/skills/
 
 # ----------------------------------------------------------------------------
 # Entrypoint scripts

--- a/services/convex/docker-entrypoint.sh
+++ b/services/convex/docker-entrypoint.sh
@@ -283,7 +283,7 @@ run_seed() {
 
   # --- Agents ---
   local agents_dir="${data_dir}/agents"
-  local agents_builtin="/app/agents-builtin"
+  local agents_builtin="/app/builtin/agents"
   mkdir -p "$agents_dir"
   if [ -d "$agents_builtin" ] && [ "$(ls -A "$agents_builtin" 2>/dev/null)" ]; then
     for src in "$agents_builtin"/*.json; do
@@ -306,7 +306,7 @@ run_seed() {
 
   # --- Workflows (nested paths allowed) ---
   local workflows_dir="${data_dir}/workflows"
-  local workflows_builtin="/app/workflows-builtin"
+  local workflows_builtin="/app/builtin/workflows"
   mkdir -p "$workflows_dir"
   if [ -d "$workflows_builtin" ] && [ "$(ls -A "$workflows_builtin" 2>/dev/null)" ]; then
     find "$workflows_builtin" -name '*.json' -type f | while read -r src; do
@@ -330,7 +330,7 @@ run_seed() {
 
   # --- Integrations (directory-based) ---
   local integrations_dir="${data_dir}/integrations"
-  local integrations_builtin="/app/integrations-builtin"
+  local integrations_builtin="/app/builtin/integrations"
   mkdir -p "$integrations_dir"
   if [ -d "$integrations_builtin" ] && [ "$(ls -A "$integrations_builtin" 2>/dev/null)" ]; then
     for src_dir in "$integrations_builtin"/*/; do
@@ -351,7 +351,7 @@ run_seed() {
 
   # --- Skills (directory bundles: SKILL.md + scripts/ + references/ + assets/) ---
   local skills_dir="${data_dir}/skills"
-  local skills_builtin="/app/skills-builtin"
+  local skills_builtin="/app/builtin/skills"
   mkdir -p "$skills_dir"
   if [ -d "$skills_builtin" ] && [ "$(ls -A "$skills_builtin" 2>/dev/null)" ]; then
     for src_dir in "$skills_builtin"/*/; do
@@ -371,7 +371,7 @@ run_seed() {
 
   # --- Providers (skip encrypted .secrets.json) ---
   local providers_dir="${data_dir}/providers"
-  local providers_builtin="/app/providers-builtin"
+  local providers_builtin="/app/builtin/providers"
   mkdir -p "$providers_dir"
   if [ -d "$providers_builtin" ] && [ "$(ls -A "$providers_builtin" 2>/dev/null)" ]; then
     for src in "$providers_builtin"/*.json; do
@@ -398,7 +398,7 @@ run_seed() {
   # the {orgSlug}.json convention. Retention has no secrets to skip
   # (compare with providers' .secrets.json branch above).
   local retention_dir="${data_dir}/retention"
-  local retention_builtin="/app/retention-builtin"
+  local retention_builtin="/app/builtin/retention"
   mkdir -p "$retention_dir"
   if [ -d "$retention_builtin" ] && [ "$(ls -A "$retention_builtin" 2>/dev/null)" ]; then
     for src in "$retention_builtin"/*.json; do

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -229,7 +229,24 @@ ENV NODE_ENV=production \
     # container. Platform forces this at push time in docker-entrypoint.sh
     # (to tombstone any stale host-side `.env` value). Convex derives the
     # sub-dirs (agents/workflows/integrations/providers) from it.
-    TALE_CONFIG_DIR=/app/data
+    TALE_CONFIG_DIR=/app/data \
+    # Read-only builtin catalogs baked into the convex image
+    # (`COPY examples/{domain}/ /app/{domain}-builtin/` in
+    # services/convex/Dockerfile). Convex Node actions only see env vars
+    # that this platform container pushes to Convex's deployment env via
+    # the entrypoint's `convex env set` loop — so even though these paths
+    # live in the *convex* container, the values must originate here.
+    # Read by scaffoldNewOrganization to seed new orgs from the catalog
+    # instead of the default org's writable workspace (which conflated
+    # shipped templates with anything created while using the default org
+    # and propagated that mix into every new org). On rollback to an
+    # image without these ENV lines, scaffold falls back to the old
+    # default-org source — intentional graceful degradation.
+    AGENTS_BUILTIN_DIR=/app/agents-builtin \
+    PROVIDERS_BUILTIN_DIR=/app/providers-builtin \
+    INTEGRATIONS_BUILTIN_DIR=/app/integrations-builtin \
+    WORKFLOWS_BUILTIN_DIR=/app/workflows-builtin \
+    SKILLS_BUILTIN_DIR=/app/skills-builtin
 
 COPY --from=pruner --chown=app:app /app/services/platform/dist ./dist
 COPY --from=pruner --chown=app:app /app/services/platform/dist-seo ./dist-seo
@@ -280,7 +297,12 @@ ENV NODE_ENV=production \
     SANDBOX_STORAGE_INTERNAL_BASE_URL=http://convex:3210 \
     INSTANCE_NAME=tale_platform \
     DO_NOT_TRACK=1 \
-    TALE_CONFIG_DIR=/app/data
+    TALE_CONFIG_DIR=/app/data \
+    AGENTS_BUILTIN_DIR=/app/agents-builtin \
+    PROVIDERS_BUILTIN_DIR=/app/providers-builtin \
+    INTEGRATIONS_BUILTIN_DIR=/app/integrations-builtin \
+    WORKFLOWS_BUILTIN_DIR=/app/workflows-builtin \
+    SKILLS_BUILTIN_DIR=/app/skills-builtin
 
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api/health || exit 1

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -230,23 +230,15 @@ ENV NODE_ENV=production \
     # (to tombstone any stale host-side `.env` value). Convex derives the
     # sub-dirs (agents/workflows/integrations/providers) from it.
     TALE_CONFIG_DIR=/app/data \
-    # Read-only builtin catalogs baked into the convex image
-    # (`COPY examples/{domain}/ /app/{domain}-builtin/` in
-    # services/convex/Dockerfile). Convex Node actions only see env vars
-    # that this platform container pushes to Convex's deployment env via
-    # the entrypoint's `convex env set` loop — so even though these paths
-    # live in the *convex* container, the values must originate here.
-    # Read by scaffoldNewOrganization to seed new orgs from the catalog
-    # instead of the default org's writable workspace (which conflated
-    # shipped templates with anything created while using the default org
-    # and propagated that mix into every new org). On rollback to an
-    # image without these ENV lines, scaffold falls back to the old
-    # default-org source — intentional graceful degradation.
-    AGENTS_BUILTIN_DIR=/app/agents-builtin \
-    PROVIDERS_BUILTIN_DIR=/app/providers-builtin \
-    INTEGRATIONS_BUILTIN_DIR=/app/integrations-builtin \
-    WORKFLOWS_BUILTIN_DIR=/app/workflows-builtin \
-    SKILLS_BUILTIN_DIR=/app/skills-builtin
+    # Read-only builtin catalog baked into the convex image (see
+    # services/convex/Dockerfile). Declared here because Convex Node
+    # actions only see env vars that this container pushes to Convex's
+    # deployment env via the entrypoint's `convex env set` loop — even
+    # though the path points at files inside the *convex* container.
+    # Per-domain catalogs are derived as $TALE_CONFIG_BUILTIN_DIR/<domain>/
+    # by services/platform/convex/organizations/scaffold.ts (mirrors the
+    # $TALE_CONFIG_DIR/<domain>/ pattern used for the writable side).
+    TALE_CONFIG_BUILTIN_DIR=/app/builtin
 
 COPY --from=pruner --chown=app:app /app/services/platform/dist ./dist
 COPY --from=pruner --chown=app:app /app/services/platform/dist-seo ./dist-seo
@@ -298,11 +290,7 @@ ENV NODE_ENV=production \
     INSTANCE_NAME=tale_platform \
     DO_NOT_TRACK=1 \
     TALE_CONFIG_DIR=/app/data \
-    AGENTS_BUILTIN_DIR=/app/agents-builtin \
-    PROVIDERS_BUILTIN_DIR=/app/providers-builtin \
-    INTEGRATIONS_BUILTIN_DIR=/app/integrations-builtin \
-    WORKFLOWS_BUILTIN_DIR=/app/workflows-builtin \
-    SKILLS_BUILTIN_DIR=/app/skills-builtin
+    TALE_CONFIG_BUILTIN_DIR=/app/builtin
 
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api/health || exit 1

--- a/services/platform/convex/agents/seed_system_defaults.ts
+++ b/services/platform/convex/agents/seed_system_defaults.ts
@@ -2,7 +2,7 @@
  * System Default Agent Seeding (legacy stubs)
  *
  * System default agents are now JSON files baked into the Docker image
- * at /app/agents-builtin/ and seeded to AGENTS_DIR by the entrypoint.
+ * at /app/builtin/agents/ and seeded to AGENTS_DIR by the entrypoint.
  * These mutations are kept as no-ops since they're called from
  * organization creation flow.
  */

--- a/services/platform/convex/organizations/scaffold.test.ts
+++ b/services/platform/convex/organizations/scaffold.test.ts
@@ -122,6 +122,47 @@ describe('scaffoldNewOrganization', () => {
     );
   });
 
+  it('flat domains (agents/providers) never recurse into catalog subdirs', async () => {
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
+    await writeText(
+      path.join(catalogRoot, 'agents', 'shipped.json'),
+      '{"displayName":"shipped"}',
+    );
+    // A subdir inside the agents catalog is unexpected (agents is file-only).
+    // The flat-domain guard must skip it rather than recurse.
+    await writeText(
+      path.join(catalogRoot, 'agents', 'stray', 'nested.json'),
+      '{"displayName":"nested"}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'agents', 'acme');
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(true);
+    expect(existsSync(path.join(acmeDir, 'stray'))).toBe(false);
+  });
+
+  it('flat-domain guard closes the agents leak on the dev fallback path (env unset)', async () => {
+    // No catalog env → source is the default-org workspace. A previously
+    // created org left a raw-slug subdir there; scaffolding a new org must
+    // not recurse into it. Here the flat-domain guard — not the source
+    // choice — is what prevents the cross-tenant copy.
+    await writeText(
+      path.join(configRoot, 'agents', 'shipped.json'),
+      '{"displayName":"shipped"}',
+    );
+    await writeText(
+      path.join(configRoot, 'agents', 'competitor', 'secret.json'),
+      '{"displayName":"leak"}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'agents', 'acme');
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(true);
+    expect(existsSync(path.join(acmeDir, 'competitor'))).toBe(false);
+  });
+
   it('skips symlinks rather than following them', async () => {
     process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     const targetPayload = await mkdtemp(path.join(tmpdir(), 'scaffold-evil-'));

--- a/services/platform/convex/organizations/scaffold.test.ts
+++ b/services/platform/convex/organizations/scaffold.test.ts
@@ -33,16 +33,12 @@ const scaffoldHandler = (scaffoldNewOrganization as unknown as ActionConfig)
 // state, then restore in afterEach so we don't poison other test files.
 const ENV_KEYS = [
   'TALE_CONFIG_DIR',
+  'TALE_CONFIG_BUILTIN_DIR',
   'AGENTS_DIR',
   'WORKFLOWS_DIR',
   'PROVIDERS_DIR',
   'INTEGRATIONS_DIR',
   'SKILLS_DIR',
-  'AGENTS_BUILTIN_DIR',
-  'WORKFLOWS_BUILTIN_DIR',
-  'PROVIDERS_BUILTIN_DIR',
-  'INTEGRATIONS_BUILTIN_DIR',
-  'SKILLS_BUILTIN_DIR',
 ] as const;
 
 let configRoot: string;
@@ -79,7 +75,7 @@ async function writeText(filePath: string, content: string): Promise<void> {
 describe('scaffoldNewOrganization', () => {
   it('seeds workflows from the catalog and ignores the default org workspace', async () => {
     // Catalog: a shipped template under workflows/shopify/sync.json.
-    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     await writeText(
       path.join(catalogRoot, 'workflows', 'shopify', 'sync.json'),
       '{"name":"sync"}',
@@ -100,7 +96,7 @@ describe('scaffoldNewOrganization', () => {
 
   it('closes the agents cross-tenant leak: raw-slug subdirs in the source are not copied', async () => {
     // Agents catalog contains only the shipped template.
-    process.env.AGENTS_BUILTIN_DIR = path.join(catalogRoot, 'agents');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     await writeText(
       path.join(catalogRoot, 'agents', 'shipped.json'),
       '{"displayName":"shipped"}',
@@ -127,7 +123,7 @@ describe('scaffoldNewOrganization', () => {
   });
 
   it('skips symlinks rather than following them', async () => {
-    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     const targetPayload = await mkdtemp(path.join(tmpdir(), 'scaffold-evil-'));
     const targetFile = path.join(targetPayload, 'payload.json');
     await writeFile(targetFile, '{"name":"escaped"}', 'utf-8');
@@ -152,8 +148,8 @@ describe('scaffoldNewOrganization', () => {
   });
 
   it('falls back to domain.resolve(default) when the catalog env is unset (dev)', async () => {
-    // No *_BUILTIN_DIR set. Default-org workspace becomes the catalog —
-    // historical behavior, preserved for local dev.
+    // No TALE_CONFIG_BUILTIN_DIR set. Default-org workspace becomes the
+    // catalog — historical behavior, preserved for local dev.
     await writeText(
       path.join(configRoot, 'workflows', 'shopify', 'sync.json'),
       '{"name":"sync"}',
@@ -166,7 +162,7 @@ describe('scaffoldNewOrganization', () => {
   });
 
   it('still applies the @-prefix, .history, and *.secrets.json skips when copying', async () => {
-    process.env.PROVIDERS_BUILTIN_DIR = path.join(catalogRoot, 'providers');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     await writeText(
       path.join(catalogRoot, 'providers', 'openai.json'),
       '{"name":"openai"}',
@@ -194,7 +190,7 @@ describe('scaffoldNewOrganization', () => {
   });
 
   it('is per-domain idempotent: a domain dir that already has files is skipped', async () => {
-    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     await writeText(
       path.join(catalogRoot, 'workflows', 'shipped.json'),
       '{"name":"shipped"}',
@@ -211,8 +207,76 @@ describe('scaffoldNewOrganization', () => {
     expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(false);
   });
 
+  it('treats a target containing only .history/ as occupied (no re-seed on top of user edit trail)', async () => {
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
+    await writeText(
+      path.join(catalogRoot, 'workflows', 'shipped.json'),
+      '{"name":"shipped"}',
+    );
+    // Realistic state: user created the org, edited a workflow (writing
+    // `.history/<slug>/<rev>.json`), then deleted the visible workflow.
+    // Re-scaffolding (e.g., via the backfill migration) must NOT silently
+    // re-seed the catalog on top of the surviving edit trail.
+    const acmeDir = path.join(configRoot, 'workflows', '@acme');
+    await writeText(
+      path.join(acmeDir, '.history', 'old.json'),
+      '{"snapshot":1}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(false);
+    expect(existsSync(path.join(acmeDir, '.history', 'old.json'))).toBe(true);
+  });
+
+  it('ignores atomicWrite tmp orphans so a crashed scaffold can retry', async () => {
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
+    await writeText(
+      path.join(catalogRoot, 'workflows', 'shipped.json'),
+      '{"name":"shipped"}',
+    );
+    // Simulate the residue a prior crashed scaffold would leave behind:
+    // atomicWrite uses `.<basename>.<ts>.<uuid>.tmp` and cleans up on
+    // success, but a crash mid-write leaves the tmp orphan in place.
+    const acmeDir = path.join(configRoot, 'workflows', '@acme');
+    await writeText(
+      path.join(acmeDir, '.shipped.json.1700000000000.deadbeef.tmp'),
+      'partial',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(true);
+  });
+
+  it('logs error when TALE_CONFIG_BUILTIN_DIR points at a missing path (deploy misconfig)', async () => {
+    // Builtin root configured but the directory doesn't exist on disk —
+    // simulates platform/convex image version skew or a missing volume mount.
+    process.env.TALE_CONFIG_BUILTIN_DIR = path.join(catalogRoot, 'missing');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+      const calls = errSpy.mock.calls.map((c) => c.join(' '));
+      expect(
+        calls.some(
+          (m) =>
+            m.includes('TALE_CONFIG_BUILTIN_DIR') &&
+            m.includes('does not exist'),
+        ),
+      ).toBe(true);
+      // Target should remain empty — no silent fallback to default-org dir.
+      expect(existsSync(path.join(configRoot, 'workflows', '@acme'))).toBe(
+        false,
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
   it('returns null without scaffolding the default org', async () => {
-    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    process.env.TALE_CONFIG_BUILTIN_DIR = catalogRoot;
     await writeText(path.join(catalogRoot, 'workflows', 'shipped.json'), '{}');
 
     const result = await scaffoldHandler({} as never, { orgSlug: 'default' });

--- a/services/platform/convex/organizations/scaffold.test.ts
+++ b/services/platform/convex/organizations/scaffold.test.ts
@@ -1,0 +1,226 @@
+import { existsSync } from 'node:fs';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the codegen surface so `internalAction(config)` returns the config
+// itself — that exposes `.handler` for direct invocation, matching the
+// pattern used by agents/file_actions.test.ts.
+vi.mock('../_generated/server', () => ({
+  action: vi.fn((config) => config),
+  internalAction: vi.fn((config) => config),
+}));
+
+const { scaffoldNewOrganization } = await import('./scaffold');
+
+type ActionConfig = {
+  handler: (ctx: never, args: { orgSlug: string }) => Promise<unknown>;
+};
+const scaffoldHandler = (scaffoldNewOrganization as unknown as ActionConfig)
+  .handler;
+
+// All env vars the scaffold code path or the per-domain resolvers consult.
+// Save + clear them in beforeEach so each test starts from a known-empty
+// state, then restore in afterEach so we don't poison other test files.
+const ENV_KEYS = [
+  'TALE_CONFIG_DIR',
+  'AGENTS_DIR',
+  'WORKFLOWS_DIR',
+  'PROVIDERS_DIR',
+  'INTEGRATIONS_DIR',
+  'SKILLS_DIR',
+  'AGENTS_BUILTIN_DIR',
+  'WORKFLOWS_BUILTIN_DIR',
+  'PROVIDERS_BUILTIN_DIR',
+  'INTEGRATIONS_BUILTIN_DIR',
+  'SKILLS_BUILTIN_DIR',
+] as const;
+
+let configRoot: string;
+let catalogRoot: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  configRoot = await mkdtemp(path.join(tmpdir(), 'scaffold-cfg-'));
+  catalogRoot = await mkdtemp(path.join(tmpdir(), 'scaffold-cat-'));
+  process.env.TALE_CONFIG_DIR = configRoot;
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = savedEnv[k];
+    }
+  }
+  await rm(configRoot, { recursive: true, force: true });
+  await rm(catalogRoot, { recursive: true, force: true });
+});
+
+async function writeText(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf-8');
+}
+
+describe('scaffoldNewOrganization', () => {
+  it('seeds workflows from the catalog and ignores the default org workspace', async () => {
+    // Catalog: a shipped template under workflows/shopify/sync.json.
+    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    await writeText(
+      path.join(catalogRoot, 'workflows', 'shopify', 'sync.json'),
+      '{"name":"sync"}',
+    );
+
+    // Default-org workspace: a junk workflow that must NOT propagate.
+    await writeText(
+      path.join(configRoot, 'workflows', 'junk.json'),
+      '{"name":"junk"}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'workflows', '@acme');
+    expect(existsSync(path.join(acmeDir, 'shopify', 'sync.json'))).toBe(true);
+    expect(existsSync(path.join(acmeDir, 'junk.json'))).toBe(false);
+  });
+
+  it('closes the agents cross-tenant leak: raw-slug subdirs in the source are not copied', async () => {
+    // Agents catalog contains only the shipped template.
+    process.env.AGENTS_BUILTIN_DIR = path.join(catalogRoot, 'agents');
+    await writeText(
+      path.join(catalogRoot, 'agents', 'shipped.json'),
+      '{"displayName":"shipped"}',
+    );
+
+    // Default-org workspace contains another tenant's raw-slug subdir.
+    // Pre-fix scaffolding (which sourced from this dir) would recursively
+    // copy `competitor/` into the new org because the @-skip in copyTree
+    // doesn't catch raw slugs. Sourcing from the catalog instead must
+    // not see this at all.
+    await writeText(
+      path.join(configRoot, 'agents', 'competitor', 'secret.json'),
+      '{"displayName":"leak"}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'agents', 'acme');
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(true);
+    expect(existsSync(path.join(acmeDir, 'competitor'))).toBe(false);
+    expect(existsSync(path.join(acmeDir, 'competitor', 'secret.json'))).toBe(
+      false,
+    );
+  });
+
+  it('skips symlinks rather than following them', async () => {
+    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    const targetPayload = await mkdtemp(path.join(tmpdir(), 'scaffold-evil-'));
+    const targetFile = path.join(targetPayload, 'payload.json');
+    await writeFile(targetFile, '{"name":"escaped"}', 'utf-8');
+
+    await mkdir(path.join(catalogRoot, 'workflows'), { recursive: true });
+    await symlink(targetFile, path.join(catalogRoot, 'workflows', 'evil.json'));
+    // Also drop a real file beside it so we know the copy loop kept running.
+    await writeText(
+      path.join(catalogRoot, 'workflows', 'legit.json'),
+      '{"name":"legit"}',
+    );
+
+    try {
+      await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+      const acmeDir = path.join(configRoot, 'workflows', '@acme');
+      expect(existsSync(path.join(acmeDir, 'evil.json'))).toBe(false);
+      expect(existsSync(path.join(acmeDir, 'legit.json'))).toBe(true);
+    } finally {
+      await rm(targetPayload, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to domain.resolve(default) when the catalog env is unset (dev)', async () => {
+    // No *_BUILTIN_DIR set. Default-org workspace becomes the catalog —
+    // historical behavior, preserved for local dev.
+    await writeText(
+      path.join(configRoot, 'workflows', 'shopify', 'sync.json'),
+      '{"name":"sync"}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'workflows', '@acme');
+    expect(existsSync(path.join(acmeDir, 'shopify', 'sync.json'))).toBe(true);
+  });
+
+  it('still applies the @-prefix, .history, and *.secrets.json skips when copying', async () => {
+    process.env.PROVIDERS_BUILTIN_DIR = path.join(catalogRoot, 'providers');
+    await writeText(
+      path.join(catalogRoot, 'providers', 'openai.json'),
+      '{"name":"openai"}',
+    );
+    await writeText(
+      path.join(catalogRoot, 'providers', 'openai.secrets.json'),
+      '{"key":"redacted"}',
+    );
+    await writeText(
+      path.join(catalogRoot, 'providers', '.history', 'snapshot.json'),
+      '{}',
+    );
+    await writeText(
+      path.join(catalogRoot, 'providers', '@stale-tenant', 'leak.json'),
+      '{}',
+    );
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    const acmeDir = path.join(configRoot, 'providers', 'acme');
+    expect(existsSync(path.join(acmeDir, 'openai.json'))).toBe(true);
+    expect(existsSync(path.join(acmeDir, 'openai.secrets.json'))).toBe(false);
+    expect(existsSync(path.join(acmeDir, '.history'))).toBe(false);
+    expect(existsSync(path.join(acmeDir, '@stale-tenant'))).toBe(false);
+  });
+
+  it('is per-domain idempotent: a domain dir that already has files is skipped', async () => {
+    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    await writeText(
+      path.join(catalogRoot, 'workflows', 'shipped.json'),
+      '{"name":"shipped"}',
+    );
+    // Pre-existing org content — scaffold must not overwrite.
+    const acmeDir = path.join(configRoot, 'workflows', '@acme');
+    await writeText(path.join(acmeDir, 'existing.json'), '{"name":"existing"}');
+
+    await scaffoldHandler({} as never, { orgSlug: 'acme' });
+
+    expect(await readFile(path.join(acmeDir, 'existing.json'), 'utf-8')).toBe(
+      '{"name":"existing"}',
+    );
+    expect(existsSync(path.join(acmeDir, 'shipped.json'))).toBe(false);
+  });
+
+  it('returns null without scaffolding the default org', async () => {
+    process.env.WORKFLOWS_BUILTIN_DIR = path.join(catalogRoot, 'workflows');
+    await writeText(path.join(catalogRoot, 'workflows', 'shipped.json'), '{}');
+
+    const result = await scaffoldHandler({} as never, { orgSlug: 'default' });
+
+    expect(result).toBeNull();
+    // Default org's workspace must not have been touched by scaffold.
+    expect(existsSync(path.join(configRoot, 'workflows', 'shipped.json'))).toBe(
+      false,
+    );
+  });
+});

--- a/services/platform/convex/organizations/scaffold.ts
+++ b/services/platform/convex/organizations/scaffold.ts
@@ -3,15 +3,28 @@
 /**
  * Scaffold per-org filesystem config on organization creation.
  *
- * Copies /examples/{agents,providers,integrations,workflows,skills}/ defaults
- * into the new org's subdir. Skips *.secrets.json (new org provides its
- * own secrets). Skips branding (intentionally global).
+ * Seeds new orgs from the immutable builtin catalog (`/app/{domain}-builtin/`
+ * baked into the convex image), addressed per-domain via `*_BUILTIN_DIR` env
+ * vars pushed from the platform Dockerfile. Falls back to the default org's
+ * dir when the env is unset (dev / local convex), preserving the historical
+ * behavior for that environment.
+ *
+ * Why the catalog and not `domain.resolve('default')`: the default org's dir
+ * is a writable workspace, so anything created there (test workflows, scratch
+ * agents) used to propagate into every newly-scaffolded org permanently.
+ * Sourcing from the read-only catalog severs that channel. For agents and
+ * providers — which use raw `<slug>/` per-org subdirs (no `@` marker) — this
+ * also closes a genuine cross-tenant leak, since the old source could
+ * recurse into other tenants' subdirs.
+ *
+ * Skips `*.secrets.json` (new org provides its own secrets) and `.history/`.
+ * Skips branding (intentionally global; read-side hardcodes 'default').
  *
  * Idempotent: if the target dir already contains files, skip that domain
  * with a warning rather than overwriting.
  */
 
-import { readdir, rm, stat, readFile } from 'node:fs/promises';
+import { readdir, rm, lstat, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { v } from 'convex/values';
@@ -31,13 +44,43 @@ import { resolveWorkflowsDir } from '../workflows/file_utils';
 
 type DirResolver = (orgSlug: string) => string;
 
+type Domain = {
+  name: string;
+  resolve: DirResolver;
+  // Env var holding the absolute path to this domain's read-only catalog
+  // (baked into the convex image as `/app/{name}-builtin/`). Set by the
+  // platform Dockerfile so the entrypoint pushes it to Convex's deployment
+  // env. Unset in local dev — see scaffoldNewOrganization for the fallback.
+  builtinEnv: string;
+};
+
 // Each domain's per-org dir convention differs — use the domain's own resolver.
-const DOMAINS: Array<{ name: string; resolve: DirResolver }> = [
-  { name: 'agents', resolve: resolveAgentsDir },
-  { name: 'providers', resolve: resolveProvidersDir },
-  { name: 'integrations', resolve: resolveIntegrationsDir },
-  { name: 'workflows', resolve: resolveWorkflowsDir },
-  { name: 'skills', resolve: resolveSkillsDir },
+const DOMAINS: Domain[] = [
+  {
+    name: 'agents',
+    resolve: resolveAgentsDir,
+    builtinEnv: 'AGENTS_BUILTIN_DIR',
+  },
+  {
+    name: 'providers',
+    resolve: resolveProvidersDir,
+    builtinEnv: 'PROVIDERS_BUILTIN_DIR',
+  },
+  {
+    name: 'integrations',
+    resolve: resolveIntegrationsDir,
+    builtinEnv: 'INTEGRATIONS_BUILTIN_DIR',
+  },
+  {
+    name: 'workflows',
+    resolve: resolveWorkflowsDir,
+    builtinEnv: 'WORKFLOWS_BUILTIN_DIR',
+  },
+  {
+    name: 'skills',
+    resolve: resolveSkillsDir,
+    builtinEnv: 'SKILLS_BUILTIN_DIR',
+  },
 ];
 
 const SKIP_FILE_SUFFIXES = ['.secrets.json'];
@@ -75,12 +118,12 @@ async function copyTree(sourceDir: string, targetDir: string): Promise<void> {
   for (const name of entries) {
     if (name.startsWith('.')) continue;
     // Per-org marker prefix used by skills / integrations / workflows for
-    // tenant subdirs (`@<orgSlug>/...`). Without this skip, scaffolding a
-    // new org would recursively copy every existing org's tenant tree
-    // into the new org's namespace. Agents / providers use raw `<slug>`
-    // subdirs with no marker, so this guard only protects the
-    // `@`-prefixed domains — see the follow-up issue for the agents /
-    // providers leak which needs a domain-aware fix.
+    // tenant subdirs (`@<orgSlug>/...`). Defence-in-depth: the builtin
+    // catalog has no `@` subdirs, but if the source ever falls back to a
+    // mutable workspace this guard prevents recursing into other orgs'
+    // trees. Agents / providers use raw `<slug>` subdirs with no marker,
+    // so this guard alone doesn't cover them — that gap is the reason
+    // scaffoldNewOrganization sources from the catalog now.
     if (name.startsWith('@')) continue;
     if (SKIP_DIR_NAMES.has(name)) continue;
     if (shouldSkipFile(name)) continue;
@@ -88,13 +131,21 @@ async function copyTree(sourceDir: string, targetDir: string): Promise<void> {
     const src = path.join(sourceDir, name);
     const dst = path.join(targetDir, name);
 
-    const info = await stat(src).catch((err) => {
+    // lstat (not stat) so a symlink in the source is detected and skipped
+    // rather than followed. The catalog is built from `examples/` which
+    // tracks no symlinks today, but this keeps the scaffold from
+    // dereferencing through to arbitrary paths if one is ever introduced.
+    const info = await lstat(src).catch((err) => {
       if (errnoCode(err) !== 'ENOENT') {
-        console.warn('[scaffold.copyTree] stat failed:', src, err);
+        console.warn('[scaffold.copyTree] lstat failed:', src, err);
       }
       return null;
     });
     if (!info) continue;
+    if (info.isSymbolicLink()) {
+      console.warn('[scaffold.copyTree] skipping symlink:', src);
+      continue;
+    }
 
     if (info.isDirectory()) {
       await copyTree(src, dst);
@@ -199,7 +250,15 @@ export const scaffoldNewOrganization = internalAction({
     }
 
     for (const domain of DOMAINS) {
-      const sourceDir = domain.resolve('default');
+      // Prefer the immutable builtin catalog (`*_BUILTIN_DIR`, set by the
+      // platform Dockerfile and pushed into Convex's deployment env). Falls
+      // back to the default org's writable dir when the env is unset — that
+      // path is what local `bun dev` uses, where `examples/{domain}` *is*
+      // the catalog. In prod the fallback also kicks in on rollback to a
+      // pre-fix platform image (intentional graceful degradation back to
+      // the prior behavior).
+      const sourceDir =
+        process.env[domain.builtinEnv] ?? domain.resolve('default');
       const targetDir = domain.resolve(args.orgSlug);
 
       const alreadyScaffolded = await dirHasFiles(targetDir);

--- a/services/platform/convex/organizations/scaffold.ts
+++ b/services/platform/convex/organizations/scaffold.ts
@@ -3,28 +3,23 @@
 /**
  * Scaffold per-org filesystem config on organization creation.
  *
- * Seeds new orgs from the immutable builtin catalog (`/app/{domain}-builtin/`
- * baked into the convex image), addressed per-domain via `*_BUILTIN_DIR` env
- * vars pushed from the platform Dockerfile. Falls back to the default org's
- * dir when the env is unset (dev / local convex), preserving the historical
- * behavior for that environment.
+ * Seeds new orgs from the immutable builtin catalog baked into the convex
+ * image at `$TALE_CONFIG_BUILTIN_DIR/<domain>/` (mirrors the writable
+ * `$TALE_CONFIG_DIR/<domain>/` pattern). The env is pushed by the platform
+ * Dockerfile via the entrypoint's `convex env set` loop. Falls back to the
+ * default org's writable dir when the env is unset, so local `bun dev`
+ * (where no catalog is built) still works. The rationale for sourcing from
+ * the read-only catalog instead of the default workspace lives at the
+ * `@`-prefix-skip comment in copyTree below — that's the load-bearing site.
  *
- * Why the catalog and not `domain.resolve('default')`: the default org's dir
- * is a writable workspace, so anything created there (test workflows, scratch
- * agents) used to propagate into every newly-scaffolded org permanently.
- * Sourcing from the read-only catalog severs that channel. For agents and
- * providers — which use raw `<slug>/` per-org subdirs (no `@` marker) — this
- * also closes a genuine cross-tenant leak, since the old source could
- * recurse into other tenants' subdirs.
+ * Skips per-org secrets (`*.secrets.json`) and local edit-history dirs
+ * (`.history/`). Skips branding entirely — read-side hardcodes 'default'.
  *
- * Skips `*.secrets.json` (new org provides its own secrets) and `.history/`.
- * Skips branding (intentionally global; read-side hardcodes 'default').
- *
- * Idempotent: if the target dir already contains files, skip that domain
- * with a warning rather than overwriting.
+ * Idempotent: if the target dir already contains user-visible files, skip
+ * that domain with a warning rather than overwriting.
  */
 
-import { readdir, rm, lstat, readFile } from 'node:fs/promises';
+import { lstat, readdir, readFile, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import { v } from 'convex/values';
@@ -47,41 +42,19 @@ type DirResolver = (orgSlug: string) => string;
 type Domain = {
   name: string;
   resolve: DirResolver;
-  // Env var holding the absolute path to this domain's read-only catalog
-  // (baked into the convex image as `/app/{name}-builtin/`). Set by the
-  // platform Dockerfile so the entrypoint pushes it to Convex's deployment
-  // env. Unset in local dev — see scaffoldNewOrganization for the fallback.
-  builtinEnv: string;
 };
 
 // Each domain's per-org dir convention differs — use the domain's own resolver.
+// The catalog subdir name matches `name` (e.g., `$TALE_CONFIG_BUILTIN_DIR/agents/`).
 const DOMAINS: Domain[] = [
-  {
-    name: 'agents',
-    resolve: resolveAgentsDir,
-    builtinEnv: 'AGENTS_BUILTIN_DIR',
-  },
-  {
-    name: 'providers',
-    resolve: resolveProvidersDir,
-    builtinEnv: 'PROVIDERS_BUILTIN_DIR',
-  },
-  {
-    name: 'integrations',
-    resolve: resolveIntegrationsDir,
-    builtinEnv: 'INTEGRATIONS_BUILTIN_DIR',
-  },
-  {
-    name: 'workflows',
-    resolve: resolveWorkflowsDir,
-    builtinEnv: 'WORKFLOWS_BUILTIN_DIR',
-  },
-  {
-    name: 'skills',
-    resolve: resolveSkillsDir,
-    builtinEnv: 'SKILLS_BUILTIN_DIR',
-  },
+  { name: 'agents', resolve: resolveAgentsDir },
+  { name: 'providers', resolve: resolveProvidersDir },
+  { name: 'integrations', resolve: resolveIntegrationsDir },
+  { name: 'workflows', resolve: resolveWorkflowsDir },
+  { name: 'skills', resolve: resolveSkillsDir },
 ];
+
+const BUILTIN_ENV = 'TALE_CONFIG_BUILTIN_DIR';
 
 const SKIP_FILE_SUFFIXES = ['.secrets.json'];
 const SKIP_DIR_NAMES = new Set(['.history']);
@@ -90,10 +63,18 @@ function shouldSkipFile(name: string): boolean {
   return SKIP_FILE_SUFFIXES.some((s) => name.endsWith(s));
 }
 
+// atomicWrite leaves `.<basename>.<ts>.<uuid>.tmp` orphans on crash. Those
+// shouldn't lock out a retry, but every other entry (including dotfiles
+// like `.history/` that agents/workflows write on every edit) means a user
+// has been here and we must not overwrite.
+function isAtomicWriteTmp(name: string): boolean {
+  return name.startsWith('.') && name.endsWith('.tmp');
+}
+
 async function dirHasFiles(dir: string): Promise<boolean> {
   try {
     const entries = await readdir(dir);
-    return entries.filter((n) => !n.startsWith('.')).length > 0;
+    return entries.some((n) => !isAtomicWriteTmp(n));
   } catch (err) {
     // ENOENT (dir doesn't exist yet) is the expected case — domain scaffold
     // simply hasn't run. Anything else (EACCES, EIO) means we can't read
@@ -249,17 +230,43 @@ export const scaffoldNewOrganization = internalAction({
       return null;
     }
 
+    const builtinRoot = process.env[BUILTIN_ENV];
+
     for (const domain of DOMAINS) {
-      // Prefer the immutable builtin catalog (`*_BUILTIN_DIR`, set by the
-      // platform Dockerfile and pushed into Convex's deployment env). Falls
-      // back to the default org's writable dir when the env is unset — that
-      // path is what local `bun dev` uses, where `examples/{domain}` *is*
-      // the catalog. In prod the fallback also kicks in on rollback to a
-      // pre-fix platform image (intentional graceful degradation back to
-      // the prior behavior).
-      const sourceDir =
-        process.env[domain.builtinEnv] ?? domain.resolve('default');
+      // Prefer `$TALE_CONFIG_BUILTIN_DIR/<domain>/` (set by platform
+      // Dockerfile, pushed into Convex's deployment env). Falls back to
+      // the default org's dir when the env is unset — covers local
+      // `bun dev` (no catalog built) and a rollback to a platform image
+      // that doesn't declare the env.
+      const sourceDir = builtinRoot
+        ? path.join(builtinRoot, domain.name)
+        : domain.resolve('default');
       const targetDir = domain.resolve(args.orgSlug);
+
+      // copyTree's ENOENT-silent contract is correct for the fallback case
+      // (default-org dir may legitimately not be seeded yet). But when an
+      // operator-configured catalog path doesn't exist, that's a deploy
+      // misconfig (e.g., platform/convex image version skew) and the
+      // resulting zero-seed should NOT look like a successful copy. Probe
+      // explicitly so the failure surfaces in logs.
+      if (builtinRoot) {
+        const sourceExists = await stat(sourceDir)
+          .then(() => true)
+          .catch((err) => {
+            if (errnoCode(err) === 'ENOENT') return false;
+            console.error(
+              `[scaffoldNewOrganization] ${domain.name}: stat ${sourceDir} failed:`,
+              err instanceof Error ? err.message : err,
+            );
+            return false;
+          });
+        if (!sourceExists) {
+          console.error(
+            `[scaffoldNewOrganization] ${domain.name}: ${BUILTIN_ENV}=${builtinRoot} is set but ${sourceDir} does not exist; new org "${args.orgSlug}" will receive zero seed data for this domain`,
+          );
+          continue;
+        }
+      }
 
       const alreadyScaffolded = await dirHasFiles(targetDir);
       if (alreadyScaffolded) {

--- a/services/platform/convex/organizations/scaffold.ts
+++ b/services/platform/convex/organizations/scaffold.ts
@@ -42,13 +42,17 @@ type DirResolver = (orgSlug: string) => string;
 type Domain = {
   name: string;
   resolve: DirResolver;
+  // Flat domains store one file per item with no subdirectories in the
+  // catalog (agents/providers: `<slug>.json`). copyTree must not recurse into
+  // subdirs for these — see the `allowSubdirs` guard in copyTree.
+  flat?: boolean;
 };
 
 // Each domain's per-org dir convention differs — use the domain's own resolver.
 // The catalog subdir name matches `name` (e.g., `$TALE_CONFIG_BUILTIN_DIR/agents/`).
 const DOMAINS: Domain[] = [
-  { name: 'agents', resolve: resolveAgentsDir },
-  { name: 'providers', resolve: resolveProvidersDir },
+  { name: 'agents', resolve: resolveAgentsDir, flat: true },
+  { name: 'providers', resolve: resolveProvidersDir, flat: true },
   { name: 'integrations', resolve: resolveIntegrationsDir },
   { name: 'workflows', resolve: resolveWorkflowsDir },
   { name: 'skills', resolve: resolveSkillsDir },
@@ -87,7 +91,11 @@ async function dirHasFiles(dir: string): Promise<boolean> {
   }
 }
 
-async function copyTree(sourceDir: string, targetDir: string): Promise<void> {
+async function copyTree(
+  sourceDir: string,
+  targetDir: string,
+  allowSubdirs = true,
+): Promise<void> {
   let entries: string[];
   try {
     entries = await readdir(sourceDir);
@@ -102,9 +110,10 @@ async function copyTree(sourceDir: string, targetDir: string): Promise<void> {
     // tenant subdirs (`@<orgSlug>/...`). Defence-in-depth: the builtin
     // catalog has no `@` subdirs, but if the source ever falls back to a
     // mutable workspace this guard prevents recursing into other orgs'
-    // trees. Agents / providers use raw `<slug>` subdirs with no marker,
-    // so this guard alone doesn't cover them — that gap is the reason
-    // scaffoldNewOrganization sources from the catalog now.
+    // trees. Agents / providers use raw `<slug>` subdirs (no `@` marker) and
+    // are flat-copied (`allowSubdirs=false` below), so a stray raw-slug subdir
+    // in a fallback workspace is never recursed into either — the cross-tenant
+    // leak is structurally impossible on any source path.
     if (name.startsWith('@')) continue;
     if (SKIP_DIR_NAMES.has(name)) continue;
     if (shouldSkipFile(name)) continue;
@@ -129,7 +138,17 @@ async function copyTree(sourceDir: string, targetDir: string): Promise<void> {
     }
 
     if (info.isDirectory()) {
-      await copyTree(src, dst);
+      if (!allowSubdirs) {
+        // Flat domain (agents / providers): the catalog has no subdirs here,
+        // so any subdir is unexpected (e.g. a raw-slug org dir leaked into a
+        // mutable fallback workspace). Skip rather than recurse.
+        console.warn(
+          '[scaffold.copyTree] skipping unexpected subdir in flat domain:',
+          src,
+        );
+        continue;
+      }
+      await copyTree(src, dst, allowSubdirs);
       continue;
     }
 
@@ -253,19 +272,23 @@ export const scaffoldNewOrganization = internalAction({
         const sourceExists = await stat(sourceDir)
           .then(() => true)
           .catch((err) => {
-            if (errnoCode(err) === 'ENOENT') return false;
-            console.error(
-              `[scaffoldNewOrganization] ${domain.name}: stat ${sourceDir} failed:`,
-              err instanceof Error ? err.message : err,
-            );
+            // ENOENT: catalog domain dir missing — a deploy misconfig
+            // (platform/convex image skew). Other errors (EACCES, EIO) are a
+            // distinct failure; log each accurately rather than mislabelling
+            // a permission error as "does not exist".
+            if (errnoCode(err) === 'ENOENT') {
+              console.error(
+                `[scaffoldNewOrganization] ${domain.name}: ${BUILTIN_ENV}=${builtinRoot} is set but ${sourceDir} does not exist; new org "${args.orgSlug}" will receive zero seed data for this domain`,
+              );
+            } else {
+              console.error(
+                `[scaffoldNewOrganization] ${domain.name}: stat ${sourceDir} failed:`,
+                err instanceof Error ? err.message : err,
+              );
+            }
             return false;
           });
-        if (!sourceExists) {
-          console.error(
-            `[scaffoldNewOrganization] ${domain.name}: ${BUILTIN_ENV}=${builtinRoot} is set but ${sourceDir} does not exist; new org "${args.orgSlug}" will receive zero seed data for this domain`,
-          );
-          continue;
-        }
+        if (!sourceExists) continue;
       }
 
       const alreadyScaffolded = await dirHasFiles(targetDir);
@@ -277,7 +300,7 @@ export const scaffoldNewOrganization = internalAction({
       }
 
       try {
-        await copyTree(sourceDir, targetDir);
+        await copyTree(sourceDir, targetDir, !domain.flat);
       } catch (err) {
         console.error(
           `[scaffoldNewOrganization] ${domain.name}: copy failed for org "${args.orgSlug}":`,

--- a/tools/cli/src/commands/deploy/index.ts
+++ b/tools/cli/src/commands/deploy/index.ts
@@ -29,8 +29,8 @@ export function createDeployCommand(): Command {
     .option('--dry-run', 'Preview deployment without making changes', false)
     .option('--host <hostname>', 'Host alias for proxy')
     .option(
-      '--fresh',
-      'force re-seed builtin agent/workflow/integration configs',
+      '--override',
+      'overwrite container state from the host workspace, including config files the operator has UI-edited (default: preserve UI-edited files; encrypted provider secrets and UI-uploaded skill bundles are always preserved)',
     )
     .option('-q, --quiet', 'Suppress container logs during deployment')
     .option(
@@ -97,7 +97,7 @@ export function createDeployCommand(): Command {
           hostAlias,
           dryRun: options.dryRun,
           services,
-          fresh: options.fresh,
+          override: options.override,
           quiet: options.quiet,
           assumeYes: options.yes || options.migrateVolumes,
           forceRecreate,

--- a/tools/cli/src/commands/deploy/index.ts
+++ b/tools/cli/src/commands/deploy/index.ts
@@ -30,7 +30,7 @@ export function createDeployCommand(): Command {
     .option('--host <hostname>', 'Host alias for proxy')
     .option(
       '--override',
-      'overwrite container state from the host workspace, including config files the operator has UI-edited (default: preserve UI-edited files; encrypted provider secrets and UI-uploaded skill bundles are always preserved)',
+      'overwrite container config from the host workspace. Without --override, host config files are NOT pushed (the container keeps its current config). With --override, the host workspace overwrites container config, except encrypted *.secrets.json files and .history/ directories, which are always preserved',
     )
     .option('-q, --quiet', 'Suppress container logs during deployment')
     .option(

--- a/tools/cli/src/commands/start/index.ts
+++ b/tools/cli/src/commands/start/index.ts
@@ -10,10 +10,6 @@ export function createStartCommand(): Command {
     .option('-p, --port <port>', 'HTTPS port to expose', '443')
     .option('--host <hostname>', 'host alias for proxy', 'tale.local')
     .option(
-      '--fresh',
-      'force re-seed builtin agent/workflow/integration configs',
-    )
-    .option(
       '-y, --yes',
       'automatically accept any pending migrations (non-interactive; required in CI/non-TTY)',
     )
@@ -22,7 +18,6 @@ export function createStartCommand(): Command {
         detach?: boolean;
         port: string;
         host: string;
-        fresh?: boolean;
         yes?: boolean;
       }) => {
         try {
@@ -30,7 +25,6 @@ export function createStartCommand(): Command {
             detach: opts.detach,
             port: Number(opts.port),
             host: opts.host,
-            fresh: opts.fresh,
             assumeYes: opts.yes,
           });
         } catch (err) {

--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -354,7 +354,6 @@ export async function deploy(options: DeployOptions): Promise<void> {
         const statefulCompose = generateStatefulCompose(
           serviceConfig,
           hostAlias,
-          { override: options.override },
         );
 
         if (dryRun) {
@@ -636,9 +635,12 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 }
 
-// Host workspace dirs that `tale deploy` copies into the convex container.
-// Each dir has its own preservation policy enforced by `buildSkipsForDir`;
-// integrations is the only one with no per-file protection today.
+// Host workspace dirs that `tale deploy --override` pushes into the convex
+// container. `*.secrets.json` files and `.history/` directories are always
+// excluded from the push (see `stageForOverride`): encrypted secrets cannot be
+// re-derived from the host, and the container's UI edit-history trail must
+// survive. `docker cp` is additive, so anything not staged is left untouched
+// on the container side.
 const SYNC_DIRS = [
   'agents',
   'workflows',
@@ -648,23 +650,6 @@ const SYNC_DIRS = [
   'skills',
 ];
 
-// Why a particular host file is being skipped during sync. Drives the log
-// output so the operator sees which protection kicked in and the right
-// escape hatch.
-type SkipReason = 'encrypted-secret' | 'ui-edited' | 'ui-uploaded-bundle';
-type SkipEntry = { relPath: string; reason: SkipReason };
-
-// History-slug → workspace-relative path. Mirrors the entrypoint's seed-
-// loop slug derivation so a UI edit's `.history/<slug>/` snapshot maps
-// back to the file it protects on the host side. workflows uses
-// `__`-flattened slugs (see services/convex/docker-entrypoint.sh:316-318).
-const HISTORY_SLUG_TO_RELPATH: Record<string, (slug: string) => string> = {
-  agents: (slug) => `${slug}.json`,
-  workflows: (slug) => `${slug.replaceAll('__', '/')}.json`,
-  providers: (slug) => `${slug}.json`,
-  branding: (slug) => `${slug}.json`,
-};
-
 async function syncProjectFiles(
   containerName: string,
   projectDir: string,
@@ -673,6 +658,20 @@ async function syncProjectFiles(
   tempStageDirs: Set<string>,
   override: boolean,
 ): Promise<void> {
+  // Default deploy never pushes host config: the container self-seeds builtin
+  // defaults on first start and UI edits stay authoritative. Host config is
+  // pushed only when the operator explicitly asks via `--override`.
+  if (!override) {
+    logger.blank();
+    logger.info(
+      `${prefix}Config files not pushed (container keeps its current config).`,
+    );
+    logger.info(
+      `${prefix}  Re-run with --override to overwrite container config from the host workspace.`,
+    );
+    return;
+  }
+
   const dirsToSync = SYNC_DIRS.filter((dir) =>
     existsSync(join(projectDir, dir)),
   );
@@ -692,39 +691,25 @@ async function syncProjectFiles(
   }
 
   logger.blank();
-  logger.step(`${prefix}Syncing project files to ${containerName}...`);
-  if (override) {
-    logger.info(
-      `${prefix}  (--override: UI-edited files will be overwritten; encrypted secrets and UI-uploaded skill bundles still preserved)`,
-    );
-  }
+  logger.step(`${prefix}Overriding container config from host workspace...`);
+  logger.info(
+    `${prefix}  (encrypted *.secrets.json and .history/ are always preserved)`,
+  );
 
   for (const dir of dirsToSync) {
     const srcPath = join(projectDir, dir);
 
     if (dryRun) {
       logger.info(
-        `${prefix}Would sync ${dir}/ → ${containerName}:/app/data/${dir}/`,
+        `${prefix}Would override ${dir}/ → ${containerName}:/app/data/${dir}/ (excluding *.secrets.json and .history/)`,
       );
       continue;
     }
 
-    const skips = await buildSkipsForDir(dir, containerName, override);
-
-    let dockerSrcDir = srcPath;
-    let tempStageDir: string | null = null;
-    let preserved: SkipEntry[] = [];
-
-    if (skips.length > 0) {
-      const staged = await stageWithSkips(srcPath, skips);
-      tempStageDir = staged.stageDir;
-      tempStageDirs.add(staged.stageDir);
-      preserved = staged.skipped;
-      dockerSrcDir = staged.stageDir;
-    }
+    const stageDir = await stageForOverride(srcPath, tempStageDirs);
 
     try {
-      const dockerSrcPath = dockerSrcDir.replaceAll('\\', '/');
+      const dockerSrcPath = stageDir.replaceAll('\\', '/');
       const result = await exec('docker', [
         'cp',
         `${dockerSrcPath}/.`,
@@ -746,221 +731,46 @@ async function syncProjectFiles(
             `Failed to fix ownership for ${dir}/: ${chownResult.stderr}`,
           );
         }
-        logger.info(`Synced ${dir}/`);
-        if (preserved.length > 0) {
-          logPreserved(dir, containerName, preserved);
-        }
+        logger.info(`Overrode ${dir}/`);
       } else {
-        logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);
+        logger.warn(`Failed to override ${dir}/: ${result.stderr}`);
       }
     } finally {
-      if (tempStageDir) {
-        tempStageDirs.delete(tempStageDir);
-        await rm(tempStageDir, { recursive: true, force: true });
-      }
+      tempStageDirs.delete(stageDir);
+      await rm(stageDir, { recursive: true, force: true });
     }
   }
 
   if (!dryRun) {
-    logger.success('Project files synced');
+    logger.success('Config override complete');
   }
 }
 
-// Compose the per-dir skip list from the container's current state and the
-// override flag. Always-on protections (encrypted secrets, UI-uploaded
-// skill bundles) survive `--override`; .history-derived protection does
-// not.
-async function buildSkipsForDir(
-  dir: string,
-  containerName: string,
-  override: boolean,
-): Promise<SkipEntry[]> {
-  const skips: SkipEntry[] = [];
-
-  if (dir === 'providers') {
-    for (const rel of await listContainerSecrets(containerName)) {
-      skips.push({ relPath: rel, reason: 'encrypted-secret' });
-    }
-  } else if (dir === 'skills') {
-    for (const slug of await listContainerSkills(containerName)) {
-      skips.push({ relPath: slug, reason: 'ui-uploaded-bundle' });
-    }
-  }
-
-  if (!override) {
-    const mapper = HISTORY_SLUG_TO_RELPATH[dir];
-    if (mapper) {
-      const historySlugs = await listContainerHistorySlugs(containerName, dir);
-      const seen = new Set<string>(skips.map((s) => s.relPath));
-      for (const slug of historySlugs) {
-        const rel = mapper(slug);
-        if (!seen.has(rel)) {
-          skips.push({ relPath: rel, reason: 'ui-edited' });
-        }
-      }
-    }
-  }
-
-  return skips;
-}
-
-function logPreserved(
-  dir: string,
-  containerName: string,
-  preserved: SkipEntry[],
-): void {
-  logger.info(
-    `Preserved ${preserved.length} file(s) in ${dir}/ (host copy skipped):`,
-  );
-  const byReason = {
-    'encrypted-secret': [] as string[],
-    'ui-edited': [] as string[],
-    'ui-uploaded-bundle': [] as string[],
-  };
-  for (const p of preserved) byReason[p.reason].push(p.relPath);
-
-  if (byReason['ui-edited'].length > 0) {
-    logger.info('  UI-edited (rerun with --override to overwrite):');
-    for (const rel of byReason['ui-edited']) logger.info(`    - ${dir}/${rel}`);
-  }
-  if (byReason['encrypted-secret'].length > 0) {
-    logger.info(
-      `  Encrypted secret(s) — cannot re-derive from host; to force-push: docker exec ${containerName} rm /app/data/${dir}/<file>, then redeploy.`,
-    );
-    for (const rel of byReason['encrypted-secret']) {
-      logger.info(`    - ${dir}/${rel}`);
-    }
-  }
-  if (byReason['ui-uploaded-bundle'].length > 0) {
-    logger.info(
-      `  UI-uploaded skill bundle(s) — to force-push: docker exec ${containerName} rm -rf /app/data/${dir}/<slug>, then redeploy.`,
-    );
-    for (const rel of byReason['ui-uploaded-bundle']) {
-      logger.info(`    - ${dir}/${rel}`);
-    }
-  }
-}
-
-// Three list helpers, all running `find` inside the convex container.
-// Each distinguishes a missing directory (benign first-deploy state) from
-// real failures so we don't silently revert to an overwriting copy when
-// the container is unreachable or has permission issues.
-
-// `providers/*.secrets.json` — SOPS-encrypted credentials written via
-// admin UI. Host CWD cannot reconstruct them, so they're always preserved
-// even under `--override`.
-async function listContainerSecrets(
-  containerName: string,
-): Promise<Set<string>> {
-  return findInContainer(containerName, '/app/data/providers', [
-    '-type',
-    'f',
-    '-name',
-    '*.secrets.json',
-    '-printf',
-    '%P\n',
-  ]);
-}
-
-// Skill bundles at the top level of `/app/data/skills/`. UI uploads land
-// here and the host has no source for them, so they're always preserved.
-// Both `<slug>/` (default org) and `@<orgSlug>/` (per-org) shapes are
-// returned verbatim.
-async function listContainerSkills(
-  containerName: string,
-): Promise<Set<string>> {
-  return findInContainer(containerName, '/app/data/skills', [
-    '-mindepth',
-    '1',
-    '-maxdepth',
-    '1',
-    '-type',
-    'd',
-    '-printf',
-    '%P\n',
-  ]);
-}
-
-// History-slug subdirs at `/app/data/<dir>/.history/<slug>/`. Existence of
-// any history snapshot under a slug means the corresponding visible file
-// was edited via UI — `--override` is the only way to clobber it.
-async function listContainerHistorySlugs(
-  containerName: string,
-  dir: string,
-): Promise<Set<string>> {
-  return findInContainer(containerName, `/app/data/${dir}/.history`, [
-    '-mindepth',
-    '1',
-    '-maxdepth',
-    '1',
-    '-type',
-    'd',
-    '-empty',
-    '-prune',
-    '-o',
-    '-mindepth',
-    '1',
-    '-maxdepth',
-    '1',
-    '-type',
-    'd',
-    '-printf',
-    '%P\n',
-  ]);
-}
-
-async function findInContainer(
-  containerName: string,
-  searchPath: string,
-  findArgs: string[],
-): Promise<Set<string>> {
-  const result = await exec('docker', [
-    'exec',
-    containerName,
-    'find',
-    searchPath,
-    ...findArgs,
-  ]);
-  if (result.success) {
-    return new Set(
-      result.stdout
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean),
-    );
-  }
-  if (/No such file or directory/.test(result.stderr)) {
-    // Target dir not yet created (first deploy, no UI activity) — nothing
-    // to protect.
-    return new Set();
-  }
-  throw new Error(
-    `Failed to enumerate ${searchPath} on ${containerName}: ${result.stderr || 'unknown error'}`,
-  );
-}
-
-// Copy host `<dir>/` into a fresh tmp dir, then remove every entry whose
-// relPath exists in the staging copy. Files and directories both handled
-// via `rm({recursive,force})`. The staging tmp dir is what `docker cp`
-// will ship — so protected entries on the container side survive and
-// non-conflicting files sync as before. fs.cp defaults to dereference=false,
-// which keeps symlinks intact.
-async function stageWithSkips(
+// Copy host `<dir>/` into a fresh tmp dir, excluding `*.secrets.json` files
+// and any `.history/` directory during the copy. The staging dir is what
+// `docker cp` ships; since `docker cp` is additive (never deletes container
+// files absent from the source), excluded paths simply never reach the
+// container and its existing secrets / edit-history survive. fs.cp defaults to
+// dereference=false, which keeps symlinks intact. The `*.secrets.json` match
+// mirrors the entrypoint's seed-skip check (services/convex/docker-entrypoint.sh).
+//
+// Registers `stageDir` in `tempStageDirs` before any I/O so an interrupt or a
+// throw mid-copy still gets cleaned up by the caller / SIGINT handler.
+async function stageForOverride(
   srcDir: string,
-  skips: SkipEntry[],
-): Promise<{ stageDir: string; skipped: SkipEntry[] }> {
+  tempStageDirs: Set<string>,
+): Promise<string> {
   const stageDir = await mkdtemp(join(tmpdir(), 'tale-sync-'));
-  await cp(srcDir, stageDir, { recursive: true });
-  const skipped: SkipEntry[] = [];
-  for (const entry of skips) {
-    // `relPath` comes from the Linux container's find, so it uses '/'.
-    // Split and re-join so Windows host paths resolve correctly against
-    // stageDir.
-    const candidate = join(stageDir, ...entry.relPath.split('/'));
-    if (existsSync(candidate)) {
-      await rm(candidate, { recursive: true, force: true });
-      skipped.push(entry);
-    }
-  }
-  return { stageDir, skipped };
+  tempStageDirs.add(stageDir);
+  await cp(srcDir, stageDir, {
+    recursive: true,
+    filter: (src) => {
+      const base = src.split(/[\\/]/).pop() ?? '';
+      // Returning false for a directory prunes its entire subtree.
+      if (base === '.history') return false;
+      if (base.endsWith('.secrets.json')) return false;
+      return true;
+    },
+  });
+  return stageDir;
 }

--- a/tools/cli/src/lib/actions/deploy.ts
+++ b/tools/cli/src/lib/actions/deploy.ts
@@ -72,7 +72,7 @@ interface DeployOptions {
   hostAlias: string;
   dryRun: boolean;
   services?: ServiceName[];
-  fresh?: boolean;
+  override?: boolean;
   quiet?: boolean;
   /** Non-interactive acceptance of any pending migrations. */
   assumeYes?: boolean;
@@ -354,7 +354,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         const statefulCompose = generateStatefulCompose(
           serviceConfig,
           hostAlias,
-          { fresh: options.fresh },
+          { override: options.override },
         );
 
         if (dryRun) {
@@ -627,6 +627,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         dryRun,
         prefix,
         tempStageDirs,
+        options.override ?? false,
       );
     });
   } finally {
@@ -635,21 +636,34 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 }
 
+// Host workspace dirs that `tale deploy` copies into the convex container.
+// Each dir has its own preservation policy enforced by `buildSkipsForDir`;
+// integrations is the only one with no per-file protection today.
 const SYNC_DIRS = [
   'agents',
   'workflows',
   'integrations',
   'branding',
   'providers',
-  // Skill bundles: SKILL.md + arbitrary assets per slug under skills/<slug>/.
-  // Kept in SYNC_DIRS so a fresh `tale init` + `tale deploy` seeds the
-  // example skill bundles (`examples/skills/<slug>/`) into the new
-  // container. SYNC PRESERVES UI UPLOADS: see the `dir === 'skills'`
-  // branch below, which uses `listContainerSkills` +
-  // `stageSkillsWithoutConflictingBundles` to skip any slug already
-  // present in the container so the upload-only model isn't clobbered.
   'skills',
 ];
+
+// Why a particular host file is being skipped during sync. Drives the log
+// output so the operator sees which protection kicked in and the right
+// escape hatch.
+type SkipReason = 'encrypted-secret' | 'ui-edited' | 'ui-uploaded-bundle';
+type SkipEntry = { relPath: string; reason: SkipReason };
+
+// History-slug → workspace-relative path. Mirrors the entrypoint's seed-
+// loop slug derivation so a UI edit's `.history/<slug>/` snapshot maps
+// back to the file it protects on the host side. workflows uses
+// `__`-flattened slugs (see services/convex/docker-entrypoint.sh:316-318).
+const HISTORY_SLUG_TO_RELPATH: Record<string, (slug: string) => string> = {
+  agents: (slug) => `${slug}.json`,
+  workflows: (slug) => `${slug.replaceAll('__', '/')}.json`,
+  providers: (slug) => `${slug}.json`,
+  branding: (slug) => `${slug}.json`,
+};
 
 async function syncProjectFiles(
   containerName: string,
@@ -657,6 +671,7 @@ async function syncProjectFiles(
   dryRun: boolean,
   prefix: string,
   tempStageDirs: Set<string>,
+  override: boolean,
 ): Promise<void> {
   const dirsToSync = SYNC_DIRS.filter((dir) =>
     existsSync(join(projectDir, dir)),
@@ -678,6 +693,11 @@ async function syncProjectFiles(
 
   logger.blank();
   logger.step(`${prefix}Syncing project files to ${containerName}...`);
+  if (override) {
+    logger.info(
+      `${prefix}  (--override: UI-edited files will be overwritten; encrypted secrets and UI-uploaded skill bundles still preserved)`,
+    );
+  }
 
   for (const dir of dirsToSync) {
     const srcPath = join(projectDir, dir);
@@ -686,62 +706,24 @@ async function syncProjectFiles(
       logger.info(
         `${prefix}Would sync ${dir}/ → ${containerName}:/app/data/${dir}/`,
       );
-      if (dir === 'providers') {
-        logger.info(
-          `${prefix}  (any existing container *.secrets.json will be preserved)`,
-        );
-      }
-      if (dir === 'skills') {
-        logger.info(
-          `${prefix}  (any skill slug already present in the container will be preserved)`,
-        );
-      }
       continue;
     }
 
-    // INVARIANTS:
-    //  - dir === 'providers': dockerSrcDir comes from
-    //    `stageProvidersWithoutConflictingSecrets()` so SOPS-encrypted
-    //    *.secrets.json files written via the admin UI are not clobbered.
-    //  - dir === 'skills': dockerSrcDir comes from
-    //    `stageSkillsWithoutConflictingBundles()` so UI-uploaded slugs
-    //    (the only legitimate write path post-skills-bundle-upload) are
-    //    not overwritten by host workspace copies.
+    const skips = await buildSkipsForDir(dir, containerName, override);
+
     let dockerSrcDir = srcPath;
     let tempStageDir: string | null = null;
-    let preserved: string[] = [];
+    let preserved: SkipEntry[] = [];
 
-    if (dir === 'providers') {
-      const containerSecrets = await listContainerSecrets(containerName);
-      if (containerSecrets.size > 0) {
-        const staged = await stageProvidersWithoutConflictingSecrets(
-          srcPath,
-          containerSecrets,
-        );
-        tempStageDir = staged.stageDir;
-        tempStageDirs.add(staged.stageDir);
-        preserved = staged.skipped;
-        dockerSrcDir = staged.stageDir;
-      }
-    } else if (dir === 'skills') {
-      const containerSkills = await listContainerSkills(containerName);
-      if (containerSkills.size > 0) {
-        const staged = await stageSkillsWithoutConflictingBundles(
-          srcPath,
-          containerSkills,
-        );
-        tempStageDir = staged.stageDir;
-        tempStageDirs.add(staged.stageDir);
-        preserved = staged.skipped;
-        dockerSrcDir = staged.stageDir;
-      }
+    if (skips.length > 0) {
+      const staged = await stageWithSkips(srcPath, skips);
+      tempStageDir = staged.stageDir;
+      tempStageDirs.add(staged.stageDir);
+      preserved = staged.skipped;
+      dockerSrcDir = staged.stageDir;
     }
 
     try {
-      // First-time seeding (empty container `/app/data/<dir>/`) flows
-      // through the same `docker cp` as subsequent syncs; for `skills`
-      // the preserve branch above strips any slug that already exists,
-      // so UI uploads survive.
       const dockerSrcPath = dockerSrcDir.replaceAll('\\', '/');
       const result = await exec('docker', [
         'cp',
@@ -766,23 +748,7 @@ async function syncProjectFiles(
         }
         logger.info(`Synced ${dir}/`);
         if (preserved.length > 0) {
-          const noun =
-            dir === 'providers' ? 'container secret(s)' : 'container skill(s)';
-          logger.info(
-            `Preserved ${preserved.length} existing ${noun} (host copy skipped to avoid overwriting UI edits):`,
-          );
-          for (const p of preserved) {
-            logger.info(`  - ${dir}/${p}`);
-          }
-          if (dir === 'providers') {
-            logger.info(
-              `  To push host values instead: docker exec ${containerName} rm /app/data/providers/<file>, then redeploy.`,
-            );
-          } else {
-            logger.info(
-              `  To push host values instead: docker exec ${containerName} rm -rf /app/data/skills/<slug>, then redeploy.`,
-            );
-          }
+          logPreserved(dir, containerName, preserved);
         }
       } else {
         logger.warn(`Failed to sync ${dir}/: ${result.stderr}`);
@@ -800,20 +766,93 @@ async function syncProjectFiles(
   }
 }
 
-// Enumerate *.secrets.json files already in the convex container so the
-// subsequent docker cp can skip host copies that would overwrite them.
-// Distinguishes benign "directory missing" (first deploy, empty volume) from
-// hard failures (container unreachable, permission denied, etc.) — the latter
-// aborts the deploy rather than silently reverting to the old overwrite
-// behavior.
+// Compose the per-dir skip list from the container's current state and the
+// override flag. Always-on protections (encrypted secrets, UI-uploaded
+// skill bundles) survive `--override`; .history-derived protection does
+// not.
+async function buildSkipsForDir(
+  dir: string,
+  containerName: string,
+  override: boolean,
+): Promise<SkipEntry[]> {
+  const skips: SkipEntry[] = [];
+
+  if (dir === 'providers') {
+    for (const rel of await listContainerSecrets(containerName)) {
+      skips.push({ relPath: rel, reason: 'encrypted-secret' });
+    }
+  } else if (dir === 'skills') {
+    for (const slug of await listContainerSkills(containerName)) {
+      skips.push({ relPath: slug, reason: 'ui-uploaded-bundle' });
+    }
+  }
+
+  if (!override) {
+    const mapper = HISTORY_SLUG_TO_RELPATH[dir];
+    if (mapper) {
+      const historySlugs = await listContainerHistorySlugs(containerName, dir);
+      const seen = new Set<string>(skips.map((s) => s.relPath));
+      for (const slug of historySlugs) {
+        const rel = mapper(slug);
+        if (!seen.has(rel)) {
+          skips.push({ relPath: rel, reason: 'ui-edited' });
+        }
+      }
+    }
+  }
+
+  return skips;
+}
+
+function logPreserved(
+  dir: string,
+  containerName: string,
+  preserved: SkipEntry[],
+): void {
+  logger.info(
+    `Preserved ${preserved.length} file(s) in ${dir}/ (host copy skipped):`,
+  );
+  const byReason = {
+    'encrypted-secret': [] as string[],
+    'ui-edited': [] as string[],
+    'ui-uploaded-bundle': [] as string[],
+  };
+  for (const p of preserved) byReason[p.reason].push(p.relPath);
+
+  if (byReason['ui-edited'].length > 0) {
+    logger.info('  UI-edited (rerun with --override to overwrite):');
+    for (const rel of byReason['ui-edited']) logger.info(`    - ${dir}/${rel}`);
+  }
+  if (byReason['encrypted-secret'].length > 0) {
+    logger.info(
+      `  Encrypted secret(s) — cannot re-derive from host; to force-push: docker exec ${containerName} rm /app/data/${dir}/<file>, then redeploy.`,
+    );
+    for (const rel of byReason['encrypted-secret']) {
+      logger.info(`    - ${dir}/${rel}`);
+    }
+  }
+  if (byReason['ui-uploaded-bundle'].length > 0) {
+    logger.info(
+      `  UI-uploaded skill bundle(s) — to force-push: docker exec ${containerName} rm -rf /app/data/${dir}/<slug>, then redeploy.`,
+    );
+    for (const rel of byReason['ui-uploaded-bundle']) {
+      logger.info(`    - ${dir}/${rel}`);
+    }
+  }
+}
+
+// Three list helpers, all running `find` inside the convex container.
+// Each distinguishes a missing directory (benign first-deploy state) from
+// real failures so we don't silently revert to an overwriting copy when
+// the container is unreachable or has permission issues.
+
+// `providers/*.secrets.json` — SOPS-encrypted credentials written via
+// admin UI. Host CWD cannot reconstruct them, so they're always preserved
+// even under `--override`.
 async function listContainerSecrets(
   containerName: string,
 ): Promise<Set<string>> {
-  const result = await exec('docker', [
-    'exec',
-    containerName,
-    'find',
-    '/app/data/providers',
+  return findInContainer(containerName, '/app/data/providers', [
     '-type',
     'f',
     '-name',
@@ -821,61 +860,16 @@ async function listContainerSecrets(
     '-printf',
     '%P\n',
   ]);
-  if (result.success) {
-    return new Set(
-      result.stdout
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean),
-    );
-  }
-  if (/No such file or directory/.test(result.stderr)) {
-    // Providers directory not yet created — nothing to protect.
-    return new Set();
-  }
-  throw new Error(
-    `Failed to enumerate container provider secrets on ${containerName}: ${result.stderr || 'unknown error'}`,
-  );
 }
 
-// Copy host `providers/` into a fresh tmp dir and delete any *.secrets.json
-// whose relative path also exists in the container. The resulting stage dir
-// is what `docker cp` will ship — so conflicting secrets are preserved on the
-// container side, non-conflicting files sync as before. fs.cp defaults to
-// dereference=false, which keeps symlinks intact.
-async function stageProvidersWithoutConflictingSecrets(
-  srcDir: string,
-  protectedRelPaths: Set<string>,
-): Promise<{ stageDir: string; skipped: string[] }> {
-  const stageDir = await mkdtemp(join(tmpdir(), 'tale-sync-'));
-  await cp(srcDir, stageDir, { recursive: true });
-  const skipped: string[] = [];
-  for (const rel of protectedRelPaths) {
-    // `rel` comes from the Linux container's find, so it uses '/'. Split
-    // and re-join so Windows host paths resolve correctly against stageDir.
-    const candidate = join(stageDir, ...rel.split('/'));
-    if (existsSync(candidate)) {
-      await rm(candidate);
-      skipped.push(rel);
-    }
-  }
-  return { stageDir, skipped };
-}
-
-// Enumerate per-org and default-org skill slugs already in the container so
-// the subsequent docker cp skips any host slug that would clobber a UI
-// upload. Returns top-level entries only — slugs are directories (e.g.
-// `pptx/`) and per-org subdirs are marked with `@` (e.g. `@acme/`). Both
-// shapes are forwarded verbatim; the staging step removes any host
-// directory whose top-level name matches.
+// Skill bundles at the top level of `/app/data/skills/`. UI uploads land
+// here and the host has no source for them, so they're always preserved.
+// Both `<slug>/` (default org) and `@<orgSlug>/` (per-org) shapes are
+// returned verbatim.
 async function listContainerSkills(
   containerName: string,
 ): Promise<Set<string>> {
-  const result = await exec('docker', [
-    'exec',
-    containerName,
-    'find',
-    '/app/data/skills',
+  return findInContainer(containerName, '/app/data/skills', [
     '-mindepth',
     '1',
     '-maxdepth',
@@ -885,6 +879,48 @@ async function listContainerSkills(
     '-printf',
     '%P\n',
   ]);
+}
+
+// History-slug subdirs at `/app/data/<dir>/.history/<slug>/`. Existence of
+// any history snapshot under a slug means the corresponding visible file
+// was edited via UI — `--override` is the only way to clobber it.
+async function listContainerHistorySlugs(
+  containerName: string,
+  dir: string,
+): Promise<Set<string>> {
+  return findInContainer(containerName, `/app/data/${dir}/.history`, [
+    '-mindepth',
+    '1',
+    '-maxdepth',
+    '1',
+    '-type',
+    'd',
+    '-empty',
+    '-prune',
+    '-o',
+    '-mindepth',
+    '1',
+    '-maxdepth',
+    '1',
+    '-type',
+    'd',
+    '-printf',
+    '%P\n',
+  ]);
+}
+
+async function findInContainer(
+  containerName: string,
+  searchPath: string,
+  findArgs: string[],
+): Promise<Set<string>> {
+  const result = await exec('docker', [
+    'exec',
+    containerName,
+    'find',
+    searchPath,
+    ...findArgs,
+  ]);
   if (result.success) {
     return new Set(
       result.stdout
@@ -894,31 +930,36 @@ async function listContainerSkills(
     );
   }
   if (/No such file or directory/.test(result.stderr)) {
-    // Skills directory not yet created — nothing to protect.
+    // Target dir not yet created (first deploy, no UI activity) — nothing
+    // to protect.
     return new Set();
   }
   throw new Error(
-    `Failed to enumerate container skills on ${containerName}: ${result.stderr || 'unknown error'}`,
+    `Failed to enumerate ${searchPath} on ${containerName}: ${result.stderr || 'unknown error'}`,
   );
 }
 
-// Copy host `skills/` into a fresh tmp dir and delete any top-level slug
-// dir whose name also exists in the container. The resulting stage dir is
-// what `docker cp` will ship — so container-side UI uploads survive,
-// brand-new host slugs (e.g. the `pptx` example installed by `tale init`
-// on first deploy) flow through.
-async function stageSkillsWithoutConflictingBundles(
+// Copy host `<dir>/` into a fresh tmp dir, then remove every entry whose
+// relPath exists in the staging copy. Files and directories both handled
+// via `rm({recursive,force})`. The staging tmp dir is what `docker cp`
+// will ship — so protected entries on the container side survive and
+// non-conflicting files sync as before. fs.cp defaults to dereference=false,
+// which keeps symlinks intact.
+async function stageWithSkips(
   srcDir: string,
-  protectedSlugs: Set<string>,
-): Promise<{ stageDir: string; skipped: string[] }> {
+  skips: SkipEntry[],
+): Promise<{ stageDir: string; skipped: SkipEntry[] }> {
   const stageDir = await mkdtemp(join(tmpdir(), 'tale-sync-'));
   await cp(srcDir, stageDir, { recursive: true });
-  const skipped: string[] = [];
-  for (const slug of protectedSlugs) {
-    const candidate = join(stageDir, slug);
+  const skipped: SkipEntry[] = [];
+  for (const entry of skips) {
+    // `relPath` comes from the Linux container's find, so it uses '/'.
+    // Split and re-join so Windows host paths resolve correctly against
+    // stageDir.
+    const candidate = join(stageDir, ...entry.relPath.split('/'));
     if (existsSync(candidate)) {
       await rm(candidate, { recursive: true, force: true });
-      skipped.push(slug);
+      skipped.push(entry);
     }
   }
   return { stageDir, skipped };

--- a/tools/cli/src/lib/actions/start.ts
+++ b/tools/cli/src/lib/actions/start.ts
@@ -122,7 +122,6 @@ interface StartOptions {
   detach?: boolean;
   port?: number;
   host?: string;
-  fresh?: boolean;
   /** Non-interactive acceptance of any pending migrations (mirrors deploy). */
   assumeYes?: boolean;
 }
@@ -248,7 +247,6 @@ export async function start(options: StartOptions): Promise<void> {
     { version, registry: env.GHCR_REGISTRY },
     hostAlias,
     port,
-    { fresh: options.fresh },
   );
 
   const overrideFile = findComposeOverride(projectDir);

--- a/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
@@ -27,7 +27,6 @@ const HOST_CONFIG_DIRS = [
 ] as const;
 
 interface DevComposeOptions {
-  fresh?: boolean;
   /** Project root, used to verify host bind-mount sources exist before
    *  emitting them. Defaults to process.cwd() (which is what `tale start`
    *  passes implicitly via the deploy-compose temp-file location). */
@@ -76,9 +75,6 @@ export function generateDevCompose(
     'caddy-data:/caddy-data:ro',
   ];
   convex.depends_on = { db: { condition: 'service_healthy' } };
-  if (options.fresh) {
-    convex.environment = { ...convex.environment, FORCE_SEED: 'true' };
-  }
 
   // Platform becomes a thin client.
   //

--- a/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
@@ -8,24 +8,12 @@ import { createSandboxEgressService } from '../services/create-sandbox-egress-se
 import { createSandboxService } from '../services/create-sandbox-service';
 import type { ComposeConfig, ServiceConfig } from '../types';
 
-interface StatefulComposeOptions {
-  // Mirrors `tale deploy --override`: force the entrypoint to re-seed
-  // builtin defaults on top of any user edits. Plumbed as FORCE_SEED into
-  // the convex container, which the entrypoint reads to bypass its own
-  // skip-if-exists / .history guards.
-  override?: boolean;
-}
-
 export function generateStatefulCompose(
   config: ServiceConfig,
   hostAlias: string,
-  options: StatefulComposeOptions = {},
 ): string {
   const prefix = `${getProjectId()}_`;
   const convex = createConvexService(config);
-  if (options.override) {
-    convex.environment = { ...convex.environment, FORCE_SEED: 'true' };
-  }
 
   const compose: ComposeConfig = {
     services: {

--- a/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-stateful-compose.ts
@@ -9,7 +9,11 @@ import { createSandboxService } from '../services/create-sandbox-service';
 import type { ComposeConfig, ServiceConfig } from '../types';
 
 interface StatefulComposeOptions {
-  fresh?: boolean;
+  // Mirrors `tale deploy --override`: force the entrypoint to re-seed
+  // builtin defaults on top of any user edits. Plumbed as FORCE_SEED into
+  // the convex container, which the entrypoint reads to bypass its own
+  // skip-if-exists / .history guards.
+  override?: boolean;
 }
 
 export function generateStatefulCompose(
@@ -19,7 +23,7 @@ export function generateStatefulCompose(
 ): string {
   const prefix = `${getProjectId()}_`;
   const convex = createConvexService(config);
-  if (options.fresh) {
+  if (options.override) {
     convex.environment = { ...convex.environment, FORCE_SEED: 'true' };
   }
 


### PR DESCRIPTION
## Why

`scaffoldNewOrganization` sourced from `domain.resolve('default')` — the
default org's _writable_ workspace. That dir doubles as both the seeded
shipped-templates location and a mutable workspace, so anything created
while using the default org (test workflows, scratch agents) got
permanently copied into every newly-scaffolded org. Users saw stale
"Default / testing 2 / testing this" workflows in the Create automation
→ From template dialog for orgs they never touched.

For **agents** and **providers** this was worse: they use raw `<slug>/`
per-org subdirs with no `@` marker, so `copyTree`'s `@`-skip didn't
catch them — scaffolding a new org would recursively copy _other
tenants'_ agent/provider subdirs into the new org. Already flagged in
the `copyTree` comment as a known leak awaiting a domain-aware fix.

Diagnosis confirmed it is **not** a live cross-org query leak:
`listWorkflows` reads only its own dir, `@`-prefixed foreign paths fail
slug validation, and `resolveOrgSlug` throws rather than defaulting.

## What

Source the scaffold from the immutable builtin catalog instead of the
default org's workspace.

- **`services/platform/Dockerfile`** — add five `*_BUILTIN_DIR` `ENV`
  lines (stage 4 + stage 5 squash). The platform entrypoint's env-sync
  loop pushes all platform env vars into Convex's deployment env, which
  is what Node actions actually read via `process.env`.
- **`services/platform/convex/organizations/scaffold.ts`** —
  - Extend the `DOMAINS` table with `builtinEnv` per domain.
  - In `scaffoldNewOrganization`, read
    `process.env[builtinEnv] ?? domain.resolve('default')`. The fallback
    preserves behavior for local `bun dev` (where `*_BUILTIN_DIR` is
    unset and `examples/{domain}` is intentionally the catalog) and
    degrades gracefully on rollback to a pre-fix platform image.
  - In `copyTree`, swap `stat` → `lstat` and skip symbolic links —
    defence-in-depth so a symlink ever planted in any catalog dir can't
    escape. Matches the existing precedent at
    `services/platform/convex/skills/file_utils.ts:249`.
- **`services/platform/convex/organizations/scaffold.test.ts`** — new
  file, 7 vitest cases covering catalog-source isolation, the agents
  cross-tenant leak, symlink rejection, dev fallback, the
  `@`/`.history`/`*.secrets.json` skips, per-domain idempotency, and the
  default-org early return.

## Out of scope (explicit)

- **No data backfill.** The per-domain `dirHasFiles` guard keeps
  scaffolding idempotent, so existing orgs keep whatever junk they
  already have. Only orgs created after this lands start clean. A
  cleanup pass for existing orgs is a separate task.
- **The default org itself.** Its template list will still show whatever
  has been created in it — that's its own workspace and the leak only
  ever was about propagation to _other_ orgs.
- **`branding` and `retention` domains.** Branding is global by design
  (all readers hardcode `'default'`); retention uses a different per-org
  shape — a single `{slug}.json` per org with explicit fallback to
  `default.json` at read time — so neither exhibits this leak class.

## Notes on degradation modes

- **Rollback to a pre-fix platform image** strips the five
  `*_BUILTIN_DIR` vars via the entrypoint's "remove vars not seen on
  platform" step. Scaffold then falls back to
  `domain.resolve('default')` — the original pre-fix behavior.
  Intentional graceful degradation; no flapping in normal forward-only
  deploys. `ENV_SYNC_DENYLIST` (would block push too) and
  `ORPHAN_DERIVED` (removes _matching_ values) are both the wrong tools
  for the job — left as-is.
- **Missing-domain backfill** (e.g. when `skills` was added to
  `DOMAINS`): `backfill_skill_scaffolding` re-invokes
  `scaffoldNewOrganization`; with the fix, domains that don't already
  exist for an org are now seeded from the catalog instead of the
  default workspace. Strict improvement.
- **Dev parity.** `bun dev` doesn't set `*_BUILTIN_DIR`, so the leak
  _can_ still occur locally if a developer creates content in their
  local default org. Acceptable: dev is single-developer and
  `examples/{domain}` is intentionally the catalog there. Flagged so
  the next person doesn't chase a "but it works in prod" ghost.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests). Only
      failure is the preexisting `@tale/docs` link-check (3 broken
      links from `fr/legal/subprocessors.md` to a not-yet-translated
      `fr/legal/data-processing-agreement`) — verified to fail on a
      clean `main` with the same 3 failed / 200 passed counts;
      unrelated to this change.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — **N/A**
      (no user-facing strings touched).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change —
      **N/A** (internal scaffolding behavior; no UI/CLI surface change).
- [x] Every touched docs page has a real opening and closing — **N/A**
      (no docs pages touched).
- [x] Ran `bun run --filter @tale/docs lint` and
      `bun run --filter @tale/docs test` — covered by `bun run check`;
      preexisting failure noted above.
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — **N/A**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced organization scaffolding with improved builtin catalog support and fallback behavior.

* **Bug Fixes**
  * Improved symlink handling to prevent unintended dereferencing during organization setup.

* **Chores**
  * Added environment variable configuration for builtin catalog directories.
  * Expanded test coverage for organization scaffolding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->