### PR TITLE
fix(design): cancel/discard, notifications, table footers, settings polish + profile-name persistence

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -327,7 +327,6 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.11",
-        "playwright": "1.58.2",
       },
     },
     "tools/cli": {

--- a/designs/platform/chat.pen
+++ b/designs/platform/chat.pen
@@ -12365,6 +12365,87 @@
                           ]
                         }
                       ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WDUBz",
+                      "name": "Actions",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Qr8r0",
+                          "name": "shareBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "nYQ73",
+                              "name": "shareIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "upload",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jH6w0",
+                              "name": "shareText",
+                              "fill": "#D1D5DB",
+                              "content": "Share",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nqOnY",
+                          "name": "exportBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "NhZuH",
+                              "name": "exportIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "S1Kvt",
+                              "name": "exportText",
+                              "fill": "#D1D5DB",
+                              "content": "Export",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
@@ -40639,6 +40720,79 @@
                               "iconFontName": "square-pen",
                               "iconFontFamily": "lucide",
                               "fill": "#374151"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uw7Bs",
+                      "name": "Actions",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RKRcv",
+                          "name": "Share Button",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "IKh7Q",
+                              "name": "shareIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "upload",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4B5563"
+                            },
+                            {
+                              "type": "text",
+                              "id": "e2In8w",
+                              "name": "shareText",
+                              "fill": "#4B5563",
+                              "content": "Share",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G9B1Qa",
+                          "name": "Export Button",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "SzMTG",
+                              "name": "exportIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4B5563"
+                            },
+                            {
+                              "type": "text",
+                              "id": "abFBM",
+                              "name": "exportText",
+                              "fill": "#4B5563",
+                              "content": "Export",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
                             }
                           ]
                         }
@@ -213165,6 +213319,16851 @@
           "width": 350,
           "height": 120,
           "content": "Split \"Help & feedback\" into \"Help Center\" and \"Send Feedback\" — they serve different purposes and link to different destinations. Help Center opens the eLearning portal; Send Feedback opens the feedback form in settings."
+        },
+        {
+          "type": "frame",
+          "id": "J1J0Vi",
+          "x": 57920,
+          "y": 0,
+          "name": "Pages/Chat/Conversation-ShareModal",
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "DigCM",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "p5AqHa",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZVpPE",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#F3F4F6",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "a8kHl5",
+                          "name": "msgText",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P60Wz",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "M4a6Ha",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#9CA3AF",
+                                "position": 0
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#9CA3AF",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F3G6H",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#D1D5DB"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "LmmsD",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D4X9I",
+                              "name": "placeholder",
+                              "fill": "#9CA3AF",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Y4Fdlq",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "SkT8f",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "S9Aftz",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "UEPeo",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "CZoFF",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "w9O2a",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Vs0yo",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "N0JzuZ",
+                                      "name": "i3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "d3Q40",
+                                      "name": "agent-label",
+                                      "fill": "#374151",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "pDkUc",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "o5OKUS",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "FNvJl",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "A9XJc",
+                                      "fill": "#374151",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "BBS2x",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "zsQcC",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "KXGHx",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "MuYCT",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#030712",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "I3Cc3",
+                                      "name": "c2",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#FFFFFF"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AVH6O",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "o8u8y2",
+                          "name": "response-text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RycsD",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "B8vBQ",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "RqEyc",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "i20lU",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "zLXle",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "jp2iF",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "dWpQD",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "C1Yf63",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#9CA3AF",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "T1iS4",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#ffffff66",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Mba2d",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NJrFz",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "o6Zag",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4b5563"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Bctas",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "n9ASH5",
+                              "name": "i1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "o0UwvC",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "OEa1c",
+                              "name": "p1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Ij1Pc",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "T6LOP",
+                      "name": "body",
+                      "fill": "#030712",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kakS0",
+                          "name": "content",
+                          "fill": "#FFFFFF",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "igc2y",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#374151",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Wx353",
+                              "name": "kbd",
+                              "fill": "#9CA3AF",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "b6jold",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#030712",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "N8XtCA",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "v7o4x",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ZDaj1",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X6iLM5",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Qj5b7",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "cz3QT",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F7Ele",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EsnR6",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "NJLvo",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UOYPx",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uFFCt",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "a4oDPY",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Bga8d",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "r5IjX9",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UIcrD",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gaFIz",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SrJqu",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "XLKGE",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Gc5Lq",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ETHle",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "k7ZlB",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k28Lp",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PA4fn",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "Omibf",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qnJG9",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EIa6n",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PlwUE",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Evp9t",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fmDiv",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "HAudc",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BARwM",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wqtdd",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rJtXU",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QTDEU",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VJdM8",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "BewF8",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cPT7y",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dZnhk",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "W17Gc",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HB4l3",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Y8MkkM",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "JuJ8m",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dbcTJ",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CtTiC",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lmvTR",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "L5v4j",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "IVBPr",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#060809",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "nwrDh",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#060809",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hy84j",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "p1lOA",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "IgHVJ",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uBMCD",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Giqcz",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "WrM2t",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bX9jl",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "KmBAq",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "n0N0b",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "NibhO",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "INDb6",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DDNUl",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Dx5Vg",
+                          "name": "bot",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pGzD8",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "eNPWs",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QYl9a",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aeH0h",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "BEqHE",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kM8v2",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T80uoG",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "J0XZL",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "d9wvD",
+                          "name": "Text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zxcM5",
+                          "name": "Text",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PCvey",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "L1NSXR",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "BY0s3",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mMKgf",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iG9jg",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#F9FAFB",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "EUIQ2",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CW6qc",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "eWaBf",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pTztc",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "NQQI8",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IJrwh",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "I45I9e",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "KvsZe",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tWMXh",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "IIu0U",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PDoni",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AcRJc",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TEPwz",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "T3nLbl",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zYXEF",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JP51I",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "yIIOD",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Zsp7Q",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ejnNC",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Wvc4V",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RYd7g",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "o6aS1F",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "iflqt",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MUgbi",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JWUCd",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JOi8K",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hxNqt",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zN4ZY",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "S2OQC",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mAsW5",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Hir5Z",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "NtvXP",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "U5fFQs",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "MC06m",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "lVShC",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rh493",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "osWAL",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "l0Jyx",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "aylY1",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Qhrdq",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "fF9MP",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "k9f1Hu",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000066",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "m8hqO",
+                  "x": 420,
+                  "y": 168,
+                  "name": "Share Dialog",
+                  "width": 384,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000001A",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "UOX6i",
+                      "name": "hdr",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TDqqG",
+                          "name": "title",
+                          "fill": "#111827",
+                          "content": "Share conversation",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.16
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qR1rH",
+                          "name": "close",
+                          "cornerRadius": 6,
+                          "padding": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Tfb4S",
+                              "name": "closeIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "x",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AIYRQ",
+                      "name": "body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Vmjdi",
+                          "name": "permissions",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "FDcjx",
+                              "name": "permLabel",
+                              "fill": "#374151",
+                              "content": "Who can access",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vJGlY",
+                              "name": "permission-select",
+                              "width": "fill_container",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E7EB"
+                              },
+                              "gap": 8,
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "hvNuP",
+                                  "name": "globeIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "globe",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "lEFsy",
+                                  "name": "permText",
+                                  "fill": "#111827",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Anyone in your organization",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "f0PF4",
+                                  "name": "chevron",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9CA3AF"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "A2TDjm",
+                          "name": "link",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "N1gCe",
+                              "name": "linkLabel",
+                              "fill": "#374151",
+                              "content": "Share link",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "uxArG",
+                              "name": "link-input",
+                              "width": "fill_container",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "kRlI7",
+                                  "name": "url",
+                                  "width": "fill_container",
+                                  "fill": "#F9FAFB",
+                                  "cornerRadius": [
+                                    8,
+                                    0,
+                                    0,
+                                    8
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E7EB"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "N6YOc",
+                                      "name": "urlText",
+                                      "fill": "#6B7280",
+                                      "content": "https://app.tale.dev/chat/a1b2c3",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "U0D3j8",
+                                  "name": "copy-btn",
+                                  "fill": "#F3F4F6",
+                                  "cornerRadius": [
+                                    0,
+                                    8,
+                                    8,
+                                    0
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E7EB"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "S3GXW",
+                                      "name": "copyIcon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "copy",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "wLd81",
+                          "name": "info-text",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Anyone in your organization with this link can view the chat.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Ql3A4",
+          "x": 57920,
+          "y": 820,
+          "name": "Pages/Chat/Conversation-ShareModal-Dark",
+          "theme": {
+            "mode": "dark"
+          },
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#0F0F0F",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "MhG5n",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VsAOY",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zXc8S",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#171717",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VDBwz",
+                          "name": "msgText",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fvFDW",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ukh4y",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#6B7280",
+                                "position": 0
+                              },
+                              {
+                                "color": "#D1D5DB",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FHYIz",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#0A0A0A",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#404040"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TSMOF",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MIh4W",
+                              "name": "placeholder",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G2rTs",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zOwxT",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "C0IihL",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "ieeOn",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "PvwIQ",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "r7h1i",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "gKMxT",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "T3zvK",
+                                      "name": "icon3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "uS5Yy",
+                                      "name": "agent-label",
+                                      "fill": "#D4D4D4",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "tGbjA",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "TOnRi",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "QJWIH",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Z05FB",
+                                      "fill": "#D4D4D4",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "SDaAH",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "EclSC",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "a998P2",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#A3A3A3"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "OLRy5",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "DrMJr",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#0A0A0A"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ig84R",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HXcxk",
+                          "name": "response-text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JAY4W",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "w4qFbc",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "KI86Z",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vEJqe",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "hQzjj",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "oXJY4",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Y7jFu",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "m4O1f5",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HFMIL",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "k43qi",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "XCmzJ",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "m6GoZ",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "P9KQn",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "uLSHQ",
+                              "name": "i2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "o4qD0m",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tGx6r",
+                              "name": "p2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h8wIm",
+                      "name": "Actions",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "s0SEER",
+                          "name": "shareBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "H0cSY",
+                              "name": "shareIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "upload",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "p4VvHb",
+                              "name": "shareText",
+                              "fill": "#D1D5DB",
+                              "content": "Share",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QPrKo",
+                          "name": "exportBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ASgjn",
+                              "name": "exportIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "C0hczU",
+                              "name": "exportText",
+                              "fill": "#D1D5DB",
+                              "content": "Export",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "j6hMLb",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n40XM",
+                      "name": "body",
+                      "fill": "#FAFAFA",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QlIau",
+                          "name": "content",
+                          "fill": "#030712",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "YaVH7",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#2E2E2E",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "r0xVw",
+                              "name": "kbd",
+                              "fill": "#A3A3A3",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "qyhzJ",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#FAFAFA",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sMDaT",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UhQON",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hEJab",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L1DEM",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SBfQ1",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "kZDFR",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "r9dTuG",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "W0DNm",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "u207g",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "f9WPvw",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fnMfV",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "tgIKx",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "FDZzn",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "N2P0R",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Eaj64",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "y1cK94",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qyMVA",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "I3qjnD",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "krJYY",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fDMSj",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ndVt9",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w9SIxk",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "UQnPN",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "Udwus",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ptUYW",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "g7Mm8e",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VLtds",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xqxuy",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "f6H8PI",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "EENYg",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K2Qj3",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "yU5g7",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ySs0j",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w3F8oC",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P0XIS",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "P4tYy",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wRUC6",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jkfE9",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "NAlcE",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JTuEu",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V3Bf7K",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "icPWe",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "g5Rwfx",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#404040"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "w0FLB5",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "CPCe8",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "yKewG",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "TU2Wv",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "PR7m7",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "chZDs",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wIKmk",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "kGfhO",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hgek1",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "irwX3",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QKFOr",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TAdQI",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "yIenH",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lCfEb",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "hoEzH",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "rT7Yu",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rOEbe",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "d0gzyF",
+                          "name": "bot",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CfLEI",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "JGlCT",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fo5iA",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "F7saT4",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "RX40l",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "VvhLk",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#0A0A0A",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#404040"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VcL1b",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZbZNX",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jmlms",
+                          "name": "Text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "a3c4t",
+                          "name": "Text",
+                          "fill": "#A3A3A3",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "whDHs",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ORl2Z",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "aJGjN",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "K24Amq",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fPgDH",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#171717",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GLD7w",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WZMcv",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Thwg9",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eGJwq",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "r6CUH3",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "kTHLh",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "R0i57",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "j57qY",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NVuWb",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "yK2nK",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QWCzg",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "icEqG",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "whvZz",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ektF2",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a2em5w",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "CKjdJ",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "pZCFg",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "glKJz",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IloJ2",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "R7RC7c",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uKlTL",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HFUjD",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "e955v",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iCdpw",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "F33m7l",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "x5yIED",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GHOhc",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FWXDl",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "y1DVlz",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Y8yRmR",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q8GlA",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vB1Jj",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OxVEh",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "t93UrL",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "ah2M5",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "b2GbnB",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vS8fb",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wF523",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F91hAY",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T5dc8p",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "SzJ0o",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "G2trv",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000080",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zg8zZ",
+                  "x": 420,
+                  "y": 168,
+                  "name": "dialog",
+                  "width": 384,
+                  "fill": "#18181B",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#00000040",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LwLfS",
+                      "name": "header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nNhqB",
+                          "name": "titleText",
+                          "fill": "#F9FAFB",
+                          "content": "Share conversation",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "tZGhr",
+                          "name": "closeFrame",
+                          "padding": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "nNUgl",
+                              "name": "closeIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "x",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9CA3AF"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "D8GoX",
+                      "name": "body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qdkGx",
+                          "name": "permSection",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "M6F7Ug",
+                              "name": "permLabel",
+                              "fill": "#D1D5DB",
+                              "content": "Who can access",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "o2j2IE",
+                              "name": "permRow",
+                              "width": "fill_container",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#404040"
+                              },
+                              "gap": 8,
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "zQOTd",
+                                  "name": "globeIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "globe",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9CA3AF"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Krsny",
+                                  "name": "permText",
+                                  "fill": "#F9FAFB",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Anyone in your organization",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Wvr50",
+                                  "name": "chevronIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "r8DdI",
+                          "name": "linkSection",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "E0aIii",
+                              "name": "linkLabel",
+                              "fill": "#D1D5DB",
+                              "content": "Share link",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "bbNwN",
+                              "name": "linkRow",
+                              "width": "fill_container",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "gzC9w",
+                                  "name": "urlFrame",
+                                  "width": "fill_container",
+                                  "fill": "#0F0F0F",
+                                  "cornerRadius": [
+                                    8,
+                                    0,
+                                    0,
+                                    8
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#404040"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "g4XpX",
+                                      "name": "urlText",
+                                      "fill": "#9CA3AF",
+                                      "content": "https://app.tale.dev/chat/a1b2c3",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Nt0kT",
+                                  "name": "copyBtnFrame",
+                                  "fill": "#27272A",
+                                  "cornerRadius": [
+                                    0,
+                                    8,
+                                    8,
+                                    0
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#404040"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "T88RE",
+                                      "name": "copyBtnIcon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "copy",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D1D5DB"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "b9NbmD",
+                          "name": "info-text",
+                          "fill": "#9CA3AF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Anyone in your organization with this link can view the chat.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "S29z1D",
+          "x": 59300,
+          "y": 0,
+          "name": "Pages/Chat/Conversation-ShareModal-DropdownOpen",
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "uKFAj",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o4ulQ",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "eVrKu",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#F3F4F6",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SNtiM",
+                          "name": "msgText",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "g5HzHu",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Yedcg",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#9CA3AF",
+                                "position": 0
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#9CA3AF",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SOPfB",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#D1D5DB"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FF668",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ko0tD",
+                              "name": "placeholder",
+                              "fill": "#9CA3AF",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "WTukO",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "hGol7",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "d4uvXu",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "eT6IV",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "ta2Mi",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "wvkc7",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "CEiFb",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "h0DyB",
+                                      "name": "i3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "lPTjD",
+                                      "name": "agent-label",
+                                      "fill": "#374151",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "fimJ2",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "d2nwf4",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "HTOYq",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "YqPnU",
+                                      "fill": "#374151",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "T6F5UK",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WJOwL",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "tpkXd",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "MChLZ",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#030712",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "j6NfLh",
+                                      "name": "c2",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#FFFFFF"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fsDTs",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YnWNW",
+                          "name": "response-text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "S3twB",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "x400yN",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "dZdDC",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "wEYlO",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "WZibB",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "HJcNP",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "Uc05U",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "H2ihzO",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#9CA3AF",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UWZ1H",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#ffffff66",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yER2G",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "p5iyQV",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "IqVGe",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4b5563"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zX0cQ",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "eqQkn",
+                              "name": "i1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qwIhN",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "yEsS9",
+                              "name": "p1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rLDnO",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "X6T0Q",
+                      "name": "body",
+                      "fill": "#030712",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Osqaa",
+                          "name": "content",
+                          "fill": "#FFFFFF",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "EfoXs",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#374151",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "fCYbD",
+                              "name": "kbd",
+                              "fill": "#9CA3AF",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "Z1Y4Q",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#030712",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "z2RONm",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VpBnO",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KGETW",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "J6QLY",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IWQep",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "VcnfE",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "keBEt",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "moGhT",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eHLpW",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "o9OaKA",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FQz53",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "D4R0H",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Q4rp0",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "snS6n",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "U3IaL",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zbGuc",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ogY1f",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "D9MNK",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MWBL8",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f3xjA",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "B5yq0O",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "o1XAYo",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "EI6Gy",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "dSoMn",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "SJCjI",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WfaPx",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "u0dxN",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VJ5no",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A2pFB",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "Uyu4v",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EGRkx",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pZmeS",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Nc9z0",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mbK2i",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z8bXo",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "fy7WX",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KtaUj",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CfkMx",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SPlPj",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BJwUs",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "M62FB",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "gPcMi",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "s7gxP3",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q9WUg",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rtxAY",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "HnSgJ",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "ndWET",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#060809",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "D1Lyg",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#060809",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hscIm",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "AwErO",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "NI0v9",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "v0CGQ",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "EEZEl",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "lt9g3",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rYXr6",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GTnmp",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h0JntV",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "YiN8U",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iqsNP",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "M1Qeg7",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "kyyIB",
+                          "name": "bot",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DfCgw",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "UoUEc",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nk7yn",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n7yyeK",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "XdLOS",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zXJVF",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sXGgx",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jixhh",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "K85DRL",
+                          "name": "Text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "yDTjw",
+                          "name": "Text",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dWOfN",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "f1jw1",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "BiwSm",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tUHmp",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JuBRA",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#F9FAFB",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "BdRh5",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m2oQ9E",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "QndKl",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "b3jpe",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "JxY3a",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QMEMU",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "iV4QH",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "sj8u3",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BIsPO",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "eOPXL",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G1tdOq",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RcIZn",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vydnD",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VJUgi",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C6ksP",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Q2r3Y",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "HdZ4j",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mHc8z",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jCHIQ",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "FtCY8",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k6qnk",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "hvKch",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "ShrSR",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "m69pD7",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zrHvw",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "exoqt",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FPrsV",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SNfUx",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "d78est",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "R3S4M6",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nC2sg",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qXwwG",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "O1otPn",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jqM20",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "fEC65",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oJDgP",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Pfu2b",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KMnEc",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yc2f0",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xW5Hs",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "utH0n",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aLzto",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000066",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CKa6A",
+                  "x": 420,
+                  "y": 168,
+                  "name": "Share Dialog",
+                  "width": 384,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000001A",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lVdzE",
+                      "name": "hdr",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HK3ds",
+                          "name": "title",
+                          "fill": "#111827",
+                          "content": "Share conversation",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.16
+                        },
+                        {
+                          "type": "frame",
+                          "id": "u6R9tN",
+                          "name": "close",
+                          "cornerRadius": 6,
+                          "padding": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Gil8U",
+                              "name": "closeIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "x",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Sh0vm",
+                      "name": "body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "s8p27",
+                          "name": "permissions",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Zy0Ry",
+                              "name": "permLabel",
+                              "fill": "#374151",
+                              "content": "Who can access",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "XCRe6",
+                              "name": "permission-select",
+                              "width": "fill_container",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "outside",
+                                "thickness": 1.5,
+                                "fill": "#056CFF"
+                              },
+                              "effect": [
+                                {
+                                  "type": "shadow",
+                                  "shadowType": "outer",
+                                  "color": "#056CFF66",
+                                  "blur": 3,
+                                  "spread": 2
+                                },
+                                {
+                                  "type": "shadow",
+                                  "shadowType": "outer",
+                                  "color": "#0000000d",
+                                  "offset": {
+                                    "x": 0,
+                                    "y": 1
+                                  },
+                                  "blur": 1.75
+                                }
+                              ],
+                              "gap": 8,
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "i5OLbo",
+                                  "name": "globeIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "globe",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "iaUYg",
+                                  "name": "permText",
+                                  "fill": "#111827",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Anyone in your organization",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Tniu3",
+                                  "name": "chevron",
+                                  "rotation": 180,
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9CA3AF"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "borRU",
+                              "name": "dropdown-panel",
+                              "width": "fill_container",
+                              "fill": "#FFFFFF",
+                              "cornerRadius": 12,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E7EB"
+                              },
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "#0000001A",
+                                "offset": {
+                                  "x": 0,
+                                  "y": 4
+                                },
+                                "blur": 16
+                              },
+                              "layout": "vertical",
+                              "padding": [
+                                4,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "LhsBz",
+                                  "name": "option-only-you",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "j4rDX4",
+                                      "name": "opt1Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "lock",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Q3j4X",
+                                      "name": "opt1Text",
+                                      "fill": "#374151",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Only you",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "hGfwu",
+                                  "name": "option-org-selected",
+                                  "width": "fill_container",
+                                  "fill": "#F3F4F6",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "LQJUJ",
+                                      "name": "opt2Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "globe",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Xr3ss",
+                                      "name": "opt2Text",
+                                      "fill": "#111827",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Anyone in your organization",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "UVoca",
+                                      "name": "opt2Check",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "check",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "kNq33",
+                                  "name": "option-link",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "qCVva",
+                                      "name": "opt3Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "link",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "pgIBR",
+                                      "name": "opt3Text",
+                                      "fill": "#374151",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Anyone with the link",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OsZlj",
+                          "name": "link",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "U0fCG",
+                              "name": "linkLabel",
+                              "fill": "#374151",
+                              "content": "Share link",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "RfPCh",
+                              "name": "link-input",
+                              "width": "fill_container",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "M4yDL",
+                                  "name": "url",
+                                  "width": "fill_container",
+                                  "fill": "#F9FAFB",
+                                  "cornerRadius": [
+                                    8,
+                                    0,
+                                    0,
+                                    8
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E7EB"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "rsuCT",
+                                      "name": "urlText",
+                                      "fill": "#6B7280",
+                                      "content": "https://app.tale.dev/chat/a1b2c3",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "lsqrb",
+                                  "name": "copy-btn",
+                                  "fill": "#F3F4F6",
+                                  "cornerRadius": [
+                                    0,
+                                    8,
+                                    8,
+                                    0
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E7EB"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "NRoCY",
+                                      "name": "copyIcon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "copy",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "i25RFx",
+                          "name": "info-text",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Anyone in your organization with this link can view the chat.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "OgTI7",
+          "x": 59300,
+          "y": 820,
+          "name": "Pages/Chat/Conversation-ShareModal-DropdownOpen-Dark",
+          "theme": {
+            "mode": "dark"
+          },
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#0F0F0F",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "LAQZ9",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YC65g",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "bCpta",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#171717",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LPJh2",
+                          "name": "msgText",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oJbIi",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "stDad",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#6B7280",
+                                "position": 0
+                              },
+                              {
+                                "color": "#D1D5DB",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mfBzs",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#0A0A0A",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#404040"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lP26p",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NBq8K",
+                              "name": "placeholder",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "otmtO",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "U4Oob2",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "vbHgx",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "M8169",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Iaql0",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "IyRyO",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "RVa9u",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "J3H4Fv",
+                                      "name": "icon3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Vqe8X",
+                                      "name": "agent-label",
+                                      "fill": "#D4D4D4",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "q3tiJ",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "qvHJU",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "qpWq6",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "IEy8u",
+                                      "fill": "#D4D4D4",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "asp89",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lTY2h",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "ADJti",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#A3A3A3"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "kFuaQ",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "JBSdI",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#0A0A0A"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "G9tiy",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qKvkk",
+                          "name": "response-text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ff6X9",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "lt2R3",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "IVwS7",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "w0UviU",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "gWGqL",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QeDFa",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "kY5fO",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "q0ZqAw",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "k0HB0",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tOUnk",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vvqR3",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "FIQue",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "K8lvxC",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dCrTX",
+                              "name": "i2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cNKQ1",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "EGy3c",
+                              "name": "p2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Q1KqPF",
+                      "name": "Actions",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lRh95",
+                          "name": "shareBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "J428Ys",
+                              "name": "shareIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "upload",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cTVeh",
+                              "name": "shareText",
+                              "fill": "#D1D5DB",
+                              "content": "Share",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Qp5Ca",
+                          "name": "exportBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "KD0PV",
+                              "name": "exportIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "QuxX3",
+                              "name": "exportText",
+                              "fill": "#D1D5DB",
+                              "content": "Export",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UXo8z",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "a9UYUG",
+                      "name": "body",
+                      "fill": "#FAFAFA",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fR56Y",
+                          "name": "content",
+                          "fill": "#030712",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uUncz",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#2E2E2E",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "X7D8Ul",
+                              "name": "kbd",
+                              "fill": "#A3A3A3",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "d72YXq",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#FAFAFA",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Qmp6F",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DGTDB",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "o1VWJb",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "PN9dZ",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bUIhL",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "ZIE6P",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "byjxr",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "k4y8lx",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "uwbse",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BUbGC",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xkucG",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "uWahj",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ATiWe",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "h2WAb",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e7C2t",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JJUt3",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uN9i1",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "NtMnh",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uXQNn",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "N3CSA",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "s3o86",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L5dof2",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HzaET",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "kdXbv",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ojifx",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "U56MHC",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "aQy34",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YeuYm",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RcZkn",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "ZUCvL",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YKVGe",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PK6D0",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zY8sK",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i2MXwZ",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "p42UI",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "L5Gpy",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Y5kR1",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ckZHP",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "xzlwY",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IucSg",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ikkEO",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "m1gfG",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wHaSP",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#404040"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PdKDi",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zy40D",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "tNsAQ",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "bhb2K",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "s4FPO2",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xZhhf",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uxOVu",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Vk0gP",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qb6Rf",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "p8Mazw",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "I3vC3V",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Y3ZaBn",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "bGp63",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KLXfq",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "M4NbGW",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HnZz2",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BOnM9",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "wlJc2",
+                          "name": "bot",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RFS9M",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "QTK3G",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "scddi",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Cv3Ph",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Z6kpK",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wkoO7",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#0A0A0A",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#404040"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YJFGQ",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "s05PZG",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uZTvp",
+                          "name": "Text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "yxgEq",
+                          "name": "Text",
+                          "fill": "#A3A3A3",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pTec9",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zprgq",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "K8Ka6t",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "v86CRH",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "IoMOV",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#171717",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "SgHsP",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Gi3gV",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "eFs4E",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tmyl6",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "gFcMb",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jDvum",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zFwOM",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G1mBB7",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iJFxv",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "BrC7i",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "OPckU",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sEyr8",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zMVBy",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pwn4P",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i21k3",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T5VQH",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "w09Eil",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YcEeh",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nZzcH",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "h0J1t",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P6wnMd",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RWHXW",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "OgsHj",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "X1o37b",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nljUl",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DibWf",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GQKPC",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "veKLO",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "G92OTU",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "HL2Vv",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TI3Qx",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qFZGX",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Vto0E",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Xylhc",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "XNjT3",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dLc2p",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "uBt2f",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Ga7h3",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L27xI",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "X9niq",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "h5un1o",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GA2YL",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000080",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mxGLO",
+                  "x": 420,
+                  "y": 168,
+                  "name": "dialog",
+                  "width": 384,
+                  "fill": "#18181B",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#00000040",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VCVxq",
+                      "name": "header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IkFbd",
+                          "name": "titleText",
+                          "fill": "#F9FAFB",
+                          "content": "Share conversation",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "pnofP",
+                          "name": "closeFrame",
+                          "padding": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "DV6cj",
+                              "name": "closeIcon",
+                              "width": 18,
+                              "height": 18,
+                              "iconFontName": "x",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9CA3AF"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "b4psU",
+                      "name": "body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WC2b3",
+                          "name": "permSection",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "WBXgL",
+                              "name": "permLabel",
+                              "fill": "#D1D5DB",
+                              "content": "Who can access",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "G4N5v",
+                              "name": "permRow",
+                              "width": "fill_container",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "outside",
+                                "thickness": 1.5,
+                                "fill": "#056CFF"
+                              },
+                              "effect": [
+                                {
+                                  "type": "shadow",
+                                  "shadowType": "outer",
+                                  "color": "#056CFF66",
+                                  "blur": 3,
+                                  "spread": 2
+                                },
+                                {
+                                  "type": "shadow",
+                                  "shadowType": "outer",
+                                  "color": "#0000000d",
+                                  "offset": {
+                                    "x": 0,
+                                    "y": 1
+                                  },
+                                  "blur": 1.75
+                                }
+                              ],
+                              "gap": 8,
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "DFbld",
+                                  "name": "globeIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "globe",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9CA3AF"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Jk0oS",
+                                  "name": "permText",
+                                  "fill": "#F9FAFB",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Anyone in your organization",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "GYqba",
+                                  "name": "chevronIcon",
+                                  "rotation": 180,
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "KKHqy",
+                              "name": "dropdown-panel",
+                              "width": "fill_container",
+                              "fill": "#27272A",
+                              "cornerRadius": 12,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#404040"
+                              },
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "#00000040",
+                                "offset": {
+                                  "x": 0,
+                                  "y": 4
+                                },
+                                "blur": 16
+                              },
+                              "layout": "vertical",
+                              "padding": [
+                                4,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "J82xGu",
+                                  "name": "option-only-you",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "wTSaL",
+                                      "name": "opt1Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "lock",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "WiNOV",
+                                      "name": "opt1Text",
+                                      "fill": "#D4D4D4",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Only you",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "fB98J",
+                                  "name": "option-org-selected",
+                                  "width": "fill_container",
+                                  "fill": "#18181B",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "pe5qT",
+                                      "name": "opt2Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "globe",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "SFv1l",
+                                      "name": "opt2Text",
+                                      "fill": "#FAFAFA",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Anyone in your organization",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "EhQyr",
+                                      "name": "opt2Check",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "check",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D1D5DB"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "r9RkB",
+                                  "name": "option-link",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "YtX4h",
+                                      "name": "opt3Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "link",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "TXGGm",
+                                      "name": "opt3Text",
+                                      "fill": "#D4D4D4",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Anyone with the link",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "lweax",
+                          "name": "linkSection",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "aUa9q",
+                              "name": "linkLabel",
+                              "fill": "#D1D5DB",
+                              "content": "Share link",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "LkMth",
+                              "name": "linkRow",
+                              "width": "fill_container",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Bc0Mx",
+                                  "name": "urlFrame",
+                                  "width": "fill_container",
+                                  "fill": "#0F0F0F",
+                                  "cornerRadius": [
+                                    8,
+                                    0,
+                                    0,
+                                    8
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#404040"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "KerZk",
+                                      "name": "urlText",
+                                      "fill": "#9CA3AF",
+                                      "content": "https://app.tale.dev/chat/a1b2c3",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "P044uQ",
+                                  "name": "copyBtnFrame",
+                                  "fill": "#27272A",
+                                  "cornerRadius": [
+                                    0,
+                                    8,
+                                    8,
+                                    0
+                                  ],
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#404040"
+                                  },
+                                  "padding": [
+                                    10,
+                                    12
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "mjJSV",
+                                      "name": "copyBtnIcon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "copy",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D1D5DB"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "SKqNh",
+                          "name": "infoText",
+                          "fill": "#9CA3AF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Anyone in your organization with this link can view the chat.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "vAS0u",
+          "x": 60680,
+          "y": 0,
+          "name": "Pages/Chat/Conversation-ExportModal",
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "gSao8",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vpBWU",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pEUwK",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#F3F4F6",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "I2F1cA",
+                          "name": "msgText",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RBJc1",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "a3SmHb",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#9CA3AF",
+                                "position": 0
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#9CA3AF",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k0Naj",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#D1D5DB"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TQklY",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "udy9i",
+                              "name": "placeholder",
+                              "fill": "#9CA3AF",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TNvQN",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "vYoXd",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "pfo6f",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "HLSiH",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "WZeWX",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "OAlYl",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Aw7Vh",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "M8oJs",
+                                      "name": "i3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "VBWOm",
+                                      "name": "agent-label",
+                                      "fill": "#374151",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "EeqFB",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "jnSXZ",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "MzTeY",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#374151"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "S4kmJ",
+                                      "fill": "#374151",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "q4lWH",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#6B7280"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "VojSi",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "GVouq",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "H6sV1S",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#030712",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "o1jfo0",
+                                      "name": "c2",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#FFFFFF"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "paKDb",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "UZHdE",
+                          "name": "response-text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Z3bzfB",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "x5yWI",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "saF2u",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "aFJg1",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "U5hJl2",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "JfmeC",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "M6dRW",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#4B5563"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "zVPCF",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#9CA3AF",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cPayK",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#ffffff66",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "SryHu",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hGBvD",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "N1ynz",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4b5563"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jo8kF",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "N5BcRE",
+                              "name": "i1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QYL84",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "iZUTy",
+                              "name": "p1",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RGAip",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "F2ap7",
+                      "name": "body",
+                      "fill": "#030712",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SrqzL",
+                          "name": "content",
+                          "fill": "#FFFFFF",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "oTLRc",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#374151",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "USgdV",
+                              "name": "kbd",
+                              "fill": "#9CA3AF",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "WvZdd",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#030712",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nGwVG",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Iivcw",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "M3Sqh7",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w6eqs",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "N8CRoe",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "RTrap",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "E2RSf",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XFxYa",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "BP7QX",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i80fhA",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mdnwz",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "ZfEEk",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "q5uwyV",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aWU2h",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ipwUu",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bxq0e",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FTwrK",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "w6HNK",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QVXFi",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Jh9rI",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Yzfiv",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "soaun",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "voOzS",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "fdwRg",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wfGNa",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "u0x7Vp",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "h5ccph",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IAGVH",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZKtnj",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "HixHh",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YIH8x",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NGRqf",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RXpWX",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Z4emR",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QYacQ",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "m8AfC",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bhxQh",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZU36H",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MSGeU",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kmDF0",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "yccqb",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "xYgEq",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bVHtS",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "tFqd0",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rUMpy",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "aeDAK",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "BaAw0",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#060809",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "iA019",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#060809",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "unb9y",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "W4cG48",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "XN5Em",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L0hvK",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "mcBtu",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "gWdJk",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Sbxud",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GhrDs",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z4StnD",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "DReQj",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "xNIPn",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "snhyZ",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "qcNEf",
+                          "name": "bot",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "T7RTjp",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "M7WPB",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rVpi4",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "G7rPK",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "slWAJ",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6b7280"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cgy3D",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AAc4c",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EL7E9",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B7aq5Q",
+                          "name": "Text",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "OuOnK",
+                          "name": "Text",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Vl875",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "x9QwTe",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "fSjlA",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gCaAq",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "roo7k",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#F9FAFB",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "zByl0",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NgymH",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "xvFFL",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gntgz",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "xUDhk",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6B7280"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gtEL7",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "OfUMF",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Y3WBax",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SFsLq",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "eYqgy",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QX7gn",
+                      "name": "Text",
+                      "fill": "#374151",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eh1Jw",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "c7D5f8",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rJFWG",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OAcfa",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OXdAQ",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "oMTwT",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WP6sz",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EeKE7",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mBQN9",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Oxanw",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "d5xIm",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "gAtf5",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GXq8N",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cLL8Y",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "GVlwr",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LPr7V",
+                      "name": "shortcut",
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JrkfC",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "G0ouU",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "u6KWAi",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aKHPm",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "p4jZq",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "En5At",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FruAi",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "Vbvgt",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "I9VQ5l",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "teI6C",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CNJpc",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Xu2IL",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iffDJ",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "S1F5cd",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sZB3x",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000066",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NAZar",
+                  "x": 420,
+                  "y": 148,
+                  "name": "Export Dialog",
+                  "width": 440,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E7EB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000001A",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RbZ1l",
+                      "name": "header-group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "LIffV",
+                          "name": "hdr",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "AsBJZ",
+                              "name": "title",
+                              "fill": "#111827",
+                              "content": "Export conversation",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600",
+                              "letterSpacing": -0.16
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lBiwO",
+                              "name": "close",
+                              "cornerRadius": 6,
+                              "padding": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "l40eIV",
+                                  "name": "closeIcon",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "ax48d",
+                          "name": "subtitle",
+                          "fill": "#6B7280",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select messages and download in your preferred format.",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DvIXs",
+                      "name": "preview",
+                      "clip": true,
+                      "width": "fill_container",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E7EB"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CzKbn",
+                          "name": "msg1",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#E5E7EB"
+                          },
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "id": "MZkOO",
+                              "type": "ref",
+                              "ref": "mxvM9",
+                              "width": 16,
+                              "height": 16,
+                              "name": "chk1"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "F9EMs",
+                              "name": "m1t",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "aXcNX",
+                                  "fill": "#111827",
+                                  "content": "You",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "P12nxi",
+                                  "fill": "#6B7280",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month's revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qOp3m",
+                          "name": "msg3",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0,
+                            "fill": "#E5E7EB"
+                          },
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "id": "DQjNv",
+                              "type": "ref",
+                              "ref": "mxvM9",
+                              "width": 16,
+                              "height": 16,
+                              "name": "chk3"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Rv5ZO",
+                              "name": "m3t",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "dvFee",
+                                  "fill": "#111827",
+                                  "content": "Assistant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "oxJt3",
+                                  "fill": "#6B7280",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Plan review timed out after 30 minutes of inactivity. Please restart when ready.",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bOqwR",
+                      "name": "footer",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "iG2uZ",
+                          "name": "PDF button",
+                          "height": 36,
+                          "fill": "#030712",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Rrrsz",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#FFFFFF"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DRKRL",
+                              "fill": "#FFFFFF",
+                              "content": "PDF",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "w079ds",
+                          "name": "Markdown button",
+                          "height": 36,
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E5E7EB"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "eiw5F",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-code",
+                              "iconFontFamily": "lucide",
+                              "fill": "#374151"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ldbky",
+                              "fill": "#374151",
+                              "content": "Markdown",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "u9f4f",
+          "x": 60680,
+          "y": 820,
+          "name": "Pages/Chat/Conversation-ExportModal-Dark",
+          "theme": {
+            "mode": "dark"
+          },
+          "clip": true,
+          "width": 1280,
+          "height": 720,
+          "fill": "#0F0F0F",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "z6bev",
+              "x": 48,
+              "y": 0,
+              "name": "Main Content",
+              "clip": true,
+              "width": 1232,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1,
+                  "left": 1
+                }
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000008",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 0.875
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "t3RS3S",
+                  "x": 0,
+                  "y": 48,
+                  "name": "Image Container",
+                  "width": 1232,
+                  "height": 672,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "M7prFC",
+                      "x": 576,
+                      "y": 40,
+                      "name": "user-message",
+                      "fill": "#171717",
+                      "cornerRadius": 20,
+                      "padding": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "e8kGs",
+                          "name": "msgText",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": 400,
+                          "content": "Can you summarize last quarter's sales performance and highlight key trends?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ckwCg",
+                      "x": 232,
+                      "y": 114,
+                      "name": "ai-thinking",
+                      "enabled": false,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "E7TiXP",
+                          "name": "shimmer",
+                          "fill": {
+                            "type": "gradient",
+                            "gradientType": "linear",
+                            "enabled": true,
+                            "rotation": -450,
+                            "size": {
+                              "height": 0.62
+                            },
+                            "colors": [
+                              {
+                                "color": "#6B7280",
+                                "position": 0
+                              },
+                              {
+                                "color": "#D1D5DB",
+                                "position": 0.5
+                              },
+                              {
+                                "color": "#6B7280",
+                                "position": 1
+                              }
+                            ],
+                            "center": {
+                              "x": 0.67
+                            }
+                          },
+                          "content": "Analyzing the data...",
+                          "lineHeight": 1.43,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.084
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iuM4X",
+                      "x": 248,
+                      "y": 496,
+                      "name": "chat-input",
+                      "width": 736,
+                      "fill": "#0A0A0A",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#404040"
+                      },
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000d",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 1.75
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "jmYtV",
+                          "name": "text-area",
+                          "width": "fill_container",
+                          "height": 72,
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ISbY2",
+                              "name": "placeholder",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask about customers, products, or documents…",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.096
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "z1hwt9",
+                          "name": "bottom-bar",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KSFNT",
+                              "name": "left-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "o39SU",
+                                  "name": "add-button",
+                                  "cornerRadius": 100,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "frpoe",
+                                      "name": "plus",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "paperclip",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "Aod1Z",
+                                  "name": "bookmark-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "yOvOf",
+                                  "name": "arena-icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "swords",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$icon-primary"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "ogSu9",
+                                  "name": "agent-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "si9Ie",
+                                      "name": "icon3",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "bot",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "HmDeG",
+                                      "name": "agent-label",
+                                      "fill": "#D4D4D4",
+                                      "content": "Assistant",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "BkaUp",
+                                      "name": "chevron-down",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "uUhEH",
+                                  "name": "model-selector",
+                                  "fill": {
+                                    "type": "color",
+                                    "color": "#F3F4F6",
+                                    "enabled": false
+                                  },
+                                  "cornerRadius": 6,
+                                  "gap": 4,
+                                  "padding": [
+                                    4,
+                                    6
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "a8MRm",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "cpu",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#D4D4D4"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "YEPRG",
+                                      "fill": "#D4D4D4",
+                                      "content": "Opus 4.6",
+                                      "lineHeight": 1.4285714285714286,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "500",
+                                      "letterSpacing": -0.084
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "VDKVu",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "chevron-down",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#A3A3A3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "K9yBZ",
+                              "name": "right-group",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "JTgwZ",
+                                  "name": "mic-button",
+                                  "width": 20,
+                                  "height": 20,
+                                  "iconFontName": "mic",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#A3A3A3"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "y5FTi",
+                                  "name": "send-button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "#FFFFFF",
+                                  "cornerRadius": 9999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "yg3fn",
+                                      "width": 16,
+                                      "height": 16,
+                                      "iconFontName": "arrow-up",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#0A0A0A"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t2xoaG",
+                      "x": 232,
+                      "y": 170,
+                      "name": "ai-response",
+                      "width": 768,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nvAdM",
+                          "name": "response-text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here's a summary of last quarter's sales performance:\n\nRevenue: Total revenue reached $4.2M, a 12% increase compared to Q2. The growth was primarily driven by enterprise plan upgrades and new customer acquisitions in the APAC region.\n\nKey Trends:\n- Enterprise deals grew by 23%, with average deal size increasing from $45K to $52K\n- Self-serve signups remained flat, suggesting a need to revisit the onboarding funnel\n- Churn rate decreased from 4.1% to 3.2%, largely due to the new customer success initiatives\n- APAC revenue doubled, now representing 18% of total revenue",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.084
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VsDMd",
+                          "name": "actions",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "OQEZQ",
+                              "name": "copy-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "YJf2l",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "copy",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vBS7c",
+                              "name": "save-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "qewiJ",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bookmark",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NziLq",
+                              "name": "info-button",
+                              "fill": {
+                                "type": "color",
+                                "color": "#171717",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "padding": 6,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "pHiH8",
+                                  "name": "infoIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "info",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#D4D4D4"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "dAlbb",
+                      "x": 248,
+                      "y": 652,
+                      "name": "AI Disclosure",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": 736,
+                      "content": "Responses are AI-generated. Verify important info.",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CW4B6",
+                  "x": 0,
+                  "y": 0,
+                  "name": "Header",
+                  "width": 1232,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 7
+                  },
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "a7nkl",
+                      "name": "Frame 427298262",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "su9ka",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 8,
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "T4etH",
+                              "name": "clock-4",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "clock-4",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "KLAMq",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dala9",
+                              "name": "i2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "search",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NsUb4",
+                          "name": "Menu Item",
+                          "clip": true,
+                          "fill": {
+                            "type": "color",
+                            "color": "#F3F4F6",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "padding": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "yoVpv",
+                              "name": "p2",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "square-pen",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4D4D4"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k4jSDI",
+                      "name": "Actions",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "uyLB6",
+                          "name": "shareBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "n9kA0",
+                              "name": "shareIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "upload",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "g8vAJf",
+                              "name": "shareText",
+                              "fill": "#D1D5DB",
+                              "content": "Share",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ljOAK",
+                          "name": "exportBtn",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0
+                          },
+                          "gap": 6,
+                          "padding": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "TPM6T",
+                              "name": "exportIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Rpmeq",
+                              "name": "exportText",
+                              "fill": "#D1D5DB",
+                              "content": "Export",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.08
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TAsxM",
+                  "x": 248,
+                  "y": 675,
+                  "name": "Tooltip - Add files",
+                  "enabled": false,
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "g1sAVz",
+                      "name": "body",
+                      "fill": "#FAFAFA",
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VvAJa",
+                          "name": "content",
+                          "fill": "#030712",
+                          "content": "Add files",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f7z7o",
+                          "x": 0,
+                          "y": 0,
+                          "name": "shortcut",
+                          "enabled": false,
+                          "fill": "#2E2E2E",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "rvpCF",
+                              "name": "kbd",
+                              "fill": "#A3A3A3",
+                              "content": "⇧N",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "polygon",
+                      "polygonCount": 3,
+                      "id": "d0gExm",
+                      "x": 0,
+                      "y": 0,
+                      "name": "arrow-down",
+                      "enabled": false,
+                      "rotation": 180,
+                      "fill": "#FAFAFA",
+                      "width": 12,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OYPng",
+              "x": 55,
+              "y": 92.5,
+              "name": "Tooltip - Chat with AI",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Tn6ll",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "L8Hd0S",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Chat with AI",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B3VFm1",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mHYcj",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "iiuuM",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Kq6IL",
+              "x": 55,
+              "y": 172.5,
+              "name": "Tooltip - Knowledge",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Nx3rh",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SkH03",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Knowledge",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "noVT0",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "c1qaU",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "p7IsoB",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ovyyj",
+              "x": 55,
+              "y": 132.5,
+              "name": "Tooltip - Conversations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ttPtW",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "IzLk3",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Conversations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "J1mTgE",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "N5a8L",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "fgi0V",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "FmBbo",
+              "x": 55,
+              "y": 212.5,
+              "name": "Tooltip - Approvals",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "E9kX5r",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "C1EkP",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Approvals",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LuYOX",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "M4kZI",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "dgm0s",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GOEGx",
+              "x": 55,
+              "y": 292,
+              "name": "Tooltip - Automations",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "J1xCB2",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "a9iwgF",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Automations",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "A25sA",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WLUV3",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "IwBiY",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "j4b2bd",
+              "x": 55,
+              "y": 252,
+              "name": "Tooltip - Custom agent",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n041q",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e9NC36",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Custom agent",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NG6xw",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "c4TDka",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "hW6d4",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aiiXl",
+              "x": 55,
+              "y": 684,
+              "name": "Tooltip - Settings",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "oDYTQ",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vU7nw",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Settings and more",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t8Ceuc",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "chgvG",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "oosVI",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qHS0q",
+              "x": 0,
+              "y": 0,
+              "name": "Side bar",
+              "width": 48,
+              "height": 720,
+              "fill": "#0A0A0A",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#404040"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Ge5i1",
+                  "name": "talelogo 1",
+                  "clip": true,
+                  "width": 48,
+                  "height": 48,
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    8,
+                    12,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "FGdPF",
+                      "name": "Menu Item/Default",
+                      "clip": true,
+                      "width": 32,
+                      "height": 32,
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "group",
+                          "id": "u7Yf7",
+                          "name": "Group 1",
+                          "flipX": true,
+                          "children": [
+                            {
+                              "type": "path",
+                              "id": "SwGg3",
+                              "x": 0,
+                              "y": 9.494771003723145,
+                              "name": "Vector",
+                              "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.81279945373535,
+                              "height": 16.505352020263672,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            },
+                            {
+                              "type": "path",
+                              "id": "Radco",
+                              "x": 7.188720703125,
+                              "y": 0,
+                              "name": "Vector",
+                              "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                              "fill": "#FFFFFF",
+                              "width": 18.814611434936523,
+                              "height": 16.50131607055664,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "w5bH1W",
+                  "name": "Frame 427298167",
+                  "height": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    36,
+                    8,
+                    16,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nFBW4",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "oyPI7",
+                          "name": "message-circle",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "message-circle",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cnE4c",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "U37XwW",
+                          "name": "inbox",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "inbox",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vJFBC",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FD9Kk",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Tspjm",
+                          "name": "brain",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nmv9D",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "VxcpE",
+                          "name": "circle-check",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "eKWFJ",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Frame 427298211",
+                          "enabled": false,
+                          "clip": true,
+                          "width": 4,
+                          "height": 4,
+                          "fill": "#056cffff",
+                          "cornerRadius": 9999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "none"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a3xip",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ulk2h",
+                          "name": "bot",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "bot",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vsjBY",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "hC70a",
+                          "name": "network",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "network",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vqT1d",
+                  "name": "Frame 427298178",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "p1IKeM",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "j8HK4",
+                          "name": "circle-user-round",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "circle-user-round",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "w4KoFW",
+              "x": 7,
+              "y": 435,
+              "name": "user profile pop up",
+              "enabled": false,
+              "clip": true,
+              "width": 217,
+              "fill": "#0A0A0A",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#404040"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 5.25
+              },
+              "layout": "vertical",
+              "padding": [
+                4,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VR2MU",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#f3f4f6ff",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c5Z2ne",
+                      "name": "Frame 427298659",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "riyAL",
+                          "name": "Text",
+                          "fill": "#FAFAFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Thelma nader",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "QIyiy",
+                          "name": "Text",
+                          "fill": "#A3A3A3",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "thelma.nader@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Yx5T0",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "egIvL",
+                      "name": "settings",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "d8Mjny",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Settings",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qVJAl",
+                  "name": "Frame 427298641",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "bottom": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BgA21",
+                      "name": "Frame 427298637",
+                      "width": "fill_container",
+                      "fill": "#171717",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "dmtXh",
+                          "name": "monitor",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "monitor",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oaj7x",
+                      "name": "Frame 427298640",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "sNOLx",
+                          "name": "sun",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "sun",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "owz2D",
+                      "name": "Frame 427298639",
+                      "width": "fill_container",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 10,
+                      "padding": [
+                        6,
+                        16
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "r4jcmo",
+                          "name": "moon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "moon",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A3A3A3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IiB14",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "enm7c",
+                      "name": "circle-help",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "circle-help",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xlEVB",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Help & feedback",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IZP8I",
+                  "name": "Rows",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "#404040"
+                  },
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "xvNQL",
+                      "name": "log-out",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "log-out",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A3A3A3"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xGJRW",
+                      "name": "Text",
+                      "fill": "#D4D4D4",
+                      "content": "Log out",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ymm1c",
+              "x": 104,
+              "y": 443,
+              "name": "Tooltip - User",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dNaUk",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e1hPDO",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Thelma Nader - Admin",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "D8Yn8",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "STDPX",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "aEnQl",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Uvl0e",
+              "x": 33,
+              "y": 44,
+              "name": "Tooltip - History",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Wj8l9",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "E1lior",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "History",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HhgVX",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "inaKx",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌘H",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "RYoOU",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l488P7",
+              "x": 104,
+              "y": 44,
+              "name": "Tooltip - New Chat",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T92G8",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    4,
+                    4,
+                    4,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ErzXp",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "New chat",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YrWlF",
+                      "name": "shortcut",
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T9k9K",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⌥⌘N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "dKoIT",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ESNam",
+              "x": 254,
+              "y": 482,
+              "name": "Tooltip - Copy",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kuInb",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "HVMXt",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N0Vjkt",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TSW4P",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "rEsfr",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zSNhR",
+              "x": 286,
+              "y": 482,
+              "name": "Tooltip - Shows info",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "v2Qn0",
+                  "name": "body",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "z5UFa",
+                      "name": "content",
+                      "fill": "#030712",
+                      "content": "Shows info",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vY7wD",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#2E2E2E",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qHTUz",
+                          "name": "kbd",
+                          "fill": "#A3A3A3",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "Z4HOxr",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#FAFAFA",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pI021",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "overlay",
+              "width": 1280,
+              "height": 720,
+              "fill": "#00000080",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XYnuG",
+                  "x": 420,
+                  "y": 120,
+                  "name": "dialog",
+                  "width": 440,
+                  "fill": "#18181B",
+                  "cornerRadius": 16,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#404040"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#00000040",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zBYcE",
+                      "name": "header-group",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "A9FhgJ",
+                          "name": "header",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "RJwuz",
+                              "fill": "#F9FAFB",
+                              "content": "Export conversation",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Q9qD5o",
+                              "name": "closeFrame",
+                              "cornerRadius": 6,
+                              "padding": 4,
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SzbPC",
+                                  "width": 18,
+                                  "height": 18,
+                                  "iconFontName": "x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9CA3AF"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "egk2T",
+                          "name": "subtitle",
+                          "fill": "#9CA3AF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select messages and download in your preferred format.",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WVXxr",
+                      "name": "preview",
+                      "clip": true,
+                      "width": "fill_container",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#404040"
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JAH3z",
+                          "name": "msg1",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "#404040"
+                          },
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "id": "CQbfG",
+                              "type": "ref",
+                              "ref": "mRGzq",
+                              "width": 16,
+                              "height": 16,
+                              "name": "cb1"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "w5FSF",
+                              "name": "col1",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Ga1O2",
+                                  "fill": "#F9FAFB",
+                                  "content": "You",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ooiDe",
+                                  "fill": "#9CA3AF",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month’s revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "S9JHPx",
+                          "name": "msg3",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "children": [
+                            {
+                              "id": "Ba7xU",
+                              "type": "ref",
+                              "ref": "mRGzq",
+                              "width": 16,
+                              "height": 16,
+                              "name": "cb3"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "IQDtk",
+                              "name": "col3",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "sQyxw",
+                                  "name": "label3",
+                                  "fill": "#F9FAFB",
+                                  "content": "Assistant",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WDW9U",
+                                  "name": "desc3",
+                                  "fill": "#9CA3AF",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Plan review timed out after 30 minutes of inactivity. The research run has been cancelled...",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EE792",
+                      "name": "footer",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "EmJSP",
+                          "name": "pdfBtn",
+                          "height": 36,
+                          "fill": "#FAFAFA",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tGXKQ",
+                              "name": "pdfIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#0A0A0A"
+                            },
+                            {
+                              "type": "text",
+                              "id": "V1P2DZ",
+                              "name": "pdfText",
+                              "fill": "#0A0A0A",
+                              "content": "PDF",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NYg7G",
+                          "name": "mdBtn",
+                          "height": 36,
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#404040"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "DwxWp",
+                              "name": "mdIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "file-code",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D1D5DB"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ACyvY",
+                              "name": "mdText",
+                              "fill": "#D1D5DB",
+                              "content": "Markdown",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/designs/web/frontpages.pen
+++ b/designs/web/frontpages.pen
@@ -19919,7 +19919,7 @@
                       "fill": {
                         "type": "image",
                         "enabled": true,
-                        "url": "Frame%2023.png",
+                        "url": "Frame%2021%202.png",
                         "mode": "fill"
                       },
                       "stroke": {

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { Check } from 'lucide-react';
 import { type ComponentType, Fragment, type ReactNode } from 'react';
 
 import { cn } from '../../lib/cn';
@@ -15,6 +16,8 @@ export interface DropdownMenuActionItem {
   className?: string;
   href?: string;
   external?: boolean;
+  /** Keep the menu open after click. Use for items that swap the menu's content in place. */
+  keepOpen?: boolean;
 }
 
 export interface DropdownMenuLabelItem {
@@ -90,51 +93,9 @@ interface DropdownMenuProps {
 
 function RadioIndicator() {
   return (
-    <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="14"
-        height="14"
-        viewBox="0 0 14 14"
-        fill="none"
-        className="size-3.5"
-      >
-        <circle
-          cx="7"
-          cy="7"
-          r="6"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          className="text-border"
-        />
-      </svg>
-      <DropdownMenuPrimitive.ItemIndicator className="absolute inset-0 flex items-center justify-center">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="14"
-          height="14"
-          viewBox="0 0 14 14"
-          fill="none"
-          className="size-3.5"
-        >
-          <circle
-            cx="7"
-            cy="7"
-            r="6"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className="text-blue-600"
-          />
-          <circle
-            cx="7"
-            cy="7"
-            r="3.5"
-            fill="currentColor"
-            className="text-blue-600"
-          />
-        </svg>
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
+    <DropdownMenuPrimitive.ItemIndicator className="absolute right-2 flex size-3.5 items-center justify-center">
+      <Check className="size-3.5" />
+    </DropdownMenuPrimitive.ItemIndicator>
   );
 }
 
@@ -239,7 +200,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
           </DropdownMenuPrimitive.SubTrigger>
           <DropdownMenuPrimitive.SubContent
             className={cn(
-              'bg-muted text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg',
+              'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg',
               item.contentClassName,
             )}
           >
@@ -260,7 +221,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
             <DropdownMenuPrimitive.RadioItem
               key={option.value}
               value={option.value}
-              className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+              className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
             >
               <RadioIndicator />
               {option.label}
@@ -279,6 +240,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
             item.className,
           )}
           onClick={item.onClick}
+          onSelect={item.keepOpen ? (e) => e.preventDefault() : undefined}
           disabled={item.disabled}
         >
           {Icon && <Icon />}

--- a/services/platform/app/components/ui/data-table/data-table-filters.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-filters.tsx
@@ -24,7 +24,7 @@ const DatePickerWithRange = lazyComponent(
       default: mod.DatePickerWithRange,
     })),
   {
-    loading: () => <Skeleton className="h-9 w-[16rem]" />,
+    loading: () => <Skeleton className="h-9 w-[18rem]" />,
   },
 );
 
@@ -161,9 +161,10 @@ export function DataTableFilters({
               placeholder={search.placeholder ?? t('search.placeholder')}
               value={search.value}
               onChange={(e) => search.onChange(e.target.value)}
+              className="max-w-none"
               wrapperClassName={cn(
                 'flex-1 sm:flex-none',
-                search.className ?? 'w-auto sm:max-w-[16rem]',
+                search.className ?? 'w-auto sm:w-[18rem]',
               )}
             />
           )}
@@ -320,7 +321,7 @@ export function DataTableFilters({
 
         {dateRange && (
           <SuspenseBoundary
-            fallback={<Skeleton className="h-9 w-[16rem]" />}
+            fallback={<Skeleton className="h-9 w-[18rem]" />}
             errorFallback={
               <Text as="span" variant="muted">
                 Date filter unavailable

--- a/services/platform/app/components/ui/data-table/data-table-pagination.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-pagination.tsx
@@ -33,6 +33,8 @@ export interface DataTablePaginationProps {
   pageSizeOptions?: number[];
   /** Callback when page size changes */
   onPageSizeChange?: (pageSize: number) => void;
+  /** Lowercase plural entity label (e.g., "agents"). Enables noun-rich copy like "Showing 1-25 of 100 agents". */
+  entityLabel?: string;
 }
 
 /**
@@ -54,6 +56,7 @@ export function DataTablePagination({
   showPageSizeSelector = false,
   pageSizeOptions = [10, 20, 50, 100],
   onPageSizeChange,
+  entityLabel,
 }: DataTablePaginationProps) {
   const { t } = useT('common');
 
@@ -161,7 +164,18 @@ export function DataTablePagination({
           variant="caption"
           className="hidden font-semibold whitespace-nowrap sm:inline"
         >
-          {t('pagination.showing', { start: startIdx, end: endIdx, total })}
+          {entityLabel
+            ? t('pagination.showingRange', {
+                start: startIdx,
+                end: endIdx,
+                total,
+                entity: entityLabel,
+              })
+            : t('pagination.showing', {
+                start: startIdx,
+                end: endIdx,
+                total,
+              })}
         </Text>
       )}
     </div>

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -676,6 +676,7 @@ export function DataTable<TData, TValue = unknown>({
         }
         pagination.onPageSizeChange?.(size);
       }}
+      entityLabel={pagination.entityLabel}
       className={pagination.className}
     />
   );
@@ -710,7 +711,7 @@ export function DataTable<TData, TValue = unknown>({
           </div>
         </>
       ) : !infiniteScroll.entityLabel ? (
-        <output className="text-muted-foreground block py-3 text-center text-xs">
+        <output className="text-muted-foreground block px-3 py-3 text-left text-xs">
           {t('pagination.noMore')}
         </output>
       ) : null}
@@ -720,7 +721,7 @@ export function DataTable<TData, TValue = unknown>({
   const entityCountFooter = infiniteScroll &&
     infiniteScroll.entityLabel &&
     data.length > 0 && (
-      <output className="bg-background border-border text-muted-foreground sticky bottom-0 z-10 block py-3 text-center text-xs">
+      <output className="bg-background border-border text-muted-foreground sticky bottom-0 z-10 block px-3 py-3 text-left text-xs">
         {infiniteScroll.totalCount !== undefined &&
         infiniteScroll.totalCount !== data.length
           ? t('pagination.showingFiltered', {

--- a/services/platform/app/components/ui/navigation/mobile-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/mobile-navigation.tsx
@@ -10,6 +10,7 @@ import { useBrandingContext } from '@/app/components/branding/branding-provider'
 import { TaleLogo } from '@/app/components/ui/logo/tale-logo';
 import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { UserButton } from '@/app/components/user-button';
+import { NotificationBell } from '@/app/features/notifications/components/notification-bell';
 import { useAbility } from '@/app/hooks/use-ability';
 import {
   useNavigationItems,
@@ -162,6 +163,10 @@ export function MobileNavigation({ organizationId }: MobileNavigationProps) {
             </NavigationMenuList>
           </div>
           <div className="border-border flex shrink-0 flex-col gap-1 border-t px-4 py-3">
+            <NotificationBell
+              organizationId={organizationId}
+              label={tNav('notifications')}
+            />
             <UserButton
               label={tNav('account')}
               onNavigate={() => setIsOpen(false)}

--- a/services/platform/app/components/ui/navigation/navigation.tsx
+++ b/services/platform/app/components/ui/navigation/navigation.tsx
@@ -6,6 +6,7 @@ import { useBrandingContext } from '@/app/components/branding/branding-provider'
 import { TaleLogo } from '@/app/components/ui/logo/tale-logo';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { UserButton } from '@/app/components/user-button';
+import { NotificationBell } from '@/app/features/notifications/components/notification-bell';
 import { useAbility } from '@/app/hooks/use-ability';
 import {
   useNavigationItems,
@@ -147,6 +148,7 @@ export function Navigation({ organizationId }: NavigationProps) {
         </NavigationMenuList>
       </div>
       <div className="flex flex-shrink-0 flex-col items-center gap-2 py-3">
+        <NotificationBell organizationId={organizationId} />
         <UserButton />
       </div>
     </NavigationMenu>

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -20,7 +20,6 @@ import {
   Languages,
   Building2,
   Settings as SettingsIcon,
-  Bell,
   Download,
 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -28,8 +27,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { IosInstallSheet } from '@/app/components/pwa/ios-install-sheet';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
-import { NotificationListPanel } from '@/app/features/notifications/components/notification-list-panel';
-import { useNotificationsUnreadCount } from '@/app/features/notifications/hooks/queries';
 import { OrganizationListPanel } from '@/app/features/organization/components/organization-list-panel';
 import { useUserOrganizationsWithDetails } from '@/app/features/organization/hooks/queries';
 import { useChangelogNotification } from '@/app/hooks/use-changelog-notification';
@@ -85,13 +82,6 @@ export function UserButton({
   const teams = teamFilter?.teams;
   const selectedTeamId = teamFilter?.selectedTeamId ?? null;
   const setSelectedTeamId = teamFilter?.setSelectedTeamId;
-  // UserButton renders inside the dashboard layout, which always has an
-  // `organizationId` in route params — but the type from `useParams({ strict:
-  // false })` is `string | undefined`, so cast for the typed hook.
-  const { data: notificationsUnread } = useNotificationsUnreadCount(
-    organizationId ?? '',
-  );
-  const unreadCount = notificationsUnread ?? 0;
   // PWA install — `canInstall` is true on browsers that fired
   // `beforeinstallprompt` (Chromium/Android), where we can prompt directly.
   // iOS can't install programmatically, so `isIOS` instead opens manual
@@ -126,22 +116,9 @@ export function UserButton({
 
   const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
   const [open, setOpen] = useState(false);
-  // Profile dropdown swaps its content between the default view and a
-  // notifications view in-place (no second popover). When it closes, reset
-  // to the default so reopening always starts at the profile.
-  const [view, setView] = useState<'profile' | 'notifications'>('profile');
 
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next);
-    if (!next) setView('profile');
-  }, []);
-
-  const handleOpenNotifications = useCallback(() => {
-    setView('notifications');
-  }, []);
-
-  const handleBackToProfile = useCallback(() => {
-    setView('profile');
   }, []);
 
   const handleSignOut = useCallback(async () => {
@@ -169,108 +146,66 @@ export function UserButton({
     memberContext?.displayName || user?.name || t('userButton.defaultName');
 
   const menuItems = useMemo<DropdownMenuGroup[]>(() => {
-    // Notifications view — replaces the entire dropdown content with the
-    // notifications list (a back chevron in the list header swaps back).
-    // Width and padding adjust via `contentClassName` below.
-    if (view === 'notifications' && organizationId) {
-      return [
-        [
-          {
-            type: 'custom',
-            content: (
-              <div className="animate-in fade-in-0 slide-in-from-right-1 duration-150">
-                <NotificationListPanel
-                  organizationId={organizationId}
-                  onBack={handleBackToProfile}
-                  className="h-[28rem]"
-                />
-              </div>
-            ),
-          },
-        ],
-      ];
-    }
-
     const groups: DropdownMenuGroup[] = [];
 
     groups.push([
       {
         type: 'label',
         content: (
-          <div className="flex items-start justify-between gap-2">
-            <Tooltip
-              content={
-                !loading && user && memberContext?.role
-                  ? `${displayName} - ${memberContext.role}`
-                  : null
-              }
-              side="top"
-            >
-              <div className="flex min-w-0 flex-1 cursor-default flex-col gap-1">
-                {loading || !user ? (
-                  <>
-                    <Skeleton className="h-4 w-32" />
-                    <Skeleton className="h-3.5 w-40" />
-                  </>
-                ) : (
-                  <>
-                    <Text className="font-semibold">{displayName}</Text>
-                    {displayName !== user.email && (
-                      <Text variant="muted">{user.email}</Text>
-                    )}
-                    {currentVersion && (
-                      <Text variant="muted" className="text-xs">
-                        {t('userButton.currentVersion', {
-                          version: currentVersion,
-                        })}
-                        {' · '}
-                        <Link
-                          to="/dashboard/changelog"
-                          search={{
-                            from: lastSeenVersion,
-                            to: currentVersion,
-                          }}
-                          onClick={markChangelogSeen}
-                          className="text-foreground relative inline-flex cursor-pointer items-center underline underline-offset-2 hover:opacity-80"
-                        >
-                          {t('userButton.whatsNew')}
-                          {hasUnseenVersion && (
-                            <>
-                              <span className="sr-only">
-                                {t('userButton.updateAvailable')}
-                              </span>
-                              <span
-                                className="ml-1.5 size-1.5 rounded-full bg-red-500"
-                                aria-hidden="true"
-                              />
-                            </>
-                          )}
-                        </Link>
-                      </Text>
-                    )}
-                  </>
-                )}
-              </div>
-            </Tooltip>
-            {organizationId && (
-              <button
-                type="button"
-                onClick={handleOpenNotifications}
-                aria-label={tNav('notifications')}
-                className="hover:bg-muted relative -my-0.5 flex size-7 shrink-0 items-center justify-center rounded-md transition-colors"
-              >
-                <Bell className="text-muted-foreground size-4" />
-                {unreadCount > 0 && (
-                  <span
-                    aria-hidden
-                    className="bg-destructive text-destructive-foreground absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold"
-                  >
-                    {unreadCount > 99 ? '99+' : unreadCount}
-                  </span>
-                )}
-              </button>
-            )}
-          </div>
+          <Tooltip
+            content={
+              !loading && user && memberContext?.role
+                ? `${displayName} - ${memberContext.role}`
+                : null
+            }
+            side="top"
+          >
+            <div className="flex min-w-0 flex-1 cursor-default flex-col gap-1">
+              {loading || !user ? (
+                <>
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3.5 w-40" />
+                </>
+              ) : (
+                <>
+                  <Text className="font-semibold">{displayName}</Text>
+                  {displayName !== user.email && (
+                    <Text variant="muted">{user.email}</Text>
+                  )}
+                  {currentVersion && (
+                    <Text variant="muted" className="text-xs">
+                      {t('userButton.currentVersion', {
+                        version: currentVersion,
+                      })}
+                      {' · '}
+                      <Link
+                        to="/dashboard/changelog"
+                        search={{
+                          from: lastSeenVersion,
+                          to: currentVersion,
+                        }}
+                        onClick={markChangelogSeen}
+                        className="text-foreground relative inline-flex cursor-pointer items-center underline underline-offset-2 hover:opacity-80"
+                      >
+                        {t('userButton.whatsNew')}
+                        {hasUnseenVersion && (
+                          <>
+                            <span className="sr-only">
+                              {t('userButton.updateAvailable')}
+                            </span>
+                            <span
+                              className="ml-1.5 size-1.5 rounded-full bg-red-500"
+                              aria-hidden="true"
+                            />
+                          </>
+                        )}
+                      </Link>
+                    </Text>
+                  )}
+                </>
+              )}
+            </div>
+          </Tooltip>
         ),
         className: 'pb-3 font-normal',
       },
@@ -490,7 +425,6 @@ export function UserButton({
 
     return groups;
   }, [
-    view,
     loading,
     user,
     memberContext,
@@ -509,12 +443,9 @@ export function UserButton({
     setLocale,
     setSelectedTeamId,
     handleSignOutClick,
-    handleOpenNotifications,
-    handleBackToProfile,
     handleInstallApp,
     canInstall,
     isIOS,
-    unreadCount,
     currentVersion,
     lastSeenVersion,
     markChangelogSeen,
@@ -531,13 +462,9 @@ export function UserButton({
     >
       <div className="relative">
         <UserCircle className="text-muted-foreground size-5 shrink-0" />
-        {(hasUnseenVersion || unreadCount > 0) && (
+        {hasUnseenVersion && (
           <>
-            <span className="sr-only">
-              {unreadCount > 0
-                ? tNav('notifications')
-                : t('userButton.updateAvailable')}
-            </span>
+            <span className="sr-only">{t('userButton.updateAvailable')}</span>
             <span
               className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-red-500"
               aria-hidden="true"
@@ -571,14 +498,7 @@ export function UserButton({
     </>
   );
 
-  // Width transitions between the compact profile view and the wider
-  // notifications view so the side-extension swap feels continuous.
-  // `max-w-[calc(100vw-2rem)]` keeps the wider variant inside the viewport
-  // on small screens.
-  const contentClassName = cn(
-    'transition-[width,max-width] duration-200',
-    view === 'notifications' ? 'w-96 max-w-[calc(100vw-2rem)] p-0' : 'w-64',
-  );
+  const contentClassName = 'w-64';
 
   if (label) {
     return (

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -35,6 +35,7 @@ interface AgentsTableProps {
 
 export function AgentsTable({ organizationId }: AgentsTableProps) {
   const { t: tEmpty } = useT('emptyStates');
+  const { t: tSettings } = useT('settings');
   const { teams } = useTeamFilter();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -109,6 +110,7 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
       fields: ['displayName', 'name'],
       placeholder: searchPlaceholder,
     },
+    entityLabel: tSettings('agents.entityLabel'),
   });
 
   return (

--- a/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
+++ b/services/platform/app/features/analytics/feedback/recent-feedback-table.tsx
@@ -219,6 +219,7 @@ export function RecentFeedbackTable({
           onLoadMore,
           isLoadingMore,
           isInitialLoading: isLoading,
+          entityLabel: tAnalytics('feedback.recent.entityLabel'),
         }}
         emptyState={{
           icon: MessageSquare,

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -131,6 +131,7 @@ export function ExecutionsTable({
   const { locale } = useLocale();
   const { t: tCommon } = useT('common');
   const { t: tTables } = useT('tables');
+  const { t: tAutomations } = useT('automations');
 
   const { searchPlaceholder, stickyLayout, pageSize } =
     useExecutionsTableConfig();
@@ -440,6 +441,7 @@ export function ExecutionsTable({
       onClear: handleClearFilters,
     },
     approxRowCount: count,
+    entityLabel: tAutomations('executions.entityLabel'),
   });
 
   const renderExpandedRow = useCallback(

--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -337,6 +337,7 @@ export function DocumentsTable({
     },
     getRowId: (row) => row.id,
     approxRowCount: docCount,
+    entityLabel: tDocuments('entityLabel'),
   });
 
   return (

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Popover } from '@tale/ui/popover';
+import { Bell } from 'lucide-react';
+import { useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { useNotificationsUnreadCount } from '../hooks/queries';
+import { NotificationListPanel } from './notification-list-panel';
+
+interface NotificationBellProps {
+  organizationId: string;
+  /** Show a text label next to the bell (mobile nav uses this). */
+  label?: string;
+}
+
+export function NotificationBell({
+  organizationId,
+  label,
+}: NotificationBellProps) {
+  const { t: tNav } = useT('navigation');
+  const [open, setOpen] = useState(false);
+  const { data: unread } = useNotificationsUnreadCount(organizationId);
+  const unreadCount = unread ?? 0;
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label={tNav('notifications')}
+      className={cn(
+        'hover:bg-muted relative flex items-center rounded-lg transition-colors cursor-pointer',
+        label ? 'gap-3 px-3 py-2 w-full' : 'justify-center p-2',
+      )}
+    >
+      <span className="relative inline-flex">
+        <Bell className="text-muted-foreground size-5 shrink-0" />
+        {unreadCount > 0 && (
+          <span
+            aria-hidden
+            className="bg-destructive text-destructive-foreground absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold"
+          >
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </span>
+      {label && <span className="text-sm font-medium">{label}</span>}
+    </button>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      align="end"
+      side="right"
+      sideOffset={8}
+      contentClassName="bg-card w-96 max-w-[calc(100vw-2rem)] p-0"
+      trigger={trigger}
+    >
+      <NotificationListPanel
+        organizationId={organizationId}
+        className="h-[28rem]"
+      />
+    </Popover>
+  );
+}

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@tale/ui/button';
 import { Tabs } from '@tale/ui/tabs';
-import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import { CheckCheck, ChevronLeft, Inbox } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFormatDate } from '@/app/hooks/use-format-date';
@@ -33,12 +33,6 @@ interface NotificationListPanelProps {
   onBack?: () => void;
 }
 
-const SEVERITY_DOT: Record<string, string> = {
-  info: 'bg-sky-500',
-  warning: 'bg-amber-500',
-  critical: 'bg-red-500',
-};
-
 const LOAD_MORE_NUM_ITEMS = 25;
 
 // Strip a leading `notifications.` namespace prefix that was accidentally
@@ -61,9 +55,6 @@ export function NotificationListPanel({
   className,
   onBack,
 }: NotificationListPanelProps) {
-  const [expandedId, setExpandedId] = useState<Id<'notifications'> | null>(
-    null,
-  );
   const [filter, setFilter] = useState<NotificationsFilter>('unread');
   const [hiddenIds, setHiddenIds] = useState(new Set<string>());
   const { t } = useT('notifications');
@@ -77,15 +68,6 @@ export function NotificationListPanel({
   const { data: unread } = useNotificationsUnreadCount(organizationId);
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllNotificationsRead();
-
-  const handleToggleExpand = useCallback(
-    (notificationId: Id<'notifications'>) => {
-      setExpandedId((current) =>
-        current === notificationId ? null : notificationId,
-      );
-    },
-    [],
-  );
 
   const handleMarkRead = useCallback(
     (notificationId: Id<'notifications'>) => {
@@ -114,7 +96,6 @@ export function NotificationListPanel({
 
   const handleFilterChange = useCallback((next: NotificationsFilter) => {
     setFilter(next);
-    setExpandedId(null);
     setHiddenIds(new Set());
   }, []);
 
@@ -184,94 +165,87 @@ export function NotificationListPanel({
       </div>
       <div className="flex-1 overflow-y-auto">
         {items.length === 0 ? (
-          <div className="text-muted-foreground px-4 py-8 text-center text-sm">
-            {status === 'LoadingFirstPage' ? t('loading') : t('empty')}
-          </div>
+          status === 'LoadingFirstPage' ? (
+            <div className="text-muted-foreground px-4 py-8 text-center text-sm">
+              {t('loading')}
+            </div>
+          ) : (
+            <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+              {filter === 'unread' ? (
+                <CheckCheck className="size-8" aria-hidden="true" />
+              ) : (
+                <Inbox className="size-8" aria-hidden="true" />
+              )}
+              <p className="text-foreground text-sm font-medium">
+                {filter === 'unread'
+                  ? t('emptyCaughtUpTitle')
+                  : t('emptyAllTitle')}
+              </p>
+              <p className="text-xs">
+                {filter === 'unread'
+                  ? t('emptyCaughtUpDescription')
+                  : t('emptyAllDescription')}
+              </p>
+            </div>
+          )
         ) : (
           <ul role="list" className="divide-border divide-y">
             {items.map((n) => {
               const params = isRecord(n.params) ? n.params : undefined;
               const title = t(stripNsPrefix(n.titleKey), params);
               const body = t(stripNsPrefix(n.bodyKey), params);
-              const isExpanded = expandedId === n._id;
-              const Chevron = isExpanded ? ChevronDown : ChevronRight;
+              const absoluteDate = formatDate(new Date(n.createdAt), 'long');
+
+              const rowClasses = cn(
+                'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors',
+                !n.read && 'bg-accent/10 hover:bg-muted/60 cursor-pointer',
+                n.read && 'opacity-70 cursor-default',
+              );
+              const rowBody = (
+                <>
+                  {!n.read && (
+                    <span className="sr-only">{t('ariaUnread')}</span>
+                  )}
+                  <span
+                    aria-hidden
+                    className={cn(
+                      'mt-1.5 size-2 shrink-0 rounded-full',
+                      n.read ? 'bg-transparent' : 'bg-sky-500',
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="text-foreground text-sm font-medium">
+                        {title}
+                      </div>
+                      <span
+                        className="text-muted-foreground shrink-0 text-[10px]"
+                        title={absoluteDate}
+                      >
+                        {formatRelative(new Date(n.createdAt))}
+                      </span>
+                    </div>
+                    <div className="text-muted-foreground mt-0.5 text-xs whitespace-pre-wrap">
+                      {body}
+                    </div>
+                  </div>
+                </>
+              );
 
               return (
-                <li
-                  key={n._id}
-                  className={cn(
-                    'transition-colors',
-                    !n.read && 'bg-accent/10',
-                    n.read && 'opacity-70',
-                  )}
-                >
-                  <button
-                    type="button"
-                    aria-expanded={isExpanded}
-                    onClick={() => handleToggleExpand(n._id)}
-                    className="hover:bg-muted/60 flex w-full items-start gap-3 px-4 py-3 text-left transition-colors"
-                  >
-                    <span
-                      className={cn(
-                        'mt-1.5 size-2 shrink-0 rounded-full',
-                        SEVERITY_DOT[n.severity] ?? 'bg-muted-foreground',
-                      )}
-                      aria-hidden
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start justify-between gap-2">
-                        <div
-                          className={cn(
-                            'text-foreground text-sm font-medium',
-                            !isExpanded && 'truncate',
-                          )}
-                        >
-                          {title}
-                        </div>
-                        <span className="text-muted-foreground shrink-0 text-[10px]">
-                          {formatRelative(new Date(n.createdAt))}
-                        </span>
-                      </div>
-                      <div
-                        className={cn(
-                          'text-muted-foreground mt-0.5 text-xs whitespace-pre-wrap',
-                          !isExpanded && 'line-clamp-2',
-                        )}
-                      >
-                        {body}
-                      </div>
-                    </div>
-                    <Chevron
-                      className="text-muted-foreground mt-1 size-4 shrink-0"
-                      aria-hidden
-                    />
-                    {!n.read && !isExpanded && (
-                      <>
-                        <span className="sr-only">{t('ariaUnread')}</span>
-                        <span
-                          aria-hidden="true"
-                          className="mt-1.5 size-2 shrink-0 rounded-full bg-sky-500"
-                        />
-                      </>
-                    )}
-                  </button>
-
-                  {isExpanded && (
-                    <div className="flex items-center justify-between gap-3 px-4 pt-0 pb-3 pl-9">
-                      <span className="text-muted-foreground text-[11px]">
-                        {formatDate(new Date(n.createdAt), 'long')}
-                      </span>
-                      {!n.read && (
-                        <Button
-                          size="sm"
-                          variant="secondary"
-                          disabled={markRead.isPending}
-                          onClick={() => handleMarkRead(n._id)}
-                        >
-                          {t('markAsRead')}
-                        </Button>
-                      )}
-                    </div>
+                <li key={n._id}>
+                  {n.read ? (
+                    <div className={rowClasses}>{rowBody}</div>
+                  ) : (
+                    <button
+                      type="button"
+                      aria-label={t('markAsRead')}
+                      disabled={markRead.isPending}
+                      onClick={() => handleMarkRead(n._id)}
+                      className={rowClasses}
+                    >
+                      {rowBody}
+                    </button>
                   )}
                 </li>
               );

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -148,6 +148,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       fields: ['name', 'description'],
       placeholder: t('list.searchPlaceholder'),
     },
+    entityLabel: t('entityLabel'),
   });
 
   return (

--- a/services/platform/app/features/settings/account/components/two-factor-section.tsx
+++ b/services/platform/app/features/settings/account/components/two-factor-section.tsx
@@ -114,11 +114,11 @@ function NotEnrolledState({ enforced }: { enforced: boolean }) {
 
   return (
     <Stack gap={3}>
-      <Text variant="muted" className="text-sm">
-        {enforced
-          ? t('enrollment.requiredByOrg')
-          : t('enrollment.notEnabledHint')}
-      </Text>
+      {enforced && (
+        <Text variant="muted" className="text-sm">
+          {t('enrollment.requiredByOrg')}
+        </Text>
+      )}
       <div>
         <Button onClick={() => setState({ step: 'password' })}>
           {t('enrollment.enableButton')}

--- a/services/platform/app/features/settings/audit-logs/components/audit-log-table.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-log-table.tsx
@@ -49,6 +49,7 @@ export function AuditLogTable({
       isLoading: paginatedResult.isLoading,
     },
     pageSize,
+    entityLabel: t('logs.audit.entityLabel'),
   });
 
   return (

--- a/services/platform/app/features/settings/branding/components/color-picker-input.tsx
+++ b/services/platform/app/features/settings/branding/components/color-picker-input.tsx
@@ -62,7 +62,7 @@ export function ColorPickerInput({
       </label>
       <div
         className={cn(
-          'border-input flex items-center overflow-clip rounded-md border shadow-sm',
+          'border-border flex items-center overflow-clip rounded-md border shadow-xs',
         )}
       >
         <button

--- a/services/platform/app/features/settings/branding/components/image-upload-field.tsx
+++ b/services/platform/app/features/settings/branding/components/image-upload-field.tsx
@@ -131,7 +131,7 @@ export function ImageUploadField({
           onClick={handleClick}
           disabled={isUploading}
           className={cn(
-            'border-input flex items-center justify-center overflow-clip rounded-lg border bg-background shadow-sm',
+            'border-border flex items-center justify-center overflow-clip rounded-lg border bg-background shadow-xs',
             sizeClasses,
             isUploading && 'cursor-wait opacity-60',
           )}

--- a/services/platform/app/features/settings/governance/data-subject-requests/requests-list-section.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/requests-list-section.tsx
@@ -220,6 +220,7 @@ export function RequestsListSection({
             onLoadMore: () => loadMore(25),
             isLoadingMore,
             isInitialLoading,
+            entityLabel: t('dataSubjectRequests.entityLabel'),
           }}
           emptyState={{
             title: t('dataSubjectRequests.sections.requestsList.empty.title'),

--- a/services/platform/app/features/settings/governance/legal-hold/release-history-section.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/release-history-section.tsx
@@ -182,6 +182,7 @@ export function ReleaseHistorySection({
           onLoadMore: () => result.loadMore(25),
           isLoadingMore,
           isInitialLoading,
+          entityLabel: t('legalHold.sections.history.entityLabel'),
         }}
         emptyState={{
           title: t('legalHold.sections.history.empty.title'),

--- a/services/platform/app/features/settings/providers/components/providers-table.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-table.tsx
@@ -153,6 +153,7 @@ export function ProvidersTable({
       fields: ['displayName', 'baseUrl'],
       placeholder: t('providers.searchProvider'),
     },
+    entityLabel: t('providers.entityLabel'),
   });
 
   return (

--- a/services/platform/app/features/skills/components/skills-table.tsx
+++ b/services/platform/app/features/skills/components/skills-table.tsx
@@ -135,6 +135,7 @@ export function SkillsTable({
       fields: ['name', 'slug', 'description'],
       placeholder: searchPlaceholder,
     },
+    entityLabel: t('skills.entityLabel'),
   });
 
   const bindingCaption = bindingMode ? (

--- a/services/platform/app/hooks/use-list-page.ts
+++ b/services/platform/app/hooks/use-list-page.ts
@@ -119,6 +119,7 @@ interface ListPagePaginationTableProps<TData> {
     pageSize: number;
     total: number;
     showPageSizeSelector: boolean;
+    entityLabel?: string;
   };
   isLoading: boolean;
   approxRowCount?: number;
@@ -362,6 +363,7 @@ export function useListPage<TData>(
           pageSize,
           total: processed.length,
           showPageSizeSelector: false,
+          entityLabel,
         },
         isLoading,
       },

--- a/services/platform/convex/users/queries.ts
+++ b/services/platform/convex/users/queries.ts
@@ -6,6 +6,7 @@
 
 import { v } from 'convex/values';
 
+import { getString, isRecord } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { query } from '../_generated/server';
 import { getStrictestPasswordPolicyForUser } from '../governance/helpers';
@@ -28,6 +29,11 @@ export const hasAnyUsers = query({
 /**
  * Get the current authenticated user.
  * Returns null if not authenticated.
+ *
+ * Reads `name` and `email` from the Better Auth `user` row, not the JWT
+ * identity, so profile updates surface immediately without forcing the user
+ * to sign out and back in. The JWT identity is only used to resolve the
+ * caller's userId (auth gate).
  */
 export const getCurrentUser = query({
   args: {},
@@ -46,7 +52,27 @@ export const getCurrentUser = query({
     email?: string;
     name?: string;
   } | null> => {
-    return await getAuthUserIdentity(ctx);
+    const identity = await getAuthUserIdentity(ctx);
+    if (!identity) return null;
+
+    const userRow = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: 'user',
+      where: [{ field: '_id', value: identity.userId, operator: 'eq' }],
+    });
+
+    const fresh = isRecord(userRow) ? userRow : undefined;
+    const name = fresh
+      ? (getString(fresh, 'name') ?? identity.name)
+      : identity.name;
+    const email = fresh
+      ? (getString(fresh, 'email') ?? identity.email)
+      : identity.email;
+
+    return {
+      userId: identity.userId,
+      email,
+      name,
+    };
   },
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -200,6 +200,7 @@
       },
       "recent": {
         "title": "Aktuelles Feedback",
+        "entityLabel": "Feedback-Einträge",
         "emptyTitle": "Kein Feedback in diesem Zeitraum",
         "emptyDescription": "Passe Zeitraum oder Filter an, um mehr zu sehen.",
         "noComment": "(kein Kommentar)",
@@ -559,6 +560,7 @@
     },
     "executions": {
       "title": "Ausführungen",
+      "entityLabel": "Ausführungen",
       "searchPlaceholder": "Ausführungen suchen"
     },
     "createDialog": {
@@ -1412,7 +1414,8 @@
       "loading": "Weitere werden geladen...",
       "noMore": "Keine weiteren Einträge",
       "showingAll": "Alle {count} {entity} werden angezeigt",
-      "showingFiltered": "{filtered} von {total} {entity} werden angezeigt"
+      "showingFiltered": "{filtered} von {total} {entity} werden angezeigt",
+      "showingRange": "{start}-{end} von {total} {entity} werden angezeigt"
     },
     "search": {
       "noResults": "Keine Ergebnisse gefunden",
@@ -1719,6 +1722,7 @@
     "errorSaveFailed": "Dokument konnte nicht gespeichert werden"
   },
   "documents": {
+    "entityLabel": "Dokumente",
     "searchPlaceholder": "Dokumente suchen",
     "deleteFolder": {
       "title": "Ordner löschen",
@@ -2807,6 +2811,7 @@
         },
         "history": {
           "title": "Freigabeverlauf",
+          "entityLabel": "Freigaben",
           "description": "Schreibgeschützte Übersicht wirksam gewordener und abgelehnter Freigabeanträge.",
           "empty": {
             "title": "Noch keine abgeschlossenen Freigabeanträge",
@@ -2983,6 +2988,7 @@
     },
     "dataSubjectRequests": {
       "title": "Anfragen betroffener Personen",
+      "entityLabel": "Anfragen",
       "description": "DSGVO Art. 17 Löschungsbelege. Neue Anfragen einreichen, Fristen überwachen und Art. 12(3)-Verlängerungen gewähren, wenn komplexe Fälle mehr Zeit brauchen.",
       "accessDenied": "Nur Administratoren.",
       "filters": {
@@ -3550,7 +3556,10 @@
   "notifications": {
     "title": "Benachrichtigungen",
     "ariaUnread": "Ungelesen",
-    "empty": "Keine Benachrichtigungen.",
+    "emptyCaughtUpTitle": "Alles erledigt",
+    "emptyCaughtUpDescription": "Wir melden uns, sobald etwas Neues eintrifft.",
+    "emptyAllTitle": "Noch keine Benachrichtigungen",
+    "emptyAllDescription": "Hinweise und System-Updates erscheinen hier, sobald sie eintreffen.",
     "markAsRead": "Als gelesen markieren",
     "markAllAsRead": "Alle als gelesen markieren",
     "filterUnread": "Ungelesen",
@@ -4163,6 +4172,7 @@
     },
     "agents": {
       "title": "Agenten",
+      "entityLabel": "Agenten",
       "createAgent": "Agent erstellen",
       "searchAgent": "Agents suchen",
       "columns": {
@@ -4411,6 +4421,7 @@
       }
     },
     "skills": {
+      "entityLabel": "Skills",
       "uploadSkill": "Skill hochladen",
       "searchPlaceholder": "Skills suchen…",
       "deleteSkill": "Skill löschen",
@@ -4706,6 +4717,7 @@
     },
     "providers": {
       "title": "Anbieter",
+      "entityLabel": "Anbieter",
       "addProvider": "Anbieter hinzufügen",
       "editProvider": "Anbieter bearbeiten",
       "deleteProvider": "Anbieter löschen",
@@ -4940,6 +4952,7 @@
         }
       },
       "audit": {
+        "entityLabel": "Audit-Protokolle",
         "tableCaption": "Audit-Protokoll-Datentabelle",
         "emptyTitle": "Keine Audit-Protokolle",
         "emptyDescription": "Audit-Protokolle werden hier angezeigt, sobald Aktionen in deiner Organisation durchgeführt werden.",
@@ -5357,7 +5370,6 @@
     "enrollment": {
       "title": "Zwei-Faktor-Authentifizierung",
       "description": "Sichere dein Konto mit einem zeitbasierten Code aus einer Authenticator-App.",
-      "notEnabledHint": "Zwei-Faktor-Authentifizierung ist für dein Konto noch nicht aktiviert.",
       "enabledHint": "Zwei-Faktor-Authentifizierung ist für dein Konto aktiv.",
       "requiredByOrg": "Deine Organisation verlangt Zwei-Faktor-Authentifizierung. Richte sie jetzt ein, um fortzufahren.",
       "enableButton": "Zwei-Faktor aktivieren",
@@ -5629,6 +5641,7 @@
   },
   "projects": {
     "title": "Projekte",
+    "entityLabel": "Projekte",
     "navigation": {
       "list": "Alle Projekte",
       "overview": "Allgemein",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -200,6 +200,7 @@
       },
       "recent": {
         "title": "Recent feedback",
+        "entityLabel": "feedback entries",
         "emptyTitle": "No feedback in this window",
         "emptyDescription": "Adjust the period or filters to see more.",
         "noComment": "(no comment)",
@@ -559,6 +560,7 @@
     },
     "executions": {
       "title": "Executions",
+      "entityLabel": "executions",
       "searchPlaceholder": "Search executions"
     },
     "createDialog": {
@@ -1412,7 +1414,8 @@
       "loading": "Loading more...",
       "noMore": "No more items to load",
       "showingAll": "Showing all {count} {entity}",
-      "showingFiltered": "Showing {filtered} of {total} {entity}"
+      "showingFiltered": "Showing {filtered} of {total} {entity}",
+      "showingRange": "Showing {start}-{end} of {total} {entity}"
     },
     "search": {
       "noResults": "No results found",
@@ -1719,6 +1722,7 @@
     "errorSaveFailed": "Failed to save document"
   },
   "documents": {
+    "entityLabel": "documents",
     "searchPlaceholder": "Search documents",
     "deleteFolder": {
       "title": "Delete folder",
@@ -2807,6 +2811,7 @@
         },
         "history": {
           "title": "Release history",
+          "entityLabel": "releases",
           "description": "Read-only audit of effected and rejected release requests.",
           "empty": {
             "title": "No completed release requests yet",
@@ -2983,6 +2988,7 @@
     },
     "dataSubjectRequests": {
       "title": "Data subject requests",
+      "entityLabel": "requests",
       "description": "GDPR Art. 17 erasure receipts. File new requests, monitor SLA deadlines, and grant Art. 12(3) extensions when complex cases need more time.",
       "accessDenied": "Admin only.",
       "filters": {
@@ -3550,7 +3556,10 @@
   "notifications": {
     "title": "Notifications",
     "ariaUnread": "Unread",
-    "empty": "No notifications.",
+    "emptyCaughtUpTitle": "You're all caught up",
+    "emptyCaughtUpDescription": "We'll let you know when anything new comes in.",
+    "emptyAllTitle": "No notifications yet",
+    "emptyAllDescription": "Alerts and system updates will appear here when they arrive.",
     "markAsRead": "Mark as read",
     "markAllAsRead": "Mark all as read",
     "filterUnread": "Unread",
@@ -4021,6 +4030,7 @@
   },
   "projects": {
     "title": "Projects",
+    "entityLabel": "projects",
     "navigation": {
       "list": "All projects",
       "overview": "General",
@@ -4420,6 +4430,7 @@
     },
     "agents": {
       "title": "Agents",
+      "entityLabel": "agents",
       "createAgent": "Create agent",
       "searchAgent": "Search agents",
       "columns": {
@@ -4668,6 +4679,7 @@
       }
     },
     "skills": {
+      "entityLabel": "skills",
       "uploadSkill": "Upload skill",
       "searchPlaceholder": "Search skills…",
       "deleteSkill": "Delete skill",
@@ -4963,6 +4975,7 @@
     },
     "providers": {
       "title": "Providers",
+      "entityLabel": "providers",
       "addProvider": "Add provider",
       "editProvider": "Edit provider",
       "deleteProvider": "Delete provider",
@@ -5197,6 +5210,7 @@
         }
       },
       "audit": {
+        "entityLabel": "audit logs",
         "tableCaption": "Audit logs data table",
         "emptyTitle": "No audit logs",
         "emptyDescription": "Audit logs will appear here as actions are performed in your organization.",
@@ -5614,7 +5628,6 @@
     "enrollment": {
       "title": "Two-factor authentication",
       "description": "Protect your account with a time-based code from an authenticator app.",
-      "notEnabledHint": "Two-factor authentication is not yet enabled on your account.",
       "enabledHint": "Two-factor authentication is active on your account.",
       "requiredByOrg": "Your organization requires two-factor authentication. Enrol now to continue.",
       "enableButton": "Enable two-factor",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -201,6 +201,7 @@
       },
       "recent": {
         "title": "Retours récents",
+        "entityLabel": "retours",
         "emptyTitle": "Aucun retour sur cette période",
         "emptyDescription": "Ajuste la période ou les filtres pour en voir davantage.",
         "noComment": "(aucun commentaire)",
@@ -560,6 +561,7 @@
     },
     "executions": {
       "title": "Exécutions",
+      "entityLabel": "exécutions",
       "searchPlaceholder": "Rechercher des exécutions"
     },
     "createDialog": {
@@ -1413,7 +1415,8 @@
       "loading": "Chargement...",
       "noMore": "Plus d'éléments à charger",
       "showingAll": "Affichage de {count} {entity} au total",
-      "showingFiltered": "Affichage de {filtered} sur {total} {entity}"
+      "showingFiltered": "Affichage de {filtered} sur {total} {entity}",
+      "showingRange": "Affichage de {start}-{end} sur {total} {entity}"
     },
     "search": {
       "noResults": "Aucun résultat trouvé",
@@ -1720,6 +1723,7 @@
     "errorSaveFailed": "Échec de l'enregistrement du document"
   },
   "documents": {
+    "entityLabel": "documents",
     "searchPlaceholder": "Rechercher des documents",
     "deleteFolder": {
       "title": "Supprimer le dossier",
@@ -2808,6 +2812,7 @@
         },
         "history": {
           "title": "Historique des libérations",
+          "entityLabel": "libérations",
           "description": "Audit en lecture seule des demandes effectives et rejetées.",
           "empty": {
             "title": "Aucune demande terminée",
@@ -2984,6 +2989,7 @@
     },
     "dataSubjectRequests": {
       "title": "Demandes de personnes concernées",
+      "entityLabel": "demandes",
       "description": "Reçus d'effacement RGPD art. 17. Dépose de nouvelles demandes, surveille les délais et accorde des prolongations art. 12(3) lorsque les dossiers complexes l'exigent.",
       "accessDenied": "Réservé aux administrateurs.",
       "filters": {
@@ -3551,7 +3557,10 @@
   "notifications": {
     "title": "Notifications",
     "ariaUnread": "Non lu",
-    "empty": "Aucune notification.",
+    "emptyCaughtUpTitle": "Tout est à jour",
+    "emptyCaughtUpDescription": "Nous vous préviendrons dès qu'il y aura du nouveau.",
+    "emptyAllTitle": "Aucune notification pour l'instant",
+    "emptyAllDescription": "Les alertes et mises à jour système apparaîtront ici à mesure qu'elles arriveront.",
     "markAsRead": "Marquer comme lu",
     "markAllAsRead": "Tout marquer comme lu",
     "filterUnread": "Non lus",
@@ -4164,6 +4173,7 @@
     },
     "agents": {
       "title": "Agents",
+      "entityLabel": "agents",
       "createAgent": "Créer un agent",
       "searchAgent": "Rechercher des agents",
       "columns": {
@@ -4412,6 +4422,7 @@
       }
     },
     "skills": {
+      "entityLabel": "skills",
       "uploadSkill": "Téléverser un skill",
       "searchPlaceholder": "Rechercher des skills…",
       "deleteSkill": "Supprimer le skill",
@@ -4707,6 +4718,7 @@
     },
     "providers": {
       "title": "Fournisseurs",
+      "entityLabel": "fournisseurs",
       "addProvider": "Ajouter un fournisseur",
       "editProvider": "Modifier le fournisseur",
       "deleteProvider": "Supprimer le fournisseur",
@@ -4941,6 +4953,7 @@
         }
       },
       "audit": {
+        "entityLabel": "journaux d'audit",
         "tableCaption": "Tableau des journaux d'audit",
         "emptyTitle": "Aucun journal d'audit",
         "emptyDescription": "Les journaux d'audit apparaîtront ici à mesure que des actions sont effectuées dans ton organisation.",
@@ -5358,7 +5371,6 @@
     "enrollment": {
       "title": "Authentification à double facteur",
       "description": "Protège ton compte avec un code temporel généré par une application d'authentification.",
-      "notEnabledHint": "L'authentification à double facteur n'est pas encore activée sur ton compte.",
       "enabledHint": "L'authentification à double facteur est active sur ton compte.",
       "requiredByOrg": "Ton organisation exige l'authentification à double facteur. Active-la maintenant pour continuer.",
       "enableButton": "Activer le double facteur",
@@ -5630,6 +5642,7 @@
   },
   "projects": {
     "title": "Projets",
+    "entityLabel": "projets",
     "navigation": {
       "list": "Tous les projets",
       "overview": "Général",


### PR DESCRIPTION
## Summary

Original work (already on this branch):
- Adds a Cancel/Discard button to settings pages so users can easily revert unsaved changes instead of manually undoing each field
- Improves user profile popup UX

Added in this session:
- **Notifications overhaul** — bell moved from inside the user dropdown into the sidebar (sibling of the avatar), opening a standalone popover. Row pattern simplified: click anywhere on an unread row to mark it read, single unread dot, dropped the chevron-expand + redundant severity icon. New empty-state copy ("You're all caught up" / "No notifications yet") with icons.
- **Data table footers** — named the entity in row-count copy across 9+ tables (agents, audit logs, providers, projects, executions, skills, documents, feedback, releases, data-subject-requests). "Showing all 7 agents" replaces the generic "No more items to load."
- **Data table search** — widened from 16rem → 18rem and fixed the invisible internal max-width that was leaving a transparent gap before adjacent buttons.
- **Dropdown menus** — replaced radio dots with right-aligned checkmarks (language picker, team filter, conversations filter), switched submenu background from `bg-muted` to `bg-card` so it matches the main menu's white surface in light mode, added a `keepOpen` flag for items that swap content in place.
- **Settings polish** — dropped the redundant "2FA not yet enabled" status line (the Enable button already conveys state); branding panels got visible borders (`border-input` was painting the border in the input-fill color, so it was invisible by design) and a lighter `shadow-xs` instead of the heavy v4 `shadow-sm`.
- **Profile name bug fix** — `getCurrentUser` now reads `name` and `email` from the Better Auth `user` table instead of the stale JWT identity. Previously, editing your name saved successfully but the form re-read the old value from the JWT and reverted on screen. Auth gate still uses the JWT — no extra cost for non-profile call sites.

Closes #1567

## Test plan

- [ ] Settings pages: Cancel/Discard appears when changes are detected and reverts to last-saved state
- [ ] User profile popover renders correctly
- [ ] Open the bell in the sidebar — popover anchors right, panel background is white in light mode
- [ ] Click an unread notification row — switches to read state (background tint + opacity drop)
- [ ] Click "Mark all as read" — unread count clears
- [ ] Empty state is centered with the correct icon + copy (Unread vs All)
- [ ] Language menu shows a checkmark on the right of the active row
- [ ] Agents table footer reads "Showing all N agents" instead of "No more items to load"
- [ ] In Account settings, change display name and save — new name persists without sign-out
- [ ] Branding settings: image upload + color picker borders are visible in both light and dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual treatment of bordered elements throughout the automations interface to enhance overall consistency and visual polish.
  * Updated the featured image displayed on a frontpage component to better align with design standards and improve visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->