### PR TITLE
feat(platform): google drive sync — recursive, reconcile, rename

### DIFF
--- a/examples/default/integrations/google_drive/config.json
+++ b/examples/default/integrations/google_drive/config.json
@@ -18,7 +18,7 @@
     {
       "name": "list_files",
       "title": "List Files in Folder",
-      "description": "List files in a Google Drive folder, optionally filtered by mime type.",
+      "description": "List files in a Google Drive folder. Pagination is handled internally — the operation returns the complete file list in one call. When recursive=true, traverses subfolders breadth-first; each file's relative path is reported as `subfolderPath`.",
       "operationType": "read",
       "parametersSchema": {
         "type": "object",
@@ -33,9 +33,9 @@
             "description": "Mime types to include (e.g. [\"application/pdf\"]). Empty/omitted returns all non-folder files.",
             "required": false
           },
-          "pageToken": {
-            "type": "string",
-            "description": "Page token from a previous list_files call for pagination.",
+          "recursive": {
+            "type": "boolean",
+            "description": "When true, traverse all subfolders breadth-first and return a flat list with each file's `subfolderPath`. Capped at 5000 files / 20 levels deep — beyond that the result is soft-truncated and `truncated: true` is set in the response. Default false.",
             "required": false
           }
         }

--- a/examples/default/integrations/google_drive/connector.ts
+++ b/examples/default/integrations/google_drive/connector.ts
@@ -78,6 +78,13 @@ interface TestConnectionContext {
 
 const API_BASE = 'https://www.googleapis.com/drive/v3';
 
+const FOLDER_MIME = 'application/vnd.google-apps.folder';
+// Soft caps for recursive listing. Hitting either returns a truncated result
+// with `truncated: true` rather than throwing, so a sync workflow can still
+// make progress on huge folders.
+const RECURSIVE_FILE_CAP = 5000;
+const RECURSIVE_DEPTH_CAP = 20;
+
 const connector = {
   operations: ['list_files', 'download_file'],
 
@@ -206,16 +213,21 @@ function escapeDriveQueryLiteral(value: string): string {
 function buildListQuery(
   folderId: string,
   mimeTypes: string[] | undefined,
+  includeFolders: boolean,
 ): string {
   const parts: string[] = [];
   parts.push("'" + escapeDriveQueryLiteral(folderId) + "' in parents");
   parts.push('trashed = false');
 
-  // Always exclude folders themselves from the file list — we're syncing files,
-  // not nested folder containers. (For now; subfolder recursion is a future op.)
-  parts.push("mimeType != 'application/vnd.google-apps.folder'");
+  if (!includeFolders) {
+    parts.push("mimeType != 'application/vnd.google-apps.folder'");
+  }
 
-  if (mimeTypes && mimeTypes.length > 0) {
+  // mimeTypes filter applies only to files, not folders. When recursing we
+  // need to enumerate folders unconditionally to descend into them, so the
+  // mimeTypes filter is intentionally skipped in that mode and applied
+  // client-side by the caller.
+  if (mimeTypes && mimeTypes.length > 0 && !includeFolders) {
     const ors: string[] = [];
     for (let i = 0; i < mimeTypes.length; i++) {
       ors.push("mimeType = '" + escapeDriveQueryLiteral(mimeTypes[i]) + "'");
@@ -224,6 +236,110 @@ function buildListQuery(
   }
 
   return parts.join(' and ');
+}
+
+// Replace characters that are valid in Drive folder names but rejected by
+// Tale's folder name validator (which forbids '/' and '\') or that would
+// otherwise corrupt the workflow's '/'-joined folderPath template. The
+// substitution is one-way and lossy by design — `a?b` and `a_b` collide,
+// which is acceptable at demo stage and avoidable by users renaming.
+function sanitizeDriveFolderName(name: string): string {
+  return name.replace(/[/\\?*<>:"|]/g, '_').slice(0, 255);
+}
+
+interface DriveRawFile {
+  id: string;
+  name: string;
+  size?: string;
+  mimeType?: string;
+  modifiedTime?: string;
+  md5Checksum?: string;
+}
+
+interface DrivePage {
+  files?: DriveRawFile[];
+  nextPageToken?: string;
+}
+
+interface OutputFile {
+  id: string;
+  name: string;
+  size: number;
+  mimeType: string | undefined;
+  modifiedTime: string | undefined;
+  md5Checksum: string | undefined;
+  subfolderPath: string;
+}
+
+// Fetch every page for one folder query (no recursion). Drive's pageSize is
+// capped at 200, so callers must paginate to get a complete list — leaving
+// pagination to the workflow layer (as the original implementation did) is
+// unsafe because reconcile_deletes uses the file list to compute deletes.
+function listOnePageFolder(
+  http: HttpApi,
+  headers: Record<string, string>,
+  folderId: string,
+  mimeTypes: string[] | undefined,
+  includeFolders: boolean,
+): DriveRawFile[] {
+  const q = buildListQuery(folderId, mimeTypes, includeFolders);
+  const fields =
+    'nextPageToken, files(id, name, size, mimeType, modifiedTime, md5Checksum)';
+
+  const allFiles: DriveRawFile[] = [];
+  let pageToken: string | undefined;
+
+  while (true) {
+    const queryParts = [
+      'q=' + encodeURIComponent(q),
+      'fields=' + encodeURIComponent(fields),
+      'pageSize=200',
+    ];
+    if (pageToken) {
+      queryParts.push('pageToken=' + encodeURIComponent(pageToken));
+    }
+
+    const url = API_BASE + '/files?' + queryParts.join('&');
+    const response = http.get(url, { headers: headers });
+    handleError(response, 'list files');
+
+    const data = response.json() as DrivePage;
+    const pageFiles = data.files || [];
+    for (let i = 0; i < pageFiles.length; i++) {
+      allFiles.push(pageFiles[i]);
+    }
+
+    if (!data.nextPageToken) {
+      break;
+    }
+    pageToken = data.nextPageToken;
+  }
+
+  return allFiles;
+}
+
+function toOutputFile(raw: DriveRawFile, subfolderPath: string): OutputFile {
+  return {
+    id: raw.id,
+    name: raw.name,
+    size: raw.size ? parseInt(raw.size, 10) : 0,
+    mimeType: raw.mimeType,
+    modifiedTime: raw.modifiedTime,
+    md5Checksum: raw.md5Checksum,
+    subfolderPath: subfolderPath,
+  };
+}
+
+function matchesMimeFilter(
+  raw: DriveRawFile,
+  mimeTypes: string[] | undefined,
+): boolean {
+  if (!mimeTypes || mimeTypes.length === 0) return true;
+  if (!raw.mimeType) return false;
+  for (let i = 0; i < mimeTypes.length; i++) {
+    if (raw.mimeType === mimeTypes[i]) return true;
+  }
+  return false;
 }
 
 function listFiles(
@@ -239,61 +355,88 @@ function listFiles(
   const mimeTypes = Array.isArray(params.mimeTypes)
     ? (params.mimeTypes as string[])
     : undefined;
+  const recursive = params.recursive === true;
 
-  const q = buildListQuery(folderId, mimeTypes);
-  const fields =
-    'nextPageToken, files(id, name, size, mimeType, modifiedTime, md5Checksum)';
+  const files: OutputFile[] = [];
+  let truncated = false;
 
-  const queryParts = [
-    'q=' + encodeURIComponent(q),
-    'fields=' + encodeURIComponent(fields),
-    'pageSize=200',
-  ];
-  if (params.pageToken) {
-    queryParts.push(
-      'pageToken=' + encodeURIComponent(params.pageToken as string),
-    );
+  if (!recursive) {
+    // Flat: one folder, exhaust pagination.
+    const raw = listOnePageFolder(http, headers, folderId, mimeTypes, false);
+    for (let i = 0; i < raw.length; i++) {
+      if (files.length >= RECURSIVE_FILE_CAP) {
+        truncated = true;
+        break;
+      }
+      files.push(toOutputFile(raw[i], ''));
+    }
+  } else {
+    // BFS over subfolders. One Drive query per folder returns files + folders
+    // mixed (no `mimeType != folder` filter); we partition client-side.
+    const queue: Array<{
+      folderId: string;
+      subfolderPath: string;
+      depth: number;
+    }> = [{ folderId: folderId, subfolderPath: '', depth: 0 }];
+
+    outer: while (queue.length > 0) {
+      const head = queue.shift() as {
+        folderId: string;
+        subfolderPath: string;
+        depth: number;
+      };
+
+      const raw = listOnePageFolder(
+        http,
+        headers,
+        head.folderId,
+        undefined,
+        true,
+      );
+
+      for (let i = 0; i < raw.length; i++) {
+        const r = raw[i];
+        if (r.mimeType === FOLDER_MIME) {
+          if (head.depth + 1 > RECURSIVE_DEPTH_CAP) {
+            truncated = true;
+            continue;
+          }
+          const segment = sanitizeDriveFolderName(r.name);
+          const childPath = head.subfolderPath
+            ? head.subfolderPath + '/' + segment
+            : segment;
+          queue.push({
+            folderId: r.id,
+            subfolderPath: childPath,
+            depth: head.depth + 1,
+          });
+        } else {
+          if (!matchesMimeFilter(r, mimeTypes)) continue;
+          if (files.length >= RECURSIVE_FILE_CAP) {
+            truncated = true;
+            break outer;
+          }
+          files.push(toOutputFile(r, head.subfolderPath));
+        }
+      }
+    }
   }
 
-  const url = API_BASE + '/files?' + queryParts.join('&');
-  console.log('Listing Drive files: ' + url);
-
-  const response = http.get(url, { headers: headers });
-  handleError(response, 'list files');
-
-  const data = response.json() as {
-    files?: Array<{
-      id: string;
-      name: string;
-      size?: string;
-      mimeType?: string;
-      modifiedTime?: string;
-      md5Checksum?: string;
-    }>;
-    nextPageToken?: string;
-  };
-
-  const rawFiles = data.files || [];
-  const files = rawFiles.map(function (f) {
-    return {
-      id: f.id,
-      name: f.name,
-      size: f.size ? parseInt(f.size, 10) : 0,
-      mimeType: f.mimeType,
-      modifiedTime: f.modifiedTime,
-      md5Checksum: f.md5Checksum,
-    };
-  });
+  console.log(
+    'Listed Drive files: count=' +
+      files.length +
+      ', recursive=' +
+      recursive +
+      ', truncated=' +
+      truncated,
+  );
 
   return {
     success: true,
     operation: 'list_files',
     data: {
       files: files,
-      pagination: {
-        hasNextPage: !!data.nextPageToken,
-        nextPageToken: data.nextPageToken || null,
-      },
+      truncated: truncated,
     },
     count: files.length,
     timestamp: Date.now(),

--- a/examples/default/integrations/google_drive/connector.ts
+++ b/examples/default/integrations/google_drive/connector.ts
@@ -239,12 +239,18 @@ function buildListQuery(
 }
 
 // Replace characters that are valid in Drive folder names but rejected by
-// Tale's folder name validator (which forbids '/' and '\') or that would
-// otherwise corrupt the workflow's '/'-joined folderPath template. The
-// substitution is one-way and lossy by design — `a?b` and `a_b` collide,
-// which is acceptable at demo stage and avoidable by users renaming.
+// Tale's folder name validator (which forbids '/' and '\' and trim-empty
+// names) or that would otherwise corrupt the workflow's '/'-joined
+// folderPath template. The substitution is one-way and lossy by design —
+// `a?b` and `a_b` collide, which is acceptable at demo stage and avoidable
+// by users renaming. Whitespace-only Drive folder names map to '_' to keep
+// the workflow from aborting at folder-creation time.
 function sanitizeDriveFolderName(name: string): string {
-  return name.replace(/[/\\?*<>:"|]/g, '_').slice(0, 255);
+  const cleaned = name
+    .replace(/[/\\?*<>:"|]/g, '_')
+    .trim()
+    .slice(0, 255);
+  return cleaned.length > 0 ? cleaned : '_';
 }
 
 interface DriveRawFile {

--- a/examples/default/integrations/google_drive/connector.ts
+++ b/examples/default/integrations/google_drive/connector.ts
@@ -158,8 +158,12 @@ const connector = {
 
 function handleError(response: HttpResponse, operation: string): void {
   if (response.status === 401) {
+    // Sentinel [401_UNAUTHORIZED] lets the integration action wrapper
+    // detect this case and retry once after force-refreshing the OAuth2
+    // access token (covers tokens that expire between buildIntegrationSecrets
+    // and the actual Drive request, or revoked tokens).
     throw new Error(
-      'Authentication failed during ' +
+      '[401_UNAUTHORIZED] Authentication failed during ' +
         operation +
         '. The access token may be expired. Please re-authorize.',
     );
@@ -250,16 +254,20 @@ function buildListQuery(
 function sanitizeDriveFolderName(name: string): string {
   let cleaned = name
     // ASCII control chars, DEL, BOM (U+FEFF), ZWSP (U+200B),
-    // bidi marks (U+200E/F, U+202A-E)
-    .replace(/[\x00-\x1F\x7F﻿​‎‏‪-‮]/g, '')
+    // bidi marks (U+200E/F, U+202A-E), and Unicode line/paragraph
+    // separators (U+2028/U+2029) which break log scraping / some
+    // terminals even though JSON allows them literally.
+    .replace(/[\x00-\x1F\x7F﻿​‎‏‪-‮ ]/g, '')
     .replace(/[/\\?*<>:"|]/g, '_')
     .trim()
     .slice(0, 255);
-  // Drop an unpaired high surrogate left at the tail by slice (e.g. a
-  // 4-byte emoji split mid-pair).
+  // Drop an unpaired surrogate left at the tail by slice. High surrogate
+  // (U+D800-U+DBFF) means an emoji split mid-pair; a lone LOW surrogate
+  // (U+DC00-U+DFFF) can survive if Drive returned a malformed name. Both
+  // produce invalid UTF-8 / U+FFFD downstream.
   if (cleaned.length > 0) {
     const lastCode = cleaned.charCodeAt(cleaned.length - 1);
-    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    if (lastCode >= 0xd800 && lastCode <= 0xdfff) {
       cleaned = cleaned.slice(0, -1);
     }
   }
@@ -500,10 +508,35 @@ function downloadFile(
   const url = API_BASE + '/files/' + encodeURIComponent(fileId) + '?alt=media';
   console.log('Downloading Drive file: ' + url);
 
-  const stored = files.download(url, {
-    headers: headers,
-    fileName: fileName,
-  });
+  // Drive lists are eventually consistent: a file present at list_files
+  // time can be deleted before download. Treat 404/410 as a soft "gone"
+  // signal so the workflow's loop continues to the next file (and
+  // reconcile drops the row on the next sync) instead of aborting the
+  // whole batch with a generic error.
+  let stored;
+  try {
+    stored = files.download(url, {
+      headers: headers,
+      fileName: fileName,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/\b(404|410|not[\s_-]?found|gone)\b/i.test(msg)) {
+      return {
+        success: false,
+        operation: 'download_file',
+        skipped: 'not_found',
+        fileId: fileId,
+        error:
+          'File no longer exists in Drive (deleted between listing and download).',
+        timestamp: Date.now(),
+      };
+    }
+    if (/\b401\b|access token may be expired/i.test(msg)) {
+      throw new Error('[401_UNAUTHORIZED] ' + msg);
+    }
+    throw e;
+  }
 
   return {
     success: true,

--- a/examples/default/integrations/google_drive/connector.ts
+++ b/examples/default/integrations/google_drive/connector.ts
@@ -239,17 +239,35 @@ function buildListQuery(
 }
 
 // Replace characters that are valid in Drive folder names but rejected by
-// Tale's folder name validator (which forbids '/' and '\' and trim-empty
-// names) or that would otherwise corrupt the workflow's '/'-joined
-// folderPath template. The substitution is one-way and lossy by design —
-// `a?b` and `a_b` collide, which is acceptable at demo stage and avoidable
-// by users renaming. Whitespace-only Drive folder names map to '_' to keep
-// the workflow from aborting at folder-creation time.
+// Tale's folder name validator (which forbids '/' and '\', trim-empty
+// names, and reserved '.' / '..') or that would otherwise corrupt the
+// workflow's '/'-joined folderPath template. Also strips ASCII control
+// characters, BOM, ZWSP, and bidi marks — Drive accepts those but they
+// produce homograph spoofing or NUL-truncation downstream. The
+// substitution is one-way and lossy by design — collisions (e.g. `a?b`
+// and `a_b` both become `a_b`) are acceptable at demo stage and avoidable
+// by users renaming.
 function sanitizeDriveFolderName(name: string): string {
-  const cleaned = name
+  let cleaned = name
+    // ASCII control chars, DEL, BOM (U+FEFF), ZWSP (U+200B),
+    // bidi marks (U+200E/F, U+202A-E)
+    .replace(/[\x00-\x1F\x7F﻿​‎‏‪-‮]/g, '')
     .replace(/[/\\?*<>:"|]/g, '_')
     .trim()
     .slice(0, 255);
+  // Drop an unpaired high surrogate left at the tail by slice (e.g. a
+  // 4-byte emoji split mid-pair).
+  if (cleaned.length > 0) {
+    const lastCode = cleaned.charCodeAt(cleaned.length - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+      cleaned = cleaned.slice(0, -1);
+    }
+  }
+  // Reserved on Tale's side and easy to silently truncate the path —
+  // substitute with a safe single underscore.
+  if (cleaned === '.' || cleaned === '..') {
+    cleaned = '_';
+  }
   return cleaned.length > 0 ? cleaned : '_';
 }
 
@@ -379,6 +397,12 @@ function listFiles(
   } else {
     // BFS over subfolders. One Drive query per folder returns files + folders
     // mixed (no `mimeType != folder` filter); we partition client-side.
+    // `visited` dedups folder IDs — Drive's legacy multi-parent items can
+    // reach the same folder via more than one branch, which without dedup
+    // would inflate the file count toward the cap and emit duplicate file
+    // rows under divergent `subfolderPath` values.
+    const visited: Record<string, boolean> = {};
+    visited[folderId] = true;
     const queue: Array<{
       folderId: string;
       subfolderPath: string;
@@ -403,10 +427,12 @@ function listFiles(
       for (let i = 0; i < raw.length; i++) {
         const r = raw[i];
         if (r.mimeType === FOLDER_MIME) {
+          if (visited[r.id]) continue;
           if (head.depth + 1 > RECURSIVE_DEPTH_CAP) {
             truncated = true;
             continue;
           }
+          visited[r.id] = true;
           const segment = sanitizeDriveFolderName(r.name);
           const childPath = head.subfolderPath
             ? head.subfolderPath + '/' + segment

--- a/examples/default/workflows/google_drive/sync.json
+++ b/examples/default/workflows/google_drive/sync.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Drive Sync",
-  "description": "Sync files from a Google Drive folder into Tale documents. Each scheduled run lists the files in the configured folder, downloads any that are new or changed, and upserts documents by external ID. RAG indexing is then handled by the document-rag-sync workflow.",
+  "description": "Sync files from a Google Drive folder into Tale documents. Each scheduled run lists every file in the configured folder (recursing into subfolders, mirroring their structure under targetFolderPath), downloads any that are new or changed, and upserts documents by external ID. Pure renames are detected and applied without re-downloading. After the loop completes, files that were removed from Drive are also removed from the target Tale folder (RAG entries are cleaned up too). For safety, if Drive returns an empty file list the reconcile step skips deletion — an empty result is more often caused by an OAuth scope downgrade or wrong folder ID than by a genuinely empty folder, and a user who really wants to clear the target folder can do so directly in the Tale UI.",
   "version": "1.0.0",
   "config": {
     "timeout": 600000,
@@ -61,7 +61,8 @@
           "operation": "list_files",
           "params": {
             "folderId": "{{input.folderId}}",
-            "mimeTypes": "{{input.mimeTypeFilter}}"
+            "mimeTypes": "{{input.mimeTypeFilter}}",
+            "recursive": true
           }
         },
         "type": "integration"
@@ -80,7 +81,7 @@
         "items": "{{steps.list_files.output.data.result.data.files}}"
       },
       "nextSteps": {
-        "done": "noop",
+        "done": "reconcile_deletes",
         "loop": "lookup_existing"
       }
     },
@@ -93,7 +94,7 @@
         "parameters": {
           "operation": "find_by_external_id",
           "externalItemId": "{{loop.item.id}}",
-          "folderPath": "{{input.targetFolderPath || 'Google Drive'}}"
+          "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}"
         }
       },
       "nextSteps": {
@@ -106,11 +107,40 @@
       "stepType": "condition",
       "config": {
         "expression": "steps.lookup_existing.output.data.exists == true && steps.lookup_existing.output.data.contentHash == loop.item.md5Checksum",
-        "description": "If a document with the same external id and md5 already exists in the target folder, skip the download entirely."
+        "description": "If a document with the same external id and md5 already exists in the target folder, skip the download. A pure rename (same md5, new name) is handled by the next step without re-downloading."
       },
       "nextSteps": {
-        "true": "loop_files",
+        "true": "check_renamed",
         "false": "download_file"
+      }
+    },
+    {
+      "stepSlug": "check_renamed",
+      "name": "Detect Rename",
+      "stepType": "condition",
+      "config": {
+        "expression": "steps.lookup_existing.output.data.title != loop.item.name",
+        "description": "Content unchanged but Drive title differs from Tale title — rename. Patch the title without touching the file blob."
+      },
+      "nextSteps": {
+        "true": "update_title",
+        "false": "loop_files"
+      }
+    },
+    {
+      "stepSlug": "update_title",
+      "name": "Apply Drive Rename",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "update",
+          "fileId": "{{steps.lookup_existing.output.data.fileId}}",
+          "title": "{{loop.item.name}}"
+        }
+      },
+      "nextSteps": {
+        "success": "loop_files"
       }
     },
     {
@@ -142,13 +172,14 @@
           "contentHash": "{{loop.item.md5Checksum}}",
           "externalItemId": "{{loop.item.id}}",
           "fileId": "{{steps.download_file.output.data.result.data.fileId}}",
-          "folderPath": "{{input.targetFolderPath || 'Google Drive'}}",
+          "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}",
           "metadata": {
             "googleDriveFileId": "{{loop.item.id}}",
             "googleDriveFolderId": "{{input.folderId}}",
             "mimeType": "{{loop.item.mimeType}}",
             "size": "{{loop.item.size}}",
             "sourceModifiedAt": "{{loop.item.modifiedTime}}",
+            "subfolderPath": "{{loop.item.subfolderPath}}",
             "syncedAt": "{{now}}"
           },
           "operation": "create",
@@ -187,6 +218,23 @@
       },
       "nextSteps": {
         "success": "loop_files"
+      }
+    },
+    {
+      "stepSlug": "reconcile_deletes",
+      "name": "Delete Documents Removed in Drive",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "reconcile_deletes",
+          "sourceProvider": "google_drive",
+          "folderPath": "{{input.targetFolderPath || 'Google Drive'}}",
+          "presentExternalIds": "{{steps.list_files.output.data.result.data.files | map('id')}}"
+        }
+      },
+      "nextSteps": {
+        "success": "noop"
       }
     },
     {

--- a/examples/default/workflows/google_drive/sync.json
+++ b/examples/default/workflows/google_drive/sync.json
@@ -81,8 +81,21 @@
         "items": "{{steps.list_files.output.data.result.data.files}}"
       },
       "nextSteps": {
-        "done": "reconcile_deletes",
+        "done": "check_truncated",
         "loop": "lookup_existing"
+      }
+    },
+    {
+      "stepSlug": "check_truncated",
+      "name": "Skip Reconcile If Listing Truncated",
+      "stepType": "condition",
+      "config": {
+        "expression": "steps.list_files.output.data.result.data.truncated == true",
+        "description": "If list_files hit the recursive cap (>5000 files or >20 levels), the present-id set is incomplete and reconcile would delete legitimate docs. Skip cleanup and surface a warning via execution logs; the next run with smaller scope or raised caps will reconcile correctly."
+      },
+      "nextSteps": {
+        "true": "noop",
+        "false": "reconcile_deletes"
       }
     },
     {
@@ -173,6 +186,7 @@
           "externalItemId": "{{loop.item.id}}",
           "fileId": "{{steps.download_file.output.data.result.data.fileId}}",
           "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}",
+          "folderPathPrefix": "{{input.targetFolderPath || 'Google Drive'}}",
           "metadata": {
             "googleDriveFileId": "{{loop.item.id}}",
             "googleDriveFolderId": "{{input.folderId}}",
@@ -230,7 +244,8 @@
           "operation": "reconcile_deletes",
           "sourceProvider": "google_drive",
           "folderPath": "{{input.targetFolderPath || 'Google Drive'}}",
-          "presentExternalIds": "{{steps.list_files.output.data.result.data.files | map('id')}}"
+          "presentExternalIds": "{{steps.list_files.output.data.result.data.files | map('id')}}",
+          "truncated": "{{steps.list_files.output.data.result.data.truncated}}"
         }
       },
       "nextSteps": {

--- a/examples/default/workflows/google_drive/sync.json
+++ b/examples/default/workflows/google_drive/sync.json
@@ -120,7 +120,8 @@
         "parameters": {
           "operation": "find_by_external_id",
           "externalItemId": "{{loop.item.id}}",
-          "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}"
+          "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}",
+          "folderPathPrefix": "{{input.targetFolderPath || 'Google Drive'}}"
         }
       },
       "nextSteps": {
@@ -196,6 +197,7 @@
       "config": {
         "parameters": {
           "contentHash": "{{loop.item.md5Checksum}}",
+          "driveId": "{{input.folderId}}",
           "externalItemId": "{{loop.item.id}}",
           "fileId": "{{steps.download_file.output.data.result.data.fileId}}",
           "folderPath": "{{(input.targetFolderPath || 'Google Drive') + (loop.item.subfolderPath ? '/' + loop.item.subfolderPath : '')}}",
@@ -273,6 +275,7 @@
           "operation": "reconcile_deletes",
           "sourceProvider": "google_drive",
           "folderPath": "{{input.targetFolderPath || 'Google Drive'}}",
+          "driveId": "{{input.folderId}}",
           "presentExternalIds": "{{steps.list_files.output.data.result.data.files | map('id')}}",
           "truncated": "{{steps.list_files.output.data.result.data.truncated}}"
         }

--- a/examples/default/workflows/google_drive/sync.json
+++ b/examples/default/workflows/google_drive/sync.json
@@ -68,7 +68,20 @@
         "type": "integration"
       },
       "nextSteps": {
-        "success": "loop_files"
+        "success": "check_has_files"
+      }
+    },
+    {
+      "stepSlug": "check_has_files",
+      "name": "Skip Loop If Drive Listing Is Empty",
+      "stepType": "condition",
+      "config": {
+        "expression": "(steps.list_files.output.data.result.data.files | length) > 0",
+        "description": "Loop steps throw on an empty items array; the throw isn't covered by continueOnError, so an empty Drive listing would otherwise abort the workflow before the reconcile-safety net runs. Route the empty case straight to check_truncated → reconcile_deletes, which has its own empty-source-list safety guard."
+      },
+      "nextSteps": {
+        "true": "loop_files",
+        "false": "check_truncated"
       }
     },
     {
@@ -211,8 +224,8 @@
       "name": "Skip RAG If Unchanged",
       "stepType": "condition",
       "config": {
-        "description": "Skip RAG re-indexing when the document was unchanged (same content hash).",
-        "expression": "steps.create_document.output.data.action != 'skipped'"
+        "description": "Re-index only when the file's contentHash actually changed. Pure folder-move or metadata-only patches return action='updated' with contentChanged=false and must not re-upload to RAG (a same-md5 cross-folder move is the canonical case).",
+        "expression": "steps.create_document.output.data.contentChanged == true"
       },
       "nextSteps": {
         "false": "loop_files",
@@ -229,6 +242,22 @@
           "operation": "index_in_rag"
         },
         "type": "document"
+      },
+      "nextSteps": {
+        "success": "finalize_content_hash"
+      }
+    },
+    {
+      "stepSlug": "finalize_content_hash",
+      "name": "Commit Content Hash",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "update",
+          "fileId": "{{steps.download_file.output.data.result.data.fileId}}",
+          "contentHash": "{{loop.item.md5Checksum}}"
+        }
       },
       "nextSteps": {
         "success": "loop_files"

--- a/services/platform/app/features/automations/components/automation-sidepanel.tsx
+++ b/services/platform/app/features/automations/components/automation-sidepanel.tsx
@@ -39,6 +39,8 @@ interface AutomationSidePanelProps {
     stepType?: Doc<'wfStepDefs'>['stepType'];
     actionType?: string;
   }>;
+  panelWidth?: number;
+  onPanelWidthChange?: (width: number) => void;
 }
 
 interface EditState {
@@ -205,11 +207,16 @@ export function AutomationSidePanel({
   automationId,
   organizationId,
   stepOptions = EMPTY_STEP_OPTIONS,
+  panelWidth,
+  onPanelWidthChange,
 }: AutomationSidePanelProps) {
   const { t } = useT('automations');
   const panelRef = useRef<HTMLDivElement>(null);
   const { width, minWidth, maxWidth, handleMouseDown, handleKeyDown } =
-    useResizable(panelRef);
+    useResizable(panelRef, {
+      width: panelWidth,
+      onWidthChange: onPanelWidthChange,
+    });
 
   const initialEditState: EditState = { config: '', nextSteps: {} };
   const [editState, setEditState] = useState(initialEditState);

--- a/services/platform/app/features/automations/components/automation-steps.tsx
+++ b/services/platform/app/features/automations/components/automation-steps.tsx
@@ -46,15 +46,12 @@ import { AutomationCallbacksProvider } from './automation-callbacks-context';
 import { AutomationEdge } from './automation-edge';
 import { AutomationGroupNode } from './automation-group-node';
 import { AutomationLoopContainer } from './automation-loop-container';
-import { AutomationSidePanel } from './automation-sidepanel';
 import { AutomationStep } from './automation-step';
 import { CreateStepDialog } from './step-create-dialog';
 
 interface AutomationStepsProps {
   steps: Doc<'wfStepDefs'>[];
   className?: string;
-  organizationId: string;
-  automationId: string;
   hasActiveTrigger: boolean;
   onStepCreated?: () => void;
   onOpenAIChat?: () => void;
@@ -111,8 +108,6 @@ function minimapNodeStrokeColor(node: Node): string {
 function AutomationStepsInner({
   steps,
   className: _className,
-  organizationId,
-  automationId,
   hasActiveTrigger,
   onStepCreated: _onStepCreated,
   onOpenAIChat,
@@ -124,24 +119,9 @@ function AutomationStepsInner({
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isCreateStepDialogOpen, setIsCreateStepDialogOpen] = useState(false);
 
-  const {
-    state: panelState,
-    setStates: setPanelStates,
-    clearAll: clearPanelState,
-  } = useUrlState({
+  const { setStates: setPanelStates } = useUrlState({
     definitions: AUTOMATION_PANEL_URL_DEFINITIONS,
   });
-
-  const sidePanelMode =
-    panelState.panel === 'step' || panelState.panel === 'test'
-      ? panelState.panel
-      : null;
-  const selectedStepSlug = panelState.step;
-
-  const selectedStep = useMemo(() => {
-    if (!selectedStepSlug) return null;
-    return steps.find((s) => s.stepSlug === selectedStepSlug) ?? null;
-  }, [steps, selectedStepSlug]);
 
   const [_parentStepForNewStep, setParentStepForNewStep] = useState<
     string | null
@@ -234,10 +214,6 @@ function AutomationStepsInner({
     },
     [steps, setPanelStates],
   );
-
-  const handleCloseSidePanel = useCallback(() => {
-    clearPanelState();
-  }, [clearPanelState]);
 
   const handleOpenTestPanel = useCallback(() => {
     setPanelStates({ panel: 'test', step: null });
@@ -475,17 +451,6 @@ function AutomationStepsInner({
           </ReactFlow>
         </div>
 
-        {sidePanelMode && (
-          <AutomationSidePanel
-            step={selectedStep}
-            isOpen={!!sidePanelMode}
-            onClose={handleCloseSidePanel}
-            showTestPanel={sidePanelMode === 'test'}
-            automationId={automationId}
-            organizationId={organizationId}
-            stepOptions={stepOptions}
-          />
-        )}
         <CreateStepDialog
           open={isCreateStepDialogOpen}
           onOpenChange={(open) => {

--- a/services/platform/app/features/automations/components/automation-steps.tsx
+++ b/services/platform/app/features/automations/components/automation-steps.tsx
@@ -71,6 +71,11 @@ const edgeTypes = {
   default: AutomationEdge,
 };
 
+export const AUTOMATION_PANEL_URL_DEFINITIONS = {
+  panel: { default: null },
+  step: { default: null },
+} as const;
+
 const MINIMAP_STYLES = `
   .react-flow__edges { z-index: auto; }
   .react-flow__nodes { z-index: auto; }
@@ -119,20 +124,12 @@ function AutomationStepsInner({
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isCreateStepDialogOpen, setIsCreateStepDialogOpen] = useState(false);
 
-  const urlStateDefinitions = useMemo(
-    () => ({
-      panel: { default: null },
-      step: { default: null },
-    }),
-    [],
-  );
-
   const {
     state: panelState,
     setStates: setPanelStates,
     clearAll: clearPanelState,
   } = useUrlState({
-    definitions: urlStateDefinitions,
+    definitions: AUTOMATION_PANEL_URL_DEFINITIONS,
   });
 
   const sidePanelMode =

--- a/services/platform/app/features/automations/components/automation-tester.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 
 import { JsonInput } from '@/app/components/ui/forms/json-input';
+import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -68,15 +69,25 @@ export function AutomationTester({
     return buildInputTemplateFromSchema(startConfig?.inputSchema);
   }, [workflowRead]);
 
-  const [testInput, setTestInput] = useState('{}');
-  const [hasUserEdited, setHasUserEdited] = useState(false);
+  // Persist per (org, workflow) so a tester reopening the panel sees the
+  // last input they ran with — typical iteration is "tweak, run, tweak, run"
+  // on the same payload.
+  const storageKey = `tale.automation-tester.input.${organizationId}.${workflowSlug}`;
+  const [testInput, setTestInput] = usePersistedState(storageKey, '{}');
 
-  // Pre-fill from inputSchema once the workflow loads, but never overwrite
-  // edits the user has already typed.
+  // Pre-fill from inputSchema only the very first time this workflow's
+  // tester is opened. We can't gate on `testInput === '{}'` here — that
+  // races with usePersistedState's own hydration effect (it would overwrite
+  // the cached value with the template before hydration commits, then the
+  // hook's persist effect would write the template back to storage and the
+  // cache would be lost forever). Reading localStorage directly avoids the
+  // race because it's the same source of truth the hook uses.
   useEffect(() => {
-    if (hasUserEdited) return;
+    if (typeof window === 'undefined') return;
+    if (inputTemplate === '{}') return;
+    if (window.localStorage.getItem(storageKey) !== null) return;
     setTestInput(inputTemplate);
-  }, [inputTemplate, hasUserEdited]);
+  }, [inputTemplate, storageKey, setTestInput]);
 
   const [isDryRunning, setIsDryRunning] = useState(false);
   const [dryRunResult, setDryRunResult] = useState<DryRunResult | null>(null);
@@ -154,8 +165,6 @@ export function AutomationTester({
         description: t('tester.toast.executionId', { id: executionId }),
       });
 
-      setTestInput(inputTemplate);
-      setHasUserEdited(false);
       setDryRunResult(null);
       onTestComplete?.();
     } catch (error) {
@@ -196,7 +205,6 @@ export function AutomationTester({
           value={testInput}
           onChange={(value) => {
             setTestInput(value);
-            setHasUserEdited(true);
             setDryRunResult(null);
           }}
           label={t('tester.inputLabel')}

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -23,12 +23,14 @@ import { PageLayout } from '@/app/components/layout/page-layout';
 import { ActiveEditorProvider } from '@/app/components/ui/editor';
 import { AutomationAIChatPanel } from '@/app/features/automations/components/automation-ai-chat-panel';
 import { AutomationNavigation } from '@/app/features/automations/components/automation-navigation';
+import { AUTOMATION_PANEL_URL_DEFINITIONS } from '@/app/features/automations/components/automation-steps';
 import { useReadWorkflow } from '@/app/features/automations/hooks/file-queries';
 import {
   WorkflowConfigProvider,
   useWorkflowConfig,
 } from '@/app/features/automations/hooks/use-workflow-config-context';
 import { useWorkflowActivity } from '@/app/features/automations/triggers/hooks/queries';
+import { useUrlState } from '@/app/hooks/use-url-state';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -251,13 +253,20 @@ function AutomationDetailInner({
   const [isAIChatOpen, setIsAIChatOpen] = useState(true);
   const [panelWidth, setPanelWidth] = useState(384);
 
+  const { state: panelState, clearAll: clearPanelUrlState } = useUrlState({
+    definitions: AUTOMATION_PANEL_URL_DEFINITIONS,
+  });
+  const isUrlSidePanelOpen =
+    panelState.panel === 'test' || panelState.panel === 'step';
+
   const handleCloseAIChat = useCallback(() => {
     setIsAIChatOpen(false);
   }, []);
 
   const handleOpenAIChat = useCallback(() => {
+    clearPanelUrlState();
     setIsAIChatOpen(true);
-  }, []);
+  }, [clearPanelUrlState]);
 
   useEffect(() => {
     const handler = () => void onRefetch();
@@ -335,7 +344,7 @@ function AutomationDetailInner({
           )}
         </div>
 
-        {isAIChatOpen && (
+        {isAIChatOpen && !isUrlSidePanelOpen && (
           <AutomationAIChatPanel
             workflowSlug={workflowSlug}
             workflowName={config.name}

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -23,6 +23,7 @@ import { PageLayout } from '@/app/components/layout/page-layout';
 import { ActiveEditorProvider } from '@/app/components/ui/editor';
 import { AutomationAIChatPanel } from '@/app/features/automations/components/automation-ai-chat-panel';
 import { AutomationNavigation } from '@/app/features/automations/components/automation-navigation';
+import { AutomationSidePanel } from '@/app/features/automations/components/automation-sidepanel';
 import { AUTOMATION_PANEL_URL_DEFINITIONS } from '@/app/features/automations/components/automation-steps';
 import { useReadWorkflow } from '@/app/features/automations/hooks/file-queries';
 import {
@@ -296,6 +297,28 @@ function AutomationDetailInner({
     [config.steps, workflowSlug, organizationId],
   );
 
+  const selectedStep = useMemo(() => {
+    if (!panelState.step) return null;
+    const found = steps.find((s) => s.stepSlug === panelState.step);
+    if (!found) return null;
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- file-based steps mapped to Doc shape; AutomationSidePanel only reads display fields
+    return found as Doc<'wfStepDefs'>;
+  }, [steps, panelState.step]);
+
+  const stepOptions = useMemo(
+    () =>
+      steps.map((s) => ({
+        stepSlug: s.stepSlug,
+        name: s.name,
+        stepType: s.stepType,
+        actionType:
+          s.stepType === 'action' && 'type' in s.config
+            ? s.config.type
+            : undefined,
+      })),
+    [steps],
+  );
+
   return (
     <PageLayout
       header={
@@ -334,8 +357,6 @@ function AutomationDetailInner({
                 className="flex-1"
                 // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- file-based steps mapped to Doc shape; component only reads display fields
                 steps={steps as Doc<'wfStepDefs'>[]}
-                organizationId={organizationId}
-                automationId={workflowSlug}
                 onOpenAIChat={handleOpenAIChat}
               />
             </Suspense>
@@ -352,7 +373,20 @@ function AutomationDetailInner({
             onClose={handleCloseAIChat}
             panelWidth={panelWidth}
             onPanelWidthChange={setPanelWidth}
-            overlay
+          />
+        )}
+
+        {isUrlSidePanelOpen && (
+          <AutomationSidePanel
+            step={selectedStep}
+            isOpen
+            onClose={clearPanelUrlState}
+            showTestPanel={panelState.panel === 'test'}
+            automationId={workflowSlug}
+            organizationId={organizationId}
+            stepOptions={stepOptions}
+            panelWidth={panelWidth}
+            onPanelWidthChange={setPanelWidth}
           />
         )}
       </div>

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -290,6 +290,7 @@ import type * as documents_update_document from "../documents/update_document.js
 import type * as documents_update_document_internal from "../documents/update_document_internal.js";
 import type * as documents_update_document_rag_info from "../documents/update_document_rag_info.js";
 import type * as documents_upload_base64_to_storage from "../documents/upload_base64_to_storage.js";
+import type * as documents_upsert_document_by_external_id from "../documents/upsert_document_by_external_id.js";
 import type * as documents_validators from "../documents/validators.js";
 import type * as feedback_mutations from "../feedback/mutations.js";
 import type * as feedback_queries from "../feedback/queries.js";
@@ -307,8 +308,10 @@ import type * as file_metadata_transcribe_audio from "../file_metadata/transcrib
 import type * as file_metadata_transcribe_dictation from "../file_metadata/transcribe_dictation.js";
 import type * as files_mutations from "../files/mutations.js";
 import type * as files_queries from "../files/queries.js";
+import type * as folders_find_folder_by_path from "../folders/find_folder_by_path.js";
 import type * as folders_get_or_create_path from "../folders/get_or_create_path.js";
 import type * as folders_internal_mutations from "../folders/internal_mutations.js";
+import type * as folders_internal_queries from "../folders/internal_queries.js";
 import type * as folders_mutations from "../folders/mutations.js";
 import type * as folders_queries from "../folders/queries.js";
 import type * as governance_budget_enforcement from "../governance/budget_enforcement.js";
@@ -1389,6 +1392,7 @@ declare const fullApi: ApiFromModules<{
   "documents/update_document_internal": typeof documents_update_document_internal;
   "documents/update_document_rag_info": typeof documents_update_document_rag_info;
   "documents/upload_base64_to_storage": typeof documents_upload_base64_to_storage;
+  "documents/upsert_document_by_external_id": typeof documents_upsert_document_by_external_id;
   "documents/validators": typeof documents_validators;
   "feedback/mutations": typeof feedback_mutations;
   "feedback/queries": typeof feedback_queries;
@@ -1406,8 +1410,10 @@ declare const fullApi: ApiFromModules<{
   "file_metadata/transcribe_dictation": typeof file_metadata_transcribe_dictation;
   "files/mutations": typeof files_mutations;
   "files/queries": typeof files_queries;
+  "folders/find_folder_by_path": typeof folders_find_folder_by_path;
   "folders/get_or_create_path": typeof folders_get_or_create_path;
   "folders/internal_mutations": typeof folders_internal_mutations;
+  "folders/internal_queries": typeof folders_internal_queries;
   "folders/mutations": typeof folders_mutations;
   "folders/queries": typeof folders_queries;
   "governance/budget_enforcement": typeof governance_budget_enforcement;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -276,6 +276,7 @@ import type * as documents_internal_queries from "../documents/internal_queries.
 import type * as documents_list_documents_for_agent from "../documents/list_documents_for_agent.js";
 import type * as documents_list_documents_paginated from "../documents/list_documents_paginated.js";
 import type * as documents_list_indexed_documents_for_agent from "../documents/list_indexed_documents_for_agent.js";
+import type * as documents_list_orphaned_external_docs from "../documents/list_orphaned_external_docs.js";
 import type * as documents_migrate_team_fields from "../documents/migrate_team_fields.js";
 import type * as documents_mutations from "../documents/mutations.js";
 import type * as documents_queries from "../documents/queries.js";
@@ -1374,6 +1375,7 @@ declare const fullApi: ApiFromModules<{
   "documents/list_documents_for_agent": typeof documents_list_documents_for_agent;
   "documents/list_documents_paginated": typeof documents_list_documents_paginated;
   "documents/list_indexed_documents_for_agent": typeof documents_list_indexed_documents_for_agent;
+  "documents/list_orphaned_external_docs": typeof documents_list_orphaned_external_docs;
   "documents/migrate_team_fields": typeof documents_migrate_team_fields;
   "documents/mutations": typeof documents_mutations;
   "documents/queries": typeof documents_queries;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -994,6 +994,7 @@ import type * as workflow_engine_helpers_step_execution_initialize_execution_var
 import type * as workflow_engine_helpers_step_execution_load_and_validate_execution from "../workflow_engine/helpers/step_execution/load_and_validate_execution.js";
 import type * as workflow_engine_helpers_step_execution_merge_execution_variables from "../workflow_engine/helpers/step_execution/merge_execution_variables.js";
 import type * as workflow_engine_helpers_step_execution_persist_execution_result from "../workflow_engine/helpers/step_execution/persist_execution_result.js";
+import type * as workflow_engine_helpers_step_execution_record_step_failure from "../workflow_engine/helpers/step_execution/record_step_failure.js";
 import type * as workflow_engine_helpers_step_execution_types from "../workflow_engine/helpers/step_execution/types.js";
 import type * as workflow_engine_helpers_validation_circular_dependency_validator from "../workflow_engine/helpers/validation/circular_dependency_validator.js";
 import type * as workflow_engine_helpers_validation_constants from "../workflow_engine/helpers/validation/constants.js";
@@ -2096,6 +2097,7 @@ declare const fullApi: ApiFromModules<{
   "workflow_engine/helpers/step_execution/load_and_validate_execution": typeof workflow_engine_helpers_step_execution_load_and_validate_execution;
   "workflow_engine/helpers/step_execution/merge_execution_variables": typeof workflow_engine_helpers_step_execution_merge_execution_variables;
   "workflow_engine/helpers/step_execution/persist_execution_result": typeof workflow_engine_helpers_step_execution_persist_execution_result;
+  "workflow_engine/helpers/step_execution/record_step_failure": typeof workflow_engine_helpers_step_execution_record_step_failure;
   "workflow_engine/helpers/step_execution/types": typeof workflow_engine_helpers_step_execution_types;
   "workflow_engine/helpers/validation/circular_dependency_validator": typeof workflow_engine_helpers_validation_circular_dependency_validator;
   "workflow_engine/helpers/validation/constants": typeof workflow_engine_helpers_validation_constants;

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -308,6 +308,7 @@ import type * as file_metadata_transcribe_audio from "../file_metadata/transcrib
 import type * as file_metadata_transcribe_dictation from "../file_metadata/transcribe_dictation.js";
 import type * as files_mutations from "../files/mutations.js";
 import type * as files_queries from "../files/queries.js";
+import type * as folders_cleanup_empty_ancestors from "../folders/cleanup_empty_ancestors.js";
 import type * as folders_find_folder_by_path from "../folders/find_folder_by_path.js";
 import type * as folders_get_or_create_path from "../folders/get_or_create_path.js";
 import type * as folders_internal_mutations from "../folders/internal_mutations.js";
@@ -1411,6 +1412,7 @@ declare const fullApi: ApiFromModules<{
   "file_metadata/transcribe_dictation": typeof file_metadata_transcribe_dictation;
   "files/mutations": typeof files_mutations;
   "files/queries": typeof files_queries;
+  "folders/cleanup_empty_ancestors": typeof folders_cleanup_empty_ancestors;
   "folders/find_folder_by_path": typeof folders_find_folder_by_path;
   "folders/get_or_create_path": typeof folders_get_or_create_path;
   "folders/internal_mutations": typeof folders_internal_mutations;

--- a/services/platform/convex/conversations/internal_actions.ts
+++ b/services/platform/convex/conversations/internal_actions.ts
@@ -125,6 +125,7 @@ export const sendMessageViaIntegrationAction = internalAction({
             ...extraAllowedHosts,
           ],
           timeoutMs: connectorConfig.timeoutMs ?? 30000,
+          organizationId: args.organizationId,
         },
       );
 
@@ -263,6 +264,7 @@ export const checkMessageDeliveryAction = internalAction({
           secrets,
           allowedHosts: connectorConfig.allowedHosts ?? [],
           timeoutMs: connectorConfig.timeoutMs ?? 30000,
+          organizationId: args.organizationId,
         },
       );
 
@@ -395,6 +397,7 @@ export const downloadAttachmentsAction = internalAction({
           secrets,
           allowedHosts: connectorConfig.allowedHosts ?? [],
           timeoutMs: connectorConfig.timeoutMs ?? 30000,
+          organizationId: args.organizationId,
         },
       );
 

--- a/services/platform/convex/documents/actions.ts
+++ b/services/platform/convex/documents/actions.ts
@@ -57,7 +57,7 @@ export const retryRagIndexing = action({
           fileName: document.title,
           contentType: document.mimeType,
         },
-        {},
+        { organizationId: document.organizationId },
       );
       const result = isRecord(rawResult) ? rawResult : undefined;
       const success = result ? (getBoolean(result, 'success') ?? false) : false;

--- a/services/platform/convex/documents/find_document_by_external_id.ts
+++ b/services/platform/convex/documents/find_document_by_external_id.ts
@@ -1,13 +1,15 @@
 /**
  * Find document by external ID (e.g., OneDrive item ID, Google Drive file ID).
  *
- * Optionally scope to a target folder. When `folderId` is provided (or `null`
- * for the root), only docs in that folder are considered — useful for sync
- * flows where the same external file may be synced to multiple Tale folders
- * via separate sync configs (each gets its own document row).
+ * Optional scope:
+ *  - `folderId` matches docs in exactly that folder (`null` for the root).
+ *  - `folderPathPrefix` matches docs whose `folderPath` equals the prefix or
+ *    sits under it (`prefix + '/'`). Used by sync workflows to confine the
+ *    cross-folder fallback to a single sync's subtree, so two independent
+ *    sync configs targeting the same external file do not ping-pong rows.
  *
- * When `folderId` is undefined, returns the first match in any folder
- * (legacy behavior, kept for callers like the OneDrive importer).
+ * Without either scope, returns the first match in any folder (legacy
+ * behavior, kept for callers like the OneDrive importer).
  */
 
 import type { Doc, Id } from '../_generated/dataModel';
@@ -19,6 +21,7 @@ export async function findDocumentByExternalId(
     organizationId: string;
     externalItemId: string;
     folderId?: Id<'folders'> | null;
+    folderPathPrefix?: string;
   },
 ): Promise<Doc<'documents'> | null> {
   const candidates = ctx.db
@@ -29,15 +32,20 @@ export async function findDocumentByExternalId(
         .eq('externalItemId', args.externalItemId),
     );
 
-  if (args.folderId === undefined) {
-    return await candidates.first();
-  }
+  const folderIdScope = args.folderId;
+  const prefix = args.folderPathPrefix;
 
-  // Scoped match: same external item id AND same folder. The expected count
-  // here is at most 1 in normal usage, so a small in-memory filter is fine.
-  const target = args.folderId;
+  // The expected match count for these scopes is at most 1 in normal usage,
+  // so a small in-memory filter is fine.
   for await (const doc of candidates) {
-    if ((doc.folderId ?? null) === target) return doc;
+    if (folderIdScope !== undefined) {
+      if ((doc.folderId ?? null) !== folderIdScope) continue;
+    }
+    if (prefix !== undefined && prefix.length > 0) {
+      const path = doc.folderPath ?? '';
+      if (path !== prefix && !path.startsWith(prefix + '/')) continue;
+    }
+    return doc;
   }
   return null;
 }

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -487,7 +487,9 @@ export const deleteDocumentFromRag = internalAction({
         { method: 'DELETE', timeoutMs: 60_000, orgSlug },
       );
 
-      if (response.ok) {
+      if (response.ok || response.status === 404) {
+        // 404 means the RAG entry was never indexed (or was already deleted)
+        // — either way, the Tale row is the only thing left to clean up.
         ragSuccess = true;
       } else {
         const errorText = await response.text();

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -444,42 +444,76 @@ export const deleteDocumentFromRag = internalAction({
   args: {
     documentId: v.id('documents'),
     attempt: v.optional(v.number()),
+    // Retry-only path: the Tale row was deleted on a previous attempt; this
+    // invocation is finishing the RAG-side cleanup with the cached key + slug.
+    rowAlreadyDeleted: v.optional(v.boolean()),
+    pendingRagFileId: v.optional(v.string()),
+    pendingOrgSlug: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
     const attempt = args.attempt ?? 0;
 
-    const document = await ctx.runQuery(
-      internal.documents.internal_queries.getDocumentByIdRaw,
-      { documentId: args.documentId },
-    );
+    let ragKey: string;
+    let orgSlug: string;
 
-    if (!document?.fileId) {
-      console.warn(
-        `[deleteDocumentFromRag] Document ${args.documentId} has no fileId, skipping RAG delete`,
+    if (args.rowAlreadyDeleted) {
+      if (!args.pendingRagFileId || !args.pendingOrgSlug) {
+        console.error(
+          `[deleteDocumentFromRag] retry invoked without cached key/slug for ${args.documentId}; aborting`,
+        );
+        return null;
+      }
+      ragKey = args.pendingRagFileId;
+      orgSlug = args.pendingOrgSlug;
+    } else {
+      const document = await ctx.runQuery(
+        internal.documents.internal_queries.getDocumentByIdRaw,
+        { documentId: args.documentId },
       );
-      return null;
-    }
 
-    const ragKey = document.fileId;
+      if (!document?.fileId) {
+        console.warn(
+          `[deleteDocumentFromRag] Document ${args.documentId} has no fileId, skipping RAG delete`,
+        );
+        return null;
+      }
 
-    // Resolve slug OUTSIDE the retry-on-RAG-failure path. A missing slug
-    // (org row deleted) is terminal — previously each retry re-threw
-    // here, exhausted DELETE_RETRY_DELAYS, then "Document remains in
-    // database" forever. Treat slug-missing as "RAG-side index is gone
-    // too" and proceed with the local-row delete.
-    const orgSlug = await orgSlugFromIdOrNull(ctx, document.organizationId);
-    if (orgSlug === null) {
-      console.warn(
-        `[deleteDocumentFromRag] org ${document.organizationId} unresolvable; assuming RAG index already purged and deleting local document ${args.documentId}`,
+      // Resolve slug OUTSIDE the retry-on-RAG-failure path. A missing slug
+      // (org row deleted) is terminal — previously each retry re-threw
+      // here, exhausted DELETE_RETRY_DELAYS, then "Document remains in
+      // database" forever. Treat slug-missing as "RAG-side index is gone
+      // too" and proceed with the local-row delete.
+      const resolvedOrgSlug = await orgSlugFromIdOrNull(
+        ctx,
+        document.organizationId,
       );
+      if (resolvedOrgSlug === null) {
+        console.warn(
+          `[deleteDocumentFromRag] org ${document.organizationId} unresolvable; assuming RAG index already purged and deleting local document ${args.documentId}`,
+        );
+        await ctx.runMutation(
+          internal.documents.internal_mutations.deleteDocumentById,
+          { documentId: args.documentId },
+        );
+        return null;
+      }
+
+      ragKey = document.fileId;
+      orgSlug = resolvedOrgSlug;
+
+      // Tale-row first. assertNotHeld may throw on legal hold — when it
+      // does, the RAG vectors stay intact (correct legal-hold semantics:
+      // held docs remain both stored and searchable). The throw propagates
+      // out of this action; scheduler logs it; no orphan side effects.
       await ctx.runMutation(
         internal.documents.internal_mutations.deleteDocumentById,
         { documentId: args.documentId },
       );
-      return null;
     }
 
+    // Tale row is now gone (either by this attempt or a previous one).
+    // Best-effort RAG-side delete; retry only the RAG step if it fails.
     let ragSuccess = false;
     try {
       const response = await ragFetch(
@@ -488,8 +522,7 @@ export const deleteDocumentFromRag = internalAction({
       );
 
       if (response.ok || response.status === 404) {
-        // 404 means the RAG entry was never indexed (or was already deleted)
-        // — either way, the Tale row is the only thing left to clean up.
+        // 404 means the RAG entry was never indexed (or was already deleted).
         ragSuccess = true;
       } else {
         const errorText = await response.text();
@@ -504,24 +537,27 @@ export const deleteDocumentFromRag = internalAction({
       );
     }
 
-    if (ragSuccess) {
-      await ctx.runMutation(
-        internal.documents.internal_mutations.deleteDocumentById,
-        { documentId: args.documentId },
-      );
-    } else if (attempt < DELETE_RETRY_DELAYS.length) {
-      console.warn(
-        `[deleteDocumentFromRag] Scheduling retry ${attempt + 1}/${DELETE_RETRY_DELAYS.length} for ${args.documentId}`,
-      );
-      await ctx.scheduler.runAfter(
-        DELETE_RETRY_DELAYS[attempt],
-        internal.documents.internal_actions.deleteDocumentFromRag,
-        { documentId: args.documentId, attempt: attempt + 1 },
-      );
-    } else {
-      console.error(
-        `[deleteDocumentFromRag] All retries exhausted for ${args.documentId}. Document remains in database.`,
-      );
+    if (!ragSuccess) {
+      if (attempt < DELETE_RETRY_DELAYS.length) {
+        console.warn(
+          `[deleteDocumentFromRag] Tale row deleted; scheduling RAG-only retry ${attempt + 1}/${DELETE_RETRY_DELAYS.length} for ${args.documentId}`,
+        );
+        await ctx.scheduler.runAfter(
+          DELETE_RETRY_DELAYS[attempt],
+          internal.documents.internal_actions.deleteDocumentFromRag,
+          {
+            documentId: args.documentId,
+            attempt: attempt + 1,
+            rowAlreadyDeleted: true,
+            pendingRagFileId: ragKey,
+            pendingOrgSlug: orgSlug,
+          },
+        );
+      } else {
+        console.error(
+          `[deleteDocumentFromRag] All RAG-side retries exhausted for ${args.documentId}. Tale row deleted; RAG entry may linger.`,
+        );
+      }
     }
 
     return null;
@@ -722,7 +758,12 @@ export const reindexDocumentInRag = internalAction({
     // A failed upload leaves the previous chunks in place so search
     // keeps returning the prior revision (degraded but consistent)
     // instead of returning nothing.
-    if (uploadSuccess) {
+    //
+    // Skip the delete when `oldFileId` matches the current `fileId` —
+    // that path covers title-only renames where the upload was a
+    // metadata refresh against the same storage handle, and a delete
+    // would erase the just-uploaded chunks.
+    if (uploadSuccess && args.oldFileId !== document.fileId) {
       const deleteOrgId =
         args.oldOrganizationId ?? document.organizationId ?? null;
       if (deleteOrgId) {

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -459,6 +459,12 @@ export const deleteDocumentFromRag = internalAction({
      */
     expectedExternalItemId: v.optional(v.string()),
     expectedFileId: v.optional(v.id('_storage')),
+    /**
+     * Sync-reconcile only: forwarded to `deleteDocumentById` so the
+     * mutation reaps now-empty ancestor folders up to (but not
+     * including) this folder id (the sync target root).
+     */
+    cleanupAncestorsUpTo: v.optional(v.id('folders')),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
@@ -528,7 +534,10 @@ export const deleteDocumentFromRag = internalAction({
         );
         await ctx.runMutation(
           internal.documents.internal_mutations.deleteDocumentById,
-          { documentId: args.documentId },
+          {
+            documentId: args.documentId,
+            cleanupAncestorsUpTo: args.cleanupAncestorsUpTo,
+          },
         );
         return null;
       }
@@ -542,7 +551,10 @@ export const deleteDocumentFromRag = internalAction({
       // out of this action; scheduler logs it; no orphan side effects.
       await ctx.runMutation(
         internal.documents.internal_mutations.deleteDocumentById,
-        { documentId: args.documentId },
+        {
+          documentId: args.documentId,
+          cleanupAncestorsUpTo: args.cleanupAncestorsUpTo,
+        },
       );
     }
 

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -449,6 +449,16 @@ export const deleteDocumentFromRag = internalAction({
     rowAlreadyDeleted: v.optional(v.boolean()),
     pendingRagFileId: v.optional(v.string()),
     pendingOrgSlug: v.optional(v.string()),
+    /**
+     * Snapshot-and-verify: when the caller (e.g. reconcile_deletes) knows
+     * the externalItemId / fileId it intended to delete, pass them so we
+     * can abort if the row was re-bound by an interleaving upsert (e.g.
+     * a restore racing with a pending reconcile delete). Missing fields
+     * preserve the legacy unconditional-delete behavior so already-
+     * scheduled jobs from earlier code keep working.
+     */
+    expectedExternalItemId: v.optional(v.string()),
+    expectedFileId: v.optional(v.id('_storage')),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
@@ -475,6 +485,30 @@ export const deleteDocumentFromRag = internalAction({
       if (!document?.fileId) {
         console.warn(
           `[deleteDocumentFromRag] Document ${args.documentId} has no fileId, skipping RAG delete`,
+        );
+        return null;
+      }
+
+      // Snapshot-and-verify (reconcile path): if the row's identifying
+      // fields no longer match what the caller staged, abandon the
+      // delete — the doc was re-bound (restore, externalItemId fixup,
+      // or new upload under same documentId) since this job was
+      // scheduled, and the orphan claim is stale.
+      if (
+        args.expectedExternalItemId !== undefined &&
+        document.externalItemId !== args.expectedExternalItemId
+      ) {
+        console.warn(
+          `[deleteDocumentFromRag] Aborting stale delete for ${args.documentId}: expected externalItemId=${args.expectedExternalItemId} but row now has ${document.externalItemId ?? 'undefined'}`,
+        );
+        return null;
+      }
+      if (
+        args.expectedFileId !== undefined &&
+        document.fileId !== args.expectedFileId
+      ) {
+        console.warn(
+          `[deleteDocumentFromRag] Aborting stale delete for ${args.documentId}: expected fileId=${args.expectedFileId} but row now has ${document.fileId}`,
         );
         return null;
       }
@@ -693,7 +727,33 @@ export const reindexDocumentInRag = internalAction({
       return null;
     }
 
-    // Upload new file to RAG FIRST.
+    // Title-only rename detection: when the caller passes the same fileId
+    // as the row's current fileId, the upload would dedup against the
+    // existing RAG row (RAG's content-hash dedup short-circuits before
+    // touching `filename`), so the new title would never reach search
+    // results. Purge the old RAG row FIRST so the subsequent upload
+    // inserts a fresh row carrying the new filename. Brief search gap
+    // until the new chunks land — acceptable; reconcile-tolerant.
+    const sameFileId = args.oldFileId === document.fileId;
+    if (sameFileId) {
+      const deleteOrgId =
+        args.oldOrganizationId ?? document.organizationId ?? null;
+      if (deleteOrgId) {
+        await deleteOldRagEntry(
+          ctx,
+          deleteOrgId,
+          args.oldFileId,
+          args.documentId,
+        );
+      } else {
+        console.warn(
+          `[reindexDocumentInRag] No org context for pre-upload old RAG delete; oldFileId ${args.oldFileId} may leak chunks (documentId=${args.documentId})`,
+        );
+      }
+    }
+
+    // Upload new file to RAG FIRST (for the content-change path; for the
+    // same-fileId rename path the old row is already gone above).
     let uploadSuccess = false;
     try {
       const rawResult = await ragAction.execute(
@@ -754,16 +814,15 @@ export const reindexDocumentInRag = internalAction({
       );
     }
 
-    // Only purge the old RAG entry once the new upload is committed.
-    // A failed upload leaves the previous chunks in place so search
-    // keeps returning the prior revision (degraded but consistent)
-    // instead of returning nothing.
+    // Content-change path: purge the old RAG entry once the new upload
+    // is committed. A failed upload leaves the previous chunks in place
+    // so search keeps returning the prior revision (degraded but
+    // consistent) instead of returning nothing.
     //
-    // Skip the delete when `oldFileId` matches the current `fileId` —
-    // that path covers title-only renames where the upload was a
-    // metadata refresh against the same storage handle, and a delete
-    // would erase the just-uploaded chunks.
-    if (uploadSuccess && args.oldFileId !== document.fileId) {
+    // Same-fileId (title-only rename) is already handled above by the
+    // pre-upload delete, so we skip the post-upload purge for that path
+    // to avoid deleting the freshly-uploaded chunks.
+    if (uploadSuccess && !sameFileId) {
       const deleteOrgId =
         args.oldOrganizationId ?? document.organizationId ?? null;
       if (deleteOrgId) {

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -637,7 +637,7 @@ export const uploadDocumentToRag = internalAction({
           fileName: document.title,
           contentType: document.mimeType,
         },
-        {},
+        { organizationId: document.organizationId },
       );
       const resultRec = isRecord(rawResult) ? rawResult : undefined;
       const success = resultRec
@@ -776,7 +776,7 @@ export const reindexDocumentInRag = internalAction({
           fileName: document.title,
           contentType: document.mimeType,
         },
-        {},
+        { organizationId: document.organizationId },
       );
       const resultRec = isRecord(rawResult) ? rawResult : undefined;
       const success = resultRec

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -7,6 +7,7 @@ import { assertNotHeld } from '../governance/legal_hold_guard';
 import { createDocument as createDocumentHelper } from './create_document';
 import { updateDocumentInternal as updateDocumentInternalHelper } from './update_document_internal';
 import { updateDocumentRagInfo as updateDocumentRagInfoHelper } from './update_document_rag_info';
+import { upsertDocumentByExternalId as upsertDocumentByExternalIdHelper } from './upsert_document_by_external_id';
 import { sourceProviderValidator, ragInfoValidator } from './validators';
 
 export const updateDocument = internalMutation({
@@ -213,5 +214,32 @@ export const createDocument = internalMutation({
   handler: async (ctx, args) => {
     const result = await createDocumentHelper(ctx, args);
     return result.documentId;
+  },
+});
+
+export const upsertDocumentByExternalId = internalMutation({
+  args: {
+    organizationId: v.string(),
+    externalItemId: v.string(),
+    folderPathPrefix: v.optional(v.string()),
+    title: v.string(),
+    fileId: v.optional(v.id('_storage')),
+    mimeType: v.optional(v.string()),
+    sourceProvider: v.optional(v.string()),
+    contentHash: v.optional(v.string()),
+    metadata: v.optional(jsonRecordValidator),
+    folderId: v.optional(v.id('folders')),
+    createdBy: v.optional(v.string()),
+  },
+  returns: v.object({
+    documentId: v.id('documents'),
+    action: v.union(
+      v.literal('created'),
+      v.literal('updated'),
+      v.literal('skipped'),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    return await upsertDocumentByExternalIdHelper(ctx, args);
   },
 });

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -230,6 +230,10 @@ export const upsertDocumentByExternalId = internalMutation({
     metadata: v.optional(jsonRecordValidator),
     folderId: v.optional(v.id('folders')),
     createdBy: v.optional(v.string()),
+    /** Integration identifier stamped on the row so reconcile can scope
+     * orphan detection per-integration (lets two Drive integrations in
+     * one org coexist under the same `folderPathPrefix`). */
+    driveId: v.optional(v.string()),
   },
   returns: v.object({
     documentId: v.id('documents'),

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -238,6 +238,7 @@ export const upsertDocumentByExternalId = internalMutation({
       v.literal('updated'),
       v.literal('skipped'),
     ),
+    contentChanged: v.boolean(),
   }),
   handler: async (ctx, args) => {
     return await upsertDocumentByExternalIdHelper(ctx, args);

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -2,6 +2,7 @@ import { ConvexError, v } from 'convex/values';
 
 import { jsonRecordValidator } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
+import { cleanupEmptyAncestorFolders } from '../folders/cleanup_empty_ancestors';
 import { eraseDocumentBlobs } from '../governance/erase_document_blobs';
 import { assertNotHeld } from '../governance/legal_hold_guard';
 import { createDocument as createDocumentHelper } from './create_document';
@@ -69,6 +70,13 @@ export const deleteDocumentById = internalMutation({
      * callers (retention sweep, workflow); REST handlers MUST pass this.
      */
     callerOrgId: v.optional(v.string()),
+    /**
+     * Sync-reconcile only: after the row is deleted, walk up from the
+     * doc's `folderId` and remove ancestor folders that became empty,
+     * stopping at (and never deleting) this id (the sync target root).
+     * Omit for user-initiated deletes — folder reaping is opt-in.
+     */
+    cleanupAncestorsUpTo: v.optional(v.id('folders')),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -113,8 +121,19 @@ export const deleteDocumentById = internalMutation({
       // _storage forever — both the storage cost and the unreachable-blob
       // privacy risk. The retention path was already correct via the
       // helper. Round-2 review CRITICAL #18.
+      const folderIdBeforeDelete = document.folderId;
+      const organizationId = document.organizationId;
       await eraseDocumentBlobs(ctx, document);
       await ctx.db.delete(args.documentId);
+
+      if (args.cleanupAncestorsUpTo && folderIdBeforeDelete) {
+        await cleanupEmptyAncestorFolders(
+          ctx,
+          folderIdBeforeDelete,
+          args.cleanupAncestorsUpTo,
+          organizationId,
+        );
+      }
     }
     return null;
   },

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -57,6 +57,10 @@ export const findDocumentByExternalId = internalQuery({
     // When provided, scopes the lookup to a specific target folder (`null`
     // means the root). Omit to match across all folders (legacy behavior).
     folderId: v.optional(v.union(v.id('folders'), v.null())),
+    // When provided, scopes the lookup to docs whose `folderPath` equals the
+    // prefix or sits under it. Used by sync workflows to keep the cross-folder
+    // fallback confined to a single sync's target subtree.
+    folderPathPrefix: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     return await DocumentsHelpers.findDocumentByExternalId(ctx, args);

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -9,6 +9,7 @@ import { getAgentScopedFileIds as getAgentScopedFileIdsHelper } from './get_agen
 import * as DocumentsHelpers from './helpers';
 import { listDocumentsForAgent as listDocumentsForAgentHelper } from './list_documents_for_agent';
 import { listIndexedDocumentsForAgent as listIndexedDocumentsForAgentHelper } from './list_indexed_documents_for_agent';
+import { listOrphanedExternalDocs as listOrphanedExternalDocsHelper } from './list_orphaned_external_docs';
 import { sourceProviderValidator } from './validators';
 
 export const getDocumentByIdRaw = internalQuery({
@@ -161,6 +162,18 @@ export const listIndexedForAgent = internalQuery({
   },
   handler: async (ctx, args) => {
     return listIndexedDocumentsForAgentHelper(ctx, args);
+  },
+});
+
+export const listOrphanedExternalDocs = internalQuery({
+  args: {
+    organizationId: v.string(),
+    sourceProvider: v.string(),
+    folderPathPrefix: v.string(),
+    presentExternalIds: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await listOrphanedExternalDocsHelper(ctx, args);
   },
 });
 

--- a/services/platform/convex/documents/internal_queries.ts
+++ b/services/platform/convex/documents/internal_queries.ts
@@ -175,6 +175,7 @@ export const listOrphanedExternalDocs = internalQuery({
     sourceProvider: v.string(),
     folderPathPrefix: v.string(),
     presentExternalIds: v.array(v.string()),
+    driveId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     return await listOrphanedExternalDocsHelper(ctx, args);

--- a/services/platform/convex/documents/list_orphaned_external_docs.test.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest';
+
+import { listOrphanedExternalDocs } from '../list_orphaned_external_docs';
+
+interface MockDoc {
+  _id: string;
+  organizationId: string;
+  sourceProvider?: string;
+  externalItemId?: string;
+  fileId?: string;
+  folderPath?: string;
+}
+
+function createMockCtx(docs: MockDoc[]) {
+  return {
+    db: {
+      query: () => ({
+        withIndex: (
+          _indexName: string,
+          builder: (q: {
+            eq: (field: string, value: unknown) => unknown;
+            gte: (field: string, value: unknown) => unknown;
+            lt: (field: string, value: unknown) => unknown;
+          }) => unknown,
+        ) => {
+          let orgEq: string | undefined;
+          let pathEq: string | undefined;
+          let pathGte: string | undefined;
+          let pathLt: string | undefined;
+
+          const q = {
+            eq: (field: string, value: unknown) => {
+              if (field === 'organizationId') orgEq = value as string;
+              else if (field === 'folderPath') pathEq = value as string;
+              return q;
+            },
+            gte: (field: string, value: unknown) => {
+              if (field === 'folderPath') pathGte = value as string;
+              return q;
+            },
+            lt: (field: string, value: unknown) => {
+              if (field === 'folderPath') pathLt = value as string;
+              return q;
+            },
+          };
+          builder(q);
+
+          const matched = docs.filter((doc) => {
+            if (doc.organizationId !== orgEq) return false;
+            const path = doc.folderPath ?? '';
+            if (pathEq !== undefined && doc.folderPath !== pathEq) return false;
+            if (pathGte !== undefined && path < pathGte) return false;
+            if (pathLt !== undefined && path >= pathLt) return false;
+            return true;
+          });
+
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              for (const m of matched) yield m;
+            },
+          };
+        },
+      }),
+    },
+  };
+}
+
+const ORG = 'org1';
+const PROVIDER = 'google_drive';
+
+describe('listOrphanedExternalDocs', () => {
+  it('returns nothing when every present id maps to a stored doc', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-1',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-2',
+        folderPath: 'Test/sub',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: ['gd-1', 'gd-2'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns the set difference (docs missing from present ids)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-1',
+        fileId: 'f1',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-2',
+        fileId: 'f2',
+        folderPath: 'Test/sub',
+      },
+      {
+        _id: 'd3',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-3',
+        fileId: 'f3',
+        folderPath: 'Test/sub/deep',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: ['gd-1'],
+    });
+
+    expect(result.map((r) => r.externalItemId).sort()).toEqual([
+      'gd-2',
+      'gd-3',
+    ]);
+  });
+
+  it('does not delete docs from a different sourceProvider', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: 'upload',
+        externalItemId: 'manual-1',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-stale',
+        folderPath: 'Test',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].externalItemId).toBe('gd-stale');
+  });
+
+  it('does not delete docs without an externalItemId (manual uploads sharing the path)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: undefined,
+        folderPath: 'Test',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('respects the prefix boundary so "Test 2/x" is NOT treated as a child of "Test"', async () => {
+    // This is the key bug from the plan review: a naive `< rootPath + '￿'`
+    // bound would match "Test 2/x" because space (0x20) < '/' (0x2F).
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-test-root',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-test-child',
+        folderPath: 'Test/sub',
+      },
+      {
+        _id: 'd3',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-test2-child',
+        folderPath: 'Test 2/x', // sibling sync, must NOT be deleted
+      },
+      {
+        _id: 'd4',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-testbang',
+        folderPath: 'Test!sibling', // also not a child
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [], // every Test-subtree doc is "missing"
+    });
+
+    const ids = result.map((r) => r.externalItemId).sort();
+    expect(ids).toEqual(['gd-test-child', 'gd-test-root']);
+  });
+
+  it('returns all candidates when presentIds is empty (caller decides safety)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-1',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-2',
+        folderPath: 'Test/sub',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('forwards fileId so the caller can branch RAG vs DB delete', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-1',
+        fileId: 'f-storage-id',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-2',
+        fileId: undefined,
+        folderPath: 'Test',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    const byId = Object.fromEntries(
+      result.map((r) => [r.externalItemId, r.fileId]),
+    );
+    expect(byId['gd-1']).toBe('f-storage-id');
+    expect(byId['gd-2']).toBeUndefined();
+  });
+});

--- a/services/platform/convex/documents/list_orphaned_external_docs.test.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.test.ts
@@ -9,6 +9,9 @@ interface MockDoc {
   externalItemId?: string;
   fileId?: string;
   folderPath?: string;
+  driveId?: string;
+  lifecycleStatus?: string;
+  title?: string;
 }
 
 function createMockCtx(docs: MockDoc[]) {
@@ -293,5 +296,143 @@ describe('listOrphanedExternalDocs', () => {
     );
     expect(byId['gd-1']).toBe('f-storage-id');
     expect(byId['gd-2']).toBeUndefined();
+  });
+
+  it('does not return docs from other organizations (cross-org isolation)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-1',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd2',
+        organizationId: 'org2',
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-2',
+        folderPath: 'Test',
+      },
+      {
+        _id: 'd3',
+        organizationId: 'org2',
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-3',
+        folderPath: 'Test/sub',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    // Only org1's doc may surface; org2's docs MUST be invisible to org1's reconcile.
+    expect(result.map((r) => r.externalItemId)).toEqual(['gd-1']);
+  });
+
+  it('skips soft-deleted docs (H5 — Trash grace window must survive reconcile)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd-active',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-active',
+        folderPath: 'Test',
+        lifecycleStatus: 'active',
+      },
+      {
+        _id: 'd-trashed',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-trashed',
+        folderPath: 'Test',
+        lifecycleStatus: 'trashed',
+      },
+      {
+        _id: 'd-expired',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-expired',
+        folderPath: 'Test/sub',
+        lifecycleStatus: 'expired',
+      },
+    ]);
+
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Test',
+      presentExternalIds: [],
+    });
+
+    expect(result.map((r) => r.externalItemId)).toEqual(['gd-active']);
+  });
+
+  it('scopes by driveId when set (H4 — two integrations sharing a folderPathPrefix)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd-acct-a',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-a-only',
+        folderPath: 'Google Drive',
+        driveId: 'drive-a',
+      },
+      {
+        _id: 'd-acct-b',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-b-only',
+        folderPath: 'Google Drive',
+        driveId: 'drive-b',
+      },
+    ]);
+
+    // Sync run for drive-a with empty listing — must NOT orphan drive-b's doc.
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Google Drive',
+      presentExternalIds: [],
+      driveId: 'drive-a',
+    });
+
+    expect(result.map((r) => r.externalItemId)).toEqual(['gd-a-only']);
+  });
+
+  it('handles trailing slash in folderPathPrefix without collapsing the subtree (M2)', async () => {
+    const ctx = createMockCtx([
+      {
+        _id: 'd-root',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-root',
+        folderPath: 'Inbox',
+      },
+      {
+        _id: 'd-child',
+        organizationId: ORG,
+        sourceProvider: PROVIDER,
+        externalItemId: 'gd-child',
+        folderPath: 'Inbox/sub',
+      },
+    ]);
+
+    // Caller passes "Inbox/" — must still find children under "Inbox/".
+    const result = await listOrphanedExternalDocs(ctx as never, {
+      organizationId: ORG,
+      sourceProvider: PROVIDER,
+      folderPathPrefix: 'Inbox/',
+      presentExternalIds: [],
+    });
+
+    expect(result.map((r) => r.externalItemId).sort()).toEqual([
+      'gd-child',
+      'gd-root',
+    ]);
   });
 });

--- a/services/platform/convex/documents/list_orphaned_external_docs.test.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { listOrphanedExternalDocs } from '../list_orphaned_external_docs';
+import { listOrphanedExternalDocs } from './list_orphaned_external_docs';
 
 interface MockDoc {
   _id: string;

--- a/services/platform/convex/documents/list_orphaned_external_docs.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.ts
@@ -1,0 +1,68 @@
+import type { Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+
+export interface OrphanedExternalDoc {
+  documentId: Id<'documents'>;
+  externalItemId: string;
+  fileId?: Id<'_storage'>;
+}
+
+export interface ListOrphanedExternalDocsArgs {
+  organizationId: string;
+  sourceProvider: string;
+  folderPathPrefix: string;
+  presentExternalIds: string[];
+}
+
+export async function listOrphanedExternalDocs(
+  ctx: QueryCtx,
+  args: ListOrphanedExternalDocsArgs,
+): Promise<OrphanedExternalDoc[]> {
+  const presentSet = new Set(args.presentExternalIds);
+  const root = args.folderPathPrefix;
+  const orphaned: OrphanedExternalDoc[] = [];
+
+  const collectIfOrphan = (doc: {
+    _id: Id<'documents'>;
+    sourceProvider?: string;
+    externalItemId?: string;
+    fileId?: Id<'_storage'>;
+  }) => {
+    if (
+      doc.sourceProvider === args.sourceProvider &&
+      doc.externalItemId &&
+      !presentSet.has(doc.externalItemId)
+    ) {
+      orphaned.push({
+        documentId: doc._id,
+        externalItemId: doc.externalItemId,
+        fileId: doc.fileId,
+      });
+    }
+  };
+
+  // Exact match for the sync root itself.
+  for await (const doc of ctx.db
+    .query('documents')
+    .withIndex('by_organizationId_and_folderPath', (q) =>
+      q.eq('organizationId', args.organizationId).eq('folderPath', root),
+    )) {
+    collectIfOrphan(doc);
+  }
+
+  // Subtree range scan: [root + '/', root + '/￿').
+  // The '/' separator is required: a bare `< root + '￿'` would also
+  // match siblings like "Test 2/x" because space (0x20) sorts below '/' (0x2F).
+  for await (const doc of ctx.db
+    .query('documents')
+    .withIndex('by_organizationId_and_folderPath', (q) =>
+      q
+        .eq('organizationId', args.organizationId)
+        .gte('folderPath', root + '/')
+        .lt('folderPath', root + '/￿'),
+    )) {
+    collectIfOrphan(doc);
+  }
+
+  return orphaned;
+}

--- a/services/platform/convex/documents/list_orphaned_external_docs.ts
+++ b/services/platform/convex/documents/list_orphaned_external_docs.ts
@@ -5,6 +5,7 @@ export interface OrphanedExternalDoc {
   documentId: Id<'documents'>;
   externalItemId: string;
   fileId?: Id<'_storage'>;
+  title?: string;
 }
 
 export interface ListOrphanedExternalDocsArgs {
@@ -12,6 +13,11 @@ export interface ListOrphanedExternalDocsArgs {
   sourceProvider: string;
   folderPathPrefix: string;
   presentExternalIds: string[];
+  /** When set, only orphan docs whose `driveId` matches. Lets two Drive
+   * (or other) integrations in one org coexist under overlapping
+   * `folderPathPrefix`es without mutually orphaning each other. Missing
+   * = legacy behavior (no integration scope). */
+  driveId?: string;
 }
 
 export async function listOrphanedExternalDocs(
@@ -19,7 +25,9 @@ export async function listOrphanedExternalDocs(
   args: ListOrphanedExternalDocsArgs,
 ): Promise<OrphanedExternalDoc[]> {
   const presentSet = new Set(args.presentExternalIds);
-  const root = args.folderPathPrefix;
+  // Normalize trailing slash so a workflow input like "Inbox/" doesn't
+  // collapse the subtree range to "Inbox//".."Inbox//￿".
+  const root = args.folderPathPrefix.replace(/\/+$/, '');
   const orphaned: OrphanedExternalDoc[] = [];
 
   const collectIfOrphan = (doc: {
@@ -27,7 +35,17 @@ export async function listOrphanedExternalDocs(
     sourceProvider?: string;
     externalItemId?: string;
     fileId?: Id<'_storage'>;
+    title?: string;
+    driveId?: string;
+    lifecycleStatus?: string;
   }) => {
+    // Skip soft-deleted rows (trashed/expired/deleted) — the Trash UI
+    // grace window depends on those rows surviving until the user
+    // restores or the grace period elapses; reconcile must not hard-
+    // delete them out from under that flow.
+    const status = doc.lifecycleStatus ?? 'active';
+    if (status !== 'active') return;
+    if (args.driveId !== undefined && doc.driveId !== args.driveId) return;
     if (
       doc.sourceProvider === args.sourceProvider &&
       doc.externalItemId &&
@@ -37,6 +55,7 @@ export async function listOrphanedExternalDocs(
         documentId: doc._id,
         externalItemId: doc.externalItemId,
         fileId: doc.fileId,
+        title: doc.title,
       });
     }
   };

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -71,12 +71,27 @@ export async function updateDocumentInternal(
     finalUpdateData.historyFiles = historyFiles;
   }
 
+  // Title-only rename on an already-indexed doc: RAG stores the filename at
+  // upload time, so the search/citation surface keeps the old name until we
+  // delete and re-upload. Same scheduler path as the content-change case;
+  // `reindexDocumentInRag` reads the (just-patched) new title at upload.
+  const titleChanged =
+    updateData.title !== undefined && document.title !== updateData.title;
+
   // If file changed and document was RAG-indexed, mark as queued for re-indexing
-  const needsReindex =
+  const needsContentReindex =
     hashChanged &&
     hasNewFile &&
     document.ragInfo?.status === 'completed' &&
     document.fileId;
+
+  const needsTitleReindex =
+    titleChanged &&
+    !hashChanged &&
+    document.ragInfo?.status === 'completed' &&
+    document.fileId;
+
+  const needsReindex = needsContentReindex || needsTitleReindex;
 
   if (needsReindex) {
     finalUpdateData.ragInfo = {

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutationCtx } from '../../_generated/server';
+import { upsertDocumentByExternalId } from '../upsert_document_by_external_id';
+
+interface MockDoc {
+  _id: string;
+  organizationId: string;
+  externalItemId?: string;
+  folderPath?: string;
+  contentHash?: string;
+  title?: string;
+  fileId?: string;
+}
+
+function createMockCtx(initial: MockDoc[]) {
+  const docs = new Map<string, MockDoc>();
+  for (const doc of initial) docs.set(doc._id, doc);
+  let counter = initial.length;
+  const inserts: MockDoc[] = [];
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+
+  const ctx = {
+    db: {
+      query: () => ({
+        withIndex: (
+          _idx: string,
+          cb: (q: {
+            eq: (field: string, value: unknown) => unknown;
+          }) => unknown,
+        ) => {
+          let orgFilter: string | undefined;
+          let externalFilter: string | undefined;
+          const qb = {
+            eq: (field: string, value: unknown) => {
+              if (field === 'organizationId') orgFilter = value as string;
+              if (field === 'externalItemId') externalFilter = value as string;
+              return qb;
+            },
+          };
+          cb(qb);
+          const matched: MockDoc[] = [];
+          for (const doc of docs.values()) {
+            if (
+              doc.organizationId === orgFilter &&
+              doc.externalItemId === externalFilter
+            ) {
+              matched.push(doc);
+            }
+          }
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              for (const m of matched) yield m;
+            },
+          };
+        },
+      }),
+      insert: (_table: string, doc: Record<string, unknown>) => {
+        const id = `doc_${++counter}`;
+        const stored: MockDoc = {
+          _id: id,
+          organizationId: doc.organizationId as string,
+          externalItemId: doc.externalItemId as string | undefined,
+          folderPath: doc.folderPath as string | undefined,
+          contentHash: doc.contentHash as string | undefined,
+          title: doc.title as string | undefined,
+          fileId: doc.fileId as string | undefined,
+        };
+        docs.set(id, stored);
+        inserts.push(stored);
+        return Promise.resolve(id);
+      },
+      patch: (id: string, patch: Record<string, unknown>) => {
+        patches.push({ id, patch });
+        const existing = docs.get(id);
+        if (existing) {
+          docs.set(id, { ...existing, ...patch });
+        }
+        return Promise.resolve(undefined);
+      },
+      get: () => Promise.resolve(null),
+    },
+  };
+
+  return { ctx, docs, inserts, patches };
+}
+
+const ORG = 'org1';
+const PROVIDER = 'google_drive';
+
+describe('upsertDocumentByExternalId', () => {
+  it('inserts a new document when none exists', async () => {
+    const { ctx, inserts } = createMockCtx([]);
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        sourceProvider: PROVIDER,
+        contentHash: 'h1',
+      },
+    );
+    expect(result.action).toBe('created');
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].externalItemId).toBe('gd-1');
+  });
+
+  it('returns "skipped" when the existing doc has the same contentHash', async () => {
+    const { ctx, inserts, patches } = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        contentHash: 'h1',
+        folderPath: 'Sync',
+      },
+    ]);
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        folderPathPrefix: 'Sync',
+      },
+    );
+    expect(result.action).toBe('skipped');
+    expect(result.documentId).toBe('d1');
+    expect(inserts).toHaveLength(0);
+    expect(patches).toHaveLength(0);
+  });
+
+  it('updates the existing doc when contentHash differs', async () => {
+    const { ctx, inserts, patches } = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        contentHash: 'h1',
+        folderPath: 'Sync',
+      },
+    ]);
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h2',
+        folderPathPrefix: 'Sync',
+      },
+    );
+    expect(result.action).toBe('updated');
+    expect(result.documentId).toBe('d1');
+    expect(inserts).toHaveLength(0);
+    expect(patches).toHaveLength(1);
+    expect(patches[0].patch.contentHash).toBe('h2');
+  });
+
+  it('finds an existing doc anywhere under the prefix subtree (cross-folder move)', async () => {
+    const { ctx, patches } = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        contentHash: 'h1',
+        folderPath: 'Sync/A',
+      },
+    ]);
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h2',
+        // The doc moved from Sync/A → Sync/B inside the same sync subtree.
+        folderPathPrefix: 'Sync',
+      },
+    );
+    expect(result.action).toBe('updated');
+    expect(result.documentId).toBe('d1');
+    expect(patches).toHaveLength(1);
+  });
+
+  it('does NOT match docs outside the prefix subtree (two independent syncs)', async () => {
+    const { ctx, inserts } = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        contentHash: 'h1',
+        folderPath: 'SyncA/files',
+      },
+    ]);
+    // Second sync targets SyncB; should NOT pick up the doc in SyncA.
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        folderPathPrefix: 'SyncB',
+      },
+    );
+    expect(result.action).toBe('created');
+    expect(inserts).toHaveLength(1);
+  });
+
+  it('does not consider "Sync 2/x" as a child of "Sync"', async () => {
+    const { ctx, inserts } = createMockCtx([
+      {
+        _id: 'd1',
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        contentHash: 'h1',
+        folderPath: 'Sync 2/x',
+      },
+    ]);
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        folderPathPrefix: 'Sync',
+      },
+    );
+    // No match → new row inserted. The 'Sync 2/x' doc is left alone.
+    expect(result.action).toBe('created');
+    expect(inserts).toHaveLength(1);
+  });
+});

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -7,15 +7,26 @@ interface MockDoc {
   _id: string;
   organizationId: string;
   externalItemId?: string;
+  folderId?: string;
   folderPath?: string;
   contentHash?: string;
   title?: string;
   fileId?: string;
+  metadata?: Record<string, unknown>;
 }
 
-function createMockCtx(initial: MockDoc[]) {
+interface MockFolder {
+  _id: string;
+  name: string;
+  parentId?: string;
+  organizationId: string;
+}
+
+function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
   const docs = new Map<string, MockDoc>();
   for (const doc of initial) docs.set(doc._id, doc);
+  const folders = new Map<string, MockFolder>();
+  for (const f of initialFolders) folders.set(f._id, f);
   let counter = initial.length;
   const inserts: MockDoc[] = [];
   const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
@@ -61,10 +72,12 @@ function createMockCtx(initial: MockDoc[]) {
           _id: id,
           organizationId: doc.organizationId as string,
           externalItemId: doc.externalItemId as string | undefined,
+          folderId: doc.folderId as string | undefined,
           folderPath: doc.folderPath as string | undefined,
           contentHash: doc.contentHash as string | undefined,
           title: doc.title as string | undefined,
           fileId: doc.fileId as string | undefined,
+          metadata: doc.metadata as Record<string, unknown> | undefined,
         };
         docs.set(id, stored);
         inserts.push(stored);
@@ -78,7 +91,8 @@ function createMockCtx(initial: MockDoc[]) {
         }
         return Promise.resolve(undefined);
       },
-      get: () => Promise.resolve(null),
+      get: (id: string) =>
+        Promise.resolve(folders.get(id) ?? docs.get(id) ?? null),
     },
   };
 
@@ -89,7 +103,7 @@ const ORG = 'org1';
 const PROVIDER = 'google_drive';
 
 describe('upsertDocumentByExternalId', () => {
-  it('inserts a new document when none exists', async () => {
+  it('inserts a new document when none exists — contentHash omitted on insert', async () => {
     const { ctx, inserts } = createMockCtx([]);
     const result = await upsertDocumentByExternalId(
       ctx as unknown as MutationCtx,
@@ -102,11 +116,16 @@ describe('upsertDocumentByExternalId', () => {
       },
     );
     expect(result.action).toBe('created');
+    expect(result.contentChanged).toBe(true);
     expect(inserts).toHaveLength(1);
     expect(inserts[0].externalItemId).toBe('gd-1');
+    // contentHash is intentionally NOT written on insert — the workflow's
+    // finalize step commits it after RAG indexing succeeds so a failed
+    // first-time RAG upload auto-retries on the next sync.
+    expect(inserts[0].contentHash).toBeUndefined();
   });
 
-  it('returns "skipped" when the existing doc has the same contentHash', async () => {
+  it('returns "skipped" only when content + folder + metadata are all unchanged', async () => {
     const { ctx, inserts, patches } = createMockCtx([
       {
         _id: 'd1',
@@ -124,15 +143,17 @@ describe('upsertDocumentByExternalId', () => {
         title: 'file.txt',
         contentHash: 'h1',
         folderPathPrefix: 'Sync',
+        // No folderId, no metadata → nothing to write.
       },
     );
     expect(result.action).toBe('skipped');
+    expect(result.contentChanged).toBe(false);
     expect(result.documentId).toBe('d1');
     expect(inserts).toHaveLength(0);
     expect(patches).toHaveLength(0);
   });
 
-  it('updates the existing doc when contentHash differs', async () => {
+  it('updates content + bumps fileId when contentHash differs', async () => {
     const { ctx, inserts, patches } = createMockCtx([
       {
         _id: 'd1',
@@ -140,6 +161,7 @@ describe('upsertDocumentByExternalId', () => {
         externalItemId: 'gd-1',
         contentHash: 'h1',
         folderPath: 'Sync',
+        fileId: 'storage_old',
       },
     ]);
     const result = await upsertDocumentByExternalId(
@@ -149,17 +171,110 @@ describe('upsertDocumentByExternalId', () => {
         externalItemId: 'gd-1',
         title: 'file.txt',
         contentHash: 'h2',
+        fileId: 'storage_new' as unknown as never,
         folderPathPrefix: 'Sync',
       },
     );
     expect(result.action).toBe('updated');
+    expect(result.contentChanged).toBe(true);
     expect(result.documentId).toBe('d1');
     expect(inserts).toHaveLength(0);
     expect(patches).toHaveLength(1);
-    expect(patches[0].patch.contentHash).toBe('h2');
+    // contentHash is finalized by the workflow's separate step, NOT here.
+    expect(patches[0].patch.contentHash).toBeUndefined();
+    expect(patches[0].patch.fileId).toBe('storage_new');
   });
 
-  it('finds an existing doc anywhere under the prefix subtree (cross-folder move)', async () => {
+  it('patches folder only on same-md5 cross-subfolder move (no contentHash bump, no fileId bump)', async () => {
+    // The C3 fix: a Drive file moved A → B with identical contents should
+    // not orphan-leak Tale rows or re-index RAG.
+    const { ctx, patches } = createMockCtx(
+      [
+        {
+          _id: 'd1',
+          organizationId: ORG,
+          externalItemId: 'gd-1',
+          contentHash: 'h1',
+          folderId: 'folder_a',
+          folderPath: 'Sync/A',
+          fileId: 'storage_keep',
+        },
+      ],
+      [
+        { _id: 'folder_sync', name: 'Sync', organizationId: ORG },
+        {
+          _id: 'folder_a',
+          name: 'A',
+          parentId: 'folder_sync',
+          organizationId: ORG,
+        },
+        {
+          _id: 'folder_b',
+          name: 'B',
+          parentId: 'folder_sync',
+          organizationId: ORG,
+        },
+      ],
+    );
+    const result = await upsertDocumentByExternalId(
+      ctx as unknown as MutationCtx,
+      {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        fileId: 'storage_new' as unknown as never,
+        folderId: 'folder_b' as unknown as never,
+        folderPathPrefix: 'Sync',
+      },
+    );
+    expect(result.action).toBe('updated');
+    expect(result.contentChanged).toBe(false);
+    expect(result.documentId).toBe('d1');
+    expect(patches).toHaveLength(1);
+    expect(patches[0].patch.folderId).toBe('folder_b');
+    expect(patches[0].patch.folderPath).toBe('Sync/B');
+    // fileId stays at the prior storage handle — the new download is not
+    // needed and should not orphan the previously-indexed blob.
+    expect(patches[0].patch.fileId).toBeUndefined();
+    expect(patches[0].patch.contentHash).toBeUndefined();
+  });
+
+  it('rejects an upsert that would move the row outside the prefix subtree (H4)', async () => {
+    const { ctx } = createMockCtx(
+      [
+        {
+          _id: 'd1',
+          organizationId: ORG,
+          externalItemId: 'gd-1',
+          contentHash: 'h1',
+          folderId: 'folder_sync_a',
+          folderPath: 'SyncA/files',
+        },
+      ],
+      [
+        { _id: 'folder_other', name: 'OtherRoot', organizationId: ORG },
+        {
+          _id: 'folder_outside',
+          name: 'X',
+          parentId: 'folder_other',
+          organizationId: ORG,
+        },
+      ],
+    );
+    await expect(
+      upsertDocumentByExternalId(ctx as unknown as MutationCtx, {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        folderId: 'folder_outside' as unknown as never,
+        folderPathPrefix: 'SyncA',
+      }),
+    ).rejects.toThrow(/PREFIX_VIOLATION|outside the sync prefix/);
+  });
+
+  it('finds an existing doc anywhere under the prefix subtree (cross-folder move with content change)', async () => {
     const { ctx, patches } = createMockCtx([
       {
         _id: 'd1',
@@ -176,11 +291,11 @@ describe('upsertDocumentByExternalId', () => {
         externalItemId: 'gd-1',
         title: 'file.txt',
         contentHash: 'h2',
-        // The doc moved from Sync/A → Sync/B inside the same sync subtree.
         folderPathPrefix: 'Sync',
       },
     );
     expect(result.action).toBe('updated');
+    expect(result.contentChanged).toBe(true);
     expect(result.documentId).toBe('d1');
     expect(patches).toHaveLength(1);
   });
@@ -195,7 +310,6 @@ describe('upsertDocumentByExternalId', () => {
         folderPath: 'SyncA/files',
       },
     ]);
-    // Second sync targets SyncB; should NOT pick up the doc in SyncA.
     const result = await upsertDocumentByExternalId(
       ctx as unknown as MutationCtx,
       {
@@ -207,6 +321,7 @@ describe('upsertDocumentByExternalId', () => {
       },
     );
     expect(result.action).toBe('created');
+    expect(result.contentChanged).toBe(true);
     expect(inserts).toHaveLength(1);
   });
 
@@ -230,7 +345,6 @@ describe('upsertDocumentByExternalId', () => {
         folderPathPrefix: 'Sync',
       },
     );
-    // No match → new row inserted. The 'Sync 2/x' doc is left alone.
     expect(result.action).toBe('created');
     expect(inserts).toHaveLength(1);
   });

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { MutationCtx } from '../../_generated/server';
-import { upsertDocumentByExternalId } from '../upsert_document_by_external_id';
+import type { MutationCtx } from '../_generated/server';
+import { upsertDocumentByExternalId } from './upsert_document_by_external_id';
 
 interface MockDoc {
   _id: string;

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -183,6 +183,13 @@ describe('upsertDocumentByExternalId', () => {
     // contentHash is finalized by the workflow's separate step, NOT here.
     expect(patches[0].patch.contentHash).toBeUndefined();
     expect(patches[0].patch.fileId).toBe('storage_new');
+    // Title and extension are part of the content-change patch — the H2
+    // skip would drop them silently if the dispatcher regressed.
+    expect(patches[0].patch.title).toBe('file.txt');
+    expect(patches[0].patch.extension).toBe('txt');
+    // H2 fix: previous storage handle must land in historyFiles so the
+    // blob is reachable for cleanup and version history.
+    expect(patches[0].patch.historyFiles).toEqual(['storage_old']);
   });
 
   it('patches folder only on same-md5 cross-subfolder move (no contentHash bump, no fileId bump)', async () => {
@@ -270,6 +277,35 @@ describe('upsertDocumentByExternalId', () => {
         contentHash: 'h1',
         folderId: 'folder_outside' as unknown as never,
         folderPathPrefix: 'SyncA',
+      }),
+    ).rejects.toThrow(/PREFIX_VIOLATION|outside the sync prefix/);
+  });
+
+  it('rejects target folder at the lex-adjacent sibling "Sync 2" against prefix "Sync"', async () => {
+    // Lex-edge guard: " " (0x20) sorts below "/" (0x2F), so a naive
+    // startsWith(prefix) without the trailing-slash boundary would
+    // wrongly accept "Sync 2/x" as a child of "Sync". Confirms
+    // isPathUnderPrefix uses the `/`-boundary form.
+    const { ctx } = createMockCtx(
+      [],
+      [
+        { _id: 'folder_sync2', name: 'Sync 2', organizationId: ORG },
+        {
+          _id: 'folder_sync2_x',
+          name: 'x',
+          parentId: 'folder_sync2',
+          organizationId: ORG,
+        },
+      ],
+    );
+    await expect(
+      upsertDocumentByExternalId(ctx as unknown as MutationCtx, {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h1',
+        folderId: 'folder_sync2_x' as unknown as never,
+        folderPathPrefix: 'Sync',
       }),
     ).rejects.toThrow(/PREFIX_VIOLATION|outside the sync prefix/);
   });

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -1,0 +1,105 @@
+/**
+ * Atomic upsert keyed by `(organizationId, externalItemId)` — and optionally
+ * scoped to a sync subtree via `folderPathPrefix`.
+ *
+ * Convex has no unique-index constraint, but a single mutation runs in one
+ * transaction with optimistic concurrency control: two parallel calls that
+ * both observe "no existing doc" and both insert will conflict on the index
+ * read+write set, and Convex retries the loser. On retry the loser sees the
+ * row inserted by the winner and takes the update branch — so concurrent
+ * sync runs converge on a single document row instead of duplicating.
+ */
+
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { buildFolderPath } from '../folders/queries';
+import { toConvexJsonRecord } from '../lib/type_cast_helpers';
+import { extractExtension } from './extract_extension';
+import { findDocumentByExternalId } from './find_document_by_external_id';
+
+export interface UpsertDocumentByExternalIdArgs {
+  organizationId: string;
+  externalItemId: string;
+  /** Optional prefix scope: docs whose folderPath equals or sits under this. */
+  folderPathPrefix?: string;
+  title: string;
+  fileId?: Id<'_storage'>;
+  mimeType?: string;
+  sourceProvider?: string;
+  contentHash?: string;
+  metadata?: Record<string, unknown>;
+  folderId?: Id<'folders'>;
+  createdBy?: string;
+}
+
+export interface UpsertDocumentByExternalIdResult {
+  documentId: Id<'documents'>;
+  action: 'created' | 'updated' | 'skipped';
+}
+
+export async function upsertDocumentByExternalId(
+  ctx: MutationCtx,
+  args: UpsertDocumentByExternalIdArgs,
+): Promise<UpsertDocumentByExternalIdResult> {
+  const existing = await findDocumentByExternalId(ctx, {
+    organizationId: args.organizationId,
+    externalItemId: args.externalItemId,
+    folderPathPrefix: args.folderPathPrefix,
+  });
+
+  if (existing) {
+    if (
+      args.contentHash !== undefined &&
+      existing.contentHash === args.contentHash
+    ) {
+      return { documentId: existing._id, action: 'skipped' };
+    }
+
+    const folderPath = args.folderId
+      ? await buildFolderPath(ctx, args.folderId)
+      : undefined;
+
+    const patch: Record<string, unknown> = {
+      title: args.title,
+      fileId: args.fileId,
+      mimeType: args.mimeType,
+      sourceProvider: args.sourceProvider,
+      externalItemId: args.externalItemId,
+      contentHash: args.contentHash,
+      metadata:
+        args.metadata !== undefined
+          ? toConvexJsonRecord(args.metadata)
+          : undefined,
+      folderId: args.folderId,
+      folderPath,
+    };
+    const cleaned = Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== undefined),
+    );
+    if (Object.keys(cleaned).length > 0) {
+      await ctx.db.patch(existing._id, cleaned);
+    }
+    return { documentId: existing._id, action: 'updated' };
+  }
+
+  const folderPath = args.folderId
+    ? await buildFolderPath(ctx, args.folderId)
+    : undefined;
+
+  const documentId = await ctx.db.insert('documents', {
+    organizationId: args.organizationId,
+    title: args.title,
+    fileId: args.fileId,
+    mimeType: args.mimeType,
+    extension: extractExtension(args.title),
+    sourceProvider: args.sourceProvider,
+    externalItemId: args.externalItemId,
+    contentHash: args.contentHash,
+    metadata: toConvexJsonRecord(args.metadata),
+    createdBy: args.createdBy,
+    folderId: args.folderId,
+    folderPath,
+  });
+
+  return { documentId, action: 'created' };
+}

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -8,7 +8,16 @@
  * read+write set, and Convex retries the loser. On retry the loser sees the
  * row inserted by the winner and takes the update branch — so concurrent
  * sync runs converge on a single document row instead of duplicating.
+ *
+ * `contentHash` is intentionally NOT written here — callers (sync workflows)
+ * finalize it in a separate `update` step after RAG indexing succeeds. If
+ * RAG fails, the stale/missing hash forces `check_unchanged` false on the
+ * next run, automatically retrying the download + index. Without this
+ * deferral, a failed first-time RAG upload writes the new hash on the row
+ * and `check_unchanged` would skip the retry forever.
  */
+
+import { ConvexError } from 'convex/values';
 
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
@@ -35,6 +44,17 @@ export interface UpsertDocumentByExternalIdArgs {
 export interface UpsertDocumentByExternalIdResult {
   documentId: Id<'documents'>;
   action: 'created' | 'updated' | 'skipped';
+  /**
+   * True when this call wrote a new file version (fresh insert, or update
+   * with differing `contentHash`). False for pure metadata / folder moves
+   * and for skips. Sync workflows key RAG re-indexing on this flag so a
+   * location-only move does not re-emit the unchanged file to RAG.
+   */
+  contentChanged: boolean;
+}
+
+function isPathUnderPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(prefix + '/');
 }
 
 export async function upsertDocumentByExternalId(
@@ -47,44 +67,74 @@ export async function upsertDocumentByExternalId(
     folderPathPrefix: args.folderPathPrefix,
   });
 
-  if (existing) {
-    if (
-      args.contentHash !== undefined &&
-      existing.contentHash === args.contentHash
-    ) {
-      return { documentId: existing._id, action: 'skipped' };
-    }
+  const newFolderPath = args.folderId
+    ? await buildFolderPath(ctx, args.folderId)
+    : undefined;
 
-    const folderPath = args.folderId
-      ? await buildFolderPath(ctx, args.folderId)
-      : undefined;
+  // Prefix-containment guard. A target folder outside the sync subtree would
+  // make the row unfindable on the next sync (prefix mismatch) and produce a
+  // duplicate. Refuse the write rather than silently desync.
+  if (
+    args.folderPathPrefix !== undefined &&
+    args.folderPathPrefix.length > 0 &&
+    newFolderPath !== undefined &&
+    !isPathUnderPrefix(newFolderPath, args.folderPathPrefix)
+  ) {
+    throw new ConvexError({
+      code: 'PREFIX_VIOLATION',
+      message: `Target folderPath "${newFolderPath}" is outside the sync prefix "${args.folderPathPrefix}".`,
+    });
+  }
+
+  if (existing) {
+    const contentChanged =
+      args.contentHash !== undefined &&
+      existing.contentHash !== args.contentHash;
+    const folderChanged =
+      args.folderId !== undefined && existing.folderId !== args.folderId;
+    // Any metadata arg counts as a change. A deep compare is not worth the
+    // cost — the patch below is cheap and idempotent.
+    const metadataChanged = args.metadata !== undefined;
+
+    if (!contentChanged && !folderChanged && !metadataChanged) {
+      return {
+        documentId: existing._id,
+        action: 'skipped',
+        contentChanged: false,
+      };
+    }
 
     const patch: Record<string, unknown> = {
       title: args.title,
-      fileId: args.fileId,
       mimeType: args.mimeType,
       sourceProvider: args.sourceProvider,
       externalItemId: args.externalItemId,
-      contentHash: args.contentHash,
       metadata:
         args.metadata !== undefined
           ? toConvexJsonRecord(args.metadata)
           : undefined,
       folderId: args.folderId,
-      folderPath,
+      folderPath: newFolderPath,
     };
+    // Only patch the storage handle when the underlying content actually
+    // changed; otherwise a same-md5 cross-folder move would orphan the old
+    // blob for no gain.
+    if (contentChanged) {
+      patch.fileId = args.fileId;
+      patch.extension = extractExtension(args.title);
+    }
     const cleaned = Object.fromEntries(
       Object.entries(patch).filter(([, value]) => value !== undefined),
     );
     if (Object.keys(cleaned).length > 0) {
       await ctx.db.patch(existing._id, cleaned);
     }
-    return { documentId: existing._id, action: 'updated' };
+    return {
+      documentId: existing._id,
+      action: 'updated',
+      contentChanged,
+    };
   }
-
-  const folderPath = args.folderId
-    ? await buildFolderPath(ctx, args.folderId)
-    : undefined;
 
   const documentId = await ctx.db.insert('documents', {
     organizationId: args.organizationId,
@@ -94,12 +144,12 @@ export async function upsertDocumentByExternalId(
     extension: extractExtension(args.title),
     sourceProvider: args.sourceProvider,
     externalItemId: args.externalItemId,
-    contentHash: args.contentHash,
+    // contentHash deliberately omitted — see file docstring.
     metadata: toConvexJsonRecord(args.metadata),
     createdBy: args.createdBy,
     folderId: args.folderId,
-    folderPath,
+    folderPath: newFolderPath,
   });
 
-  return { documentId, action: 'created' };
+  return { documentId, action: 'created', contentChanged: true };
 }

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -19,6 +19,7 @@
 
 import { ConvexError } from 'convex/values';
 
+import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { buildFolderPath } from '../folders/queries';
@@ -39,6 +40,9 @@ export interface UpsertDocumentByExternalIdArgs {
   metadata?: Record<string, unknown>;
   folderId?: Id<'folders'>;
   createdBy?: string;
+  /** Integration identifier stamped on the row so reconcile can scope
+   * orphan detection per-integration (see `listOrphanedExternalDocs`). */
+  driveId?: string;
 }
 
 export interface UpsertDocumentByExternalIdResult {
@@ -54,7 +58,11 @@ export interface UpsertDocumentByExternalIdResult {
 }
 
 function isPathUnderPrefix(path: string, prefix: string): boolean {
-  return path === prefix || path.startsWith(prefix + '/');
+  // Normalize trailing slash on the prefix so user inputs like
+  // "Google Drive/" don't false-reject every write.
+  const p = prefix.replace(/\/+$/, '');
+  if (p.length === 0) return true;
+  return path === p || path.startsWith(p + '/');
 }
 
 export async function upsertDocumentByExternalId(
@@ -109,6 +117,7 @@ export async function upsertDocumentByExternalId(
       mimeType: args.mimeType,
       sourceProvider: args.sourceProvider,
       externalItemId: args.externalItemId,
+      driveId: args.driveId,
       metadata:
         args.metadata !== undefined
           ? toConvexJsonRecord(args.metadata)
@@ -118,10 +127,19 @@ export async function upsertDocumentByExternalId(
     };
     // Only patch the storage handle when the underlying content actually
     // changed; otherwise a same-md5 cross-folder move would orphan the old
-    // blob for no gain.
+    // blob for no gain. When we do swap fileId, preserve the previous
+    // storage handle in `historyFiles` so `eraseDocumentBlobs` can clean
+    // it up on later deletion and so version-history readers can still
+    // reach prior revisions.
     if (contentChanged) {
       patch.fileId = args.fileId;
       patch.extension = extractExtension(args.title);
+      if (existing.fileId && existing.fileId !== args.fileId) {
+        patch.historyFiles = [
+          ...(existing.historyFiles ?? []),
+          existing.fileId,
+        ];
+      }
     }
     const cleaned = Object.fromEntries(
       Object.entries(patch).filter(([, value]) => value !== undefined),
@@ -129,6 +147,31 @@ export async function upsertDocumentByExternalId(
     if (Object.keys(cleaned).length > 0) {
       await ctx.db.patch(existing._id, cleaned);
     }
+
+    // When a previously RAG-indexed row gets a new storage handle, the
+    // old RAG entry stays orphaned unless we schedule its purge. The
+    // C4-retry path (RAG indexed, finalize_content_hash threw, next sync
+    // re-uploads) is the main producer of this state. `reindexDocumentInRag`
+    // dedup-skips a re-upload when the new content already exists in RAG,
+    // so the only work it does here is the old-fileId DELETE.
+    if (
+      contentChanged &&
+      existing.fileId &&
+      args.fileId &&
+      existing.fileId !== args.fileId &&
+      existing.ragInfo?.status === 'completed'
+    ) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.documents.internal_actions.reindexDocumentInRag,
+        {
+          documentId: existing._id,
+          oldFileId: existing.fileId,
+          oldOrganizationId: existing.organizationId,
+        },
+      );
+    }
+
     return {
       documentId: existing._id,
       action: 'updated',
@@ -144,6 +187,7 @@ export async function upsertDocumentByExternalId(
     extension: extractExtension(args.title),
     sourceProvider: args.sourceProvider,
     externalItemId: args.externalItemId,
+    driveId: args.driveId,
     // contentHash deliberately omitted — see file docstring.
     metadata: toConvexJsonRecord(args.metadata),
     createdBy: args.createdBy,

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -22,6 +22,7 @@ import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
  */
 export const uploadFileToRag = internalAction({
   args: {
+    organizationId: v.string(),
     storageId: v.id('_storage'),
     fileName: v.string(),
     contentType: v.string(),
@@ -37,7 +38,7 @@ export const uploadFileToRag = internalAction({
           fileName: args.fileName,
           contentType: args.contentType,
         },
-        {},
+        { organizationId: args.organizationId },
       );
     } catch (error) {
       console.error(

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -103,6 +103,7 @@ export const saveFileMetadata = internalMutation({
         0,
         internal.file_metadata.internal_actions.uploadFileToRag,
         {
+          organizationId: args.organizationId,
           storageId: args.storageId,
           fileName: args.fileName,
           contentType: args.contentType,

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -126,6 +126,7 @@ export const saveFileMetadata = mutation({
           0,
           internal.file_metadata.internal_actions.uploadFileToRag,
           {
+            organizationId: args.organizationId,
             storageId: args.storageId,
             fileName: args.fileName,
             contentType: args.contentType,
@@ -170,6 +171,7 @@ export const saveFileMetadata = mutation({
         0,
         internal.file_metadata.internal_actions.uploadFileToRag,
         {
+          organizationId: args.organizationId,
           storageId: args.storageId,
           fileName: args.fileName,
           contentType: args.contentType,

--- a/services/platform/convex/folders/cleanup_empty_ancestors.test.ts
+++ b/services/platform/convex/folders/cleanup_empty_ancestors.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cleanupEmptyAncestorFolders } from './cleanup_empty_ancestors';
+
+type MockFolder = {
+  _id: string;
+  organizationId: string;
+  name: string;
+  parentId?: string;
+};
+
+type MockDoc = {
+  _id: string;
+  organizationId: string;
+  folderId?: string;
+  lifecycleStatus?: string;
+};
+
+interface MockQB {
+  eq: (field: string, value: unknown) => MockQB;
+}
+
+function createMockCtx() {
+  const folders = new Map<string, MockFolder>();
+  const documents = new Map<string, MockDoc>();
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  const ctx = {
+    db: {
+      get: (id: string) =>
+        Promise.resolve(folders.get(id) ?? documents.get(id) ?? null),
+      delete: vi.fn((id: string) => {
+        folders.delete(id);
+        documents.delete(id);
+        return Promise.resolve();
+      }),
+      query: (table: string) => {
+        const store = table === 'folders' ? folders : documents;
+        const filters: Record<string, unknown> = {};
+
+        return {
+          withIndex: (_index: string, cb: (q: MockQB) => void) => {
+            const qb: MockQB = {
+              eq: (field: string, value: unknown) => {
+                filters[field] = value;
+                return qb;
+              },
+            };
+            cb(qb);
+            return {
+              first: () => {
+                for (const row of store.values()) {
+                  const r = row as Record<string, unknown>;
+                  const ok = Object.entries(filters).every(
+                    ([k, v]) => r[k] === v,
+                  );
+                  if (ok) return Promise.resolve(row);
+                }
+                return Promise.resolve(null);
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+
+  return { ctx, folders, documents, warnSpy };
+}
+
+const ORG = 'org_1';
+
+describe('cleanupEmptyAncestorFolders', () => {
+  it('deletes a linear chain up to the sync root (exclusive)', async () => {
+    const { ctx, folders } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+    folders.set('sub1', {
+      _id: 'sub1',
+      organizationId: ORG,
+      name: 'sub1',
+      parentId: 'root',
+    });
+    folders.set('sub2', {
+      _id: 'sub2',
+      organizationId: ORG,
+      name: 'sub2',
+      parentId: 'sub1',
+    });
+
+    // doc has just been deleted; we walk from its former folderId
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'sub2' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('sub2')).toBe(false);
+    expect(folders.has('sub1')).toBe(false);
+    expect(folders.has('root')).toBe(true);
+  });
+
+  it('preserves a folder that still has a sibling document', async () => {
+    const { ctx, folders, documents } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+    folders.set('sub2', {
+      _id: 'sub2',
+      organizationId: ORG,
+      name: 'sub2',
+      parentId: 'root',
+    });
+    documents.set('d_keep', {
+      _id: 'd_keep',
+      organizationId: ORG,
+      folderId: 'sub2',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'sub2' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('sub2')).toBe(true);
+    expect(folders.has('root')).toBe(true);
+  });
+
+  it('preserves a folder that still has a sibling subfolder', async () => {
+    const { ctx, folders } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+    folders.set('sub2', {
+      _id: 'sub2',
+      organizationId: ORG,
+      name: 'sub2',
+      parentId: 'root',
+    });
+    folders.set('manual', {
+      _id: 'manual',
+      organizationId: ORG,
+      name: 'manual',
+      parentId: 'sub2',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'sub2' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('sub2')).toBe(true);
+    expect(folders.has('manual')).toBe(true);
+    expect(folders.has('root')).toBe(true);
+  });
+
+  it('a trashed sibling document keeps the folder alive', async () => {
+    // The by_organizationId_and_folderId index does not filter on
+    // lifecycleStatus, so a soft-deleted (trashed) doc still occupies
+    // the folder until purge. Cleanup must respect this.
+    const { ctx, folders, documents } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+    folders.set('sub2', {
+      _id: 'sub2',
+      organizationId: ORG,
+      name: 'sub2',
+      parentId: 'root',
+    });
+    documents.set('d_trashed', {
+      _id: 'd_trashed',
+      organizationId: ORG,
+      folderId: 'sub2',
+      lifecycleStatus: 'trashed',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'sub2' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('sub2')).toBe(true);
+  });
+
+  it('aborts when parentId chain reaches root before stopAt (cross-subtree folderId)', async () => {
+    // The deleted doc's folderId pointed at a folder OUTSIDE the sync
+    // subtree. Climbing up never hits stopAt — we must not delete any
+    // folder in this case.
+    const { ctx, folders, warnSpy } = createMockCtx();
+    folders.set('user_folder', {
+      _id: 'user_folder',
+      organizationId: ORG,
+      name: 'user-stuff',
+    });
+    folders.set('sync_root', {
+      _id: 'sync_root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'user_folder' as never,
+      'sync_root' as never,
+      ORG,
+    );
+
+    expect(folders.has('user_folder')).toBe(true);
+    expect(folders.has('sync_root')).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reached root'),
+    );
+  });
+
+  it('stops immediately if start === stopAt (sync root never deleted)', async () => {
+    const { ctx, folders } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'root' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('root')).toBe(true);
+  });
+
+  it('stops cleanly if the folder is already missing', async () => {
+    const { ctx, folders } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'Google Drive',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'ghost' as never,
+      'root' as never,
+      ORG,
+    );
+
+    expect(folders.has('root')).toBe(true);
+  });
+
+  it('aborts on cross-tenant folderId without deleting', async () => {
+    const { ctx, folders, warnSpy } = createMockCtx();
+    folders.set('foreign', {
+      _id: 'foreign',
+      organizationId: 'other_org',
+      name: 'foreign',
+    });
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'foreign' as never,
+      'never' as never,
+      ORG,
+    );
+
+    expect(folders.has('foreign')).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('org mismatch'),
+    );
+  });
+
+  it('warns and stops at MAX_FOLDER_DEPTH', async () => {
+    const { ctx, folders, warnSpy } = createMockCtx();
+    folders.set('root', {
+      _id: 'root',
+      organizationId: ORG,
+      name: 'root',
+    });
+    for (let i = 1; i <= 25; i++) {
+      folders.set(`level_${i}`, {
+        _id: `level_${i}`,
+        organizationId: ORG,
+        name: `level-${i}`,
+        parentId: i === 1 ? 'root' : `level_${i - 1}`,
+      });
+    }
+
+    await cleanupEmptyAncestorFolders(
+      ctx as never,
+      'level_25' as never,
+      'root' as never,
+      ORG,
+    );
+
+    // Deleted exactly MAX_FOLDER_DEPTH (20) levels then warned.
+    expect(folders.has('root')).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('depth cap'));
+  });
+});

--- a/services/platform/convex/folders/cleanup_empty_ancestors.ts
+++ b/services/platform/convex/folders/cleanup_empty_ancestors.ts
@@ -1,0 +1,84 @@
+import type { Doc, Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { MAX_FOLDER_DEPTH } from './mutations';
+
+/**
+ * Walk up from `startFolderId` and delete folders that have no remaining
+ * documents and no child folders, stopping at (and never deleting)
+ * `stopAtFolderId`. Aborts safely if the walk would escape the sync
+ * subtree (parentId becomes undefined before reaching the stop boundary).
+ *
+ * Convex mutation semantics: each existence check + delete runs in a
+ * single serializable transaction, so concurrent inserts under a folder
+ * trigger an OCC retry on the inserting tx — the cleanup never strands
+ * a dangling parentId.
+ */
+export async function cleanupEmptyAncestorFolders(
+  ctx: MutationCtx,
+  startFolderId: Id<'folders'>,
+  stopAtFolderId: Id<'folders'>,
+  organizationId: string,
+): Promise<void> {
+  let currentId: Id<'folders'> | undefined = startFolderId;
+  let depth = 0;
+
+  while (currentId && depth < MAX_FOLDER_DEPTH) {
+    if (currentId === stopAtFolderId) {
+      return;
+    }
+
+    const folder: Doc<'folders'> | null = await ctx.db.get(currentId);
+    if (!folder) {
+      return;
+    }
+
+    if (folder.organizationId !== organizationId) {
+      console.warn(
+        `[cleanupEmptyAncestorFolders] org mismatch at folderId=${currentId} (expected ${organizationId}, got ${folder.organizationId}); aborting`,
+      );
+      return;
+    }
+
+    // Reaching the org root without hitting the stop boundary means
+    // either the doc's folderId pointed outside the sync subtree, or
+    // the sync root was deleted concurrently. Either way: do not delete
+    // — we would otherwise reap unrelated user-owned folders.
+    if (folder.parentId === undefined) {
+      console.warn(
+        `[cleanupEmptyAncestorFolders] reached root folderId=${currentId} without hitting stopAt=${stopAtFolderId}; aborting`,
+      );
+      return;
+    }
+
+    const childFolder = await ctx.db
+      .query('folders')
+      .withIndex('by_org_parent_name', (q) =>
+        q.eq('organizationId', organizationId).eq('parentId', currentId),
+      )
+      .first();
+    if (childFolder) {
+      return;
+    }
+
+    const childDoc = await ctx.db
+      .query('documents')
+      .withIndex('by_organizationId_and_folderId', (q) =>
+        q.eq('organizationId', organizationId).eq('folderId', currentId),
+      )
+      .first();
+    if (childDoc) {
+      return;
+    }
+
+    const parentId: Id<'folders'> | undefined = folder.parentId;
+    await ctx.db.delete(currentId);
+    currentId = parentId;
+    depth++;
+  }
+
+  if (depth >= MAX_FOLDER_DEPTH && currentId && currentId !== stopAtFolderId) {
+    console.warn(
+      `[cleanupEmptyAncestorFolders] depth cap (${MAX_FOLDER_DEPTH}) hit before stopAt=${stopAtFolderId}; remaining folderId=${currentId}`,
+    );
+  }
+}

--- a/services/platform/convex/folders/find_folder_by_path.test.ts
+++ b/services/platform/convex/folders/find_folder_by_path.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import type { QueryCtx } from '../../_generated/server';
+import { findFolderByPath } from '../find_folder_by_path';
+
+interface MockFolder {
+  _id: string;
+  name: string;
+  organizationId: string;
+  parentId?: string;
+}
+
+function createMockCtx(folders: MockFolder[]) {
+  return {
+    db: {
+      query: () => ({
+        withIndex: (
+          _indexName: string,
+          cb: (q: {
+            eq: (field: string, value: unknown) => unknown;
+          }) => unknown,
+        ) => {
+          let orgFilter: string | undefined;
+          let parentFilter: string | undefined;
+          let nameFilter: string | undefined;
+
+          const qb = {
+            eq: (field: string, value: unknown) => {
+              if (field === 'organizationId') orgFilter = value as string;
+              if (field === 'parentId')
+                parentFilter = value as string | undefined;
+              if (field === 'name') nameFilter = value as string;
+              return qb;
+            },
+          };
+          cb(qb);
+
+          return {
+            first: () => {
+              for (const doc of folders) {
+                if (
+                  doc.organizationId === orgFilter &&
+                  doc.parentId === parentFilter &&
+                  (nameFilter === undefined || doc.name === nameFilter)
+                ) {
+                  return Promise.resolve(doc);
+                }
+              }
+              return Promise.resolve(null);
+            },
+          };
+        },
+      }),
+    },
+  };
+}
+
+const ORG = 'org1';
+
+describe('findFolderByPath', () => {
+  it('returns null for empty path', async () => {
+    const ctx = createMockCtx([]);
+    const result = await findFolderByPath(ctx as unknown as QueryCtx, ORG, []);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when path is whitespace-only', async () => {
+    const ctx = createMockCtx([]);
+    const result = await findFolderByPath(ctx as unknown as QueryCtx, ORG, [
+      '  ',
+      '\t',
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns the leaf id for an existing nested path', async () => {
+    const ctx = createMockCtx([
+      { _id: 'f1', name: 'A', organizationId: ORG, parentId: undefined },
+      { _id: 'f2', name: 'B', organizationId: ORG, parentId: 'f1' },
+      { _id: 'f3', name: 'C', organizationId: ORG, parentId: 'f2' },
+    ]);
+    const result = await findFolderByPath(ctx as unknown as QueryCtx, ORG, [
+      'A',
+      'B',
+      'C',
+    ]);
+    expect(result).toBe('f3');
+  });
+
+  it('returns null when an intermediate folder is missing', async () => {
+    const ctx = createMockCtx([
+      { _id: 'f1', name: 'A', organizationId: ORG, parentId: undefined },
+      // Missing 'B'
+      { _id: 'f3', name: 'C', organizationId: ORG, parentId: 'f2' },
+    ]);
+    const result = await findFolderByPath(ctx as unknown as QueryCtx, ORG, [
+      'A',
+      'B',
+      'C',
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a segment fails the validator', async () => {
+    const ctx = createMockCtx([]);
+    // '..' is reserved → validator throws → helper returns null without writing.
+    const result = await findFolderByPath(ctx as unknown as QueryCtx, ORG, [
+      'A',
+      '..',
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('does not insert any folders (read-only)', async () => {
+    let inserts = 0;
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: (
+            _idx: string,
+            cb: (q: {
+              eq: (field: string, value: unknown) => unknown;
+            }) => unknown,
+          ) => {
+            const qb = { eq: () => qb };
+            cb(qb);
+            return { first: () => Promise.resolve(null) };
+          },
+        }),
+        insert: () => {
+          inserts++;
+          return Promise.resolve('should-not-happen');
+        },
+      },
+    };
+    await findFolderByPath(ctx as unknown as QueryCtx, ORG, ['NewFolder']);
+    expect(inserts).toBe(0);
+  });
+});

--- a/services/platform/convex/folders/find_folder_by_path.test.ts
+++ b/services/platform/convex/folders/find_folder_by_path.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { QueryCtx } from '../../_generated/server';
-import { findFolderByPath } from '../find_folder_by_path';
+import type { QueryCtx } from '../_generated/server';
+import { findFolderByPath } from './find_folder_by_path';
 
 interface MockFolder {
   _id: string;

--- a/services/platform/convex/folders/find_folder_by_path.test.ts
+++ b/services/platform/convex/folders/find_folder_by_path.test.ts
@@ -111,6 +111,29 @@ describe('findFolderByPath', () => {
     expect(result).toBeNull();
   });
 
+  it('does not match folders from a different organization (cross-org isolation)', async () => {
+    // Both orgs have a folder structure "A/B"; querying org1 must never
+    // see org2's leaf even though the path matches structurally. This
+    // catches regressions to the (organizationId, parentId, name) index
+    // scope.
+    const ctx = createMockCtx([
+      { _id: 'org1-A', name: 'A', organizationId: ORG, parentId: undefined },
+      { _id: 'org1-B', name: 'B', organizationId: ORG, parentId: 'org1-A' },
+      { _id: 'org2-A', name: 'A', organizationId: 'org2', parentId: undefined },
+      { _id: 'org2-B', name: 'B', organizationId: 'org2', parentId: 'org2-A' },
+    ]);
+    const r1 = await findFolderByPath(ctx as unknown as QueryCtx, ORG, [
+      'A',
+      'B',
+    ]);
+    expect(r1).toBe('org1-B');
+    const r2 = await findFolderByPath(ctx as unknown as QueryCtx, 'org2', [
+      'A',
+      'B',
+    ]);
+    expect(r2).toBe('org2-B');
+  });
+
   it('does not insert any folders (read-only)', async () => {
     let inserts = 0;
     const ctx = {

--- a/services/platform/convex/folders/find_folder_by_path.ts
+++ b/services/platform/convex/folders/find_folder_by_path.ts
@@ -1,0 +1,51 @@
+import type { Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import { validateFolderName } from './mutations';
+
+/**
+ * Read-only path lookup. Mirrors the traversal in `getOrCreateFolderPath`
+ * but never inserts. Returns the leaf folder id, or `null` if any segment is
+ * missing (or the input path is empty / fully invalid).
+ *
+ * Use this from action contexts that want to *find* a doc inside a sync-target
+ * folder without materializing the folder hierarchy as a side effect — when
+ * the path does not exist, no document can either, so the caller short-circuits.
+ */
+export async function findFolderByPath(
+  ctx: QueryCtx,
+  organizationId: string,
+  pathSegments: string[],
+): Promise<Id<'folders'> | null> {
+  const segments = pathSegments.filter((s) => s.trim().length > 0);
+  if (segments.length === 0) {
+    return null;
+  }
+
+  let parentId: Id<'folders'> | undefined;
+
+  for (const segment of segments) {
+    let validName: string;
+    try {
+      validName = validateFolderName(segment);
+    } catch {
+      return null;
+    }
+
+    const existing = await ctx.db
+      .query('folders')
+      .withIndex('by_org_parent_name', (q) =>
+        q
+          .eq('organizationId', organizationId)
+          .eq('parentId', parentId)
+          .eq('name', validName),
+      )
+      .first();
+
+    if (!existing) {
+      return null;
+    }
+    parentId = existing._id;
+  }
+
+  return parentId ?? null;
+}

--- a/services/platform/convex/folders/internal_queries.ts
+++ b/services/platform/convex/folders/internal_queries.ts
@@ -1,0 +1,19 @@
+import { v } from 'convex/values';
+
+import { internalQuery } from '../_generated/server';
+import { findFolderByPath as findFolderByPathHelper } from './find_folder_by_path';
+
+export const findFolderByPath = internalQuery({
+  args: {
+    organizationId: v.string(),
+    pathSegments: v.array(v.string()),
+  },
+  returns: v.union(v.id('folders'), v.null()),
+  handler: async (ctx, args) => {
+    return await findFolderByPathHelper(
+      ctx,
+      args.organizationId,
+      args.pathSegments,
+    );
+  },
+});

--- a/services/platform/convex/folders/mutations.ts
+++ b/services/platform/convex/folders/mutations.ts
@@ -121,7 +121,7 @@ async function deleteFolderContents(
 }
 
 const MAX_FOLDER_NAME_LENGTH = 255;
-const MAX_FOLDER_DEPTH = 20;
+export const MAX_FOLDER_DEPTH = 20;
 const RESERVED_NAMES = new Set(['.', '..']);
 
 export function validateFolderName(name: string): string {

--- a/services/platform/convex/integrations/build_test_secrets.ts
+++ b/services/platform/convex/integrations/build_test_secrets.ts
@@ -13,6 +13,7 @@ export async function buildIntegrationSecrets(
   ctx: ActionCtx,
   integration: IntegrationWithCredentials,
   credentialId?: Id<'integrationCredentials'>,
+  options?: { forceRefresh?: boolean },
 ): Promise<Record<string, string>> {
   const secrets: Record<string, string> = {};
 
@@ -57,6 +58,7 @@ export async function buildIntegrationSecrets(
       ctx,
       integration,
       credentialId,
+      options,
     );
   }
 

--- a/services/platform/convex/integrations/decrypt_and_refresh_oauth2.ts
+++ b/services/platform/convex/integrations/decrypt_and_refresh_oauth2.ts
@@ -55,6 +55,7 @@ export async function decryptAndRefreshIntegrationOAuth2(
   ctx: ActionCtx,
   integration: IntegrationWithCredentials,
   credentialId?: Id<'integrationCredentials'>,
+  options?: { forceRefresh?: boolean },
 ): Promise<string> {
   const { oauth2Auth, oauth2Config } = integration;
 
@@ -66,8 +67,9 @@ export async function decryptAndRefreshIntegrationOAuth2(
 
   const currentTime = Math.floor(Date.now() / 1000);
   const needsRefresh =
-    oauth2Auth.tokenExpiry != null &&
-    currentTime >= oauth2Auth.tokenExpiry - 300;
+    options?.forceRefresh === true ||
+    (oauth2Auth.tokenExpiry != null &&
+      currentTime >= oauth2Auth.tokenExpiry - 300);
 
   if (!needsRefresh) {
     debugLog(

--- a/services/platform/convex/integrations/run_health_check.ts
+++ b/services/platform/convex/integrations/run_health_check.ts
@@ -10,6 +10,7 @@ import type { ConnectorConfig, SqlConnectionConfig } from './types';
 const debugLog = createDebugLog('DEBUG_INTEGRATIONS', '[Integrations]');
 
 interface HealthCheckArgs {
+  organizationId: string;
   name: string;
   type?: 'rest_api' | 'sql';
   connector?: ConnectorConfig;
@@ -121,6 +122,7 @@ async function runRestHealthCheck(
       secrets,
       allowedHosts,
       timeoutMs: timeoutMs ?? 15000,
+      organizationId: args.organizationId,
     },
   );
 

--- a/services/platform/convex/integrations/test_connection.ts
+++ b/services/platform/convex/integrations/test_connection.ts
@@ -161,6 +161,7 @@ async function testRestConnection(
       secrets,
       allowedHosts,
       timeoutMs: timeoutMs ?? 15000,
+      organizationId: integration.organizationId,
     },
   );
 

--- a/services/platform/convex/integrations/update_integration.ts
+++ b/services/platform/convex/integrations/update_integration.ts
@@ -63,6 +63,7 @@ async function runHealthCheckIfNeeded(
     args.connectionConfig?.domain ?? integration.connectionConfig?.domain;
 
   await runHealthCheck(ctx, {
+    organizationId: integration.organizationId,
     name: integration.name,
     type: integration.type ?? undefined,
     connector: args.connector ?? integration.connector ?? undefined,

--- a/services/platform/convex/node_only/integration_sandbox/internal_actions.ts
+++ b/services/platform/convex/node_only/integration_sandbox/internal_actions.ts
@@ -35,7 +35,7 @@ export const executeIntegration = internalAction({
     secrets: jsonRecordValidator,
     allowedHosts: v.optional(v.array(v.string())),
     timeoutMs: v.optional(v.number()),
-    organizationId: v.optional(v.string()),
+    organizationId: v.string(),
   },
   returns: v.object({
     success: v.boolean(),
@@ -67,10 +67,7 @@ export const executeIntegration = internalAction({
       secrets: args.secrets as Record<string, string>,
       allowedHosts: args.allowedHosts,
       timeoutMs: args.timeoutMs,
-      storageProvider: createConvexStorageProvider(
-        ctx,
-        args.organizationId ?? 'system',
-      ),
+      storageProvider: createConvexStorageProvider(ctx, args.organizationId),
     });
   },
 });

--- a/services/platform/convex/video_links/internal_mutations.ts
+++ b/services/platform/convex/video_links/internal_mutations.ts
@@ -282,6 +282,7 @@ export const insertSyntheticFileMetadata = internalMutation({
       0,
       internal.file_metadata.internal_actions.uploadFileToRag,
       {
+        organizationId: args.organizationId,
         storageId: args.storageId,
         fileName: `${args.videoTitle}.txt`,
         contentType: 'text/plain; charset=utf-8',

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -146,6 +146,8 @@ type DocumentActionParams =
       externalItemId?: string;
       contentHash?: string;
       metadata?: Record<string, unknown>;
+      /** Integration identifier stamped on the row for reconcile scoping. */
+      driveId?: string;
     }
   | {
       operation: 'extract_docx_structured';
@@ -186,6 +188,13 @@ type DocumentActionParams =
       sourceProvider: string;
       folderPath: string;
       presentExternalIds: string[];
+      /**
+       * When set, scopes the orphan candidate set to docs whose `driveId`
+       * matches. Lets two sync workflows targeting the same `folderPath`
+       * coexist (e.g. two Drive accounts under the default "Google Drive"
+       * folder) without mutually orphaning each other.
+       */
+      driveId?: string;
       /**
        * When true, the upstream listing was truncated and `presentExternalIds`
        * is incomplete — reconcile must skip to avoid deleting legitimate docs.
@@ -241,6 +250,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       externalItemId: v.optional(v.string()),
       contentHash: v.optional(v.string()),
       metadata: v.optional(jsonRecordValidator),
+      driveId: v.optional(v.string()),
     }),
     v.object({
       operation: v.literal('compare'),
@@ -283,6 +293,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       sourceProvider: v.string(),
       folderPath: v.string(),
       presentExternalIds: v.array(v.string()),
+      driveId: v.optional(v.string()),
       truncated: v.optional(v.boolean()),
     }),
   ),
@@ -555,6 +566,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
               sourceProvider,
               contentHash: params.contentHash,
               metadata: params.metadata,
+              driveId: params.driveId,
               ...(folderId ? { folderId: toId<'folders'>(folderId) } : {}),
               createdBy: userId,
             },
@@ -567,6 +579,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             folderPath: params.folderPath ?? null,
             documentId: result.documentId,
             action: result.action,
+            contentChanged: result.contentChanged,
           };
         }
 
@@ -936,6 +949,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             sourceProvider: params.sourceProvider,
             folderPathPrefix: params.folderPath,
             presentExternalIds: params.presentExternalIds,
+            driveId: params.driveId,
           },
         );
 
@@ -953,16 +967,53 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           };
         }
 
+        // Mass-delete sanity bound: a Drive folder narrowed by permissions
+        // or mime-filter can return a small-but-non-empty listing that
+        // would silently delete every other doc under the prefix. Abort
+        // when more than half (and >20 absolute) would be deleted.
+        const scanned = params.presentExternalIds.length;
+        const MAX_DELETE_ABS = 20;
+        const MAX_DELETE_RATIO = 0.5;
+        if (
+          orphaned.length > MAX_DELETE_ABS &&
+          orphaned.length > scanned * MAX_DELETE_RATIO
+        ) {
+          return {
+            success: false,
+            deleted: 0,
+            scanned,
+            skippedReason: `Skipping reconcile: ${orphaned.length} orphans vs ${scanned} present — exceeds safety bound (>${MAX_DELETE_ABS} and >${Math.round(MAX_DELETE_RATIO * 100)}% of scanned).`,
+          };
+        }
+
+        // Operator audit trail: one line per scheduled delete so the
+        // affected docs can be identified and (if needed) restored from
+        // backup. Keep individual log lines so they survive log rotation
+        // by id rather than depending on one giant payload.
+        for (const doc of orphaned) {
+          console.warn(
+            `[reconcile_deletes] Scheduling delete documentId=${doc.documentId} externalItemId=${doc.externalItemId} title=${JSON.stringify(doc.title ?? null)} sourceProvider=${params.sourceProvider}`,
+          );
+        }
+
         // Stagger deletes by 100ms to avoid swamping the scheduler and the
         // RAG service when a folder churns. deleteDocumentFromRag's own
         // backoff still applies on top.
+        //
+        // Snapshot-and-verify: pass `expectedExternalItemId` / `expectedFileId`
+        // into the scheduled args so a doc re-bound by an interleaving
+        // upsert (e.g. restore-during-pending-reconcile) is not deleted.
         for (let i = 0; i < orphaned.length; i++) {
           const doc = orphaned[i];
           if (doc.fileId) {
             await ctx.scheduler.runAfter(
               i * 100,
               internal.documents.internal_actions.deleteDocumentFromRag,
-              { documentId: doc.documentId },
+              {
+                documentId: doc.documentId,
+                expectedExternalItemId: doc.externalItemId,
+                expectedFileId: doc.fileId,
+              },
             );
           } else {
             await ctx.scheduler.runAfter(
@@ -976,7 +1027,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
         return {
           success: true,
           deleted: orphaned.length,
-          scanned: params.presentExternalIds.length,
+          scanned,
         };
       }
 

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -12,7 +12,7 @@
 import { v } from 'convex/values';
 
 import { internal } from '../../../_generated/api';
-import type { Id } from '../../../_generated/dataModel';
+import type { Doc, Id } from '../../../_generated/dataModel';
 import type { ActionCtx } from '../../../_generated/server';
 import { fetchDocumentComparisonByUrls } from '../../../agent_tools/documents/helpers/fetch_document_comparison';
 import { fetchDocumentContent } from '../../../agent_tools/documents/helpers/fetch_document_content';
@@ -103,6 +103,7 @@ type DocumentActionParams =
       extension?: string;
       metadata?: Record<string, unknown>;
       sourceProvider?: string;
+      contentHash?: string;
     }
   | {
       operation: 'retrieve';
@@ -172,6 +173,13 @@ type DocumentActionParams =
       operation: 'find_by_external_id';
       externalItemId: string;
       folderPath?: string;
+      /**
+       * Optional sync-subtree scope. Mirrors `create` — when set, the
+       * lookup includes docs anywhere under this prefix (subtree), so a
+       * cross-subfolder move is detected at lookup time instead of
+       * triggering a wasteful download.
+       */
+      folderPathPrefix?: string;
     }
   | {
       operation: 'reconcile_deletes';
@@ -204,6 +212,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       extension: v.optional(v.string()),
       metadata: v.optional(jsonRecordValidator),
       sourceProvider: v.optional(v.string()),
+      contentHash: v.optional(v.string()),
     }),
     v.object({
       operation: v.literal('retrieve'),
@@ -267,6 +276,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       operation: v.literal('find_by_external_id'),
       externalItemId: v.string(),
       folderPath: v.optional(v.string()),
+      folderPathPrefix: v.optional(v.string()),
     }),
     v.object({
       operation: v.literal('reconcile_deletes'),
@@ -324,6 +334,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             mimeType: params.mimeType,
             extension: params.extension,
             sourceProvider: params.sourceProvider,
+            contentHash: params.contentHash,
           },
         );
 
@@ -831,6 +842,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
         }
 
         let folderId: Id<'folders'> | null = null;
+        let folderResolved = true;
         if (params.folderPath) {
           const resolved = await ctx.runQuery(
             internal.folders.internal_queries.findFolderByPath,
@@ -840,25 +852,42 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             },
           );
           if (resolved === null) {
-            // Path does not exist — no document can live there yet.
-            return { exists: false };
+            folderResolved = false;
+          } else {
+            folderId = resolved;
           }
-          folderId = resolved;
         }
 
-        const lookupFolderId =
-          folderId ?? (params.folderPath ? null : undefined);
+        let existing: Doc<'documents'> | null = null;
 
-        const existing = await ctx.runQuery(
-          internal.documents.internal_queries.findDocumentByExternalId,
-          {
-            organizationId,
-            externalItemId: params.externalItemId,
-            ...(lookupFolderId !== undefined
-              ? { folderId: lookupFolderId }
-              : {}),
-          },
-        );
+        if (folderResolved) {
+          const lookupFolderId =
+            folderId ?? (params.folderPath ? null : undefined);
+          existing = await ctx.runQuery(
+            internal.documents.internal_queries.findDocumentByExternalId,
+            {
+              organizationId,
+              externalItemId: params.externalItemId,
+              ...(lookupFolderId !== undefined
+                ? { folderId: lookupFolderId }
+                : {}),
+            },
+          );
+        }
+
+        // Prefix fallback closes the unscoped-first-match hole when
+        // `folderPath` is omitted, and lets callers detect cross-folder
+        // moves at lookup time when the exact folder lookup misses.
+        if (!existing && params.folderPathPrefix) {
+          existing = await ctx.runQuery(
+            internal.documents.internal_queries.findDocumentByExternalId,
+            {
+              organizationId,
+              externalItemId: params.externalItemId,
+              folderPathPrefix: params.folderPathPrefix,
+            },
+          );
+        }
 
         if (!existing) {
           return { exists: false };
@@ -871,6 +900,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           externalItemId: existing.externalItemId,
           fileId: existing.fileId,
           title: existing.title,
+          folderPath: existing.folderPath,
         };
       }
 

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -12,6 +12,7 @@
 import { v } from 'convex/values';
 
 import { internal } from '../../../_generated/api';
+import type { Id } from '../../../_generated/dataModel';
 import type { ActionCtx } from '../../../_generated/server';
 import { fetchDocumentComparisonByUrls } from '../../../agent_tools/documents/helpers/fetch_document_comparison';
 import { fetchDocumentContent } from '../../../agent_tools/documents/helpers/fetch_document_content';
@@ -133,6 +134,13 @@ type DocumentActionParams =
       fileId: string;
       title?: string;
       folderPath?: string;
+      /**
+       * Optional sync-subtree scope for the cross-folder fallback. When two
+       * independent sync configs target the same external item but different
+       * Tale folders, scoping the fallback to each sync's root prevents the
+       * doc from ping-ponging between rows.
+       */
+      folderPathPrefix?: string;
       sourceProvider?: string;
       externalItemId?: string;
       contentHash?: string;
@@ -170,6 +178,14 @@ type DocumentActionParams =
       sourceProvider: string;
       folderPath: string;
       presentExternalIds: string[];
+      /**
+       * When true, the upstream listing was truncated and `presentExternalIds`
+       * is incomplete — reconcile must skip to avoid deleting legitimate docs.
+       * Defense-in-depth: the workflow JSON should also gate this step on a
+       * truncation check, but enforcing it here closes the gap if the workflow
+       * is forked without that check.
+       */
+      truncated?: boolean;
     };
 
 export const documentAction: ActionDefinition<DocumentActionParams> = {
@@ -211,6 +227,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       fileId: v.string(),
       title: v.optional(v.string()),
       folderPath: v.optional(v.string()),
+      folderPathPrefix: v.optional(v.string()),
       sourceProvider: v.optional(v.string()),
       externalItemId: v.optional(v.string()),
       contentHash: v.optional(v.string()),
@@ -256,6 +273,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       sourceProvider: v.string(),
       folderPath: v.string(),
       presentExternalIds: v.array(v.string()),
+      truncated: v.optional(v.boolean()),
     }),
   ),
 
@@ -506,88 +524,48 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
         }
 
         const sourceProvider = params.sourceProvider ?? 'agent';
+
+        // Sync flows pass `externalItemId` and rely on dedup. Route through the
+        // atomic upsert mutation: a single transaction reads+writes the index,
+        // and Convex OCC retries one of two concurrent calls so duplicate rows
+        // can't be created. `folderPathPrefix` constrains the cross-folder
+        // fallback to a single sync's subtree (prevents two independent syncs
+        // from ping-ponging the same external file).
+        if (params.externalItemId) {
+          const result = await ctx.runMutation(
+            internal.documents.internal_mutations.upsertDocumentByExternalId,
+            {
+              organizationId,
+              externalItemId: params.externalItemId,
+              folderPathPrefix: params.folderPathPrefix,
+              title: docTitle,
+              fileId: storageId,
+              mimeType: fileMetadata.contentType,
+              sourceProvider,
+              contentHash: params.contentHash,
+              metadata: params.metadata,
+              ...(folderId ? { folderId: toId<'folders'>(folderId) } : {}),
+              createdBy: userId,
+            },
+          );
+
+          return {
+            success: true,
+            fileId: params.fileId,
+            title: docTitle,
+            folderPath: params.folderPath ?? null,
+            documentId: result.documentId,
+            action: result.action,
+          };
+        }
+
+        // Non-sync ad-hoc create (no externalItemId) — straight insert, no dedup.
         const folderIdPatch = folderId
           ? { folderId: toId<'folders'>(folderId) }
           : {};
         const metadataPatch = params.metadata
           ? { metadata: toConvexJsonRecord(params.metadata) }
           : {};
-
-        if (params.externalItemId) {
-          // Scope dedup to the target folder. The same external file synced to
-          // two different Tale folders should produce two document rows — not
-          // ping-pong between folders on each run.
-          const lookupFolderId = folderId
-            ? toId<'folders'>(folderId)
-            : params.folderPath
-              ? null // folderPath was given but resolved empty → root
-              : undefined; // no folderPath given → match across all folders
-
-          let existing = await ctx.runQuery(
-            internal.documents.internal_queries.findDocumentByExternalId,
-            {
-              organizationId,
-              externalItemId: params.externalItemId,
-              ...(lookupFolderId !== undefined
-                ? { folderId: lookupFolderId }
-                : {}),
-            },
-          );
-
-          // Cross-folder move: a file that previously lived in folder A is now
-          // in folder B. The scoped lookup misses it; without this fallback
-          // we'd insert a duplicate row and reconcile would spare both
-          // (since the externalId is still in the present set).
-          if (!existing && lookupFolderId !== undefined) {
-            existing = await ctx.runQuery(
-              internal.documents.internal_queries.findDocumentByExternalId,
-              {
-                organizationId,
-                externalItemId: params.externalItemId,
-              },
-            );
-          }
-
-          if (existing) {
-            if (
-              params.contentHash &&
-              existing.contentHash === params.contentHash
-            ) {
-              return {
-                success: true,
-                fileId: params.fileId,
-                title: docTitle,
-                folderPath: params.folderPath ?? null,
-                documentId: existing._id,
-                action: 'skipped',
-              };
-            }
-
-            await ctx.runMutation(
-              internal.documents.internal_mutations.updateDocument,
-              {
-                documentId: existing._id,
-                title: docTitle,
-                fileId: storageId,
-                mimeType: fileMetadata.contentType,
-                sourceProvider,
-                externalItemId: params.externalItemId,
-                contentHash: params.contentHash,
-                ...folderIdPatch,
-                ...metadataPatch,
-              },
-            );
-
-            return {
-              success: true,
-              fileId: params.fileId,
-              title: docTitle,
-              folderPath: params.folderPath ?? null,
-              documentId: existing._id,
-              action: 'updated',
-            };
-          }
-        }
 
         const documentId = await ctx.runMutation(
           internal.documents.internal_mutations.createDocument,
@@ -597,7 +575,6 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             fileId: storageId,
             mimeType: fileMetadata.contentType,
             sourceProvider,
-            externalItemId: params.externalItemId,
             contentHash: params.contentHash,
             createdBy: userId,
             ...folderIdPatch,
@@ -839,9 +816,9 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
 
       case 'find_by_external_id': {
         // Cheap pre-flight lookup used by sync workflows to skip the download
-        // step when the source file's hash hasn't changed. Scoped by folder
-        // when `folderPath` is provided so the same external file synced to
-        // two different Tale folders stays distinct.
+        // step when the source file's hash hasn't changed. Read-only by design:
+        // resolves the folder via a query (no folder rows created) and short-
+        // circuits to `exists: false` if the path does not yet exist.
         const organizationId =
           typeof _variables.organizationId === 'string'
             ? _variables.organizationId
@@ -853,26 +830,24 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           );
         }
 
-        let folderId: string | null = null;
+        let folderId: Id<'folders'> | null = null;
         if (params.folderPath) {
-          folderId = await ctx.runMutation(
-            internal.folders.internal_mutations.getOrCreateFolderPath,
+          const resolved = await ctx.runQuery(
+            internal.folders.internal_queries.findFolderByPath,
             {
               organizationId,
               pathSegments: params.folderPath.split('/').filter(Boolean),
-              createdBy:
-                typeof _variables.userId === 'string'
-                  ? _variables.userId
-                  : undefined,
             },
           );
+          if (resolved === null) {
+            // Path does not exist — no document can live there yet.
+            return { exists: false };
+          }
+          folderId = resolved;
         }
 
-        const lookupFolderId = folderId
-          ? toId<'folders'>(folderId)
-          : params.folderPath
-            ? null
-            : undefined;
+        const lookupFolderId =
+          folderId ?? (params.folderPath ? null : undefined);
 
         const existing = await ctx.runQuery(
           internal.documents.internal_queries.findDocumentByExternalId,
@@ -909,6 +884,19 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           throw new Error(
             'organizationId is required in workflow variables to reconcile deletes',
           );
+        }
+
+        // Defense-in-depth: a truncated upstream listing means the present-id
+        // set is incomplete and reconcile would delete legitimate docs. The
+        // workflow JSON should already gate this step on a truncation check;
+        // enforce it here too so a forked workflow without that gate is safe.
+        if (params.truncated) {
+          return {
+            success: false,
+            deleted: 0,
+            scanned: params.presentExternalIds.length,
+            skippedReason: `Skipping reconcile: ${params.sourceProvider} listing was truncated (present-id set incomplete).`,
+          };
         }
 
         const orphaned = await ctx.runQuery(

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -164,13 +164,19 @@ type DocumentActionParams =
       operation: 'find_by_external_id';
       externalItemId: string;
       folderPath?: string;
+    }
+  | {
+      operation: 'reconcile_deletes';
+      sourceProvider: string;
+      folderPath: string;
+      presentExternalIds: string[];
     };
 
 export const documentAction: ActionDefinition<DocumentActionParams> = {
   type: 'document',
   title: 'Document Operation',
   description:
-    'Execute document-specific operations (list, update, retrieve, generate_docx, create, extract_docx_structured, apply_docx_structured). organizationId is automatically read from workflow context variables.',
+    'Execute document-specific operations (list, update, retrieve, generate_docx, create, extract_docx_structured, apply_docx_structured, find_by_external_id, index_in_rag, reconcile_deletes). organizationId is automatically read from workflow context variables.',
 
   parametersValidator: v.union(
     v.object({
@@ -244,6 +250,12 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
       operation: v.literal('find_by_external_id'),
       externalItemId: v.string(),
       folderPath: v.optional(v.string()),
+    }),
+    v.object({
+      operation: v.literal('reconcile_deletes'),
+      sourceProvider: v.string(),
+      folderPath: v.string(),
+      presentExternalIds: v.array(v.string()),
     }),
   ),
 
@@ -511,7 +523,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
               ? null // folderPath was given but resolved empty → root
               : undefined; // no folderPath given → match across all folders
 
-          const existing = await ctx.runQuery(
+          let existing = await ctx.runQuery(
             internal.documents.internal_queries.findDocumentByExternalId,
             {
               organizationId,
@@ -521,6 +533,20 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
                 : {}),
             },
           );
+
+          // Cross-folder move: a file that previously lived in folder A is now
+          // in folder B. The scoped lookup misses it; without this fallback
+          // we'd insert a duplicate row and reconcile would spare both
+          // (since the externalId is still in the present set).
+          if (!existing && lookupFolderId !== undefined) {
+            existing = await ctx.runQuery(
+              internal.documents.internal_queries.findDocumentByExternalId,
+              {
+                organizationId,
+                externalItemId: params.externalItemId,
+              },
+            );
+          }
 
           if (existing) {
             if (
@@ -869,6 +895,70 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           contentHash: existing.contentHash,
           externalItemId: existing.externalItemId,
           fileId: existing.fileId,
+          title: existing.title,
+        };
+      }
+
+      case 'reconcile_deletes': {
+        const organizationId =
+          typeof _variables.organizationId === 'string'
+            ? _variables.organizationId
+            : undefined;
+
+        if (!organizationId) {
+          throw new Error(
+            'organizationId is required in workflow variables to reconcile deletes',
+          );
+        }
+
+        const orphaned = await ctx.runQuery(
+          internal.documents.internal_queries.listOrphanedExternalDocs,
+          {
+            organizationId,
+            sourceProvider: params.sourceProvider,
+            folderPathPrefix: params.folderPath,
+            presentExternalIds: params.presentExternalIds,
+          },
+        );
+
+        // Empty present set + non-empty orphan candidates means the source
+        // listing very likely failed silently (Drive returns 200+empty for
+        // OAuth scope downgrades, lost shared-drive access, or wrong folder
+        // ids). Always skip in this case — a user who really wants to clear
+        // the target can do so directly in the Tale UI.
+        if (params.presentExternalIds.length === 0 && orphaned.length > 0) {
+          return {
+            success: false,
+            deleted: 0,
+            scanned: 0,
+            skippedReason: `Skipping reconcile: ${params.sourceProvider} listing returned 0 files for "${params.folderPath}". ${orphaned.length} documents preserved as a safety against transient source-side failures.`,
+          };
+        }
+
+        // Stagger deletes by 100ms to avoid swamping the scheduler and the
+        // RAG service when a folder churns. deleteDocumentFromRag's own
+        // backoff still applies on top.
+        for (let i = 0; i < orphaned.length; i++) {
+          const doc = orphaned[i];
+          if (doc.fileId) {
+            await ctx.scheduler.runAfter(
+              i * 100,
+              internal.documents.internal_actions.deleteDocumentFromRag,
+              { documentId: doc.documentId },
+            );
+          } else {
+            await ctx.scheduler.runAfter(
+              i * 100,
+              internal.documents.internal_mutations.deleteDocumentById,
+              { documentId: doc.documentId },
+            );
+          }
+        }
+
+        return {
+          success: true,
+          deleted: orphaned.length,
+          scanned: params.presentExternalIds.length,
         };
       }
 

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -986,6 +986,24 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
           };
         }
 
+        // Resolve the sync target root so per-doc deletes can reap their
+        // now-empty ancestor folders without ever crossing this boundary.
+        // Read-only — never create folders during a delete pass. Missing
+        // root → skip cleanup (no orphans should exist either).
+        const rootPathSegments = params.folderPath
+          .split('/')
+          .filter((s: string) => s.trim().length > 0);
+        const cleanupAncestorsUpTo: Id<'folders'> | undefined =
+          rootPathSegments.length > 0
+            ? ((await ctx.runQuery(
+                internal.folders.internal_queries.findFolderByPath,
+                {
+                  organizationId,
+                  pathSegments: rootPathSegments,
+                },
+              )) ?? undefined)
+            : undefined;
+
         // Operator audit trail: one line per scheduled delete so the
         // affected docs can be identified and (if needed) restored from
         // backup. Keep individual log lines so they survive log rotation
@@ -1013,13 +1031,17 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
                 documentId: doc.documentId,
                 expectedExternalItemId: doc.externalItemId,
                 expectedFileId: doc.fileId,
+                cleanupAncestorsUpTo,
               },
             );
           } else {
             await ctx.scheduler.runAfter(
               i * 100,
               internal.documents.internal_mutations.deleteDocumentById,
-              { documentId: doc.documentId },
+              {
+                documentId: doc.documentId,
+                cleanupAncestorsUpTo,
+              },
             );
           }
         }

--- a/services/platform/convex/workflow_engine/action_defs/integration/helpers/build_secrets_from_integration.ts
+++ b/services/platform/convex/workflow_engine/action_defs/integration/helpers/build_secrets_from_integration.ts
@@ -10,10 +10,12 @@ import type { LoadedIntegration } from '../../../../integrations/load_integratio
 export async function buildSecretsFromIntegration(
   ctx: ActionCtx,
   integration: LoadedIntegration,
+  options?: { forceRefresh?: boolean },
 ): Promise<Record<string, string>> {
   return buildIntegrationSecrets(
     ctx,
     { ...integration, secretBindings: integration.connector?.secretBindings },
     integration._id,
+    options,
   );
 }

--- a/services/platform/convex/workflow_engine/action_defs/integration/integration_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/integration/integration_action.ts
@@ -171,12 +171,12 @@ export const integrationAction: ActionDefinition<{
     }
 
     // 7. Build secrets from integration credentials
-    const secrets = await buildSecretsFromIntegration(ctx, integration);
+    let secrets = await buildSecretsFromIntegration(ctx, integration);
 
     // 8. Execute the connector in sandbox (via Node.js action)
     debugLog(`Executing ${name}.${operation} (v${connectorConfig.version})`);
 
-    const result = await ctx.runAction(
+    let result = await ctx.runAction(
       internal.node_only.integration_sandbox.internal_actions
         .executeIntegration,
       {
@@ -189,6 +189,39 @@ export const integrationAction: ActionDefinition<{
         timeoutMs: connectorConfig.timeoutMs ?? 30000,
       },
     );
+
+    // OAuth2 force-refresh + one retry on 401. The connector marks
+    // unauthorized failures with the [401_UNAUTHORIZED] sentinel; that
+    // path fires when the access token expired or was revoked between
+    // buildIntegrationSecrets and the actual upstream request. Forcing
+    // a refresh and retrying once recovers cleanly without surfacing
+    // the failure to the workflow.
+    if (
+      !result.success &&
+      integration.authMethod === 'oauth2' &&
+      typeof result.error === 'string' &&
+      result.error.includes('[401_UNAUTHORIZED]')
+    ) {
+      debugLog(
+        `[integration] 401 from ${name}.${operation}; force-refreshing OAuth2 token and retrying once`,
+      );
+      secrets = await buildSecretsFromIntegration(ctx, integration, {
+        forceRefresh: true,
+      });
+      result = await ctx.runAction(
+        internal.node_only.integration_sandbox.internal_actions
+          .executeIntegration,
+        {
+          code: connectorConfig.code,
+          operation,
+          params: toConvexJsonRecord(opParams),
+          variables: {},
+          secrets,
+          allowedHosts: connectorConfig.allowedHosts ?? [],
+          timeoutMs: connectorConfig.timeoutMs ?? 30000,
+        },
+      );
+    }
 
     if (result.logs && result.logs.length > 0) {
       debugLog('Logs:', result.logs);

--- a/services/platform/convex/workflow_engine/action_defs/integration/integration_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/integration/integration_action.ts
@@ -187,6 +187,7 @@ export const integrationAction: ActionDefinition<{
         secrets,
         allowedHosts: connectorConfig.allowedHosts ?? [],
         timeoutMs: connectorConfig.timeoutMs ?? 30000,
+        organizationId,
       },
     );
 
@@ -219,6 +220,7 @@ export const integrationAction: ActionDefinition<{
           secrets,
           allowedHosts: connectorConfig.allowedHosts ?? [],
           timeoutMs: connectorConfig.timeoutMs ?? 30000,
+          organizationId,
         },
       );
     }

--- a/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
@@ -100,6 +100,13 @@ export async function handleDynamicWorkflow(
     )?.stepSlug ||
       stepDefinitions[0]?.stepSlug);
 
+  // Stack of currently-active loop step slugs. Pushed when a loop step emits
+  // `port: 'loop'` for the first iteration, popped when the same loop emits
+  // `port: 'done'`. Used to honor `continueOnError` on the body's exception
+  // path: when a body step throws, walk the stack from the innermost loop
+  // outward and recover at the first loop that opted in.
+  const activeLoopStack: string[] = [];
+
   while (currentStepSlug) {
     const stepDef = stepMap.get(currentStepSlug);
     if (!stepDef) {
@@ -129,26 +136,67 @@ export async function handleDynamicWorkflow(
       stepRetryPolicy ?? workflowRetryPolicy ?? undefined;
     const retryBehavior = buildRetryBehaviorFromPolicy(effectiveRetryPolicy);
 
-    const stepResult = await step.runAction(
-      internal.workflow_engine.internal_actions.executeStep,
-      {
-        organizationId: stepDef.organizationId,
-        executionId: executionId,
-        stepSlug: stepDef.stepSlug,
-        stepType: stepDef.stepType,
-        stepName: stepDef.name,
-        threadId: args.threadId, // Pass shared threadId for agent orchestration workflows
-        initialInput: args.input,
-        resumeVariables: args.resumeVariables,
-      },
-      {
-        name: `${stepDef.name} (${stepDef.stepType})`,
-        retry: retryBehavior,
-      },
-    );
+    let stepResult;
+    try {
+      stepResult = await step.runAction(
+        internal.workflow_engine.internal_actions.executeStep,
+        {
+          organizationId: stepDef.organizationId,
+          executionId: executionId,
+          stepSlug: stepDef.stepSlug,
+          stepType: stepDef.stepType,
+          stepName: stepDef.name,
+          threadId: args.threadId, // Pass shared threadId for agent orchestration workflows
+          initialInput: args.input,
+          resumeVariables: args.resumeVariables,
+        },
+        {
+          name: `${stepDef.name} (${stepDef.stepType})`,
+          retry: retryBehavior,
+        },
+      );
+    } catch (err) {
+      // Honor `continueOnError` on a surrounding loop. We never recover
+      // exceptions thrown by a loop step itself — that would risk an infinite
+      // re-entry. Walk the stack inside-out so the innermost opt-in loop wins.
+      let recovered = false;
+      if (stepDef.stepType !== 'loop') {
+        for (let i = activeLoopStack.length - 1; i >= 0; i--) {
+          const ownerSlug = activeLoopStack[i];
+          const ownerStep = stepMap.get(ownerSlug);
+          const rawConfig: unknown = ownerStep?.config;
+          const ownerCfg = isRecord(rawConfig) ? rawConfig : undefined;
+          if (
+            ownerStep?.stepType === 'loop' &&
+            ownerCfg?.continueOnError === true
+          ) {
+            console.warn(
+              `[loop:${ownerSlug}] step '${stepDef.stepSlug}' failed, continuing iteration: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+            // Trim nested loops nested above the recovery point — their
+            // remaining body is being skipped together with the failing step.
+            activeLoopStack.length = i + 1;
+            currentStepSlug = ownerSlug;
+            recovered = true;
+            break;
+          }
+        }
+      }
+      if (!recovered) throw err;
+      continue;
+    }
 
-    // Note: If step execution fails, it will throw an exception
-    // No need to check for success field anymore
+    // Track loop-step entry/exit so the catch above knows the active loop.
+    if (stepDef.stepType === 'loop') {
+      const top = activeLoopStack[activeLoopStack.length - 1];
+      if (stepResult.port === 'loop' && top !== stepDef.stepSlug) {
+        activeLoopStack.push(stepDef.stepSlug);
+      } else if (stepResult.port === 'done' && top === stepDef.stepSlug) {
+        activeLoopStack.pop();
+      }
+    }
 
     let nextStepSlug: string | null = null;
 

--- a/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
@@ -170,10 +170,22 @@ export async function handleDynamicWorkflow(
             ownerStep?.stepType === 'loop' &&
             ownerCfg?.continueOnError === true
           ) {
+            const errMsg = err instanceof Error ? err.message : String(err);
             console.warn(
-              `[loop:${ownerSlug}] step '${stepDef.stepSlug}' failed, continuing iteration: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
+              `[loop:${ownerSlug}] step '${stepDef.stepSlug}' failed, continuing iteration: ${errMsg}`,
+            );
+            // Persist a minimal failure marker so (a) operators see which
+            // step in which iteration broke (audit trail), and (b)
+            // subsequent steps that read `steps.<slug>.output` see a
+            // failure record instead of stale data from a prior iteration.
+            await step.runAction(
+              internal.workflow_engine.internal_actions.recordBodyStepFailure,
+              {
+                executionId: executionId,
+                stepSlug: stepDef.stepSlug,
+                stepName: stepDef.name,
+                error: errMsg,
+              },
             );
             // Trim nested loops nested above the recovery point — their
             // remaining body is being skipped together with the failing step.

--- a/services/platform/convex/workflow_engine/helpers/step_execution/record_step_failure.ts
+++ b/services/platform/convex/workflow_engine/helpers/step_execution/record_step_failure.ts
@@ -1,0 +1,98 @@
+/**
+ * Record a body-step failure into wfExecutions.stepsMap.
+ *
+ * The catch arm in the dynamic-workflow engine (continueOnError recovery)
+ * needs to mark the failed step so that (a) operators can see which
+ * iteration broke and (b) subsequent steps reading `steps.<slug>.output`
+ * see a failure marker instead of stale data from a prior successful
+ * iteration.
+ *
+ * Pattern mirrors buildStepsMap → persistExecutionResult, but operates on
+ * a failure synthesizing a minimal StepExecutionResult so we don't need
+ * to invent a new persistence path.
+ */
+
+import { isRecord } from '../../../../lib/utils/type-guards';
+import { internal } from '../../../_generated/api';
+import type { Id } from '../../../_generated/dataModel';
+import type { ActionCtx } from '../../../_generated/server';
+import { toId } from '../../../lib/type_cast_helpers';
+import { deserializeVariablesInAction } from '../serialization/deserialize_variables';
+import { serializeVariables } from '../serialization/serialize_variables';
+
+export async function recordStepFailure(
+  ctx: ActionCtx,
+  args: {
+    executionId: string;
+    stepSlug: string;
+    stepName?: string;
+    error: string;
+  },
+): Promise<void> {
+  const rawExecution = await ctx.runQuery(
+    internal.wf_executions.internal_queries.getRawExecution,
+    { executionId: toId<'wfExecutions'>(args.executionId) },
+  );
+
+  if (!rawExecution) return;
+
+  let existingVars: Record<string, unknown> = {};
+  if (rawExecution.variables) {
+    try {
+      const parsed: unknown = JSON.parse(rawExecution.variables);
+      if (isRecord(parsed) && parsed['_storageRef']) {
+        existingVars = await deserializeVariablesInAction(
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex context type
+          ctx as unknown as {
+            storage: { get: (id: Id<'_storage'>) => Promise<Blob | null> };
+          },
+          rawExecution.variables,
+        );
+      } else if (isRecord(parsed)) {
+        existingVars = parsed;
+      }
+    } catch {
+      existingVars = {};
+    }
+  }
+
+  const existingSteps = isRecord(existingVars['steps'])
+    ? existingVars['steps']
+    : {};
+
+  const failureMarker = {
+    stepType: 'action',
+    name: args.stepName ?? args.stepSlug,
+    output: {
+      type: 'action',
+      data: null,
+    },
+    port: 'error',
+    error: args.error,
+    failedAt: Date.now(),
+  };
+
+  const merged: Record<string, unknown> = {
+    ...existingVars,
+    steps: {
+      ...existingSteps,
+      [args.stepSlug]: failureMarker,
+    },
+  };
+
+  const oldStorageId = rawExecution.variablesStorageId;
+  const { serialized, storageId } = await serializeVariables(
+    ctx,
+    merged,
+    oldStorageId,
+  );
+
+  await ctx.runMutation(
+    internal.wf_executions.internal_mutations.updateExecutionVariables,
+    {
+      executionId: toId<'wfExecutions'>(args.executionId),
+      variablesSerialized: serialized,
+      variablesStorageId: storageId,
+    },
+  );
+}

--- a/services/platform/convex/workflow_engine/internal_actions.ts
+++ b/services/platform/convex/workflow_engine/internal_actions.ts
@@ -11,6 +11,7 @@ import * as ConditionNodeHelpers from './helpers/nodes/condition/execute_conditi
 import * as LLMNodeHelpers from './helpers/nodes/llm/execute_llm_node';
 import * as LoopNodeHelpers from './helpers/nodes/loop/execute_loop_node';
 import * as SchedulerHelpers from './helpers/scheduler';
+import { recordStepFailure } from './helpers/step_execution/record_step_failure';
 import type { LLMNodeConfig } from './types';
 import {
   llmStepConfigValidator,
@@ -67,6 +68,20 @@ export const executeStep = internalAction({
   }),
   handler: async (ctx, args) => {
     return await EngineHelpers.handleExecuteStep(ctx, args);
+  },
+});
+
+export const recordBodyStepFailure = internalAction({
+  args: {
+    executionId: v.string(),
+    stepSlug: v.string(),
+    stepName: v.optional(v.string()),
+    error: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await recordStepFailure(ctx, args);
+    return null;
   },
 });
 


### PR DESCRIPTION
## Summary

Extends the Google Drive integration from flat-folder snapshot sync to a full recursive mirror with delete reconciliation and rename detection, plus the safety hardening from a two-round multi-agent review of that initial branch.

### Feature (commit 1)

- **Recursive listing.** `list_files` always exhausts pagination; new `recursive` flag does BFS through subfolders and tags each file with a sanitized `subfolderPath` so Drive's hierarchy mirrors under `targetFolderPath`. Soft cap 5000 files / 20 levels.
- **Delete reconcile.** New `document.reconcile_deletes` op removes synced docs that no longer appear in the listing and cleans their RAG entries. Prefix query uses exact-match + `[root + '/', root + '/￿')` to avoid lex-edge bugs (`Test 2/x` being treated as a child of `Test`). Empty source list always skips deletion (OAuth scope downgrade / lost shared-drive access safety net).
- **Rename detection.** When md5 matches but Drive title differs, dispatch a title-only `document.update` — no re-download, no orphan storage.
- **Cross-folder move detection.** Scoped lookup falls back to unscoped before insert, so a file moved between Drive subfolders updates the existing doc instead of creating a duplicate.
- **Connector sanitization.** Replaces folder-name chars Tale rejects (`/\?*<>:\"|`) with `_`.
- **Automation tester UX.** Persists test input per (org, workflow) in localStorage.

### Safety hardening (commit 2)

Multi-agent review of the above flagged data-loss and consistency issues. All CRITICAL + HIGH findings closed:

- **C1 — truncation guard.** When `list_files` soft-truncates, the workflow now skips reconcile (condition step + defense-in-depth check inside the action) so partial listings cannot delete legitimate Tale docs.
- **C2 — `loop.continueOnError` was dead code.** Engine now tracks active loops on a stack, catches body-step errors, and recovers at the innermost loop that opted in.
- **C3 — `find_by_external_id` is read-only.** New `findFolderByPath` query replaces the `getOrCreateFolderPath` mutation call so a 'find' no longer materializes folder rows.
- **H1 — cross-sync isolation.** `findDocumentByExternalId` now takes `folderPathPrefix`; two syncs targeting the same external file no longer ping-pong the document between Tale folders.
- **H2 — atomic upsert.** `upsertDocumentByExternalId` collapses find-then-insert into one transaction; Convex OCC retries the loser so concurrent runs converge on a single row.
- **H3 — whitespace folder names.** `sanitizeDriveFolderName` trims and falls back to `_`.
- **H4 — RAG 404 = success.** `deleteDocumentFromRag` treats 404 as success; never-indexed docs no longer retry 3x then orphan the Tale row.

## Test plan

- [x] `bun run check` clean (tsc, oxlint, 3013/3013 platform tests)
- [x] New unit tests: `findFolderByPath` (read-only), `upsertDocumentByExternalId` (cross-folder + prefix isolation), `list_orphaned_external_docs` (lex-edge prefix bounds)
- [ ] Manual: run sync workflow against a nested Drive folder, verify subfolder hierarchy mirrors and md5 unchanged → no re-download
- [ ] Manual: delete a file in Drive, re-run sync, verify doc + RAG entry removed
- [ ] Manual: rename a file in Drive, re-run sync, verify title updates without re-download
- [ ] Manual: simulate truncation (lower cap locally), verify reconcile step is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Drive integration now supports recursive folder mirroring with breadth-first traversal and relative path tracking
  * Automation tester input persists per workflow for streamlined testing iterations
  * Workflow loops support graceful error recovery with fallback mechanisms

* **Bug Fixes**
  * Google Drive sync now detects file renames and patches metadata without re-downloading content
  * Improved document deletion reconciliation to prevent accidental removals during synchronization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tale-project/tale/pull/1756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->