### PR TITLE
fix(cli): gate db healthcheck on init-completion marker

### DIFF
--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -12,7 +12,8 @@
     "check:bundle": "bun run scripts/check-bundle.ts dist/tale",
     "lint": "bunx oxlint",
     "lint:fix": "bunx oxlint --fix",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@inquirer/prompts": "8.4.1",

--- a/tools/cli/src/lib/compose/services/create-db-service.test.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+
+import { setProjectId } from '../../project/project-context';
+import type { ServiceConfig } from '../types';
+import { createDbService } from './create-db-service';
+
+// getProjectId() (used for container_name) throws unless the project context
+// has been initialised, so seed it once for these unit tests.
+setProjectId('test-project');
+
+const config = {
+  version: '0.2.17',
+  registry: 'ghcr.io/tale-project',
+} satisfies ServiceConfig;
+
+describe('createDbService healthcheck', () => {
+  // Regression tests for #1411: on a fresh volume the first `tale start` could
+  // abort with "dependency failed to start: container ...-db is unhealthy"
+  // because the db healthcheck reported ready (pg_isready) before the
+  // background init scripts had finished and within too short a window.
+
+  test('gates on the init-completion marker, not just pg_isready', () => {
+    const command = createDbService(config).healthcheck?.test;
+    if (!Array.isArray(command)) {
+      throw new Error('db healthcheck test should be a CMD-SHELL array');
+    }
+    const shell = command.join(' ');
+    expect(shell).toContain('pg_isready');
+    // The tale-db image touches /tmp/.db_ready only after init completes, so
+    // dependents can't race the bootstrap (matches the canonical compose.yml).
+    expect(shell).toContain('/tmp/.db_ready');
+  });
+
+  test('allows a cold-boot-sized start_period', () => {
+    // 60s was too short for first-boot initdb + extensions + migrations on a
+    // slow disk; align with the canonical compose.yml window.
+    expect(createDbService(config).healthcheck?.start_period).toBe('120s');
+  });
+});

--- a/tools/cli/src/lib/compose/services/create-db-service.ts
+++ b/tools/cli/src/lib/compose/services/create-db-service.ts
@@ -14,15 +14,24 @@ export function createDbService(config: ServiceConfig): ComposeService {
     ],
     env_file: ['.env'],
     restart: 'unless-stopped',
+    // Gate dependents on BOTH PostgreSQL accepting connections AND the
+    // post-start init scripts finishing (they create `tale_knowledge` +
+    // extensions and run migrations in the background, so `pg_isready` alone
+    // races init on a fresh volume / slow disk). The tale-db image touches
+    // `/tmp/.db_ready` once init completes (services/db/docker-entrypoint.sh).
+    // Without the marker + a long enough start_period, the first cold boot
+    // could flip the db `unhealthy` and abort `docker compose up` with
+    // "dependency failed to start: container ...-db is unhealthy" (#1411).
+    // Keep this in lockstep with the canonical compose.yml db healthcheck.
     healthcheck: {
       test: [
         'CMD-SHELL',
-        'pg_isready -U ${POSTGRES_USER:-tale} -d ${POSTGRES_DB:-tale}',
+        'pg_isready -U ${POSTGRES_USER:-tale} -d ${POSTGRES_DB:-tale} && [ -f /tmp/.db_ready ]',
       ],
-      interval: '30s',
+      interval: '5s',
       timeout: '10s',
       retries: 3,
-      start_period: '60s',
+      start_period: '120s',
     },
     logging: DEFAULT_LOGGING,
     networks: ['internal'],


### PR DESCRIPTION
## What

On a fresh machine/volume the first `tale start` could abort with:

```
dependency failed to start: container <project>-db is unhealthy
```

(reported in #1411; a second `tale start` then succeeds because the volume is already initialised).

## Root cause

`tale start` generates a dev compose where `convex`/`platform`/`rag`/`crawler` gate on `depends_on: { db: { condition: service_healthy } }`. But the CLI-generated **db healthcheck** (`tools/cli/src/lib/compose/services/create-db-service.ts`) ran `pg_isready` alone with `interval: 30s` and `start_period: 60s`. On a cold boot the db image runs init scripts in the background (create `tale_knowledge` + extensions, run migrations) which can outlast 60s on a slow disk — so `pg_isready` reports ready (or the check flips `unhealthy`) **before** init finishes, and compose aborts.

The canonical root `compose.yml` db service already guards against exactly this by *also* requiring the `/tmp/.db_ready` marker the `tale-db` image writes once init completes (`services/db/docker-entrypoint.sh`), with a 5s interval and 120s start_period. The CLI generator had drifted out of lockstep.

## Fix

Bring the generated healthcheck in lockstep with `compose.yml`:
- `test`: `pg_isready … && [ -f /tmp/.db_ready ]`
- `interval`: `5s`, `start_period`: `120s` (timeout/retries unchanged)

## Tests

- Added `create-db-service.test.ts` asserting the healthcheck gates on the marker (not just `pg_isready`) and uses the cold-boot-sized `start_period`.
- **Wired up `@tale/cli`'s `test` task** — the workspace had tests (`compare-versions.test.ts`) but no `test` script, so `turbo run test` skipped them entirely. They now run in CI (42 tests pass).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — green (now includes 42 `@tale/cli` tests).
- [x] No hand-rolled skeletons — N/A.
- [ ] Updated `messages/{en,de,fr}.json` — N/A (no strings).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (internal healthcheck config; no user-facing behavior/flag/copy change — failure mode is removed, not documented).
- [x] Docs openings/closings — N/A.
- [ ] Ran docs lint/test — N/A.
- [ ] Updated `README.*` — N/A.

Closes #1411
