### PR TITLE
fix(platform): accept uiLanguage in shared userContext validator

### DIFF
--- a/services/platform/convex/agents/arena_chat.ts
+++ b/services/platform/convex/agents/arena_chat.ts
@@ -10,6 +10,7 @@ import { v } from 'convex/values';
 import { api, internal } from '../_generated/api';
 import { action } from '../_generated/server';
 import { authComponent } from '../auth';
+import { userContextValidator } from '../lib/agent_response/validators';
 
 export const arenaChat = action({
   args: {
@@ -30,13 +31,7 @@ export const arenaChat = action({
         }),
       ),
     ),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-        uiLanguage: v.optional(v.string()),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
     copyHistoryToB: v.optional(v.boolean()),
   },
   returns: v.object({

--- a/services/platform/convex/agents/start_chat.ts
+++ b/services/platform/convex/agents/start_chat.ts
@@ -18,6 +18,7 @@ import {
 import { components } from '../_generated/api';
 import { internalMutation } from '../_generated/server';
 import { startAgentChat } from '../lib/agent_chat';
+import { userContextValidator } from '../lib/agent_response/validators';
 import { getOrganizationMember } from '../lib/rls';
 
 const beforeGenerateHookRef = makeFunctionReference<'action'>(
@@ -47,13 +48,7 @@ export const startChat = internalMutation({
       ),
     ),
     additionalContext: v.optional(v.record(v.string(), v.string())),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-        uiLanguage: v.optional(v.string()),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
     agentConfig: v.any(),
     agentSlug: v.string(),
     preAllocatedStreamId: v.optional(v.string()),

--- a/services/platform/convex/agents/unified_chat.ts
+++ b/services/platform/convex/agents/unified_chat.ts
@@ -24,6 +24,7 @@ import {
   sanitizeMessage,
 } from '../governance/sanitize';
 import type { SerializableAgentConfig } from '../lib/agent_chat/types';
+import { userContextValidator } from '../lib/agent_response/validators';
 import { readJsonFile } from '../lib/file_io';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
 import { applyModelOverride, toSerializableConfig } from './config';
@@ -61,13 +62,7 @@ export const chatWithAgent = action({
      */
     capabilityBindings: v.optional(v.array(v.string())),
     additionalContext: v.optional(v.record(v.string(), v.string())),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-        uiLanguage: v.optional(v.string()),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
     /**
      * Projects feature: when the chat is sent from inside a project,
      * the client passes the `projectId`. The server validates access

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -45,6 +45,7 @@ import type {
   BeforeContextResult,
   BeforeGenerateResult,
 } from '../agent_response/types';
+import { userContextValidator } from '../agent_response/validators';
 import { buildInlineMultiModalPrompt } from '../attachments/build_inline_multi_modal_prompt';
 import {
   estimateTokens,
@@ -151,12 +152,7 @@ export const runAgentGeneration = internalAction({
      */
     originalUserText: v.optional(v.string()),
     additionalContext: v.optional(v.record(v.string(), v.string())),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
     parentThreadId: v.optional(v.string()),
     agentOptions: v.optional(v.any()),
     attachments: v.optional(

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -71,10 +71,13 @@ export interface StartAgentChatArgs {
   attachments?: FileAttachment[];
   /** Additional context to pass to the agent (key-value pairs) */
   additionalContext?: Record<string, string>;
-  /** User environment context (timezone, language) for template variables */
+  /** User environment context (timezone, language, UI locale) for template variables */
   userContext?: {
     timezone: string;
     language: string;
+    /** App UI locale (i18n), preferred over the browser locale for the
+     * response-language fallback when the user's input language is unclear. */
+    uiLanguage?: string;
   };
   /** Agent configuration (serializable) */
   agentConfig: SerializableAgentConfig;

--- a/services/platform/convex/lib/agent_response/validators.test.ts
+++ b/services/platform/convex/lib/agent_response/validators.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { userContextValidator } from './validators';
+
+// Regression guard for a shipped bug: the client sends userContext as
+// `{ timezone, language, uiLanguage }`, and Convex arg-validation is STRICT —
+// an extra field that the validator doesn't declare throws ArgumentValidationError
+// at runtime. Six chat/thread entry points used to carry duplicated inline
+// userContext validators; three had drifted to omit `uiLanguage`, so a turn that
+// reached `runAgentGeneration` was rejected with "extra field `uiLanguage`".
+//
+// All six now share `userContextValidator`. Locking its shape here catches the
+// drift the moment `uiLanguage` is dropped or made required again.
+describe('userContextValidator', () => {
+  it('declares timezone, language, and an optional uiLanguage', () => {
+    const { fields } = userContextValidator;
+
+    expect(Object.keys(fields).sort()).toEqual([
+      'language',
+      'timezone',
+      'uiLanguage',
+    ]);
+    expect(fields.timezone.isOptional).toBe('required');
+    expect(fields.language.isOptional).toBe('required');
+    expect(fields.uiLanguage.isOptional).toBe('optional');
+  });
+});

--- a/services/platform/convex/lib/agent_response/validators.ts
+++ b/services/platform/convex/lib/agent_response/validators.ts
@@ -8,6 +8,20 @@
 
 import { v } from 'convex/values';
 
+/**
+ * Client-supplied environment context (timezone, browser language, and the
+ * app UI locale) threaded from the chat entry points down through
+ * `runAgentGeneration` into `generateResponse`, where `uiLanguage` feeds the
+ * response-language fallback. Centralized here so the shape can't drift across
+ * the many actions that accept it — a missing `uiLanguage` on one hop in the
+ * chain surfaces as an opaque ArgumentValidationError at runtime.
+ */
+export const userContextValidator = v.object({
+  timezone: v.string(),
+  language: v.string(),
+  uiLanguage: v.optional(v.string()),
+});
+
 export const agentUsageValidator = v.object({
   inputTokens: v.optional(v.number()),
   outputTokens: v.optional(v.number()),

--- a/services/platform/convex/threads/edit_and_branch.ts
+++ b/services/platform/convex/threads/edit_and_branch.ts
@@ -11,6 +11,7 @@ import { ConvexError, v } from 'convex/values';
 
 import { components, internal } from '../_generated/api';
 import { action, type ActionCtx } from '../_generated/server';
+import { userContextValidator } from '../lib/agent_response/validators';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
 
 /**
@@ -57,12 +58,7 @@ export const editAndBranch = action({
     organizationId: v.string(),
     agentSlug: v.string(),
     modelId: v.optional(v.string()),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
   },
   returns: v.object({
     branchThreadId: v.string(),

--- a/services/platform/convex/threads/fork_and_chat.ts
+++ b/services/platform/convex/threads/fork_and_chat.ts
@@ -11,6 +11,7 @@ import { ConvexError, v } from 'convex/values';
 
 import { api, internal } from '../_generated/api';
 import { action } from '../_generated/server';
+import { userContextValidator } from '../lib/agent_response/validators';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
 
 export const forkAndChat = action({
@@ -20,12 +21,7 @@ export const forkAndChat = action({
     agentSlug: v.string(),
     organizationId: v.string(),
     modelId: v.optional(v.string()),
-    userContext: v.optional(
-      v.object({
-        timezone: v.string(),
-        language: v.string(),
-      }),
-    ),
+    userContext: v.optional(userContextValidator),
   },
   returns: v.object({
     threadId: v.string(),


### PR DESCRIPTION
## What

Chat turns were failing in `runAgentGeneration` with:

```
ArgumentValidationError: Object contains extra field `uiLanguage` that is not in the validator.
Path: .userContext
Object: {language: "zh-CN", timezone: "Asia/Shanghai", uiLanguage: "en"}
Validator: v.object({language: v.string(), timezone: v.string()})
```

The client sends `userContext` as `{ timezone, language, uiLanguage }` on the `chatWithAgent` / `arenaChat` paths. Convex arg-validation is strict, so the extra `uiLanguage` field was rejected one hop downstream at the internal `runAgentGeneration` action. `uiLanguage` is genuinely consumed in `generate_response` for the response-language fallback (`clientLocale = [uiLanguage, language]`), so it must flow through intact rather than be stripped.

## Root cause

Six chat/thread entry points carried **duplicated inline `userContext` validators that had drifted** — three already accepted `uiLanguage`, three (`runAgentGeneration`, `edit_and_branch`, `fork_and_chat`) did not. The field passed the entry validator only to be rejected by the next one in the chain.

## Fix

- Add a single shared `userContextValidator` to `lib/agent_response/validators.ts` (the file that exists to keep agent-action validators from drifting) and route all six entry points through it, so the shape can't diverge again.
- Add `uiLanguage?: string` to the intermediate `startAgentChat` TS type so the field is type-honest through that layer.
- `edit_and_branch` / `fork_and_chat` gain the optional field too — purely additive, no behavior change for current callers.
- Regression test locks the shared validator's shape (`timezone` + `language` required, `uiLanguage` optional).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests). Format/lint/typecheck clean. Test suite: 71449/71458 passed; the 9 failures were unrelated `convexTest` 5000ms-timeout flakes under turbo load (slack, governance/erasure, members, users, documents, workflows, dashboard — none touch this change) and **pass in isolation** (re-ran all 9 files → 89/89 green).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (backend validator change, no UI).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no message keys).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change — N/A (internal Convex action arg; bug fix removes a runtime error, no new user-visible/configurable surface).
- [x] Docs openings/closings — N/A (no docs touched).
- [x] Ran `bun run --filter @tale/docs lint` and `test` — N/A (no docs touched).
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated user context validation (timezone, language, and optional UI language preference) across chat and thread endpoints for improved consistency and maintainability.

* **Tests**
  * Added validation test coverage for user context structure to prevent runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->