### PR TITLE
fix(platform): re-authenticate after a voluntary password change (#1255)

### DIFF
--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -27,6 +27,7 @@ import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { useToast } from '@/app/hooks/use-toast';
+import { getEnv } from '@/lib/env';
 import { useT } from '@/lib/i18n/client';
 import { createPasswordSchema } from '@/lib/shared/schemas/password';
 
@@ -238,6 +239,7 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
   const { t: tAuth } = useT('auth');
   const { t: tToast } = useT('toast');
   const { mutateAsync: updatePassword } = useUpdatePassword();
+  const { signOut } = useAuth();
   const { toast } = useToast();
   const organizationId = useOrganizationId();
   const policy = usePasswordPolicy(organizationId);
@@ -297,20 +299,28 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
         currentPassword: data.currentPassword,
         newPassword: data.newPassword,
       });
-
-      toast({
-        title: tToast('success.passwordChanged'),
-        variant: 'success',
-      });
-
-      reset();
-      onOpenChange(false);
     } catch {
       toast({
         title: tToast('error.passwordChangeFailed'),
         variant: 'destructive',
       });
+      return;
     }
+
+    // Changing the password revokes/rotates the user's sessions server-side,
+    // so the current client token is now stale — every subsequent query would
+    // fail with "Unauthenticated" and a manual refresh would bounce the user to
+    // login mid-action (#1255). Sign the user out and hard-navigate to login so
+    // they re-authenticate with the new password. Hard navigation (not the
+    // router) avoids the stale-auth query race documented in the sign-out flow.
+    reset();
+    onOpenChange(false);
+    try {
+      await signOut();
+    } catch (error) {
+      console.warn('Sign-out after password change failed', error);
+    }
+    window.location.href = getEnv('BASE_PATH') || '/';
   };
 
   const handleOpenChange = (isOpen: boolean) => {


### PR DESCRIPTION
## Problem

After a user changed their own password (**Settings → Account → Change password**), the platform appeared to break — every action failed and a refresh logged them out mid-task (#1255).

Root cause: `updateUserPassword` calls Better Auth `changePassword({ revokeOtherSessions: true })`, which rotates/revokes sessions server-side. The client kept its now-stale token, so subsequent Convex queries/mutations returned **Unauthenticated**, and a refresh dropped the user at the login screen. The change dialog only showed a success toast — it never re-established the session.

This is the same class of stale-auth race already documented in `user-button.tsx` (the sign-out handler deliberately uses a hard navigation to avoid queries firing with stale auth).

## Fix

On a **successful** password change, the dialog now:
1. closes and resets the form,
2. calls `signOut()` (best-effort; logged if it fails),
3. hard-navigates to the login page (`window.location.href = BASE_PATH || '/'`),

so the user cleanly re-authenticates with their new password. Re-login after a credential change is also the expected, secure behavior. The failure path is unchanged (still shows the error toast and keeps the dialog open).

## Verification

- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt` → clean.
- Mirrors the existing, commented sign-out pattern in `user-button.tsx`. (No unit test added — the change is a sign-out + `window.location` navigation that doesn't lend itself to a non-brittle unit test; the behavior is exercised by the shared sign-out path.)

Closes #1255
