### PR TITLE
fix(convex,cli): harden org-first config-layout migration

### DIFF
--- a/services/convex/docker-entrypoint.sh
+++ b/services/convex/docker-entrypoint.sh
@@ -569,15 +569,80 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# Legacy flat-layout detector
+# Legacy flat-layout: self-heal provider secrets, warn about the rest
 # ----------------------------------------------------------------------------
-# The pre-orgfirst layout placed config at the data-root level
-# (`/app/data/agents/`, `/app/data/workflows/`, …). Under org-first that
-# tree is now at `/app/data/<org>/<domain>/`. If an upgrading operator's
-# volume still contains the legacy flat trees, the new runtime ignores
-# them — `seed_marker` already promoted seed data to `default/`, but the
-# operator's edits at the old root are unreachable. Warn loudly so they
-# know to run `tale migrate config-layout` on the host.
+# The pre-orgfirst layout placed config at the data root
+# (`$data_dir/providers/`, `$data_dir/agents/`, …). The org-first runtime
+# reads ONLY `<root>/<org>/<domain>/`.
+#
+# Provider `*.secrets.json` are the one thing that can't be reconstructed from
+# the builtin catalog (non-secret config is reseeded by `run_seed` above and by
+# `tale deploy --override-all`). So we SELF-HEAL them here on every boot:
+# idempotently copy each legacy-path provider secret to its org-first home when
+# that home doesn't already hold it. This recovers deployments whose host dirs
+# were migrated but whose container secrets were stranded (e.g. an interrupted
+# `tale upgrade`) — without it the platform's resolver hits the new path,
+# finds nothing, and reports "No API key configured".
+#
+# `cp` (not `mv`) keeps the legacy copy as rollback insurance until the
+# operator runs `tale migrate config-layout --cleanup-old`. Runs as the `app`
+# user (the script re-execs as `app` above), before the backend starts — so
+# secrets are in place before any request reads them.
+#
+# Mapping mirrors tools/cli/src/lib/actions/migrate-config-layout.ts:
+#   $data_dir/providers/<name>.secrets.json       → $data_dir/default/providers/<name>.secrets.json
+#   $data_dir/providers/<org>/<name>.secrets.json → $data_dir/<org>/providers/<name>.secrets.json
+
+# Copy one secret only when the org-first dest is absent. The new path is
+# authoritative — never clobber a secret the UI may have written there since.
+heal_provider_secret() {
+  local src="$1" dst="$2"
+  [ -f "$src" ] || return 0
+  [ -e "$dst" ] && return 0
+  mkdir -p "$(dirname "$dst")"
+  if atomic_cp "$src" "$dst"; then
+    chmod 600 "$dst" 2>/dev/null || true
+    echo "   ✓ Migrated provider secret → ${dst#"${data_dir}"/}"
+    healed_secrets=$((healed_secrets + 1))
+  else
+    log_warn "Failed to migrate provider secret: $src → $dst"
+  fi
+}
+
+migrate_legacy_provider_secrets() {
+  [ -d "${data_dir}/providers" ] || return 0
+  # Default org: flat $data_dir/providers/*.secrets.json
+  for f in "${data_dir}"/providers/*.secrets.json; do
+    [ -f "$f" ] || continue
+    heal_provider_secret "$f" "${data_dir}/default/providers/$(basename "$f")"
+  done
+  # Non-default orgs: $data_dir/providers/<org>/*.secrets.json
+  for d in "${data_dir}"/providers/*/; do
+    [ -d "$d" ] || continue
+    local org; org="$(basename "$d")"
+    case "$org" in .*) continue ;; esac
+    # Validate the slug shape (keep in sync with ORG_SLUG_REGEX in
+    # services/platform/lib/shared/constants/org-slug.ts). No length cap —
+    # dropping a long-but-valid slug would lose its secrets.
+    if ! echo "$org" | grep -qE '^[a-z0-9][a-z0-9_-]*$'; then
+      log_warn "Skipping provider secrets under invalid org slug: providers/$org/"
+      continue
+    fi
+    for f in "${d}"*.secrets.json; do
+      [ -f "$f" ] || continue
+      heal_provider_secret "$f" "${data_dir}/${org}/providers/$(basename "$f")"
+    done
+  done
+}
+
+healed_secrets=0
+migrate_legacy_provider_secrets
+[ "$healed_secrets" -gt 0 ] && \
+  log_ok "Self-healed $healed_secrets legacy provider secret(s) into the org-first layout"
+
+# Warn about any remaining legacy flat trees. Non-secret edits there are not
+# loaded (builtin config is reseeded into `<org>/`); the kept secret copies are
+# rollback insurance.
 legacy_flat_dirs=()
 for d in agents workflows integrations branding providers skills; do
   if [ -d "${data_dir}/${d}" ]; then
@@ -592,12 +657,12 @@ if [ ${#legacy_flat_dirs[@]} -gt 0 ]; then
   done
   echo
   echo "  The org-first runtime reads only from '<root>/<org>/<domain>/'."
-  echo "  Edits at the paths above are NOT loaded by the platform or any"
-  echo "  per-org config resolver. To migrate them into the new layout,"
+  echo "  Provider *.secrets.json were auto-migrated and are live; the legacy"
+  echo "  copies are kept as rollback insurance. Custom NON-secret edits at the"
+  echo "  paths above are NOT loaded. To migrate host-side config and finalize,"
   echo "  run on the operator host:"
-  echo "    tale migrate config-layout"
-  echo "  then:"
-  echo "    tale deploy --override-all -y"
+  echo "    tale deploy --override-all -y              # migrates host layout + reseeds"
+  echo "    tale migrate config-layout --cleanup-old   # after verifying health"
   echo
 fi
 

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -705,7 +705,7 @@ export function ChatInterface({
           ref={contentRef}
           className={cn(
             'flex flex-col overflow-y-visible p-4 sm:p-6',
-            showWelcome && 'flex-1 items-center justify-center',
+            showWelcome && 'flex-1 justify-center',
           )}
         >
           {showWelcome && (

--- a/services/platform/app/features/chat/components/welcome-view.tsx
+++ b/services/platform/app/features/chat/components/welcome-view.tsx
@@ -48,7 +48,7 @@ export function WelcomeView({
 
   return (
     <Skeletonize loading={isLoading} label={t('skeleton.loadingWelcome')}>
-      <div className="flex w-full max-w-(--chat-max-width) flex-col gap-6 self-center">
+      <div className="mx-auto flex w-full max-w-(--chat-max-width) flex-col gap-6">
         <Heading level={1} weight="semibold" className="text-[1.75rem]">
           <SkeletonBox>
             {hasStarters ? (

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -354,9 +354,13 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
     [teams],
   );
 
+  // Memoize on the consumed value (`policy?.config`), not the `policy` wrapper.
+  // A query hook that hands back a fresh wrapper object each render would
+  // otherwise give `savedConfig` a new identity every render, and the
+  // `[savedConfig]` effect below would `setRules` in a loop.
   const savedConfig = useMemo(
     () => parseBudgetConfig(policy?.config),
-    [policy],
+    [policy?.config],
   );
 
   const [rules, setRules] = useState<BudgetRule[]>([]);

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -388,9 +388,13 @@ export function DefaultModelEditor({
     return list;
   }, [providers]);
 
+  // Memoize on the consumed value (`policy?.config`), not the `policy` wrapper.
+  // A query hook that hands back a fresh wrapper object each render would
+  // otherwise give `savedConfig` a new identity every render, and the
+  // `[savedConfig]` effect below would `setRules` in a loop.
   const savedConfig = useMemo(
     () => parseDefaultModelsConfig(policy?.config),
-    [policy],
+    [policy?.config],
   );
 
   const [rules, setRules] = useState<DefaultModelRule[]>([]);

--- a/services/platform/app/features/settings/governance/components/retention-policy-summary.tsx
+++ b/services/platform/app/features/settings/governance/components/retention-policy-summary.tsx
@@ -46,7 +46,9 @@ export function RetentionPolicySummary({
         </div>
       </dl>
       <div className="border-border/50 border-t pt-4">
-        <RetentionTimeline graceDays={graceDays} />
+        <SkeletonBox fullWidth>
+          <RetentionTimeline graceDays={graceDays} />
+        </SkeletonBox>
       </div>
     </div>
   );

--- a/tools/cli/src/lib/actions/migrate-config-layout.ts
+++ b/tools/cli/src/lib/actions/migrate-config-layout.ts
@@ -403,6 +403,12 @@ export async function migrateConfigLayout(
   const { dryRun, cleanupOld } = options;
   const projectDir = options.projectDir ?? process.cwd();
 
+  // Resolve the container name up front — `getProjectId()` throws if the
+  // caller forgot to bootstrap the project context. Do this BEFORE Phase 1's
+  // irreversible host-dir renames so a missing bootstrap fails fast instead of
+  // leaving the project half-migrated (host moved, container not).
+  const containerName = `${getProjectId()}-convex`;
+
   // ---------------------------------------------------------------------------
   // Phase 1 — host layout
   //
@@ -448,7 +454,6 @@ export async function migrateConfigLayout(
   // ---------------------------------------------------------------------------
   // Phase 2 — container layout (providers/*.secrets.json under $DATA)
   // ---------------------------------------------------------------------------
-  const containerName = `${getProjectId()}-convex`;
   if (!(await isContainerRunning(containerName))) {
     // Earlier the message said "e.g. `tale deploy`", but `tale deploy`
     // now hard-fails on legacy layout — creating a deadlock for fresh

--- a/tools/cli/src/lib/actions/start.ts
+++ b/tools/cli/src/lib/actions/start.ts
@@ -153,6 +153,14 @@ export async function start(options: StartOptions): Promise<void> {
     );
   }
 
+  // Resolve project ID from tale.json before any Docker-resource naming —
+  // and before the legacy-layout preflight, whose `migrateConfigLayout`
+  // derives the convex container name from `getProjectId()`. Resolving after
+  // the preflight would crash with "Project context not initialized" once the
+  // preflight reached its container-side phase, leaving the host dirs already
+  // moved. This only reads/writes tale.json (no Docker), so it is safe here.
+  await resolveOrAssignProjectContext(projectDir);
+
   // Detect legacy flat-layout dirs at the project root (`agents/`,
   // `workflows/`, …, `retention/`). Under the org-first layout these
   // belong under `default/<domain>/` — the platform's resolvers won't
@@ -167,9 +175,6 @@ export async function start(options: StartOptions): Promise<void> {
   });
 
   await assertDockerAvailable();
-
-  // Resolve project ID from tale.json before any Docker-resource naming.
-  await resolveOrAssignProjectContext(projectDir);
 
   // Ensure dev infrastructure under a project-scoped lock so parallel
   // `tale start` / `tale deploy` shells can't race on docker volumes.

--- a/tools/cli/src/lib/actions/update.ts
+++ b/tools/cli/src/lib/actions/update.ts
@@ -57,6 +57,28 @@ export async function update(options: UpdateOptions): Promise<void> {
   logger.info(`Current version: ${project.cliVersion}`);
   logger.info(`Target version:  ${pkg.version}`);
 
+  // Resolve (or assign) the project ID and prime the module-level singleton
+  // BEFORE the legacy-layout preflight. The preflight may run
+  // `migrateConfigLayout`, whose container-side phase derives the convex
+  // container name from `getProjectId()`; without a primed singleton it throws
+  // "Project context not initialized" — and by then Phase 1 has already
+  // irreversibly moved the host dirs. Legacy projects (pre-ID) get an ID
+  // auto-assigned + persisted here; projects that already have one still need
+  // the singleton primed (the old `!project.id` branch skipped them).
+  let assignedId: string | undefined;
+  if (!project.id) {
+    assignedId = generateProjectId(basename(projectDir));
+    project.id = assignedId;
+    if (!options.dryRun) {
+      await writeProject(join(projectDir, 'tale.json'), project);
+    }
+    logger.blank();
+    logger.info(`Assigned project ID: ${assignedId}`);
+  }
+  if (!options.dryRun && project.id) {
+    setProjectId(project.id);
+  }
+
   // If the project is on the pre-org-first layout, migrate now (before
   // we write any new `default/<domain>/...` files). Without this gate
   // `tale update` happily lays the new tree down next to the legacy
@@ -69,22 +91,6 @@ export async function update(options: UpdateOptions): Promise<void> {
       assumeYes: options.assumeYes ?? false,
       context: 'update',
     });
-  }
-
-  // Legacy projects (pre-ID) get an ID auto-assigned here. We also attempt
-  // volume migration immediately, but the migration function itself defers
-  // (via a marker file) if any legacy containers are running, so production
-  // deployments are never impacted by `tale upgrade`.
-  let assignedId: string | undefined;
-  if (!project.id) {
-    assignedId = generateProjectId(basename(projectDir));
-    project.id = assignedId;
-    if (!options.dryRun) {
-      await writeProject(join(projectDir, 'tale.json'), project);
-      setProjectId(assignedId);
-    }
-    logger.blank();
-    logger.info(`Assigned project ID: ${assignedId}`);
   }
 
   // Update reference code


### PR DESCRIPTION
## Summary

Makes the org-first config-layout migration robust against partial/interrupted runs, so deployments can't end up with stranded provider secrets or a half-migrated host tree.

- **convex entrypoint** (`services/convex/docker-entrypoint.sh`): self-heal stranded provider secrets on every boot — idempotently copy legacy-path `*.secrets.json` into their org-first homes (`<root>/<org>/providers/`). This recovers deployments whose host dirs were migrated but whose container secrets were stranded (e.g. an interrupted `tale upgrade`), which otherwise surfaced as "No API key configured". Uses `cp` (not `mv`) so the legacy copies remain as rollback insurance until `tale migrate config-layout --cleanup-old`. Validates the org slug shape and never clobbers a secret already at the new path. The legacy-tree warning is updated to reflect the new flow.
- **cli `start` / `update`**: resolve/prime the project-ID singleton **before** the legacy-layout preflight. `migrateConfigLayout`'s container-side phase derives the convex container name from `getProjectId()`; previously that threw "Project context not initialized" only *after* Phase 1 had irreversibly moved the host dirs, leaving the project half-migrated.
- **`migrate-config-layout`**: resolve the container name up front so a missing bootstrap fails fast instead of half-migrating.
- **chat welcome view**: center via `mx-auto` instead of flex-item centering.

## Test plan

- [ ] `bun run check`
- [ ] Upgrade-in-place against a deployment with legacy flat-layout provider secrets → secrets land in `<org>/providers/` and the platform resolves API keys.
- [ ] `tale start` / `tale update` on a legacy (pre-ID) project → ID assigned and singleton primed before preflight; no "Project context not initialized".
- [ ] Verify welcome view stays centered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider secrets are now automatically migrated during deployment with proper permissions applied.

* **Bug Fixes**
  * Fixed chat interface alignment in welcome view.
  * Improved project initialization timing in CLI tools to prevent context resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->