### PR TITLE
fix(platform): right-align team row action menu

### DIFF
--- a/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
+++ b/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
@@ -68,7 +68,7 @@ export function useTeamsTableConfig(
         size: 44,
         meta: { isAction: true },
         cell: ({ row }) => (
-          <HStack gap={1} justify="end">
+          <HStack justify="end">
             <TeamRowActions
               team={row.original}
               organizationId={organizationId}

--- a/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
+++ b/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
@@ -67,11 +68,13 @@ export function useTeamsTableConfig(
         size: 44,
         meta: { isAction: true },
         cell: ({ row }) => (
-          <TeamRowActions
-            team={row.original}
-            organizationId={organizationId}
-            onView={onViewTeam ? () => onViewTeam(row.original) : undefined}
-          />
+          <HStack gap={1} justify="end">
+            <TeamRowActions
+              team={row.original}
+              organizationId={organizationId}
+              onView={onViewTeam ? () => onViewTeam(row.original) : undefined}
+            />
+          </HStack>
         ),
       },
     ],


### PR DESCRIPTION
## What

The 3-dot action menu in the Teams list rendered slightly inward instead of flush to the far right of the row (reported in #1381).

## Change

Every other entity table (e.g. agents) wraps its row actions in `<HStack gap={1} justify="end">`; the teams table rendered `TeamRowActions` bare in the actions cell. Wrap it the same way so the menu aligns consistently to the right.

## Testing

Pure layout change matching the established agents-table pattern. `tsc --noEmit` and `oxlint --type-aware` clean.

Closes #1381