### PR TITLE
fix(platform): reject conflicting allow/block extensions in upload policy (#1479)

### DIFF
--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.test.ts
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { findConflictingExtensions } from './upload-policy-editor';
+
+// Regression test for #1479: the upload policy must not accept the same
+// extension in both the allowed and blocked lists.
+describe('findConflictingExtensions (#1479)', () => {
+  it('returns extensions present in both lists', () => {
+    expect(findConflictingExtensions('pdf, docx', 'pdf, exe')).toEqual(['pdf']);
+  });
+
+  it('matches case-insensitively and ignores a leading dot (echoes the blocked-list spelling)', () => {
+    expect(findConflictingExtensions('PDF, .docx', 'pdf, .DOCX')).toEqual([
+      'pdf',
+      'DOCX',
+    ]);
+  });
+
+  it('returns an empty array when the lists are disjoint', () => {
+    expect(findConflictingExtensions('pdf, docx', 'exe, bat')).toEqual([]);
+  });
+
+  it('handles empty inputs', () => {
+    expect(findConflictingExtensions('', '')).toEqual([]);
+    expect(findConflictingExtensions('pdf', '')).toEqual([]);
+    expect(findConflictingExtensions('', 'pdf')).toEqual([]);
+  });
+
+  it('supports space- and comma-separated values', () => {
+    expect(findConflictingExtensions('pdf docx xlsx', 'xlsx,zip')).toEqual([
+      'xlsx',
+    ]);
+  });
+});

--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
@@ -55,6 +55,22 @@ function stringToExtensions(value: string): string[] | undefined {
     .filter(Boolean);
 }
 
+/**
+ * Returns the extensions present in BOTH the allowed and blocked lists
+ * (case-insensitive). Used to reject a contradictory upload policy (#1479).
+ */
+export function findConflictingExtensions(
+  allowedValue: string,
+  blockedValue: string,
+): string[] {
+  const allowed = new Set(
+    (stringToExtensions(allowedValue) ?? []).map((e) => e.toLowerCase()),
+  );
+  return (stringToExtensions(blockedValue) ?? []).filter((e) =>
+    allowed.has(e.toLowerCase()),
+  );
+}
+
 function buildConfig(
   values: UploadPolicyForm,
   enabledValue: boolean,
@@ -116,27 +132,45 @@ export function UploadPolicyEditor({
 
   const schema = useMemo(
     () =>
-      z.object({
-        allowedExtensions: z.string(),
-        blockedExtensions: z.string(),
-        allowedMimeTypes: z.string(),
-        maxFileSizeMB: z.string().refine(
-          (v) => {
-            if (!v.trim()) return true;
-            const n = Number(v);
-            return !Number.isNaN(n) && n >= 0;
-          },
-          { message: t('uploadPolicy.invalidMaxFileSize') },
-        ),
-        maxVolumeGB: z.string().refine(
-          (v) => {
-            if (!v.trim()) return true;
-            const n = Number(v);
-            return !Number.isNaN(n) && n >= 0;
-          },
-          { message: t('uploadPolicy.invalidMaxVolume') },
-        ),
-      }),
+      z
+        .object({
+          allowedExtensions: z.string(),
+          blockedExtensions: z.string(),
+          allowedMimeTypes: z.string(),
+          maxFileSizeMB: z.string().refine(
+            (v) => {
+              if (!v.trim()) return true;
+              const n = Number(v);
+              return !Number.isNaN(n) && n >= 0;
+            },
+            { message: t('uploadPolicy.invalidMaxFileSize') },
+          ),
+          maxVolumeGB: z.string().refine(
+            (v) => {
+              if (!v.trim()) return true;
+              const n = Number(v);
+              return !Number.isNaN(n) && n >= 0;
+            },
+            { message: t('uploadPolicy.invalidMaxVolume') },
+          ),
+        })
+        .superRefine((values, ctx) => {
+          // An extension cannot be both allowed and blocked — flag the
+          // conflict instead of silently saving a contradictory policy (#1479).
+          const conflicts = findConflictingExtensions(
+            values.allowedExtensions,
+            values.blockedExtensions,
+          );
+          if (conflicts.length > 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['blockedExtensions'],
+              message: t('uploadPolicy.conflictingExtensions', {
+                extensions: conflicts.join(', '),
+              }),
+            });
+          }
+        }),
     [t],
   );
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2164,6 +2164,7 @@
       "enabled": "Upload-Richtlinie aktivieren",
       "allowedExtensions": "Erlaubte Dateierweiterungen",
       "blockedExtensions": "Blockierte Dateierweiterungen",
+      "conflictingExtensions": "Diese Erweiterungen sind sowohl erlaubt als auch blockiert: {extensions}. Entferne sie aus einer der Listen.",
       "allowedMimeTypes": "Erlaubte MIME-Typen",
       "maxFileSize": "Maximale Dateigrösse",
       "maxVolumePerUser": "Maximales Gesamtvolumen pro Benutzer",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2164,6 +2164,7 @@
       "enabled": "Enable upload policy",
       "allowedExtensions": "Allowed file extensions",
       "blockedExtensions": "Blocked file extensions",
+      "conflictingExtensions": "These extensions are both allowed and blocked: {extensions}. Remove them from one list.",
       "allowedMimeTypes": "Allowed MIME types",
       "maxFileSize": "Maximum file size",
       "maxVolumePerUser": "Maximum total volume per user",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2165,6 +2165,7 @@
       "enabled": "Activer la politique de téléversement",
       "allowedExtensions": "Extensions de fichiers autorisées",
       "blockedExtensions": "Extensions de fichiers bloquées",
+      "conflictingExtensions": "Ces extensions sont à la fois autorisées et bloquées : {extensions}. Retire-les de l'une des listes.",
       "allowedMimeTypes": "Types MIME autorisés",
       "maxFileSize": "Taille maximale de fichier",
       "maxVolumePerUser": "Volume total maximum par utilisateur",


### PR DESCRIPTION
## Problem

In **Settings → Governance → Upload Policy**, the same file extension could be entered in **both** the *Allowed* and *Blocked* lists, and the editor saved that contradictory configuration silently (#1479). The backend resolves the conflict deterministically (blocked wins), so there's no security hole — but the UI gave the admin no indication their policy was self-contradictory.

## Fix

Added a `superRefine` cross-field validation to the editor schema: when an extension appears in both lists (case-insensitive, leading dot ignored), an error is shown on the blocked-extensions field listing the offending entries, and the policy can't be saved until it's resolved.

The conflict detection is extracted into a pure, exported `findConflictingExtensions(allowed, blocked)` helper. Added `governance.uploadPolicy.conflictingExtensions` to `en`/`de`/`fr`.

## Tests

- New `upload-policy-editor.test.ts` covering `findConflictingExtensions`: overlap detection, case-insensitivity + dot stripping, disjoint lists, empty inputs, space/comma separators. 5 passed.
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt`, i18n parity (22) all pass.

Closes #1479
