### PR TITLE
fix(platform): paginate the organization members table

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table-pagination.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-pagination.tsx
@@ -108,6 +108,7 @@ export function DataTablePagination({
             value={pageSize.toString()}
             onValueChange={(value) => onPageSizeChange(parseInt(value, 10))}
             className="h-8 w-auto min-w-16"
+            aria-label={t('pagination.rowsPerPage')}
             options={pageSizeOptions.map((size) => ({
               value: size.toString(),
               label: size.toString(),
@@ -136,6 +137,7 @@ export function DataTablePagination({
           value={currentPage.toString()}
           onValueChange={handlePageSelect}
           className="h-8 w-auto min-w-16"
+          aria-label={t('aria.goToPage')}
           options={Array.from({ length: totalPageCount }, (_, i) => ({
             value: (i + 1).toString(),
             label: (i + 1).toString(),

--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -148,11 +148,12 @@ export function MemberTable({
       getRowId={(row) => row._id}
       isLoading={isLoading}
       approxRowCount={approxRowCount}
-      infiniteScroll={{
-        hasMore: false,
-        onLoadMore: () => {},
+      pagination={{
+        clientSide: true,
+        pageSize: 10,
+        total: members.length,
+        showPageSizeSelector: true,
         entityLabel: tSettings('organization.membersEntityLabel'),
-        totalCount: members.length,
       }}
       emptyState={{
         icon: Users,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1421,6 +1421,7 @@
       "dismiss": "Verwerfen",
       "previousPage": "Vorherige Seite",
       "nextPage": "Nächste Seite",
+      "goToPage": "Zur Seite",
       "zoomIn": "Vergrößern",
       "zoomOut": "Verkleinern",
       "selectAll": "Alle auswählen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1421,6 +1421,7 @@
       "dismiss": "Dismiss",
       "previousPage": "Previous page",
       "nextPage": "Next page",
+      "goToPage": "Go to page",
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
       "selectAll": "Select all",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1422,6 +1422,7 @@
       "dismiss": "Ignorer",
       "previousPage": "Page précédente",
       "nextPage": "Page suivante",
+      "goToPage": "Aller à la page",
       "zoomIn": "Zoom avant",
       "zoomOut": "Zoom arrière",
       "selectAll": "Tout sélectionner",


### PR DESCRIPTION
## What

The organization members table showed all members at once with no pagination (#1463) — unwieldy and slow to scan as an org grows.

## Change

Switch `MemberTable` from a no-op `infiniteScroll` to the `DataTable`'s **client-side pagination** (`clientSide: true`, 10/page, with a page-size selector). It paginates the already-fetched set *after* the existing client-side search + sort, so filtering still narrows the whole list and pagination applies to the result.

No backend change — the members query already returns the (≤100) set; this is purely a presentation improvement using the DataTable's built-in pagination footer.

## Testing

`tsc --noEmit` + `oxlint --type-aware` clean. Suggested quick visual check: open Settings → Members with >10 members, confirm the pager + page-size selector work and that search/sort interact correctly with paging.

Closes #1463