### PR TITLE
fix(platform): label custom condition branches in the automation flow (#1486)

### DIFF
--- a/services/platform/app/features/automations/hooks/use-automation-layout.test.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-layout.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveConditionBranchEdge } from './use-automation-layout';
+
+// Regression test for #1486: condition branches with a custom key used to
+// render as an unlabeled gray line, making the flow ambiguous. Every branch
+// must now carry a label.
+describe('resolveConditionBranchEdge (#1486)', () => {
+  it('maps negative keys to a red "false" edge (case-insensitive)', () => {
+    for (const key of ['false', 'No', 'REJECT', 'failure', 'error']) {
+      expect(resolveConditionBranchEdge(key)).toEqual({
+        color: 'hsl(var(--destructive))',
+        label: 'false',
+      });
+    }
+  });
+
+  it('maps positive keys to a green "true" edge (case-insensitive)', () => {
+    for (const key of ['true', 'Yes', 'APPROVE', 'success', 'default']) {
+      expect(resolveConditionBranchEdge(key)).toEqual({
+        color: 'hsl(var(--chart-2))',
+        label: 'true',
+      });
+    }
+  });
+
+  it('labels a custom branch key with its own name (no longer unlabeled)', () => {
+    const result = resolveConditionBranchEdge('Check Has Cursor');
+    expect(result.label).toBe('Check Has Cursor');
+    expect(result.color).toBeTruthy();
+  });
+});

--- a/services/platform/app/features/automations/hooks/use-automation-layout.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-layout.ts
@@ -8,9 +8,21 @@ import type { Doc } from '@/convex/_generated/dataModel';
 
 import { getLayoutedElements } from '../utils/dagre-layout';
 
-const LOOP_EXIT_KEYS = ['done', 'complete', 'finished', 'exit'];
-const NEGATIVE_BRANCH_KEYS = ['reject', 'false', 'no', 'failure', 'error'];
-const POSITIVE_BRANCH_KEYS = ['approve', 'true', 'yes', 'success', 'default'];
+const LOOP_EXIT_KEYS = new Set(['done', 'complete', 'finished', 'exit']);
+const NEGATIVE_BRANCH_KEYS = new Set([
+  'reject',
+  'false',
+  'no',
+  'failure',
+  'error',
+]);
+const POSITIVE_BRANCH_KEYS = new Set([
+  'approve',
+  'true',
+  'yes',
+  'success',
+  'default',
+]);
 const NEUTRAL_EDGE_COLOR = '#9CA3AF';
 
 /**
@@ -24,10 +36,10 @@ export function resolveConditionBranchEdge(key: string): {
   label: string;
 } {
   const keyLower = key.toLowerCase();
-  if (NEGATIVE_BRANCH_KEYS.includes(keyLower)) {
+  if (NEGATIVE_BRANCH_KEYS.has(keyLower)) {
     return { color: 'hsl(var(--destructive))', label: 'false' };
   }
-  if (POSITIVE_BRANCH_KEYS.includes(keyLower)) {
+  if (POSITIVE_BRANCH_KEYS.has(keyLower)) {
     return { color: 'hsl(var(--chart-2))', label: 'true' };
   }
   return { color: NEUTRAL_EDGE_COLOR, label: key };
@@ -281,9 +293,9 @@ export function useAutomationLayout(steps: Doc<'wfStepDefs'>[]) {
               return;
             }
 
-            const isLoopExit = LOOP_EXIT_KEYS.includes(keyLower);
-            const isNegativePath = NEGATIVE_BRANCH_KEYS.includes(keyLower);
-            const isPositivePath = POSITIVE_BRANCH_KEYS.includes(keyLower);
+            const isLoopExit = LOOP_EXIT_KEYS.has(keyLower);
+            const isNegativePath = NEGATIVE_BRANCH_KEYS.has(keyLower);
+            const isPositivePath = POSITIVE_BRANCH_KEYS.has(keyLower);
 
             let edgeColor = NEUTRAL_EDGE_COLOR;
             let edgeLabel: string | undefined = undefined;

--- a/services/platform/app/features/automations/hooks/use-automation-layout.ts
+++ b/services/platform/app/features/automations/hooks/use-automation-layout.ts
@@ -8,6 +8,31 @@ import type { Doc } from '@/convex/_generated/dataModel';
 
 import { getLayoutedElements } from '../utils/dagre-layout';
 
+const LOOP_EXIT_KEYS = ['done', 'complete', 'finished', 'exit'];
+const NEGATIVE_BRANCH_KEYS = ['reject', 'false', 'no', 'failure', 'error'];
+const POSITIVE_BRANCH_KEYS = ['approve', 'true', 'yes', 'success', 'default'];
+const NEUTRAL_EDGE_COLOR = '#9CA3AF';
+
+/**
+ * Resolve the color + label for a condition step's branch edge. Standard
+ * positive/negative outcomes map to green/"true" and red/"false"; any other
+ * (custom) branch key keeps a neutral color but is labeled with its own key,
+ * so the path is identifiable rather than an unlabeled gray line (#1486).
+ */
+export function resolveConditionBranchEdge(key: string): {
+  color: string;
+  label: string;
+} {
+  const keyLower = key.toLowerCase();
+  if (NEGATIVE_BRANCH_KEYS.includes(keyLower)) {
+    return { color: 'hsl(var(--destructive))', label: 'false' };
+  }
+  if (POSITIVE_BRANCH_KEYS.includes(keyLower)) {
+    return { color: 'hsl(var(--chart-2))', label: 'true' };
+  }
+  return { color: NEUTRAL_EDGE_COLOR, label: key };
+}
+
 export function useAutomationLayout(steps: Doc<'wfStepDefs'>[]) {
   return useMemo(() => {
     if (!steps || steps.length === 0) {
@@ -256,30 +281,11 @@ export function useAutomationLayout(steps: Doc<'wfStepDefs'>[]) {
               return;
             }
 
-            const isLoopExit = [
-              'done',
-              'complete',
-              'finished',
-              'exit',
-            ].includes(keyLower);
+            const isLoopExit = LOOP_EXIT_KEYS.includes(keyLower);
+            const isNegativePath = NEGATIVE_BRANCH_KEYS.includes(keyLower);
+            const isPositivePath = POSITIVE_BRANCH_KEYS.includes(keyLower);
 
-            const isNegativePath = [
-              'reject',
-              'false',
-              'no',
-              'failure',
-              'error',
-            ].includes(keyLower);
-
-            const isPositivePath = [
-              'approve',
-              'true',
-              'yes',
-              'success',
-              'default',
-            ].includes(keyLower);
-
-            let edgeColor = '#9CA3AF';
+            let edgeColor = NEUTRAL_EDGE_COLOR;
             let edgeLabel: string | undefined = undefined;
             let edgeStyle: React.CSSProperties = {
               strokeWidth: 1.5,
@@ -295,13 +301,9 @@ export function useAutomationLayout(steps: Doc<'wfStepDefs'>[]) {
                 edgeLabel = undefined;
               }
             } else if (step.stepType === 'condition') {
-              if (isNegativePath) {
-                edgeColor = 'hsl(var(--destructive))';
-                edgeLabel = 'false';
-              } else if (isPositivePath) {
-                edgeColor = 'hsl(var(--chart-2))';
-                edgeLabel = 'true';
-              }
+              const branch = resolveConditionBranchEdge(key);
+              edgeColor = branch.color;
+              edgeLabel = branch.label;
               edgeStyle = { strokeWidth: 1.5, stroke: edgeColor };
             } else if (step.stepType === 'action' || step.stepType === 'llm') {
               if (isNegativePath) {


### PR DESCRIPTION
## Problem

In the automation flow diagram, a condition step's branch edges were only labeled/colored when the branch key matched a known **positive** (`true`/`yes`/`approve`/…) or **negative** (`false`/`no`/`reject`/…) keyword. A **custom** branch key (e.g. `Check Has Cursor`) fell through to an unlabeled gray line, so you couldn't tell which path was which — the "confusing conditional flow visualization" in #1486.

## Fix

Custom condition branches are now **labeled with their own branch key** (keeping a neutral color), so every path on the canvas is identifiable. Known positive/negative outcomes still render green/"true" and red/"false".

Refactored the inline keyword lists into shared module constants and a pure, exported `resolveConditionBranchEdge(key)` helper.

## Tests

New `use-automation-layout.test.ts`:
- negative keys → red `false` (case-insensitive),
- positive keys → green `true`,
- custom key → labeled with its own name (no longer unlabeled). 3 passed.

`tsc --noEmit`, `oxlint --type-aware`, `oxfmt` clean.

Closes #1486
