### PR TITLE
docs: cryptography reference aligned with BSI TR-02102-1 (#1500)

### DIFF
--- a/docs/de/self-hosted/operate/security/cryptography.md
+++ b/docs/de/self-hosted/operate/security/cryptography.md
@@ -1,0 +1,53 @@
+---
+title: Kryptografie
+description: Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt — und wie sie auf BSI TR-02102-1 abgebildet sind.
+---
+
+Diese Seite ist die Inventur jedes kryptografischen Primitivs, auf das sich Tale stützt: was Secrets auf der Festplatte schützt, was den Verkehr auf der Leitung schützt, wie Passwörter gehasht werden und wie das Audit-Log beweist, dass es nicht manipuliert wurde. Sie ist für Betreiber und Compliance-Prüfer geschrieben, die "welche Algorithmen, welche Schlüssellängen, wo liegen die Schlüssel" gegen einen Standard wie BSI TR-02102-1 beantworten müssen — Tale nutzt bereits konforme Primitive, und auf dieser Seite sind sie festgehalten.
+
+Die Angaben hier sind gegen den Quellcode verifiziert; wo ein Primitiv konfigurierbar ist, wird die Umgebungsvariable benannt, die es steuert, damit du dein eigenes Deployment prüfen kannst. Das ist kein Ersatz dafür, die Host-Festplatte zu verschlüsseln — siehe [Härtung](/de/self-hosted/operate/security/hardening) für die Schicht unter der Anwendung.
+
+## Ruhende Daten
+
+Tale verschlüsselt zwei Klassen von Secrets im Ruhezustand, mit zwei verschiedenen Mechanismen.
+
+**Provider-API-Schlüssel** liegen in `providers/*.secrets.json` und werden mit [SOPS](/de/self-hosted/configuration/secrets-with-sops) unter Nutzung eines **age**-Schlüssels verschlüsselt. SOPS verschlüsselt jeden Wert mit **AES-256-GCM** und wrappt den Datenschlüssel an den age-Empfänger, dessen Schlüsselaustausch **X25519** ist. Ein verschlüsselter Wert liest sich auf der Festplatte als `ENC[AES256_GCM,data:…,iv:…,tag:…]`; die Entschlüsselung passiert in-process und der private age-Schlüssel verlässt den Speicher des platform-Containers nie.
+
+**Anwendungsverschlüsselte Felder** — OAuth-Integrations-Tokens und ähnliche Credentials in der Datenbank — werden mit **AES-256-GCM** über ein kompaktes JWE (`alg: dir`, `enc: A256GCM`) verschlüsselt. Der 32-Byte-Schlüssel kommt aus `ENCRYPTION_SECRET` (base64) oder `ENCRYPTION_SECRET_HEX` (hex); die Plattform verweigert den Start des Verschlüsselungspfads mit einem Schlüssel, der nicht exakt 32 Byte hat.
+
+Der Convex-Datenspeicher und die Postgres-Volumes werden vom Host geschützt: betreibe sie auf einem verschlüsselten Dateisystem (LUKS oder die Volume-Verschlüsselung deines Cloud-Anbieters). Tale speichert Credentials nicht im Klartext — ein Provider-Schlüssel oder OAuth-Token ist entweder SOPS-verschlüsselt auf der Festplatte oder AES-256-GCM-verschlüsselt in der Datenbank, nie im Klartext geschrieben.
+
+## Daten bei der Übertragung
+
+Aller Browser- und API-Verkehr terminiert TLS am Reverse-Proxy (Caddy), der TLS 1.3 (mit TLS 1.2 als Untergrenze) aushandelt und Zertifikate automatisch bezieht. Die Cipher-Suites sind die modernen Defaults des Proxys — AES-256-GCM und ChaCha20-Poly1305 mit ECDHE-Schlüsselaustausch. Konfiguriere Domain und Zertifikatsquelle in [TLS und Domains](/de/self-hosted/configuration/tls-and-domains); der Verkehr zwischen Containern bleibt im internen Docker-Netz des Hosts.
+
+## Passwort-Hashing
+
+Lokale-Passwort-Konten werden mit **bcrypt** gehasht (über Better Auth), sodass eine gestohlene Datenbankzeile das Passwort nicht preisgibt und eine Verifikation bewusst ~100 ms kostet — was auch der Grund ist, warum das Timing des Login-Pfads verschleiert wird (siehe [Authentifizierung](/de/self-hosted/configuration/authentication)). Sessions werden mit `BETTER_AUTH_SECRET` (HMAC) signiert; das Rotieren dieses Secrets entwertet jede bestehende Session.
+
+## Integrität des Audit-Logs
+
+Das Audit-Log ist über eine **SHA-256-Hash-Kette** manipulationssicher: jeder Eintrag speichert `SHA-256(previousHash + kanonisierter Datensatz)`, sodass das Ändern oder Löschen eines historischen Eintrags die Kette an dieser Stelle und bei jedem folgenden Eintrag bricht. Einträge tragen zusätzlich eine **HMAC-SHA-256**-Signatur. Die Admin-Integritätsprüfung verifiziert beides; siehe [Audit-Logs](/de/platform/admin/governance/audit-logs).
+
+## Zuordnung zu BSI TR-02102-1
+
+Jedes Primitiv unten liegt im empfohlenen Satz von BSI TR-02102-1. Tale liefert keinen veralteten Algorithmus aus (kein MD5, SHA-1, DES oder RSA &lt; 3072 auf einem selbst erzeugten Schlüssel).
+
+| Verwendung              | Algorithmus                       | Schlüssel-/Ausgabegröße | Gesteuert durch                               |
+| ----------------------- | --------------------------------- | ----------------------- | --------------------------------------------- |
+| Provider-Secrets (Disk) | AES-256-GCM + age (X25519)        | 256-Bit                 | `SOPS_AGE_KEY` / `SOPS_AGE_KEY_FILE`          |
+| App-Felder (Datenbank)  | AES-256-GCM (JWE `dir`/`A256GCM`) | 256-Bit                 | `ENCRYPTION_SECRET` / `ENCRYPTION_SECRET_HEX` |
+| Übertragung             | TLS 1.3 (AES-256-GCM, ECDHE)      | 256-Bit                 | Reverse-Proxy / `tls-and-domains`             |
+| Passwort-Hashing        | bcrypt                            | Salt pro Hash           | Better Auth (eingebaut)                       |
+| Session-Signierung      | HMAC-SHA-256                      | 256-Bit                 | `BETTER_AUTH_SECRET`                          |
+| Audit-Integrität        | SHA-256-Kette + HMAC-SHA-256      | 256-Bit                 | eingebaut                                     |
+
+## Schlüsselspeicherung und -rotation
+
+Drei Secrets sind tragend, und jedes hat einen Rotationspfad. Der **private age-Schlüssel** (`SOPS_AGE_KEY`) entschlüsselt Provider-Secrets; rotier ihn, indem du einen neuen Empfänger hinzufügst und neu verschlüsselst, entlang des Wegs in [Secrets mit SOPS](/de/self-hosted/configuration/secrets-with-sops). Der **Feld-Verschlüsselungsschlüssel** (`ENCRYPTION_SECRET`) entschlüsselt Datenbank-Credentials; ihn zu rotieren erfordert das Neu-Verschlüsseln der betroffenen Zeilen, plan es also als Wartungsschritt statt als Hot-Swap. Das **Auth-Secret** (`BETTER_AUTH_SECRET`) signiert Sessions; es zu rotieren loggt alle bei ihrer nächsten Anfrage aus. Alle drei leben nur in der Umgebung des platform-Containers — committe sie nie und leg sie in deinem Secret-Manager der Wahl ab.
+
+## Wo das hingehört
+
+Kryptografie in Tale ist geschichtet: SOPS+age und AES-256-GCM schützen Secrets im Ruhezustand, TLS 1.3 schützt sie bei der Übertragung, bcrypt schützt Passwörter, und eine SHA-256-Kette beweist, dass das Audit-Log intakt ist — alles Primitive, die im empfohlenen Satz von BSI TR-02102-1 liegen, mit den steuernden Umgebungsvariablen oben, damit du deine eigene Instanz verifizieren kannst.
+
+Die Schicht unter der Anwendung ist der Host selbst: [Härtung](/de/self-hosted/operate/security/hardening) deckt die Egress-Allowlist, die Container-Isolation und die Erwartungen an die Festplattenverschlüsselung ab, die diese Seite voraussetzt, und [Secrets mit SOPS](/de/self-hosted/configuration/secrets-with-sops) ist die operative Anleitung für den age-Schlüssel, von dem diese Algorithmen abhängen.

--- a/docs/en/self-hosted/operate/security/cryptography.md
+++ b/docs/en/self-hosted/operate/security/cryptography.md
@@ -1,0 +1,53 @@
+---
+title: Cryptography
+description: The algorithms Tale uses for data at rest, data in transit, password hashing, and audit-log integrity — and how they map to BSI TR-02102-1.
+---
+
+This page is the inventory of every cryptographic primitive Tale relies on: what protects secrets on disk, what protects traffic on the wire, how passwords are hashed, and how the audit log proves it has not been tampered with. It is written for operators and compliance reviewers who need to answer "which algorithms, which key lengths, where are the keys" against a standard such as BSI TR-02102-1 — Tale already uses compliant primitives, and this page is where they are written down.
+
+The claims here are verified against the source; where a primitive is configurable, the environment variable that controls it is named so you can audit your own deployment. None of this is a substitute for encrypting the host disk — see [Hardening](/self-hosted/operate/security/hardening) for the layer below the application.
+
+## Data at rest
+
+Tale encrypts two classes of secret at rest, with two different mechanisms.
+
+**Provider API keys** live in `providers/*.secrets.json` and are encrypted with [SOPS](/self-hosted/configuration/secrets-with-sops) using an **age** key. SOPS encrypts each value with **AES-256-GCM** and wraps the data key to the age recipient, whose key agreement is **X25519**. An encrypted value reads `ENC[AES256_GCM,data:…,iv:…,tag:…]` on disk; decryption happens in-process and the age private key never leaves the platform container's memory.
+
+**Application-encrypted fields** — OAuth integration tokens and similar credentials stored in the database — are encrypted with **AES-256-GCM** through a compact JWE (`alg: dir`, `enc: A256GCM`). The 32-byte key comes from `ENCRYPTION_SECRET` (base64) or `ENCRYPTION_SECRET_HEX` (hex); the platform refuses to start the encryption path with a key that is not exactly 32 bytes.
+
+The Convex data store and Postgres volumes are protected by the host: run them on an encrypted filesystem (LUKS, or your cloud provider's volume encryption). Tale does not store credentials in plaintext — a provider key or OAuth token is either SOPS-encrypted on disk or AES-256-GCM-encrypted in the database, never written in the clear.
+
+## Data in transit
+
+All browser and API traffic terminates TLS at the reverse proxy (Caddy), which negotiates TLS 1.3 (with TLS 1.2 as the floor) and obtains certificates automatically. The cipher suites are the proxy's modern defaults — AES-256-GCM and ChaCha20-Poly1305 with ECDHE key exchange. Configure the domain and certificate source in [TLS and domains](/self-hosted/configuration/tls-and-domains); traffic between containers stays on the host's internal Docker network.
+
+## Password hashing
+
+Local-password accounts are hashed with **bcrypt** (via Better Auth), so a stolen database row does not reveal the password and a verification deliberately costs ~100 ms — which is also why the login path's timing is fuzzed (see [Authentication](/self-hosted/configuration/authentication)). Sessions are signed with `BETTER_AUTH_SECRET` (HMAC); rotating that secret invalidates every existing session.
+
+## Audit-log integrity
+
+The audit log is tamper-evident through a **SHA-256 hash chain**: each entry stores `SHA-256(previousHash + canonicalized record)`, so altering or deleting any historical entry breaks the chain at that point and every entry after it. Entries additionally carry an **HMAC-SHA-256** signature. The admin integrity-check verifies both; see [Audit logs](/platform/admin/governance/audit-logs).
+
+## Mapping to BSI TR-02102-1
+
+Every primitive below is in the recommended set of BSI TR-02102-1. Tale does not ship any deprecated algorithm (no MD5, SHA-1, DES, or RSA &lt; 3072 on a key it generates).
+
+| Use                     | Algorithm                         | Key / output size | Controlled by                                 |
+| ----------------------- | --------------------------------- | ----------------- | --------------------------------------------- |
+| Provider secrets (disk) | AES-256-GCM + age (X25519)        | 256-bit           | `SOPS_AGE_KEY` / `SOPS_AGE_KEY_FILE`          |
+| App fields (database)   | AES-256-GCM (JWE `dir`/`A256GCM`) | 256-bit           | `ENCRYPTION_SECRET` / `ENCRYPTION_SECRET_HEX` |
+| Transport               | TLS 1.3 (AES-256-GCM, ECDHE)      | 256-bit           | Reverse proxy / `tls-and-domains`             |
+| Password hashing        | bcrypt                            | per-hash salt     | Better Auth (built in)                        |
+| Session signing         | HMAC-SHA-256                      | 256-bit           | `BETTER_AUTH_SECRET`                          |
+| Audit integrity         | SHA-256 chain + HMAC-SHA-256      | 256-bit           | built in                                      |
+
+## Key storage and rotation
+
+Three secrets are load-bearing, and each has a rotation path. The **age private key** (`SOPS_AGE_KEY`) decrypts provider secrets; rotate it by adding a new recipient and re-encrypting, following the walk in [Secrets with SOPS](/self-hosted/configuration/secrets-with-sops). The **field-encryption key** (`ENCRYPTION_SECRET`) decrypts database credentials; rotating it requires re-encrypting the affected rows, so plan it as a maintenance step rather than a hot swap. The **auth secret** (`BETTER_AUTH_SECRET`) signs sessions; rotating it logs everyone out on their next request. All three live only in the platform container's environment — never commit them, and store them in your secret manager of record.
+
+## Where this fits
+
+Cryptography in Tale is layered: SOPS+age and AES-256-GCM protect secrets at rest, TLS 1.3 protects them in transit, bcrypt protects passwords, and a SHA-256 chain proves the audit log is intact — all primitives that sit inside BSI TR-02102-1's recommended set, with the controlling environment variables named above so you can verify your own instance.
+
+The layer beneath the application is the host itself: [Hardening](/self-hosted/operate/security/hardening) covers the egress allowlist, container isolation, and disk-encryption expectations that this page assumes, and [Secrets with SOPS](/self-hosted/configuration/secrets-with-sops) is the operational walk-through for the age key these algorithms depend on.

--- a/docs/fr/self-hosted/operate/security/cryptography.md
+++ b/docs/fr/self-hosted/operate/security/cryptography.md
@@ -1,0 +1,53 @@
+---
+title: Cryptographie
+description: Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit — et leur correspondance avec BSI TR-02102-1.
+---
+
+Cette page est l'inventaire de chaque primitive cryptographique sur laquelle Tale s'appuie : ce qui protège les secrets sur le disque, ce qui protège le trafic sur le réseau, comment les mots de passe sont hachés, et comment le journal d'audit prouve qu'il n'a pas été altéré. Elle est écrite pour les opérateurs et les auditeurs de conformité qui doivent répondre à « quels algorithmes, quelles longueurs de clé, où sont les clés » face à une norme comme BSI TR-02102-1 — Tale utilise déjà des primitives conformes, et cette page est l'endroit où elles sont consignées.
+
+Les affirmations ici sont vérifiées contre le code source ; là où une primitive est configurable, la variable d'environnement qui la contrôle est nommée pour que tu puisses auditer ton propre déploiement. Ce n'est pas un substitut au chiffrement du disque hôte — vois [Durcissement](/fr/self-hosted/operate/security/hardening) pour la couche sous l'application.
+
+## Données au repos
+
+Tale chiffre deux classes de secrets au repos, avec deux mécanismes différents.
+
+**Les clés API des fournisseurs** vivent dans `providers/*.secrets.json` et sont chiffrées avec [SOPS](/fr/self-hosted/configuration/secrets-with-sops) en utilisant une clé **age**. SOPS chiffre chaque valeur avec **AES-256-GCM** et enveloppe la clé de données vers le destinataire age, dont l'échange de clés est **X25519**. Une valeur chiffrée se lit `ENC[AES256_GCM,data:…,iv:…,tag:…]` sur le disque ; le déchiffrement se fait in-process et la clé privée age ne quitte jamais la mémoire du conteneur platform.
+
+**Les champs chiffrés par l'application** — tokens d'intégration OAuth et identifiants similaires stockés en base — sont chiffrés avec **AES-256-GCM** via un JWE compact (`alg: dir`, `enc: A256GCM`). La clé de 32 octets vient de `ENCRYPTION_SECRET` (base64) ou `ENCRYPTION_SECRET_HEX` (hex) ; la plateforme refuse de démarrer le chemin de chiffrement avec une clé qui ne fait pas exactement 32 octets.
+
+Le magasin de données Convex et les volumes Postgres sont protégés par l'hôte : fais-les tourner sur un système de fichiers chiffré (LUKS, ou le chiffrement de volume de ton fournisseur cloud). Tale ne stocke pas d'identifiants en clair — une clé de fournisseur ou un token OAuth est soit chiffré par SOPS sur le disque, soit chiffré en AES-256-GCM en base, jamais écrit en clair.
+
+## Données en transit
+
+Tout le trafic navigateur et API termine TLS au reverse proxy (Caddy), qui négocie TLS 1.3 (avec TLS 1.2 comme plancher) et obtient les certificats automatiquement. Les suites de chiffrement sont les défauts modernes du proxy — AES-256-GCM et ChaCha20-Poly1305 avec échange de clés ECDHE. Configure le domaine et la source de certificat dans [TLS et domaines](/fr/self-hosted/configuration/tls-and-domains) ; le trafic entre conteneurs reste sur le réseau Docker interne de l'hôte.
+
+## Hachage des mots de passe
+
+Les comptes à mot de passe local sont hachés avec **bcrypt** (via Better Auth), de sorte qu'une ligne de base de données volée ne révèle pas le mot de passe et qu'une vérification coûte délibérément ~100 ms — ce qui explique aussi pourquoi le timing du chemin de connexion est brouillé (vois [Authentification](/fr/self-hosted/configuration/authentication)). Les sessions sont signées avec `BETTER_AUTH_SECRET` (HMAC) ; faire tourner ce secret invalide toute session existante.
+
+## Intégrité du journal d'audit
+
+Le journal d'audit est inviolable grâce à une **chaîne de hachage SHA-256** : chaque entrée stocke `SHA-256(previousHash + enregistrement canonisé)`, donc modifier ou supprimer une entrée historique casse la chaîne à cet endroit et à chaque entrée suivante. Les entrées portent en plus une signature **HMAC-SHA-256**. La vérification d'intégrité admin vérifie les deux ; vois [Journaux d'audit](/fr/platform/admin/governance/audit-logs).
+
+## Correspondance avec BSI TR-02102-1
+
+Chaque primitive ci-dessous est dans l'ensemble recommandé de BSI TR-02102-1. Tale ne livre aucun algorithme déprécié (pas de MD5, SHA-1, DES ni RSA &lt; 3072 sur une clé qu'il génère).
+
+| Usage                         | Algorithme                        | Taille de clé / sortie | Contrôlé par                                  |
+| ----------------------------- | --------------------------------- | ---------------------- | --------------------------------------------- |
+| Secrets fournisseurs (disque) | AES-256-GCM + age (X25519)        | 256 bits               | `SOPS_AGE_KEY` / `SOPS_AGE_KEY_FILE`          |
+| Champs app (base de données)  | AES-256-GCM (JWE `dir`/`A256GCM`) | 256 bits               | `ENCRYPTION_SECRET` / `ENCRYPTION_SECRET_HEX` |
+| Transport                     | TLS 1.3 (AES-256-GCM, ECDHE)      | 256 bits               | Reverse proxy / `tls-and-domains`             |
+| Hachage des mots de passe     | bcrypt                            | sel par hachage        | Better Auth (intégré)                         |
+| Signature de session          | HMAC-SHA-256                      | 256 bits               | `BETTER_AUTH_SECRET`                          |
+| Intégrité d'audit             | chaîne SHA-256 + HMAC-SHA-256     | 256 bits               | intégré                                       |
+
+## Stockage et rotation des clés
+
+Trois secrets sont porteurs, et chacun a un chemin de rotation. La **clé privée age** (`SOPS_AGE_KEY`) déchiffre les secrets fournisseurs ; fais-la tourner en ajoutant un nouveau destinataire et en re-chiffrant, en suivant le parcours dans [Secrets avec SOPS](/fr/self-hosted/configuration/secrets-with-sops). La **clé de chiffrement de champ** (`ENCRYPTION_SECRET`) déchiffre les identifiants en base ; la faire tourner exige de re-chiffrer les lignes concernées, planifie-la donc comme une étape de maintenance plutôt qu'un échange à chaud. Le **secret d'auth** (`BETTER_AUTH_SECRET`) signe les sessions ; le faire tourner déconnecte tout le monde à la requête suivante. Les trois ne vivent que dans l'environnement du conteneur platform — ne les committe jamais et range-les dans ton gestionnaire de secrets de référence.
+
+## Où cela s'inscrit
+
+La cryptographie dans Tale est en couches : SOPS+age et AES-256-GCM protègent les secrets au repos, TLS 1.3 les protège en transit, bcrypt protège les mots de passe, et une chaîne SHA-256 prouve que le journal d'audit est intact — toutes des primitives qui sont dans l'ensemble recommandé de BSI TR-02102-1, avec les variables d'environnement de contrôle ci-dessus pour que tu puisses vérifier ta propre instance.
+
+La couche sous l'application est l'hôte lui-même : [Durcissement](/fr/self-hosted/operate/security/hardening) couvre l'allowlist d'egress, l'isolation des conteneurs et les attentes de chiffrement de disque que cette page présuppose, et [Secrets avec SOPS](/fr/self-hosted/configuration/secrets-with-sops) est le guide opérationnel pour la clé age dont ces algorithmes dépendent.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -61,6 +61,7 @@
               "label": "security",
               "pages": [
                 "self-hosted/operate/security/hardening",
+                "self-hosted/operate/security/cryptography",
                 "self-hosted/operate/security/advisories"
               ]
             },

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -908,6 +908,14 @@
       "description": "Postgres-Backups über das `db-backup`-Volume, was sonst zu erfassen ist und der Restore-from-Dump-Drill."
     }
   },
+  "de:self-hosted/operate/security/cryptography": {
+    "slug": "self-hosted/operate/security/cryptography",
+    "locale": "de",
+    "frontmatter": {
+      "title": "Kryptografie",
+      "description": "Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt — und wie sie auf BSI TR-02102-1 abgebildet sind."
+    }
+  },
   "de:self-hosted/operate/security/hardening": {
     "slug": "self-hosted/operate/security/hardening",
     "locale": "de",
@@ -1908,6 +1916,14 @@
       "description": "Backups Postgres via le volume `db-backup`, ce qu'il faut capturer en plus, et le drill de restauration depuis un dump."
     }
   },
+  "fr:self-hosted/operate/security/cryptography": {
+    "slug": "self-hosted/operate/security/cryptography",
+    "locale": "fr",
+    "frontmatter": {
+      "title": "Cryptographie",
+      "description": "Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit — et leur correspondance avec BSI TR-02102-1."
+    }
+  },
   "fr:self-hosted/operate/security/hardening": {
     "slug": "self-hosted/operate/security/hardening",
     "locale": "fr",
@@ -2906,6 +2922,14 @@
     "frontmatter": {
       "title": "Backups and restore",
       "description": "Postgres backups via the `db-backup` volume, what else to capture, and the restore-from-dump drill."
+    }
+  },
+  "en:self-hosted/operate/security/cryptography": {
+    "slug": "self-hosted/operate/security/cryptography",
+    "locale": "en",
+    "frontmatter": {
+      "title": "Cryptography",
+      "description": "The algorithms Tale uses for data at rest, data in transit, password hashing, and audit-log integrity — and how they map to BSI TR-02102-1."
     }
   },
   "en:self-hosted/operate/security/hardening": {


### PR DESCRIPTION
## What

Adds a **Cryptography** reference page (`self-hosted/operate/security/cryptography`, en/de/fr) documenting every primitive Tale relies on, mapped to **BSI TR-02102-1**:

- **At rest** — provider secrets via SOPS + age (**AES-256-GCM** values, **X25519** key agreement); app-encrypted DB fields (OAuth tokens) via **AES-256-GCM** JWE (`dir`/`A256GCM`, 32-byte `ENCRYPTION_SECRET`); host-level disk-encryption guidance.
- **In transit** — TLS 1.3 (AES-256-GCM / ChaCha20-Poly1305, ECDHE) at the Caddy proxy.
- **Passwords** — bcrypt (Better Auth).
- **Sessions** — HMAC-SHA-256 (`BETTER_AUTH_SECRET`).
- **Audit integrity** — SHA-256 hash chain + HMAC-SHA-256 signature.
- A BSI TR-02102-1 mapping table, key-storage/rotation guidance for the three load-bearing secrets, and an explicit statement that plaintext credential storage is not used.

Every claim is verified against source (`lib/crypto/encrypt_string.ts`, `secrets-with-sops`, `audit_logs/helpers.ts` + `internal_mutations.ts`, `auth.ts`).

## Notes

The issue referenced `docs/security/cryptography.md` + `docs/docs.json` (the old Mintlify layout). The repo now uses `docs/<locale>/…` + `nav.json`, so the page is placed under the existing **self-hosted › security** group and registered in `nav.json`; the regenerated `frontmatter.json` is included.

## Verification

`bun run --filter @tale/docs test` → 139 passed; `lint` → 0 warnings/errors.

Closes #1500
