### PR TITLE
docs: fix OpenAI-compatible endpoint path (/api/v1, not /api/v1/openai)

### DIFF
--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -35,7 +35,7 @@ Cookies authentifizieren die Browser-Session; API-Aufrufe aus dem Browser innerh
 | ------------------------------------------------ | ------------ | ----------------------------------- | ----------- | ---------------------------------------------------------- |
 | Agents                                           | verschiedene | `/api/v1/agents/...`                | API-Key     | List, get, run.                                            |
 | Chat                                             | verschiedene | `/api/v1/chat/...`                  | API-Key     | Stream Chat-Completions gegen einen Agent oder ein Modell. |
-| OpenAI-kompatibel                                | POST         | `/api/v1/openai/chat/completions`   | API-Key     | OpenAI-Chat-Completions-Form; bestehende SDKs nutzen.      |
+| OpenAI-kompatibel                                | POST         | `/api/v1/chat/completions`          | API-Key     | OpenAI-Chat-Completions-Form; bestehende SDKs nutzen.      |
 | Automatisierungen                                | verschiedene | `/api/v1/automations/...`           | API-Key     | List, get, trigger, executions.                            |
 | Workflow-Trigger                                 | POST         | `/api/v1/workflows/triggers/<name>` | Trigger-Key | Webhook-getriggerte Workflow-Auslösungen.                  |
 | Wissen — Dokumente                               | verschiedene | `/api/v1/documents/...`             | API-Key     | Upload, list, get, delete.                                 |
@@ -47,9 +47,9 @@ Exakte Feld-Formen für jeden Endpoint leben im OpenAPI-Dokument, das die Plattf
 
 ## OpenAI-kompatible Endpoints
 
-`POST /api/v1/openai/chat/completions` akzeptiert einen Payload in OpenAI-Chat-Completions-Form und gibt eine streaming- oder nicht-streaming-Antwort in derselben Form zurück. Das Feld `model` wird als Agent-ID interpretiert — übergib eine Agent-ID, um durch die Anweisungen, das Wissen und die Tools dieses Agents zu routen. Übergib einen rohen Modellnamen (z. B. `gpt-4o`), um Agents zu überspringen und den Provider direkt aufzurufen.
+`POST /api/v1/chat/completions` akzeptiert einen Payload in OpenAI-Chat-Completions-Form und gibt eine streaming- oder nicht-streaming-Antwort in derselben Form zurück. Das Feld `model` wird als Agent-ID interpretiert — übergib eine Agent-ID, um durch die Anweisungen, das Wissen und die Tools dieses Agents zu routen. Übergib einen rohen Modellnamen (z. B. `gpt-4o`), um Agents zu überspringen und den Provider direkt aufzurufen.
 
-Bestehende OpenAI-SDKs funktionieren mit einer Änderung: zeig die Base-URL auf `https://your-host.example.com/api/v1/openai` und tausch den API-Key. Streaming nutzt Server-Sent Events.
+Bestehende OpenAI-SDKs funktionieren mit einer Änderung: zeig die Base-URL auf `https://your-host.example.com/api/v1` und tausch den API-Key. Streaming nutzt Server-Sent Events.
 
 ## Fehlermodell
 

--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -36,6 +36,7 @@ Cookies authentifizieren die Browser-Session; API-Aufrufe aus dem Browser innerh
 | Agents                                           | verschiedene | `/api/v1/agents/...`                | API-Key     | List, get, run.                                            |
 | Chat                                             | verschiedene | `/api/v1/chat/...`                  | API-Key     | Stream Chat-Completions gegen einen Agent oder ein Modell. |
 | OpenAI-kompatibel                                | POST         | `/api/v1/chat/completions`          | API-Key     | OpenAI-Chat-Completions-Form; bestehende SDKs nutzen.      |
+| OpenAI-kompatibel                                | GET          | `/api/v1/models`                    | API-Key     | Verfügbare Modelle im OpenAI-Format auflisten.             |
 | Automatisierungen                                | verschiedene | `/api/v1/automations/...`           | API-Key     | List, get, trigger, executions.                            |
 | Workflow-Trigger                                 | POST         | `/api/v1/workflows/triggers/<name>` | Trigger-Key | Webhook-getriggerte Workflow-Auslösungen.                  |
 | Wissen — Dokumente                               | verschiedene | `/api/v1/documents/...`             | API-Key     | Upload, list, get, delete.                                 |

--- a/docs/de/tutorials/developer/call-tale-from-a-script.md
+++ b/docs/de/tutorials/developer/call-tale-from-a-script.md
@@ -45,7 +45,7 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1/openai",
+    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1",
     api_key=os.environ["TALE_API_KEY"],
 )
 reply = client.chat.completions.create(

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -35,7 +35,7 @@ Cookies authenticate the browser session; API calls from the browser inside the 
 | -------------------------------------------------- | ------- | ----------------------------------- | ------------- | -------------------------------------------------- |
 | Agents                                             | various | `/api/v1/agents/...`                | API key       | List, get, run.                                    |
 | Chat                                               | various | `/api/v1/chat/...`                  | API key       | Stream chat completions against an agent or model. |
-| OpenAI-compatible                                  | POST    | `/api/v1/openai/chat/completions`   | API key       | OpenAI Chat Completions shape; use existing SDKs.  |
+| OpenAI-compatible                                  | POST    | `/api/v1/chat/completions`          | API key       | OpenAI Chat Completions shape; use existing SDKs.  |
 | Automations                                        | various | `/api/v1/automations/...`           | API key       | List, get, trigger, executions.                    |
 | Workflow triggers                                  | POST    | `/api/v1/workflows/triggers/<name>` | Trigger key   | Webhook-triggered workflow invocations.            |
 | Knowledge — Documents                              | various | `/api/v1/documents/...`             | API key       | Upload, list, get, delete.                         |
@@ -47,9 +47,9 @@ Exact field shapes for each endpoint live in the OpenAPI document the platform e
 
 ## OpenAI-compatible endpoints
 
-`POST /api/v1/openai/chat/completions` accepts a payload in OpenAI Chat Completions shape and returns a streaming or non-streaming response in the same shape. The `model` field is interpreted as the agent ID — pass an agent's ID to route through that agent's instructions, knowledge, and tools. Pass a raw model name (e.g. `gpt-4o`) to bypass agents and call the provider directly.
+`POST /api/v1/chat/completions` accepts a payload in OpenAI Chat Completions shape and returns a streaming or non-streaming response in the same shape. The `model` field is interpreted as the agent ID — pass an agent's ID to route through that agent's instructions, knowledge, and tools. Pass a raw model name (e.g. `gpt-4o`) to bypass agents and call the provider directly.
 
-Existing OpenAI SDKs work with one change: point the base URL at `https://your-host.example.com/api/v1/openai` and substitute the API key. Streaming uses Server-Sent Events.
+Existing OpenAI SDKs work with one change: point the base URL at `https://your-host.example.com/api/v1` and substitute the API key. Streaming uses Server-Sent Events.
 
 ## Error model
 

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -36,6 +36,7 @@ Cookies authenticate the browser session; API calls from the browser inside the 
 | Agents                                             | various | `/api/v1/agents/...`                | API key       | List, get, run.                                    |
 | Chat                                               | various | `/api/v1/chat/...`                  | API key       | Stream chat completions against an agent or model. |
 | OpenAI-compatible                                  | POST    | `/api/v1/chat/completions`          | API key       | OpenAI Chat Completions shape; use existing SDKs.  |
+| OpenAI-compatible                                  | GET     | `/api/v1/models`                    | API key       | List available models in OpenAI format.            |
 | Automations                                        | various | `/api/v1/automations/...`           | API key       | List, get, trigger, executions.                    |
 | Workflow triggers                                  | POST    | `/api/v1/workflows/triggers/<name>` | Trigger key   | Webhook-triggered workflow invocations.            |
 | Knowledge — Documents                              | various | `/api/v1/documents/...`             | API key       | Upload, list, get, delete.                         |

--- a/docs/en/tutorials/developer/call-tale-from-a-script.md
+++ b/docs/en/tutorials/developer/call-tale-from-a-script.md
@@ -45,7 +45,7 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1/openai",
+    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1",
     api_key=os.environ["TALE_API_KEY"],
 )
 reply = client.chat.completions.create(

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -35,7 +35,7 @@ Les cookies authentifient la session navigateur ; les appels API depuis le navig
 | ---------------------------------------------------------- | -------- | ---------------------------------- | --------------- | ---------------------------------------------------------- |
 | Agents                                                     | diverses | `/api/v1/agents/...`               | Clé API         | List, get, run.                                            |
 | Chat                                                       | diverses | `/api/v1/chat/...`                 | Clé API         | Stream de complétions chat contre un agent ou un modèle.   |
-| Compatible OpenAI                                          | POST     | `/api/v1/openai/chat/completions`  | Clé API         | Forme Chat Completions OpenAI ; utilise les SDK existants. |
+| Compatible OpenAI                                          | POST     | `/api/v1/chat/completions`         | Clé API         | Forme Chat Completions OpenAI ; utilise les SDK existants. |
 | Automatisations                                            | diverses | `/api/v1/automations/...`          | Clé API         | List, get, trigger, executions.                            |
 | Déclencheurs de workflow                                   | POST     | `/api/v1/workflows/triggers/<nom>` | Clé déclencheur | Invocations de workflow déclenchées par webhook.           |
 | Connaissances — Documents                                  | diverses | `/api/v1/documents/...`            | Clé API         | Upload, list, get, delete.                                 |
@@ -47,9 +47,9 @@ Les formes exactes de champs pour chaque endpoint vivent dans le document OpenAP
 
 ## Endpoints compatibles OpenAI
 
-`POST /api/v1/openai/chat/completions` accepte un payload en forme Chat Completions OpenAI et retourne une réponse streaming ou non en même forme. Le champ `model` est interprété comme l'ID d'agent — passe un ID d'agent pour router via les instructions, connaissances et outils de cet agent. Passe un nom de modèle brut (ex. `gpt-4o`) pour contourner les agents et appeler le fournisseur directement.
+`POST /api/v1/chat/completions` accepte un payload en forme Chat Completions OpenAI et retourne une réponse streaming ou non en même forme. Le champ `model` est interprété comme l'ID d'agent — passe un ID d'agent pour router via les instructions, connaissances et outils de cet agent. Passe un nom de modèle brut (ex. `gpt-4o`) pour contourner les agents et appeler le fournisseur directement.
 
-Les SDK OpenAI existants marchent avec un changement : pointe l'URL de base sur `https://your-host.example.com/api/v1/openai` et substitue la clé API. Le streaming utilise les Server-Sent Events.
+Les SDK OpenAI existants marchent avec un changement : pointe l'URL de base sur `https://your-host.example.com/api/v1` et substitue la clé API. Le streaming utilise les Server-Sent Events.
 
 ## Modèle d'erreur
 

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -36,6 +36,7 @@ Les cookies authentifient la session navigateur ; les appels API depuis le navig
 | Agents                                                     | diverses | `/api/v1/agents/...`               | Clé API         | List, get, run.                                            |
 | Chat                                                       | diverses | `/api/v1/chat/...`                 | Clé API         | Stream de complétions chat contre un agent ou un modèle.   |
 | Compatible OpenAI                                          | POST     | `/api/v1/chat/completions`         | Clé API         | Forme Chat Completions OpenAI ; utilise les SDK existants. |
+| Compatible OpenAI                                          | GET      | `/api/v1/models`                   | Clé API         | Liste les modèles disponibles au format OpenAI.            |
 | Automatisations                                            | diverses | `/api/v1/automations/...`          | Clé API         | List, get, trigger, executions.                            |
 | Déclencheurs de workflow                                   | POST     | `/api/v1/workflows/triggers/<nom>` | Clé déclencheur | Invocations de workflow déclenchées par webhook.           |
 | Connaissances — Documents                                  | diverses | `/api/v1/documents/...`            | Clé API         | Upload, list, get, delete.                                 |

--- a/docs/fr/tutorials/developer/call-tale-from-a-script.md
+++ b/docs/fr/tutorials/developer/call-tale-from-a-script.md
@@ -45,7 +45,7 @@ from openai import OpenAI
 import os
 
 client = OpenAI(
-    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1/openai",
+    base_url=f"{os.environ['TALE_BASE_URL']}/api/v1",
     api_key=os.environ["TALE_API_KEY"],
 )
 reply = client.chat.completions.create(


### PR DESCRIPTION
## What

The OpenAI-compatible Chat Completions endpoint is documented at the wrong path. The docs say `POST /api/v1/openai/chat/completions` and tell users to set their OpenAI SDK `base_url` to `…/api/v1/openai`, but the route registered in `convex/http.ts` is **`POST /api/v1/chat/completions`** — there is no `/api/v1/openai/` prefix anywhere in the code. Following the docs produces a 404.

## Fix

Corrected the endpoint path and the SDK base URL across all three base locales:

- `docs/{en,de,fr}/develop/api-reference.md` — endpoint table row + the "OpenAI-compatible endpoints" section (path `/api/v1/chat/completions`, base URL `/api/v1`).
- `docs/{en,de,fr}/tutorials/developer/call-tale-from-a-script.md` — the Python example's `base_url` (the OpenAI SDK appends `/chat/completions` to the base URL, so `…/api/v1` is correct).

## Verification

- `convex/http.ts` registers only `/api/v1/chat/completions` and `/api/v1/models`; `grep` for `v1/openai` in `services/platform/convex` returns nothing.
- `bun run --filter @tale/docs test` → 139 passed.
- `bun run --filter @tale/docs lint` → 0 warnings, 0 errors.

Closes #1477


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAI-compatible endpoint path from `/api/v1/openai/chat/completions` to `/api/v1/chat/completions`
  * Updated base URL configuration for OpenAI SDK clients from `https://your-host.example.com/api/v1/openai` to `https://your-host.example.com/api/v1`
  * Updated API reference and tutorial examples across multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->