### PR TITLE
fix(platform): add bottom spacing to governance guardrails page

### DIFF
--- a/services/platform/app/routes/dashboard/$id/settings/governance/guardrails.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/guardrails.tsx
@@ -15,7 +15,7 @@ function GuardrailsRoute() {
   const { id: organizationId } = Route.useParams();
 
   return (
-    <div className="divide-border flex flex-col divide-y">
+    <div className="divide-border flex flex-col divide-y pb-8">
       <div className="pb-7">
         <GuardrailsOverview organizationId={organizationId} />
       </div>


### PR DESCRIPTION
## What

The Settings → Governance → Guardrails page (which contains **PII Protection**, Chat filter, and Moderation provider sections) had no bottom padding — its last section used `pt-7` only, so content sat flush against the bottom of the scroll area and looked cramped.

Reported in #1474.

## Change

Wrap the section stack in `pb-8`, matching the bottom-spacing convention already used by sibling settings pages (`usage.tsx`, `feedback.tsx` both wrap in `pb-8`).

```diff
-    <div className="divide-border flex flex-col divide-y">
+    <div className="divide-border flex flex-col divide-y pb-8">
```

## Testing

Pure layout/className change — no logic affected. Verified the page renders with consistent bottom spacing matching other governance/settings pages.

Closes #1474