### PR TITLE
docs(pii): document PII at-rest posture (Option B)

### DIFF
--- a/docs/de/self-hosted/operate/security/cryptography.md
+++ b/docs/de/self-hosted/operate/security/cryptography.md
@@ -17,6 +17,12 @@ Tale verschlüsselt zwei Klassen von Secrets im Ruhezustand, mit zwei verschiede
 
 Der Convex-Datenspeicher und die Postgres-Volumes werden vom Host geschützt: betreibe sie auf einem verschlüsselten Dateisystem (LUKS oder die Volume-Verschlüsselung deines Cloud-Anbieters). Tale speichert Credentials nicht im Klartext — ein Provider-Schlüssel oder OAuth-Token ist entweder SOPS-verschlüsselt auf der Festplatte oder AES-256-GCM-verschlüsselt in der Datenbank, nie im Klartext geschrieben.
 
+**Kunden-PII und Anwendungsdaten** — Namen, E-Mail- und Postadressen, Gesprächsinhalte — sind im Ruhezustand durch dieselben Schichten geschützt, die die Datenbank als Ganzes schützen: Convex' Verschlüsselung im Ruhezustand, TLS 1.3 bei der Übertragung und zeilenbasierte Sicherheitsregeln (RLS), die jeden Lesezugriff auf die Organisation des Aufrufers begrenzen.
+
+Anwendungsseitige Feldverschlüsselung ist gezielt für Secrets gemacht — Provider-Schlüssel und OAuth-Tokens, die einmal geschrieben und von einem einzigen Code-Pfad gelesen werden. PII ist anders: Sie wird gefiltert, sortiert und über den exakten Wert nachgeschlagen, und die Kundentabelle ist nach Organisation und E-Mail indiziert. Diese Spalten auf Feldebene zu verschlüsseln würde Gleichheitsabfragen und indizierte Suche brechen — sofern nicht mit einem suchbaren Hash-Verfahren kombiniert, das genau die Gleichheit preisgibt, die es verbergen soll — bei zusätzlichen Kosten für die Schlüsselrotation und ohne Schutz, den die verschlüsselte Host-Festplatte unter der Anwendung gegen ein gestohlenes Volume nicht ohnehin bietet.
+
+Wenn dein Compliance-Regime zusätzlich Feldverschlüsselung für PII verlangt, ist das eine bewusste Anwendungsänderung statt eines Standards, den Tale mitliefert.
+
 ## Daten bei der Übertragung
 
 Aller Browser- und API-Verkehr terminiert TLS am Reverse-Proxy (Caddy), der TLS 1.3 (mit TLS 1.2 als Untergrenze) aushandelt und Zertifikate automatisch bezieht. Die Cipher-Suites sind die modernen Defaults des Proxys — AES-256-GCM und ChaCha20-Poly1305 mit ECDHE-Schlüsselaustausch. Konfiguriere Domain und Zertifikatsquelle in [TLS und Domains](/de/self-hosted/configuration/tls-and-domains); der Verkehr zwischen Containern bleibt im internen Docker-Netz des Hosts.

--- a/docs/en/self-hosted/operate/security/cryptography.md
+++ b/docs/en/self-hosted/operate/security/cryptography.md
@@ -17,6 +17,12 @@ Tale encrypts two classes of secret at rest, with two different mechanisms.
 
 The Convex data store and Postgres volumes are protected by the host: run them on an encrypted filesystem (LUKS, or your cloud provider's volume encryption). Tale does not store credentials in plaintext — a provider key or OAuth token is either SOPS-encrypted on disk or AES-256-GCM-encrypted in the database, never written in the clear.
 
+**Customer PII and application records** — names, email and postal addresses, conversation content — are protected at rest by the same layers that protect the database as a whole: Convex's at-rest encryption, TLS 1.3 in transit, and row-level security that scopes every read to the caller's organisation.
+
+Application-level field encryption is purpose-built for secrets — provider keys and OAuth tokens, written once and read by a single code path. PII is different: it is filtered, sorted, and looked up by exact value, and the customer table is indexed by organisation and email. Encrypting those columns at the field level would break equality lookups and indexed search — unless paired with a searchable-hash scheme that leaks the very equality it is meant to hide — while adding a key-rotation cost and no protection the encrypted host disk beneath the application doesn't already provide against a stolen volume.
+
+If your compliance regime calls for field-level PII encryption on top of these layers, that is a deliberate application change rather than a default Tale ships.
+
 ## Data in transit
 
 All browser and API traffic terminates TLS at the reverse proxy (Caddy), which negotiates TLS 1.3 (with TLS 1.2 as the floor) and obtains certificates automatically. The cipher suites are the proxy's modern defaults — AES-256-GCM and ChaCha20-Poly1305 with ECDHE key exchange. Configure the domain and certificate source in [TLS and domains](/self-hosted/configuration/tls-and-domains); traffic between containers stays on the host's internal Docker network.

--- a/docs/fr/self-hosted/operate/security/cryptography.md
+++ b/docs/fr/self-hosted/operate/security/cryptography.md
@@ -17,6 +17,12 @@ Tale chiffre deux classes de secrets au repos, avec deux mécanismes différents
 
 Le magasin de données Convex et les volumes Postgres sont protégés par l'hôte : fais-les tourner sur un système de fichiers chiffré (LUKS, ou le chiffrement de volume de ton fournisseur cloud). Tale ne stocke pas d'identifiants en clair — une clé de fournisseur ou un token OAuth est soit chiffré par SOPS sur le disque, soit chiffré en AES-256-GCM en base, jamais écrit en clair.
 
+**Les données personnelles des clients et les enregistrements applicatifs** — noms, adresses e-mail et postales, contenu des conversations — sont protégés au repos par les mêmes couches qui protègent la base dans son ensemble : le chiffrement au repos de Convex, TLS 1.3 en transit, et la sécurité au niveau des lignes (RLS) qui restreint chaque lecture à l'organisation de l'appelant.
+
+Le chiffrement applicatif au niveau des champs est conçu pour les secrets — clés de fournisseur et tokens OAuth, écrits une fois et lus par un unique chemin de code. Les données personnelles sont différentes : elles sont filtrées, triées et recherchées par valeur exacte, et la table des clients est indexée par organisation et e-mail. Chiffrer ces colonnes au niveau des champs casserait les recherches par égalité et l'indexation — sauf à les coupler à un schéma de hachage recherchable qui révèle l'égalité même qu'il est censé masquer — au prix d'une rotation des clés et sans protection que le système de fichiers hôte chiffré sous l'application n'offre déjà contre un volume volé.
+
+Si ta réglementation de conformité exige en plus un chiffrement des données personnelles au niveau des champs, c'est une modification applicative délibérée plutôt qu'un défaut livré par Tale.
+
 ## Données en transit
 
 Tout le trafic navigateur et API termine TLS au reverse proxy (Caddy), qui négocie TLS 1.3 (avec TLS 1.2 comme plancher) et obtient les certificats automatiquement. Les suites de chiffrement sont les défauts modernes du proxy — AES-256-GCM et ChaCha20-Poly1305 avec échange de clés ECDHE. Configure le domaine et la source de certificat dans [TLS et domaines](/fr/self-hosted/configuration/tls-and-domains) ; le trafic entre conteneurs reste sur le réseau Docker interne de l'hôte.


### PR DESCRIPTION
## What

Resolves the `needs discussion` decision in #1509 — **PII at rest = Option B**: document Tale's existing posture as policy rather than building app-level field encryption.

Adds a paragraph to the **Data at rest** section of the cryptography page (en/de/fr) stating explicitly: customer PII and application records (names, email/postal addresses, conversation content) are **not** application-encrypted by design; field-level encryption stays reserved for secrets (provider keys via SOPS, OAuth tokens via JWE). PII is filtered/sorted/looked up by exact value — the `customers` table is indexed by organisation and email — so encrypting those columns would break equality lookups and indexed search (absent a searchable-hash scheme that leaks the same equality it hides) and add key-rotation cost **without** changing the host-disk threat model the encrypted filesystem already covers. Application data therefore relies on Convex at-rest encryption + TLS 1.3 + row-level org isolation.

## Why this is the decision record

There's no separate ADR tree in this repo, and the docs contract forbids dated status-chatter in page prose. The published, auditor-facing cryptography page **is** the policy statement (it already maps primitives to BSI TR-02102-1); this PR + the security epic #1803 are the dated decision record for SOC 2 / ISO 27001 traceability (control CC6.7 / A.8.24).

## Verification

- `bun run --filter @tale/docs lint` ✓, `test` ✓ (139 tests — locale parity, terminology, loanword, opening/closing), `build` ✓ (no broken links; cryptography page prerenders).
- `bun run check` ✓.
- CodeRabbit: no findings.

## Pre-PR checklist

- [x] Ran `bun run check` — green.
- [x] No hand-rolled skeletons — N/A.
- [ ] Updated `messages/{en,de,fr}.json` — N/A (no UI strings).
- [x] Updated `/docs/{en,de,fr}/` for the change — **yes** (cryptography page, all three base locales).
- [x] Every touched docs page has a real opening/closing — unchanged page already satisfies; addition is body prose in narrator voice.
- [x] Ran `bun run --filter @tale/docs lint` and `test` — yes.
- [ ] Updated `README.*` — N/A.

Closes #1509
Part of #1803


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated security documentation across multiple languages to clarify how customer PII and application data are protected, explaining encryption policies at the application, database, and transport layers, and providing guidance for implementing field-level encryption if required for compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->