### PR TITLE
fix(platform): comment cascade, screenshot, notif skeleton, labels

### DIFF
--- a/services/platform/app/components/ui/forms/label.tsx
+++ b/services/platform/app/components/ui/forms/label.tsx
@@ -9,20 +9,22 @@ import { cn } from '@/lib/utils/cn';
 interface LabelProps extends ComponentPropsWithoutRef<
   typeof LabelPrimitive.Root
 > {
+  /**
+   * Controls the suffix shown after the label text. Optionality is opt-in:
+   * the consuming field passes this explicitly so non-field labels (group
+   * headings, decorative labels) stay clean by default.
+   * - `true` → red required asterisk (`*`)
+   * - `false` → muted `(optional)` hint
+   * - `undefined` (default) → nothing
+   */
   required?: boolean;
   error?: boolean;
-  /**
-   * Suppress the automatic "(optional)" hint that every non-required labelled
-   * field shows. Set on labels that aren't form inputs (group headings,
-   * decorative labels) or where optionality is irrelevant.
-   */
-  hideOptional?: boolean;
 }
 
 export const Label = forwardRef<
   ComponentRef<typeof LabelPrimitive.Root>,
   LabelProps
->(({ className, required, error, hideOptional, children, ...props }, ref) => {
+>(({ className, required, error, children, ...props }, ref) => {
   const { t } = useT('common');
   return (
     <LabelPrimitive.Root
@@ -35,18 +37,18 @@ export const Label = forwardRef<
       {...props}
     >
       {children}
-      {/* Required → red asterisk; otherwise a muted "(optional)" hint so every
-          optional field is labelled consistently without editing each form.
-          Opt out with `hideOptional` for non-field labels. */}
-      {required ? (
+      {/* Tri-state: `required` is only rendered when set explicitly. Required →
+          red asterisk; explicitly-optional → muted "(optional)" hint; left
+          undefined → no suffix (the default, for labels not tied to a field). */}
+      {required === true ? (
         <span className="ml-1 text-red-600" aria-label={t('aria.required')}>
           *
         </span>
-      ) : hideOptional ? null : (
+      ) : required === false ? (
         <span className="text-muted-foreground/70 ml-1 text-xs font-normal lowercase">
           ({t('optional')})
         </span>
-      )}
+      ) : null}
     </LabelPrimitive.Root>
   );
 });

--- a/services/platform/app/features/chat/utils/capture-screenshot.ts
+++ b/services/platform/app/features/chat/utils/capture-screenshot.ts
@@ -8,6 +8,49 @@
  * user cancellation (`NotAllowedError` / `AbortError`) — callers should
  * treat those as a silent no-op.
  */
+
+// `requestVideoFrameCallback` isn't in the DOM lib types everywhere yet.
+type VideoWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (callback: () => void) => number;
+};
+
+/**
+ * Resolve once the video element actually has a decoded frame ready to draw.
+ * `play()` resolving only means playback *started* — the first frame may not
+ * be painted yet, and drawing too early is what produces a black capture.
+ *
+ * Prefer `requestVideoFrameCallback` (fires precisely when a frame is
+ * presentable). Fall back to the `loadeddata` event plus two animation frames
+ * so the frame is committed before we read it. A timeout backstop keeps us
+ * from hanging if neither ever fires.
+ */
+function waitForVideoFrame(video: HTMLVideoElement): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    const rvfc = (video as VideoWithFrameCallback).requestVideoFrameCallback;
+    if (typeof rvfc === 'function') {
+      rvfc.call(video, finish);
+    } else {
+      const onReady = () =>
+        requestAnimationFrame(() => requestAnimationFrame(finish));
+      if (video.readyState >= 2 /* HAVE_CURRENT_DATA */) {
+        onReady();
+      } else {
+        video.addEventListener('loadeddata', onReady, { once: true });
+      }
+    }
+
+    // Backstop: never wait forever for a frame callback that doesn't arrive.
+    setTimeout(finish, 1000);
+  });
+}
+
 export async function captureScreenshot(): Promise<File | null> {
   if (
     typeof navigator === 'undefined' ||
@@ -25,11 +68,11 @@ export async function captureScreenshot(): Promise<File | null> {
     const video = document.createElement('video');
     video.srcObject = stream;
     video.muted = true;
+    video.playsInline = true;
     await video.play();
-    // One rAF lets the first frame paint into the element before we draw it.
-    await new Promise<void>((resolve) =>
-      requestAnimationFrame(() => resolve()),
-    );
+    // Wait for a real decoded frame — drawing before one exists yields a
+    // black rectangle.
+    await waitForVideoFrame(video);
 
     const width = video.videoWidth;
     const height = video.videoHeight;

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -63,10 +63,7 @@ export function NotificationListPanel({
   const { t: tCommon } = useT('common');
   const { formatRelative, formatDate } = useFormatDate();
 
-  const { results, status, loadMore } = useNotificationsList(
-    organizationId,
-    filter,
-  );
+  const { results, status, loadMore } = useNotificationsList(organizationId);
   const { data: unread } = useNotificationsUnreadCount(organizationId);
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllNotificationsRead();
@@ -112,9 +109,15 @@ export function NotificationListPanel({
     }
   }, [results, hiddenIds]);
 
+  // Filter client-side so toggling Unread/All never changes the query key (a
+  // query reset would re-flash the skeleton). `hiddenIds` covers the optimistic
+  // "just marked read" gap before the server-side `read` flag catches up.
   const items = useMemo(
-    () => results.filter((n) => !hiddenIds.has(n._id)),
-    [results, hiddenIds],
+    () =>
+      results.filter(
+        (n) => !hiddenIds.has(n._id) && (filter === 'all' || !n.read),
+      ),
+    [results, hiddenIds, filter],
   );
   const unreadCount = unread ?? 0;
   const canLoadMore = status === 'CanLoadMore';
@@ -168,9 +171,9 @@ export function NotificationListPanel({
       <div className="flex-1 overflow-y-auto">
         {items.length === 0 ? (
           status === 'LoadingFirstPage' ? (
-            // Skeleton list mirroring the real row layout so switching the
-            // Unread/All filter (which re-queries from the first page) doesn't
-            // collapse the panel to a tiny "loading" label and shift everything.
+            // Skeleton list mirroring the real row layout for the genuine first
+            // load only. The Unread/All filter is client-side, so toggling it no
+            // longer resets the query — the skeleton won't reappear on switch.
             <Skeletonize loading label={t('loading')}>
               <ul role="list" className="divide-border divide-y" aria-hidden>
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/services/platform/app/features/notifications/hooks/queries.ts
+++ b/services/platform/app/features/notifications/hooks/queries.ts
@@ -4,13 +4,13 @@ import { api } from '@/convex/_generated/api';
 
 export type NotificationsFilter = 'all' | 'unread';
 
-export function useNotificationsList(
-  organizationId: string,
-  filter: NotificationsFilter = 'unread',
-) {
+// The Unread/All filter is applied client-side (see `NotificationListPanel`),
+// so it is intentionally NOT a query argument — toggling it must not change the
+// query key, or pagination resets to `LoadingFirstPage` and the skeleton flashes.
+export function useNotificationsList(organizationId: string) {
   return useConvexPaginatedQuery(
     api.notifications.queries.list,
-    { organizationId, filter },
+    { organizationId },
     { initialNumItems: 25 },
   );
 }

--- a/services/platform/app/features/prompts/components/tag-chip-input.test.tsx
+++ b/services/platform/app/features/prompts/components/tag-chip-input.test.tsx
@@ -36,9 +36,8 @@ function setup(initial: string[] = []) {
       placeholder="add tag"
     />,
   );
-  // Anchored at the start so the auto-appended "(optional)" hint is tolerated
-  // without also matching the per-chip remove buttons (aria-label contains
-  // "tagsInput").
+  // Anchored at the start so we match the input by its label without also
+  // matching the per-chip remove buttons (aria-label contains "tagsInput").
   const input = utils.getByLabelText(/^Tags\b/) as HTMLInputElement;
   return { input, onChange, ...utils };
 }

--- a/services/platform/convex/notifications/queries.ts
+++ b/services/platform/convex/notifications/queries.ts
@@ -32,7 +32,6 @@ export const list = query({
   args: {
     organizationId: v.string(),
     paginationOpts: paginationOptsValidator,
-    filter: v.optional(v.union(v.literal('all'), v.literal('unread'))),
   },
   returns: v.object({
     page: v.array(notificationDocValidator),
@@ -49,7 +48,6 @@ export const list = query({
       name: authUser.name,
     });
     const userId = String(authUser._id);
-    const filter = args.filter ?? 'all';
 
     const result = await ctx.db
       .query('notifications')
@@ -59,11 +57,10 @@ export const list = query({
       .order('desc')
       .paginate(args.paginationOpts);
 
-    // When filtering to unread we drop already-read rows from the returned
-    // page. The `isDone` / `continueCursor` still reflect the underlying
-    // pagination cursor, so pages can be shorter than `numItems` but the
-    // client can keep calling `loadMore` until the index is exhausted.
-    const mapped = result.page.map((n) => ({
+    // The full page is returned with a per-row `read` flag; the Unread/All
+    // filter is applied client-side so toggling it never changes the query
+    // arguments (which would reset pagination and re-flash the skeleton).
+    const page = result.page.map((n) => ({
       _id: n._id,
       _creationTime: n._creationTime,
       organizationId: n.organizationId,
@@ -80,7 +77,7 @@ export const list = query({
     return {
       isDone: result.isDone,
       continueCursor: result.continueCursor,
-      page: filter === 'unread' ? mapped.filter((n) => !n.read) : mapped,
+      page,
     };
   },
 });

--- a/services/platform/convex/tasks/mutations.ts
+++ b/services/platform/convex/tasks/mutations.ts
@@ -992,13 +992,41 @@ export const deleteTaskComment = mutation({
     }
 
     const now = Date.now();
-    await ctx.db.patch(args.commentId, { deletedAt: now, updatedAt: now });
 
-    // Soft-delete drops the comment from the live set, so the denormalized
-    // count must follow. Clamp at 0 so a stale/missing baseline can't go
-    // negative.
+    // Deleting a comment must take its replies down with it — otherwise the
+    // thread is left pointing at a deleted parent. Threading is single-level
+    // today (replies re-root to their thread root), but we walk the
+    // parent → child links transitively so a deeper chain can never strand
+    // orphaned replies. Build the link map from the task's live comments first.
+    const childrenByParent = new Map<string, Id<'taskComments'>[]>();
+    for await (const c of ctx.db
+      .query('taskComments')
+      .withIndex('by_task_createdAt', (q) => q.eq('taskId', comment.taskId))) {
+      if (c.deletedAt || !c.parentCommentId) continue;
+      const parentKey = c.parentCommentId as string;
+      const siblings = childrenByParent.get(parentKey) ?? [];
+      siblings.push(c._id);
+      childrenByParent.set(parentKey, siblings);
+    }
+
+    // Breadth-first walk from the target comment, appending descendants as we
+    // go. Each comment has a single parent, so it is enqueued at most once.
+    const toDelete: Id<'taskComments'>[] = [args.commentId];
+    for (let i = 0; i < toDelete.length; i++) {
+      for (const childId of childrenByParent.get(toDelete[i] as string) ?? []) {
+        toDelete.push(childId);
+      }
+    }
+
+    for (const id of toDelete) {
+      await ctx.db.patch(id, { deletedAt: now, updatedAt: now });
+    }
+
+    // Soft-delete drops the comment (and every cascaded reply) from the live
+    // set, so the denormalized count must follow. Clamp at 0 so a stale/missing
+    // baseline can't go negative.
     await ctx.db.patch(comment.taskId, {
-      commentCount: Math.max(0, (task.commentCount ?? 0) - 1),
+      commentCount: Math.max(0, (task.commentCount ?? 0) - toDelete.length),
     });
 
     await createAuditLog(ctx, {
@@ -1011,7 +1039,10 @@ export const deleteTaskComment = mutation({
       resourceType: TASK_COMMENT_RESOURCE_TYPE,
       resourceId: String(args.commentId),
       resourceName: task.title,
-      metadata: { taskId: String(comment.taskId) },
+      metadata: {
+        taskId: String(comment.taskId),
+        cascadedReplyCount: toDelete.length - 1,
+      },
       status: 'success',
     });
 


### PR DESCRIPTION
## Summary

Four independent bug fixes (one commit each):

### 1. `fix(convex)` — cascade soft-delete to comment replies
Deleting a task comment only soft-deleted the target row, leaving its replies pointing at a deleted parent (orphaned threads). `deleteTaskComment` now walks the parent → child links of the task's live comments breadth-first and soft-deletes the comment **plus every reply in the chain**, decrements `commentCount` by the full count, and records `cascadedReplyCount` in the audit log. Threading is single-level today, but the transitive walk is safe against any depth.

### 2. `fix(platform)` — screenshot captured a black rectangle
The capture drew the canvas after a single `requestAnimationFrame`, before the display-media video had a decoded frame → black image. It now waits for a real frame via `requestVideoFrameCallback` (with a `loadeddata` + double-rAF fallback and a 1s timeout backstop) and sets `playsInline` before drawing.

### 3. `fix(platform)` — notification skeleton flashed on filter toggle
The Unread/All filter was a Convex query argument, so toggling it changed the query key and reset pagination to `LoadingFirstPage`, re-flashing the skeleton on every switch. The filter is now applied **client-side** on the per-row `read` flag; the query key is stable across tab switches, so the skeleton only appears on the genuine first load. This also removes the buggy post-pagination server filter that returned short pages.

### 4. `fix(platform)` — form label `(optional)`/required hint is now opt-in
`Label` auto-appended `(optional)` to every non-required field, so labels not tied to a field (group headings, the tools settings page) wrongly read as optional. `required` is now a true tri-state:
- `true` → red asterisk `*`
- `false` → `(optional)`
- `undefined` (default) → nothing

Field wrappers already forward `required`, so the hint is opt-in per field. Removed the now-redundant `hideOptional` prop.

## Testing

- CodeRabbit review: **0 findings**.
- `@tale/platform` typecheck ✓, lint (oxlint) ✓, format (oxfmt) ✓.
- Server + pii suite: **71,357 tests pass**. Affected UI suites (forms, settings, notifications, chat, prompts, customers, vendors, label): **all pass**.
- `bun run check` is green for every workspace this PR touches. It fails only in `@tale/rag` and `@tale/crawler` with a pre-existing local venv error (`ModuleNotFoundError: No module named 'tale_shared.config.org_slug'`) — unrelated to these TypeScript-only changes.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, tests) — green for all touched workspaces; only pre-existing, unrelated `rag`/`crawler` Python venv import errors remain.
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — notification loading uses the existing `<Skeletonize>` + skeleton-aware leaves.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no string changes; reuses existing `optional` / `aria.required` keys).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change — N/A (bug fixes, no documented feature/config/API change).
- [x] Every touched docs page has a real opening/closing — N/A (no docs changes).
- [x] Ran `bun run --filter @tale/docs lint` and `test` — N/A.
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When deleting a comment, its replies are now removed as well.

* **Bug Fixes**
  * Fixed black screenshots by improving video frame timing.
  * Notifications no longer flicker when switching between Unread and All views.

* **Refactor**
  * Simplified required/optional label display logic in forms.
  * Notification filtering now occurs client-side for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->