### PR TITLE
fix(platform): gate create-dialog submit buttons on form validity (#1466, #1425, #1426)

### DIFF
--- a/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, screen, waitFor } from '@/test/utils/render';
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: (ns: string) => ({
@@ -58,6 +58,63 @@ describe('CreateAgentDialog', () => {
         />,
       );
       await checkAccessibility(container);
+    });
+  });
+
+  // Regression test for #1466: the Continue button must stay disabled
+  // until the required fields (name, displayName) are valid, instead of
+  // only failing after a submit attempt.
+  describe('submit gating (#1466)', () => {
+    it('keeps Continue disabled until required fields are valid', async () => {
+      const { user } = render(
+        <CreateAgentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          organizationId="test-org-id"
+        />,
+      );
+
+      const submit = screen.getByRole('button', {
+        name: 'settings.agents.createDialog.continue',
+      });
+      expect(submit).toBeDisabled();
+
+      await user.type(
+        screen.getByLabelText('settings.agents.form.name'),
+        'support-bot',
+      );
+      await user.type(
+        screen.getByLabelText('settings.agents.form.displayName'),
+        'Support Bot',
+      );
+
+      await waitFor(() => expect(submit).toBeEnabled());
+    });
+
+    it('keeps Continue disabled when name violates the slug pattern', async () => {
+      const { user } = render(
+        <CreateAgentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          organizationId="test-org-id"
+        />,
+      );
+
+      const submit = screen.getByRole('button', {
+        name: 'settings.agents.createDialog.continue',
+      });
+
+      // Uppercase/spaces violate the ^[a-z0-9][a-z0-9_-]*$ slug rule.
+      await user.type(
+        screen.getByLabelText('settings.agents.form.name'),
+        'Invalid Name',
+      );
+      await user.type(
+        screen.getByLabelText('settings.agents.form.displayName'),
+        'Support Bot',
+      );
+
+      await waitFor(() => expect(submit).toBeDisabled());
     });
   });
 });

--- a/services/platform/app/features/agents/components/agent-create-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.tsx
@@ -119,9 +119,12 @@ export function CreateAgentDialog({
     handleSubmit,
     reset,
     setError,
-    formState: { isSubmitting, errors },
+    formState: { isSubmitting, errors, isValid },
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
+    // Validate on change so the Continue button can gate on validity
+    // (required fields filled) instead of only after a submit attempt.
+    mode: 'onChange',
     defaultValues: {
       name: '',
       displayName: '',
@@ -198,6 +201,7 @@ export function CreateAgentDialog({
       submitText={t('agents.createDialog.continue')}
       submittingText={t('agents.createDialog.creating')}
       isSubmitting={isSubmitting}
+      isValid={isValid}
       onSubmit={handleSubmit(onSubmit)}
     >
       <Input

--- a/services/platform/app/features/automations/components/automation-create-dialog.test.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, waitFor } from '@/test/utils/render';
 
 import { CreateAutomationDialog } from './automation-create-dialog';
 
@@ -36,6 +36,34 @@ describe('CreateAutomationDialog', () => {
         />,
       );
       await checkAccessibility(container);
+    });
+  });
+
+  // Regression test for #1425: Continue must stay disabled until the
+  // required name field is filled.
+  describe('submit gating (#1425)', () => {
+    it('keeps Continue disabled until the name is filled', async () => {
+      const { user } = render(
+        <CreateAutomationDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          organizationId="test-org-id"
+        />,
+      );
+
+      // The dialog renders in a Radix portal (document.body), not inside
+      // the render container.
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      expect(submit).toBeDisabled();
+
+      const nameInput = document.querySelector(
+        'input[name="name"]',
+      ) as HTMLInputElement;
+      await user.type(nameInput, 'My Automation');
+
+      await waitFor(() => expect(submit).toBeEnabled());
     });
   });
 });

--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -83,9 +83,12 @@ function BlankTabContent({
     register,
     handleSubmit,
     setError,
-    formState: { isSubmitting, errors },
+    formState: { isSubmitting, errors, isValid },
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
+    // Validate on change so Continue stays disabled until the required
+    // name is filled, instead of only failing after a submit attempt.
+    mode: 'onChange',
   });
 
   const onSubmit = useCallback(
@@ -181,7 +184,7 @@ function BlankTabContent({
         >
           {tCommon('actions.cancel')}
         </Button>
-        <Button type="submit" disabled={isSubmitting}>
+        <Button type="submit" disabled={isSubmitting || !isValid}>
           {isSubmitting
             ? t('createDialog.creating')
             : t('createDialog.continue')}

--- a/services/platform/app/features/automations/triggers/components/schedule-create-dialog.test.tsx
+++ b/services/platform/app/features/automations/triggers/components/schedule-create-dialog.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, waitFor } from '@/test/utils/render';
 
 import { ScheduleCreateDialog } from './schedule-create-dialog';
 
@@ -59,6 +59,58 @@ describe('ScheduleCreateDialog', () => {
         />,
       );
       await checkAccessibility(container);
+    });
+  });
+
+  // Regression test for #1426: Create must stay disabled until a valid
+  // cron expression is entered.
+  describe('submit gating (#1426)', () => {
+    it('keeps Create disabled until a valid cron expression is entered', async () => {
+      const { user } = render(
+        <ScheduleCreateDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          workflowRootId="wf-root-1"
+          organizationId="test-org-id"
+          workflowSlug="my-workflow"
+        />,
+      );
+
+      // The dialog renders in a Radix portal (document.body).
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      expect(submit).toBeDisabled();
+
+      const cronInput = document.querySelector(
+        'input[name="cronExpression"]',
+      ) as HTMLInputElement;
+      await user.type(cronInput, '0 * * * *');
+
+      await waitFor(() => expect(submit).toBeEnabled());
+    });
+
+    it('keeps Create disabled for an invalid cron expression', async () => {
+      const { user } = render(
+        <ScheduleCreateDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          workflowRootId="wf-root-1"
+          organizationId="test-org-id"
+          workflowSlug="my-workflow"
+        />,
+      );
+
+      // The dialog renders in a Radix portal (document.body).
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      const cronInput = document.querySelector(
+        'input[name="cronExpression"]',
+      ) as HTMLInputElement;
+      await user.type(cronInput, 'not-a-cron');
+
+      await waitFor(() => expect(submit).toBeDisabled());
     });
   });
 });

--- a/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
+++ b/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
@@ -122,6 +122,9 @@ export function ScheduleCreateDialog({
 
   const form = useForm<ScheduleFormData>({
     resolver: zodResolver(schema),
+    // Validate on change so Create stays disabled until the cron
+    // expression is present and valid.
+    mode: 'onChange',
     defaultValues: {
       cronExpression: schedule?.cronExpression ?? '',
     },
@@ -131,7 +134,7 @@ export function ScheduleCreateDialog({
     handleSubmit,
     register,
     reset,
-    formState: { errors: formErrors },
+    formState: { errors: formErrors, isValid },
     setValue,
   } = form;
 
@@ -244,6 +247,7 @@ export function ScheduleCreateDialog({
       submitText={isEdit ? tCommon('actions.save') : tCommon('actions.create')}
       submittingText={tCommon('actions.loading')}
       isSubmitting={isSubmitting}
+      isValid={isValid}
       onSubmit={handleSubmit(onSubmit)}
     >
       <FormSection>


### PR DESCRIPTION
## What

Three "create" dialogs left their submit button **enabled while required fields were empty**, so the user could click Continue/Create and only then get a validation error:

- **Create Agent** (`agent-create-dialog.tsx`) — #1466
- **Create Automation** (`automation-create-dialog.tsx`) — #1425
- **Create Schedule** (`schedule-create-dialog.tsx`) — #1426

The pattern was that the forms didn't validate on change and didn't gate the submit button on `formState.isValid` (the existing `team-create-dialog.tsx` does this correctly and is the reference).

## Fix

Each form now uses `mode: 'onChange'` and gates the submit button on validity:

- `agent-create-dialog` and `schedule-create-dialog` pass `isValid={formState.isValid}` to `FormDialog` (which already disables submit on `isSubmitting || !isDirty || !isValid`).
- `automation-create-dialog` uses a raw `<form>`, so its submit button is now `disabled={isSubmitting || !isValid}`.

## Tests

Added regression tests in each dialog's `.test.tsx`:
- Submit/Continue/Create is **disabled** with empty required fields.
- Becomes **enabled** once required fields are valid.
- Stays **disabled** for invalid input (agent name slug-pattern violation; invalid cron expression).

## Verification

- `bunx vitest --run --project client` for the three dialogs → 9 passed.
- `oxfmt`, `oxlint --type-aware`, `tsc --noEmit` on the platform → clean.

Closes #1466
Closes #1425
Closes #1426
