### PR TITLE
fix(platform): add timeout to MCP server connection test

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -613,6 +613,7 @@ import type * as mcp_servers_mutations from "../mcp_servers/mutations.js";
 import type * as mcp_servers_oauth2_helpers from "../mcp_servers/oauth2_helpers.js";
 import type * as mcp_servers_public_mutations from "../mcp_servers/public_mutations.js";
 import type * as mcp_servers_queries from "../mcp_servers/queries.js";
+import type * as mcp_servers_timeout from "../mcp_servers/timeout.js";
 import type * as members_helpers from "../members/helpers.js";
 import type * as members_internal_queries from "../members/internal_queries.js";
 import type * as members_mutations from "../members/mutations.js";
@@ -1812,6 +1813,7 @@ declare const fullApi: ApiFromModules<{
   "mcp_servers/oauth2_helpers": typeof mcp_servers_oauth2_helpers;
   "mcp_servers/public_mutations": typeof mcp_servers_public_mutations;
   "mcp_servers/queries": typeof mcp_servers_queries;
+  "mcp_servers/timeout": typeof mcp_servers_timeout;
   "members/helpers": typeof members_helpers;
   "members/internal_queries": typeof members_internal_queries;
   "members/mutations": typeof members_mutations;

--- a/services/platform/convex/mcp_servers/client_factory.ts
+++ b/services/platform/convex/mcp_servers/client_factory.ts
@@ -16,6 +16,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 import { decryptString } from '../lib/crypto/decrypt_string';
 import { getOrRefreshToken } from './oauth2_helpers';
+import { MCP_CONNECTION_TIMEOUT_MS, withTimeout } from './timeout';
 
 interface HttpConfig {
   url: string;
@@ -143,70 +144,81 @@ async function withMcpClient<T>(
     { capabilities: {} },
   );
 
-  let transport;
+  const connectAndRun = async (): Promise<T> => {
+    let transport;
 
-  if (config.transportType === 'http' && config.httpConfig) {
-    const url = new URL(config.httpConfig.url);
+    if (config.transportType === 'http' && config.httpConfig) {
+      const url = new URL(config.httpConfig.url);
 
-    // Merge custom headers with auth headers
-    const allHeaders: Record<string, string> = {};
-    if (config.httpConfig.headers) {
-      for (const [key, value] of Object.entries(config.httpConfig.headers)) {
-        if (typeof value === 'string') {
-          allHeaders[key] = value;
+      // Merge custom headers with auth headers
+      const allHeaders: Record<string, string> = {};
+      if (config.httpConfig.headers) {
+        for (const [key, value] of Object.entries(config.httpConfig.headers)) {
+          if (typeof value === 'string') {
+            allHeaders[key] = value;
+          }
         }
       }
-    }
-    Object.assign(allHeaders, authHeaders);
+      Object.assign(allHeaders, authHeaders);
 
-    // Try Streamable HTTP first, fall back to SSE
-    try {
-      transport = new StreamableHTTPClientTransport(url, {
-        requestInit: {
-          headers: allHeaders,
-        },
-      });
-      await client.connect(transport);
-    } catch {
-      // Fall back to SSE transport
-      transport = new SSEClientTransport(url, {
-        requestInit: {
-          headers: allHeaders,
-        },
-      });
-      await client.connect(transport);
-    }
-  } else if (config.transportType === 'stdio' && config.stdioConfig) {
-    const env: Record<string, string> = {};
-    for (const [k, v] of Object.entries(process.env)) {
-      if (v !== undefined) env[k] = v;
-    }
-    if (config.stdioConfig.env) {
-      for (const [key, value] of Object.entries(config.stdioConfig.env)) {
-        if (typeof value === 'string') {
-          env[key] = value;
+      // Try Streamable HTTP first, fall back to SSE
+      try {
+        transport = new StreamableHTTPClientTransport(url, {
+          requestInit: {
+            headers: allHeaders,
+          },
+        });
+        await client.connect(transport);
+      } catch {
+        // Fall back to SSE transport
+        transport = new SSEClientTransport(url, {
+          requestInit: {
+            headers: allHeaders,
+          },
+        });
+        await client.connect(transport);
+      }
+    } else if (config.transportType === 'stdio' && config.stdioConfig) {
+      const env: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined) env[k] = v;
+      }
+      if (config.stdioConfig.env) {
+        for (const [key, value] of Object.entries(config.stdioConfig.env)) {
+          if (typeof value === 'string') {
+            env[key] = value;
+          }
         }
       }
+
+      transport = new StdioClientTransport({
+        command: config.stdioConfig.command,
+        args: config.stdioConfig.args,
+        env,
+      });
+      await client.connect(transport);
+    } else {
+      throw new Error('Invalid transport configuration');
     }
 
-    transport = new StdioClientTransport({
-      command: config.stdioConfig.command,
-      args: config.stdioConfig.args,
-      env,
-    });
-    await client.connect(transport);
-  } else {
-    throw new Error('Invalid transport configuration');
-  }
+    return callback(client);
+  };
 
   try {
-    const result = await callback(client);
+    // Bound the connect handshake + operation. On timeout the race rejects
+    // with McpTimeoutError; the `finally` below closes the client, which
+    // aborts the transport's in-flight request so an unreachable endpoint is
+    // torn down rather than left dangling.
+    const result = await withTimeout(
+      connectAndRun(),
+      MCP_CONNECTION_TIMEOUT_MS,
+    );
     return { result, tokenUpdate };
   } finally {
     try {
       await client.close();
-    } catch {
-      // Ignore close errors
+    } catch (closeErr) {
+      console.warn('MCP client close failed:', closeErr);
     }
   }
 }

--- a/services/platform/convex/mcp_servers/timeout.test.ts
+++ b/services/platform/convex/mcp_servers/timeout.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  MCP_CONNECTION_TIMEOUT_MS,
+  McpTimeoutError,
+  withTimeout,
+} from './timeout';
+
+const delay = <T>(ms: number, value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+const reject = (ms: number, err: Error): Promise<never> =>
+  new Promise((_, r) => setTimeout(() => r(err), ms));
+
+describe('McpTimeoutError', () => {
+  it('uses the default timeout in its message', () => {
+    const err = new McpTimeoutError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('McpTimeoutError');
+    expect(err.message).toContain('15s');
+  });
+
+  it('renders a rounded seconds value from the given ms', () => {
+    expect(new McpTimeoutError(15_000).message).toContain('15s');
+    expect(new McpTimeoutError(3_000).message).toContain('3s');
+  });
+});
+
+describe('withTimeout', () => {
+  it('resolves with the operation result when it finishes in time', async () => {
+    const onTimeout = vi.fn();
+    const result = await withTimeout(delay(5, 'ok'), 200, onTimeout);
+    expect(result).toBe('ok');
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('rejects with McpTimeoutError and aborts when the operation is too slow', async () => {
+    const onTimeout = vi.fn();
+    // Operation never settles within the window.
+    await expect(
+      withTimeout(delay(1_000, 'late'), 10, onTimeout),
+    ).rejects.toBeInstanceOf(McpTimeoutError);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the operation error when it fails before the timeout', async () => {
+    const boom = new Error('connect refused');
+    await expect(withTimeout(reject(5, boom), 200)).rejects.toBe(boom);
+  });
+
+  it('still rejects with McpTimeoutError if the abort handler throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onTimeout = vi.fn(() => {
+      throw new Error('abort failed');
+    });
+    await expect(
+      withTimeout(delay(1_000, 'late'), 10, onTimeout),
+    ).rejects.toBeInstanceOf(McpTimeoutError);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('does not leak an unhandled rejection when the aborted operation settles late', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Operation rejects AFTER the timeout has already won the race.
+    const op = reject(30, new Error('late abort error'));
+    await expect(withTimeout(op, 10)).rejects.toBeInstanceOf(McpTimeoutError);
+    // Give the late rejection time to settle and be observed by the
+    // internal .catch (otherwise it would become an unhandledRejection).
+    await delay(40, null);
+    expect(warn).toHaveBeenCalledWith(
+      'MCP operation aborted after timeout:',
+      'late abort error',
+    );
+    warn.mockRestore();
+  });
+
+  it('exposes a sane default connection timeout', () => {
+    expect(MCP_CONNECTION_TIMEOUT_MS).toBe(15_000);
+  });
+});

--- a/services/platform/convex/mcp_servers/timeout.ts
+++ b/services/platform/convex/mcp_servers/timeout.ts
@@ -1,0 +1,75 @@
+/**
+ * Timeout primitives for MCP client operations.
+ *
+ * Kept dependency-free (no MCP SDK / Node imports) so the behavior can be
+ * unit-tested in isolation. Consumed by {@link ../client_factory} to bound
+ * the connect handshake + tool discovery/call.
+ */
+
+/**
+ * Max time we wait for an MCP server to complete the connect handshake +
+ * the requested operation (tool discovery / tool call). A slow or
+ * unreachable endpoint would otherwise hang the request until the SDK's
+ * 60s default fires — far too long for an interactive "Test connection".
+ */
+export const MCP_CONNECTION_TIMEOUT_MS = 15_000;
+
+/**
+ * Thrown when an MCP operation exceeds {@link MCP_CONNECTION_TIMEOUT_MS}.
+ * The message is surfaced verbatim to the UI by the testConnection action,
+ * so it reads as a clear, actionable timeout notice.
+ */
+export class McpTimeoutError extends Error {
+  constructor(timeoutMs: number = MCP_CONNECTION_TIMEOUT_MS) {
+    super(
+      `MCP server did not respond within ${Math.round(timeoutMs / 1000)}s. Check that the endpoint is reachable and not blocked by a firewall.`,
+    );
+    this.name = 'McpTimeoutError';
+  }
+}
+
+/**
+ * Race an operation against a timeout. On timeout, invoke `onTimeout`
+ * (used to abort the in-flight transport request so the underlying fetch
+ * is cancelled rather than left dangling) and reject with
+ * {@link McpTimeoutError}. The operation's late settlement is observed and
+ * logged so it never surfaces as an unhandled rejection once the race is
+ * lost.
+ */
+export async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        onTimeout?.();
+      } catch (err) {
+        console.warn('MCP timeout abort handler failed:', err);
+      }
+      reject(new McpTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+
+  // Prevent an unhandled rejection if the aborted operation settles after
+  // the timeout already won the race.
+  operation.catch((err: unknown) => {
+    if (timedOut) {
+      console.warn(
+        'MCP operation aborted after timeout:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  });
+
+  try {
+    return await Promise.race([operation, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## What

"Test connection" for an MCP server had no timeout. A slow or unreachable endpoint hung the connect handshake + tool discovery until the MCP SDK's 60s default fired, leaving the user with a spinner and no feedback.

Reported in #1514.

## Change

- Wrap the connect + operation in `withMcpClient` with a **15s timeout** (`withTimeout` / `Promise.race`). On timeout it rejects with `McpTimeoutError` — *"MCP server did not respond within 15s. Check that the endpoint is reachable and not blocked by a firewall."* — which the `testConnection` action already surfaces verbatim to the server panel and persists as `lastErrorMessage`.
- The client is closed in `finally`, which aborts the transport's in-flight request so an unreachable endpoint is torn down rather than dangling. The aborted operation's late settlement is observed/logged so it never becomes an unhandled rejection.
- Timeout primitives live in a new dependency-free `timeout.ts` so they're unit-testable without importing the MCP SDK.

## Testing

New `timeout.test.ts` (8 cases, all green): resolves-in-time, timeout rejection + abort-handler invocation, operation-error passthrough, throwing abort handler still rejects as timeout, and no unhandled rejection when the aborted op settles late.

`bunx tsc --noEmit` clean; `oxlint --type-aware` clean.

Closes #1514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP client connections now include a 15-second timeout to prevent indefinite hangs and improve system reliability.

* **Tests**
  * Added comprehensive test coverage for timeout behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->