### PR TITLE
fix(platform): assign documents/folders to multiple teams (#1325, #1324)

### DIFF
--- a/services/platform/app/features/documents/components/document-team-tags-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/document-team-tags-dialog.test.tsx
@@ -63,49 +63,55 @@ vi.mock('@/convex/lib/type_cast_helpers', () => ({
   toId: (id: string) => id,
 }));
 
-vi.mock('@/app/components/ui/forms/select', () => ({
-  Select: ({
-    value,
-    onValueChange,
-    options,
-    label,
+// Lightweight stand-in for the real multi-select: one checkbox per team that
+// toggles membership in the selected set, plus an org-wide indicator when the
+// selection is empty.
+vi.mock('./team-multi-select', () => ({
+  TeamMultiSelect: ({
+    teams,
+    selectedTeamIds,
+    onSelectionChange,
+    orgWideLabel,
     disabled,
-    id,
   }: {
-    value: string;
-    onValueChange: (v: string) => void;
-    options: Array<{ value: string; label: string }>;
-    label?: string;
+    teams: Array<{ id: string; name: string }>;
+    selectedTeamIds: string[];
+    onSelectionChange: (ids: string[]) => void;
+    orgWideLabel: string;
     disabled?: boolean;
-    id?: string;
-    placeholder?: string;
-  }) => {
-    return (
-      <div data-testid="mock-select">
-        {label && <label htmlFor={id}>{label}</label>}
-        <select
-          id={id}
-          value={value}
-          disabled={disabled}
-          onChange={(e) => onValueChange(e.target.value)}
-          data-testid="team-select"
-        >
-          {options.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </div>
-    );
-  },
+  }) => (
+    <div data-testid="mock-team-multi-select">
+      <span data-testid="selection">
+        {selectedTeamIds.length === 0
+          ? orgWideLabel
+          : selectedTeamIds.join(',')}
+      </span>
+      {teams.map((team) => (
+        <label key={team.id}>
+          <input
+            type="checkbox"
+            data-testid={`team-${team.id}`}
+            checked={selectedTeamIds.includes(team.id)}
+            disabled={disabled}
+            onChange={() =>
+              onSelectionChange(
+                selectedTeamIds.includes(team.id)
+                  ? selectedTeamIds.filter((id) => id !== team.id)
+                  : [...selectedTeamIds, team.id],
+              )
+            }
+          />
+          {team.name}
+        </label>
+      ))}
+    </div>
+  ),
 }));
 
 import { DocumentTeamTagsDialog } from './document-team-tags-dialog';
 
-function selectTeam(teamValue: string) {
-  const select = screen.getByTestId('team-select');
-  fireEvent.change(select, { target: { value: teamValue } });
+function toggleTeam(teamId: string) {
+  fireEvent.click(screen.getByTestId(`team-${teamId}`));
 }
 
 describe('DocumentTeamTagsDialog', () => {
@@ -155,23 +161,18 @@ describe('DocumentTeamTagsDialog', () => {
     expect(screen.getByText('Report.pdf')).toBeInTheDocument();
   });
 
-  it('renders the team select dropdown with all options', () => {
+  it('renders a checkbox for every team', () => {
     render(<DocumentTeamTagsDialog {...defaultProps} />);
-    const select = screen.getByTestId('team-select');
-    expect(select).toBeInTheDocument();
-
-    const options = select.querySelectorAll('option');
-    expect(options).toHaveLength(4);
-    expect(options[0]).toHaveTextContent('documents.teamTags.orgWide');
-    expect(options[1]).toHaveTextContent('Sales');
-    expect(options[2]).toHaveTextContent('Support');
-    expect(options[3]).toHaveTextContent('Operations');
+    expect(screen.getByTestId('team-team-1')).toBeInTheDocument();
+    expect(screen.getByTestId('team-team-2')).toBeInTheDocument();
+    expect(screen.getByTestId('team-team-3')).toBeInTheDocument();
   });
 
   it('defaults to org-wide when no team is selected', () => {
     render(<DocumentTeamTagsDialog {...defaultProps} />);
-    const select = screen.getByTestId('team-select');
-    expect(select).toHaveValue('__org_wide__');
+    expect(screen.getByTestId('selection')).toHaveTextContent(
+      'documents.teamTags.orgWide',
+    );
   });
 
   it('shows loading state', () => {
@@ -194,13 +195,6 @@ describe('DocumentTeamTagsDialog', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows footer with disabled save when no teams', () => {
-    mockTeamsData = { teams: [], isLoading: false };
-    render(<DocumentTeamTagsDialog {...defaultProps} />);
-    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument();
-    expect(screen.getByText('common.actions.save')).toBeDisabled();
-  });
-
   it('navigates to settings on go to settings click', () => {
     mockTeamsData = { teams: [], isLoading: false };
     const onOpenChange = vi.fn();
@@ -216,49 +210,72 @@ describe('DocumentTeamTagsDialog', () => {
     });
   });
 
-  it('pre-selects current team', () => {
+  it('pre-selects the current teams', () => {
     render(
       <DocumentTeamTagsDialog {...defaultProps} currentTeamIds={['team-1']} />,
     );
-    const select = screen.getByTestId('team-select');
-    expect(select).toHaveValue('team-1');
+    expect(screen.getByTestId('team-team-1')).toBeChecked();
+    expect(screen.getByTestId('team-team-2')).not.toBeChecked();
   });
 
-  it('disables save when no changes', () => {
-    render(<DocumentTeamTagsDialog {...defaultProps} />);
-    const saveButton = screen.getByText('common.actions.save');
-    expect(saveButton).toBeDisabled();
-  });
+  // Core of #1325: a document already assigned to multiple teams must show all
+  // of them selected and keep them on save (no silent drop to a single team).
+  it('pre-selects multiple current teams and preserves them on save', async () => {
+    render(
+      <DocumentTeamTagsDialog
+        {...defaultProps}
+        currentTeamIds={['team-1', 'team-2']}
+      />,
+    );
+    expect(screen.getByTestId('team-team-1')).toBeChecked();
+    expect(screen.getByTestId('team-team-2')).toBeChecked();
 
-  it('enables save when team changes', () => {
-    render(<DocumentTeamTagsDialog {...defaultProps} />);
-
-    selectTeam('team-1');
-
-    const saveButton = screen.getByText('common.actions.save');
-    expect(saveButton).toBeEnabled();
-  });
-
-  it('submits with the selected team id', async () => {
-    render(<DocumentTeamTagsDialog {...defaultProps} />);
-
-    selectTeam('team-1');
+    // Add a third team and save — all three must be submitted.
+    toggleTeam('team-3');
     await act(async () => {
       fireEvent.click(screen.getByText('common.actions.save'));
     });
 
     expect(mockMutateAsync).toHaveBeenCalledWith({
       documentId: 'doc-1',
-      teamIds: ['team-1'],
+      teamIds: ['team-1', 'team-2', 'team-3'],
     });
   });
 
-  it('submits empty array when org-wide is selected', async () => {
+  it('disables save when no changes', () => {
+    render(<DocumentTeamTagsDialog {...defaultProps} />);
+    expect(screen.getByText('common.actions.save')).toBeDisabled();
+  });
+
+  it('enables save when the selection changes', () => {
+    render(<DocumentTeamTagsDialog {...defaultProps} />);
+    toggleTeam('team-1');
+    expect(screen.getByText('common.actions.save')).toBeEnabled();
+  });
+
+  it('allows selecting multiple teams', async () => {
+    render(<DocumentTeamTagsDialog {...defaultProps} />);
+
+    toggleTeam('team-1');
+    toggleTeam('team-2');
+    expect(screen.getByTestId('team-team-1')).toBeChecked();
+    expect(screen.getByTestId('team-team-2')).toBeChecked();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.actions.save'));
+    });
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      documentId: 'doc-1',
+      teamIds: ['team-1', 'team-2'],
+    });
+  });
+
+  it('submits an empty array when all teams are deselected (org-wide)', async () => {
     render(
       <DocumentTeamTagsDialog {...defaultProps} currentTeamIds={['team-1']} />,
     );
 
-    selectTeam('__org_wide__');
+    toggleTeam('team-1'); // deselect -> org-wide
     await act(async () => {
       fireEvent.click(screen.getByText('common.actions.save'));
     });
@@ -272,7 +289,7 @@ describe('DocumentTeamTagsDialog', () => {
   it('shows success toast after save', async () => {
     render(<DocumentTeamTagsDialog {...defaultProps} />);
 
-    selectTeam('team-1');
+    toggleTeam('team-1');
     await act(async () => {
       fireEvent.click(screen.getByText('common.actions.save'));
     });
@@ -287,7 +304,7 @@ describe('DocumentTeamTagsDialog', () => {
     mockMutateAsync.mockRejectedValue(new Error('fail'));
     render(<DocumentTeamTagsDialog {...defaultProps} />);
 
-    selectTeam('team-1');
+    toggleTeam('team-1');
     await act(async () => {
       fireEvent.click(screen.getByText('common.actions.save'));
     });
@@ -314,23 +331,12 @@ describe('DocumentTeamTagsDialog', () => {
       <DocumentTeamTagsDialog {...defaultProps} onOpenChange={onOpenChange} />,
     );
 
-    selectTeam('team-1');
+    toggleTeam('team-1');
     await act(async () => {
       fireEvent.click(screen.getByText('common.actions.save'));
     });
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
-  });
-
-  it('only allows single team selection', () => {
-    render(<DocumentTeamTagsDialog {...defaultProps} />);
-
-    selectTeam('team-1');
-    const select = screen.getByTestId('team-select');
-    expect(select).toHaveValue('team-1');
-
-    selectTeam('team-2');
-    expect(select).toHaveValue('team-2');
   });
 
   describe('folder entity type', () => {
@@ -348,13 +354,13 @@ describe('DocumentTeamTagsDialog', () => {
         screen.getByRole('heading', { name: 'documents.teamTags.title' }),
       ).toBeInTheDocument();
       expect(screen.getByText('My Folder')).toBeInTheDocument();
-      expect(screen.getByTestId('team-select')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-team-multi-select')).toBeInTheDocument();
     });
 
     it('calls folder mutation when submitting with entityType folder', async () => {
       render(<DocumentTeamTagsDialog {...folderProps} />);
 
-      selectTeam('team-1');
+      toggleTeam('team-1');
       await act(async () => {
         fireEvent.click(screen.getByText('common.actions.save'));
       });
@@ -369,7 +375,7 @@ describe('DocumentTeamTagsDialog', () => {
     it('calls document mutation when submitting with default entityType', async () => {
       render(<DocumentTeamTagsDialog {...defaultProps} />);
 
-      selectTeam('team-1');
+      toggleTeam('team-1');
       await act(async () => {
         fireEvent.click(screen.getByText('common.actions.save'));
       });
@@ -379,24 +385,6 @@ describe('DocumentTeamTagsDialog', () => {
         teamIds: ['team-1'],
       });
       expect(mockFolderMutateAsync).not.toHaveBeenCalled();
-    });
-
-    it('uses entityId prop correctly for folder submissions', async () => {
-      const customProps = {
-        ...folderProps,
-        entityId: 'folder-custom-99',
-      };
-      render(<DocumentTeamTagsDialog {...customProps} />);
-
-      selectTeam('team-3');
-      await act(async () => {
-        fireEvent.click(screen.getByText('common.actions.save'));
-      });
-
-      expect(mockFolderMutateAsync).toHaveBeenCalledWith({
-        folderId: 'folder-custom-99',
-        teamIds: ['team-3'],
-      });
     });
   });
 });

--- a/services/platform/app/features/documents/components/document-team-tags-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-team-tags-dialog.tsx
@@ -8,7 +8,7 @@ import { Settings, Users } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
-import { Select } from '@/app/components/ui/forms/select';
+import { Label } from '@/app/components/ui/forms/label';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { toast } from '@/app/hooks/use-toast';
@@ -16,8 +16,7 @@ import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 
 import { useUpdateDocument, useUpdateFolderTeams } from '../hooks/mutations';
-
-const ORG_WIDE_VALUE = '__org_wide__';
+import { TeamMultiSelect } from './team-multi-select';
 
 type EntityType = 'file' | 'folder';
 
@@ -49,8 +48,13 @@ function DocumentTeamDialogContent({
   const navigate = useNavigate();
   const organizationId = useOrganizationId();
 
-  const currentTeamId = currentTeamIds?.[0] ?? ORG_WIDE_VALUE;
-  const [selectedTeamId, setSelectedTeamId] = useState(currentTeamId);
+  // A document/folder can belong to multiple teams (backend stores teamIds as
+  // an array). Edit the full set here so re-assigning doesn't silently drop the
+  // other teams (#1325). An empty selection means org-wide.
+  const initialTeamIds = useMemo(() => currentTeamIds ?? [], [currentTeamIds]);
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>(
+    () => currentTeamIds ?? [],
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const updateDocument = useUpdateDocument();
@@ -69,10 +73,7 @@ function DocumentTeamDialogContent({
     setIsSubmitting(true);
 
     try {
-      const teamIds =
-        selectedTeamId && selectedTeamId !== ORG_WIDE_VALUE
-          ? [selectedTeamId]
-          : [];
+      const teamIds = selectedTeamIds;
 
       if (entityType === 'folder') {
         await updateFolderTeams.mutateAsync({
@@ -104,14 +105,16 @@ function DocumentTeamDialogContent({
   }, [
     entityId,
     entityType,
-    selectedTeamId,
+    selectedTeamIds,
     updateDocument,
     updateFolderTeams,
     onOpenChange,
     tDocuments,
   ]);
 
-  const hasChanges = selectedTeamId !== currentTeamId;
+  const hasChanges =
+    selectedTeamIds.length !== initialTeamIds.length ||
+    selectedTeamIds.some((id) => !initialTeamIds.includes(id));
 
   const displayName = useMemo(() => {
     if (!documentName) return '';
@@ -128,23 +131,18 @@ function DocumentTeamDialogContent({
     });
   }, [organizationId, onOpenChange, navigate]);
 
-  const teamOptions = useMemo(
-    () => [
-      { value: ORG_WIDE_VALUE, label: tDocuments('teamTags.orgWide') },
-      ...(teams ?? []).map((team: { id: string; name: string }) => ({
-        value: team.id,
-        label: team.name,
-      })),
-    ],
-    [teams, tDocuments],
-  );
-
   return (
     <Dialog
       open={open}
       onOpenChange={handleClose}
       title={tDocuments('teamTags.title')}
-      description={displayName || undefined}
+      // break-all so a long file name with no spaces wraps instead of
+      // overflowing the dialog header (#1324).
+      description={
+        displayName ? (
+          <span className="break-all">{displayName}</span>
+        ) : undefined
+      }
       footerClassName="px-6 pt-4 pb-5"
       footer={
         <>
@@ -191,14 +189,13 @@ function DocumentTeamDialogContent({
           className="py-8"
         />
       ) : (
-        <div className="px-6 pt-2 pb-4">
-          <Select
-            id="team-assignment"
-            label={tDocuments('teamTags.team')}
-            placeholder={tDocuments('teamTags.orgWide')}
-            value={selectedTeamId}
-            onValueChange={setSelectedTeamId}
-            options={teamOptions}
+        <div className="space-y-1.5 px-6 pt-2 pb-4">
+          <Label>{tDocuments('teamTags.team')}</Label>
+          <TeamMultiSelect
+            teams={teams ?? []}
+            selectedTeamIds={selectedTeamIds}
+            onSelectionChange={setSelectedTeamIds}
+            orgWideLabel={tDocuments('teamTags.orgWide')}
             disabled={isSubmitting}
           />
         </div>


### PR DESCRIPTION
## Problem

The per-document/folder **team assignment** dialog only let you pick a **single** team (or org-wide), even though the backend stores `teamIds` as an array and the upload dialog already supports multiple teams. Worse, the dialog received the full `currentTeamIds` array but collapsed it to `currentTeamIds[0]`, so **editing a document already assigned to several teams silently dropped all but the first** (#1325).

Separately, a long file **name with no spaces** overflowed the dialog header because the shared `Dialog` description has no `break-all` (#1324).

## Fix

- Replaced the single `Select` with the existing **`TeamMultiSelect`** (empty selection = org-wide), so the dialog edits the full set of teams and preserves multi-team assignments on save.
- Wrapped the document name passed as the dialog description in `<span className="break-all">` so long unbroken names wrap instead of overflowing (#1324).

## Tests

Rewrote `document-team-tags-dialog.test.tsx` for the multi-select behavior (the old test drove a mocked single `Select`):
- renders a checkbox per team; empty = org-wide;
- **pre-selects multiple current teams and preserves them on save** (the core #1325 regression);
- allows selecting multiple teams; deselecting all submits `[]` (org-wide);
- folder vs document mutation routing; success/error toasts; loading/empty/navigation.

22 passed. `tsc --noEmit`, `oxlint --type-aware`, `oxfmt` clean.

Closes #1325
Closes #1324
