### PR TITLE
fix(platform): show price, category, and status in the product list (#1310, #1356)

### DIFF
--- a/services/platform/app/features/products/hooks/use-products-table-config.tsx
+++ b/services/platform/app/features/products/hooks/use-products-table-config.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { Badge } from '@tale/ui/badge';
 import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 
 import { createTableConfigHook } from '@/app/hooks/use-table-config-factory';
 import type { Doc } from '@/convex/_generated/dataModel';
+import { formatCurrency } from '@/lib/utils/format/number';
 
 import { ProductImage } from '../components/product-image';
 import { ProductRowActions } from '../components/product-row-actions';
@@ -63,6 +65,50 @@ export const useProductsTableConfig = createTableConfigHook<'products'>(
           {row.original.stock !== undefined ? row.original.stock : '-'}
         </span>
       ),
+    },
+    {
+      accessorKey: 'price',
+      header: () => (
+        <span className="block w-full text-right">
+          {tTables('headers.price')}
+        </span>
+      ),
+      size: 100,
+      meta: { headerLabel: tTables('headers.price') },
+      cell: ({ row }) => (
+        <span className="text-muted-foreground block text-right text-xs">
+          {row.original.price !== undefined
+            ? formatCurrency(row.original.price, row.original.currency || 'USD')
+            : '-'}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'category',
+      header: tTables('headers.category'),
+      size: 140,
+      cell: ({ row }) => (
+        <Text as="span" variant="caption" className="text-muted-foreground">
+          {row.original.category || '-'}
+        </Text>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      header: tTables('headers.status'),
+      size: 110,
+      cell: ({ row }) =>
+        row.original.status ? (
+          <Badge
+            variant={row.original.status === 'active' ? 'blue' : 'outline'}
+          >
+            {row.original.status}
+          </Badge>
+        ) : (
+          <Text as="span" variant="caption" className="text-muted-foreground">
+            -
+          </Text>
+        ),
     },
     builders.createDateColumn('lastUpdated', 'headers.updated', tTables, {
       alignRight: true,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5511,6 +5511,8 @@
       "product": "Produkt",
       "scanned": "Gescannt",
       "stock": "Bestand",
+      "price": "Preis",
+      "category": "Kategorie",
       "title": "Titel",
       "website": "Website"
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5772,6 +5772,8 @@
       "product": "Product",
       "scanned": "Scanned",
       "stock": "Stock",
+      "price": "Price",
+      "category": "Category",
       "title": "Title",
       "website": "Website"
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5512,6 +5512,8 @@
       "product": "Produit",
       "scanned": "Analysé",
       "stock": "Stock",
+      "price": "Prix",
+      "category": "Catégorie",
       "title": "Titre",
       "website": "Site web"
     },


### PR DESCRIPTION
## What

The products list only rendered **name, description, stock, and updated date**, even though every product carries `price` / `currency`, `category`, and `status` (captured on create and import). #1310 and #1356 report that price, category, and status are missing from the list view.

## Fix

Added three columns to `use-products-table-config.tsx`:

- **Price** — right-aligned, formatted with the product's currency via the existing `formatCurrency` helper (falls back to `USD`), `-` when unset.
- **Category** — plain text, `-` when unset.
- **Status** — rendered as a `Badge` (`blue` for `active`, `outline` otherwise), matching the product view dialog.

Added the `tables.headers.price` and `tables.headers.category` i18n keys in `en`/`de`/`fr` (`status` already existed).

## Verification

- Verified in the running app: the products table now shows **Produit · Description · Stock · Prix · Catégorie · Statut · Mis à jour** with correct localized headers.
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt`, and the i18n parity test all pass.

Closes #1310
Closes #1356
