### PR TITLE
docs: Prometheus and Grafana worked example (#181)

### DIFF
--- a/docs/de/self-hosted/operate/observability/prometheus-grafana.md
+++ b/docs/de/self-hosted/operate/observability/prometheus-grafana.md
@@ -1,0 +1,118 @@
+---
+title: Prometheus und Grafana
+description: Ein Copy-paste-Stack aus Prometheus und Grafana, der Tales vier Metrics-Endpoints scrapt — plus ein Starter-Dashboard und eine erste Alert-Regel.
+---
+
+Das ist das durchgespielte Beispiel hinter [Observability-Konfiguration](/de/self-hosted/configuration/observability-config): ein Paar aus Prometheus und Grafana, das du neben Tale stellst, auf die vier Bearer-Token-Metrics-Endpoints gerichtet, mit einem Starter-Dashboard und einer Alert-Regel zum Ausbauen. Es ist für selbst hostende Betreiber, die `METRICS_BEARER_TOKEN` bereits gesetzt haben und jetzt Live-Graphen statt eines `curl` gegen `/metrics` wollen.
+
+Die Konfigurations-Referenzseite listet die Endpoints und die einzelne Scrape-Stanza; diese Seite stellt den ganzen Stack von Anfang bis Ende auf. Alles hier läuft auf demselben Host wie Tale, also verlässt keine Metrik die Maschine.
+
+## Bevor du startest
+
+Setz `METRICS_BEARER_TOKEN` in deiner `.env` und starte den Proxy neu — ohne ihn geben die vier Endpoints auf jede Anfrage 401 zurück, und Prometheus zeigt jedes Target als down. Die Endpoints, und was jeder trägt, sind die Tabelle in [Observability-Konfiguration](/de/self-hosted/configuration/observability-config#metrics): `/metrics/platform`, `/metrics/convex`, `/metrics/rag`, `/metrics/crawler`, alle von `tale-proxy` über denselben Hostnamen wie die App ausgeliefert.
+
+## Prometheus und Grafana zu deinem Stack hinzufügen
+
+Leg diese zwei Services in ein Compose-Override neben Tale. Prometheus scrapt in einem Intervall und speichert eine lokale TSDB; Grafana liest Prometheus und rendert die Dashboards. Beide binden nur an localhost — erreich Grafana über einen SSH-Tunnel oder stell es mit Auth hinter denselben Proxy, exponier es nie roh.
+
+```yaml
+# docker-compose.metrics.yml — start with: docker compose -f docker-compose.yml -f docker-compose.metrics.yml up -d
+services:
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set a strong password}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - '127.0.0.1:3001:3000'
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:
+```
+
+## Scrape-Konfiguration
+
+Tales vier Endpoints teilen sich ein Bearer-Token, also ist die Scrape-Konfiguration die veröffentlichte Stanza, einmal pro Pfad wiederholt. Speicher das als `prometheus.yml` neben dem Override oben und setz deinen Host und dein Token ein — Prometheus liest das Token aus der Datei, also halt sie `chmod 600` und aus der Versionskontrolle raus.
+
+```yaml
+global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: tale-platform
+    scheme: https
+    metrics_path: /metrics/platform
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-convex
+    scheme: https
+    metrics_path: /metrics/convex
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-rag
+    scheme: https
+    metrics_path: /metrics/rag
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-crawler
+    scheme: https
+    metrics_path: /metrics/crawler
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+```
+
+Öffne `http://127.0.0.1:9090/targets` nach dem Start — alle vier Jobs sollten **UP** anzeigen. Ein Target, das mit 401 auf **DOWN** hängt, heisst, das Token in `prometheus.yml` stimmt nicht mit `METRICS_BEARER_TOKEN` überein; ein Verbindungsfehler heisst, Hostname oder Schema sind falsch.
+
+## Ein Starter-Dashboard
+
+Richte Grafana zuerst auf Prometheus — füg eine Prometheus-Datenquelle unter `http://prometheus:9090` hinzu (Grafana erreicht sie über den Compose-Servicenamen). Bau dann ein Dashboard aus diesen Panels; die ersten drei nutzen Metriken, die immer vorhanden sind, und der Rest bildet die Signale in [Operations](/de/self-hosted/operate/observability/operations) ab.
+
+| Panel           | Query                                                | Liest sich als                                               |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| Targets up      | `up{job=~"tale-.*"}`                                 | `1` pro gesundem Endpoint, `0` wenn das Scraping fehlschlägt |
+| Platform-Memory | `process_resident_memory_bytes{job="tale-platform"}` | Resident-Memory des platform-Containers                      |
+| Event-Loop-Lag  | `nodejs_eventloop_lag_seconds{job="tale-platform"}`  | Springt, wenn die Plattform gesättigt ist                    |
+| Convex up       | `up{job="tale-convex"}`                              | Backend-Erreichbarkeit — `0` ist ein Page                    |
+
+Der platform-Endpoint trägt Nodes Default-Prozessmetriken (CPU, Memory, Event-Loop-Lag, GC), darum zielen die konkreten Queries oben auf ihn. Die Endpoints Convex, RAG und Crawler exponieren ihre eigenen reicheren Reihen — öffne jeden Endpoint einmal (`curl -H "Authorization: Bearer $TOKEN" https://tale.example.com/metrics/convex`), um die exakten Metriknamen deiner Version zu lesen, und füg dann Panels für die RAG-Indexierungs-Queue-Tiefe und die Provider-Fehlerrate aus Operations hinzu.
+
+## Eine erste Alert-Regel
+
+Fang mit dem einen Signal an, das eindeutig ist — ein Metrics-Target, das aufhört zu antworten. Füg diese Regel-Datei zu Prometheus hinzu (mounte sie und referenzier sie unter `rule_files:` in `prometheus.yml`), dann verdrahte Alertmanager oder Grafana-Alerting mit deinem Pager.
+
+```yaml
+groups:
+  - name: tale
+    rules:
+      - alert: TaleTargetDown
+        expr: up{job=~"tale-.*"} == 0
+        for: 2m
+        labels: { severity: page }
+        annotations:
+          summary: 'Tale metrics target {{ $labels.job }} is down'
+```
+
+Die volle Liste, was ein Page wert ist gegenüber was warten kann — platform-5xx-Rate, Postgres-Pool-Sättigung, RAG-Queue-Tiefe, tägliches-Backup-nicht-geschrieben — ist die Signaltabelle in [Operations](/de/self-hosted/operate/observability/operations); übersetz jede Zeile in eine Regel, sobald die passende Reihe auf deinem Dashboard ist.
+
+## Wo das hingehört
+
+Diese Seite verwandelt die vier dokumentierten Metrics-Endpoints in einen laufenden Prometheus-und-Grafana-Stack: ein Compose-Override, eine Vier-Job-Scrape-Konfiguration, ein Starter-Dashboard und einen Target-down-Alert, den du mit den Operations-Schwellen ausbaust. Halt beide Services an localhost gebunden und das Bearer-Token nicht im Klartext auf der Festplatte, und die ganze Monitoring-Oberfläche bleibt mit Tale auf dem Host.
+
+Die Endpoints und das Token, das sie absichert, gehören [Observability-Konfiguration](/de/self-hosted/configuration/observability-config); die Schwellen und die Oncall-Checkliste sind [Operations](/de/self-hosted/operate/observability/operations). Wenn ein Panel rot wird, ist die Symptom-zu-Fix-Suche [Troubleshooting](/de/self-hosted/operate/observability/troubleshooting).

--- a/docs/en/self-hosted/operate/observability/prometheus-grafana.md
+++ b/docs/en/self-hosted/operate/observability/prometheus-grafana.md
@@ -1,0 +1,118 @@
+---
+title: Prometheus and Grafana
+description: A copy-paste Prometheus and Grafana stack that scrapes Tale's four metrics endpoints, plus a starter dashboard and a first alert rule.
+---
+
+This is the worked example behind [Observability config](/self-hosted/configuration/observability-config): a Prometheus and Grafana pair you can drop next to Tale, pointed at the four bearer-token metrics endpoints, with a starter dashboard and one alert rule to build on. It's for self-hosted operators who have already set `METRICS_BEARER_TOKEN` and now want live graphs instead of a `curl` against `/metrics`.
+
+The config-reference page lists the endpoints and the single scrape stanza; this page stands the whole stack up end to end. Everything here runs on the same host as Tale, so no metric leaves the box.
+
+## Before you start
+
+Set `METRICS_BEARER_TOKEN` in your `.env` and restart the proxy — without it the four endpoints return 401 to every request, and Prometheus will show each target as down. The endpoints, and what each one carries, are the table in [Observability config](/self-hosted/configuration/observability-config#metrics): `/metrics/platform`, `/metrics/convex`, `/metrics/rag`, `/metrics/crawler`, all served by `tale-proxy` over the same hostname as the app.
+
+## Add Prometheus and Grafana to your stack
+
+Drop these two services into a compose override next to Tale. Prometheus scrapes on an interval and stores a local TSDB; Grafana reads Prometheus and renders the dashboards. Both bind to localhost only — reach Grafana through an SSH tunnel or put it behind the same proxy with auth, never expose it raw.
+
+```yaml
+# docker-compose.metrics.yml — start with: docker compose -f docker-compose.yml -f docker-compose.metrics.yml up -d
+services:
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set a strong password}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - '127.0.0.1:3001:3000'
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:
+```
+
+## Scrape configuration
+
+Tale's four endpoints share one bearer token, so the scrape config is the published stanza repeated once per path. Save this as `prometheus.yml` next to the override above and substitute your host and token — Prometheus reads the token from the file, so keep it `chmod 600` and out of version control.
+
+```yaml
+global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: tale-platform
+    scheme: https
+    metrics_path: /metrics/platform
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-convex
+    scheme: https
+    metrics_path: /metrics/convex
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-rag
+    scheme: https
+    metrics_path: /metrics/rag
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-crawler
+    scheme: https
+    metrics_path: /metrics/crawler
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+```
+
+Open `http://127.0.0.1:9090/targets` after start — all four jobs should read **UP**. A target stuck **DOWN** with a 401 means the token in `prometheus.yml` does not match `METRICS_BEARER_TOKEN`; a connection error means the hostname or scheme is wrong.
+
+## A starter dashboard
+
+Point Grafana at Prometheus first — add a Prometheus data source at `http://prometheus:9090` (Grafana reaches it by the compose service name). Then build a dashboard from these panels; the first three use metrics that are always present, and the rest map to the signals in [Operations](/self-hosted/operate/observability/operations).
+
+| Panel           | Query                                                | Reads as                                          |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------- |
+| Targets up      | `up{job=~"tale-.*"}`                                 | `1` per healthy endpoint, `0` when scraping fails |
+| Platform memory | `process_resident_memory_bytes{job="tale-platform"}` | Resident memory of the platform container         |
+| Event-loop lag  | `nodejs_eventloop_lag_seconds{job="tale-platform"}`  | Spikes when the platform is saturated             |
+| Convex up       | `up{job="tale-convex"}`                              | Backend reachability — `0` is a page              |
+
+The platform endpoint carries Node's default process metrics (CPU, memory, event-loop lag, GC), which is why the concrete queries above target it. The Convex, RAG, and crawler endpoints expose their own richer series — open each endpoint once (`curl -H "Authorization: Bearer $TOKEN" https://tale.example.com/metrics/convex`) to read the exact metric names your version exposes, then add panels for the RAG indexing queue depth and provider error rate called out in Operations.
+
+## A first alert rule
+
+Start with the one signal that is unambiguous — a metrics target that stops responding. Add this rule file to Prometheus (mount it and reference it under `rule_files:` in `prometheus.yml`), then wire Alertmanager or Grafana alerting to your pager.
+
+```yaml
+groups:
+  - name: tale
+    rules:
+      - alert: TaleTargetDown
+        expr: up{job=~"tale-.*"} == 0
+        for: 2m
+        labels: { severity: page }
+        annotations:
+          summary: 'Tale metrics target {{ $labels.job }} is down'
+```
+
+The full list of what's worth paging on versus what can wait — platform 5xx rate, Postgres pool saturation, RAG queue depth, daily-backup-did-not-write — is the signal table in [Operations](/self-hosted/operate/observability/operations); translate each row into a rule once the matching series is on your dashboard.
+
+## Where this fits
+
+This page turns the four documented metrics endpoints into a running Prometheus and Grafana stack: a compose override, a four-job scrape config, a starter dashboard, and a target-down alert you extend with the Operations thresholds. Keep both services bound to localhost and the bearer token off disk-in-the-clear, and the whole monitoring surface stays on the host with Tale.
+
+The endpoints and the token that gate them are owned by [Observability config](/self-hosted/configuration/observability-config); the thresholds and the oncall checklist are [Operations](/self-hosted/operate/observability/operations). When a panel goes red, the symptom-to-fix lookup is [Troubleshooting](/self-hosted/operate/observability/troubleshooting).

--- a/docs/fr/self-hosted/operate/observability/prometheus-grafana.md
+++ b/docs/fr/self-hosted/operate/observability/prometheus-grafana.md
@@ -1,0 +1,118 @@
+---
+title: Prometheus et Grafana
+description: Un stack Prometheus et Grafana en copier-coller qui scrape les quatre endpoints de métriques de Tale, plus un tableau de bord de départ et une première règle d'alerte.
+---
+
+C'est l'exemple mis en pratique derrière [Configuration de l'observabilité](/fr/self-hosted/configuration/observability-config) : une paire Prometheus et Grafana que tu poses à côté de Tale, pointée sur les quatre endpoints de métriques à bearer token, avec un tableau de bord de départ et une règle d'alerte à étoffer. C'est pour les opérateurs auto-hébergés qui ont déjà défini `METRICS_BEARER_TOKEN` et veulent maintenant des graphes en direct plutôt qu'un `curl` contre `/metrics`.
+
+La page de référence de configuration liste les endpoints et la stanza de scrape unique ; cette page monte tout le stack de bout en bout. Tout ici tourne sur le même hôte que Tale, donc aucune métrique ne quitte la machine.
+
+## Avant de commencer
+
+Définis `METRICS_BEARER_TOKEN` dans ton `.env` et redémarre le proxy — sans lui, les quatre endpoints renvoient 401 à chaque requête, et Prometheus affichera chaque cible comme down. Les endpoints, et ce que chacun porte, sont le tableau dans [Configuration de l'observabilité](/fr/self-hosted/configuration/observability-config#metrics) : `/metrics/platform`, `/metrics/convex`, `/metrics/rag`, `/metrics/crawler`, tous servis par `tale-proxy` sur le même nom d'hôte que l'app.
+
+## Ajouter Prometheus et Grafana à ta stack
+
+Pose ces deux services dans un override compose à côté de Tale. Prometheus scrape à un intervalle et stocke une TSDB locale ; Grafana lit Prometheus et rend les tableaux de bord. Les deux se lient à localhost uniquement — atteins Grafana via un tunnel SSH ou mets-le derrière le même proxy avec auth, ne l'expose jamais brut.
+
+```yaml
+# docker-compose.metrics.yml — start with: docker compose -f docker-compose.yml -f docker-compose.metrics.yml up -d
+services:
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set a strong password}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - '127.0.0.1:3001:3000'
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:
+```
+
+## Configuration du scraping
+
+Les quatre endpoints de Tale partagent un bearer token, donc la config de scrape est la stanza publiée, répétée une fois par chemin. Enregistre ceci comme `prometheus.yml` à côté de l'override ci-dessus et substitue ton hôte et ton token — Prometheus lit le token depuis le fichier, garde-le donc en `chmod 600` et hors du contrôle de version.
+
+```yaml
+global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: tale-platform
+    scheme: https
+    metrics_path: /metrics/platform
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-convex
+    scheme: https
+    metrics_path: /metrics/convex
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-rag
+    scheme: https
+    metrics_path: /metrics/rag
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+  - job_name: tale-crawler
+    scheme: https
+    metrics_path: /metrics/crawler
+    authorization: { credentials: '${METRICS_BEARER_TOKEN}' }
+    static_configs:
+      - targets: ['tale.example.com']
+```
+
+Ouvre `http://127.0.0.1:9090/targets` après le démarrage — les quatre jobs devraient afficher **UP**. Une cible bloquée en **DOWN** avec un 401 signifie que le token dans `prometheus.yml` ne correspond pas à `METRICS_BEARER_TOKEN` ; une erreur de connexion signifie que le nom d'hôte ou le schéma est faux.
+
+## Un tableau de bord de départ
+
+Pointe d'abord Grafana sur Prometheus — ajoute une source de données Prometheus à `http://prometheus:9090` (Grafana l'atteint par le nom de service compose). Construis ensuite un tableau de bord à partir de ces panneaux ; les trois premiers utilisent des métriques toujours présentes, et le reste correspond aux signaux dans [Operations](/fr/self-hosted/operate/observability/operations).
+
+| Panneau             | Requête                                              | Se lit comme                                        |
+| ------------------- | ---------------------------------------------------- | --------------------------------------------------- |
+| Cibles up           | `up{job=~"tale-.*"}`                                 | `1` par endpoint sain, `0` quand le scraping échoue |
+| Mémoire plateforme  | `process_resident_memory_bytes{job="tale-platform"}` | Mémoire résidente du conteneur platform             |
+| Lag de l'event-loop | `nodejs_eventloop_lag_seconds{job="tale-platform"}`  | Bondit quand la plateforme est saturée              |
+| Convex up           | `up{job="tale-convex"}`                              | Joignabilité du backend — `0` est un page           |
+
+L'endpoint platform porte les métriques de processus par défaut de Node (CPU, mémoire, lag de l'event-loop, GC), c'est pourquoi les requêtes concrètes ci-dessus le ciblent. Les endpoints Convex, RAG et crawler exposent leurs propres séries plus riches — ouvre chaque endpoint une fois (`curl -H "Authorization: Bearer $TOKEN" https://tale.example.com/metrics/convex`) pour lire les noms de métriques exacts qu'expose ta version, puis ajoute des panneaux pour la profondeur de la file d'indexation RAG et le taux d'erreur fournisseur évoqués dans Operations.
+
+## Une première règle d'alerte
+
+Commence par le seul signal sans ambiguïté — une cible de métriques qui cesse de répondre. Ajoute ce fichier de règle à Prometheus (monte-le et référence-le sous `rule_files:` dans `prometheus.yml`), puis câble Alertmanager ou l'alerting Grafana sur ton pager.
+
+```yaml
+groups:
+  - name: tale
+    rules:
+      - alert: TaleTargetDown
+        expr: up{job=~"tale-.*"} == 0
+        for: 2m
+        labels: { severity: page }
+        annotations:
+          summary: 'Tale metrics target {{ $labels.job }} is down'
+```
+
+La liste complète de ce qui vaut un page contre ce qui peut attendre — taux de 5xx de la plateforme, saturation du pool Postgres, profondeur de la file RAG, sauvegarde-quotidienne-non-écrite — est le tableau de signaux dans [Operations](/fr/self-hosted/operate/observability/operations) ; traduis chaque ligne en règle dès que la série correspondante est sur ton tableau de bord.
+
+## Où cela s'inscrit
+
+Cette page transforme les quatre endpoints de métriques documentés en un stack Prometheus et Grafana qui tourne : un override compose, une config de scrape à quatre jobs, un tableau de bord de départ et une alerte cible-down que tu étoffes avec les seuils d'Operations. Garde les deux services liés à localhost et le bearer token hors du disque en clair, et toute la surface de monitoring reste sur l'hôte avec Tale.
+
+Les endpoints et le token qui les protège appartiennent à [Configuration de l'observabilité](/fr/self-hosted/configuration/observability-config) ; les seuils et la checklist d'astreinte sont [Operations](/fr/self-hosted/operate/observability/operations). Quand un panneau passe au rouge, la recherche symptôme-vers-correction est [Troubleshooting](/fr/self-hosted/operate/observability/troubleshooting).

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -54,6 +54,7 @@
               "label": "observability",
               "pages": [
                 "self-hosted/operate/observability/operations",
+                "self-hosted/operate/observability/prometheus-grafana",
                 "self-hosted/operate/observability/troubleshooting"
               ]
             },

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -956,6 +956,14 @@
       "description": "Symptomorientierter Index für die Probleme, die Operator auf Tale-Instanzen tatsächlich getroffen haben — was der Benutzer meldet, was kaputt ist und was zu tun ist."
     }
   },
+  "de:self-hosted/operate/observability/prometheus-grafana": {
+    "slug": "self-hosted/operate/observability/prometheus-grafana",
+    "locale": "de",
+    "frontmatter": {
+      "title": "Prometheus und Grafana",
+      "description": "Ein Copy-paste-Stack aus Prometheus und Grafana, der Tales vier Metrics-Endpoints scrapt — plus ein Starter-Dashboard und eine erste Alert-Regel."
+    }
+  },
   "de:self-hosted/operate/release-notes/format": {
     "slug": "self-hosted/operate/release-notes/format",
     "locale": "de",
@@ -1956,6 +1964,14 @@
       "description": "Index par symptôme pour les problèmes que les opérateurs ont réellement rencontrés sur des instances Tale — ce que l'utilisateur rapporte, ce qui est cassé et quoi faire à ce sujet."
     }
   },
+  "fr:self-hosted/operate/observability/prometheus-grafana": {
+    "slug": "self-hosted/operate/observability/prometheus-grafana",
+    "locale": "fr",
+    "frontmatter": {
+      "title": "Prometheus et Grafana",
+      "description": "Un stack Prometheus et Grafana en copier-coller qui scrape les quatre endpoints de métriques de Tale, plus un tableau de bord de départ et une première règle d'alerte."
+    }
+  },
   "fr:self-hosted/operate/release-notes/format": {
     "slug": "self-hosted/operate/release-notes/format",
     "locale": "fr",
@@ -2954,6 +2970,14 @@
     "frontmatter": {
       "title": "Troubleshooting",
       "description": "Symptom-first index for the issues operators have actually hit on Tale instances — what the user reports, what is broken, and what to do about it."
+    }
+  },
+  "en:self-hosted/operate/observability/prometheus-grafana": {
+    "slug": "self-hosted/operate/observability/prometheus-grafana",
+    "locale": "en",
+    "frontmatter": {
+      "title": "Prometheus and Grafana",
+      "description": "A copy-paste Prometheus and Grafana stack that scrapes Tale's four metrics endpoints, plus a starter dashboard and a first alert rule."
     }
   },
   "en:self-hosted/operate/release-notes/format": {


### PR DESCRIPTION
## What

Adds a **Prometheus and Grafana** worked-example page (`self-hosted/operate/observability/prometheus-grafana`, en/de/fr). [Observability config](https://tale.dev/docs/self-hosted/configuration/observability-config) already documents the four metrics endpoints and a scrape stanza, and [Operations](https://tale.dev/docs/self-hosted/operate/observability/operations) lists what to alert on — this page is the missing end-to-end example that stands the stack up:

- a `docker-compose` override adding Prometheus + Grafana (localhost-bound),
- a four-job `prometheus.yml` sharing `METRICS_BEARER_TOKEN`,
- a starter dashboard using always-present queries (`up{job=~"tale-.*"}`, default Node process metrics) plus pointers to the Operations signals,
- a `TaleTargetDown` alert rule, linking back to the Operations threshold table.

Registered in `nav.json`; regenerated `frontmatter.json`. Also expanded the issue's "TBD" description.

## Verification

`bun run --filter @tale/docs test` → 139 passed; `lint` → clean. Endpoints, token, and scrape format mirror the existing `observability-config` reference.

Closes #181
