### PR TITLE
fix(platform): stop dictation when a chat message is sent (#1462)

### DIFF
--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -38,7 +38,10 @@ import { useArenaModeOptional } from './arena/arena-mode-context';
 import { ArenaModelSelector } from './arena/arena-model-selector';
 import { ComposerCapabilityPills } from './composer-capability-pills';
 import { ComposerModeMenu } from './composer-mode-menu';
-import { DictationButton } from './dictation-button';
+import {
+  DictationButton,
+  type DictationButtonHandle,
+} from './dictation-button';
 import { ImagePreviewDialog } from './message-bubble';
 import { ModelSelector } from './model-selector';
 import { QuotedReferenceChip } from './quoted-reference-chip';
@@ -207,6 +210,7 @@ export function ChatInput({
   const textareaLabelId = `${textareaId}-label`;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const dictationRef = useRef<DictationButtonHandle>(null);
   // True while a CJK IME (Chinese / Japanese / Korean) is composing a
   // pre-commit string. Cross-browser fallback for
   // `e.nativeEvent.isComposing`, which not every browser surfaces on the
@@ -264,6 +268,10 @@ export function ChatInput({
       ? `> ${quotedText.replace(/\n/g, '\n> ')}\n\n${trimmed}`
       : trimmed;
     if (quotedText) setQuotedText(null);
+
+    // Stop any in-progress dictation so the mic doesn't keep recording after
+    // the message is sent (#1462).
+    dictationRef.current?.stop();
 
     onSendMessage(messageToSend, attachmentsToSend);
   };
@@ -894,6 +902,7 @@ export function ChatInput({
             <HStack gap={1} align="center" className="shrink-0">
               <VoiceModeToggle threadId={threadId} disabled={inputDisabled} />
               <DictationButton
+                ref={dictationRef}
                 organizationId={organizationId}
                 disabled={inputDisabled}
                 lang={speechLang}

--- a/services/platform/app/features/chat/components/dictation-button.test.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.test.tsx
@@ -1,9 +1,13 @@
+import { createRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
 import { render, screen } from '@/test/utils/render';
 
-import { DictationButton } from './dictation-button';
+import {
+  DictationButton,
+  type DictationButtonHandle,
+} from './dictation-button';
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({
@@ -162,6 +166,42 @@ describe('DictationButton', () => {
       mockOnTranscriptRef?.('hello world');
 
       expect(onTranscript).toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  // Regression test for #1462: sending a message must be able to stop an
+  // active recording so the mic doesn't keep listening after send.
+  describe('imperative stop() handle (#1462)', () => {
+    it('stops an active recording when stop() is called', () => {
+      mockIsListening = true;
+      const ref = createRef<DictationButtonHandle>();
+      render(
+        <DictationButton
+          ref={ref}
+          organizationId={orgId}
+          onTranscript={vi.fn()}
+        />,
+      );
+
+      ref.current?.stop();
+
+      expect(mockStopListening).toHaveBeenCalled();
+    });
+
+    it('is a no-op when not currently recording', () => {
+      mockIsListening = false;
+      const ref = createRef<DictationButtonHandle>();
+      render(
+        <DictationButton
+          ref={ref}
+          organizationId={orgId}
+          onTranscript={vi.fn()}
+        />,
+      );
+
+      ref.current?.stop();
+
+      expect(mockStopListening).not.toHaveBeenCalled();
     });
   });
 

--- a/services/platform/app/features/chat/components/dictation-button.tsx
+++ b/services/platform/app/features/chat/components/dictation-button.tsx
@@ -2,7 +2,14 @@
 
 import { Button } from '@tale/ui/button';
 import { AlertCircle, Loader2, Mic, RotateCcw, X } from 'lucide-react';
-import { useCallback, useEffect, useRef, memo } from 'react';
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { toast } from '@/app/hooks/use-toast';
@@ -24,12 +31,18 @@ interface DictationButtonProps {
   onTranscript: (transcript: string) => void;
 }
 
-function DictationButtonComponent({
-  organizationId,
-  disabled = false,
-  lang,
-  onTranscript,
-}: DictationButtonProps) {
+export interface DictationButtonHandle {
+  /** Stop an in-progress recording, if any (e.g. when the message is sent). */
+  stop: () => void;
+}
+
+const DictationButtonComponent = forwardRef<
+  DictationButtonHandle,
+  DictationButtonProps
+>(function DictationButtonComponent(
+  { organizationId, disabled = false, lang, onTranscript },
+  ref,
+) {
   const { t } = useT('chat');
 
   const handleTranscript = useCallback(
@@ -114,6 +127,18 @@ function DictationButtonComponent({
     }
     prevListeningRef.current = isListening;
   }, [isListening]);
+
+  // Let the parent (chat input) stop an active recording when the message is
+  // sent, so the mic doesn't keep listening after send (#1462).
+  useImperativeHandle(
+    ref,
+    () => ({
+      stop: () => {
+        if (isListening) stopListening();
+      },
+    }),
+    [isListening, stopListening],
+  );
 
   if (!isSupported) return null;
 
@@ -212,6 +237,6 @@ function DictationButtonComponent({
       )}
     </span>
   );
-}
+});
 
 export const DictationButton = memo(DictationButtonComponent);


### PR DESCRIPTION
## Problem

When dictating a chat message, the recorder kept listening **after** the message was sent — the mic only stopped on an explicit second click of the mic button. The send action and the recording state were decoupled, so the microphone stayed active unexpectedly (#1462).

## Fix

- `DictationButton` now exposes an imperative `stop()` handle via `forwardRef` + `useImperativeHandle` (stops the active recording, whether on the Web Speech or MediaRecorder path).
- `chat-input` holds a `dictationRef` and calls `dictationRef.current?.stop()` inside `handleSendMessage`, so sending a message stops any in-progress recording.

## Tests

- `dictation-button.test.tsx`: `stop()` calls `stopListening` when recording, and is a no-op when not recording. 20 passed (2 new).
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt` clean.

Closes #1462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dictation recording now automatically stops when a message is sent, preventing unintended continued recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->