### PR TITLE
docs: modular AI-directed test guides for each feature module (#110)

### DIFF
--- a/tests/ACCESSIBILITY_TESTING.md
+++ b/tests/ACCESSIBILITY_TESTING.md
@@ -1,0 +1,76 @@
+# Accessibility Testing Guide (AI-Directed)
+
+> **Purpose**: A cross-cutting WCAG 2.1 Level AA sweep of the whole app — keyboard, focus, structure, labels, contrast, screen-reader, alt text, and live regions — and collect defects in Issues Found. The per-module guides each carry an "Accessibility tests" block; this guide is the shared checklist and the place to run an automated axe pass on every major page.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. Have the browser tooling's accessibility snapshot and console available; the component suite also ships `vitest-axe`, so unit-level a11y is covered — this guide is the live-page pass.
+
+> **AI Instructions**: For each page in the matrix, run the checks below, capture the accessibility snapshot, and log any violation in Issues Found with the page, the check ID, and the element. Treat axe "serious"/"critical" as failures; "moderate" as warnings to record.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/a11y
+```
+
+## Page matrix
+
+Run the full checklist against each of these, then spot-check dialogs (add-member, create-team, document team, schedule):
+
+```
+/                                  (login)
+/dashboard/{id}/chat
+/dashboard/{id}/conversations/open
+/dashboard/{id}/approvals
+/dashboard/{id}/automations
+/dashboard/{id}/documents
+/dashboard/{id}/products
+/dashboard/{id}/settings
+/dashboard/{id}/settings/people
+/dashboard/{id}/settings/governance
+```
+
+## Checklist (WCAG 2.1 AA)
+
+| ID  | Check                  | How to verify                                            | Expected                                                                  |
+| --- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A1  | Keyboard navigation    | Tab through the page without a mouse                     | Every interactive control is reachable and operable; no keyboard trap     |
+| A2  | Focus visibility       | Tab and watch the focus ring                             | A visible focus indicator on every focused control                        |
+| A3  | Focus order            | Tab order vs visual order                                | Order is logical (left→right, top→bottom); dialogs trap + restore focus   |
+| A4  | Heading hierarchy      | Inspect the heading outline                              | One H1 per page; no skipped levels (H1→H3 without H2)                     |
+| A5  | Form labels            | Inspect inputs                                           | Every field has a programmatic label; placeholders are not the only label |
+| A6  | Error identification   | Submit an invalid form                                   | Errors are text (not colour-only) and associated with their field         |
+| A7  | Colour contrast        | Sample body text, buttons, badges, muted text            | ≥ 4.5:1 for normal text, ≥ 3:1 for large text and UI boundaries           |
+| A8  | Non-text contrast      | Icons-as-controls, input borders, focus ring             | ≥ 3:1 against adjacent colours                                            |
+| A9  | Images / icons         | Inspect meaningful images and icon-only buttons          | Meaningful images have alt text; icon buttons have an accessible name     |
+| A10 | Live regions           | Trigger a toast, a streaming chat reply, a status change | Announced via `aria-live` / appropriate role                              |
+| A11 | Landmarks              | Inspect the page regions                                 | `nav`, `main`, and notification regions are present and named             |
+| A12 | Motion / reduce-motion | Enable OS "reduce motion"                                | Animations (spinners, typewriter, pulse) respect `prefers-reduced-motion` |
+| A13 | Zoom / reflow          | Zoom to 200%                                             | Content reflows without horizontal scroll or clipped controls             |
+| A14 | Target size            | Inspect small controls (row 3-dot menus, mic, close)     | Hit targets are comfortably tappable (coarse-pointer friendly)            |
+
+## Automated pass
+
+For each page in the matrix:
+
+1. Navigate, wait for load (spinners gone).
+2. Capture the accessibility snapshot.
+3. Run an axe-style audit if available; record serious/critical violations.
+4. Screenshot, then move on.
+
+## Issues Found
+
+| #   | Check ID | Page / URL | Element | Severity (crit/serious/moderate) | Description | Screenshot |
+| --- | -------- | ---------- | ------- | -------------------------------- | ----------- | ---------- |
+|     |          |            |         |                                  |             |            |
+
+## Test summary
+
+```
+Module: Accessibility (WCAG 2.1 AA)
+Pages audited: ___/10   Dialogs spot-checked: ___
+Checks run per page: 14
+Violations: crit ___ / serious ___ / moderate ___
+Status: PASS / FAIL
+```

--- a/tests/APPROVALS_TESTING.md
+++ b/tests/APPROVALS_TESTING.md
@@ -1,0 +1,71 @@
+# Approvals Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the approval workflow — how AI-proposed write actions surface for human review, the pending/approved/rejected lifecycle, and the confidence display — and collect defects in Issues Found. Approvals are the gate that keeps an agent's write operations from applying without a human in the loop.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. To generate an approval, ask the chat agent to perform a write (e.g. "update customer X's locale") so a pending approval is raised; then open `/dashboard/{id}/approvals`.
+
+> **AI Instructions**: Run in order; one finding per defect with a screenshot. If you cannot raise a real approval (no provider configured), still test the list, empty state, and tab filters, and note "no data" on the action tests.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/approvals
+```
+
+## Functional tests
+
+| ID  | Test                 | Steps                                                    | Expected                                                              |
+| --- | -------------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| F1  | Approvals list loads | Open approvals                                           | Pending list (or empty state); status tabs render                     |
+| F2  | Pending item detail  | Open a pending approval                                  | Shows the proposed action, target resource, and confidence percentage |
+| F3  | Approve              | Approve a pending item                                   | State → Approved; the underlying write now applies; audited           |
+| F4  | Reject               | Reject a pending item                                    | State → Rejected; the write does NOT apply; audited                   |
+| F5  | Types render         | View a "Review Reply" and a "Recommend Product" approval | Each type shows its relevant payload                                  |
+| F6  | Verify-approval tool | In chat, agent calls `verify_approval` after raising one | Agent waits for the human decision before continuing                  |
+
+## Boundary & state tests
+
+| ID  | Test                    | Steps                                           | Expected                                              |
+| --- | ----------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| B1  | Double-decision guard   | Approve, then try to act on the same item again | Second action is a no-op / disabled (already decided) |
+| B2  | Confidence bounds       | Inspect confidence values                       | Always 0–100%; no NaN/blank                           |
+| B3  | Rejected stays rejected | Reject, refresh                                 | Item remains Rejected; write never applied            |
+| B4  | Permission              | As a role without approve rights, open an item  | Approve/Reject hidden or disabled                     |
+
+## API / integration tests
+
+| ID  | Test             | Steps                          | Expected                                  |
+| --- | ---------------- | ------------------------------ | ----------------------------------------- |
+| A1  | Approval audited | Approve, then check Audit logs | An audit row records the decision + actor |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check                      | Expected                                             |
+| --- | -------------------------- | ---------------------------------------------------- |
+| X1  | Keyboard decide            | Approve/Reject reachable + operable by keyboard      |
+| X2  | Confidence not colour-only | Confidence conveyed by text/number, not colour alone |
+| X3  | Status announced           | Decision result is announced to assistive tech       |
+
+## Performance tests
+
+| ID  | Metric              | Target                       |
+| --- | ------------------- | ---------------------------- |
+| P1  | List load           | < 1.5 s                      |
+| P2  | Decision round-trip | < 1.5 s to reflect new state |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | ---------- |
+|     |         |            |          |             |            |
+
+## Test summary
+
+```
+Module: Approvals
+Functional: ___/6   Boundary: ___/4   API: ___/1   A11y: ___/3   Perf: ___/2
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/tests/AUTH_TESTING.md
+++ b/tests/AUTH_TESTING.md
@@ -1,0 +1,93 @@
+# Authentication Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the authentication module — sign-in, the admin-driven account model, password policy, forced password change, 2FA, and lockout — and collect every defect in the Issues Found table. Tale is offline-first: there is **no self-service sign-up** after the first owner, so most account creation happens in Settings → Members.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) (steps 1–5) and confirm `http://localhost:3000` is reachable. Then sign in as the seeded admin:
+
+- Email: `admin@admin.test`
+- Password: `Admin@123`
+
+> **AI Instructions**: Run each test in order. For every row, record the actual result; if it differs from **Expected**, add a row to **Issues Found** with a screenshot. Ignore console warnings; treat 4xx/5xx and uncaught errors as failures.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/auth
+```
+
+Naming: `auth_{test_id}.png` (e.g. `auth_F1.png`).
+
+## Functional tests
+
+| ID  | Test                         | Steps                                                    | Expected                                                                             |
+| --- | ---------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| F1  | Login page renders           | Open `/`                                                 | Email + password fields, sign-in button, "Forgot password?" link; no console error   |
+| F2  | Valid login                  | Enter seeded admin credentials, submit                   | Redirects to `/dashboard/{id}/chat`; session cookie set                              |
+| F3  | Wrong password               | Enter valid email, wrong password                        | Inline error; stays on `/`; no redirect                                              |
+| F4  | Unknown email                | Enter `nobody@nowhere.test` + any password               | Generic failure (no account enumeration — same message as wrong password)            |
+| F5  | Forgot-password link         | Click "Forgot password?"                                 | Toast "Contact your administrator — password reset is managed by your organization"  |
+| F6  | No self-service sign-up      | With ≥1 user existing, open `/sign-up`                   | Redirects to `/` (sign-up only for initial owner)                                    |
+| F7  | Admin creates a member       | Settings → Members → Add member; email + password + role | Member created; credentials panel shown; admin stays signed in                       |
+| F8  | New member forced change     | Sign in as the member from F7                            | Redirected to forced-change-password screen; cannot proceed until a new password set |
+| F9  | Sign out                     | User menu → Sign out → confirm                           | Hard redirect to `/`; protected routes now bounce to login                           |
+| F10 | Change own password re-auths | Settings → Account → Change password; submit valid       | Signed out + redirected to login; new password works, old does not (#1255)           |
+
+## Boundary & error tests
+
+| ID  | Test                            | Input                                          | Expected                                                                                                                   |
+| --- | ------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Empty password on add-member    | Add member, valid email, blank password        | Field-level error on the password field, not a generic toast (#1470)                                                       |
+| B2  | Password policy — too short     | Set a password below the org minimum length    | Rejected with the policy hint; live validation list updates as you type                                                    |
+| B3  | Password policy — missing class | Omit a required upper/lower/digit/special char | Rejected, naming the missing requirement                                                                                   |
+| B4  | Duplicate member email          | Add member with an existing email              | "already a member" / existing-user path, no duplicate created                                                              |
+| B5  | Login lockout                   | Enter wrong password repeatedly (5–10×)        | Account locks; further attempts rejected even with the right password; timing stays roughly constant (no fast/slow oracle) |
+| B6  | Session persists across reload  | Log in, hard-refresh                           | Still authenticated; no re-login                                                                                           |
+
+## 2FA tests
+
+| ID  | Test            | Steps                                                    | Expected                                          |
+| --- | --------------- | -------------------------------------------------------- | ------------------------------------------------- |
+| T1  | Enroll TOTP     | Settings → Account → enable two-factor; scan, enter code | 2FA enabled; backup codes shown once              |
+| T2  | Login with 2FA  | Sign out, sign in                                        | Prompted for a TOTP code after password           |
+| T3  | Wrong TOTP code | Enter an invalid 6-digit code                            | Rejected; repeated failures contribute to lockout |
+
+## API / integration tests
+
+| ID  | Test                    | Steps                                                  | Expected                                               |
+| --- | ----------------------- | ------------------------------------------------------ | ------------------------------------------------------ |
+| A1  | API key requires bearer | `curl /api/v1/agents` with no `Authorization` header   | `401`                                                  |
+| A2  | API key valid           | `curl /api/v1/agents -H "Authorization: Bearer <key>"` | `200` with `{ "agents": [...] }`                       |
+| A3  | Cross-org key rejected  | Use a key from org A against org B's resource          | `403`/`404` — keys can't act outside their issuing org |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check               | Expected                                                           |
+| --- | ------------------- | ------------------------------------------------------------------ |
+| X1  | Keyboard-only login | Tab to email → password → submit; Enter submits; no mouse needed   |
+| X2  | Labels & focus      | Inputs have associated labels; focus ring visible on each control  |
+| X3  | Error announced     | A failed login error is exposed to assistive tech (role/aria-live) |
+| X4  | Contrast            | Body and button text ≥ 4.5:1 against their background              |
+
+## Performance tests
+
+| ID  | Metric                 | Target                                |
+| --- | ---------------------- | ------------------------------------- |
+| P1  | Login page first paint | Interactive < 2 s on a warm container |
+| P2  | Login round-trip       | Submit → dashboard < 2 s              |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity (crit/high/med/low) | Description | Screenshot |
+| --- | ------- | ---------- | ---------------------------- | ----------- | ---------- |
+|     |         |            |                              |             |            |
+
+## Test summary
+
+```
+Module: Authentication
+Functional: ___/10   Boundary: ___/6   2FA: ___/3   API: ___/3   A11y: ___/4   Perf: ___/2
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/tests/AUTOMATIONS_TESTING.md
+++ b/tests/AUTOMATIONS_TESTING.md
@@ -1,0 +1,88 @@
+# Automations Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the workflow automation module — creation, triggers, the step types, the action catalogue, conditions, schedules, dry-run, and execution logs — and collect defects in Issues Found. Workflows are built from a start step plus LLM / condition / action / loop steps and are fired by manual, scheduled (cron), webhook, or event triggers.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. Open `/dashboard/{id}/automations`.
+
+> **AI Instructions**: Run in order; one finding per defect with a screenshot. Some actions require a configured integration/provider — note "needs integration" where a step can't run, rather than logging it as a builder bug.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/automations
+```
+
+## Functional tests
+
+| ID  | Test                   | Steps                                                 | Expected                                                                                             |
+| --- | ---------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| F1  | Automations list       | Open automations                                      | Cards/list or empty state; "Create automation" button                                                |
+| F2  | Create (blank)         | Create automation → blank → name → continue           | New workflow opens in the builder with a start step                                                  |
+| F3  | Create from template   | Create → template tab → pick one                      | Template installs; opens in builder                                                                  |
+| F4  | Add steps              | Add an LLM step, a condition, an action               | Steps appear on the canvas, connectable                                                              |
+| F5  | Condition branches     | Add a condition with true/false + a custom branch key | Each branch edge is **labelled** (true/false and the custom key), not an unlabeled gray line (#1486) |
+| F6  | Save & publish         | Save the workflow; publish                            | Saved state persists; draft/published state is clear                                                 |
+| F7  | Manual run             | Trigger a manual run with valid input JSON            | Execution starts; result lands in Executions                                                         |
+| F8  | Create schedule (cron) | Triggers → add schedule → enter a cron expression     | Created; **Create** stays disabled until a valid cron is entered (#1426)                             |
+| F9  | Webhook trigger        | Configure a webhook trigger                           | Trigger URL/key shown; posting fires the workflow                                                    |
+| F10 | Execution logs         | Open Executions for a run                             | Per-run status + step output visible                                                                 |
+
+## Boundary & validation tests
+
+| ID  | Test                     | Steps                                     | Expected                                                                                              |
+| --- | ------------------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| B1  | Create-automation gating | Open create dialog, leave name empty      | Continue disabled until name filled (#1425)                                                           |
+| B2  | Invalid test-input JSON  | Enter malformed JSON in the tester, run   | "Invalid JSON" feedback; run blocked                                                                  |
+| B3  | Dry run (file-based)     | Click Dry Run on a file-based workflow    | Either a real per-step preview, or a clear "not supported yet" message — never a silent no-op (#1484) |
+| B4  | Long condition dropdown  | Open a condition with many branch options | Dropdown scrolls / stays within the panel; "End workflow" reachable (#1492)                           |
+| B5  | Delete step              | Remove a step that others point to        | Edges update; no orphaned dangling connection                                                         |
+
+## Action-catalogue smoke
+
+The action catalogue includes Customer, Conversation, Product, Document, Integration, Set Variables, RAG, IMAP, Email Provider, Workflow Processing Records, Approval, Tone of Voice, OneDrive, Crawler, Website, Website Pages, and Workflow actions.
+
+| ID  | Test                     | Steps                                                           | Expected                                                |
+| --- | ------------------------ | --------------------------------------------------------------- | ------------------------------------------------------- |
+| AC1 | Set Variables            | Add a Set Variables step, define a var, reference it downstream | Variable resolves in a later step                       |
+| AC2 | Customer/Product action  | Add a read action against seeded data                           | Runs; output visible in the execution                   |
+| AC3 | Approval action          | Add an Approval step                                            | Run pauses for a human decision (see APPROVALS_TESTING) |
+| AC4 | Each action configurable | Add each action type once                                       | Each opens a config panel without a console error       |
+
+## API / integration tests
+
+| ID  | Test                 | Steps                                                      | Expected                                     |
+| --- | -------------------- | ---------------------------------------------------------- | -------------------------------------------- |
+| A1  | List/trigger via API | `GET /api/v1/automations/...`; trigger one                 | Lists workflows; trigger starts an execution |
+| A2  | Webhook idempotency  | Fire the same webhook event twice with one Idempotency-Key | Second call does not double-run the workflow |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check                   | Expected                                                  |
+| --- | ----------------------- | --------------------------------------------------------- |
+| X1  | Builder keyboard access | Steps/edges reachable; config panels operable by keyboard |
+| X2  | Branch labels readable  | Condition branches identifiable without relying on colour |
+| X3  | Dialog focus trap       | Create/schedule dialogs trap focus + restore it on close  |
+
+## Performance tests
+
+| ID  | Metric           | Target                      |
+| --- | ---------------- | --------------------------- |
+| P1  | Builder load     | < 2 s for a medium workflow |
+| P2  | Manual run start | Execution row appears < 2 s |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | ---------- |
+|     |         |            |          |             |            |
+
+## Test summary
+
+```
+Module: Automations
+Functional: ___/10   Boundary: ___/5   Actions: ___/4   API: ___/2   A11y: ___/3   Perf: ___/2
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/tests/CHAT_TESTING.md
+++ b/tests/CHAT_TESTING.md
@@ -1,0 +1,95 @@
+# Chat Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the AI chat module — message flow, attachments, the agent/model pickers, the tool surface, arena mode, and voice/dictation — and collect defects in Issues Found. The chat agent reaches a broad tool surface (knowledge reads, sub-agents, document generation, integrations); write operations route through approvals.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. At least one **model provider** must be configured (Settings → Providers) for the AI to respond — if none is set, F2 and the tool tests will fail with a provider error rather than a chat bug; note that distinction.
+
+> **AI Instructions**: Run in order; one finding per defect in Issues Found with a screenshot. Capture **TTFT** (time to first token) where asked. A "Something went wrong" with a Retry button is the friendly error path, not a crash.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/chat
+```
+
+## Functional tests
+
+| ID  | Test                  | Steps                                            | Expected                                                            |
+| --- | --------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
+| F1  | Chat loads            | Open `/dashboard/{id}/chat`                      | Composer, agent picker, model picker, conversation starters render  |
+| F2  | Send a message        | Type "Reply with the single word ready", send    | Response streams; send button disabled while empty                  |
+| F3  | New chat              | Click "New chat"                                 | Fresh thread; previous one preserved in history                     |
+| F4  | Thread title auto-gen | Send a first message in a new thread             | Thread gets a concise AI title (not "New Chat", not raw metadata)   |
+| F5  | Agent picker          | Open the agent selector, pick a different agent  | Selected agent drives the next turn                                 |
+| F6  | Model picker          | Open the model selector, pick a model            | Next turn uses it; "Auto" routes to the agent default               |
+| F7  | Edit a message        | Hover a sent user message → Edit → change → save | A branch is created; latest edit is shown; branch navigator appears |
+| F8  | Stop generation       | Send a long prompt, click Stop                   | Streaming halts; partial response retained                          |
+| F9  | Copy / save-as-prompt | Use the message actions on an assistant reply    | Copy puts text on clipboard; save-prompt opens the prompt save flow |
+
+## Attachment tests
+
+| ID  | Test                        | Input                                             | Expected                                                                       |
+| --- | --------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| AT1 | Attach a PDF/DOCX           | Attach a small document, send a question about it | File chip shows in the bubble (no raw `(fileId: …)` text leaks); agent uses it |
+| AT2 | Attach an image             | Attach a PNG/JPEG                                 | Image preview renders; vision-capable model can describe it                    |
+| AT3 | Duplicate file in one batch | Attach the same file twice before sending         | Second attach rejected with a "duplicate file" toast                           |
+| AT4 | Too many files              | Attach 11 files                                   | Rejected — max 10 per message                                                  |
+| AT5 | Oversized file              | Attach a file > 100 MB                            | Rejected with a size toast                                                     |
+| AT6 | Attachment-only message     | Attach a file, send with no text                  | Sends; thread title derives from the file name, not metadata (#1468)           |
+
+## Tool-surface tests
+
+The chat agent exposes knowledge reads (`customer_read`, `product_read`, `rag_search`, `context_search`), sub-agents (`web_assistant`, `document_assistant`, `integration_assistant`, `workflow_assistant`), document generation (`pdf`, `image`, `docx`, `pptx`, `generate_excel`), and integration tools (`integration`, `integration_batch`, `integration_introspect`, `verify_approval`). Governance feature flags can disable web search / code execution / file upload per scope.
+
+| ID  | Test                    | Prompt                                               | Expected                                                             |
+| --- | ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| TL1 | Knowledge read          | Ask about a seeded product/customer                  | Agent calls `product_read`/`customer_read`; tool card shows the call |
+| TL2 | RAG over documents      | Ask about an uploaded document's content             | `rag_search` runs; answer cites the document                         |
+| TL3 | Web search scope        | Ask something only on a crawled org website          | `web_assistant` searches org sites only (not the open internet)      |
+| TL4 | Document generation     | "Generate a one-page PDF summary of …"               | `pdf` tool produces a downloadable file part in the reply            |
+| TL5 | Write op needs approval | Ask the agent to create/update a record              | An approval is raised; the write does not apply until approved       |
+| TL6 | Feature flag enforced   | Disable web search for your role, ask a web question | Tool refused server-side; no web call                                |
+
+## Arena & voice tests
+
+| ID  | Test                    | Steps                                  | Expected                                                         |
+| --- | ----------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| AR1 | Arena mode              | Start Arena, send a prompt             | Two threads (A/B) respond side by side; verdict controls show    |
+| AR2 | Arena verdict merge     | Pick "B is better"                     | B's messages merge into A; other verdicts keep A (B discarded)   |
+| V1  | Dictation start/stop    | Click the mic, speak, click stop       | Transcript inserted into the composer                            |
+| V2  | Dictation stops on send | Start dictation, then send the message | Mic recording stops on send — it does not keep listening (#1462) |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check               | Expected                                                          |
+| --- | ------------------- | ----------------------------------------------------------------- |
+| X1  | Keyboard send       | Compose + Enter sends; Shift+Enter newlines                       |
+| X2  | Streaming announced | New assistant text is exposed via an `aria-live` region           |
+| X3  | Focus order         | Tab cycles composer → attach → pickers → send in a sensible order |
+| X4  | Mic button labelled | Dictation button has an accessible name + `aria-pressed` state    |
+
+## Performance tests
+
+| ID  | Metric               | Target                                 |
+| --- | -------------------- | -------------------------------------- |
+| P1  | TTFT (simple prompt) | First token < 3 s with a warm provider |
+| P2  | Attachment upload    | A small PDF uploads + chips in < 3 s   |
+| P3  | Thread switch        | Opening a history thread renders < 1 s |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | TTFT (if applicable) | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | -------------------- | ---------- |
+|     |         |            |          |             |                      |            |
+
+## Test summary
+
+```
+Module: Chat
+Functional: ___/9   Attachments: ___/6   Tools: ___/6   Arena+Voice: ___/4   A11y: ___/4   Perf: ___/3
+Issues found: ___ (crit __ / high __ / med __ / low __)
+TTFT median: ___ s
+Status: PASS / FAIL
+```

--- a/tests/CONVERSATIONS_TESTING.md
+++ b/tests/CONVERSATIONS_TESTING.md
@@ -1,0 +1,75 @@
+# Conversations Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the Conversations (inbox) module — statuses, priority, bulk actions, AI reply assistance, and the archive — and collect defects in Issues Found. Note: this is the **inbox** module, distinct from AI **chat threads**; archived chat threads live in the chat history sidebar, not here.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. Open `/dashboard/{id}/conversations/open`.
+
+> **AI Instructions**: Run in order; record one finding per defect with a screenshot. If the inbox is empty, the status tabs and empty states are still testable — note "no data" where a test needs a seeded conversation.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/conversations
+```
+
+## Functional tests
+
+| ID  | Test                | Steps                                        | Expected                                                      |
+| --- | ------------------- | -------------------------------------------- | ------------------------------------------------------------- |
+| F1  | Inbox loads         | Open conversations                           | Status tabs (Open/Closed/Archived/Spam) + list or empty state |
+| F2  | Status tabs filter  | Click each status tab                        | List filters to that status; URL reflects the tab             |
+| F3  | Open a conversation | Click a row                                  | Thread view with message history + reply composer             |
+| F4  | Set priority        | Change priority to Low/Medium/High/Urgent    | Priority persists; reflected in the list                      |
+| F5  | Close / reopen      | Close a conversation, then reopen            | Moves between Open and Closed tabs accordingly                |
+| F6  | AI improve reply    | Draft a reply, use the AI improvement action | Suggested rewrite returned; user can accept/edit before send  |
+| F7  | Send reply          | Send a reply                                 | Appended to the thread; status/timestamps update              |
+| F8  | Archive             | Archive a conversation                       | Appears under the Archived tab; removed from Open             |
+
+## Bulk-action & boundary tests
+
+| ID  | Test                     | Steps                                                                 | Expected                                                           |
+| --- | ------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| B1  | Multi-select bulk close  | Select several rows → Close                                           | All selected move to Closed; one undo/toast                        |
+| B2  | Bulk reopen              | Select closed rows → Reopen                                           | All move back to Open                                              |
+| B3  | Empty reply blocked      | Try to send an empty reply                                            | Send disabled / rejected                                           |
+| B4  | Archived vs chat archive | Archive a chat thread (in Chat), then open Conversations Archived tab | The chat thread is NOT here — archives are separate stores (#1290) |
+| B5  | Long thread render       | Open a conversation with many messages                                | Renders without freeze; scroll to latest works                     |
+
+## API / integration tests
+
+| ID  | Test            | Steps                                              | Expected                       |
+| --- | --------------- | -------------------------------------------------- | ------------------------------ |
+| A1  | List by status  | `GET /api/v1/conversations/...` filtered by status | Returns only that status       |
+| A2  | Write a message | Post a message via the API                         | Appears in the thread; audited |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check           | Expected                                                        |
+| --- | --------------- | --------------------------------------------------------------- |
+| X1  | Tab navigation  | Status tabs reachable + operable by keyboard; active tab marked |
+| X2  | Row semantics   | List rows have accessible names; selection state announced      |
+| X3  | Composer labels | Reply field + actions labelled; focus visible                   |
+
+## Performance tests
+
+| ID  | Metric            | Target                              |
+| --- | ----------------- | ----------------------------------- |
+| P1  | Inbox list load   | < 1.5 s for the first page          |
+| P2  | Bulk action (10+) | Completes < 2 s with one round-trip |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | ---------- |
+|     |         |            |          |             |            |
+
+## Test summary
+
+```
+Module: Conversations
+Functional: ___/8   Bulk+Boundary: ___/5   API: ___/2   A11y: ___/3   Perf: ___/2
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/tests/KNOWLEDGE_BASE_TESTING.md
+++ b/tests/KNOWLEDGE_BASE_TESTING.md
@@ -1,0 +1,94 @@
+# Knowledge Base Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the six knowledge sub-modules — Products, Customers, Documents, Websites, Vendors, Tone of Voice — and collect defects in Issues Found. These are the structured + unstructured sources agents ground their answers on, so import correctness and RAG indexing matter as much as CRUD.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. The knowledge tabs live under the **Base de connaissances / Knowledge** area (Documents · Websites · Products · Customers · Vendors).
+
+> **AI Instructions**: Run each sub-module's block in order; one finding per defect with a screenshot. For imports, keep a small valid CSV/XLSX and a deliberately malformed one to hand.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/knowledge
+```
+
+## Products
+
+| ID  | Test                     | Steps                                                    | Expected                                                                                            |
+| --- | ------------------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| PR1 | List columns             | Open Products                                            | Table shows Name, Description, Stock, **Price, Category, Status**, Updated (#1310/#1356)            |
+| PR2 | Create product           | Add product with name, price, currency, category, status | Created; price + category + status visible in the list                                              |
+| PR3 | CSV/XLSX import (valid)  | Import a well-formed file                                | Rows imported; count reported                                                                       |
+| PR4 | Import (header mismatch) | Import a file whose columns don't match                  | Fails loudly with a clear "missing required column" error — no silent partial import (#1310 family) |
+| PR5 | Edit / delete            | Edit a product; delete it                                | Changes persist; deletion removes the row                                                           |
+
+## Customers
+
+| ID  | Test                        | Steps                                                 | Expected                                                        |
+| --- | --------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| CU1 | Create / list               | Add a customer (email, name, locale)                  | Appears in the list                                             |
+| CU2 | Import aliased headers      | Import CSV with `Email Address` / `Full Name` columns | Maps via aliases — name not dropped (#1312)                     |
+| CU3 | Import missing email column | Import a file with no email-like column               | Rejected with a clear error; nothing partially imported (#1312) |
+| CU4 | Dedup on import             | Import a file with a duplicate email                  | Duplicate handled (skipped/merged), not double-created          |
+
+## Documents
+
+| ID  | Test                     | Steps                                              | Expected                                                                   |
+| --- | ------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------- |
+| DO1 | Upload                   | Upload a PDF/DOCX                                  | "Uploaded — indexing in background" copy; row appears (#1460)              |
+| DO2 | RAG indexing status      | Watch the document's status badge                  | Moves to indexed; on failure shows a Retry/error-detail affordance (#1459) |
+| DO3 | Multi-team assignment    | Open a document's team dialog, assign 2 teams      | Multiple teams selectable + preserved on save (#1325)                      |
+| DO4 | Upload into team folder  | Upload into a team-scoped folder                   | Team selector locked to the folder's team with a hint (#1469)              |
+| DO5 | Long file name in dialog | Open the team dialog for a long no-space file name | Name wraps; dialog doesn't overflow (#1324)                                |
+| DO6 | Unsupported type         | Upload a disallowed extension                      | Rejected with a clear message                                              |
+
+## Websites
+
+| ID  | Test                     | Steps                                  | Expected                                                |
+| --- | ------------------------ | -------------------------------------- | ------------------------------------------------------- |
+| WS1 | Add website              | Add a domain + scan interval (60m–30d) | Crawl scheduled; row shows next scan                    |
+| WS2 | Domain read-only on edit | Edit an existing website               | Domain is read-only (by design); scan interval editable |
+| WS3 | Rescan now               | Trigger an on-demand rescan            | Crawl runs; page count updates                          |
+
+## Vendors
+
+| ID  | Test                    | Steps                                    | Expected                                                  |
+| --- | ----------------------- | ---------------------------------------- | --------------------------------------------------------- |
+| VE1 | Create / list           | Add a vendor                             | Appears in the list                                       |
+| VE2 | Bulk delete             | Select multiple vendor rows → delete     | Bulk-delete bar appears; rows removed in one action       |
+| VE3 | Import (xlsx, mismatch) | Import an xlsx with non-matching columns | Loud error instead of dropping the name silently (#1323)  |
+| VE4 | Import form copy        | Open the vendor import form              | Format hint renders real text, not a raw i18n key (#1412) |
+
+## Tone of Voice
+
+| ID  | Test          | Steps                                          | Expected                                       |
+| --- | ------------- | ---------------------------------------------- | ---------------------------------------------- |
+| TV1 | Edit tone     | Change the tone description + example messages | Saved; reflected when an agent drafts a reply  |
+| TV2 | AI generation | Use the AI tone-generation helper              | Produces a draft tone the user can accept/edit |
+
+## Accessibility & performance (all sub-modules)
+
+| ID  | Check                     | Expected                                                    |
+| --- | ------------------------- | ----------------------------------------------------------- |
+| X1  | Tables keyboard-navigable | Sort, select, row actions reachable by keyboard             |
+| X2  | Import dialogs labelled   | File inputs + team selectors have labels + focus management |
+| X3  | Status not colour-only    | Indexing / stock status conveyed by text, not colour alone  |
+| P1  | List load                 | Each list's first page < 1.5 s                              |
+| P2  | Import feedback           | Progress + completion reported within the dialog            |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | ---------- |
+|     |         |            |          |             |            |
+
+## Test summary
+
+```
+Module: Knowledge Base
+Products: ___/5  Customers: ___/4  Documents: ___/6  Websites: ___/3  Vendors: ___/4  Tone: ___/2  A11y+Perf: ___/5
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# AI-directed test guides
+
+Modular, AI-directed test documentation for comprehensive site testing. Each guide is a self-contained playbook for one feature module: it lists concrete, codebase-grounded test cases (functional, boundary, API/integration, accessibility, performance) and an **Issues Found** table for collecting discovered problems.
+
+These are manual / AI-agent testing playbooks — not the automated suites. Unit and component tests live in `services/*/`; this directory is for end-to-end, exploratory, and accessibility passes driven by a human or an AI agent against a running instance.
+
+## How to use
+
+1. Bring a clean instance up once via [`FULL_SITE_TESTING.md`](FULL_SITE_TESTING.md) (steps 1–5) — every module guide assumes that environment and the seeded admin (`admin@admin.test` / `Admin@123`).
+2. Run the modules in dependency order: **Auth first**, then Chat, then the rest.
+3. For each defect, add a row to that guide's **Issues Found** table with the test ID, page, severity, description, and screenshot.
+4. Finish with [`ACCESSIBILITY_TESTING.md`](ACCESSIBILITY_TESTING.md) as a cross-cutting WCAG 2.1 AA sweep.
+
+## Guides
+
+| Guide                                                            | Module                                                           |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [`FULL_SITE_TESTING.md`](FULL_SITE_TESTING.md)                   | Smoke test — every page loads, environment bring-up              |
+| [`AUTH_TESTING.md`](AUTH_TESTING.md)                             | Authentication, account model, password policy, 2FA, lockout     |
+| [`CHAT_TESTING.md`](CHAT_TESTING.md)                             | AI chat: messages, attachments, tool surface, arena, voice       |
+| [`CONVERSATIONS_TESTING.md`](CONVERSATIONS_TESTING.md)           | Inbox: statuses, priority, bulk actions, AI reply assistance     |
+| [`APPROVALS_TESTING.md`](APPROVALS_TESTING.md)                   | Approval workflows: lifecycle, confidence, audit                 |
+| [`AUTOMATIONS_TESTING.md`](AUTOMATIONS_TESTING.md)               | Workflows: triggers, step types, action catalogue, schedules     |
+| [`KNOWLEDGE_BASE_TESTING.md`](KNOWLEDGE_BASE_TESTING.md)         | Products, Customers, Documents, Websites, Vendors, Tone of Voice |
+| [`SETTINGS_TESTING.md`](SETTINGS_TESTING.md)                     | Account, People & Teams, Providers, Integrations, Governance     |
+| [`ACCESSIBILITY_TESTING.md`](ACCESSIBILITY_TESTING.md)           | Cross-cutting WCAG 2.1 AA sweep                                  |
+| [`PROTEL_INTEGRATION_TESTING.md`](PROTEL_INTEGRATION_TESTING.md) | Protel PMS integration                                           |
+
+## Shared template
+
+Each module guide follows the same shape so coverage is comparable across modules:
+
+```
+# [Module] Testing Guide (AI-Directed)
+> Purpose
+## Prerequisites          (references FULL_SITE_TESTING.md for bring-up)
+## Screenshot Setup
+## Functional tests
+## Boundary & error tests
+## API / integration tests
+## Accessibility tests (WCAG 2.1 AA)
+## Performance tests
+## Issues Found            (collection table)
+## Test summary
+```

--- a/tests/SETTINGS_TESTING.md
+++ b/tests/SETTINGS_TESTING.md
@@ -1,0 +1,93 @@
+# Settings Testing Guide (AI-Directed)
+
+> **Purpose**: Exercise the settings area — Account, Organization (People + Teams), Providers, Integrations, API keys, Branding, and Governance — and collect defects in Issues Found. Settings is where admins provision people, wire providers/integrations, and set the governance policies the rest of the product enforces.
+
+## Prerequisites
+
+Bring the stack up per [FULL_SITE_TESTING.md](FULL_SITE_TESTING.md) and sign in as `admin@admin.test` / `Admin@123`. Open `/dashboard/{id}/settings`.
+
+> **AI Instructions**: Run in order; one finding per defect with a screenshot. Changing the admin password (Account) will sign you out by design — do that test last, and re-login with the new password.
+
+## Screenshot Setup
+
+```bash
+mkdir -p tests/screenshots/$(date +%Y-%m-%d_%H_%M)/settings
+```
+
+## Account
+
+| ID  | Test                      | Steps                                | Expected                                                     |
+| --- | ------------------------- | ------------------------------------ | ------------------------------------------------------------ |
+| AC1 | Edit display name         | Change name, save                    | Persists; reflected in the user menu                         |
+| AC2 | Change password (re-auth) | Change password with a valid new one | Signed out + redirected to login; new password works (#1255) |
+| AC3 | Password policy on change | Try a password below policy          | Rejected with the policy hint                                |
+| AC4 | Two-factor section        | Toggle 2FA enrollment                | Enroll/disable flow works (see AUTH_TESTING)                 |
+
+## Organization — People & Teams
+
+| ID  | Test                        | Steps                                | Expected                                           |
+| --- | --------------------------- | ------------------------------------ | -------------------------------------------------- |
+| OR1 | Edit org name               | Change org name, save                | Persists                                           |
+| OR2 | Add member                  | Add member (email + password + role) | Created; credentials shown                         |
+| OR3 | Add member — empty password | Submit new user with blank password  | Password field error, not a generic toast (#1470)  |
+| OR4 | Create team                 | Create a team (name only)            | Created; creator auto-added as a member (#1378)    |
+| OR5 | Rename team                 | Edit a team's name, save             | List updates to the new name immediately (#1374)   |
+| OR6 | Add/remove team members     | Add then remove a member from a team | Membership updates reactively                      |
+| OR7 | Members pagination/scale    | View an org with many members        | List remains usable (note if it truncates — #1463) |
+
+## Providers
+
+| ID  | Test                  | Steps                                            | Expected                                                           |
+| --- | --------------------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| PV1 | Add provider          | Add a provider, save                             | Reachable from agents; row turns healthy                           |
+| PV2 | Add-provider gating   | Open add-provider, leave required fields empty   | Submit disabled until valid (#1382)                                |
+| PV3 | Fetch + search models | Fetch models, use the search field, multi-select | Searchable, checkbox-selectable list after fetch (#1569/#1570)     |
+| PV4 | Local/private host    | Add a provider pointing at `localhost`           | Rejected unless `TALE_ALLOW_PRIVATE_PROVIDER_HOSTS=1` (#1427 docs) |
+
+## Integrations
+
+| ID  | Test              | Steps                                              | Expected                                                        |
+| --- | ----------------- | -------------------------------------------------- | --------------------------------------------------------------- |
+| IN1 | Integrations list | Open Integrations                                  | Catalogue renders                                               |
+| IN2 | Connect (OAuth2)  | Connect an OAuth2 integration                      | Redirect to provider; callback returns; tokens stored encrypted |
+| IN3 | MCP server add    | Settings → MCP Servers → add (None/API key/OAuth2) | Auth options present; test-connection reports handshake result  |
+
+## Governance
+
+| ID  | Test                       | Steps                                                     | Expected                                                 |
+| --- | -------------------------- | --------------------------------------------------------- | -------------------------------------------------------- |
+| GV1 | Password policy editor     | Set min length + complexity                               | Saved; enforced on add-member + change-password (#1503)  |
+| GV2 | Upload policy conflict     | Put the same extension in allowed + blocked               | Rejected with a conflict error (#1479)                   |
+| GV3 | Budget rule confirm-delete | Delete a budget rule                                      | Confirmation dialog before removal (#1419)               |
+| GV4 | Feature flags              | Toggle web search / code execution / file upload by scope | Enforced server-side in chat (see CHAT_TESTING TL6)      |
+| GV5 | Audit logs + export        | Open Audit logs; export CSV/JSON                          | Filtered export downloads with documented columns (#190) |
+
+## Accessibility tests (WCAG 2.1 AA)
+
+| ID  | Check                   | Expected                                                |
+| --- | ----------------------- | ------------------------------------------------------- |
+| X1  | Settings nav keyboard   | Section tabs reachable + operable; active tab marked    |
+| X2  | Form labels + errors    | Every field labelled; validation errors announced       |
+| X3  | Dialog focus management | Add-member / create-team / editors trap + restore focus |
+
+## Performance tests
+
+| ID  | Metric          | Target                          |
+| --- | --------------- | ------------------------------- |
+| P1  | Section switch  | < 1 s between settings sections |
+| P2  | Save round-trip | < 1.5 s for a settings save     |
+
+## Issues Found
+
+| #   | Test ID | Page / URL | Severity | Description | Screenshot |
+| --- | ------- | ---------- | -------- | ----------- | ---------- |
+|     |         |            |          |             |            |
+
+## Test summary
+
+```
+Module: Settings
+Account: ___/4  People&Teams: ___/7  Providers: ___/4  Integrations: ___/3  Governance: ___/5  A11y: ___/3  Perf: ___/2
+Issues found: ___ (crit __ / high __ / med __ / low __)
+Status: PASS / FAIL
+```


### PR DESCRIPTION
## What

Replaces the two-file test docs (`FULL_SITE_TESTING.md`, `PROTEL_INTEGRATION_TESTING.md`) with **eight modular AI-directed test guides** plus an index, each grounded in the actual codebase and following one shared template.

New files under `tests/`:

- `README.md` — index, run order (Auth first), and the shared template
- `AUTH_TESTING.md` — offline-first account model, password policy, forced change, 2FA, lockout
- `CHAT_TESTING.md` — messages, attachments (limits), the 24-tool surface, arena, voice/dictation
- `CONVERSATIONS_TESTING.md` — statuses, priority, bulk actions, AI reply assistance, archive
- `APPROVALS_TESTING.md` — pending/approved/rejected lifecycle, confidence, audit
- `AUTOMATIONS_TESTING.md` — triggers, step types, the action catalogue, conditions, schedules, dry-run
- `KNOWLEDGE_BASE_TESTING.md` — Products, Customers, Documents, Websites, Vendors, Tone of Voice
- `SETTINGS_TESTING.md` — Account, People & Teams, Providers, Integrations, Governance
- `ACCESSIBILITY_TESTING.md` — cross-cutting WCAG 2.1 AA sweep with a page matrix

Each module guide carries **Functional / Boundary / API-Integration / Accessibility / Performance** sections and an **Issues Found** collection table, in a unified structure so coverage is comparable. The cases are tied to real features (and several recently-fixed behaviours are encoded as regression checks, e.g. attachment-only titles, dialog validation gating, multi-team documents, folder-team lock, condition-branch labels).

## Notes

These are **manual / AI-agent playbooks** run against a live instance — the automated unit/component suites live in `services/*`. They're plain repo-root `tests/*.md` (not the docs site), so no localization or docs-site test applies. Across the eight modules there are 200+ documented test rows plus the accessibility matrix (14 checks × the page list).

Closes #110
