### PR TITLE
fix(ui): make form field borders visible in light mode

### DIFF
--- a/packages/ui/src/components/forms/input.test.tsx
+++ b/packages/ui/src/components/forms/input.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render } from '@/test/utils/render';
+
+import { Input } from './input';
+
+describe('Input', () => {
+  describe('accessibility', () => {
+    it('passes axe audit', async () => {
+      const { container } = render(<Input aria-label="Email" type="email" />);
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('border visibility', () => {
+    // Regression test for #1478: in light mode the field edge was barely
+    // visible because inputs used the faint incidental --color-border-base
+    // (#e5e7eb on a white surface). They must use the stronger, input-specific
+    // --color-border-input token instead.
+    it('uses the input-specific border token, not the faint base border', () => {
+      const { container } = render(<Input aria-label="Name" />);
+      const input = container.querySelector('input');
+      expect(input?.className).toContain('--color-border-input');
+      expect(input?.className).not.toContain('--color-border-base');
+    });
+  });
+});

--- a/packages/ui/src/components/forms/input.tsx
+++ b/packages/ui/src/components/forms/input.tsx
@@ -18,7 +18,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           'h-10 w-full rounded-lg border px-3 py-2 text-base md:text-sm',
-          'border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
+          'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',

--- a/packages/ui/src/components/forms/textarea.test.tsx
+++ b/packages/ui/src/components/forms/textarea.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render } from '@/test/utils/render';
+
+import { Textarea } from './textarea';
+
+describe('Textarea', () => {
+  describe('accessibility', () => {
+    it('passes axe audit', async () => {
+      const { container } = render(<Textarea aria-label="Bio" />);
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('border visibility', () => {
+    // Regression test for #1478: textareas shared the faint light-mode border
+    // with inputs and must likewise use the stronger --color-border-input token.
+    it('uses the input-specific border token, not the faint base border', () => {
+      const { container } = render(<Textarea aria-label="Notes" />);
+      const textarea = container.querySelector('textarea');
+      expect(textarea?.className).toContain('--color-border-input');
+      expect(textarea?.className).not.toContain('--color-border-base');
+    });
+  });
+});

--- a/packages/ui/src/components/forms/textarea.tsx
+++ b/packages/ui/src/components/forms/textarea.tsx
@@ -18,7 +18,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         rows={rows}
         className={cn(
           'min-h-[96px] w-full rounded-lg border px-3 py-2 text-base md:text-sm',
-          'border-[color:var(--color-border-base)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
+          'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -41,6 +41,10 @@
 
   --color-border-base: #e5e7eb;
   --color-border-strong: #d1d5db;
+  /* Form fields need a more visible edge than incidental borders. In light mode
+     the base #e5e7eb on a white field/card is barely perceptible (~1.2:1), so
+     inputs use a stronger border. Dark mode already reads well (see .dark). */
+  --color-border-input: var(--color-border-strong);
 
   --color-accent-base: #030712;
   --color-accent-fg: #ffffff;
@@ -206,6 +210,8 @@
 
   --color-border-base: #404040;
   --color-border-strong: #525252;
+  /* Dark inputs already have a clearly visible edge — keep the existing base. */
+  --color-border-input: var(--color-border-base);
 
   --color-accent-base: #ffffff;
   --color-accent-fg: #030712;

--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -165,6 +165,17 @@ describe('Input', () => {
     });
   });
 
+  describe('border visibility', () => {
+    // Regression test for #1478: the resting field edge was barely visible in
+    // light mode. The input ring must use the stronger --color-border-input
+    // token rather than the faint generic border.
+    it('uses the input border token for its ring', () => {
+      render(<Input label="Email" />);
+      const input = screen.getByLabelText('Email', { exact: false });
+      expect(input.className).toContain('--color-border-input');
+    });
+  });
+
   describe('error animation', () => {
     it('has transition classes', () => {
       render(<Input label="Email" />);

--- a/services/platform/app/components/ui/forms/input.tsx
+++ b/services/platform/app/components/ui/forms/input.tsx
@@ -26,7 +26,7 @@ const inputVariants = cva(
     variants: {
       variant: {
         default:
-          'rounded-lg border border-transparent bg-input px-3 py-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-1 ring-border focus-visible:ring-primary',
+          'rounded-lg border border-transparent bg-input px-3 py-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-1 ring-[color:var(--color-border-input)] focus-visible:ring-primary',
         unstyled: 'bg-transparent border-0 ring-0 ring-offset-0',
       },
       size: {

--- a/services/platform/app/components/ui/forms/textarea.test.tsx
+++ b/services/platform/app/components/ui/forms/textarea.test.tsx
@@ -91,6 +91,17 @@ describe('Textarea', () => {
     });
   });
 
+  describe('border visibility', () => {
+    // Regression test for #1478: the resting field edge was barely visible in
+    // light mode. The textarea border must use the stronger --color-border-input
+    // token rather than the faint generic border.
+    it('uses the input border token', () => {
+      render(<Textarea label="Message" />);
+      const textarea = screen.getByLabelText('Message', { exact: false });
+      expect(textarea.className).toContain('--color-border-input');
+    });
+  });
+
   describe('error animation', () => {
     it('has transition classes', () => {
       render(<Textarea label="Message" />);

--- a/services/platform/app/components/ui/forms/textarea.tsx
+++ b/services/platform/app/components/ui/forms/textarea.tsx
@@ -61,7 +61,7 @@ const TextareaBase = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         <textarea
           id={id}
           className={cn(
-            'border-border bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-base transition-[border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+            'border-(--color-border-input) bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-base transition-[border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
             hasError && 'border-destructive focus-visible:ring-destructive',
             showShake && 'animate-shake',
             className,


### PR DESCRIPTION
## What

In **light mode** the resting edge of form fields was barely visible (#1478). Two separate token systems were both too faint against a white field/card (~1.2:1):
- `@tale/ui` `Input`/`Textarea` used `--color-border-base` (`#e5e7eb`).
- The platform's own `Input`/`Textarea` used the generic `--border` (`hsl 240 5.9% 90%` ≈ `#e3e3e8`) via `ring-border` / `border-border`.

## Fix

Introduce a single dedicated token `--color-border-input` (in the shared `packages/ui/src/globals.css`):
- **Light:** `var(--color-border-strong)` = `#d1d5db` (gray-300) — a clearly visible edge.
- **Dark:** `var(--color-border-base)` = `#404040` — **unchanged** (dark already reads well).

Point **both** component systems at it:
- `@tale/ui` `Input`/`Textarea` border → `--color-border-input`.
- Platform `Input` resting ring + `Textarea` border → `--color-border-input`.

One token, one source of truth for "input border", light-only improvement.

## Verification

- **Live (light mode):** the platform Add-provider name input's resting ring is now `rgb(209,213,219)` / `#d1d5db` (was the fainter `--border`); the `--color-border-input` var resolves to `#d1d5db`.
- **Dark mode:** ring goes `hsl(0 0% 24%)` (`#3d3d3d`) → `#404040` — a 3-unit, imperceptible difference (no regression).
- New regression tests assert all four primitives use `--color-border-input` (and not the faint base). 45 platform + 4 ui form tests pass.

## CodeRabbit

Two findings, both intentionally not changed:
- *Syntax consistency (trivial):* `ring-[color:var(--color-border-input)]` vs `border-(--color-border-input)` — driven by the repo's oxlint `suggestCanonicalClasses` rule (border has a canonical shorthand; ring-color does not), so the difference is unavoidable.
- *Conflicting focus ring (minor):* `focus-visible:ring-ring` + `focus-visible:ring-primary` is **pre-existing** on that line; altering focus-ring semantics is out of scope for this visibility fix.

## Note on contrast

`#d1d5db` on white is ~1.5:1 — a clear visual improvement over the prior ~1.2:1, matching the conventional gray-300 input border. Strict WCAG 1.4.11 (3:1 non-text) would need a noticeably darker border (~gray-500) across every field, which is a larger design decision; this PR delivers the minimal, low-risk improvement.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — green.
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A.
- [ ] Updated `messages/{en,de,fr}.json` — N/A (no strings).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (visual refinement of an existing control; no behavior/config/copy change to document).
- [x] Touched docs openings/closings — N/A (no docs touched).
- [ ] Ran docs lint/test — N/A.
- [ ] Updated `README.*` — N/A.

Closes #1478
