### PR TITLE
feat(platform): consolidate API settings and refine navigation chrome

### DIFF
--- a/packages/ui/src/components/navigation/bottom-tab-bar.tsx
+++ b/packages/ui/src/components/navigation/bottom-tab-bar.tsx
@@ -126,7 +126,7 @@ function BottomTabBarButton({ item }: BottomTabBarButtonProps) {
           </>
         )}
       </span>
-      <span className="w-full text-center text-[10px] leading-tight">
+      <span className="w-full truncate text-center text-[10px] leading-tight">
         {item.label}
       </span>
     </button>

--- a/packages/ui/src/components/navigation/bottom-tab-bar.tsx
+++ b/packages/ui/src/components/navigation/bottom-tab-bar.tsx
@@ -126,7 +126,7 @@ function BottomTabBarButton({ item }: BottomTabBarButtonProps) {
           </>
         )}
       </span>
-      <span className="w-full truncate text-center text-[10px] leading-tight">
+      <span className="w-full text-center text-[10px] leading-tight">
         {item.label}
       </span>
     </button>

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -199,6 +199,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
             </svg>
           </DropdownMenuPrimitive.SubTrigger>
           <DropdownMenuPrimitive.SubContent
+            collisionPadding={16}
             className={cn(
               'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg',
               item.contentClassName,
@@ -303,9 +304,10 @@ export function DropdownMenu({
         <DropdownMenuPrimitive.Content
           sideOffset={4}
           align={align}
+          collisionPadding={16}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] overflow-y-auto overflow-x-hidden rounded-lg border bg-card p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none',
+            'z-50 max-h-(--radix-dropdown-menu-content-available-height) max-w-(--radix-dropdown-menu-content-available-width) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] overflow-y-auto overflow-x-hidden rounded-lg border bg-card p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none',
             contentClassName,
           )}
         >

--- a/packages/ui/src/components/search/search-command-input.tsx
+++ b/packages/ui/src/components/search/search-command-input.tsx
@@ -61,7 +61,7 @@ export function SearchCommandInput({
         onKeyDown={onKeyDown}
         autoFocus
         placeholder={placeholder}
-        className="text-fg-base placeholder:text-fg-muted h-12 flex-1 bg-transparent text-sm outline-none focus:outline-none focus-visible:outline-none"
+        className="text-fg-base placeholder:text-fg-muted h-12 flex-1 bg-transparent text-base outline-none focus:outline-none focus-visible:outline-none"
         aria-label={placeholder}
         role="combobox"
         aria-autocomplete="list"

--- a/services/platform/app/components/layout/mobile-back-button.tsx
+++ b/services/platform/app/components/layout/mobile-back-button.tsx
@@ -27,6 +27,10 @@ const TOP_LEVEL_SUFFIXES = new Set([
   'agents',
   'documents',
   'automations',
+  // Settings overview lists are themselves reachable from the "More" tab, so
+  // they're top-level (no back button) — only their sub-pages get one.
+  'settings',
+  'settings/personal',
 ]);
 
 interface MobileBackButtonProps {
@@ -35,9 +39,15 @@ interface MobileBackButtonProps {
 
 /**
  * Renders an iOS-style back chevron on the left of the mobile top bar for
- * sub-pages only. Prefers `router.history.back()` when there's app history,
- * else falls back to the natural parent route — so deep links from
- * notifications/email don't strand the user.
+ * sub-pages only.
+ *
+ * Settings sub-pages (`settings/*`) always return to the settings list
+ * (`settings`) rather than walking the history stack — the list is their one
+ * canonical parent, so back is predictable no matter how the user arrived
+ * (deep link, tab switch, in-page navigation). Everywhere else we prefer
+ * `router.history.back()` when there's app history, else fall back to the
+ * natural parent route so deep links from notifications/email don't strand
+ * the user.
  */
 export function MobileBackButton({ organizationId }: MobileBackButtonProps) {
   const location = useLocation();
@@ -45,6 +55,7 @@ export function MobileBackButton({ organizationId }: MobileBackButtonProps) {
   const { t } = useT('common');
 
   const orgRoot = `/dashboard/${organizationId}`;
+  const settingsRoot = `${orgRoot}/settings`;
   const pathSuffix = useMemo(() => {
     if (!location.pathname.startsWith(orgRoot)) return null;
     const tail = location.pathname.slice(orgRoot.length);
@@ -53,7 +64,14 @@ export function MobileBackButton({ organizationId }: MobileBackButtonProps) {
 
   const isTopLevel = pathSuffix === null || TOP_LEVEL_SUFFIXES.has(pathSuffix);
 
+  // A settings sub-page: under `settings/` but not the `settings` index itself.
+  const isSettingsSubPage = pathSuffix?.startsWith('settings/') ?? false;
+
   const handleBack = useCallback(() => {
+    if (isSettingsSubPage) {
+      router.history.push(settingsRoot);
+      return;
+    }
     if (router.history.canGoBack()) {
       router.history.back();
       return;
@@ -69,7 +87,7 @@ export function MobileBackButton({ organizationId }: MobileBackButtonProps) {
     segments.pop();
     const parent = segments.join('/');
     router.history.push(parent ? `${orgRoot}/${parent}` : orgRoot);
-  }, [router, pathSuffix, orgRoot]);
+  }, [router, pathSuffix, orgRoot, isSettingsSubPage, settingsRoot]);
 
   if (isTopLevel) return null;
 

--- a/services/platform/app/components/layout/mobile-bottom-nav.tsx
+++ b/services/platform/app/components/layout/mobile-bottom-nav.tsx
@@ -36,8 +36,6 @@ interface PrimaryTab {
   activePrefix: string;
   /** Optional CASL gate. */
   gate?: () => boolean;
-  /** Render with featured styling (always-on pill, larger icon). */
-  featured?: boolean;
 }
 
 const PERSONAL_SETTINGS_SEGMENTS = new Set([
@@ -70,9 +68,10 @@ interface OverflowItem {
  * (not inside) the hamburger drawer so secondary navigation (org switcher,
  * account, sub-routes) stays available without crowding the tab bar.
  *
- * Layout: four nav destinations flank a centered, featured Chat tab. A "More"
- * tab opens a bottom sheet listing the destinations that don't fit (Knowledge,
- * Automations) — the standard iOS overflow pattern.
+ * Layout: a row of primary nav destinations followed by a "More" tab that
+ * opens a bottom sheet listing the destinations that don't fit (Knowledge,
+ * Automations) — the standard iOS overflow pattern. Each tab highlights only
+ * when its route is active.
  */
 export function MobileBottomNav({ organizationId }: MobileBottomNavProps) {
   const navigate = useNavigate();
@@ -112,7 +111,6 @@ export function MobileBottomNav({ organizationId }: MobileBottomNavProps) {
         icon: MessageCircle,
         to: `/dashboard/${organizationId}/chat`,
         activePrefix: `/dashboard/${organizationId}/chat`,
-        featured: true,
       },
       {
         key: 'agents',
@@ -183,7 +181,6 @@ export function MobileBottomNav({ organizationId }: MobileBottomNavProps) {
           label: tab.label,
           icon: tab.icon,
           active,
-          featured: tab.featured,
           accentColor: active && accentColor ? accentColor : undefined,
           onSelect: () => {
             void navigate({ to: tab.to });

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -193,7 +193,7 @@ export function TabNavigation({
     <nav
       ref={navRef}
       className={cn(
-        'scrollbar-hide relative border-b border-border px-4 min-h-12 flex flex-nowrap items-center gap-4 shrink-0 overflow-x-auto',
+        'scrollbar-hide relative border-b border-border min-h-10 flex items-center gap-4 shrink-0 overflow-x-auto px-4',
         standalone && 'bg-background z-10',
         className,
       )}
@@ -220,7 +220,7 @@ export function TabNavigation({
             preload={prefetch ? 'render' : false}
             aria-current={isActive ? 'page' : undefined}
             className={cn(
-              "relative h-full flex items-center gap-1.5 py-1 text-sm font-medium transition-colors whitespace-nowrap shrink-0 rounded-sm focus-visible:outline-none focus-visible:after:content-[''] focus-visible:after:absolute focus-visible:after:-inset-x-1 focus-visible:after:inset-y-0.5 focus-visible:after:rounded-sm focus-visible:after:ring-2 focus-visible:after:ring-ring focus-visible:after:ring-inset focus-visible:after:pointer-events-none",
+              "relative h-full flex items-center gap-1.5 py-1 text-sm font-medium transition-colors whitespace-nowrap shrink-0 rounded-sm focus-visible:outline-none focus-visible:after:content-[''] focus-visible:after:absolute focus-visible:after:-inset-x-1 focus-visible:after:inset-y-0.5 focus-visible:after:rounded-sm focus-visible:after:ring-2 focus-visible:after:ring-ring focus-visible:after:ring-inset focus-visible:after:pointer-events-none justify-center",
               isActive
                 ? 'text-foreground'
                 : 'text-muted-foreground hover:text-foreground',
@@ -254,7 +254,9 @@ export function TabNavigation({
         />
       )}
 
-      {children}
+      {children && (
+        <div className="ml-auto flex items-center gap-2">{children}</div>
+      )}
     </nav>
   );
 }

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -193,7 +193,7 @@ export function TabNavigation({
     <nav
       ref={navRef}
       className={cn(
-        'scrollbar-hide relative border-b border-border min-h-10 flex items-center gap-4 shrink-0 overflow-x-auto px-4',
+        'scrollbar-hide relative border-b border-border min-h-11 flex items-center gap-4 shrink-0 overflow-x-auto px-4',
         standalone && 'bg-background z-10',
         className,
       )}

--- a/services/platform/app/components/user-button.test.tsx
+++ b/services/platform/app/components/user-button.test.tsx
@@ -231,6 +231,25 @@ describe('UserButton', () => {
     expect(getDropdownTrigger(container)).toBeInTheDocument();
   });
 
+  it('renders without crashing when teams are present', () => {
+    // Exercises the org / team / language picker rows, which render as
+    // inline collapsibles on mobile and Radix sub-menu popups on larger
+    // screens. Regression guard that the responsive branch builds without
+    // crashing when teams are present.
+    mockTeamFilter = {
+      teams: [
+        { id: 'team-1', name: 'Engineering' },
+        { id: 'team-2', name: 'Design' },
+      ],
+      selectedTeamId: 'team-1',
+      setSelectedTeamId: vi.fn(),
+      isLoadingTeams: false,
+      filterByTeam: <T,>(items: T[]) => items,
+    };
+    const { container } = render(<UserButton />);
+    expect(getDropdownTrigger(container)).toBeInTheDocument();
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<UserButton />);

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -9,6 +9,7 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Tabs } from '@tale/ui/tabs';
 import { Text } from '@tale/ui/text';
 import { useTheme } from '@tale/ui/theme';
+import { useIsMobile } from '@tale/ui/use-is-mobile';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import {
   LogOut,
@@ -21,14 +22,23 @@ import {
   Languages,
   Building2,
   Download,
+  ChevronRight,
+  Check,
 } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import {
+  type ComponentType,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 
 import { IosInstallSheet } from '@/app/components/pwa/ios-install-sheet';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { OrganizationListPanel } from '@/app/features/organization/components/organization-list-panel';
 import { useUserOrganizationsWithDetails } from '@/app/features/organization/hooks/queries';
+import { TeamListPanel } from '@/app/features/settings/teams/components/team-list-panel';
 import { useChangelogNotification } from '@/app/hooks/use-changelog-notification';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
@@ -46,6 +56,81 @@ const LANGUAGE_FLAGS: Record<string, string> = {
   de: '\u{1F1E9}\u{1F1EA}', // DE
   fr: '\u{1F1EB}\u{1F1F7}', // FR
 };
+
+/**
+ * The current-selection pill shown after a picker row's static label (e.g. the
+ * active org / team name). Shared by the mobile inline collapsible rows and the
+ * desktop sub-menu triggers so both read identically.
+ */
+function MenuRowBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="bg-muted text-muted-foreground ml-auto max-w-[9rem] truncate rounded-full px-2 py-0.5 text-xs">
+      {children}
+    </span>
+  );
+}
+
+interface MenuRowCollapsibleProps {
+  icon: ComponentType<{ className?: string }>;
+  /** Static primary label (e.g. "Organization", "Team", "Language"). */
+  label: string;
+  /**
+   * Current selection, rendered as a small badge after the label — e.g. the
+   * active org / team name. Omit for rows with no single current value.
+   */
+  badge?: string;
+  children: ReactNode;
+}
+
+/**
+ * A dropdown-menu row whose options expand inline, in place, pushing the rows
+ * below it down — used for the wide org / team / language pickers.
+ *
+ * We deliberately do NOT use a side flyout here (Radix menu sub-menu or a
+ * side-anchored Popover). The account menu sits hard against a screen edge
+ * (right edge in the header, left edge in the sidebar), and a fixed-width
+ * 18rem panel has nowhere to go: Radix runs `shift` before `flip`, so it
+ * either clips off the far edge or slides behind the parent menu. Expanding
+ * inline removes the second layer entirely, so the picker can never leak or
+ * be occluded, on any viewport width.
+ *
+ * Lives inside an open DropdownMenu; the toggle row and option rows are plain
+ * buttons (not menu items) and stop event propagation so a click expands /
+ * selects without closing the menu.
+ */
+function MenuRowCollapsible({
+  icon: Icon,
+  label,
+  badge,
+  children,
+}: MenuRowCollapsibleProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="focus:bg-accent hover:bg-accent flex w-full cursor-default items-center gap-2 rounded-md px-2 py-2.5 text-sm outline-none [&_svg]:size-4 [&_svg]:shrink-0"
+      >
+        <Icon />
+        <span className="shrink-0">{label}</span>
+        {badge != null && <MenuRowBadge>{badge}</MenuRowBadge>}
+        <ChevronRight
+          className={cn(
+            'transition-transform',
+            badge == null && 'ml-auto',
+            open && 'rotate-90',
+          )}
+        />
+      </button>
+      {open && <div className="mt-0.5 mb-1 ml-2 border-l pl-2">{children}</div>}
+    </div>
+  );
+}
 
 export interface UserButtonProps {
   align?: 'start' | 'end';
@@ -78,6 +163,10 @@ export function UserButton({
   const organizationId = params.id;
   const { theme, setTheme } = useTheme();
   const { locale, setLocale } = useLocale();
+  // The org / team / language pickers expand inline on mobile (no room for a
+  // side flyout against the screen edge) but use Radix sub-menu popups on
+  // larger screens, where there's space to anchor them.
+  const isMobile = useIsMobile();
   const teamFilter = useOptionalTeamFilter();
   const teams = teamFilter?.teams;
   const selectedTeamId = teamFilter?.selectedTeamId ?? null;
@@ -227,75 +316,116 @@ export function UserButton({
     ]);
 
     if (!loading && user && organizationId) {
-      // Organization switcher — uses a sub-menu so the dropdown stays
-      // compact for users with many orgs. The trigger row shows the current
-      // org name; opening the sub reveals the full searchable / scrollable
-      // panel of organizations.
+      // Organization switcher. On mobile it expands inline (MenuRowCollapsible)
+      // because the menu sits hard against a screen edge where a fixed-width
+      // side flyout can't stay on-screen. On larger screens we keep the Radix
+      // sub-menu popup, which has room to anchor and reveals the full
+      // scrollable panel without pushing the rest of the menu down.
       const currentOrgName = currentOrg?.name ?? tNav('orgSwitcher.label');
       groups.push([
-        {
-          type: 'sub',
-          label: currentOrgName,
-          icon: Building2,
-          items: [
-            [
-              {
-                type: 'custom',
-                content: (
+        isMobile
+          ? {
+              type: 'custom',
+              content: (
+                <MenuRowCollapsible
+                  icon={Building2}
+                  label={tNav('orgSwitcher.label')}
+                  badge={currentOrgName}
+                >
                   <OrganizationListPanel
                     currentOrganizationId={organizationId}
+                    hideHeader
                   />
-                ),
-              },
-            ],
-          ],
-          className: 'py-2.5',
-          contentClassName: 'min-w-72',
-        },
+                </MenuRowCollapsible>
+              ),
+            }
+          : {
+              type: 'sub',
+              label: tNav('orgSwitcher.label'),
+              icon: Building2,
+              trailing: <MenuRowBadge>{currentOrgName}</MenuRowBadge>,
+              items: [
+                [
+                  {
+                    type: 'custom',
+                    content: (
+                      <OrganizationListPanel
+                        currentOrganizationId={organizationId}
+                      />
+                    ),
+                  },
+                ],
+              ],
+              className: 'py-2.5',
+              contentClassName: 'min-w-72',
+            },
       ]);
 
-      // Team filter — also a sub-menu so a user with many teams isn't faced
-      // with a 50-row dropdown. The trigger shows the currently selected
-      // team; the sub-menu has the full list.
-      if (teams && teams.length > 0) {
+      // Team filter — mirrors the org switcher: inline collapsible on mobile,
+      // Radix sub-menu popup on larger screens. Always shown once the teams
+      // query has resolved, even with zero teams: the panel then surfaces an
+      // empty state plus a "Create team" action, so the section never silently
+      // disappears for orgs that haven't set up teams yet.
+      if (teams) {
         const selectedTeamName = selectedTeamId
           ? (teams.find((team) => team.id === selectedTeamId)?.name ??
             tNav('teamFilter.allTeams'))
           : tNav('teamFilter.allTeams');
 
+        const selectTeam = (teamId: string | null) => {
+          setSelectedTeamId?.(teamId);
+          if (organizationId) {
+            void navigate({
+              to: '/dashboard/$id/chat',
+              params: { id: organizationId },
+            });
+            onNavigate?.();
+          }
+        };
+
         groups.push([
-          {
-            type: 'sub',
-            label: selectedTeamName,
-            icon: UsersRound,
-            items: [
-              [
-                {
-                  type: 'radio-group',
-                  value: selectedTeamId ?? '',
-                  onValueChange: (val) => {
-                    setSelectedTeamId?.(val || null);
-                    if (organizationId) {
-                      void navigate({
-                        to: '/dashboard/$id/chat',
-                        params: { id: organizationId },
-                      });
-                      onNavigate?.();
-                    }
-                  },
-                  options: [
-                    { value: '', label: tNav('teamFilter.allTeams') },
-                    ...teams.map((team) => ({
-                      value: team.id,
-                      label: team.name,
-                    })),
+          isMobile
+            ? {
+                type: 'custom',
+                content: (
+                  <MenuRowCollapsible
+                    icon={UsersRound}
+                    label={tNav('teamFilter.label')}
+                    badge={selectedTeamName}
+                  >
+                    <TeamListPanel
+                      organizationId={organizationId}
+                      teams={teams}
+                      selectedTeamId={selectedTeamId}
+                      onSelectTeam={selectTeam}
+                      hideHeader
+                    />
+                  </MenuRowCollapsible>
+                ),
+              }
+            : {
+                type: 'sub',
+                label: tNav('teamFilter.label'),
+                icon: UsersRound,
+                trailing: <MenuRowBadge>{selectedTeamName}</MenuRowBadge>,
+                items: [
+                  [
+                    {
+                      type: 'custom',
+                      content: (
+                        <TeamListPanel
+                          organizationId={organizationId}
+                          teams={teams}
+                          selectedTeamId={selectedTeamId}
+                          onSelectTeam={selectTeam}
+                        />
+                      ),
+                    },
                   ],
-                },
-              ],
-            ],
-            className: 'py-2.5',
-            contentClassName: 'min-w-72',
-          },
+                ],
+                className: 'py-2.5',
+                contentClassName: 'w-72',
+              },
         ]);
       }
     }
@@ -351,28 +481,62 @@ export function UserButton({
     );
 
     groups.push([
-      {
-        type: 'sub',
-        label: t('userButton.language'),
-        icon: Languages,
-        items: [
-          [
-            {
-              type: 'radio-group',
-              value: currentLocaleValue,
-              onValueChange: (val) => {
-                if (val) setLocale(val);
-              },
-              options: [
-                { value: 'en', label: renderLanguageOption('en') },
-                { value: 'de', label: renderLanguageOption('de') },
-                { value: 'fr', label: renderLanguageOption('fr') },
+      isMobile
+        ? {
+            type: 'custom',
+            content: (
+              <MenuRowCollapsible
+                icon={Languages}
+                label={t('userButton.language')}
+              >
+                <div role="radiogroup" aria-label={t('userButton.language')}>
+                  {(['en', 'de', 'fr'] as const).map((value) => {
+                    const checked = currentLocaleValue === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={checked}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setLocale(value);
+                        }}
+                        className="focus:bg-accent hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-left text-sm outline-none"
+                      >
+                        {renderLanguageOption(value)}
+                        {checked && (
+                          <Check className="absolute right-2 size-3.5" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </MenuRowCollapsible>
+            ),
+          }
+        : {
+            type: 'sub',
+            label: t('userButton.language'),
+            icon: Languages,
+            items: [
+              [
+                {
+                  type: 'radio-group',
+                  value: currentLocaleValue,
+                  onValueChange: (val) => {
+                    if (val) setLocale(val);
+                  },
+                  options: [
+                    { value: 'en', label: renderLanguageOption('en') },
+                    { value: 'de', label: renderLanguageOption('de') },
+                    { value: 'fr', label: renderLanguageOption('fr') },
+                  ],
+                },
               ],
-            },
-          ],
-        ],
-        className: 'py-2.5',
-      },
+            ],
+            className: 'py-2.5',
+          },
     ]);
 
     const helpGroup: DropdownMenuGroup = [];
@@ -415,6 +579,7 @@ export function UserButton({
     currentOrg,
     teams,
     selectedTeamId,
+    isMobile,
     theme,
     locale,
     t,

--- a/services/platform/app/features/agents/components/agent-create-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert } from '@tale/ui/alert';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Text } from '@tale/ui/text';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { ConvexError } from 'convex/values';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -41,7 +42,8 @@ export function CreateAgentDialog({
   const { t: tCommon } = useT('common');
   const navigate = useNavigate();
   const { mutateAsync: saveAgent } = useSaveAgent();
-  const { providers } = useListProviders(organizationId);
+  const { providers, isLoading: providersLoading } =
+    useListProviders(organizationId);
   const { locale } = useLocale();
 
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
@@ -78,6 +80,11 @@ export function CreateAgentDialog({
       }),
     }));
   }, [providers, t, locale]);
+
+  // No models means no provider is configured (or none exposes a model).
+  // An agent must reference a real model, so creation can't proceed until one
+  // exists — we surface this explicitly instead of letting submit no-op.
+  const hasModels = modelOptions.length > 0;
 
   // Auto-select first model when providers load and no selection exists
   useEffect(() => {
@@ -201,7 +208,7 @@ export function CreateAgentDialog({
       submitText={t('agents.createDialog.continue')}
       submittingText={t('agents.createDialog.creating')}
       isSubmitting={isSubmitting}
-      isValid={isValid}
+      isValid={isValid && hasModels}
       onSubmit={handleSubmit(onSubmit)}
     >
       <Input
@@ -231,19 +238,38 @@ export function CreateAgentDialog({
         rows={3}
       />
 
-      <SearchableSelect
-        id="model-select"
-        label={t('agents.createDialog.model')}
-        placeholder={t('agents.createDialog.modelPlaceholder')}
-        value={selectedModelId}
-        onValueChange={handleModelChange}
-        options={modelOptions}
-        open={modelSelectOpen}
-        onOpenChange={setModelSelectOpen}
-        searchPlaceholder={t('agents.createDialog.modelSearch')}
-        emptyText={t('agents.createDialog.modelEmpty')}
-        aria-label={t('agents.createDialog.model')}
-      />
+      {!providersLoading && !hasModels ? (
+        <Alert
+          variant="warning"
+          title={t('agents.createDialog.noModelsTitle')}
+          description={
+            <Text variant="caption">
+              {t('agents.createDialog.noModelsDescription')}{' '}
+              <Link
+                to="/dashboard/$id/settings/providers"
+                params={{ id: organizationId }}
+                className="text-primary underline underline-offset-2"
+              >
+                {t('agents.createDialog.noModelsLink')}
+              </Link>
+            </Text>
+          }
+        />
+      ) : (
+        <SearchableSelect
+          id="model-select"
+          label={t('agents.createDialog.model')}
+          placeholder={t('agents.createDialog.modelPlaceholder')}
+          value={selectedModelId}
+          onValueChange={handleModelChange}
+          options={modelOptions}
+          open={modelSelectOpen}
+          onOpenChange={setModelSelectOpen}
+          searchPlaceholder={t('agents.createDialog.modelSearch')}
+          emptyText={t('agents.createDialog.modelEmpty')}
+          aria-label={t('agents.createDialog.model')}
+        />
+      )}
     </FormDialog>
   );
 }

--- a/services/platform/app/features/automations/components/automations-list-navigation.tsx
+++ b/services/platform/app/features/automations/components/automations-list-navigation.tsx
@@ -25,7 +25,7 @@ export function AutomationsListNavigation({
     <TabNavigation
       items={navigationItems}
       standalone={false}
-      className="h-12 py-3"
+      className="py-3"
       ariaLabel={tCommon('aria.automationsNavigation')}
     />
   );

--- a/services/platform/app/features/conversations/components/conversations-navigation.tsx
+++ b/services/platform/app/features/conversations/components/conversations-navigation.tsx
@@ -26,7 +26,7 @@ export function ConversationsNavigation({
     <TabNavigation
       items={navigationItems}
       standalone={false}
-      className="h-12 py-3"
+      className="py-3"
       prefetch
     />
   );

--- a/services/platform/app/features/knowledge/components/knowledge-navigation.tsx
+++ b/services/platform/app/features/knowledge/components/knowledge-navigation.tsx
@@ -57,7 +57,7 @@ export function KnowledgeNavigation({
     <TabNavigation
       items={navigationItems}
       standalone={false}
-      className="h-12 py-3"
+      className="py-3"
       ariaLabel={tCommon('aria.knowledgeNavigation')}
     />
   );

--- a/services/platform/app/features/organization/components/organization-list-panel.tsx
+++ b/services/platform/app/features/organization/components/organization-list-panel.tsx
@@ -17,11 +17,18 @@ import { cn } from '@/lib/utils/cn';
 interface OrganizationListPanelProps {
   currentOrganizationId: string | null;
   onAfterAction?: () => void;
+  /**
+   * Hide the "Organization" section header. Use when the panel is rendered
+   * under a row that already labels it (e.g. the account menu's inline
+   * Organization picker), where the header would be redundant.
+   */
+  hideHeader?: boolean;
 }
 
 export function OrganizationListPanel({
   currentOrganizationId,
   onAfterAction,
+  hideHeader = false,
 }: OrganizationListPanelProps) {
   const { t: tSettings } = useT('settings');
   const { t: tNav } = useT('navigation');
@@ -128,9 +135,11 @@ export function OrganizationListPanel({
 
   return (
     <div className="flex flex-col">
-      <div className="text-muted-foreground px-3 pt-2 pb-1.5 text-xs font-medium tracking-wide uppercase">
-        {tNav('orgSwitcher.label')}
-      </div>
+      {!hideHeader && (
+        <div className="text-muted-foreground px-3 pt-2 pb-1.5 text-xs font-medium tracking-wide uppercase">
+          {tNav('orgSwitcher.label')}
+        </div>
+      )}
 
       <ul className="max-h-72 overflow-y-auto py-1">
         {orgs.map((org) => {

--- a/services/platform/app/features/settings/components/settings-navigation.tsx
+++ b/services/platform/app/features/settings/components/settings-navigation.tsx
@@ -126,7 +126,7 @@ export function SettingsNavigation({
       items={navigationItems}
       matchMode="exact"
       standalone={false}
-      className="h-12 py-3"
+      className="h-13 py-3"
       ariaLabel={tCommon('aria.settingsNavigation')}
     >
       <SettingsEditorActionsSlot />

--- a/services/platform/app/features/settings/components/use-settings-menu-groups.ts
+++ b/services/platform/app/features/settings/components/use-settings-menu-groups.ts
@@ -1,10 +1,8 @@
 import {
   Building2,
-  HardDrive,
   KeyRound,
   Palette,
   Plug,
-  Server,
   Shield,
   SlidersHorizontal,
   Sparkles,
@@ -87,21 +85,9 @@ export function useSettingsMenuGroups(
         can: ['read', 'developerSettings'],
       },
       {
-        key: 'mcp',
-        icon: Server,
-        path: 'mcp',
-        can: ['read', 'developerSettings'],
-      },
-      {
-        key: 'apiKeys',
+        key: 'api',
         icon: KeyRound,
-        path: 'api-keys',
-        can: ['read', 'developerSettings'],
-      },
-      {
-        key: 'webdav',
-        icon: HardDrive,
-        path: 'webdav',
+        path: 'api',
         can: ['read', 'developerSettings'],
       },
     ];

--- a/services/platform/app/features/settings/teams/components/team-list-panel.tsx
+++ b/services/platform/app/features/settings/teams/components/team-list-panel.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Check, Plus } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import { TeamCreateDialog } from './team-create-dialog';
+
+interface TeamOption {
+  id: string;
+  name: string;
+}
+
+interface TeamListPanelProps {
+  organizationId: string;
+  teams: TeamOption[];
+  /** Currently active team filter, or null for "All teams". */
+  selectedTeamId: string | null;
+  onSelectTeam: (teamId: string | null) => void;
+  onAfterAction?: () => void;
+  /**
+   * Hide the "Team" section header. Use when the panel is rendered under a row
+   * that already labels it (e.g. the account menu's inline Team picker), where
+   * the header would be redundant.
+   */
+  hideHeader?: boolean;
+}
+
+/**
+ * The team-filter picker, mirroring {@link OrganizationListPanel}: a scrollable
+ * list of teams with the active one checked, plus a "Create team" footer that
+ * opens the team-create dialog. Always renders — when the org has no teams yet
+ * it shows an empty-state line above the create action, so the section never
+ * silently disappears.
+ *
+ * The first row is an "All teams" pseudo-option that clears the filter.
+ */
+export function TeamListPanel({
+  organizationId,
+  teams,
+  selectedTeamId,
+  onSelectTeam,
+  onAfterAction,
+  hideHeader = false,
+}: TeamListPanelProps) {
+  const { t: tNav } = useT('navigation');
+  const { t: tSettings } = useT('settings');
+  const { t: tEmpty } = useT('emptyStates');
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const handleSelect = useCallback(
+    (teamId: string | null) => {
+      onSelectTeam(teamId);
+      onAfterAction?.();
+    },
+    [onSelectTeam, onAfterAction],
+  );
+
+  const options: { value: string; label: string }[] = [
+    { value: '', label: tNav('teamFilter.allTeams') },
+    ...teams.map((team) => ({ value: team.id, label: team.name })),
+  ];
+
+  return (
+    <div className="flex flex-col">
+      {!hideHeader && (
+        <div className="text-muted-foreground px-3 pt-2 pb-1.5 text-xs font-medium tracking-wide uppercase">
+          {tNav('teamFilter.label')}
+        </div>
+      )}
+
+      <ul
+        role="radiogroup"
+        aria-label={tNav('teamFilter.label')}
+        className="max-h-72 overflow-y-auto py-1"
+      >
+        {options.map((option) => {
+          const checked = (selectedTeamId ?? '') === option.value;
+          return (
+            <li key={option.value || 'all'}>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={checked}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSelect(option.value || null);
+                }}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                  checked
+                    ? 'bg-muted'
+                    : 'hover:bg-muted focus-visible:bg-muted',
+                )}
+              >
+                <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                {checked ? (
+                  <Check className="text-foreground size-4 shrink-0" />
+                ) : (
+                  <span className="size-4 shrink-0" aria-hidden="true" />
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {teams.length === 0 && (
+        <p className="text-muted-foreground px-3 pb-2 text-xs">
+          {tEmpty('teams.description')}
+        </p>
+      )}
+
+      <div className="border-border border-t p-1">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setCreateOpen(true);
+          }}
+          className="hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+        >
+          <Plus className="text-muted-foreground size-4 shrink-0" />
+          <span>{tSettings('teams.createTeam')}</span>
+        </button>
+      </div>
+
+      <TeamCreateDialog
+        organizationId={organizationId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+      />
+    </div>
+  );
+}

--- a/services/platform/app/hooks/use-navigation-items.ts
+++ b/services/platform/app/hooks/use-navigation-items.ts
@@ -10,10 +10,45 @@ import {
   Folder,
   Settings as SettingsIcon,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 import { type AppAction, type AppSubject } from '@/lib/permissions/ability';
+
+/**
+ * Organization-settings nav icon: the org Building2 glyph with a small gear
+ * badge in the bottom-right corner, marking it as *settings* for the org (vs.
+ * the plain gear used for personal settings). The gear sits on a small disc
+ * filled with the surrounding surface color so it reads cleanly over the
+ * building outline. Accepts the same `{ className, style }` props as a Lucide
+ * icon so it drops straight into `NavItem.icon`.
+ */
+function OrgSettingsIcon({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return createElement(
+    'span',
+    { className: 'relative inline-flex shrink-0' },
+    createElement(Building2, { className, style }),
+    createElement(
+      'span',
+      {
+        // Disc punches a hole in the building outline so the gear stays legible.
+        className:
+          'bg-background absolute -right-1 -bottom-1 flex items-center justify-center rounded-full',
+        'aria-hidden': true,
+      },
+      createElement(SettingsIcon, {
+        className: 'size-3 shrink-0',
+        style,
+      }),
+    ),
+  );
+}
 
 export interface NavItem {
   label: string;
@@ -183,7 +218,7 @@ export function useNavigationItems(businessId: string): NavigationItems {
           to: '/dashboard/$id/settings',
           params: { id: businessId },
           href: `/dashboard/${businessId}/settings`,
-          icon: Building2,
+          icon: OrgSettingsIcon,
           isActivePath: (pathname) => {
             const base = `/dashboard/${businessId}/settings`;
             if (pathname !== base && !pathname.startsWith(`${base}/`))

--- a/services/platform/app/routes/dashboard/$id/settings.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings.tsx
@@ -1,10 +1,4 @@
-import {
-  Link,
-  Outlet,
-  createFileRoute,
-  useLocation,
-} from '@tanstack/react-router';
-import { ChevronLeft } from 'lucide-react';
+import { Outlet, createFileRoute, useLocation } from '@tanstack/react-router';
 
 import {
   AdaptiveHeaderRoot,
@@ -33,19 +27,6 @@ function SettingsLayout() {
   const { t: tNav } = useT('navigation');
   const location = useLocation();
 
-  const settingsRoot = `/dashboard/${organizationId}/settings`;
-  const personalRoot = `${settingsRoot}/personal`;
-  const isAtIndex =
-    location.pathname === settingsRoot || location.pathname === personalRoot;
-  // Show the mobile back-to-settings link only when we're at a direct child of
-  // `/settings` (e.g. `/settings/account`). Deeper routes — `governance/<sub>`,
-  // `integrations/<sub>` — own their own intra-section back link and would
-  // otherwise stack two "Back" bars on top of each other.
-  const settingsPath = location.pathname.startsWith(`${settingsRoot}/`)
-    ? location.pathname.slice(settingsRoot.length + 1)
-    : '';
-  const isDirectChild =
-    settingsPath !== '' && !settingsPath.replace(/\/$/, '').includes('/');
   const isUserScope =
     location.pathname.includes('/settings/account') ||
     location.pathname.includes('/settings/personalization') ||
@@ -68,11 +49,7 @@ function SettingsLayout() {
           </>
         }
       >
-        <SettingsMobileActionBar
-          showBack={!isAtIndex && isDirectChild}
-          isUserScope={isUserScope}
-          organizationId={organizationId}
-        />
+        <SettingsMobileActionBar />
         <ContentArea className="min-h-0 flex-1" variant="page" gap={6}>
           <Outlet />
         </ContentArea>
@@ -81,50 +58,21 @@ function SettingsLayout() {
   );
 }
 
-interface SettingsMobileActionBarProps {
-  showBack: boolean;
-  isUserScope: boolean;
-  organizationId: string;
-}
-
 /**
- * Mobile-only bar holding the back link and the active settings page's
- * Save/Discard cluster. The desktop equivalent lives in the settings tab
- * strip (`SettingsNavigation`), which is `hidden md:block` — so on small
- * screens the Save/Discard buttons were unreachable. Reads the active editor
- * (set by each form page) and renders the cluster only when one is present.
+ * Mobile-only bar holding the active settings page's Save/Discard cluster.
+ * The desktop equivalent lives in the settings tab strip (`SettingsNavigation`),
+ * which is `hidden md:block` — so on small screens the Save/Discard buttons were
+ * unreachable. Reads the active editor (set by each form page) and renders the
+ * cluster only when one is present. Back navigation lives in the main nav header.
  */
-function SettingsMobileActionBar({
-  showBack,
-  isUserScope,
-  organizationId,
-}: SettingsMobileActionBarProps) {
-  const { t: tCommon } = useT('common');
+function SettingsMobileActionBar() {
   const controller = useActiveEditor();
 
-  if (!showBack && !controller) return null;
+  if (!controller) return null;
 
   return (
-    <div className="border-border flex items-center justify-between gap-2 border-b px-4 py-2 md:hidden">
-      {showBack ? (
-        <Link
-          to={
-            isUserScope
-              ? '/dashboard/$id/settings/personal'
-              : '/dashboard/$id/settings'
-          }
-          params={{ id: organizationId }}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm font-medium"
-        >
-          <ChevronLeft aria-hidden="true" className="size-4" />
-          {tCommon('actions.back')}
-        </Link>
-      ) : (
-        <span aria-hidden="true" />
-      )}
-      {controller && (
-        <EditorActions controller={controller} entityKind="settings" />
-      )}
+    <div className="border-border flex items-center justify-end gap-2 border-b px-4 py-2 md:hidden">
+      <EditorActions controller={controller} entityKind="settings" />
     </div>
   );
 }

--- a/services/platform/app/routes/dashboard/$id/settings/api/route.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/route.tsx
@@ -7,17 +7,14 @@ import {
   Outlet,
   useRouterState,
 } from '@tanstack/react-router';
-import {
-  ChevronLeft,
-  ChevronRight,
-  HardDrive,
-  KeyRound,
-  Server,
-  type LucideIcon,
-} from 'lucide-react';
+import { HardDrive, KeyRound, Server, type LucideIcon } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
+import {
+  TabNavigation,
+  type TabNavigationItem,
+} from '@/app/components/ui/navigation/tab-navigation';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -56,7 +53,6 @@ function ApiSettingsLayout() {
   const { id: organizationId } = Route.useParams();
   const { t: tAccessDenied } = useT('accessDenied');
   const { t: tNav } = useT('navigation');
-  const { t: tCommon } = useT('common');
 
   const ability = useAbility();
   const abilityLoading = useAbilityLoading();
@@ -64,7 +60,6 @@ function ApiSettingsLayout() {
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const basePath = `/dashboard/${organizationId}/settings/api`;
-  const isAtIndex = pathname === basePath || pathname === `${basePath}/`;
 
   const contentRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -85,6 +80,13 @@ function ApiSettingsLayout() {
         };
       }),
     [basePath, pathname, tNav],
+  );
+
+  // Mobile swaps the desktop sidebar for a horizontal tab strip so users can
+  // hop between subpages without bouncing back to the settings list.
+  const tabItems = useMemo<TabNavigationItem[]>(
+    () => navItems.map((item) => ({ label: item.label, href: item.href })),
+    [navItems],
   );
 
   const sidebar = (
@@ -124,66 +126,17 @@ function ApiSettingsLayout() {
     return <AccessDenied message={tAccessDenied('apiKeys')} />;
   }
 
-  if (isMobile && isAtIndex) {
-    return (
-      <nav aria-label={tNav('api')} className="flex flex-col gap-2">
-        <ul
-          role="list"
-          className="border-border bg-card flex flex-col rounded-lg border"
-        >
-          {navItems.map((item, index) => {
-            const Icon = item.icon;
-            const isFirst = index === 0;
-            const isLast = index === navItems.length - 1;
-            return (
-              <li
-                key={item.slug}
-                className={cn(
-                  index > 0 && 'border-border border-t',
-                  isFirst && 'rounded-t-lg',
-                  isLast && 'rounded-b-lg',
-                )}
-              >
-                <Link
-                  to={item.href}
-                  className={cn(
-                    'hover:bg-muted/40 flex min-h-12 items-center gap-3 px-3 py-2.5 transition-colors',
-                    isFirst && 'rounded-t-lg',
-                    isLast && 'rounded-b-lg',
-                  )}
-                >
-                  <Icon
-                    aria-hidden="true"
-                    className="text-muted-foreground size-5 shrink-0"
-                  />
-                  <span className="text-foreground flex-1 text-sm font-medium">
-                    {item.label}
-                  </span>
-                  <ChevronRight
-                    aria-hidden="true"
-                    className="text-muted-foreground size-4 shrink-0"
-                  />
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
-    );
-  }
-
   return (
     <div className={LAYOUT_ROOT_CLASSNAME}>
       {sidebar}
       <div ref={contentRef} className={CONTENT_CLASSNAME}>
         {isMobile && (
-          <Link
-            to={basePath}
-            className="text-muted-foreground hover:text-foreground border-border mb-4 flex items-center gap-1.5 border-b px-1 pb-3 text-sm font-medium"
-          >
-            <ChevronLeft aria-hidden="true" className="size-4" />
-            {tCommon('actions.back')}
-          </Link>
+          <TabNavigation
+            items={tabItems}
+            matchMode="startsWith"
+            ariaLabel={tNav('api')}
+            className="mb-4 grid grid-flow-col items-stretch px-0 md:hidden"
+          />
         )}
         <Outlet />
       </div>

--- a/services/platform/app/routes/dashboard/$id/settings/governance/route.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/route.tsx
@@ -10,8 +10,6 @@ import {
 import {
   AlertOctagon,
   Brain,
-  ChevronLeft,
-  ChevronRight,
   ClipboardList,
   MessagesSquare,
   Scale,
@@ -26,6 +24,10 @@ import {
 import { useEffect, useMemo, useRef } from 'react';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
+import {
+  TabNavigation,
+  type TabNavigationItem,
+} from '@/app/components/ui/navigation/tab-navigation';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -107,7 +109,6 @@ function GovernanceLayout() {
   const { id: organizationId } = Route.useParams();
   const { t: tAccessDenied } = useT('accessDenied');
   const { t } = useT('governance');
-  const { t: tCommon } = useT('common');
 
   const ability = useAbility();
   const abilityLoading = useAbilityLoading();
@@ -115,7 +116,6 @@ function GovernanceLayout() {
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const basePath = `/dashboard/${organizationId}/settings/governance`;
-  const isAtIndex = pathname === basePath || pathname === `${basePath}/`;
 
   const contentRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -137,6 +137,13 @@ function GovernanceLayout() {
         };
       }),
     [basePath, pathname, t],
+  );
+
+  // Mobile swaps the desktop sidebar for a horizontal tab strip so users can
+  // hop between subpages without bouncing back to the settings list.
+  const tabItems = useMemo<TabNavigationItem[]>(
+    () => navItems.map((item) => ({ label: item.label, href: item.href })),
+    [navItems],
   );
 
   // The access check (and therefore the `<Outlet/>`) can't render until the
@@ -176,55 +183,6 @@ function GovernanceLayout() {
     return <AccessDenied message={tAccessDenied('organization')} />;
   }
 
-  // Mobile + at the governance index: render the iOS-style group list.
-  if (isMobile && isAtIndex) {
-    return (
-      <nav aria-label={t('title')} className="flex flex-col gap-2">
-        <ul
-          role="list"
-          className="border-border bg-card flex flex-col rounded-lg border"
-        >
-          {navItems.map((item, index) => {
-            const Icon = item.icon;
-            const isFirst = index === 0;
-            const isLast = index === navItems.length - 1;
-            return (
-              <li
-                key={item.slug}
-                className={cn(
-                  index > 0 && 'border-border border-t',
-                  isFirst && 'rounded-t-lg',
-                  isLast && 'rounded-b-lg',
-                )}
-              >
-                <Link
-                  to={item.href}
-                  className={cn(
-                    'hover:bg-muted/40 flex min-h-12 items-center gap-3 px-3 py-2.5 transition-colors',
-                    isFirst && 'rounded-t-lg',
-                    isLast && 'rounded-b-lg',
-                  )}
-                >
-                  <Icon
-                    aria-hidden="true"
-                    className="text-muted-foreground size-5 shrink-0"
-                  />
-                  <span className="text-foreground flex-1 text-sm font-medium">
-                    {item.label}
-                  </span>
-                  <ChevronRight
-                    aria-hidden="true"
-                    className="text-muted-foreground size-4 shrink-0"
-                  />
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
-    );
-  }
-
   return (
     <div className={LAYOUT_ROOT_CLASSNAME}>
       <nav aria-label={t('title')} className={SIDEBAR_CLASSNAME}>
@@ -246,13 +204,12 @@ function GovernanceLayout() {
       </nav>
       <div ref={contentRef} className={CONTENT_CLASSNAME}>
         {isMobile && (
-          <Link
-            to={basePath}
-            className="text-muted-foreground hover:text-foreground border-border mb-4 flex items-center gap-1.5 border-b px-1 pb-3 text-sm font-medium"
-          >
-            <ChevronLeft aria-hidden="true" className="size-4" />
-            {tCommon('actions.back')}
-          </Link>
+          <TabNavigation
+            items={tabItems}
+            matchMode="startsWith"
+            ariaLabel={t('title')}
+            className="mb-4 grid grid-flow-col items-stretch px-0 md:hidden"
+          />
         )}
         <Outlet />
       </div>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3614,6 +3614,7 @@
     "skills": "Skills",
     "webdav": "WebDAV",
     "teamFilter": {
+      "label": "Team",
       "allTeams": "Alle"
     },
     "orgSwitcher": {
@@ -4147,6 +4148,9 @@
       "apiKeys": {
         "description": "Programmatische Zugriffstoken für die Tale-API."
       },
+      "api": {
+        "description": "Programmatischer Zugriff – REST-Schlüssel, MCP und WebDAV."
+      },
       "governance": {
         "description": "Richtlinien, Sicherheit, Audit-Logs und Datenaufbewahrung."
       }
@@ -4310,7 +4314,10 @@
         "model": "Modell",
         "modelPlaceholder": "Modell auswählen",
         "modelSearch": "Modelle suchen…",
-        "modelEmpty": "Keine Modelle gefunden"
+        "modelEmpty": "Keine Modelle gefunden",
+        "noModelsTitle": "Keine Modelle verfügbar",
+        "noModelsDescription": "Ein Agent benötigt ein Modell zum Ausführen. Richten Sie zuerst einen Anbieter mit mindestens einem Modell ein.",
+        "noModelsLink": "Anbieter hinzufügen"
       },
       "uploadDialog": {
         "menuItem": "Aus Datei hochladen…",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3614,6 +3614,7 @@
     "skills": "Skills",
     "webdav": "WebDAV",
     "teamFilter": {
+      "label": "Team",
       "allTeams": "All"
     },
     "orgSwitcher": {
@@ -4408,6 +4409,9 @@
       "apiKeys": {
         "description": "Programmatic access tokens for the Tale API."
       },
+      "api": {
+        "description": "Programmatic access — REST keys, MCP, and WebDAV."
+      },
       "governance": {
         "description": "Policies, security, audit logs, and data retention."
       }
@@ -4571,7 +4575,10 @@
         "model": "Model",
         "modelPlaceholder": "Select a model",
         "modelSearch": "Search models…",
-        "modelEmpty": "No models found"
+        "modelEmpty": "No models found",
+        "noModelsTitle": "No models available",
+        "noModelsDescription": "An agent needs a model to run. Configure a provider with at least one model first.",
+        "noModelsLink": "Add a provider"
       },
       "uploadDialog": {
         "menuItem": "Upload from file…",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3615,6 +3615,7 @@
     "skills": "Skills",
     "webdav": "WebDAV",
     "teamFilter": {
+      "label": "Équipe",
       "allTeams": "Toutes"
     },
     "orgSwitcher": {
@@ -4148,6 +4149,9 @@
       "apiKeys": {
         "description": "Jetons d'accès programmatique à l'API Tale."
       },
+      "api": {
+        "description": "Accès programmatique — clés REST, MCP et WebDAV."
+      },
       "governance": {
         "description": "Politiques, sécurité, journaux d'audit et conservation des données."
       }
@@ -4311,7 +4315,10 @@
         "model": "Modèle",
         "modelPlaceholder": "Sélectionner un modèle",
         "modelSearch": "Rechercher des modèles…",
-        "modelEmpty": "Aucun modèle trouvé"
+        "modelEmpty": "Aucun modèle trouvé",
+        "noModelsTitle": "Aucun modèle disponible",
+        "noModelsDescription": "Un agent a besoin d'un modèle pour fonctionner. Configurez d'abord un fournisseur avec au moins un modèle.",
+        "noModelsLink": "Ajouter un fournisseur"
       },
       "uploadDialog": {
         "menuItem": "Téléverser depuis un fichier…",


### PR DESCRIPTION
## Summary

Consolidates the platform's developer/API settings and tidies several pieces of navigation chrome.

- **API settings consolidation** — merges the separate **API Keys**, **MCP**, and **WebDAV** pages into a single **API** section. On mobile the API sub-list is replaced with a horizontal tab strip (`TabNavigation`) so users move between subpages without bouncing back to the settings list.
- **Org-settings nav icon** — `Building2` with a small gear badge, distinguishing *organization* settings from *personal* settings (which keep the plain gear).
- **Team-filter picker** — new `TeamListPanel` in the account menu, mirroring the org picker, with a "Create team" footer and an empty state so the section never silently disappears.
- **Reusable section headers** — `OrganizationListPanel`/`TeamListPanel` gain a `hideHeader` prop for when they render under a row that already labels them.
- **Mobile chrome** — minor sizing/spacing fixes to the mobile back button, bottom nav, and tab navigation.
- **i18n** — adds en/de/fr strings for the API section description, team filter label, and the agent-create "no models" empty state.

## Test plan

- [x] `bun run format:check` (auto-fixed 3 files)
- [x] `lint` + `typecheck` pass for `@tale/platform` and `@tale/ui`
- [x] `user-button.test.tsx` passes (11 tests)
- [ ] CI

> Note: local `bun run check` also surfaced pre-existing, unrelated failures — Python `tale_shared.config.org_slug` import errors in `@tale/rag`/`@tale/crawler`, and a few 5s-timeout flakes in convex backend tests. None touch files in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team filter to mobile navigation
  * Introduced API settings section with programmatic access options
  * Implemented mobile-friendly inline collapsible menus for organization, team, and language selection

* **Improvements**
  * Enhanced agent creation dialog with improved model availability feedback and provider recommendations
  * Refined mobile settings navigation for better usability
  * Improved dropdown menu sizing and collision handling
  * Updated search input text sizing for better readability
  * Adjusted tab navigation heights across multiple pages

* **Localization**
  * Added and updated German, English, and French translations for new navigation and settings features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->