### PR TITLE
fix(platform): surface missing-password error on the add-member form (#1470)

### DIFF
--- a/services/platform/app/features/settings/organization/components/member-add-dialog.test.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.test.tsx
@@ -1,9 +1,14 @@
-import { describe, it, vi } from 'vitest';
+import { ConvexError } from 'convex/values';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
-import { render } from '@/test/utils/render';
+import { render, screen, waitFor } from '@/test/utils/render';
 
 import { AddMemberDialog } from './member-add-dialog';
+
+const { createMemberMock } = vi.hoisted(() => ({
+  createMemberMock: vi.fn(),
+}));
 
 vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'test-org-id',
@@ -14,7 +19,7 @@ vi.mock('@/app/hooks/use-toast', () => ({
 }));
 
 vi.mock('../hooks/mutations', () => ({
-  useCreateMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateMember: () => ({ mutateAsync: createMemberMock, isPending: false }),
 }));
 
 vi.mock('@/app/features/settings/governance/hooks/queries', async () => {
@@ -47,6 +52,43 @@ describe('AddMemberDialog', () => {
         />,
       );
       await checkAccessibility(container);
+    });
+  });
+
+  // Regression test for #1470: creating a new user without a password failed
+  // with a generic toast. The backend now returns a PASSWORD_REQUIRED code and
+  // the dialog shows a field-level error on the password input.
+  describe('missing password for a new user (#1470)', () => {
+    it('shows a password field error when the backend requires a password', async () => {
+      createMemberMock.mockRejectedValueOnce(
+        new ConvexError({
+          code: 'PASSWORD_REQUIRED',
+          message: 'Password is required when creating a new user',
+        }),
+      );
+
+      const { user } = render(
+        <AddMemberDialog
+          organizationId="org-1"
+          open={true}
+          onOpenChange={vi.fn()}
+        />,
+      );
+
+      const email = document.querySelector(
+        'input[name="email"]',
+      ) as HTMLInputElement;
+      await user.type(email, 'new.user@example.com');
+
+      const submit = document.querySelector(
+        'button[type="submit"]',
+      ) as HTMLButtonElement;
+      await waitFor(() => expect(submit).toBeEnabled());
+      await user.click(submit);
+
+      // The specific error is surfaced on the field, not as a generic toast.
+      await screen.findByText('Password is required to create a new user');
+      expect(createMemberMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
+import { ConvexError } from 'convex/values';
 import { useState, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
@@ -97,7 +98,15 @@ export function AddMemberDialog({
     },
   });
 
-  const { handleSubmit, register, reset, setValue, watch, formState } = form;
+  const {
+    handleSubmit,
+    register,
+    reset,
+    setValue,
+    setError,
+    watch,
+    formState,
+  } = form;
   const selectedRole = watch('role');
   const password = watch('password') ?? '';
 
@@ -133,6 +142,17 @@ export function AddMemberDialog({
       }
     } catch (error) {
       console.error(error);
+      // A new user requires a password; surface it on the field rather than a
+      // generic toast, so the user knows what to fix (#1470).
+      if (
+        error instanceof ConvexError &&
+        error.data?.code === 'PASSWORD_REQUIRED'
+      ) {
+        setError('password', {
+          message: tAuth('validation.passwordRequiredForNewUser'),
+        });
+        return;
+      }
       toast({
         title: tToast('error.addMemberFailed'),
         variant: 'destructive',
@@ -221,6 +241,7 @@ export function AddMemberDialog({
             placeholder={tSettings('form.passwordPlaceholder')}
             description={tSettings('form.forgotPassword')}
             {...register('password')}
+            errorMessage={formState.errors.password?.message}
             className="w-full"
           />
           {password && (

--- a/services/platform/convex/users/create_member.ts
+++ b/services/platform/convex/users/create_member.ts
@@ -2,6 +2,8 @@
  * Create member - Business logic
  */
 
+import { ConvexError } from 'convex/values';
+
 import { isRecord, getString } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
@@ -147,9 +149,14 @@ export async function createMember(
     };
   }
 
-  // User doesn't exist — create a new account
+  // User doesn't exist — create a new account. Surface a structured code so
+  // the add-member dialog can show a field-level error on the password input
+  // instead of a generic "failed" toast (#1470).
   if (!args.password) {
-    throw new Error('Password is required when creating a new user');
+    throw new ConvexError({
+      code: 'PASSWORD_REQUIRED',
+      message: 'Password is required when creating a new user',
+    });
   }
 
   const auth = createAuth(ctx);

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -270,6 +270,7 @@
     },
     "validation": {
       "emailRequired": "E-Mail ist erforderlich",
+      "passwordRequiredForNewUser": "Passwort ist erforderlich, um einen neuen Benutzer zu erstellen",
       "passwordMinLength": "Passwort muss mindestens {n} Zeichen lang sein",
       "passwordLowercase": "Passwort muss einen Kleinbuchstaben enthalten",
       "passwordUppercase": "Passwort muss einen Großbuchstaben enthalten",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -270,6 +270,7 @@
     },
     "validation": {
       "emailRequired": "Email is required",
+      "passwordRequiredForNewUser": "Password is required to create a new user",
       "passwordMinLength": "Password must be at least {n} characters",
       "passwordLowercase": "Password must contain a lowercase letter",
       "passwordUppercase": "Password must contain an uppercase letter",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -271,6 +271,7 @@
     },
     "validation": {
       "emailRequired": "L'email est requis",
+      "passwordRequiredForNewUser": "Un mot de passe est requis pour créer un nouvel utilisateur",
       "passwordMinLength": "Le mot de passe doit contenir au moins {n} caractères",
       "passwordLowercase": "Le mot de passe doit contenir une lettre minuscule",
       "passwordUppercase": "Le mot de passe doit contenir une lettre majuscule",


### PR DESCRIPTION
## Problem

On **Settings → Organization → Add member**, creating a brand-new user with an empty password failed with a generic "Failed to add member" toast and **no field-level feedback** — and the password field isn't marked required, so the user had no way to tell what was wrong (#1470).

Two underlying issues:
1. `create_member` threw a plain `Error('Password is required when creating a new user')`, surfaced only as a generic toast.
2. The password `Input` had **no `errorMessage` prop**, so a field-level error could never be displayed even if set.

## Fix

- `create_member` now throws a structured `ConvexError({ code: 'PASSWORD_REQUIRED', … })` (same pattern as the existing `DUPLICATE_NAME` handling).
- The add-member dialog catches that code and calls `setError('password', …)`, keeping the dialog open so the user can add a password — instead of a generic toast.
- Wired `errorMessage={formState.errors.password?.message}` onto the password `Input`.
- Added `auth.validation.passwordRequiredForNewUser` in `en`/`de`/`fr`.

(Password stays optional when re-adding an **existing** user — that path is unaffected.)

## Tests

- `member-add-dialog.test.tsx` — new regression test: submitting with a valid email but empty password, with the backend rejecting `PASSWORD_REQUIRED`, shows the password field error and does not just toast. 3 passed.
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt`, i18n parity (22) all pass.

Closes #1470
