### PR TITLE
fix(platform): sensible thread titles for attachment-only chats (#1468)

### DIFF
--- a/services/platform/convex/lib/agent_chat/start_agent_chat.test.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.test.ts
@@ -73,7 +73,7 @@ const { resolveFeatureFlags } =
   await import('../../governance/feature_enforcement');
 const mockedResolveFeatureFlags = vi.mocked(resolveFeatureFlags);
 
-const { startAgentChat } = await import('./start_agent_chat');
+const { startAgentChat, buildTitleSource } = await import('./start_agent_chat');
 
 function createMockCtx(
   threadMeta: {
@@ -311,5 +311,38 @@ describe('startAgentChat — feature flag enforcement', () => {
     await startAgentChat(createDefaultArgs(ctx));
 
     expect(ctx.scheduler.runAfter).toHaveBeenCalled();
+  });
+});
+
+// Regression test for #1468: an attachment-only message used to generate the
+// thread title from the raw attachment markdown/fileId metadata block. The
+// title source must be the user's words, or the file names when there is no
+// text — never the metadata block.
+describe('buildTitleSource (#1468)', () => {
+  it('uses the user message when present', () => {
+    expect(buildTitleSource('How do I reset my budget?', undefined)).toBe(
+      'How do I reset my budget?',
+    );
+  });
+
+  it('prefers the user message over attachment names', () => {
+    expect(
+      buildTitleSource('Summarize this', [{ fileName: 'report.md' }]),
+    ).toBe('Summarize this');
+  });
+
+  it('falls back to attachment file names for an attachment-only message', () => {
+    expect(buildTitleSource('', [{ fileName: 'report.md' }])).toBe('report.md');
+    expect(
+      buildTitleSource('   ', [
+        { fileName: 'q3.xlsx' },
+        { fileName: 'notes.md' },
+      ]),
+    ).toBe('q3.xlsx, notes.md');
+  });
+
+  it('returns an empty string when there is neither text nor attachments', () => {
+    expect(buildTitleSource('', undefined)).toBe('');
+    expect(buildTitleSource('', [])).toBe('');
   });
 });

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -339,7 +339,11 @@ export async function startAgentChat(
     await ctx.scheduler.runAfter(
       0,
       internal.threads.generate_thread_title.generateThreadTitle,
-      { threadId, firstMessage: messageContent, organizationId },
+      {
+        threadId,
+        firstMessage: buildTitleSource(trimmedMessage, attachments),
+        organizationId,
+      },
     );
   }
 
@@ -422,6 +426,25 @@ export async function startAgentChat(
 /**
  * Check if a file is a text file based on type or extension.
  */
+/**
+ * Pick the text used to generate the thread title. Prefer the user's actual
+ * words; fall back to the attachment file names when the message is
+ * attachment-only — never the attachment markdown/fileId metadata block, which
+ * would otherwise become the title of an attachment-only chat (#1468).
+ */
+export function buildTitleSource(
+  trimmedMessage: string,
+  attachments: readonly Pick<FileAttachment, 'fileName'>[] | undefined,
+): string {
+  if (trimmedMessage.trim()) return trimmedMessage;
+  return (
+    attachments
+      ?.map((a) => a.fileName)
+      .filter(Boolean)
+      .join(', ') ?? ''
+  );
+}
+
 function isTextFile(attachment: FileAttachment): boolean {
   return (
     attachment.fileType.startsWith('text/plain') ||


### PR DESCRIPTION
## Problem

Starting a chat by uploading a file with no typed text produced a meaningless/blank thread title (#1468). `startAgentChat` passed the full message content to the title generator, and for attachments that content includes the markdown link plus an internal metadata block:

```
📎 [report.md](…) (text/markdown, 12 KB)
*(fileId: abc123 | fileName: report.md | fileType: text/markdown | fileSize: 12345)*
```

For an attachment-only first message the title LLM saw only that metadata, so the title was generated from `fileId`/`fileSize` noise.

## Fix

`startAgentChat` now derives the title source via a pure `buildTitleSource(trimmedMessage, attachments)` helper:
- the user's typed text when present,
- otherwise the attachment file names (e.g. `report.md`, `q3.xlsx, notes.md`),
- never the attachment markdown/metadata block.

## Tests

- Extended `start_agent_chat.test.ts` with `buildTitleSource` cases: prefers user text, falls back to file names for attachment-only (incl. whitespace-only text), empty when neither present. 12 passed (4 new).
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt` clean.

Note: the **display** side of this report (raw metadata showing in the chat bubble) is already handled on `main` by `stripInternalFileReferences` + attachment-chip extraction in `use-message-processing.ts` — see #1467.

Closes #1468
