### PR TITLE
fix(platform): cap select dropdown height to the viewport

### DIFF
--- a/services/platform/app/components/ui/forms/select.test.tsx
+++ b/services/platform/app/components/ui/forms/select.test.tsx
@@ -49,6 +49,26 @@ describe('Select', () => {
       });
     });
 
+    // Regression test for #1492: near the bottom of a short viewport the
+    // dropdown must shrink to the space Radix measures instead of keeping a
+    // fixed max-height, otherwise its first option ("End workflow" in the
+    // automation next-step selector) gets clipped behind the scroll buttons.
+    it('caps the dropdown height to the available viewport space', async () => {
+      const { user } = render(
+        <Select options={options} placeholder="Select fruit" />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      });
+
+      const heightAware = document.querySelector(
+        '[class*="radix-select-content-available-height"]',
+      );
+      expect(heightAware).not.toBeNull();
+    });
+
     it('selects option on click', async () => {
       const handleChange = vi.fn();
       const { user } = render(

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -14,7 +14,13 @@ import { cn } from '@/lib/utils/cn';
 import { Label } from './label';
 
 const selectContentVariants = cva(
-  'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-muted text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+  // Cap the dropdown at the smaller of 24rem (the historical max) and the space
+  // Radix measures between the trigger and the viewport edge. Without this the
+  // content kept a fixed 24rem height and, near the bottom of a short viewport,
+  // could extend past the edge and clip its first option (e.g. "End workflow")
+  // behind the scroll buttons. The `,24rem` fallback keeps the cap for the
+  // `item-aligned` position, where Radix does not expose the available-height var.
+  'relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height,24rem))] min-w-[8rem] overflow-hidden rounded-md border bg-muted text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   {
     variants: {
       position: {
@@ -170,6 +176,9 @@ const SelectBase = forwardRef<
             className={selectContentVariants({ position })}
             position={position}
             sideOffset={sideOffset}
+            // Keep a small gap from the viewport edge so the dropdown (and its
+            // first option) is never flush against / clipped by the edge (#1492).
+            collisionPadding={8}
           >
             <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
               <ChevronUp className="size-4" aria-hidden="true" />


### PR DESCRIPTION
## What

The shared platform `Select` dropdown used a fixed `max-h-96` (24rem) with `overflow-hidden`, ignoring the space between the trigger and the viewport edge. Near the bottom of a short viewport the content could extend past the edge and clip its **first option** behind the scroll buttons — most visibly the **"End workflow"** option in the automation condition/action **next-step selector** (`next-steps-editor.tsx`), which is exactly what #1492 reports.

## Fix

`services/platform/app/components/ui/forms/select.tsx`:
- Cap the content at `min(24rem, var(--radix-select-content-available-height,24rem))` so it never exceeds the space Radix measures, and scrolls within the viewport instead of overflowing. The `24rem` fallback preserves the historical cap for the `item-aligned` position (where Radix doesn't expose the available-height variable).
- Add `collisionPadding={8}` so the dropdown keeps a small gap from the viewport edge.

This mirrors the height-aware pattern already used by `packages/ui/src/components/overlays/dropdown-menu.tsx`.

## Verification

- **Reproduced live (before):** opened the automation next-step `Select`; content computed `max-height: 384px` with `overflow: hidden` and did **not** consume `--radix-select-content-available-height` — so on a short viewport it overflowed/clipped the first option.
- **Verified live (after):** opened a locale `Select` ~193px above the viewport bottom; content now computes `max-height: 145.5px` (= the measured available height), fits fully inside the viewport, and its first option is reachable.
- New regression test in `select.test.tsx` asserts the content is viewport-height-aware.
- CodeRabbit CLI: 1 trivial nitpick (test is implementation-coupled — acceptable smoke test given jsdom can't measure layout; behaviour is also verified live).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — green (71,378 platform tests pass).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (Select content height is intentionally viewport-aware, not a skeleton).
- [ ] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no strings).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (no user-visible copy/behavior to document; internal layout fix).
- [x] Every touched docs page has a real opening/closing — N/A (no docs touched).
- [ ] Ran docs lint/test — N/A.
- [ ] Updated `README.*` — N/A.

Closes #1492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select dropdowns now intelligently adjust height based on available viewport space instead of a fixed maximum height
  * Select dropdowns maintain proper spacing from viewport edges to prevent content clipping at screen boundaries

* **Tests**
  * Added regression test verifying Select dropdown sizing and viewport-aware positioning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->