### PR TITLE
fix(platform): clarify upload-success vs background-indexing copy (#1460)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1925,7 +1925,7 @@
       "dropZoneDescription": "PDF, DOCX, XLSX, CSV bis zu {maxSize} MB",
       "retryUpload": "Upload erneut versuchen",
       "retry": "Erneut versuchen",
-      "documentsUploadedSuccessfully": "{count} {count, plural, one {Dokument} other {Dokumente}} hochgeladen",
+      "documentsUploadedSuccessfully": "{count} {count, plural, one {Dokument} other {Dokumente}} hochgeladen — Indexierung läuft im Hintergrund",
       "unsupportedFileType": "Nicht unterstützter Dateityp",
       "unsupportedFileTypeDescription": "{name} ist kein unterstütztes Format. Unterstützte Formate: PDF, DOCX, XLSX, CSV, TXT, PPTX, Bilder.",
       "extensionBlocked": "{name}:.{ext}-Dateien sind durch die Upload-Richtlinie blockiert.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1925,7 +1925,7 @@
       "dropZoneDescription": "PDF, DOCX, XLSX, CSV up to {maxSize} MB",
       "retryUpload": "Retry upload",
       "retry": "Retry",
-      "documentsUploadedSuccessfully": "{count} {count, plural, one {document} other {documents}} uploaded successfully",
+      "documentsUploadedSuccessfully": "{count} {count, plural, one {document} other {documents}} uploaded — indexing runs in the background",
       "unsupportedFileType": "Unsupported file type",
       "unsupportedFileTypeDescription": "{name} is not a supported format. Supported formats: PDF, DOCX, XLSX, CSV, TXT, PPTX, images.",
       "extensionBlocked": "{name}: .{ext} files are blocked by upload policy.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1926,7 +1926,7 @@
       "dropZoneDescription": "PDF, DOCX, XLSX, CSV jusqu'à {maxSize} Mo",
       "retryUpload": "Réessayer le téléversement",
       "retry": "Réessayer",
-      "documentsUploadedSuccessfully": "{count} {count, plural, one {document téléversé} other {documents téléversés}} avec succès",
+      "documentsUploadedSuccessfully": "{count} {count, plural, one {document téléversé} other {documents téléversés}} — indexation en cours en arrière-plan",
       "unsupportedFileType": "Type de fichier non pris en charge",
       "unsupportedFileTypeDescription": "{name} n'est pas un format pris en charge. Formats acceptés : PDF, DOCX, XLSX, CSV, TXT, PPTX, images.",
       "extensionBlocked": "{name} : les fichiers .{ext} sont bloqués par la politique de téléversement.",


### PR DESCRIPTION
## Problem

Uploading documents shows a success banner — "{n} documents uploaded successfully" — as soon as the **upload** (to storage) completes. RAG **indexing** is a separate async phase that can fail afterward and surfaces as an "Index failed" badge on the document. The result reads as contradictory: success, then failure on the same file (#1460).

## Fix

Reworded the success copy so it sets the right expectation — the upload succeeded and **indexing runs in the background** — making the subsequent per-document indexing status (and its retry, #1459) expected rather than surprising. Updated `documents.upload.documentsUploadedSuccessfully` in `en`/`de`/`fr` (value only; key unchanged).

## Tests

- i18n parity (22) + `document-upload-dialog.test.tsx` (10) → 32 passed.

Closes #1460
