### PR TITLE
fix(platform): lock upload team selection to the folder's team (#1469)

### DIFF
--- a/services/platform/app/features/documents/components/document-upload-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.test.tsx
@@ -47,6 +47,12 @@ vi.mock('@/app/features/settings/teams/hooks/queries', () => ({
   useTeams: () => ({ teams: mockTeams, isLoading: false }),
 }));
 
+// Destination folder lookup (#1469). Default: no folder / no team binding.
+let mockFolderData: { teamId?: string } | undefined = undefined;
+vi.mock('../hooks/queries', () => ({
+  useFolder: () => ({ data: mockFolderData }),
+}));
+
 vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
   useUploadPolicy: () => ({
     maxFileSize: 10 * 1024 * 1024,
@@ -107,6 +113,7 @@ import { DocumentUploadDialog } from './document-upload-dialog';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockFolderData = undefined;
   mockHookState = {
     isUploading: false,
     trackedFiles: [],
@@ -143,6 +150,22 @@ describe('DocumentUploadDialog', () => {
       screen.getByText('documents.upload.selectTeams'),
     ).toBeInTheDocument();
     expect(screen.getByText('documents.teamTags.orgWide')).toBeInTheDocument();
+  });
+
+  // Regression test for #1469: uploading into a team-scoped folder must lock
+  // the team selection to that folder's team (the create mutation forces it),
+  // instead of presenting a freely-editable selector.
+  it('locks the team selection to the folder team when uploading into a team folder', () => {
+    mockFolderData = { teamId: 'team-1' };
+    render(<DocumentUploadDialog {...defaultProps} folderId="folder-1" />);
+
+    // The folder's team (Sales) is pre-selected and the inheritance hint shows.
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(
+      screen.getByText('documents.upload.teamLockedToFolder'),
+    ).toBeInTheDocument();
+    // No hint / free selection for an org-wide folder is covered by the
+    // default-props test above (mockFolderData undefined).
   });
 
   it('renders drop zone description with file types', () => {

--- a/services/platform/app/features/documents/components/document-upload-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.test.tsx
@@ -164,6 +164,11 @@ describe('DocumentUploadDialog', () => {
     expect(
       screen.getByText('documents.upload.teamLockedToFolder'),
     ).toBeInTheDocument();
+
+    // The TeamMultiSelect control must be disabled to enforce the lock.
+    const teamSelector = screen.getByRole('combobox');
+    expect(teamSelector).toHaveAttribute('aria-disabled', 'true');
+
     // No hint / free selection for an org-wide folder is covered by the
     // default-props test above (mockFolderData undefined).
   });

--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -124,11 +124,17 @@ export function DocumentUploadDialog({
       if (!newOpen && isUploading) return; // Block close while uploading
       if (!newOpen) {
         clearTrackedFiles();
-        setSelectedTeamIds(selectedTeamId ? [selectedTeamId] : []);
+        setSelectedTeamIds(
+          folderTeamId
+            ? [folderTeamId]
+            : selectedTeamId
+              ? [selectedTeamId]
+              : [],
+        );
       }
       onOpenChange(newOpen);
     },
-    [onOpenChange, isUploading, clearTrackedFiles, selectedTeamId],
+    [onOpenChange, isUploading, clearTrackedFiles, folderTeamId, selectedTeamId],
   );
 
   const processFiles = useCallback(

--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -134,7 +134,13 @@ export function DocumentUploadDialog({
       }
       onOpenChange(newOpen);
     },
-    [onOpenChange, isUploading, clearTrackedFiles, folderTeamId, selectedTeamId],
+    [
+      onOpenChange,
+      isUploading,
+      clearTrackedFiles,
+      folderTeamId,
+      selectedTeamId,
+    ],
   );
 
   const processFiles = useCallback(

--- a/services/platform/app/features/documents/components/document-upload-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-upload-dialog.tsx
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils/cn';
 import { formatBytes } from '@/lib/utils/format/number';
 
 import { useDocumentUpload } from '../hooks/mutations';
+import { useFolder } from '../hooks/queries';
 import { TeamMultiSelect } from './team-multi-select';
 import { UploadFileRow } from './upload-file-row';
 
@@ -58,6 +59,20 @@ export function DocumentUploadDialog({
 
   const { teams, isLoading: isLoadingTeams } = useTeams();
   const policyLimits = useUploadPolicy(organizationId);
+
+  // A team-scoped folder forces its team on every document created inside it
+  // (the create mutation overrides teamId with the folder's). Lock the team
+  // selector to that team so the UI reflects what actually happens instead of
+  // implying the upload can be assigned elsewhere (#1469).
+  const { data: folder } = useFolder(folderId);
+  const folderTeamId = folder?.teamId ?? undefined;
+  const isTeamLockedToFolder = !!folderTeamId;
+
+  useEffect(() => {
+    if (folderTeamId) {
+      setSelectedTeamIds([folderTeamId]);
+    }
+  }, [folderTeamId]);
 
   const effectiveMaxFileSize = policyLimits.policyEnabled
     ? policyLimits.documentMaxFileSize
@@ -289,8 +304,13 @@ export function DocumentUploadDialog({
               selectedTeamIds={selectedTeamIds}
               onSelectionChange={handleTeamSelectionChange}
               orgWideLabel={tDocuments('teamTags.orgWide')}
-              disabled={isUploading || allCompleted}
+              disabled={isUploading || allCompleted || isTeamLockedToFolder}
             />
+          )}
+          {isTeamLockedToFolder && (
+            <span className="text-muted-foreground text-[13px]">
+              {tDocuments('upload.teamLockedToFolder')}
+            </span>
           )}
         </div>
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1918,6 +1918,7 @@
       "filesCompletedSummary": "{completed} von {total} Dateien abgeschlossen",
       "filesCompletedWithFailures": "{completed} von {total} Dateien abgeschlossen - {failed} fehlgeschlagen",
       "selectTeams": "Teams zuweisen",
+      "teamLockedToFolder": "Hier hochgeladene Dateien werden dem Team dieses Ordners zugewiesen.",
       "selectTeamsDescription": "Wähle, welchem Team die hochgeladenen Dokumente zugeordnet werden",
       "noTeamsAvailable": "Du bist kein Mitglied eines Teams",
       "allMembersHint": "Organisationsweite Dokumente sind für alle in der Organisation zugänglich.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1918,6 +1918,7 @@
       "filesCompletedSummary": "{completed} of {total} files completed",
       "filesCompletedWithFailures": "{completed} of {total} files completed · {failed} failed",
       "selectTeams": "Assign to teams",
+      "teamLockedToFolder": "Files uploaded here are assigned to this folder’s team.",
       "selectTeamsDescription": "Choose which team the uploaded documents belong to",
       "noTeamsAvailable": "You are not a member of any teams",
       "allMembersHint": "Organization-wide documents are accessible to everyone in the organization.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1919,6 +1919,7 @@
       "filesCompletedSummary": "{completed} sur {total} fichiers terminés",
       "filesCompletedWithFailures": "{completed} sur {total} fichiers terminés · {failed} échoués",
       "selectTeams": "Assigner aux équipes",
+      "teamLockedToFolder": "Les fichiers téléversés ici sont assignés à l'équipe de ce dossier.",
       "selectTeamsDescription": "Choisis à quelle équipe les documents téléversés appartiennent",
       "noTeamsAvailable": "Tu n'es membre d'aucune équipe",
       "allMembersHint": "Les documents accessibles à toute l'organisation sont disponibles pour tous les membres de l'organisation.",


### PR DESCRIPTION
## Problem

Uploading documents into a **team-scoped folder** still showed a freely-editable team multi-select, so it looked like you could assign the files to a different team than the folder. In reality the create mutation **overrides** the team with the folder's (`effectiveTeamId = folder.teamId` in `documents/mutations.ts`), so the picker was misleading (#1469).

## Fix

The upload dialog now looks up the destination folder (`useFolder(folderId)`). When the folder has a `teamId`:
- the team selection is pre-filled with that team, and
- the `TeamMultiSelect` is **disabled**, with a hint that files inherit the folder's team.

Org-wide folders (no `teamId`) keep the existing free selection. Added `documents.upload.teamLockedToFolder` to `en`/`de`/`fr`.

## Tests

- `document-upload-dialog.test.tsx`: new test asserts that with a team-scoped destination folder the folder's team is pre-selected and the inheritance hint shows; existing tests still pass (added a `useFolder` mock). 11 passed.
- `tsc --noEmit`, `oxlint`, `oxfmt`, i18n parity all green.

Closes #1469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document uploads now support team-scoped folder destinations. When uploading to a team-scoped folder, the team is automatically pre-selected and locked, preventing manual changes.
  * Added "team locked to folder" message to clarify upload behavior.

* **Documentation**
  * Added translations for the team-scoped upload feature in English, German, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->