### PR TITLE
fix(platform): pickers, AI disclaimer polish, settings + agents UX explorations

### DIFF
--- a/designs/agents-models-ux-gaps.md
+++ b/designs/agents-models-ux-gaps.md
@@ -1,0 +1,114 @@
+# Agents & Models — UX Gaps
+
+A working list of friction points in how Tale surfaces agents, their capabilities, and the models that back them. Ordered by impact, not by effort.
+
+## Top three (start here)
+
+### 1. "Auto" model selection is opaque
+
+Chat agents default to **Auto** mode and silently pick a model. The user never sees which one ran. When a response is bad, they can't tell whether it's the model, the agent, or the prompt.
+
+**Fix idea:** show the actual model name on each AI message — a small "via deepseek-v4-flash" chip below the bubble, optionally clickable to reveal "Auto picked this because cost / latency / context length."
+
+### 2. Capabilities aren't scannable or persistent
+
+The agent picker shows real descriptions today — "Image Creator generates and edits images from text prompts using FLUX, Imagen, or Nano Banana," "Researcher: live planning, web search via Tavily, cited sources," etc. That covers more than I initially gave it credit for.
+
+What's still missing:
+
+- **Only visible at picker time.** Once you've selected an agent and are in the conversation, you can't see its tools anymore. Forget whether Researcher has web access? You have to re-open the picker to check.
+- **Prose, not structured flags.** Descriptions read well but aren't scannable. Comparing two agents means reading two paragraphs. A visual capability strip (`📡 Web · 📄 Docs · 🖼 Vision`) lets users diff agents at a glance.
+- **Inconsistent depth.** Descriptions are admin-authored, so quality varies. "Automation Assistant — creates and manages automation workflows" is vague compared to Image Creator's specific model list. Structured capability flags would be uniform regardless of who wrote the agent.
+
+**Fix idea:** keep the existing descriptions in the picker, but also surface a structured capability strip on the agent row (in the picker) and a small persistent indicator on the active-agent chip during chat (clickable to reveal full details).
+
+### 3. No cross-agent suggestion when you hit a wall
+
+Ask Assistant for an image, it politely declines. There's no _"looks like you want an image — try the Image Creator agent"_ link. High-impact discoverability moment, zero built today.
+
+**Fix idea:** when an agent refuses a task that another agent can do, surface a one-line suggestion + "Switch agent" button under the refusal.
+
+---
+
+## Why models don't show up (the original question)
+
+When the user switches agents and the model dropdown changes silently, three things are happening invisibly:
+
+1. The new agent has a different `supportedModels` allowlist
+2. Models must match the agent's capability tag (`chat` vs `image-generation`)
+3. Governance policies (`model_access`) filter further
+
+When the result is zero models, the UI just shows **"No models available"** with a red triangle. That single string covers four very different situations:
+
+- No providers configured at all
+- Providers exist but none offer the required capability (e.g. no image-gen provider for Image Creator)
+- All models blocked by governance
+- Tag mismatch (dev-only)
+
+**Fix idea — reason-aware empty state.** Branch on the actual cause:
+
+- _No providers:_ "No models available — connect a provider in Settings → Providers."
+- _Capability mismatch:_ "Image Creator needs image-generation models. None of your configured providers offer them — try adding Vercel Gateway or OpenRouter."
+- _Blocked by governance:_ "None of this agent's models are approved by your organization. Ask an admin to update the model access policy."
+
+Each one points to a different next action; the current single string forces guessing.
+
+**Related:** when switching agents drops the user's previous selection, say so. Currently it changes without notice. A toast like _"Switched to FLUX 2 Pro — Image Creator doesn't use Claude Opus"_ would convert silent loss into noticed swap.
+
+---
+
+## The rest of the gap list
+
+### 4. Quantization variants are jargon
+
+The picker shows "GLM 5.1 (fp8)" vs "GLM 5.1 (fp4)". Most users don't know what this means. Either explain (hover tooltip: _"fp8 = higher quality, slower; fp4 = faster, cheaper"_) or hide variants behind a developer toggle.
+
+### 5. No model count at agent-picker time
+
+You pick an agent and _then_ discover whether it has 17 models, 4 models, or zero. Showing "Researcher · 17 models" / "Image Creator · 0 (admin blocked)" on the agent row sets expectations before the click.
+
+### 6. No agent discovery surface
+
+Outside the settings page, agents aren't browseable. New users don't learn what exists. A first-run agent picker with descriptions and example use cases would help.
+
+### 7. No model history per message
+
+After a long chat you can't see which model produced which response. Critical for trust, retrospection, and debugging "why was that answer worse." Subtle "via {model}" footer per AI message solves it.
+
+### 8. No graceful model degradation
+
+If FLUX 2 Pro is rate-limited or down, the user probably sees a generic "something went wrong." There's no built-in fallback ("FLUX 2 Pro hit rate limit — try FLUX Kontext Pro?") or auto-switch notice.
+
+### 9. Agent switching mid-conversation is ambiguous
+
+Unclear whether context carries over and whether the change is signaled visibly. A divider in the message stream ("Switched to Image Creator") would make it traceable.
+
+### 10. No agent personality preview
+
+Agents that differ in tone (Sales vs Researcher vs Assistant) look identical at the picker. One-line excerpts or example outputs would set expectations.
+
+### 11. Costs are invisible
+
+Some models cost meaningfully more per call. No preview before send, no running total, no "you've used $X this month." For paying teams, this is a glaring miss.
+
+### 12. End users can't tweak agents
+
+Only admins can create/edit. Power users with a niche need (different instructions, fewer tools) have no path. A "duplicate this agent and modify" affordance would unlock a lot.
+
+---
+
+## Framing for the design exploration
+
+The unifying principle behind most of these:
+
+> **Agents define a curated model space. The model picker is the result, not a generic chooser.**
+
+Once that framing lands — through reason-aware empty states (#3-style), capability strips (#2), and visible model attribution (#1) — most of the "why is my model gone" / "what does this agent do" confusion evaporates.
+
+The exploration in `untitled.pen` should focus on three small frames showing this principle in practice:
+
+1. Reason-aware empty state (the "no models available" rewrite)
+2. AI message bubble with the "via {model}" attribution chip (#1)
+3. Agent row with capability strip and model count (#2 + #5)
+
+Three frames, same design language, demonstrating the explicit-relationship pattern.

--- a/designs/platform/chat.pen
+++ b/designs/platform/chat.pen
@@ -229940,7 +229940,8 @@
                           "width": "fill_container",
                           "content": "Select messages and download in your preferred format.",
                           "fontFamily": "Inter",
-                          "fontSize": 13
+                          "fontSize": 13,
+                          "fontWeight": "normal"
                         }
                       ]
                     },
@@ -240423,6 +240424,10019 @@
       "width": 320,
       "height": 80,
       "content": "Popover used for adding categories — provides clear Cancel/Add actions, consistent with filter dropdown pattern, minimal footprint without disrupting the modal layout."
+    },
+    {
+      "type": "frame",
+      "id": "FKQqH",
+      "x": 56933,
+      "y": -2232,
+      "name": "Pages/Chat/Model Invalidated — Chat Agent",
+      "theme": {
+        "mode": "light"
+      },
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "$bg-color",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1,
+        "fill": "$border-primary"
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "EPxkF",
+          "x": 0,
+          "y": 0,
+          "name": "Chat Backdrop",
+          "width": 1280,
+          "height": 720,
+          "fill": "$bg-color",
+          "layout": "vertical",
+          "padding": 24,
+          "justifyContent": "end",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "QwPg7",
+              "name": "Composer",
+              "width": 768,
+              "height": 96,
+              "fill": "$surface-secondary",
+              "cornerRadius": 16,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-primary"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                16
+              ],
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hwbPr",
+                  "name": "Placeholder",
+                  "fill": "$text-tertiary",
+                  "content": "Ask anything…",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "g32vf",
+                  "name": "Composer Row",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ODnyd",
+                      "name": "Pickers",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UQvXi",
+                          "name": "Agent Pick",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "$border-primary"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            6,
+                            10,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "wGU06",
+                              "name": "Bot",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "bot",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jkuQc",
+                              "name": "Agent Label",
+                              "fill": "$text-primary",
+                              "content": "Assistant",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ppomt",
+                              "name": "Chevron",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-tertiary"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Yt9KJ",
+                          "name": "Model Pick",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "$border-primary"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            6,
+                            10,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Y6NyX3",
+                              "name": "Cpu",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "cpu",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DhsYV",
+                              "name": "Model Label",
+                              "fill": "$text-primary",
+                              "content": "Auto",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "yvHGR",
+                              "name": "Chevron",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-tertiary"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QVCRH",
+                      "name": "Send Btn",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$button-primary-bg",
+                      "cornerRadius": 16,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "m7i55y",
+                          "name": "Arrow",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrow-up",
+                          "iconFontFamily": "lucide",
+                          "fill": "$button-primary-text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "IjO6a",
+          "x": 920,
+          "y": 24,
+          "name": "Toast Slot",
+          "width": 340,
+          "layout": "vertical",
+          "children": [
+            {
+              "id": "Xmxah",
+              "type": "ref",
+              "ref": "1AyUW",
+              "name": "Model Swap Toast",
+              "width": 340,
+              "descendants": {
+                "3gyRX": {
+                  "iconFontName": "info",
+                  "fill": "$icon-primary"
+                },
+                "sQGAR": {
+                  "content": "Your model isn't available anymore"
+                },
+                "8WNYs": {
+                  "enabled": true,
+                  "content": "Now using Auto. Pick another from the model menu.",
+                  "fill": "$text-tertiary"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "note",
+      "id": "FyuUg",
+      "x": 58273,
+      "y": -2232,
+      "name": "Toast Rationale",
+      "width": 380,
+      "height": 0,
+      "content": "Model unavailability — UX rationale\n\nThree cases in code. Each has a different surface, not all use toasts.\n\n1) Mid-session model invalidation (CHAT agent)\nThe user's selected model becomes inaccessible while they're sitting in the chat — admin tightened the model_access policy, removed the provider, or edited the agent JSON. Backend silently clears the override and falls back to Auto. Toast acknowledges the change so the user isn't confused why the picker now reads 'Auto'.\n\n2) Mid-session model invalidation (IMAGE-GEN agent)\nSame trigger as case 1, but image-gen agents can't use Auto — they fall back to the first supported model (e.g. FLUX Kontext Pro). Toast names the specific model that took over so the user knows what their image generation is now using.\n\n3) Picker fully empty\nWhen filteredModels.length is 0, the dropdown itself shows the message — no toast. Branch the copy by cause so the user knows what to do:\n  • No providers configured → 'Connect a provider' + open Settings CTA.\n  • Capability mismatch → 'Image Creator needs image models' + add-provider CTA.\n  • Blocked by governance → 'Blocked by your organization. Ask an admin.'\n\nThe agent-switch scenario does NOT need a toast — model overrides are per-agent and persist independently. Switching agents shows the other agent's stored override (or its default), it doesn't lose anything."
+    },
+    {
+      "type": "frame",
+      "id": "VInTE",
+      "x": 56933,
+      "y": -1432,
+      "name": "Pages/Chat/Model Invalidated — Image Agent",
+      "theme": {
+        "mode": "light"
+      },
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "$bg-color",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1,
+        "fill": "$border-primary"
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "X2IAVO",
+          "x": 0,
+          "y": 0,
+          "name": "Chat Backdrop",
+          "width": 1280,
+          "height": 720,
+          "fill": "$bg-color",
+          "layout": "vertical",
+          "padding": 24,
+          "justifyContent": "end",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rXXNp",
+              "name": "Composer",
+              "width": 768,
+              "height": 96,
+              "fill": "$surface-secondary",
+              "cornerRadius": 16,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-primary"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                16
+              ],
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "J91E5B",
+                  "name": "Placeholder",
+                  "fill": "$text-tertiary",
+                  "content": "Generate or edit an image…",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "Qwg7N",
+                  "name": "Composer Row",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jsBDV",
+                      "name": "Pickers",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "N0YSLL",
+                          "name": "Agent Pick",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "$border-primary"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            6,
+                            10,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tHJvL",
+                              "name": "Bot",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "bot",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "agr4v",
+                              "name": "Agent Label",
+                              "fill": "$text-primary",
+                              "content": "Image Creator",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "UnVPL",
+                              "name": "Chevron",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-tertiary"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "PPK3e",
+                          "name": "Model Pick",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "$border-primary"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            6,
+                            10,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "baUo1",
+                              "name": "Cpu",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "cpu",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cVXcm",
+                              "name": "Model Label",
+                              "fill": "$text-primary",
+                              "content": "FLUX Kontext Pro",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "B8S4r",
+                              "name": "Chevron",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-tertiary"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vklyg",
+                      "name": "Send Btn",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$button-primary-bg",
+                      "cornerRadius": 16,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "wpCU4",
+                          "name": "Arrow",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "arrow-up",
+                          "iconFontFamily": "lucide",
+                          "fill": "$button-primary-text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "S0Dgd",
+          "x": 920,
+          "y": 24,
+          "name": "Toast Slot",
+          "width": 340,
+          "layout": "vertical",
+          "children": [
+            {
+              "id": "RI64f",
+              "type": "ref",
+              "ref": "1AyUW",
+              "name": "Model Swap Toast",
+              "width": 340,
+              "descendants": {
+                "3gyRX": {
+                  "iconFontName": "info",
+                  "fill": "$icon-primary"
+                },
+                "sQGAR": {
+                  "content": "Your model isn't available anymore"
+                },
+                "8WNYs": {
+                  "enabled": true,
+                  "content": "Now using FLUX Kontext Pro. Pick another from the model menu.",
+                  "fill": "$text-tertiary"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "YGF4J",
+      "x": 58273,
+      "y": -632,
+      "name": "Pages/Chat/AgentSelectorOpen",
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "#FFFFFF",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Dfk6N",
+          "x": 48,
+          "y": 0,
+          "name": "Main Content",
+          "clip": true,
+          "width": 1232,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1,
+              "left": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000008",
+            "offset": {
+              "x": 0,
+              "y": 2
+            },
+            "blur": 0.875
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "GSFbx",
+              "x": 0,
+              "y": 48,
+              "name": "Image Container",
+              "width": 1232,
+              "height": 672,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "beHfj",
+                  "name": "Frame 427298899",
+                  "width": 736,
+                  "height": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 24,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hyYOA",
+                      "name": "Frame 427298898",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 24,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "EAu5r",
+                          "name": "What are you working on?",
+                          "fill": "#111827",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "What are you working on?",
+                          "lineHeight": 1.25,
+                          "fontFamily": "Inter",
+                          "fontSize": 28,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.42
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hgLbn",
+                      "name": "Frame 427298892",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Vndkv",
+                          "name": "Frame 427298891",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "VrYhU",
+                              "name": "Frame 427298894",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "cHP0d",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Draft a project proposal for Q4",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ufAMg",
+                              "name": "Frame 427298895",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "KbFdF",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month’s revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "LsX1T",
+                              "name": "Frame 427298896",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pFxkm",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Write a follow-up email to the client",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "L6wxus",
+                              "name": "sug4",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Dtbdd",
+                                  "name": "sug4txt",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Summarize our latest product updates",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WNZYj",
+                  "name": "Chat Input",
+                  "width": 736,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": [
+                    16,
+                    16,
+                    0,
+                    0
+                  ],
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "right": 1,
+                      "left": 1
+                    },
+                    "fill": "#D1D5DB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000d",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 1.75
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "p68ye9",
+                      "name": "text-area",
+                      "width": "fill_container",
+                      "height": 72,
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vhLDQ",
+                          "name": "placeholder",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Can you summarize the latest customer feedback from last week?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.096
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pv036",
+                      "name": "bottom-bar",
+                      "width": "fill_container",
+                      "padding": [
+                        4,
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yQHJM",
+                          "name": "left-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "bv7Xw",
+                              "name": "add-button",
+                              "cornerRadius": 100,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "ZIMn3",
+                                  "name": "plus",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "paperclip",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "M1aL1I",
+                              "name": "bookmark-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "bookmark",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "a8ueUv",
+                              "name": "arena-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "swords",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "j1z2d",
+                              "name": "agent-selector",
+                              "fill": "#F3F4F6",
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "orqyC",
+                                  "name": "i2",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bot",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "AQmZ9",
+                                  "name": "agent-label",
+                                  "fill": "#374151",
+                                  "content": "Assistant",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "eIApH",
+                                  "name": "chevron-down",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "EAerO",
+                              "name": "model-selector",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "M23zdV",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cpu",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "s5tz5",
+                                  "fill": "#374151",
+                                  "content": "Opus 4.6",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "itpgR",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "r57asn",
+                          "name": "right-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "USJdb",
+                              "name": "mic-button",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "mic",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "qdVHy",
+                              "name": "send-button",
+                              "width": 32,
+                              "height": 32,
+                              "fill": [
+                                "#030712",
+                                {
+                                  "type": "gradient",
+                                  "gradientType": "linear",
+                                  "enabled": true,
+                                  "opacity": 0.16,
+                                  "rotation": -180,
+                                  "size": {
+                                    "height": 1
+                                  },
+                                  "colors": [
+                                    {
+                                      "color": "#ffffffff",
+                                      "position": 0
+                                    },
+                                    {
+                                      "color": "#ffffff00",
+                                      "position": 1
+                                    }
+                                  ]
+                                }
+                              ],
+                              "cornerRadius": 9999,
+                              "padding": [
+                                10,
+                                16
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "yS4Uo",
+                                  "name": "send-horizontal",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "arrow-up",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qua99",
+              "x": 0,
+              "y": 0,
+              "name": "Header",
+              "width": 1232,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 7
+              },
+              "padding": [
+                8,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SBvh2",
+                  "name": "Frame 427298262",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "knfpi",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 0
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "O95gJ",
+                          "name": "clock-4",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "clock-4",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4B5563"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "glUX1",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "o1fpK",
+                          "name": "i1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Oqk1z",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "pKsKI",
+                          "name": "p1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "square-pen",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bjyaF",
+              "x": 353,
+              "y": 419,
+              "name": "Tooltip - Add files",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q0U83",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S7Vi3",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Add files",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s89nd",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KPB6Y",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "tw7dn",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OTJit",
+              "x": 704,
+              "y": 375,
+              "name": "Agent Selector Dropdown",
+              "clip": true,
+              "width": 260,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 1.75
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UYoF1",
+                  "name": "search",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "EsHnC",
+                      "name": "search",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "GYB0B",
+                      "name": "Search agents...",
+                      "fill": "#9CA3AF",
+                      "content": "Search agents...",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                      "letterSpacing": -0.0840000033378601
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yvTnN",
+                  "name": "Frame 427298908",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "padding": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zHE78",
+                      "name": "Frame 427298906",
+                      "width": "fill_container",
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 12,
+                      "padding": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hvzRm",
+                          "name": "Frame 427298904",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "u3FhwK",
+                              "name": "Assistant",
+                              "fill": "#030712",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Assistant",
+                              "lineHeight": 1.1428571428571428,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.0840000033378601
+                            },
+                            {
+                              "type": "text",
+                              "id": "buJTm",
+                              "name": "General-purpose AI assistant",
+                              "fill": "#6B7280",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "General-purpose AI assistant",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.07200000286102295
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "B9us9",
+                          "name": "check",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#030712"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XgVt2",
+                      "name": "Frame 427298907",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 12,
+                      "padding": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WHrRP",
+                          "name": "Frame 427298904",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lSkBS",
+                              "name": "Assistant",
+                              "fill": "#030712",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Assistant - Opus-4-6",
+                              "lineHeight": 1.1428571428571428,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.0840000033378601
+                            },
+                            {
+                              "type": "text",
+                              "id": "f8Eno",
+                              "name": "General-purpose AI assistant",
+                              "fill": "#6B7280",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Advanced reasoning model",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.07200000286102295
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hIGu1",
+                      "name": "Frame 427298908",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 12,
+                      "padding": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Wemfh",
+                          "name": "Frame 427298904",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D3avUx",
+                              "name": "Assistant",
+                              "fill": "#030712",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "fast rag test",
+                              "lineHeight": 1.1428571428571428,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.0840000033378601
+                            },
+                            {
+                              "type": "text",
+                              "id": "kt9Bs",
+                              "name": "General-purpose AI assistant",
+                              "fill": "#6B7280",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "RAG-powered search assistant",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.07200000286102295
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m14qs",
+                      "name": "agent4l",
+                      "width": "fill_container",
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": 12,
+                      "padding": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "f1C5IP",
+                          "name": "agent4ltxt",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "f5hnIP",
+                              "name": "agent4lname",
+                              "fill": "#030712",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "QA Tester Agent",
+                              "lineHeight": 1.1428571428571428,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.084
+                            },
+                            {
+                              "type": "text",
+                              "id": "QnrHh",
+                              "name": "agent4ldesc",
+                              "fill": "#6B7280",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Automated testing specialist",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.072
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mY3JP",
+                  "name": "sepl",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#E5E7EB"
+                },
+                {
+                  "type": "frame",
+                  "id": "D7H0q",
+                  "name": "addRowL",
+                  "width": "fill_container",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Efflb",
+                      "name": "addIconL",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Movmy",
+                      "name": "addTextL",
+                      "fill": "#374151",
+                      "content": "Add agent",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.084
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "tFsij",
+          "x": 55,
+          "y": 92.5,
+          "name": "Tooltip - Chat with AI",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "hioB3",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "p9rG8V",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Chat with AI",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "z0rUVU",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "u3nGvn",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "zX7yX",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "AZCOH",
+          "x": 55,
+          "y": 172.5,
+          "name": "Tooltip - Knowledge",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "zXIV4",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "GZts9",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Knowledge",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "ZM0GJ",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SKmS5",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "u2Gqx",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jTwCr",
+          "x": 55,
+          "y": 132.5,
+          "name": "Tooltip - Conversations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "eoIWU",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "A9T7A",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Conversations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "KKXdW",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "n0evJJ",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "HiLaR",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dlBXX",
+          "x": 55,
+          "y": 212.5,
+          "name": "Tooltip - Approvals",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "VgYEA",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "z3fV0",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Approvals",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "W9yO4s",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "GP7pV",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "A4CQNx",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "X570N",
+          "x": 55,
+          "y": 292,
+          "name": "Tooltip - Automations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "DBVAf",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "GXc4E",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Automations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "Kw7Lh",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "I7nGz",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "C3KCG",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "gFlKN",
+          "x": 55,
+          "y": 252,
+          "name": "Tooltip - Custom agent",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "h9VKl9",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "nOGHh",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Custom agent",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "J7Ca4h",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V0w1d",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "WsRN4",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "SdQBh",
+          "x": 55,
+          "y": 684,
+          "name": "Tooltip - Settings",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "S6bFpE",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "O8r5Kn",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Settings and more",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "s7qDbA",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Jdkan",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "DvD86",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "C4hsi",
+          "x": 0,
+          "y": 0,
+          "name": "Side bar",
+          "width": 48,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "FyUOW",
+              "name": "talelogo 1",
+              "clip": true,
+              "width": 48,
+              "height": 48,
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                10,
+                8,
+                12,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S7jOls",
+                  "name": "Menu Item/Default",
+                  "clip": true,
+                  "width": 32,
+                  "height": 32,
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "group",
+                      "id": "jVu9x",
+                      "name": "Group 1",
+                      "flipX": true,
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "jCLCh",
+                          "x": 0,
+                          "y": 9.494771003723145,
+                          "name": "Vector",
+                          "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                          "fill": "#060809",
+                          "width": 18.81279945373535,
+                          "height": 16.505352020263672,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        },
+                        {
+                          "type": "path",
+                          "id": "dlAwc",
+                          "x": 7.188720703125,
+                          "y": 0,
+                          "name": "Vector",
+                          "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                          "fill": "#060809",
+                          "width": 18.814611434936523,
+                          "height": 16.50131607055664,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "S98T21",
+              "name": "Frame 427298167",
+              "height": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                36,
+                8,
+                16,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "LMir3",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "xN2QT",
+                      "name": "message-circle",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "message-circle",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WSTOs",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "w4YgyC",
+                      "name": "inbox",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "inbox",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ovFEj",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QsDN0",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "s2pv4",
+                      "name": "brain",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "brain",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zWClu",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "qsCIg",
+                      "name": "circle-check",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-check",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BN0jH",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ROlil",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "mckEX",
+                      "name": "bot",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "bot",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "a1Oui2",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "mvPV7",
+                      "name": "network",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "network",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ky0N7",
+              "name": "Frame 427298178",
+              "width": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 10,
+              "padding": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IPY5I",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "daVfr",
+                      "name": "circle-user-round",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-user-round",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "hfafK",
+          "x": 7,
+          "y": 435,
+          "name": "user profile pop up",
+          "enabled": false,
+          "clip": true,
+          "width": 217,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000d",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 5.25
+          },
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Am6Sx",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#f3f4f6ff",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "v2aeB",
+                  "name": "Frame 427298659",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "j1KVz",
+                      "name": "Text",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Thelma nader",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JyuX7",
+                      "name": "Text",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "thelma.nader@company.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "idVFI",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "R5NPyj",
+                  "name": "settings",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "vRYCw",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Settings",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MkBWU",
+              "name": "Frame 427298641",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1,
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EIaOH",
+                  "name": "Frame 427298637",
+                  "width": "fill_container",
+                  "fill": "#F9FAFB",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "I0LEdy",
+                      "name": "monitor",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "monitor",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "y1rvB",
+                  "name": "Frame 427298640",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "M8oTN",
+                      "name": "sun",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sun",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B6pI2E",
+                  "name": "Frame 427298639",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "C0Vh4",
+                      "name": "moon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "moon",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AonTL",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "tgGKG",
+                  "name": "circle-help",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "circle-help",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "cSfSH",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Help & feedback",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ka3j3",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "w9eGMW",
+                  "name": "log-out",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "log-out",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "KpMH3",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Log out",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GvNtv",
+          "x": 104,
+          "y": 443,
+          "name": "Tooltip - User",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "V9fpn4",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "edAWx",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Thelma Nader - Admin",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "RT1iy",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "I5cfX",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "O6ojd2",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "lADft",
+      "x": 56933,
+      "y": -632,
+      "name": "Pages/Chat/Model Picker Empty — No Providers",
+      "theme": {
+        "mode": "light"
+      },
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "#FFFFFF",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "sUXTg",
+          "x": 48,
+          "y": 0,
+          "name": "Main Content",
+          "clip": true,
+          "width": 1232,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1,
+              "left": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000008",
+            "offset": {
+              "x": 0,
+              "y": 2
+            },
+            "blur": 0.875
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "CFGvC",
+              "x": 0,
+              "y": 48,
+              "name": "Image Container",
+              "width": 1232,
+              "height": 672,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "bufBu",
+                  "name": "Frame 427298899",
+                  "width": 736,
+                  "height": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 24,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ue7Xo",
+                      "name": "Frame 427298898",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 24,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kPOzT",
+                          "name": "What are you working on?",
+                          "fill": "#111827",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "What are you working on?",
+                          "lineHeight": 1.25,
+                          "fontFamily": "Inter",
+                          "fontSize": 28,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.42
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "y37GXK",
+                      "name": "Frame 427298892",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "mw09t",
+                          "name": "Frame 427298891",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iVNfx",
+                              "name": "Frame 427298894",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "IqwF0",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Draft a project proposal for Q4",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Hdq6O",
+                              "name": "Frame 427298895",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "drxpg",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month’s revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "AxMgP",
+                              "name": "Frame 427298896",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "fBzPo",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Write a follow-up email to the client",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "g5HzGp",
+                              "name": "sug4",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "HOmLn",
+                                  "name": "sug4txt",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Summarize our latest product updates",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c20mp",
+                  "name": "Chat Input",
+                  "width": 736,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": [
+                    16,
+                    16,
+                    0,
+                    0
+                  ],
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "right": 1,
+                      "left": 1
+                    },
+                    "fill": "#D1D5DB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000d",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 1.75
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fUiTS",
+                      "name": "text-area",
+                      "width": "fill_container",
+                      "height": 72,
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZjCiG",
+                          "name": "placeholder",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Can you summarize the latest customer feedback from last week?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.096
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E2z7v",
+                      "name": "bottom-bar",
+                      "width": "fill_container",
+                      "padding": [
+                        4,
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vFxyb",
+                          "name": "left-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Z1vqY",
+                              "name": "add-button",
+                              "cornerRadius": 100,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "U1wGt",
+                                  "name": "plus",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "paperclip",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "YuB0d",
+                              "name": "bookmark-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "bookmark",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "SCJkR",
+                              "name": "arena-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "swords",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "PHCLw",
+                              "name": "agent-selector",
+                              "fill": "#F3F4F6",
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "p9SY1Q",
+                                  "name": "i2",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bot",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pP5ND",
+                                  "name": "agent-label",
+                                  "fill": "#374151",
+                                  "content": "Assistant",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "pHl9E",
+                                  "name": "chevron-down",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "y40ZEf",
+                              "name": "model-selector",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "q9Ru7Y",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cpu",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fZtdS",
+                                  "fill": "#374151",
+                                  "content": "Opus 4.6",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "EouIu",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Z272F9",
+                          "name": "right-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dbrhm",
+                              "name": "mic-button",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "mic",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "TXyRf",
+                              "name": "send-button",
+                              "width": 32,
+                              "height": 32,
+                              "fill": [
+                                "#030712",
+                                {
+                                  "type": "gradient",
+                                  "gradientType": "linear",
+                                  "enabled": true,
+                                  "opacity": 0.16,
+                                  "rotation": -180,
+                                  "size": {
+                                    "height": 1
+                                  },
+                                  "colors": [
+                                    {
+                                      "color": "#ffffffff",
+                                      "position": 0
+                                    },
+                                    {
+                                      "color": "#ffffff00",
+                                      "position": 1
+                                    }
+                                  ]
+                                }
+                              ],
+                              "cornerRadius": 9999,
+                              "padding": [
+                                10,
+                                16
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "VfFNA",
+                                  "name": "send-horizontal",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "arrow-up",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TpTid",
+              "x": 0,
+              "y": 0,
+              "name": "Header",
+              "width": 1232,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 7
+              },
+              "padding": [
+                8,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cbWhB",
+                  "name": "Frame 427298262",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y3kYoD",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 0
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "IKNvb",
+                          "name": "clock-4",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "clock-4",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4B5563"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gagxe",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "opSBF",
+                          "name": "i1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fbDO6",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "oXbwa",
+                          "name": "p1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "square-pen",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "H7LFWe",
+              "x": 353,
+              "y": 419,
+              "name": "Tooltip - Add files",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o0fTs6",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OLqFS",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Add files",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E6jOO",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zXIs9",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "y9IXa0",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Q0h7x",
+              "x": 460,
+              "y": 374,
+              "name": "Agent Selector Dropdown",
+              "clip": true,
+              "width": 260,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 1.75
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zB5XS",
+                  "name": "search",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "U08MH",
+                      "name": "search",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dxqm7",
+                      "name": "Search agents...",
+                      "fill": "#9CA3AF",
+                      "content": "Search models...",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                      "letterSpacing": -0.0840000033378601
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FGfFm",
+                  "name": "Empty State",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "layout": "vertical",
+                  "gap": 14,
+                  "padding": [
+                    60,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "J9j2d",
+                      "name": "Icon",
+                      "width": 24,
+                      "height": 24,
+                      "iconFontName": "plug",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "MoOKf",
+                      "name": "Title",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "No models available",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "CAVL0",
+                      "name": "Desc",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Connect a provider to get started.",
+                      "lineHeight": 1.4,
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "p4PjCq",
+                      "name": "CTA",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E7EB"
+                      },
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Leh04",
+                          "name": "CTA Label",
+                          "fill": "#030712",
+                          "content": "Open settings →",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xrmez",
+                  "name": "sepl",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#E5E7EB"
+                },
+                {
+                  "type": "frame",
+                  "id": "Drbyc",
+                  "x": 0,
+                  "y": 249,
+                  "name": "addRowL",
+                  "enabled": false,
+                  "width": "fill_container(260)",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "eLmxs",
+                      "name": "addIconL",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eCEeV",
+                      "name": "addTextL",
+                      "fill": "#374151",
+                      "content": "Add agent",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.084
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "d0SORw",
+          "x": 55,
+          "y": 92.5,
+          "name": "Tooltip - Chat with AI",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "JAPTB",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Lj89e",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Chat with AI",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "lT6Ol",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wdQWp",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "o1USb",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fVeXH",
+          "x": 55,
+          "y": 172.5,
+          "name": "Tooltip - Knowledge",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "FFY6O",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "a92hv",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Knowledge",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "CoP2m",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "FO7IW",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "rRjnV",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ycPbA",
+          "x": 55,
+          "y": 132.5,
+          "name": "Tooltip - Conversations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "RK910",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "obXcG",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Conversations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "ZuUpE",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yFfRD",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "bPSfy",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "PqOoz",
+          "x": 55,
+          "y": 212.5,
+          "name": "Tooltip - Approvals",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "KC169",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "MMKq0",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Approvals",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "oEbXF",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "TLjW4",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "DuPyK",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "P6111a",
+          "x": 55,
+          "y": 292,
+          "name": "Tooltip - Automations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "my6d6",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "IaejH",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Automations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "Jz5Cn",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "dW7rF",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "nF9Mq",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "sLzyV",
+          "x": 55,
+          "y": 252,
+          "name": "Tooltip - Custom agent",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Q0f538",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "F0QCyV",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Custom agent",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "F7i8Mm",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tNBcv",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "Cgkqk",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "l5twis",
+          "x": 55,
+          "y": 684,
+          "name": "Tooltip - Settings",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Wqrft",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "miZah",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Settings and more",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "sjf85",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "YmVM6",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "NctrO",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "yYndM",
+          "x": 0,
+          "y": 0,
+          "name": "Side bar",
+          "width": 48,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "rPEq9",
+              "name": "talelogo 1",
+              "clip": true,
+              "width": 48,
+              "height": 48,
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                10,
+                8,
+                12,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QV9qv",
+                  "name": "Menu Item/Default",
+                  "clip": true,
+                  "width": 32,
+                  "height": 32,
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "group",
+                      "id": "fISXm",
+                      "name": "Group 1",
+                      "flipX": true,
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "BnX3D",
+                          "x": 0,
+                          "y": 9.494771003723145,
+                          "name": "Vector",
+                          "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                          "fill": "#060809",
+                          "width": 18.81279945373535,
+                          "height": 16.505352020263672,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        },
+                        {
+                          "type": "path",
+                          "id": "oXaD4",
+                          "x": 7.188720703125,
+                          "y": 0,
+                          "name": "Vector",
+                          "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                          "fill": "#060809",
+                          "width": 18.814611434936523,
+                          "height": 16.50131607055664,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EFyi8",
+              "name": "Frame 427298167",
+              "height": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                36,
+                8,
+                16,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SLnR0",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "h0o60U",
+                      "name": "message-circle",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "message-circle",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r7dY3",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "EzYWD",
+                      "name": "inbox",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "inbox",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cbPlD",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "S0PI1r",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "d1TI3",
+                      "name": "brain",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "brain",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Xy5OD",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "HKKeV",
+                      "name": "circle-check",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-check",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XGVuO",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "z9pyPo",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "G65iYU",
+                      "name": "bot",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "bot",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tS8CJ",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "VArjy",
+                      "name": "network",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "network",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "e3wxRg",
+              "name": "Frame 427298178",
+              "width": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 10,
+              "padding": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "W2Df2Q",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "M6Shw",
+                      "name": "circle-user-round",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-user-round",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "D9mSI",
+          "x": 7,
+          "y": 435,
+          "name": "user profile pop up",
+          "enabled": false,
+          "clip": true,
+          "width": 217,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000d",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 5.25
+          },
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "dujTt",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#f3f4f6ff",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YM1zb",
+                  "name": "Frame 427298659",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fraxe",
+                      "name": "Text",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Thelma nader",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "F6HCW7",
+                      "name": "Text",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "thelma.nader@company.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mQ2tm",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "qhpt9",
+                  "name": "settings",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "Bkb1t",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Settings",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "U0COAS",
+              "name": "Frame 427298641",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1,
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S7l3q",
+                  "name": "Frame 427298637",
+                  "width": "fill_container",
+                  "fill": "#F9FAFB",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "EdA1U",
+                      "name": "monitor",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "monitor",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KuHvt",
+                  "name": "Frame 427298640",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "A0L4t",
+                      "name": "sun",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sun",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "P08EH",
+                  "name": "Frame 427298639",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "U1rPN",
+                      "name": "moon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "moon",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "U6WEc",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "fRRsq",
+                  "name": "circle-help",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "circle-help",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "uO6Zm",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Help & feedback",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LMGYb",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "eJzwA",
+                  "name": "log-out",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "log-out",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "sAaFw",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Log out",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "miNKo",
+          "x": 104,
+          "y": 443,
+          "name": "Tooltip - User",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "VfcI5",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Q6uOjS",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Thelma Nader - Admin",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "GWTl3",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "s58sI",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "beVgO",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "a82BQ",
+      "x": 56933,
+      "y": 168,
+      "name": "Pages/Chat/Model Picker Empty — Capability Mismatch",
+      "theme": {
+        "mode": "light"
+      },
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "#FFFFFF",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Ill3K",
+          "x": 48,
+          "y": 0,
+          "name": "Main Content",
+          "clip": true,
+          "width": 1232,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1,
+              "left": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000008",
+            "offset": {
+              "x": 0,
+              "y": 2
+            },
+            "blur": 0.875
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "qcJxw",
+              "x": 0,
+              "y": 48,
+              "name": "Image Container",
+              "width": 1232,
+              "height": 672,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "J6qxX",
+                  "name": "Frame 427298899",
+                  "width": 736,
+                  "height": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 24,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gCkWF",
+                      "name": "Frame 427298898",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 24,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "seJPn",
+                          "name": "What are you working on?",
+                          "fill": "#111827",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "What are you working on?",
+                          "lineHeight": 1.25,
+                          "fontFamily": "Inter",
+                          "fontSize": 28,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.42
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LP1PM",
+                      "name": "Frame 427298892",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BZrWC",
+                          "name": "Frame 427298891",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "pnFSV",
+                              "name": "Frame 427298894",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "L9BjA",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Draft a project proposal for Q4",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "a76ovK",
+                              "name": "Frame 427298895",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "FsZVL",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month’s revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "A7ogs",
+                              "name": "Frame 427298896",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TLyXo",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Write a follow-up email to the client",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "y1AlKL",
+                              "name": "sug4",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "jc5yB",
+                                  "name": "sug4txt",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Summarize our latest product updates",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FqZI6",
+                  "name": "Chat Input",
+                  "width": 736,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": [
+                    16,
+                    16,
+                    0,
+                    0
+                  ],
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "right": 1,
+                      "left": 1
+                    },
+                    "fill": "#D1D5DB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000d",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 1.75
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "r3oJQY",
+                      "name": "text-area",
+                      "width": "fill_container",
+                      "height": 72,
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "N7YgD",
+                          "name": "placeholder",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Can you summarize the latest customer feedback from last week?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.096
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OGcyI",
+                      "name": "bottom-bar",
+                      "width": "fill_container",
+                      "padding": [
+                        4,
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tkDhI",
+                          "name": "left-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "h4gz6",
+                              "name": "add-button",
+                              "cornerRadius": 100,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "t7ZkxF",
+                                  "name": "plus",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "paperclip",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "jI6hX",
+                              "name": "bookmark-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "bookmark",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "DqyDS",
+                              "name": "arena-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "swords",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Zq1YZ",
+                              "name": "agent-selector",
+                              "fill": "#F3F4F6",
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "o4MIn",
+                                  "name": "i2",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bot",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "xTYOn",
+                                  "name": "agent-label",
+                                  "fill": "#374151",
+                                  "content": "Assistant",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "e9MVn",
+                                  "name": "chevron-down",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lsr1R",
+                              "name": "model-selector",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "x820qX",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cpu",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "p2yxp6",
+                                  "fill": "#374151",
+                                  "content": "Opus 4.6",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "xLX9A",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Y0Y8K",
+                          "name": "right-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "F0DuM",
+                              "name": "mic-button",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "mic",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QIaGd",
+                              "name": "send-button",
+                              "width": 32,
+                              "height": 32,
+                              "fill": [
+                                "#030712",
+                                {
+                                  "type": "gradient",
+                                  "gradientType": "linear",
+                                  "enabled": true,
+                                  "opacity": 0.16,
+                                  "rotation": -180,
+                                  "size": {
+                                    "height": 1
+                                  },
+                                  "colors": [
+                                    {
+                                      "color": "#ffffffff",
+                                      "position": 0
+                                    },
+                                    {
+                                      "color": "#ffffff00",
+                                      "position": 1
+                                    }
+                                  ]
+                                }
+                              ],
+                              "cornerRadius": 9999,
+                              "padding": [
+                                10,
+                                16
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "N2WIt3",
+                                  "name": "send-horizontal",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "arrow-up",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F0D4K2",
+              "x": 0,
+              "y": 0,
+              "name": "Header",
+              "width": 1232,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 7
+              },
+              "padding": [
+                8,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "K4WfgM",
+                  "name": "Frame 427298262",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xu0xI",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 0
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cMnSh",
+                          "name": "clock-4",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "clock-4",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4B5563"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RRqyA",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "P0B2hV",
+                          "name": "i1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Y2Rer",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "nnB1F",
+                          "name": "p1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "square-pen",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ME7BQ",
+              "x": 353,
+              "y": 419,
+              "name": "Tooltip - Add files",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f7wYw",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fydZ4",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Add files",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "j1U7m",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "oGTid",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "u9Y58",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UYpK4",
+              "x": 460,
+              "y": 335,
+              "name": "Agent Selector Dropdown",
+              "clip": true,
+              "width": 260,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 1.75
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZOcNB",
+                  "name": "search",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "fHbC1",
+                      "name": "search",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "WKiXi",
+                      "name": "Search agents...",
+                      "fill": "#9CA3AF",
+                      "content": "Search models...",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                      "letterSpacing": -0.0840000033378601
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Jiwm8",
+                  "name": "Empty State",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "layout": "vertical",
+                  "gap": 14,
+                  "padding": [
+                    60,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Z96io",
+                      "name": "Icon",
+                      "width": 24,
+                      "height": 24,
+                      "iconFontName": "image",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "A1R99x",
+                      "name": "Title",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Image Creator needs image models",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eFU47",
+                      "name": "Desc",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "None of your providers offer image-generation models.",
+                      "lineHeight": 1.4,
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VLMHG",
+                      "name": "CTA",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E7EB"
+                      },
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rCLP6",
+                          "name": "CTA Label",
+                          "fill": "#030712",
+                          "content": "Add a provider →",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HM2DB",
+                  "name": "sepl",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#E5E7EB"
+                },
+                {
+                  "type": "frame",
+                  "id": "WztVc",
+                  "x": 0,
+                  "y": 249,
+                  "name": "addRowL",
+                  "enabled": false,
+                  "width": "fill_container(260)",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "SmKfw",
+                      "name": "addIconL",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yy6UU",
+                      "name": "addTextL",
+                      "fill": "#374151",
+                      "content": "Add agent",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.084
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NR2oP",
+          "x": 55,
+          "y": 92.5,
+          "name": "Tooltip - Chat with AI",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "MgsWF",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "FBPNG",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Chat with AI",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "cywzI",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "jheu9",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "NhRTO",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "U3xllB",
+          "x": 55,
+          "y": 172.5,
+          "name": "Tooltip - Knowledge",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "C8PCY",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hgyyS",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Knowledge",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "x85MLZ",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "s2ilN",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "yBb0x",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "w4Y2V6",
+          "x": 55,
+          "y": 132.5,
+          "name": "Tooltip - Conversations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yNdir",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Sp6QX",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Conversations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "Qe7cS",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "K3sRSm",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "h4tKHx",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Tktjy",
+          "x": 55,
+          "y": 212.5,
+          "name": "Tooltip - Approvals",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Fvgla",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "qnoHh",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Approvals",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "E4vOo",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Fc7Iy",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "lHnAw",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "r9D5hk",
+          "x": 55,
+          "y": 292,
+          "name": "Tooltip - Automations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tPVUs",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "XTviv",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Automations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "u6Tyma",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Od1Yj",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "gChma",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NNdPl",
+          "x": 55,
+          "y": 252,
+          "name": "Tooltip - Custom agent",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "M5SrKI",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "UhIeI",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Custom agent",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "cXpP2",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vKMRI",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "EHrbb",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NiQwh",
+          "x": 55,
+          "y": 684,
+          "name": "Tooltip - Settings",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "h0VsD",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "d0m7d",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Settings and more",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "BkGDw",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SzB4D",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "yZdzz",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "wHYP6",
+          "x": 0,
+          "y": 0,
+          "name": "Side bar",
+          "width": 48,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "o7CS0",
+              "name": "talelogo 1",
+              "clip": true,
+              "width": 48,
+              "height": 48,
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                10,
+                8,
+                12,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "yVaac",
+                  "name": "Menu Item/Default",
+                  "clip": true,
+                  "width": 32,
+                  "height": 32,
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "group",
+                      "id": "j8ud0",
+                      "name": "Group 1",
+                      "flipX": true,
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "sIUCp",
+                          "x": 0,
+                          "y": 9.494771003723145,
+                          "name": "Vector",
+                          "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                          "fill": "#060809",
+                          "width": 18.81279945373535,
+                          "height": 16.505352020263672,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        },
+                        {
+                          "type": "path",
+                          "id": "xKLVw",
+                          "x": 7.188720703125,
+                          "y": 0,
+                          "name": "Vector",
+                          "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                          "fill": "#060809",
+                          "width": 18.814611434936523,
+                          "height": 16.50131607055664,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dsTfi",
+              "name": "Frame 427298167",
+              "height": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                36,
+                8,
+                16,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "x2GGEx",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wj1kX",
+                      "name": "message-circle",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "message-circle",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r1MiqM",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "v2LSo",
+                      "name": "inbox",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "inbox",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lQ5fz",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gmP1P",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "x82Mt",
+                      "name": "brain",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "brain",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ce0Tw",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FxCML",
+                      "name": "circle-check",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-check",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "D3MPu",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Qm7TA",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "D6U6y8",
+                      "name": "bot",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "bot",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yxgAp",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "BZbyI",
+                      "name": "network",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "network",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hylxi",
+              "name": "Frame 427298178",
+              "width": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 10,
+              "padding": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Ei3zi",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Mgthm",
+                      "name": "circle-user-round",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-user-round",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "AHLUh",
+          "x": 7,
+          "y": 435,
+          "name": "user profile pop up",
+          "enabled": false,
+          "clip": true,
+          "width": 217,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000d",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 5.25
+          },
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "m0O2Ef",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#f3f4f6ff",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qePUE",
+                  "name": "Frame 427298659",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "WwWhD",
+                      "name": "Text",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Thelma nader",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "C4S9h",
+                      "name": "Text",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "thelma.nader@company.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uEhI4",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "XRxrd",
+                  "name": "settings",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "hBXna",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Settings",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "L8W2mo",
+              "name": "Frame 427298641",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1,
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sgO7x",
+                  "name": "Frame 427298637",
+                  "width": "fill_container",
+                  "fill": "#F9FAFB",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "D4DEbj",
+                      "name": "monitor",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "monitor",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e7UxBP",
+                  "name": "Frame 427298640",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "CZUGL",
+                      "name": "sun",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sun",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "edEbl",
+                  "name": "Frame 427298639",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "l5HgG",
+                      "name": "moon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "moon",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nzzvy",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "DlvWI",
+                  "name": "circle-help",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "circle-help",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "ftJ4Z",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Help & feedback",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "k8PSsw",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "CwOIT",
+                  "name": "log-out",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "log-out",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "HX1qE",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Log out",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "k12Dp",
+          "x": 104,
+          "y": 443,
+          "name": "Tooltip - User",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Qs1SL",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "l5VilS",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Thelma Nader - Admin",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "vJR5E",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JIh7D",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "nayAx",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ghTSX",
+      "x": 56933,
+      "y": 968,
+      "name": "Pages/Chat/Model Picker Empty — Blocked by Governance",
+      "theme": {
+        "mode": "light"
+      },
+      "clip": true,
+      "width": 1280,
+      "height": 720,
+      "fill": "#FFFFFF",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "wXkZ3",
+          "x": 48,
+          "y": 0,
+          "name": "Main Content",
+          "clip": true,
+          "width": 1232,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1,
+              "left": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000008",
+            "offset": {
+              "x": 0,
+              "y": 2
+            },
+            "blur": 0.875
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "bSXkS",
+              "x": 0,
+              "y": 48,
+              "name": "Image Container",
+              "width": 1232,
+              "height": 672,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UssbB",
+                  "name": "Frame 427298899",
+                  "width": 736,
+                  "height": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 24,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Y52AW",
+                      "name": "Frame 427298898",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": 24,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W8v3sd",
+                          "name": "What are you working on?",
+                          "fill": "#111827",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "What are you working on?",
+                          "lineHeight": 1.25,
+                          "fontFamily": "Inter",
+                          "fontSize": 28,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.42
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Nfwh6",
+                      "name": "Frame 427298892",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NtsgD",
+                          "name": "Frame 427298891",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "T9oJF",
+                              "name": "Frame 427298894",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "i3p7E",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Draft a project proposal for Q4",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rxBnB",
+                              "name": "Frame 427298895",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "sSUq2",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Analyze last month’s revenue trends",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "GmYvf",
+                              "name": "Frame 427298896",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "y1LZH",
+                                  "name": "Summarize last 5 emails",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Write a follow-up email to the client",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "K7FjU",
+                              "name": "sug4",
+                              "width": "fill_container",
+                              "fill": "#00000000",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#E5E7EB"
+                              },
+                              "layout": "vertical",
+                              "gap": 8,
+                              "padding": [
+                                14,
+                                0
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "m7oALU",
+                                  "name": "sug4txt",
+                                  "fill": "#374151",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Summarize our latest product updates",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "normal",
+                                  "letterSpacing": -0.084
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "a4xiO",
+                  "name": "Chat Input",
+                  "width": 736,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": [
+                    16,
+                    16,
+                    0,
+                    0
+                  ],
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "right": 1,
+                      "left": 1
+                    },
+                    "fill": "#D1D5DB"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000d",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 1.75
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "b6IcCE",
+                      "name": "text-area",
+                      "width": "fill_container",
+                      "height": 72,
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eUoDj",
+                          "name": "placeholder",
+                          "fill": "#030712",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Can you summarize the latest customer feedback from last week?",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "normal",
+                          "letterSpacing": -0.096
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xUdAi",
+                      "name": "bottom-bar",
+                      "width": "fill_container",
+                      "padding": [
+                        4,
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Vx9ox",
+                          "name": "left-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iq57d",
+                              "name": "add-button",
+                              "cornerRadius": 100,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "L1cbOX",
+                                  "name": "plus",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "paperclip",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "A74cw",
+                              "name": "bookmark-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "bookmark",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "m58o5z",
+                              "name": "arena-icon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "swords",
+                              "iconFontFamily": "lucide",
+                              "fill": "$icon-primary"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rO9Xc",
+                              "name": "agent-selector",
+                              "fill": "#F3F4F6",
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "kWdFS",
+                                  "name": "i2",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "bot",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WteRG",
+                                  "name": "agent-label",
+                                  "fill": "#374151",
+                                  "content": "Assistant",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "ULuYI",
+                                  "name": "chevron-down",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "El7Mk",
+                              "name": "model-selector",
+                              "fill": {
+                                "type": "color",
+                                "color": "#F3F4F6",
+                                "enabled": false
+                              },
+                              "cornerRadius": 6,
+                              "gap": 4,
+                              "padding": [
+                                4,
+                                6
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "HmoNd",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "cpu",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#374151"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "t4NGK",
+                                  "fill": "#374151",
+                                  "content": "Opus 4.6",
+                                  "lineHeight": 1.4285714285714286,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500",
+                                  "letterSpacing": -0.084
+                                },
+                                {
+                                  "type": "icon_font",
+                                  "id": "OIVuC",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "chevron-down",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#6B7280"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "IKcRF",
+                          "name": "right-group",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "jr2la",
+                              "name": "mic-button",
+                              "width": 20,
+                              "height": 20,
+                              "iconFontName": "mic",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6B7280"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "sD5LW",
+                              "name": "send-button",
+                              "width": 32,
+                              "height": 32,
+                              "fill": [
+                                "#030712",
+                                {
+                                  "type": "gradient",
+                                  "gradientType": "linear",
+                                  "enabled": true,
+                                  "opacity": 0.16,
+                                  "rotation": -180,
+                                  "size": {
+                                    "height": 1
+                                  },
+                                  "colors": [
+                                    {
+                                      "color": "#ffffffff",
+                                      "position": 0
+                                    },
+                                    {
+                                      "color": "#ffffff00",
+                                      "position": 1
+                                    }
+                                  ]
+                                }
+                              ],
+                              "cornerRadius": 9999,
+                              "padding": [
+                                10,
+                                16
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "biggo",
+                                  "name": "send-horizontal",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "arrow-up",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFFFFF"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iTDi7",
+              "x": 0,
+              "y": 0,
+              "name": "Header",
+              "width": 1232,
+              "fill": "#FFFFFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": 0,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 7
+              },
+              "padding": [
+                8,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZkeAD",
+                  "name": "Frame 427298262",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GmqIE",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "fill": {
+                        "type": "color",
+                        "color": "#F3F4F6",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 0
+                      },
+                      "gap": 8,
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "AE1F7",
+                          "name": "clock-4",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "clock-4",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4B5563"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i7EazI",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "aGgbp",
+                          "name": "i1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nO5DF",
+                      "name": "Menu Item",
+                      "clip": true,
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "padding": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "t75yT",
+                          "name": "p1",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "square-pen",
+                          "iconFontFamily": "lucide",
+                          "fill": "#374151"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GYqk3",
+              "x": 353,
+              "y": 419,
+              "name": "Tooltip - Add files",
+              "enabled": false,
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "g2LyzK",
+                  "name": "body",
+                  "fill": "#030712",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VYaIi",
+                      "name": "content",
+                      "fill": "#FFFFFF",
+                      "content": "Add files",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pacRC",
+                      "x": 0,
+                      "y": 0,
+                      "name": "shortcut",
+                      "enabled": false,
+                      "fill": "#374151",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xNexw",
+                          "name": "kbd",
+                          "fill": "#9CA3AF",
+                          "content": "⇧N",
+                          "textAlign": "center",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "polygon",
+                  "polygonCount": 3,
+                  "id": "IcK35",
+                  "x": 0,
+                  "y": 0,
+                  "name": "arrow-down",
+                  "enabled": false,
+                  "rotation": 180,
+                  "fill": "#030712",
+                  "width": 12,
+                  "height": 6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "L8xYUa",
+              "x": 460,
+              "y": 375,
+              "name": "Agent Selector Dropdown",
+              "clip": true,
+              "width": 260,
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000d",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 1.75
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XtVQw",
+                  "name": "search",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "LQ56x",
+                      "name": "search",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "DbXsv",
+                      "name": "Search agents...",
+                      "fill": "#9CA3AF",
+                      "content": "Search models...",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal",
+                      "letterSpacing": -0.0840000033378601
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Sb3Rf",
+                  "name": "Empty State",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "layout": "vertical",
+                  "gap": 14,
+                  "padding": [
+                    60,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "E6DXQ",
+                      "name": "Icon",
+                      "width": 24,
+                      "height": 24,
+                      "iconFontName": "shield",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "swKO0",
+                      "name": "Title",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Blocked by your organization",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "UDIEE",
+                      "name": "Desc",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "None of this agent's models are approved. Ask an admin to update the model access policy.",
+                      "lineHeight": 1.4,
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c0LOEF",
+                  "name": "sepl",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#E5E7EB"
+                },
+                {
+                  "type": "frame",
+                  "id": "aMxxb",
+                  "x": 0,
+                  "y": 249,
+                  "name": "addRowL",
+                  "enabled": false,
+                  "width": "fill_container(260)",
+                  "fill": {
+                    "type": "color",
+                    "color": "#F3F4F6",
+                    "enabled": false
+                  },
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "M16lw",
+                      "name": "addIconL",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    },
+                    {
+                      "type": "text",
+                      "id": "nqDuo",
+                      "name": "addTextL",
+                      "fill": "#374151",
+                      "content": "Add agent",
+                      "lineHeight": 1.1428571428571428,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.084
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "elSxj",
+          "x": 55,
+          "y": 92.5,
+          "name": "Tooltip - Chat with AI",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "jHaKv",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HePDE",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Chat with AI",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "olQYc",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fKKSg",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "N6nB0I",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "n6Zqy4",
+          "x": 55,
+          "y": 172.5,
+          "name": "Tooltip - Knowledge",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "GPuGr",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "SeT0b",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Knowledge",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "dmxBV",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fWqdE",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "ffG9L",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fvBAx",
+          "x": 55,
+          "y": 132.5,
+          "name": "Tooltip - Conversations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ldusE",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rcGrj",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Conversations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "v3AlKd",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "K7aETl",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "Smqf8",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Ty1Nv",
+          "x": 55,
+          "y": 212.5,
+          "name": "Tooltip - Approvals",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "d5RK3Q",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hdIkP",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Approvals",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "AH4wA",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "YKxOK",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "LLiYA",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ur3bh",
+          "x": 55,
+          "y": 292,
+          "name": "Tooltip - Automations",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZJgNe",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "E5BNLR",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Automations",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "N7fr8r",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Sl3aa",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "R6BuQI",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "SktHA",
+          "x": 55,
+          "y": 252,
+          "name": "Tooltip - Custom agent",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "V9dkp",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "j24RiS",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Custom agent",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "o1tM6z",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Us8U8",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "rN1MY",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "zZ6dp",
+          "x": 55,
+          "y": 684,
+          "name": "Tooltip - Settings",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "CmTMk",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "aLDLB",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Settings and more",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "kTCm6",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "o32q5e",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "QL0Ef",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "U7afR",
+          "x": 0,
+          "y": 0,
+          "name": "Side bar",
+          "width": 48,
+          "height": 720,
+          "fill": "#FFFFFF",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E7EB"
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "AOzG5",
+              "name": "talelogo 1",
+              "clip": true,
+              "width": 48,
+              "height": 48,
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                10,
+                8,
+                12,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XTaVJ",
+                  "name": "Menu Item/Default",
+                  "clip": true,
+                  "width": 32,
+                  "height": 32,
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "group",
+                      "id": "ShCau",
+                      "name": "Group 1",
+                      "flipX": true,
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "OHtEd",
+                          "x": 0,
+                          "y": 9.494771003723145,
+                          "name": "Vector",
+                          "geometry": "M104.18 55.31c0.01663 8.6366-3.07908 16.99004-8.72 23.53-0.82 0.93333-1.68 1.83333-2.58 2.7l-0.06 0.05c-6.02096 5.66766-13.80556 9.09588-22.05151 9.71114-8.24596 0.61526-16.45311-1.61974-23.24849-6.33113l-35.52-27.43001c-3.73421-2.88421-6.75757-6.58603-8.83782-10.82107-2.08025-4.23503-3.16201-8.89057-3.16218-13.60893l0-33.11 54.67 42.22c3.26194 2.43279 7.00377 4.14438 10.97741 5.02128 3.97363 0.8769 8.08829 0.89907 12.07114 0.06505 3.98286-0.83402 7.74292-2.50516 11.03089-4.90265 3.28797-2.39749 6.02873-5.46655 8.04056-9.00368 4.80959 6.28988 7.40744 13.99202 7.39 21.91z",
+                          "fill": "#060809",
+                          "width": 18.81279945373535,
+                          "height": 16.505352020263672,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        },
+                        {
+                          "type": "path",
+                          "id": "KJZj6",
+                          "x": 7.188720703125,
+                          "y": 0,
+                          "name": "Vector",
+                          "geometry": "M0.00012 36.06889c-0.02202-8.63756 3.07436-16.99283 8.71999-23.53 0.82-0.92667 1.68-1.82667 2.58001-2.7l0.05999 0c6.01335-5.67444 13.79317-9.11144 22.03756-9.73582 8.24438-0.62438 16.45309 1.60173 23.25245 6.30582l35.54 27.43c3.73421 2.88421 6.75757 6.58603 8.83781 10.82106 2.08025 4.23504 3.16201 8.89057 3.16219 13.60894l0 33.11-54.69001-42.22c-3.26112-2.43263-7.00217-4.14412-10.97505-5.02094-3.97288-0.87682-8.08678-0.89894-12.06885-0.06488-3.98208 0.83405-7.74132 2.50521-11.02841 4.90264-3.28708 2.39743-6.02688 5.46634-8.03768 9.00318-4.8096-6.28988-7.40744-13.99201-7.39-21.91z",
+                          "fill": "#060809",
+                          "width": 18.814611434936523,
+                          "height": 16.50131607055664,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fcwwV",
+              "name": "Frame 427298167",
+              "height": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                36,
+                8,
+                16,
+                8
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hdBSH",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "nYHUj",
+                      "name": "message-circle",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "message-circle",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HbNmK",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "u4PQ5W",
+                      "name": "inbox",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "inbox",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yP5bv",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iHhM8",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "nl5gS",
+                      "name": "brain",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "brain",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NON9u",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "jQboK",
+                      "name": "circle-check",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-check",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "A0Ymb",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Frame 427298211",
+                      "enabled": false,
+                      "clip": true,
+                      "width": 4,
+                      "height": 4,
+                      "fill": "#056cffff",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "none"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B0BfUR",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "n3yho",
+                      "name": "bot",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "bot",
+                      "iconFontFamily": "lucide",
+                      "fill": "#374151"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SCiwj",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "cBlYh",
+                      "name": "network",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "network",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "a3LFu",
+              "name": "Frame 427298178",
+              "width": "fill_container",
+              "fill": "#00000000",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 10,
+              "padding": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pJcGo",
+                  "name": "Menu Item",
+                  "clip": true,
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 8,
+                  "padding": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Hmy4j",
+                      "name": "circle-user-round",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "circle-user-round",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6b7280"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Wr7yt",
+          "x": 7,
+          "y": 435,
+          "name": "user profile pop up",
+          "enabled": false,
+          "clip": true,
+          "width": 217,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000d",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 5.25
+          },
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "p5NdK",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#f3f4f6ff",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rs7Ct",
+                  "name": "Frame 427298659",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S3vYT",
+                      "name": "Text",
+                      "fill": "#030712",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Thelma nader",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Y2GgX",
+                      "name": "Text",
+                      "fill": "#6B7280",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "thelma.nader@company.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hLNpg",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Fwlaq",
+                  "name": "settings",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "i07kmV",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Settings",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "DxkJZ",
+              "name": "Frame 427298641",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1,
+                  "bottom": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hwLMh",
+                  "name": "Frame 427298637",
+                  "width": "fill_container",
+                  "fill": "#F9FAFB",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "B1wm1",
+                      "name": "monitor",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "monitor",
+                      "iconFontFamily": "lucide",
+                      "fill": "#030712"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rVtkf",
+                  "name": "Frame 427298640",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Y12C9F",
+                      "name": "sun",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sun",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "X7JQo",
+                  "name": "Frame 427298639",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "rBPLD",
+                      "name": "moon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "moon",
+                      "iconFontFamily": "lucide",
+                      "fill": "#6B7280"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ln1m1",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Z6TGBO",
+                  "name": "circle-help",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "circle-help",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "u8crJ",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Help & feedback",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MkiLj",
+              "name": "Rows",
+              "clip": true,
+              "width": "fill_container",
+              "fill": {
+                "type": "color",
+                "color": "#F3F4F6",
+                "enabled": false
+              },
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "#E5E7EB"
+              },
+              "gap": 8,
+              "padding": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "YjNsO",
+                  "name": "log-out",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "log-out",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                },
+                {
+                  "type": "text",
+                  "id": "giTKL",
+                  "name": "Text",
+                  "fill": "#374151",
+                  "content": "Log out",
+                  "lineHeight": 1.1428571428571428,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "lVtFm",
+          "x": 104,
+          "y": 443,
+          "name": "Tooltip - User",
+          "enabled": false,
+          "layout": "vertical",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Xngod",
+              "name": "body",
+              "fill": "#030712",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                6,
+                8
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HSJFk",
+                  "name": "content",
+                  "fill": "#FFFFFF",
+                  "content": "Thelma Nader - Admin",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "HAGq5",
+                  "x": 0,
+                  "y": 0,
+                  "name": "shortcut",
+                  "enabled": false,
+                  "fill": "#374151",
+                  "cornerRadius": 4,
+                  "layout": "vertical",
+                  "padding": [
+                    2,
+                    6
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "b9nEr",
+                      "name": "kbd",
+                      "fill": "#9CA3AF",
+                      "content": "⇧N",
+                      "textAlign": "center",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "polygon",
+              "polygonCount": 3,
+              "id": "hA5W4",
+              "x": 0,
+              "y": 0,
+              "name": "arrow-down",
+              "enabled": false,
+              "rotation": 180,
+              "fill": "#030712",
+              "width": 12,
+              "height": 6
+            }
+          ]
+        }
+      ]
     }
   ],
   "themes": {

--- a/designs/session-ux-changes.md
+++ b/designs/session-ux-changes.md
@@ -1,0 +1,63 @@
+# Session notes — UX changes
+
+Quick log of what changed and why. Pair with [`agents-models-ux-gaps.md`](agents-models-ux-gaps.md) for the gap inventory.
+
+## Notifications
+
+Moved the bell out of the user dropdown and into the sidebar — notifications are a primary surface, burying them in a user menu makes them undiscoverable.
+
+Rewrote the row pattern: dropped the chevron-expand, the duplicate severity dot (people kept reading it as an unread indicator), and the hidden "Mark as read" button. The whole row is now clickable to mark read. Same pattern as Gmail, Linear, GitHub.
+
+New empty states: "You're all caught up" on the Unread tab, "No notifications yet" on All — with icons. Empty states are a positive design moment, not just absence of content.
+
+Popover background switched to `bg-card` so light mode is white (matching the rest of the app's dropdowns).
+
+## Data tables
+
+Named the entity in row-count footers across 9+ tables. "Showing all 7 agents" instead of "No more items to load" — the old copy described the loading mechanism, users care about the data.
+
+Search input bumped from 256px → 288px and fixed an internal `max-w-70` that was leaving a phantom gap before adjacent buttons. Footer copy left-aligned with `px-3` to match cell padding.
+
+## Dropdown menus
+
+Radio dots → checkmarks. Radios imply "select pending submit" but menus commit on click — wrong affordance. macOS, VS Code, Notion all use checkmarks. Submenu background flipped from `bg-muted` (grey) to `bg-card` to match the parent menu. Added a `keepOpen` flag for menu items that swap content in place.
+
+## Settings
+
+Dropped the redundant "Two-factor authentication is not yet enabled" line — the "Enable" button alone conveys state. Kept the org-enforced variant since "you must do this" is real context.
+
+Branding panel borders were invisible because `border-input` paints with the input _fill_ color (white in light, near-black in dark) — switched to `border-border`. Lightened the heavy v4 `shadow-sm` to `shadow-xs`.
+
+## Profile name save bug
+
+`getCurrentUser` was reading from the JWT identity, which doesn't refresh on profile updates. So edits saved correctly to the DB but the form re-read the stale JWT name and "reverted" on screen. Now reads from the user table directly. One extra query per profile read — fine for this path.
+
+## Agent picker
+
+Capability icons (🌐 Web, 📄 Docs, 💻 Code, 🖼 Image, 🔌 Integrations) under each agent's description — scannable structured layer on top of the admin-authored prose. Descriptions vary in quality by agent author; icons are uniform.
+
+Layout fix: icons originally sat in the right rail and competed with the selection checkmark; moved them into a new `meta` slot below the description. "Requires Tavily" warning moved to the same row, opposite the icons. Free side benefit: descriptions stopped wrapping. Background → `bg-card`.
+
+## Model picker
+
+Same pattern as the agent picker: dropped the radio, moved capability tag icons from the right rail to the `meta` slot, switched to `bg-card`.
+
+Added hover tooltips on the provider badge ("Routed via Openrouter") and quantization badges (fp8 = "Higher quality, slower" / fp4 = "Faster, cheaper" etc.). This is option 1 from gap #4. **Option 2 (hide variants behind a developer toggle) is the better long-term fix** — most users have no reason to pick between fp8 and fp4 of the same model, that's a cost-vs-quality decision configuration shouldn't surface in the runtime picker. Tooltips are the band-aid.
+
+## AI disclaimer
+
+Hid the "AI can make mistakes—verify responses and do not share sensitive data." footer on the empty/new-chat homepage. It still appears in active chats (gated on `threadId`).
+
+Why: the empty homepage is a _welcoming_ moment — the prompt is asking the user what they want to do, the composer is inviting them to start. A disclaimer underneath that says "be careful" before they've typed a word disclaims a thing that hasn't happened, and works against the inviting tone. The risk the disclaimer mitigates only exists once the AI starts generating, so that's the moment it earns its place — small, persistent, at the bottom of the active chat. Legally, this also matches how Swiss revFADP and the EU AI Act treat disclosure: required at the _point of interaction_, not pre-engagement.
+
+Caveat documented for whoever owns compliance at Tale: if there's a contractual or vertical-industry reason it must stay on the homepage (regulated customers, enterprise contracts), revert. Otherwise this matches the industry default.
+
+## Still open
+
+From [agents-models-ux-gaps.md](agents-models-ux-gaps.md):
+
+- "Auto" model attribution chip on AI messages (#1)
+- Persistent capability indicator during chat — not just at picker time (#2)
+- Cross-agent suggestion when the wrong agent is picked (#3)
+- Reason-aware "No models available" empty state
+- Quantization variants behind a developer toggle (the real fix for #4)

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -33,6 +33,12 @@ export interface SearchableSelectOption {
    */
   labelBadge?: ReactNode;
   description?: string;
+  /**
+   * Optional meta row rendered below the description (e.g. capability icons,
+   * "Requires X" hints). Lets rows expose structured info without competing
+   * with the title for horizontal space.
+   */
+  meta?: ReactNode;
   disabled?: boolean;
 }
 
@@ -526,6 +532,7 @@ function SearchableSelectOptionItem({
             {option.description}
           </Text>
         )}
+        {option.meta && <div className="mt-1.5">{option.meta}</div>}
       </div>
       {!showRadio && isSelected && (
         <Check className="text-primary size-4 shrink-0" aria-hidden="true" />

--- a/services/platform/app/components/ui/navigation/navigation.tsx
+++ b/services/platform/app/components/ui/navigation/navigation.tsx
@@ -150,11 +150,6 @@ export function Navigation({ organizationId }: NavigationProps) {
       </div>
       <div className="flex flex-shrink-0 flex-col items-center gap-2 py-3">
         <NotificationBell organizationId={organizationId} />
-        <NavigationMenuList className="block space-y-2 space-x-0">
-          {pinned.map((item) => (
-            <NavigationItem key={item.href} item={item} />
-          ))}
-        </NavigationMenuList>
         <UserButton />
       </div>
     </NavigationMenu>

--- a/services/platform/app/components/ui/navigation/navigation.tsx
+++ b/services/platform/app/components/ui/navigation/navigation.tsx
@@ -125,7 +125,7 @@ export interface NavigationProps {
 
 export function Navigation({ organizationId }: NavigationProps) {
   const { t: tCommon } = useT('common');
-  const { primary, pinned } = useNavigationItems(organizationId);
+  const { primary } = useNavigationItems(organizationId);
 
   return (
     <NavigationMenu

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -21,7 +21,6 @@ import {
   UsersRound,
   Languages,
   Building2,
-  Settings as SettingsIcon,
   Download,
   ChevronRight,
   Check,

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -21,6 +21,7 @@ import {
   UsersRound,
   Languages,
   Building2,
+  Settings as SettingsIcon,
   Download,
   ChevronRight,
   Check,
@@ -250,9 +251,6 @@ export function UserButton({
             side="top"
           >
             <div className="flex min-w-0 flex-1 cursor-default flex-col gap-1">
-              {/* One real label tree, masked while auth/member context loads.
-                  Name + email are the dynamic leaves; the version row only
-                  exists once loaded (it has no placeholder counterpart). */}
               <Skeletonize
                 loading={loading || !user}
                 label={t('userButton.defaultName')}

--- a/services/platform/app/features/agents/components/agent-capability-badges.tsx
+++ b/services/platform/app/features/agents/components/agent-capability-badges.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Code, FileText, Globe, Image, Plug } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+
+interface AgentLike {
+  primaryBehavior?: 'chat' | 'image-generation';
+  toolNames?: string[];
+  integrationBindings?: string[];
+}
+
+const WEB_TOOLS = new Set(['web']);
+const DOC_TOOLS = new Set([
+  'rag_search',
+  'document_retrieve',
+  'document_find',
+  'document_write',
+  'pdf',
+  'docx',
+  'excel',
+]);
+const CODE_TOOLS = new Set(['run_code']);
+const IMAGE_TOOLS = new Set(['image']);
+
+function hasAny(tools: string[] | undefined, set: Set<string>): boolean {
+  if (!tools) return false;
+  for (const t of tools) {
+    if (set.has(t)) return true;
+  }
+  return false;
+}
+
+/**
+ * Renders a compact row of capability icons for an agent — `🌐 Web`,
+ * `📄 Docs`, `💻 Code`, `🖼 Image`, `🔌 Integrations`. Each icon has a
+ * native `title` tooltip so hovering reveals the full capability name.
+ */
+export function AgentCapabilityBadges({ agent }: { agent: AgentLike }) {
+  const { t } = useT('chat');
+
+  const capabilities = useMemo(() => {
+    const items: { key: string; icon: typeof Globe; label: string }[] = [];
+    if (hasAny(agent.toolNames, WEB_TOOLS)) {
+      items.push({
+        key: 'web',
+        icon: Globe,
+        label: t('agentSelector.capabilities.web'),
+      });
+    }
+    if (hasAny(agent.toolNames, DOC_TOOLS)) {
+      items.push({
+        key: 'docs',
+        icon: FileText,
+        label: t('agentSelector.capabilities.docs'),
+      });
+    }
+    if (hasAny(agent.toolNames, CODE_TOOLS)) {
+      items.push({
+        key: 'code',
+        icon: Code,
+        label: t('agentSelector.capabilities.code'),
+      });
+    }
+    if (
+      agent.primaryBehavior === 'image-generation' ||
+      hasAny(agent.toolNames, IMAGE_TOOLS)
+    ) {
+      items.push({
+        key: 'image',
+        icon: Image,
+        label: t('agentSelector.capabilities.image'),
+      });
+    }
+    if (agent.integrationBindings && agent.integrationBindings.length > 0) {
+      items.push({
+        key: 'integrations',
+        icon: Plug,
+        label: t('agentSelector.capabilities.integrations'),
+      });
+    }
+    return items;
+  }, [agent.primaryBehavior, agent.toolNames, agent.integrationBindings, t]);
+
+  if (capabilities.length === 0) return null;
+
+  return (
+    <span
+      className="text-muted-foreground flex shrink-0 items-center gap-1.5"
+      aria-label={t('agentSelector.capabilities.label')}
+    >
+      {capabilities.map(({ key, icon: Icon, label }) => (
+        <span key={key} title={label} aria-label={label}>
+          <Icon className="size-3.5" aria-hidden="true" />
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -8,6 +8,7 @@ import { Bot, ChevronDown, Plus } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
+import { AgentCapabilityBadges } from '@/app/features/agents/components/agent-capability-badges';
 import { CreateAgentDialog } from '@/app/features/agents/components/agent-create-dialog';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
@@ -74,11 +75,16 @@ export const AgentSelector = memo(function AgentSelector({
           label: agent.displayName,
           description: agent.description || '',
           isDefaultChat: agent.name === 'chat-agent',
-          labelBadge: missingTitle ? (
-            <span className="text-muted-foreground text-xs">
-              {tComposer('requiresIntegration', { name: missingTitle })}
-            </span>
-          ) : undefined,
+          meta: (
+            <div className="flex items-center justify-between gap-2">
+              <AgentCapabilityBadges agent={agent} />
+              {missingTitle && (
+                <span className="text-muted-foreground shrink-0 text-xs">
+                  {tComposer('requiresIntegration', { name: missingTitle })}
+                </span>
+              )}
+            </div>
+          ),
           ready: missing.length === 0,
         };
       })
@@ -131,7 +137,7 @@ export const AgentSelector = memo(function AgentSelector({
         align="start"
         side="top"
         sideOffset={8}
-        contentClassName="w-[16.25rem]"
+        contentClassName="bg-card w-[16.25rem]"
         tooltip={t('agentSelector.label')}
         tooltipSide="top"
         searchPlaceholder={t('agentSelector.searchPlaceholder')}

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -991,7 +991,12 @@ export function ChatInput({
         </div>
       </FileUpload.DropZone>
 
-      <DataNoticeFooter organizationId={organizationId} className="pt-1 pb-1" />
+      {threadId && (
+        <DataNoticeFooter
+          organizationId={organizationId}
+          className="pt-1 pb-1"
+        />
+      )}
 
       {previewImage && (
         <ImagePreviewDialog

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -7,14 +7,7 @@ import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import startCase from 'lodash/startCase';
 import { AlertTriangle, ChevronDown, Cpu } from 'lucide-react';
-import {
-  memo,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   SearchableSelect,

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -54,6 +54,25 @@ function getModelShortName(modelId: string): string {
   return slash >= 0 ? modelId.slice(slash + 1) : modelId;
 }
 
+// Quantization labels (fp8, fp4, fp6, ...) are opaque to most users — they
+// describe the numeric precision of the model's weights. Each variant trades
+// quality for speed/cost. Known variants get a plain-English hover tooltip;
+// unknown variants fall back to a generic "variant {X}" hint.
+function getQuantizationTooltip(
+  quantization: string,
+  t: (key: string, vars?: Record<string, string>) => string,
+): string {
+  const known: Record<string, string> = {
+    fp8: 'modelSelector.quantization.fp8',
+    fp6: 'modelSelector.quantization.fp6',
+    fp4: 'modelSelector.quantization.fp4',
+  };
+  const key = known[quantization.toLowerCase()];
+  return key
+    ? t(key)
+    : t('modelSelector.quantization.unknown', { variant: quantization });
+}
+
 export const ModelSelector = memo(function ModelSelector({
   organizationId,
   projectId,
@@ -134,15 +153,6 @@ export const ModelSelector = memo(function ModelSelector({
       return modelInfoMap.get(parsed.modelId)?.providerName;
     },
     [modelInfoMap],
-  );
-
-  const renderTagIcons = useCallback(
-    (option: SearchableSelectOption): ReactNode => {
-      const info = modelInfoMap.get(stripModelRefQualifier(option.value));
-      if (!info?.tags.length) return null;
-      return <ModelTagIcons tags={info.tags} t={t} />;
-    },
-    [modelInfoMap, t],
   );
 
   const chatModels = useMemo(() => {
@@ -329,14 +339,25 @@ export const ModelSelector = memo(function ModelSelector({
         </Badge>
       ) : null;
       const providerBadge = providerSlug ? (
-        <Badge variant="outline" className="text-[10px] font-normal">
-          {startCase(providerSlug)}
-        </Badge>
+        <span
+          title={t('modelSelector.providerTooltip', {
+            provider: startCase(providerSlug),
+          })}
+        >
+          <Badge variant="outline" className="text-[10px] font-normal">
+            {startCase(providerSlug)}
+          </Badge>
+        </span>
       ) : null;
       const variantBadge = quantization ? (
-        <Badge variant="outline" className="text-[10px] font-normal">
-          {getVariantBadgeLabel(quantization)}
-        </Badge>
+        <span title={getQuantizationTooltip(quantization, t)}>
+          <Badge variant="outline" className="text-[10px] font-normal">
+            {getVariantBadgeLabel(quantization)}
+          </Badge>
+        </span>
+      ) : null;
+      const tagIcons = info?.tags.length ? (
+        <ModelTagIcons tags={info.tags} t={t} />
       ) : null;
       return {
         value: ref,
@@ -351,6 +372,11 @@ export const ModelSelector = memo(function ModelSelector({
             </>
           ) : undefined,
         description: info?.description,
+        meta: tagIcons ? (
+          <span className="text-muted-foreground flex items-center gap-1.5">
+            {tagIcons}
+          </span>
+        ) : undefined,
       };
     })
     // Project-recommended models float to the top; order is otherwise stable.
@@ -378,14 +404,12 @@ export const ModelSelector = memo(function ModelSelector({
       align="start"
       side="top"
       sideOffset={8}
-      contentClassName="w-[22rem]"
+      contentClassName="bg-card w-[22rem]"
       tooltip={t('modelSelector.label')}
       tooltipSide="top"
       searchPlaceholder={t('modelSelector.searchPlaceholder')}
       emptyText={t('modelSelector.noResults')}
       aria-label={t('modelSelector.label')}
-      optionAction={renderTagIcons}
-      showRadio
       trigger={
         <Button
           type="button"

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -193,6 +193,7 @@ export function useChatAgents(organizationId: string) {
               ? a.primaryBehavior
               : undefined,
           supportedModels: a.supportedModels,
+          toolNames: Array.isArray(a.toolNames) ? a.toolNames : undefined,
           integrationBindings: Array.isArray(a.integrationBindings)
             ? a.integrationBindings
             : undefined,

--- a/services/platform/app/features/governance/components/data-notice-footer.tsx
+++ b/services/platform/app/features/governance/components/data-notice-footer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Text } from '@tale/ui/text';
-import { ShieldAlert } from 'lucide-react';
 
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -27,7 +26,7 @@ interface DataNoticeFooterProps {
  * `requireAcknowledgment` policy field is preserved server-side for a
  * future regulated-customer rewire.
  *
- * Visual: muted icon + small text.
+ * Visual: small muted text.
  */
 export function DataNoticeFooter({
   organizationId,
@@ -43,12 +42,11 @@ export function DataNoticeFooter({
       role="note"
       aria-label={t('footer.ariaLabel', 'Confidentiality notice')}
       className={cn(
-        'flex items-center justify-center gap-1.5 px-3 py-1.5',
-        'text-muted-foreground',
+        'flex items-center justify-center px-3 py-1.5',
+        'text-gray-400 dark:text-gray-500',
         className,
       )}
     >
-      <ShieldAlert aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
       <Text className="text-xs leading-tight">{notice.message}</Text>
     </div>
   );

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -171,9 +171,6 @@ export function NotificationListPanel({
       <div className="flex-1 overflow-y-auto">
         {items.length === 0 ? (
           status === 'LoadingFirstPage' ? (
-            // Skeleton list mirroring the real row layout for the genuine first
-            // load only. The Unread/All filter is client-side, so toggling it no
-            // longer resets the query — the skeleton won't reappear on switch.
             <Skeletonize loading label={t('loading')}>
               <ul role="list" className="divide-border divide-y" aria-hidden>
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/services/platform/app/features/settings/account/components/passkey-section.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.tsx
@@ -53,6 +53,9 @@ export function PasskeySection() {
       if (res.error) {
         throw new Error(res.error.message ?? 'Failed to list passkeys');
       }
+      // Better Auth's SDK return type isn't exposed as `PasskeyRow[]`; rows match
+      // the shape at runtime.
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
       return (res.data ?? []) as PasskeyRow[];
     },
     enabled: Boolean(status?.authenticated && status.hasCredential),

--- a/services/platform/app/features/settings/api-keys/hooks/use-api-keys.ts
+++ b/services/platform/app/features/settings/api-keys/hooks/use-api-keys.ts
@@ -23,7 +23,10 @@ export function useApiKeys(organizationId: string) {
       if (result.error) {
         throw new Error(result.error.message);
       }
-      // authClient.apiKey.list() now returns { apiKeys, total, limit, offset }
+      // authClient.apiKey.list() now returns { apiKeys, total, limit, offset }.
+      // Better Auth's SDK return type isn't exposed as `ApiKey[]`; rows match
+      // the shape at runtime.
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
       return (result.data?.apiKeys ?? []) as ApiKey[];
     },
   });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -837,7 +837,15 @@
       "defaultAgent": "Assistent",
       "searchPlaceholder": "Agents suchen",
       "noResults": "Keine Agents gefunden",
-      "addAgent": "Agent hinzufügen"
+      "addAgent": "Agent hinzufügen",
+      "capabilities": {
+        "label": "Fähigkeiten",
+        "web": "Websuche",
+        "docs": "Dokumente",
+        "code": "Codeausführung",
+        "image": "Bildgenerierung",
+        "integrations": "Integrationen"
+      }
     },
     "modelSelector": {
       "label": "Modell auswählen",
@@ -848,6 +856,13 @@
       "noModelsAvailable": "Keine Modelle verfügbar",
       "recommended": "Empfohlen",
       "noApiKey": "Für den Anbieter dieses Modells ist kein API-Schlüssel konfiguriert — füge in Einstellungen → API einen hinzu.",
+      "providerTooltip": "Über {provider} geleitet",
+      "quantization": {
+        "fp8": "Höhere Qualität, langsamer",
+        "fp6": "Ausgewogene Qualität und Geschwindigkeit",
+        "fp4": "Schneller und günstiger, etwas geringere Qualität",
+        "unknown": "Quantisierungsvariante {variant}"
+      },
       "tags": {
         "chat": "Chat",
         "embedding": "Embedding",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -837,7 +837,15 @@
       "defaultAgent": "Assistant",
       "searchPlaceholder": "Search agents",
       "noResults": "No agents found",
-      "addAgent": "Add agent"
+      "addAgent": "Add agent",
+      "capabilities": {
+        "label": "Capabilities",
+        "web": "Web search",
+        "docs": "Documents",
+        "code": "Code execution",
+        "image": "Image generation",
+        "integrations": "Integrations"
+      }
     },
     "modelSelector": {
       "label": "Select model",
@@ -848,6 +856,13 @@
       "noModelsAvailable": "No models available",
       "recommended": "Recommended",
       "noApiKey": "No API key configured for this model's provider — add one in Settings → API.",
+      "providerTooltip": "Routed via {provider}",
+      "quantization": {
+        "fp8": "Higher quality, slower",
+        "fp6": "Balanced quality and speed",
+        "fp4": "Faster and cheaper, slightly lower quality",
+        "unknown": "Quantization variant {variant}"
+      },
       "tags": {
         "chat": "Chat",
         "embedding": "Embedding",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -838,7 +838,15 @@
       "defaultAgent": "Assistant",
       "searchPlaceholder": "Rechercher des agents",
       "noResults": "Aucun agent trouvé",
-      "addAgent": "Ajouter un agent"
+      "addAgent": "Ajouter un agent",
+      "capabilities": {
+        "label": "Capacités",
+        "web": "Recherche web",
+        "docs": "Documents",
+        "code": "Exécution de code",
+        "image": "Génération d'images",
+        "integrations": "Intégrations"
+      }
     },
     "modelSelector": {
       "label": "Sélectionner un modèle",
@@ -849,6 +857,13 @@
       "noModelsAvailable": "Aucun modèle disponible",
       "recommended": "Recommandé",
       "noApiKey": "Aucune clé API configurée pour le fournisseur de ce modèle — ajoutes-en une dans Paramètres → API.",
+      "providerTooltip": "Acheminé via {provider}",
+      "quantization": {
+        "fp8": "Qualité supérieure, plus lent",
+        "fp6": "Qualité et vitesse équilibrées",
+        "fp4": "Plus rapide et moins cher, qualité légèrement inférieure",
+        "unknown": "Variante de quantification {variant}"
+      },
       "tags": {
         "chat": "Chat",
         "embedding": "Embedding",


### PR DESCRIPTION
## Summary

Bundle of UX work across the chat pickers, the AI disclaimer placement, and two design exploration files for settings and agents/models. Plus a small lint cleanup so check passes.

### Pickers — scannable capabilities + cleaner model picker
- `AgentCapabilityBadges` reads each agent's `toolNames`, `integrationBindings`, and `primaryBehavior` and renders a compact icon row (🌐 web, 📄 docs, 💻 code, 🖼 image, 🔌 integrations) so users can diff agents at a glance instead of reading prose.
- `SearchableSelect` gains a `meta` slot below the description. Agent and model pickers both move their per-row metadata (capability badges, "Requires Tavily" warning, chat/image tag icons) into the meta slot, freeing the right rail for the selection checkmark.
- Model picker drops `showRadio` so the checkmark is the only selection cue, and gets `bg-card` so light-mode matches the rest of the dropdowns.
- Provider and quantization badges (`fp8` / `fp4` / `fp6`) get plain-English hover tooltips via native `title`.

### AI disclaimer + footer polish
- The "AI can make mistakes…" disclaimer now only renders inside an active thread, not on the empty/new-chat homepage. Pre-engagement disclosure on an empty page works against the welcoming "How can I help you today?" moment. Matches how Swiss revFADP and the EU AI Act treat disclosure — required at the point of interaction, not pre-engagement.
- Dropped the ShieldAlert icon from the footer; switched text color to a lighter gray. Stays a quiet reminder instead of reading as a warning bar.

### Design exploration (no runtime impact)
- `designs/agents-models-ux-gaps.md` — inventory of friction points (opaque Auto mode, non-scannable capability info, no cross-agent suggestion when the wrong agent is picked, vague empty state, quantization jargon).
- `designs/session-ux-changes.md` — log of UX changes made this session and the reasoning behind each, paired with the gap doc.
- `designs/platform/settings.pen` — `Pages/Settings/Settings Sample` (light + dark): single gear-in-sidebar settings home with Personal/Organization left rail, centered 720px column, top-down sections, disabled-input read-only fields, sticky save bar.
- `designs/platform/chat.pen` — two interaction patterns for model availability: mid-session invalidation toast (chat-agent → Auto fallback, image-agent → named-model fallback) and four reason-aware empty states inside the picker dropdown (no providers, capability mismatch, blocked by governance, restricted by project). Each anchored over the model dropdown in a real chat backdrop. Sticky notes cover what the samples show and open decisions (role-aware CTA, backend reason detection, precedence, single-model auto-pin).

### Lint cleanup
- Removed a stray `ReactNode` import (mine, leftover from the picker refactor)
- Removed unused `SettingsIcon` and `pinned` (pre-existing on `main`)
- Suppressed `no-unsafe-type-assertion` on two Better Auth SDK casts with explanatory comments (third-party gap per AGENTS.md)

## Test plan
- [ ] Open the agent picker in chat — each agent row shows a capability icon row under its description; long descriptions no longer wrap because the right rail is free.
- [ ] Active agent gets the checkmark on the right side of the row, not a radio circle.
- [ ] Open the model picker — same structure (tag icons below description, no radio dot, checkmark on the right, white background in light mode).
- [ ] Hover the `Openrouter` provider badge → "Routed via Openrouter". Hover `fp8` → "Higher quality, slower". Same for `fp4` and `fp6`.
- [ ] On the empty/new chat homepage, no AI disclaimer footer. Send a first message → disclaimer appears once the thread starts.
- [ ] Disclaimer text reads lighter than before and no longer carries a shield icon.

Closes #1567