### PR TITLE
fix(ui): hide masked content behind skeleton while loading

### DIFF
--- a/packages/ui/src/components/feedback/skeleton.test.tsx
+++ b/packages/ui/src/components/feedback/skeleton.test.tsx
@@ -33,8 +33,11 @@ describe('SkeletonBox', () => {
         </SkeletonBox>
       </Skeletonize>,
     );
-    // The real content stays in the tree; an opaque overlay covers it.
-    expect(screen.getByTestId('value')).toBeInTheDocument();
+    // The real content stays in the tree (so the mask sizes to it) but is
+    // visibility-hidden behind the opaque overlay — it can't peek through.
+    const value = screen.getByTestId('value');
+    expect(value).toBeInTheDocument();
+    expect(value.parentElement).toHaveClass('invisible', 'contents');
   });
 });
 

--- a/packages/ui/src/components/feedback/skeleton.tsx
+++ b/packages/ui/src/components/feedback/skeleton.tsx
@@ -34,6 +34,25 @@ interface SkeletonWrapProps {
 }
 
 /**
+ * While loading, render the real content inside a `display: contents` wrapper
+ * that carries `visibility: hidden`. `contents` generates no box (so layout is
+ * identical to rendering `children` bare — the skeleton still sizes to the
+ * content), while `visibility: hidden` inherits down to every leaf so nothing
+ * can peek out from under the opaque mask, and masked controls drop out of the
+ * focus/hit-test order. When not loading the content renders untouched.
+ */
+function MaskedContent({
+  loading,
+  children,
+}: {
+  loading: boolean;
+  children: ReactNode;
+}) {
+  if (!loading) return children;
+  return <span className="invisible contents">{children}</span>;
+}
+
+/**
  * The universal masking primitive — `<SkeletonBox>{value}</SkeletonBox>`.
  *
  * Renders the real value as-is. While loading (`useSkeleton()` is true, i.e.
@@ -68,7 +87,7 @@ export function SkeletonBox({ children, fullWidth }: SkeletonWrapProps) {
           : 'contents'
       }
     >
-      {children}
+      <MaskedContent loading={loading}>{children}</MaskedContent>
       {loading && (
         <span className="bg-muted absolute -inset-0.5 overflow-hidden rounded-[inherit]">
           <span className={SKELETON_SHIMMER} />
@@ -97,7 +116,7 @@ export function SkeletonCircle({ children, fullWidth }: SkeletonWrapProps) {
           : 'contents'
       }
     >
-      {children}
+      <MaskedContent loading={loading}>{children}</MaskedContent>
       {loading && (
         <span className="bg-muted absolute -inset-0.5 overflow-hidden rounded-full">
           <span className={SKELETON_SHIMMER} />


### PR DESCRIPTION
## What

While loading, `SkeletonBox` / `SkeletonCircle` previously kept the real content fully rendered and relied **only** on the opaque overlay to cover it (with a `-inset-0.5` overhang to stop edges peeking through). This explicitly hides the masked content as well.

## How

Added a small `MaskedContent` helper that, while loading, wraps the children in `<span className="invisible contents">`:

- **`contents`** generates no box, so layout is identical to rendering `children` bare — the mask still sizes itself to the real content (no drift).
- **`invisible`** (`visibility: hidden`) inherits down to every leaf, so nothing can peek out from under the mask and masked controls also drop out of the focus/hit-test order.

Both `SkeletonBox` and `SkeletonCircle` now route their children through `MaskedContent`. When not loading, content renders untouched. `SkeletonText` is unchanged — it was already content-free (zero-width glyph + pulse overlay).

## Testing

- Strengthened the existing "hides the region while loading" test to assert the `invisible contents` wrapper is applied.
- All skeleton / skeleton-context tests pass (16 tests).