### PR TITLE
fix(platform): harden customer/vendor import against silent data loss (#1312, #1323, #1412)

### DIFF
--- a/services/platform/app/features/customers/components/customers-import-dialog.tsx
+++ b/services/platform/app/features/customers/components/customers-import-dialog.tsx
@@ -6,7 +6,11 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
-import { useFileImport, customerMappers } from '@/app/hooks/use-file-import';
+import {
+  CONTACT_REQUIRED_COLUMNS,
+  customerMappers,
+  useFileImport,
+} from '@/app/hooks/use-file-import';
 import { toast } from '@/app/hooks/use-toast';
 import { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -52,6 +56,7 @@ export function ImportCustomersDialog({
   const { parseFile, parseCSV } = useFileImport<ParsedCustomer>({
     csvMapper: customerMappers.csv,
     excelMapper: customerMappers.excel,
+    requiredColumns: CONTACT_REQUIRED_COLUMNS,
   });
 
   // Create Zod schema with translated validation messages
@@ -122,6 +127,7 @@ export function ImportCustomersDialog({
     async (values: FormValues) => {
       try {
         let customers: ParsedCustomer[] = [];
+        let parseErrors: string[] = [];
 
         // Handle different data sources
         if (values.dataSource === 'circuly') {
@@ -134,9 +140,11 @@ export function ImportCustomersDialog({
         } else if (values.dataSource === 'manual_import' && values.customers) {
           const result = parseCSV(values.customers);
           customers = result.data;
+          parseErrors = result.errors;
         } else if (values.dataSource === 'file_upload' && values.file) {
           const result = await parseFile(values.file);
           customers = result.data;
+          parseErrors = result.errors;
         } else {
           toast({
             title: tCustomers('import.provideData'),
@@ -148,6 +156,9 @@ export function ImportCustomersDialog({
         if (customers.length === 0) {
           toast({
             title: tCustomers('import.noValidData'),
+            // Surface the specific parse failure (e.g. a missing required
+            // column) instead of a generic message, so the user can fix it.
+            description: parseErrors[0],
             variant: 'destructive',
           });
           return;

--- a/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
@@ -6,7 +6,11 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
-import { useFileImport, vendorMappers } from '@/app/hooks/use-file-import';
+import {
+  CONTACT_REQUIRED_COLUMNS,
+  useFileImport,
+  vendorMappers,
+} from '@/app/hooks/use-file-import';
 import { toast } from '@/app/hooks/use-toast';
 import { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -50,6 +54,7 @@ export function ImportVendorsDialog({
   const { parseFile, parseCSV } = useFileImport<ParsedVendor>({
     csvMapper: vendorMappers.csv,
     excelMapper: vendorMappers.excel,
+    requiredColumns: CONTACT_REQUIRED_COLUMNS,
   });
 
   // Create Zod schema with translated validation messages
@@ -120,14 +125,17 @@ export function ImportVendorsDialog({
     async (values: FormValues) => {
       try {
         let vendors: ParsedVendor[] = [];
+        let parseErrors: string[] = [];
 
         // Handle different data sources using shared utilities
         if (values.dataSource === 'manual_import' && values.vendors) {
           const result = parseCSV(values.vendors);
           vendors = result.data;
+          parseErrors = result.errors;
         } else if (values.dataSource === 'file_upload' && values.file) {
           const result = await parseFile(values.file);
           vendors = result.data;
+          parseErrors = result.errors;
         } else {
           toast({
             title: t('import.provideData'),
@@ -139,6 +147,9 @@ export function ImportVendorsDialog({
         if (vendors.length === 0) {
           toast({
             title: t('noValidData'),
+            // Surface the specific parse failure (e.g. a missing required
+            // column) instead of a generic message, so the user can fix it.
+            description: parseErrors[0],
             variant: 'destructive',
           });
           return;

--- a/services/platform/app/hooks/use-file-import.test.ts
+++ b/services/platform/app/hooks/use-file-import.test.ts
@@ -120,6 +120,31 @@ describe('vendorMappers.excel', () => {
     const result = vendorMappers.excel({ name: 'Acme Corp' });
     expect(result).toBeNull();
   });
+
+  // Regression test for #1323: a vendor file whose columns are named
+  // differently ("Email Address", "Company", "Language") must still map
+  // every field instead of silently dropping the name/locale.
+  it('maps aliased header columns (email address / company / language)', () => {
+    const result = vendorMappers.excel({
+      'email address': 'vendor@example.com',
+      company: 'Acme Corp',
+      language: 'de',
+    });
+    expect(result).toEqual({
+      email: 'vendor@example.com',
+      name: 'Acme Corp',
+      locale: 'de',
+      source: 'file_upload',
+    });
+  });
+
+  it('maps "vendor name" alias to name', () => {
+    const result = vendorMappers.excel({
+      email: 'vendor@example.com',
+      'vendor name': 'Beta LLC',
+    });
+    expect(result).toMatchObject({ name: 'Beta LLC' });
+  });
 });
 
 describe('customerMappers.excel', () => {
@@ -152,6 +177,22 @@ describe('customerMappers.excel', () => {
   it('returns null when email is missing', () => {
     const result = customerMappers.excel({ name: 'John Doe' });
     expect(result).toBeNull();
+  });
+
+  // Regression test for #1312: aliased header columns must still map.
+  it('maps aliased header columns (e-mail / full name / lang)', () => {
+    const result = customerMappers.excel({
+      'e-mail': 'user@example.com',
+      'full name': 'John Doe',
+      lang: 'fr',
+    });
+    expect(result).toEqual({
+      email: 'user@example.com',
+      name: 'John Doe',
+      locale: 'fr',
+      status: 'active',
+      source: 'file_upload',
+    });
   });
 });
 

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -6,6 +6,7 @@ import {
   parseImportFile,
   parseCSVWithMapper,
   type FileParseResult,
+  type RequiredColumn,
 } from '@/lib/utils/file-parsing';
 
 export interface UseFileImportOptions<T> {
@@ -13,6 +14,12 @@ export interface UseFileImportOptions<T> {
   csvMapper: (row: string[], index: number) => T | null;
   /** Function to map Excel records to objects */
   excelMapper: (record: Record<string, unknown>) => T | null;
+  /**
+   * Columns the uploaded file's header row must contain. When provided, a
+   * file/CSV whose headers are missing a required column fails with a clear
+   * error rather than silently dropping rows.
+   */
+  requiredColumns?: RequiredColumn[];
 }
 
 export interface UseFileImportReturn<T> {
@@ -55,6 +62,7 @@ export interface UseFileImportReturn<T> {
 export function useFileImport<T>({
   csvMapper,
   excelMapper,
+  requiredColumns,
 }: UseFileImportOptions<T>): UseFileImportReturn<T> {
   const [isParsing, setIsParsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -65,7 +73,9 @@ export function useFileImport<T>({
       setError(null);
 
       try {
-        const result = await parseImportFile(file, csvMapper, excelMapper);
+        const result = await parseImportFile(file, csvMapper, excelMapper, {
+          requiredColumns,
+        });
 
         if (result.errors.length > 0 && result.data.length === 0) {
           setError(result.errors[0]);
@@ -81,7 +91,7 @@ export function useFileImport<T>({
         setIsParsing(false);
       }
     },
-    [csvMapper, excelMapper],
+    [csvMapper, excelMapper, requiredColumns],
   );
 
   const parseCSV = useCallback(
@@ -134,6 +144,52 @@ function getNumber(value: unknown): number | undefined {
   return undefined;
 }
 
+// Accepted (lowercase) header spellings for contact imports. Headers are
+// already lowercased/trimmed by the parser, so a file with "Email Address"
+// or "Company" maps correctly instead of silently dropping the field.
+const EMAIL_HEADER_ALIASES = [
+  'email',
+  'e-mail',
+  'emailaddress',
+  'email address',
+  'e-mail address',
+  'mail',
+];
+const NAME_HEADER_ALIASES = [
+  'name',
+  'full name',
+  'fullname',
+  'display name',
+  'contact',
+  'contact name',
+  'company',
+  'company name',
+  'vendor name',
+  'customer name',
+];
+const LOCALE_HEADER_ALIASES = ['locale', 'language', 'lang'];
+
+/** Return the first non-empty value among the given header aliases. */
+function pickField(
+  record: Record<string, unknown>,
+  aliases: string[],
+): string | undefined {
+  for (const alias of aliases) {
+    const value = getString(record[alias]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Required columns for customer/vendor imports. Email is the only hard
+ * requirement; a file whose header row has no email-like column is rejected
+ * with a clear error instead of importing partial/empty data.
+ */
+export const CONTACT_REQUIRED_COLUMNS: RequiredColumn[] = [
+  { label: 'email', aliases: EMAIL_HEADER_ALIASES },
+];
+
 /**
  * Customer import mapper utilities.
  */
@@ -160,13 +216,13 @@ export const customerMappers = {
     };
   },
   excel: (record: Record<string, unknown>) => {
-    const email = getString(record.email);
+    const email = pickField(record, EMAIL_HEADER_ALIASES);
     if (!email) return null;
 
     return {
       email,
-      name: getString(record.name) || undefined,
-      locale: getString(record.locale) || 'en',
+      name: pickField(record, NAME_HEADER_ALIASES),
+      locale: pickField(record, LOCALE_HEADER_ALIASES) || 'en',
       status: 'active' as const,
       source: 'file_upload' as const,
     };
@@ -198,13 +254,13 @@ export const vendorMappers = {
     };
   },
   excel: (record: Record<string, unknown>) => {
-    const email = getString(record.email);
+    const email = pickField(record, EMAIL_HEADER_ALIASES);
     if (!email) return null;
 
     return {
       email,
-      name: getString(record.name) || undefined,
-      locale: getString(record.locale) || 'en',
+      name: pickField(record, NAME_HEADER_ALIASES),
+      locale: pickField(record, LOCALE_HEADER_ALIASES) || 'en',
       source: 'file_upload' as const,
     };
   },

--- a/services/platform/lib/utils/file-parsing.test.ts
+++ b/services/platform/lib/utils/file-parsing.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseCSVWithMapper, type RequiredColumn } from './file-parsing';
+
+type Row = { email: string; name?: string };
+
+// A record mapper that accepts a couple of header aliases for email/name.
+const recordMapper = (record: Record<string, unknown>): Row | null => {
+  const email = (record.email as string) || (record['email address'] as string);
+  if (!email) return null;
+  const name = (record.name as string) || (record.company as string);
+  return { email, name: name || undefined };
+};
+
+const requiredColumns: RequiredColumn[] = [
+  { label: 'email', aliases: ['email', 'e-mail', 'email address'] },
+];
+
+describe('parseCSVWithMapper required-column validation (#1312, #1323)', () => {
+  it('maps rows when the required column is present', () => {
+    const csv = 'email,name\nuser@example.com,Acme';
+    const result = parseCSVWithMapper(csv, () => null, {
+      recordMapper,
+      requiredColumns,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual([{ email: 'user@example.com', name: 'Acme' }]);
+  });
+
+  it('maps rows when the required column is present under an alias', () => {
+    const csv = 'Email Address,Company\nuser@example.com,Acme';
+    const result = parseCSVWithMapper(csv, () => null, {
+      recordMapper,
+      requiredColumns,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual([{ email: 'user@example.com', name: 'Acme' }]);
+  });
+
+  it('fails loudly (no partial import) when the required column is absent', () => {
+    // "name,locale" has no email-like column — previously this silently
+    // dropped every row; now it returns a clear error and imports nothing.
+    const csv = 'name,locale\nAcme,en';
+    const result = parseCSVWithMapper(csv, () => null, {
+      recordMapper,
+      requiredColumns,
+    });
+    expect(result.data).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Missing required column(s): email');
+  });
+
+  it('does not validate when no required columns are configured', () => {
+    const csv = 'name\nAcme';
+    const result = parseCSVWithMapper(csv, () => null, { recordMapper });
+    // No email column, recordMapper returns null for the row -> dropped,
+    // but no header error because validation was not requested.
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual([]);
+  });
+});

--- a/services/platform/lib/utils/file-parsing.ts
+++ b/services/platform/lib/utils/file-parsing.ts
@@ -10,6 +10,33 @@ export type FileParseResult<T> = {
   errors: string[];
 };
 
+/**
+ * A column the import file must contain. `label` is the canonical name shown
+ * to the user; `aliases` are the accepted (case-insensitive) header spellings.
+ */
+export type RequiredColumn = { label: string; aliases: string[] };
+
+/**
+ * Returns the labels of required columns that are absent from `headers`.
+ * A column counts as present when any of its aliases matches a header.
+ * Returns [] when there is nothing to validate (no headers / no requirements).
+ */
+function detectMissingColumns(
+  headers: string[] | null,
+  required?: RequiredColumn[],
+): string[] {
+  if (!required || required.length === 0 || !headers) return [];
+  const present = new Set(headers.map((h) => h.trim().toLowerCase()));
+  return required
+    .filter((col) => !col.aliases.some((a) => present.has(a.toLowerCase())))
+    .map((col) => col.label);
+}
+
+function missingColumnsError(missing: string[], headers: string[]): string {
+  const found = headers.length > 0 ? headers.join(', ') : '(none)';
+  return `Missing required column(s): ${missing.join(', ')}. Found columns: ${found}.`;
+}
+
 type CSVParseOptions = {
   /** Column delimiter (default: comma) */
   delimiter?: string;
@@ -111,15 +138,29 @@ export function parseCSVWithMapper<T>(
   mapper: (row: string[], index: number) => T | null,
   options: CSVParseOptions & {
     recordMapper?: (record: Record<string, unknown>) => T | null;
+    /** When set (header mode), the parse fails loudly if a required column is absent. */
+    requiredColumns?: RequiredColumn[];
   } = {},
 ): FileParseResult<T> {
-  const { recordMapper, ...csvOptions } = options;
+  const { recordMapper, requiredColumns, ...csvOptions } = options;
   const { headers, rows } = parseCSVText(csvText, {
     ...csvOptions,
     hasHeaders: !!recordMapper,
   });
   const data: T[] = [];
   const errors: string[] = [];
+
+  // Fail loudly when the header row is missing a required column, instead of
+  // silently dropping rows or importing partial data (see #1312, #1323).
+  if (recordMapper) {
+    const missing = detectMissingColumns(headers, requiredColumns);
+    if (missing.length > 0) {
+      return {
+        data: [],
+        errors: [missingColumnsError(missing, headers ?? [])],
+      };
+    }
+  }
 
   rows.forEach((row, index) => {
     try {
@@ -230,6 +271,7 @@ export async function parseImportFile<T>(
   file: File,
   csvMapper: (row: string[], index: number) => T | null,
   excelMapper: (record: Record<string, unknown>) => T | null,
+  options: { requiredColumns?: RequiredColumn[] } = {},
 ): Promise<FileParseResult<T>> {
   const errors: string[] = [];
   const data: T[] = [];
@@ -239,10 +281,20 @@ export async function parseImportFile<T>(
       const text = await readFileAsText(file);
       const result = parseCSVWithMapper(text, csvMapper, {
         recordMapper: excelMapper,
+        requiredColumns: options.requiredColumns,
       });
       return result;
     } else if (isExcelFile(file)) {
       const records = await parseExcelFile(file);
+
+      // Validate the header row (the keys of the first record) so a
+      // mismatched schema fails loudly rather than dropping data silently.
+      const headerKeys = records.length > 0 ? Object.keys(records[0]) : [];
+      const missing = detectMissingColumns(headerKeys, options.requiredColumns);
+      if (missing.length > 0) {
+        return { data: [], errors: [missingColumnsError(missing, headerKeys)] };
+      }
+
       records.forEach((record, index) => {
         try {
           const mapped = excelMapper(record);

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5648,6 +5648,7 @@
     "importForm": {
       "manualEntry": "Manuelle Eingabe",
       "upload": "Upload",
+      "formatHint": "Format: E-Mail, Name (optional), Sprache (optional). Ein Lieferant pro Zeile.",
       "localeHint": "Sprache kann ein beliebiger BCP 47-Tag sein (z. B. en, en-US, de-DE, zh-Hans).",
       "expectedColumns": "Erwartete Spalten: email, name, locale"
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5909,6 +5909,7 @@
     "importForm": {
       "manualEntry": "Manual entry",
       "upload": "Upload",
+      "formatHint": "Format: email, name (optional), locale (optional). One vendor per line.",
       "localeHint": "Locale can be any valid BCP 47 tag (e.g. en, en-US, de-DE, zh-Hans).",
       "expectedColumns": "Expected columns: email, name, locale"
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5649,6 +5649,7 @@
     "importForm": {
       "manualEntry": "Saisie manuelle",
       "upload": "Téléversement",
+      "formatHint": "Format : email, nom (optionnel), locale (optionnel). Un fournisseur par ligne.",
       "localeHint": "La locale peut être n'importe quelle balise BCP 47 valide (ex. en, en-US, de-DE, zh-Hans).",
       "expectedColumns": "Colonnes attendues : email, name, locale"
     },


### PR DESCRIPTION
## Problem

Importing a customer or vendor CSV/spreadsheet whose columns didn't match the expected schema **"succeeded" while silently losing data**:

- The record mappers (`customerMappers.excel`, `vendorMappers.excel`, also used for CSV-with-headers) read only the exact keys `email` / `name` / `locale`. A column named **"Vendor Name"**, **"Company"**, or **"Email Address"** mapped to `undefined`, so the name/locale were dropped (#1323, #1312).
- A file with **no recognizable email column** dropped every row, but the dialog only showed a generic "no valid data" message.
- Separately, the vendor import form rendered the **raw i18n key** `importForm.formatHint` because `vendors.importForm.formatHint` was missing (#1412).

## Fix

- **Alias-aware mapping** — record mappers now accept common header spellings for email (`email`, `e-mail`, `email address`, …), name (`name`, `full name`, `company`, `vendor name`, …) and locale (`locale`, `language`, `lang`). Differently-named columns now map instead of being silently dropped.
- **Required-column validation** — `file-parsing.ts` gained an optional `requiredColumns` check. Customer/vendor imports declare email as required; a header row missing it now fails loudly with `Missing required column(s): email. Found columns: …` and imports **nothing** (no partial data).
- The import dialogs surface that specific parse error as the toast description.
- Added `vendors.importForm.formatHint` to `en`/`de`/`fr`.

## Tests

- `use-file-import.test.ts` — alias mapping for vendor (`email address` / `company` / `language`, `vendor name`) and customer (`e-mail` / `full name` / `lang`). 26 passed.
- New `file-parsing.test.ts` — required-column validation: maps when present (canonical + alias), fails loudly with a clear error when absent, no validation when not configured. 4 passed.
- i18n parity test → 22 passed. `tsc --noEmit`, `oxlint`, `oxfmt` → clean.

Closes #1312
Closes #1323
Closes #1412
