### PR TITLE
feat(platform): recover failed audio transcriptions without losing the recording

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@tale/ui/button';
 import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { X, ArrowUp, CircleStop, Eye, Loader } from 'lucide-react';
+import { X, ArrowUp, CircleStop, Eye, Loader, RotateCcw } from 'lucide-react';
 import {
   ComponentPropsWithoutRef,
   useCallback,
@@ -95,6 +95,13 @@ interface ChatInputProps extends Omit<
       ragError?: string;
     }
   >;
+  /** True when any audio attachment's transcription terminally `failed`.
+   * Blocks send so the user retries or removes it first — mirrors
+   * `hasFailedVideoJobs`. */
+  hasFailedAudioJobs?: boolean;
+  /** Re-run a failed audio transcription (reuses the persisted `_storage`
+   * blob; no re-upload). Wired to the retry button on the audio chip. */
+  retryAudioTranscription?: (fileId: Id<'_storage'>) => void;
   onSavePrompt?: (content: string) => void;
   onOpenPromptLibrary?: () => void;
   /**
@@ -151,6 +158,8 @@ export function ChatInput({
   indexingStatuses,
   isTranscribing = false,
   transcriptionStatuses,
+  hasFailedAudioJobs = false,
+  retryAudioTranscription,
   videoLinkJobs = [],
   isProcessingVideo = false,
   hasFailedVideoJobs = false,
@@ -224,6 +233,7 @@ export function ChatInput({
       isTranscribing ||
       isProcessingVideo ||
       hasFailedVideoJobs ||
+      hasFailedAudioJobs ||
       pasteIngestPending ||
       sendBlocked
     )
@@ -689,6 +699,26 @@ export function ChatInput({
                         <Eye className="size-3" />
                       </button>
                     )}
+                    {audioInfo?.status === 'failed' &&
+                      retryAudioTranscription && (
+                        // Retry a failed transcription — reuses the persisted
+                        // `_storage` blob (no re-upload). Mutually exclusive
+                        // with the view-transcript (Eye) button, which only
+                        // renders on `completed`, so both can share the
+                        // bottom-right corner. Mirrors the video-link chip's
+                        // retry affordance.
+                        <button
+                          type="button"
+                          aria-label={tChat('transcription.retry')}
+                          title={tChat('transcription.retry')}
+                          onClick={() =>
+                            retryAudioTranscription(attachment.fileId)
+                          }
+                          className="bg-background text-muted-foreground hover:text-foreground absolute right-0.5 bottom-0.5 flex size-5 items-center justify-center rounded-full transition-colors"
+                        >
+                          <RotateCcw className="size-3" />
+                        </button>
+                      )}
                   </div>
                 );
               })}
@@ -820,6 +850,7 @@ export function ChatInput({
                     isTranscribing ||
                     isProcessingVideo ||
                     hasFailedVideoJobs ||
+                    hasFailedAudioJobs ||
                     pasteIngestPending ||
                     sendBlocked;
                 const tooltipContent =
@@ -829,9 +860,11 @@ export function ChatInput({
                       ? tChat('videoLink.chip.inProgressTooltip')
                       : hasFailedVideoJobs && !isLoading
                         ? tChat('videoLink.chip.failedSendBlockedTooltip')
-                        : sendBlocked && sendBlockedReason && !isLoading
-                          ? sendBlockedReason
-                          : '';
+                        : hasFailedAudioJobs && !isLoading
+                          ? tChat('transcription.failedSendBlockedTooltip')
+                          : sendBlocked && sendBlockedReason && !isLoading
+                            ? sendBlockedReason
+                            : '';
                 // Native `disabled` swallows pointer events on
                 // Chromium/WebKit, so the Tooltip trigger never fires
                 // when the button is in exactly the states the tooltip

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -239,6 +239,7 @@ export function ChatInterface({
     uploadingFiles,
     uploadFiles,
     removeAttachment,
+    retryAttachmentTranscription,
     clearAttachments,
   } = useConvexFileUpload({ organizationId, threadId });
 
@@ -249,6 +250,7 @@ export function ChatInterface({
     isTranscribing,
     isQueryLoading: isTranscriptionQueryLoading,
     statusMap: transcriptionStatuses,
+    hasFailedAudioJobs,
   } = useFileTranscriptionStatus(attachments);
 
   const {
@@ -1166,6 +1168,8 @@ export function ChatInterface({
               indexingStatuses={indexingStatuses}
               isTranscribing={isTranscribing || isTranscriptionQueryLoading}
               transcriptionStatuses={transcriptionStatuses}
+              hasFailedAudioJobs={hasFailedAudioJobs}
+              retryAudioTranscription={retryAttachmentTranscription}
               videoLinkJobs={videoLinkJobs}
               isProcessingVideo={isProcessingVideo}
               hasFailedVideoJobs={hasFailedVideoJobs}

--- a/services/platform/app/features/chat/components/dictation-button.test.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.test.tsx
@@ -14,7 +14,9 @@ vi.mock('@/lib/i18n/client', () => ({
         'dictation.stop': 'Stop dictation',
         'dictation.transcribing': 'Transcribing',
         'dictation.permissionDenied': 'Microphone access denied',
-        'dictation.transcriptionFailed': 'Could not transcribe',
+        'dictation.transcriptionFailedShort': 'Transcription failed',
+        'dictation.retry': 'Try again',
+        'dictation.discard': 'Discard recording',
       };
       return translations[key] ?? key;
     },
@@ -52,6 +54,9 @@ vi.mock('../hooks/use-speech-to-text', () => ({
 // neither path is available.
 let mockRecorderSupported = false;
 let mockRecorderIsTranscribing = false;
+let mockRecorderHasFailedRecording = false;
+const mockRecorderRetry = vi.fn();
+const mockRecorderDiscard = vi.fn();
 
 vi.mock('../hooks/use-media-recorder-dictation', () => ({
   useMediaRecorderDictation: () => ({
@@ -61,6 +66,9 @@ vi.mock('../hooks/use-media-recorder-dictation', () => ({
     error: null,
     startListening: vi.fn(),
     stopListening: vi.fn(),
+    hasFailedRecording: mockRecorderHasFailedRecording,
+    retryTranscription: mockRecorderRetry,
+    discardFailedRecording: mockRecorderDiscard,
   }),
 }));
 
@@ -75,6 +83,7 @@ beforeEach(() => {
   mockError = null;
   mockRecorderSupported = false;
   mockRecorderIsTranscribing = false;
+  mockRecorderHasFailedRecording = false;
   mockOnTranscriptRef = null;
 });
 
@@ -175,6 +184,47 @@ describe('DictationButton', () => {
         'aria-pressed',
         'true',
       );
+    });
+  });
+
+  describe('failed-recording pill (MediaRecorder fallback)', () => {
+    function renderFailed() {
+      mockIsSupported = false;
+      mockRecorderSupported = true;
+      mockRecorderHasFailedRecording = true;
+      return render(
+        <DictationButton organizationId={orgId} onTranscript={vi.fn()} />,
+      );
+    }
+
+    it('renders the failed pill with retry and discard when a recording failed', () => {
+      renderFailed();
+      expect(screen.getByText('Transcription failed')).toBeInTheDocument();
+      expect(screen.getByLabelText('Try again')).toBeInTheDocument();
+      expect(screen.getByLabelText('Discard recording')).toBeInTheDocument();
+    });
+
+    it('retry button calls retryTranscription', async () => {
+      const { user } = renderFailed();
+      await user.click(screen.getByLabelText('Try again'));
+      expect(mockRecorderRetry).toHaveBeenCalledOnce();
+    });
+
+    it('discard button calls discardFailedRecording', async () => {
+      const { user } = renderFailed();
+      await user.click(screen.getByLabelText('Discard recording'));
+      expect(mockRecorderDiscard).toHaveBeenCalledOnce();
+    });
+
+    it('does not render the pill on the Web Speech path', () => {
+      // Web Speech supported → fallback inert → no pill even if the recorder
+      // hook reports a (stale) failed recording.
+      mockIsSupported = true;
+      mockRecorderHasFailedRecording = true;
+      render(<DictationButton organizationId={orgId} onTranscript={vi.fn()} />);
+      expect(
+        screen.queryByText('Transcription failed'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/services/platform/app/features/chat/components/dictation-button.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.tsx
@@ -195,7 +195,7 @@ function DictationButtonComponent({
             aria-label={t('dictation.retry')}
             title={t('dictation.retry')}
             onClick={recorder.retryTranscription}
-            className="hover:bg-destructive/10 flex size-5 items-center justify-center rounded-full transition-colors"
+            className="hover:bg-destructive/10 flex size-6 items-center justify-center rounded-full transition-colors"
           >
             <RotateCcw className="size-3" />
           </button>
@@ -204,7 +204,7 @@ function DictationButtonComponent({
             aria-label={t('dictation.discard')}
             title={t('dictation.discard')}
             onClick={recorder.discardFailedRecording}
-            className="hover:bg-destructive/10 flex size-5 items-center justify-center rounded-full transition-colors"
+            className="hover:bg-destructive/10 flex size-6 items-center justify-center rounded-full transition-colors"
           >
             <X className="size-3" />
           </button>

--- a/services/platform/app/features/chat/components/dictation-button.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { Loader2, Mic } from 'lucide-react';
+import { AlertCircle, Loader2, Mic, RotateCcw, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, memo } from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
@@ -65,6 +65,10 @@ function DictationButtonComponent({
     ? recorder.stopListening
     : speech.stopListening;
 
+  // Failed-recording recovery only exists on the MediaRecorder fallback
+  // (the Web Speech path has no server round-trip to fail or retry).
+  const hasFailedRecording = useFallback && recorder.hasFailedRecording;
+
   const level = useMicrophoneLevel({ enabled: isListening });
 
   const prevErrorRef = useRef<string | null>(null);
@@ -79,7 +83,10 @@ function DictationButtonComponent({
       if (error === 'not-allowed' || error === 'audio-capture') {
         message = t('dictation.permissionDenied');
       } else if (error === 'transcription-failed') {
-        message = t('dictation.transcriptionFailed');
+        // Surfaced by the persistent failed-dictation pill (with retry /
+        // discard) instead of a transient toast — mirrors the video-link
+        // "chip not toast" pattern. No toast here.
+        message = null;
       } else if (
         error === 'not-supported' ||
         error === 'language-not-supported'
@@ -136,45 +143,74 @@ function DictationButtonComponent({
   const levelPercent = Math.round(Math.min(1, Math.max(0, level)) * 100);
 
   return (
-    <Tooltip content={tooltipContent} side="top">
-      <Button
-        variant={isListening ? 'destructive' : 'ghost'}
-        size={isListening ? 'sm' : 'icon'}
-        onClick={handleClick}
-        disabled={disabled || isTranscribing}
-        aria-label={ariaLabel}
-        aria-busy={isTranscribing}
-        aria-pressed={isListening}
-        className={cn('relative rounded-full', isListening && 'gap-2 px-3')}
-      >
-        {isTranscribing ? (
-          <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
-        ) : (
-          <Mic
-            className={cn(
-              'size-4',
-              isListening && 'animate-pulse motion-reduce:animate-none',
-            )}
-          />
-        )}
-        {isListening && (
-          <span
-            className="bg-destructive-foreground/30 relative h-1.5 w-12 overflow-hidden rounded-full"
-            role="progressbar"
-            aria-label={t('dictation.level')}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={levelPercent}
-          >
-            <span
-              className="bg-destructive-foreground absolute inset-y-0 left-0 rounded-full transition-[width] duration-75 ease-out"
-              style={{ width: `${levelPercent}%` }}
-              aria-hidden="true"
+    <span className="flex items-center gap-1">
+      <Tooltip content={tooltipContent} side="top">
+        <Button
+          variant={isListening ? 'destructive' : 'ghost'}
+          size={isListening ? 'sm' : 'icon'}
+          onClick={handleClick}
+          disabled={disabled || isTranscribing}
+          aria-label={ariaLabel}
+          aria-busy={isTranscribing}
+          aria-pressed={isListening}
+          className={cn('relative rounded-full', isListening && 'gap-2 px-3')}
+        >
+          {isTranscribing ? (
+            <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Mic
+              className={cn(
+                'size-4',
+                isListening && 'animate-pulse motion-reduce:animate-none',
+              )}
             />
-          </span>
-        )}
-      </Button>
-    </Tooltip>
+          )}
+          {isListening && (
+            <span
+              className="bg-destructive-foreground/30 relative h-1.5 w-12 overflow-hidden rounded-full"
+              role="progressbar"
+              aria-label={t('dictation.level')}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={levelPercent}
+            >
+              <span
+                className="bg-destructive-foreground absolute inset-y-0 left-0 rounded-full transition-[width] duration-75 ease-out"
+                style={{ width: `${levelPercent}%` }}
+                aria-hidden="true"
+              />
+            </span>
+          )}
+        </Button>
+      </Tooltip>
+      {hasFailedRecording && !isTranscribing && (
+        // Persistent recovery affordance: the failed recording is held in
+        // memory so the user can fix their provider and retry without
+        // re-recording. Discard drops the retained audio.
+        <span className="border-destructive/40 bg-destructive/5 text-destructive flex items-center gap-1 rounded-full border px-2 py-1 text-xs">
+          <AlertCircle className="size-3 shrink-0" aria-hidden="true" />
+          <span>{t('dictation.transcriptionFailedShort')}</span>
+          <button
+            type="button"
+            aria-label={t('dictation.retry')}
+            title={t('dictation.retry')}
+            onClick={recorder.retryTranscription}
+            className="hover:bg-destructive/10 flex size-5 items-center justify-center rounded-full transition-colors"
+          >
+            <RotateCcw className="size-3" />
+          </button>
+          <button
+            type="button"
+            aria-label={t('dictation.discard')}
+            title={t('dictation.discard')}
+            onClick={recorder.discardFailedRecording}
+            className="hover:bg-destructive/10 flex size-5 items-center justify-center rounded-full transition-colors"
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -69,6 +69,9 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
   const { mutateAsync: skipTranscription } = useConvexMutation(
     api.file_metadata.mutations.skipTranscription,
   );
+  const { mutateAsync: retryTranscription } = useConvexMutation(
+    api.file_metadata.mutations.retryTranscription,
+  );
 
   const policyLimits = useUploadPolicy(config.organizationId);
 
@@ -390,6 +393,22 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
     [skipTranscription, config.organizationId],
   );
 
+  const retryAttachmentTranscription = useCallback(
+    (fileId: Id<'_storage'>) => {
+      // Reuse the existing backend retry: resets status to `queued`, clears
+      // the error, and reschedules the transcribe action. The reactive
+      // transcription-status query flips the chip back to queued/running on
+      // its own, so no optimistic local state is needed here.
+      retryTranscription({
+        storageId: fileId,
+        organizationId: config.organizationId,
+      }).catch((err) => {
+        console.warn('[retryAttachmentTranscription] failed:', err);
+      });
+    },
+    [retryTranscription, config.organizationId],
+  );
+
   const clearAttachments = useCallback(() => {
     const clearedAttachments = attachmentsRef.current;
     for (const att of clearedAttachments) {
@@ -418,6 +437,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
     isUploading: uploadingFiles.length > 0,
     uploadFiles,
     removeAttachment,
+    retryAttachmentTranscription,
     clearAttachments,
   };
 }

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -393,7 +393,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
     [skipTranscription, config.organizationId],
   );
 
-  const retryInFlightRef = useRef<Set<Id<'_storage'>>>(new Set());
+  const retryInFlightRef = useRef(new Set<Id<'_storage'>>());
 
   const retryAttachmentTranscription = useCallback(
     (fileId: Id<'_storage'>) => {

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -393,18 +393,31 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
     [skipTranscription, config.organizationId],
   );
 
+  const retryInFlightRef = useRef<Set<Id<'_storage'>>>(new Set());
+
   const retryAttachmentTranscription = useCallback(
     (fileId: Id<'_storage'>) => {
       // Reuse the existing backend retry: resets status to `queued`, clears
       // the error, and reschedules the transcribe action. The reactive
       // transcription-status query flips the chip back to queued/running on
       // its own, so no optimistic local state is needed here.
+      //
+      // Guard against rapid double-taps: the chip stays clickable until the
+      // reactive status flips out of `failed`, so without this an impatient
+      // user could schedule several transcribe jobs for the same file. The
+      // in-flight set drops the duplicates until the first call settles.
+      if (retryInFlightRef.current.has(fileId)) return;
+      retryInFlightRef.current.add(fileId);
       retryTranscription({
         storageId: fileId,
         organizationId: config.organizationId,
-      }).catch((err) => {
-        console.warn('[retryAttachmentTranscription] failed:', err);
-      });
+      })
+        .catch((err) => {
+          console.warn('[retryAttachmentTranscription] failed:', err);
+        })
+        .finally(() => {
+          retryInFlightRef.current.delete(fileId);
+        });
     },
     [retryTranscription, config.organizationId],
   );

--- a/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
@@ -89,5 +89,15 @@ export function useFileTranscriptionStatus(attachments: FileAttachment[]) {
     );
   }, [metadata, audioFileIds.length]);
 
-  return { statusMap, isTranscribing, isQueryLoading };
+  // True when any audio attachment's transcription terminally `failed`. The
+  // send-gate uses this to force the user to retry or remove before sending,
+  // mirroring `hasFailedVideoJobs`. `skipped` is intentionally excluded — it
+  // is a deliberate user action (remove → skipTranscription), so re-offering
+  // a retry there would fight the user's own intent.
+  const hasFailedAudioJobs = useMemo(() => {
+    if (!metadata) return false;
+    return metadata.some((m) => m.transcriptionStatus === 'failed');
+  }, [metadata]);
+
+  return { statusMap, isTranscribing, isQueryLoading, hasFailedAudioJobs };
 }

--- a/services/platform/app/features/chat/hooks/use-media-recorder-dictation.test.ts
+++ b/services/platform/app/features/chat/hooks/use-media-recorder-dictation.test.ts
@@ -413,6 +413,85 @@ describe('useMediaRecorderDictation', () => {
     });
   });
 
+  describe('failed-recording retry (in-browser, no re-record)', () => {
+    async function failOnce(onTranscript: (t: string) => void) {
+      mockTranscribeDictation.mockRejectedValueOnce(new Error('UNKNOWN_MODEL'));
+      const hook = renderHook(() =>
+        useMediaRecorderDictation({ organizationId: ORG_ID, onTranscript }),
+      );
+      await act(async () => {
+        hook.result.current.startListening();
+      });
+      const recorder = latestRecorder();
+      const audioChunk = new Blob([new Uint8Array([9, 8, 7, 6])], {
+        type: 'audio/webm',
+      });
+      await act(async () => {
+        recorder._fireEvent('dataavailable', { data: audioChunk });
+        recorder._fireEvent('stop');
+      });
+      await waitFor(() => {
+        expect(hook.result.current.hasFailedRecording).toBe(true);
+      });
+      return hook;
+    }
+
+    it('retains the recording when transcription fails', async () => {
+      const { result } = await failOnce(vi.fn());
+      expect(result.current.hasFailedRecording).toBe(true);
+      expect(result.current.error).toBe('transcription-failed');
+    });
+
+    it('retry re-sends the same bytes without re-recording, and clears on success', async () => {
+      const onTranscript = vi.fn();
+      const { result } = await failOnce(onTranscript);
+
+      const recordersBefore = recorders.length;
+      mockTranscribeDictation.mockResolvedValueOnce({ text: 'recovered' });
+
+      await act(async () => {
+        result.current.retryTranscription();
+      });
+
+      await waitFor(() => {
+        expect(onTranscript).toHaveBeenCalledWith('recovered');
+      });
+      // No new MediaRecorder / getUserMedia — retry reuses the retained blob.
+      expect(recorders.length).toBe(recordersBefore);
+      expect(mockTranscribeDictation).toHaveBeenCalledTimes(2);
+      // Same bytes re-sent.
+      const retryCall = mockTranscribeDictation.mock.calls[1]?.[0];
+      expect(new Uint8Array(retryCall.audio as ArrayBuffer)).toEqual(
+        new Uint8Array([9, 8, 7, 6]),
+      );
+      await waitFor(() => {
+        expect(result.current.hasFailedRecording).toBe(false);
+      });
+    });
+
+    it('discardFailedRecording clears the retained recording and error', async () => {
+      const { result } = await failOnce(vi.fn());
+
+      act(() => {
+        result.current.discardFailedRecording();
+      });
+
+      expect(result.current.hasFailedRecording).toBe(false);
+      expect(result.current.error).toBeNull();
+      // Retry after discard is a no-op (nothing retained).
+      act(() => {
+        result.current.retryTranscription();
+      });
+      expect(mockTranscribeDictation).toHaveBeenCalledTimes(1);
+    });
+
+    it('retained recording survives a re-render', async () => {
+      const { result, rerender } = await failOnce(vi.fn());
+      rerender();
+      expect(result.current.hasFailedRecording).toBe(true);
+    });
+  });
+
   describe('cleanup', () => {
     it('releases stream tracks on unmount during active recording', async () => {
       const { result, unmount } = renderHook(() =>

--- a/services/platform/app/features/chat/hooks/use-media-recorder-dictation.ts
+++ b/services/platform/app/features/chat/hooks/use-media-recorder-dictation.ts
@@ -17,6 +17,14 @@ interface UseMediaRecorderDictationReturn {
   error: string | null;
   startListening: () => void;
   stopListening: () => void;
+  /** True when the last transcription failed and the recording is being
+   * held in memory for retry. Drives the failed-dictation pill. */
+  hasFailedRecording: boolean;
+  /** Re-send the retained recording to the transcription action. No
+   * re-recording — reuses the exact bytes captured before the failure. */
+  retryTranscription: () => void;
+  /** Drop the retained recording and clear the failed state. */
+  discardFailedRecording: () => void;
 }
 
 /**
@@ -36,10 +44,19 @@ export function useMediaRecorderDictation({
   const [isListening, setIsListening] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasFailedRecording, setHasFailedRecording] = useState(false);
 
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  // Holds the recording when transcription fails so the user can retry
+  // without re-recording. In-browser only — never persisted server-side
+  // (the transcribeDictation action stays ephemeral by design). A ref, not
+  // state, so it survives re-renders and StrictMode's dev double-invoke; a
+  // separate `hasFailedRecording` flag drives the UI.
+  const failedRecordingRef = useRef<{ blob: Blob; mimeType: string } | null>(
+    null,
+  );
   const isMountedRef = useRef(true);
   // Guards against rapid double-clicks: getUserMedia is async and the
   // button stays clickable until isListening flips to true, so without
@@ -68,6 +85,40 @@ export function useMediaRecorderDictation({
     recorderRef.current = null;
     chunksRef.current = [];
   }, []);
+
+  // Shared transcribe round-trip used by both the initial stop and retry.
+  // On success forwards the text and clears any retained recording; on
+  // failure retains the blob so the user can fix the provider and retry.
+  const runTranscription = useCallback(
+    async (blob: Blob, mimeType: string) => {
+      setIsTranscribing(true);
+      setError(null);
+      try {
+        const audio = await blob.arrayBuffer();
+        const { text } = await transcribeDictation({
+          audio,
+          mimeType,
+          organizationId,
+        });
+
+        if (text.trim().length > 0) {
+          onTranscriptRef.current(text);
+        }
+        failedRecordingRef.current = null;
+        if (isMountedRef.current) setHasFailedRecording(false);
+      } catch (err) {
+        console.warn('[dictation] transcription failed:', err);
+        failedRecordingRef.current = { blob, mimeType };
+        if (isMountedRef.current) {
+          setHasFailedRecording(true);
+          setError('transcription-failed');
+        }
+      } finally {
+        if (isMountedRef.current) setIsTranscribing(false);
+      }
+    },
+    [transcribeDictation, organizationId],
+  );
 
   const startListening = useCallback(async () => {
     if (
@@ -148,26 +199,7 @@ export function useMediaRecorderDictation({
         return;
       }
 
-      setIsTranscribing(true);
-      void (async () => {
-        try {
-          const audio = await audioBlob.arrayBuffer();
-          const { text } = await transcribeDictation({
-            audio,
-            mimeType,
-            organizationId,
-          });
-
-          if (text.trim().length > 0) {
-            onTranscriptRef.current(text);
-          }
-        } catch (err) {
-          console.warn('[dictation] transcription failed:', err);
-          setError('transcription-failed');
-        } finally {
-          setIsTranscribing(false);
-        }
-      })();
+      void runTranscription(audioBlob, mimeType);
     });
 
     try {
@@ -181,7 +213,7 @@ export function useMediaRecorderDictation({
     } finally {
       startingRef.current = false;
     }
-  }, [isSupported, cleanup, transcribeDictation, organizationId]);
+  }, [isSupported, cleanup, runTranscription]);
 
   const stopListening = useCallback(() => {
     const recorder = recorderRef.current;
@@ -190,7 +222,25 @@ export function useMediaRecorderDictation({
     }
   }, []);
 
+  const retryTranscription = useCallback(() => {
+    const retained = failedRecordingRef.current;
+    if (retained) {
+      void runTranscription(retained.blob, retained.mimeType);
+    }
+  }, [runTranscription]);
+
+  const discardFailedRecording = useCallback(() => {
+    failedRecordingRef.current = null;
+    setHasFailedRecording(false);
+    setError(null);
+  }, []);
+
   useEffect(() => {
+    // Re-arm on (re)mount. The ref persists across React StrictMode's
+    // dev-mode unmount/remount, and the cleanup below sets it false — so
+    // without this line it stays false after the remount, and the stop
+    // handler silently drops every recording via the isMountedRef guard.
+    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
       if (recorderRef.current && recorderRef.current.state !== 'inactive') {
@@ -213,5 +263,8 @@ export function useMediaRecorderDictation({
       void startListening();
     },
     stopListening,
+    hasFailedRecording,
+    retryTranscription,
+    discardFailedRecording,
   };
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -914,7 +914,9 @@
       "indexingFailed": "Indizierung fehlgeschlagen",
       "couldNotTranscribe": "Konnte nicht transkribiert werden",
       "viewTranscript": "Transkript anzeigen",
-      "previewSubtitle": "{seconds}s transkribiert"
+      "previewSubtitle": "{seconds}s transkribiert",
+      "retry": "Erneut versuchen",
+      "failedSendBlockedTooltip": "Transkription fehlgeschlagen — versuch es erneut oder entferne den Anhang vor dem Senden"
     },
     "videoLink": {
       "statuses": {
@@ -1063,7 +1065,9 @@
       "level": "Mikrofonpegel",
       "notSupported": "Spracherkennung wird in diesem Browser nicht unterstützt",
       "permissionDenied": "Mikrofonzugriff wurde verweigert. Bitte erlaube den Mikrofonzugriff in den Browsereinstellungen.",
-      "transcriptionFailed": "Dein Diktat konnte nicht transkribiert werden. Versuch es nochmal."
+      "transcriptionFailedShort": "Transkription fehlgeschlagen",
+      "retry": "Erneut versuchen",
+      "discard": "Aufnahme verwerfen"
     },
     "citations": {
       "source": "Quelle {number}",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -914,7 +914,9 @@
       "indexingFailed": "Indexing failed",
       "couldNotTranscribe": "Could not be transcribed",
       "viewTranscript": "View transcript",
-      "previewSubtitle": "{seconds}s transcribed"
+      "previewSubtitle": "{seconds}s transcribed",
+      "retry": "Try again",
+      "failedSendBlockedTooltip": "Transcription failed — retry it or remove the attachment before sending"
     },
     "videoLink": {
       "statuses": {
@@ -1063,7 +1065,9 @@
       "level": "Microphone level",
       "notSupported": "Speech recognition is not supported in this browser",
       "permissionDenied": "Microphone access was denied. Please allow microphone access in your browser settings.",
-      "transcriptionFailed": "Could not transcribe your dictation. Please try again."
+      "transcriptionFailedShort": "Transcription failed",
+      "retry": "Try again",
+      "discard": "Discard recording"
     },
     "citations": {
       "source": "Source {number}",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -915,7 +915,9 @@
       "indexingFailed": "Échec de l'indexation",
       "couldNotTranscribe": "N'a pas pu être transcrit",
       "viewTranscript": "Voir la transcription",
-      "previewSubtitle": "{seconds}s transcrites"
+      "previewSubtitle": "{seconds}s transcrites",
+      "retry": "Réessayer",
+      "failedSendBlockedTooltip": "Échec de la transcription — réessaie ou retire la pièce jointe avant d'envoyer"
     },
     "videoLink": {
       "statuses": {
@@ -1064,7 +1066,9 @@
       "level": "Niveau du microphone",
       "notSupported": "La reconnaissance vocale n'est pas prise en charge par ce navigateur",
       "permissionDenied": "L'accès au microphone a été refusé. Merci d'autoriser l'accès au microphone dans les paramètres de ton navigateur.",
-      "transcriptionFailed": "Impossible de transcrire ta dictée. Réessaie."
+      "transcriptionFailedShort": "Échec de la transcription",
+      "retry": "Réessayer",
+      "discard": "Supprimer l'enregistrement"
     },
     "citations": {
       "source": "Source {number}",


### PR DESCRIPTION
## Problem

Audio transcription is effort-heavy and fragile. When it fails — AI provider down, network blip, or no transcription model configured — the user's effort could vanish with no way to recover. A long recording would have to be redone from scratch.

This was raised after a Firefox dictation report; investigation found the dictation fallback discards audio on failure, and the file-upload path already had a backend retry that was never wired to the UI.

## What this does

Recovery on **both** transcription paths — no re-recording, no re-uploading.

### File-upload path (longer audio)
- Wires the **existing** `retryTranscription` mutation to the UI (backend unchanged — audio is already persisted in `_storage`).
- Failed audio chips get a retry (RotateCcw) button that reuses the stored blob.
- New `hasFailedAudioJobs` flag blocks send until the user retries or removes the attachment — mirrors `hasFailedVideoJobs`. `skipped` is excluded (it's a deliberate user action).

### Dictation path (Firefox MediaRecorder fallback)
- On failure, the recorded blob is **retained in-browser** (never persisted server-side — preserves the deliberate ephemeral/privacy stance of `transcribeDictation`).
- A persistent failed pill next to the mic offers **retry** (re-sends the same bytes) and **discard**.
- The redundant `transcription-failed` toast is suppressed in favour of the pill (matches the video-link "chip not toast" pattern).

### i18n
Added `transcription.{retry,failedSendBlockedTooltip}` and `dictation.{transcriptionFailedShort,retry,discard}` across en/de/fr (de-CH inherits as a sparse regional overlay), reusing established translations. Dropped the now-orphaned `dictation.transcriptionFailed`.

## Verification
- ✅ Typecheck (full platform), lint (oxlint), format (oxfmt) — clean
- ✅ i18n parity + usage tests (enforce mode): 22/22 — caught and fixed an orphan-key issue
- ✅ Tests added: retry/discard/retention in the dictation hook test; pill render + retry/discard wiring + no-toast in the button test

## Notes / caveats
- ⚠️ The **UI vitest environment is currently broken project-wide** by an `html-encoding-sniffer` ESM error in `node_modules` (fails on a clean `main` too). The added component/hook tests pass typecheck + lint but **could not be executed locally**; they are written to run once the env is fixed. A `bun install` may resolve it.
- **Deferred:** RAG-indexing-failed retry (needs a new backend mutation) — the chip already surfaces "Indexing failed" and the agent degrades gracefully; the send-gate intentionally does not block on RAG failure.
- This makes failures **recoverable**; it does not configure a transcription model — one is still required for transcription to ultimately succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry functionality for failed audio and video transcriptions without re-uploading
  * Failed transcription attachments now display with retry and discard options
  * Improved persistent UI feedback for failed dictation recordings

* **Bug Fixes**
  * Enhanced error handling for transcription failures—send is now blocked until issues are resolved or attachments removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->