### PR TITLE
feat(platform): upload product images during create/edit

### DIFF
--- a/services/platform/app/features/products/components/product-create-dialog.tsx
+++ b/services/platform/app/features/products/components/product-create-dialog.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/shared/constants/convex-enums';
 
 import { useCreateProduct } from '../hooks/mutations';
+import { ProductImageField } from './product-image-field';
 
 function isProductStatus(value: string): value is ProductStatus {
   return (Object.values(PRODUCT_STATUS) as string[]).includes(value);
@@ -172,12 +173,9 @@ export function ProductCreateDialog({
         rows={3}
       />
 
-      <Input
-        id="imageUrl"
-        type="url"
-        label={tProducts('edit.labels.imageUrl')}
-        {...register('imageUrl')}
-        placeholder={tProducts('edit.imageUrlPlaceholder')}
+      <ProductImageField
+        value={watch('imageUrl')}
+        onChange={(v) => setValue('imageUrl', v, { shouldDirty: true })}
         disabled={isSubmitting}
       />
 

--- a/services/platform/app/features/products/components/product-edit-dialog.tsx
+++ b/services/platform/app/features/products/components/product-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
 import { useUpdateProduct } from '../hooks/mutations';
+import { ProductImageField } from './product-image-field';
 
 interface EditProductDialogProps {
   isOpen: boolean;
@@ -186,12 +187,9 @@ export function ProductEditDialog({
         rows={3}
       />
 
-      <Input
-        id="imageUrl"
-        type="url"
-        label={tProducts('edit.labels.imageUrl')}
-        {...register('imageUrl')}
-        placeholder={tProducts('edit.imageUrlPlaceholder')}
+      <ProductImageField
+        value={watch('imageUrl')}
+        onChange={(v) => setValue('imageUrl', v, { shouldDirty: true })}
         disabled={isSubmitting}
       />
 

--- a/services/platform/app/features/products/components/product-image-field.tsx
+++ b/services/platform/app/features/products/components/product-image-field.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { Spinner } from '@tale/ui/spinner';
+import { ImagePlus, X } from 'lucide-react';
+import { useRef } from 'react';
+
+import { Image } from '@/app/components/ui/data-display/image';
+import { Input } from '@/app/components/ui/forms/input';
+import { toast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+
+import {
+  PRODUCT_IMAGE_ACCEPT,
+  PRODUCT_IMAGE_MAX_BYTES,
+  useProductImageUpload,
+} from '../hooks/use-product-image-upload';
+
+interface ProductImageFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Product image field: paste a URL or upload a file. Uploads go to Convex
+ * storage and resolve to a stable public URL stored in `imageUrl`, so the
+ * rest of the product UI (which renders `imageUrl` directly) is unchanged.
+ */
+export function ProductImageField({
+  value,
+  onChange,
+  disabled,
+}: ProductImageFieldProps) {
+  const { t: tProducts } = useT('products');
+  const { uploadImage, isUploading } = useProductImageUpload();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isDisabled = disabled || isUploading;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset so selecting the same file again still fires onChange.
+    e.target.value = '';
+    if (!file) return;
+
+    if (file.size > PRODUCT_IMAGE_MAX_BYTES) {
+      toast({
+        title: tProducts('edit.imageTooLarge'),
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      const url = await uploadImage(file);
+      if (url) {
+        onChange(url);
+      } else {
+        toast({
+          title: tProducts('edit.imageUploadFailed'),
+          variant: 'destructive',
+        });
+      }
+    } catch (err) {
+      console.error('Product image upload failed:', err);
+      toast({
+        title: tProducts('edit.imageUploadFailed'),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Input
+        id="imageUrl"
+        type="url"
+        label={tProducts('edit.labels.imageUrl')}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={tProducts('edit.imageUrlPlaceholder')}
+        disabled={isDisabled}
+      />
+      <div className="flex items-center gap-3">
+        {value && (
+          <Image
+            src={value}
+            alt=""
+            className="border-border size-12 shrink-0 rounded-md border object-cover"
+          />
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={PRODUCT_IMAGE_ACCEPT}
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={isDisabled}
+          onClick={() => inputRef.current?.click()}
+          className="gap-1.5"
+        >
+          {isUploading ? (
+            <Spinner size="sm" />
+          ) : (
+            <ImagePlus className="size-4" />
+          )}
+          {tProducts('edit.uploadImage')}
+        </Button>
+        {value && !isUploading && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled}
+            onClick={() => onChange('')}
+            aria-label={tProducts('edit.removeImage')}
+          >
+            <X className="size-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/products/hooks/use-product-image-upload.test.ts
+++ b/services/platform/app/features/products/hooks/use-product-image-upload.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useProductImageUpload } from './use-product-image-upload';
+
+const mutation = vi.fn();
+const query = vi.fn();
+
+vi.mock('@/app/hooks/use-convex-client', () => ({
+  useConvexClient: () => ({ mutation, query }),
+}));
+
+function file() {
+  return new File([new Uint8Array([1, 2, 3])], 'pic.png', {
+    type: 'image/png',
+  });
+}
+
+describe('useProductImageUpload', () => {
+  beforeEach(() => {
+    mutation.mockReset();
+    query.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uploads to storage and resolves a public URL', async () => {
+    mutation.mockResolvedValue('https://upload.example/post');
+    query.mockResolvedValue('https://files.example/pic.png');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ storageId: 'storage123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useProductImageUpload());
+    const url = await result.current.uploadImage(file());
+
+    expect(url).toBe('https://files.example/pic.png');
+    expect(mutation).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://upload.example/post',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(query).toHaveBeenCalledWith(expect.anything(), {
+      fileId: 'storage123',
+    });
+  });
+
+  it('throws when the upload POST fails', async () => {
+    mutation.mockResolvedValue('https://upload.example/post');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+
+    const { result } = renderHook(() => useProductImageUpload());
+    await expect(result.current.uploadImage(file())).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('throws when the response has no storageId', async () => {
+    mutation.mockResolvedValue('https://upload.example/post');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+
+    const { result } = renderHook(() => useProductImageUpload());
+    await expect(result.current.uploadImage(file())).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/products/hooks/use-product-image-upload.ts
+++ b/services/platform/app/features/products/hooks/use-product-image-upload.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useConvexClient } from '@/app/hooks/use-convex-client';
+import { api } from '@/convex/_generated/api';
+
+/** Product images are small thumbnails; cap uploads at 5 MB. */
+export const PRODUCT_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const PRODUCT_IMAGE_ACCEPT =
+  'image/png,image/jpeg,image/webp,image/gif,image/svg+xml';
+
+/**
+ * Uploads a product image to Convex storage and resolves a stable public URL
+ * suitable for the product's `imageUrl` field. Reuses the same
+ * generateUploadUrl → POST → getFileUrl flow as chat attachments, so no new
+ * storage/serving infrastructure is introduced.
+ */
+export function useProductImageUpload() {
+  const client = useConvexClient();
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadImage = useCallback(
+    async (file: File): Promise<string | null> => {
+      setIsUploading(true);
+      try {
+        const uploadUrl = await client.mutation(
+          api.files.mutations.generateUploadUrl,
+          {},
+        );
+        const res = await fetch(uploadUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': file.type || 'application/octet-stream' },
+          body: file,
+        });
+        if (!res.ok) {
+          throw new Error(`Upload failed with status ${res.status}`);
+        }
+        const { storageId } = await res.json();
+        if (!storageId) {
+          throw new Error('Upload response missing storageId');
+        }
+        return await client.query(api.files.queries.getFileUrl, {
+          fileId: storageId,
+        });
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [client],
+  );
+
+  return { uploadImage, isUploading };
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3858,6 +3858,10 @@
       "pricePlaceholder": "0.00",
       "stockPlaceholder": "0",
       "imageUrlPlaceholder": "https://example.com/image.jpg",
+      "uploadImage": "Bild hochladen",
+      "removeImage": "Bild entfernen",
+      "imageTooLarge": "Bild ist zu groß (max. 5 MB).",
+      "imageUploadFailed": "Bild-Upload fehlgeschlagen. Bitte versuche es erneut.",
       "currencyPlaceholder": "USD",
       "labels": {
         "name": "Produktname",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3858,6 +3858,10 @@
       "pricePlaceholder": "0.00",
       "stockPlaceholder": "0",
       "imageUrlPlaceholder": "https://example.com/image.jpg",
+      "uploadImage": "Upload image",
+      "removeImage": "Remove image",
+      "imageTooLarge": "Image is too large (max 5 MB).",
+      "imageUploadFailed": "Image upload failed. Please try again.",
       "currencyPlaceholder": "USD",
       "labels": {
         "name": "Product name",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3859,6 +3859,10 @@
       "pricePlaceholder": "0,00",
       "stockPlaceholder": "0",
       "imageUrlPlaceholder": "https://example.com/image.jpg",
+      "uploadImage": "Téléverser une image",
+      "removeImage": "Supprimer l'image",
+      "imageTooLarge": "L'image est trop volumineuse (max. 5 Mo).",
+      "imageUploadFailed": "Échec du téléversement de l'image. Réessaie.",
       "currencyPlaceholder": "EUR",
       "labels": {
         "name": "Nom du produit",


### PR DESCRIPTION
## What

Creating/editing a product only let you paste an image **URL** — there was no upload option (#1357).

## Change

- New `ProductImageField` (shared by the create + edit dialogs): the existing URL input **plus** a file picker and a thumbnail preview, with a clear/remove button.
- New `useProductImageUpload` hook: uploads via the same proven flow as chat attachments — `files.mutations.generateUploadUrl` → POST to Convex storage → `files.queries.getFileUrl` — and returns a **stable public URL** (`toPublicUrl`).
- The resolved URL is stored in the product's existing `imageUrl` string field, so **no schema change** and **no change to anywhere products are displayed** (they already render `imageUrl`). Pasting a URL still works.
- Images capped at 5 MB; accepts png/jpeg/webp/gif/svg.

## Testing

- New `use-product-image-upload.test.ts` (3): success resolves the public URL + calls the right endpoints; throws on failed POST; throws when the response has no `storageId`.
- `tsc --noEmit`, `oxlint --type-aware`, and i18n parity (en/de/fr keys added) all clean.
- Suggested live check: create a product, upload a PNG, confirm the thumbnail renders and the saved product shows the image.

Closes #1357