### PR TITLE
feat(platform): default team context in prompt library Team tab

### DIFF
--- a/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
+++ b/services/platform/app/features/prompts/components/prompt-library-dialog.tsx
@@ -10,6 +10,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { Select } from '@/app/components/ui/forms/select';
+import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { useCurrentUser } from '@/app/hooks/use-current-user';
 import { useDebounce } from '@/app/hooks/use-debounce';
@@ -60,6 +62,18 @@ function PromptLibraryDialogContent({
 
   const [activeTab, setActiveTab] = useState<TabValue>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const { teams } = useTeams();
+  const [selectedTeamId, setSelectedTeamId] = useState<string | undefined>(
+    undefined,
+  );
+
+  // Give the "Team" tab a default team context: select the user's first team
+  // once teams load, so the tab doesn't open with no active team (#1465).
+  useEffect(() => {
+    if (!selectedTeamId && teams && teams.length > 0) {
+      setSelectedTeamId(teams[0].id);
+    }
+  }, [teams, selectedTeamId]);
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<
     Id<'promptCategories'>[]
   >([]);
@@ -85,6 +99,7 @@ function PromptLibraryDialogContent({
   const { prompts, isLoading, canLoadMore, isLoadingMore, loadMore } =
     usePrompts(organizationId ?? '', {
       scope: scopeArg,
+      teamId: selectedTeamId,
       search: debouncedSearch || undefined,
       categoryIds: selectedCategoryIds,
       categories: selectedLegacyCategories,
@@ -323,6 +338,23 @@ function PromptLibraryDialogContent({
               </Button>
             }
           />
+
+          {activeTab === 'team' &&
+            (teams && teams.length > 0 ? (
+              <Select
+                value={selectedTeamId ?? ''}
+                onValueChange={setSelectedTeamId}
+                aria-label={t('library.teamContextLabel')}
+                options={teams.map((team) => ({
+                  value: team.id,
+                  label: team.name,
+                }))}
+              />
+            ) : (
+              <Text variant="caption" className="text-muted-foreground">
+                {t('library.noTeamsHint')}
+              </Text>
+            ))}
 
           <HStack gap={2} align="center">
             <div className="relative flex-1">

--- a/services/platform/app/features/prompts/hooks/queries.ts
+++ b/services/platform/app/features/prompts/hooks/queries.ts
@@ -77,6 +77,8 @@ export interface CategoriesBucketed {
 
 interface UsePromptsOptions {
   scope?: 'global' | 'team' | 'personal';
+  /** Active team context for the "Team" scope; ignored for other scopes. */
+  teamId?: string;
   search?: string;
   /** Legacy string filter; clients should prefer `categoryIds`. */
   categories?: string[];
@@ -99,6 +101,7 @@ export function usePrompts(
     ? {
         organizationId,
         scope: options.scope,
+        teamId: options.scope === 'team' ? options.teamId : undefined,
         search: options.search,
         categories:
           options.categories && options.categories.length > 0

--- a/services/platform/convex/prompts/queries.ts
+++ b/services/platform/convex/prompts/queries.ts
@@ -90,6 +90,9 @@ export const listPrompts = queryWithRLS({
   args: {
     organizationId: v.string(),
     scope: v.optional(promptScopeValidator),
+    /** Restrict team-scope results to a single team (the active team context
+     * in the Prompt Library "Team" tab). Ignored for other scopes. */
+    teamId: v.optional(v.string()),
     search: v.optional(v.string()),
     /**
      * Legacy string-based facet filter. Kept for backward compatibility
@@ -154,8 +157,12 @@ export const listPrompts = queryWithRLS({
         .order('desc')
         .paginate(paginationOpts);
       // Team membership filter can't be expressed in the index — must
-      // post-filter. Acceptable: team prompt counts are bounded.
-      postFilter = (p) => isActivePrompt(p) && hasTeamAccess(p, userTeamIds);
+      // post-filter. Acceptable: team prompt counts are bounded. When a
+      // specific team is requested, narrow to it too.
+      postFilter = (p) =>
+        isActivePrompt(p) &&
+        hasTeamAccess(p, userTeamIds) &&
+        (!args.teamId || p.teamId === args.teamId);
     } else if (args.scope === 'global') {
       result = await ctx.db
         .query('promptTemplates')

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3937,7 +3937,9 @@
       "searchPlaceholder": "Prompts suchen...",
       "loading": "Prompts werden geladen...",
       "loadMore": "Mehr laden",
-      "loadingMore": "Lädt..."
+      "loadingMore": "Lädt...",
+      "teamContextLabel": "Team",
+      "noTeamsHint": "Du bist noch in keinem Team. Bitte eine Administratorin, dich hinzuzufügen, um Team-Prompts zu nutzen."
     },
     "emptyState": {
       "title": "Noch keine Prompts",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3937,7 +3937,9 @@
       "searchPlaceholder": "Search prompts...",
       "loading": "Loading prompts...",
       "loadMore": "Load more",
-      "loadingMore": "Loading..."
+      "loadingMore": "Loading...",
+      "teamContextLabel": "Team",
+      "noTeamsHint": "You're not a member of any team yet. Ask an admin to add you to one to use team prompts."
     },
     "emptyState": {
       "title": "No prompts yet",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3938,7 +3938,9 @@
       "searchPlaceholder": "Rechercher des prompts...",
       "loading": "Chargement des prompts...",
       "loadMore": "Charger plus",
-      "loadingMore": "Chargement..."
+      "loadingMore": "Chargement...",
+      "teamContextLabel": "Équipe",
+      "noTeamsHint": "Tu ne fais encore partie d'aucune équipe. Demande à une administratrice de t'ajouter pour utiliser les prompts d'équipe."
     },
     "emptyState": {
       "title": "Aucun prompt pour le moment",


### PR DESCRIPTION
## What

In the Prompt Library **Team** tab there was no default team and no team selector — it listed all team prompts the user could access with no indication of which team's context was active, and nothing prompting users with no team (#1465).

## Change

- **Team selector** on the Team tab (only shown there), populated from `useTeams`, **defaulting to the user's first team** once teams load.
- Results filter to the selected team: `listPrompts` gains an optional `teamId` that narrows the existing team-scope post-filter (`p.teamId === teamId`); `usePrompts` threads it through (only for team scope).
- When the user is in **no team**, a clear hint replaces the empty list.

## Testing

- i18n parity green (en/de/fr keys: `teamContextLabel`, `noTeamsHint`); existing `prompt-library-dialog.test.tsx` still passes (mocks `useTeams`).
- `tsc --noEmit` + `oxlint --type-aware` clean.

Closes #1465