### PR TITLE
fix(platform): validate required columns on product CSV import

### DIFF
--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -6,7 +6,11 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
-import { useFileImport, productMappers } from '@/app/hooks/use-file-import';
+import {
+  useFileImport,
+  productMappers,
+  PRODUCT_REQUIRED_COLUMNS,
+} from '@/app/hooks/use-file-import';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import {
@@ -93,6 +97,7 @@ export function ProductsImportDialog({
   const { parseFile } = useFileImport<ParsedProduct>({
     csvMapper: productMappers.csv,
     excelMapper: recordMapper,
+    requiredColumns: PRODUCT_REQUIRED_COLUMNS,
   });
 
   const resetForm = useCallback(() => {

--- a/services/platform/app/hooks/use-file-import.test.ts
+++ b/services/platform/app/hooks/use-file-import.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
+import { parseCSVWithMapper } from '@/lib/utils/file-parsing';
+
 import {
   customerMappers,
   productMappers,
+  PRODUCT_REQUIRED_COLUMNS,
   vendorMappers,
 } from './use-file-import';
 
@@ -245,6 +248,45 @@ describe('productMappers.record', () => {
     expect(result).toMatchObject({
       imageUrl: 'https://example.com/pic.png',
     });
+  });
+});
+
+describe('product import column validation (PRODUCT_REQUIRED_COLUMNS)', () => {
+  const parse = (csv: string) =>
+    parseCSVWithMapper(csv, productMappers.csv, {
+      recordMapper: productMappers.record,
+      requiredColumns: PRODUCT_REQUIRED_COLUMNS,
+    });
+
+  it('imports rows when all required headers are present', () => {
+    const result = parse('name,price,stock\nWidget,9.99,100\nGadget,5,0');
+    expect(result.errors).toEqual([]);
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toMatchObject({ name: 'Widget', price: 9.99 });
+  });
+
+  it('accepts the title alias in place of name', () => {
+    const result = parse('title,price,stock\nGizmo,1.5,3');
+    expect(result.errors).toEqual([]);
+    expect(result.data[0]).toMatchObject({ name: 'Gizmo' });
+  });
+
+  it('fails with a clear error when headers are wrong/misnamed', () => {
+    const result = parse('col1,col2,col3\nWidget,9.99,100');
+    expect(result.data).toHaveLength(0);
+    expect(result.errors[0]).toContain('Missing required column(s)');
+    expect(result.errors[0]).toContain('name');
+    expect(result.errors[0]).toContain('price');
+    expect(result.errors[0]).toContain('stock');
+    // Surfaces what was actually found so the user can correct the file.
+    expect(result.errors[0]).toContain('col1');
+  });
+
+  it('reports only the specific missing required column', () => {
+    const result = parse('name,price\nWidget,9.99');
+    expect(result.data).toHaveLength(0);
+    expect(result.errors[0]).toContain('stock');
+    expect(result.errors[0]).not.toContain('Missing required column(s): name');
   });
 });
 

--- a/services/platform/app/hooks/use-file-import.ts
+++ b/services/platform/app/hooks/use-file-import.ts
@@ -266,6 +266,23 @@ export const vendorMappers = {
   },
 };
 
+// Accepted (lowercase) header spellings for the product columns that gate a
+// valid import. `name` mirrors the record mapper's name/title fallback.
+const PRODUCT_NAME_HEADER_ALIASES = ['name', 'title'];
+
+/**
+ * Required columns for product imports. A file whose header row is missing the
+ * product name, price, or stock column is rejected with a clear error instead
+ * of silently importing misaligned data or zero-filled defaults (see #1308).
+ * Optional columns (description, imageUrl, currency, category, status) keep
+ * their per-field defaults and are not gated here.
+ */
+export const PRODUCT_REQUIRED_COLUMNS: RequiredColumn[] = [
+  { label: 'name', aliases: PRODUCT_NAME_HEADER_ALIASES },
+  { label: 'price', aliases: ['price'] },
+  { label: 'stock', aliases: ['stock'] },
+];
+
 /**
  * Product import mapper utilities.
  * Creates products with full field support including status, stock, currency, category.


### PR DESCRIPTION
## What

Importing a product CSV/Excel with the wrong column order or misnamed headers was accepted silently — header-based mapping left fields `undefined`, numeric columns (price/stock) fell back to `0`, and data could land misaligned. No error told the user the file's columns were wrong.

Reported in #1308.

## Change

The required-column validation already exists in `file-parsing.ts` (`detectMissingColumns` → `Missing required column(s): … Found columns: …`) and is used by customer/vendor imports via `CONTACT_REQUIRED_COLUMNS` — the **product** importer just never opted in.

- Add `PRODUCT_REQUIRED_COLUMNS`: `name` (with the `title` alias the record mapper already accepts), `price`, and `stock`.
- Pass it to `useFileImport` in the products import dialog.

Now a file whose header row is missing any of those fails up front with a clear error naming the missing column(s) and the columns actually found — instead of importing misaligned/zero-filled rows. Optional columns (description, imageUrl, currency, category, status) keep their per-field defaults.

## Testing

New cases in `use-file-import.test.ts` (30 pass total): all-required-present imports rows, `title` alias accepted, wrong/misnamed headers fail with the full missing-column list + found columns, and a single missing column (`stock`) is reported specifically.

`tsc --noEmit` and `oxlint --type-aware` clean.

Closes #1308