### PR TITLE
feat(platform): Confluence Cloud read-only sync integration

### DIFF
--- a/examples/default/integrations/confluence/config.json
+++ b/examples/default/integrations/confluence/config.json
@@ -14,7 +14,7 @@
     {
       "name": "list_pages",
       "title": "List Pages in Space",
-      "description": "List current pages in a Confluence space. Cursor pagination is handled internally — the operation returns the complete page list in one call (soft-capped at 4000 pages; beyond that the result is truncated and `truncated: true` is set). Each page reports its version number (for change detection), last-modified time, space key, ancestor path, and canonical web URL.",
+      "description": "List a Confluence space's pages. Cursor pagination is handled internally (soft-capped; `truncated: true` beyond the cap). Returns `pages` — the current pages, each with version number (for change detection), last-modified time, space key, ancestor path, folder sub-path, and canonical web URL — plus `presentIds`, the IDs of all current AND archived pages (collected in a second id-only pass) so a delete-reconcile can distinguish genuinely-removed pages from merely-archived ones.",
       "operationType": "read",
       "parametersSchema": {
         "type": "object",

--- a/examples/default/integrations/confluence/config.json
+++ b/examples/default/integrations/confluence/config.json
@@ -1,0 +1,62 @@
+{
+  "title": "Confluence",
+  "description": "Sync Confluence Cloud pages into Tale documents and RAG (read-only).",
+  "version": 1,
+  "authMethod": "basic_auth",
+  "supportedAuthMethods": ["basic_auth"],
+  "secretBindings": ["username", "password"],
+  "allowedHosts": ["atlassian.net"],
+  "connectionConfig": {
+    "domain": "",
+    "timeout": 300000
+  },
+  "operations": [
+    {
+      "name": "list_pages",
+      "title": "List Pages in Space",
+      "description": "List current pages in a Confluence space. Cursor pagination is handled internally — the operation returns the complete page list in one call (soft-capped at 4000 pages; beyond that the result is truncated and `truncated: true` is set). Each page reports its version number (for change detection), last-modified time, space key, ancestor path, and canonical web URL.",
+      "operationType": "read",
+      "parametersSchema": {
+        "type": "object",
+        "properties": {
+          "spaceKey": {
+            "type": "string",
+            "description": "Space key — the <KEY> segment in https://<site>.atlassian.net/wiki/spaces/<KEY>/overview (e.g. ENG). This is the short code, not the space's display name.",
+            "required": true
+          },
+          "label": {
+            "type": "string",
+            "description": "Optional label to filter pages (CQL `label`). Leave empty to sync every page in the space.",
+            "required": false
+          }
+        }
+      }
+    },
+    {
+      "name": "get_page",
+      "title": "Get Page Content",
+      "description": "Fetch a single page's rendered content by pageId, convert it to plain text, and store it as a text/plain file in Convex storage.",
+      "operationType": "read",
+      "parametersSchema": {
+        "type": "object",
+        "properties": {
+          "pageId": {
+            "type": "string",
+            "description": "Confluence page ID returned by list_pages.",
+            "required": true
+          },
+          "title": {
+            "type": "string",
+            "description": "Page title to use when storing the converted text.",
+            "required": true
+          }
+        }
+      }
+    }
+  ],
+  "capabilities": {
+    "canSync": true,
+    "syncFrequency": "0 */6 * * *"
+  },
+  "setupGuide": "1. Create an Atlassian API token at [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens). Atlassian tokens expire (max 1 year) — set a reminder to rotate, or the scheduled sync will start failing with a 401.\n2. Enter your **site** (the `<site>` in `https://<site>.atlassian.net`) as the domain, your Atlassian account **email** as the Username, and the **API token** as the Password.\n3. Click **Test** to verify the connection.\n4. Install the **Confluence Sync** automation, then create a schedule for it. In the schedule's variables, set `spaceKey` to your space's key — the `<KEY>` in `https://<site>.atlassian.net/wiki/spaces/<KEY>/overview` (e.g. `ENG`), not the display name. Add a separate schedule per space you want to sync, and stagger their cron minutes (e.g. `0 */6 * * *`, `15 */6 * * *`) so they don't burst the API together."
+}

--- a/examples/default/integrations/confluence/connector.ts
+++ b/examples/default/integrations/confluence/connector.ts
@@ -1,0 +1,495 @@
+// ─── Sandbox API Types ──────────────────────────────────────────────────────
+// These types describe the APIs available inside the integration sandbox.
+// They are stripped during transpilation and exist only for editor support.
+
+interface HttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  text(): string;
+  json(): unknown;
+}
+
+interface HttpMethodOptions {
+  headers?: Record<string, string>;
+  responseType?: 'base64';
+}
+
+interface HttpApi {
+  get(url: string, options?: HttpMethodOptions): HttpResponse;
+}
+
+interface SecretsApi {
+  get(key: string): string | undefined;
+}
+
+interface FileReference {
+  fileId: string;
+  url: string;
+  fileName: string;
+  contentType: string;
+  size: number;
+}
+
+interface FilesApi {
+  store(
+    data: string,
+    options: {
+      encoding: 'base64' | 'utf-8';
+      contentType: string;
+      fileName: string;
+    },
+  ): FileReference;
+}
+
+interface ConnectorContext {
+  operation: string;
+  params: Record<string, unknown>;
+  http: HttpApi;
+  secrets: SecretsApi;
+  base64Encode(input: string): string;
+  base64Decode(input: string): string;
+  files?: FilesApi;
+}
+
+interface TestConnectionContext {
+  http: HttpApi;
+  secrets: SecretsApi;
+  base64Encode(input: string): string;
+  base64Decode(input: string): string;
+  files?: FilesApi;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// One Confluence search page returns up to 100 results. Each in-connector
+// `http.get` consumes one sandbox pass (MAX_PASSES=50), so cursor pagination is
+// bounded: cap at 40 requests (~4000 pages) and report `truncated` rather than
+// risk exhausting the pass budget — which would surface as a silent empty
+// result. Spaces larger than this need workflow-layer pagination (see plan).
+const PAGE_LIMIT = 100;
+const MAX_LIST_PAGES = 40;
+
+// Below this many characters of extracted text we treat `export_view` as having
+// rendered to a husk (a page that is mostly dynamic/Connect macros — Jira issue
+// tables, draw.io, aggregating excerpts — which the REST renderer leaves empty)
+// and fall back to the raw storage format so the page indexes *something*.
+const NEAR_EMPTY_TEXT = 16;
+
+interface ConfluenceAuth {
+  apiBase: string;
+  origin: string;
+  headers: Record<string, string>;
+}
+
+// Confluence "Connect" credentials are an account email + API token sent as
+// HTTP Basic. The site is supplied per-install as `domain`; normalize it down
+// to the bare tenant label so the request URL is always well-formed and a
+// malformed value fails with a clear setup error instead of `new URL` throwing
+// or — worse — building a request against the wrong host.
+function buildAuth(
+  ctx: ConnectorContext | TestConnectionContext,
+): ConfluenceAuth {
+  const email = ctx.secrets.get('username');
+  const token = ctx.secrets.get('password');
+  if (!email || !token) {
+    throw new Error(
+      'Confluence requires an Atlassian account email (Username) and API token (Password).',
+    );
+  }
+
+  const raw = String(ctx.secrets.get('domain') || '').trim();
+  const site = raw
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/.*$/, '')
+    .replace(/\.atlassian\.net$/i, '')
+    .toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(site)) {
+    throw new Error(
+      'Confluence site is not configured or is invalid. Enter just the <site> from ' +
+        'https://<site>.atlassian.net (letters, digits, and hyphens only).',
+    );
+  }
+
+  const origin = 'https://' + site + '.atlassian.net';
+  return {
+    apiBase: origin + '/wiki/rest/api',
+    origin: origin,
+    headers: {
+      Authorization: 'Basic ' + ctx.base64Encode(email + ':' + token),
+      Accept: 'application/json',
+    },
+  };
+}
+
+function handleError(response: HttpResponse, operation: string): void {
+  if (response.status === 401) {
+    throw new Error(
+      'Authentication failed during ' +
+        operation +
+        ' (401). Check the Atlassian account email and API token (the token may have expired — they last at most one year).',
+    );
+  }
+  if (response.status === 403) {
+    throw new Error(
+      'Permission denied during ' +
+        operation +
+        ' (403). The Atlassian account may not have access to this space or page.',
+    );
+  }
+  if (response.status === 429) {
+    throw new Error(
+      'Rate limited by the Confluence API during ' +
+        operation +
+        ' (429). Try again later or stagger sync schedules.',
+    );
+  }
+  if (response.status >= 400) {
+    let detail = '';
+    try {
+      const err = response.json() as { message?: string };
+      detail = err && err.message ? err.message : response.text();
+    } catch (_e) {
+      detail = response.text();
+    }
+    throw new Error(
+      'Confluence API error during ' +
+        operation +
+        ' (' +
+        response.status +
+        '): ' +
+        detail,
+    );
+  }
+}
+
+// CQL string literals are double-quoted; escape backslashes and quotes so a
+// space key or label can never break out of the literal or alter the query.
+function cqlEscape(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// CQL has no `status` field, and the content-search endpoint already defaults
+// to current content (archived and trashed are excluded) — exactly what this
+// additive sync wants. Adding `status=...` returns HTTP 400 ("No field exists
+// with the name: 'status'").
+function buildCql(spaceKey: string, label: string | undefined): string {
+  let cql = 'space="' + cqlEscape(spaceKey) + '" and type=page';
+  if (label) {
+    cql += ' and label="' + cqlEscape(label) + '"';
+  }
+  return cql;
+}
+
+// Page titles can contain characters that are valid in Confluence but would
+// corrupt the '/'-joined folderPath or trip Tale's folder-name validator.
+// Strip ASCII control characters, substitute reserved path characters, and
+// never emit an empty segment.
+function sanitizeFolderName(name: string): string {
+  let cleaned = String(name || '')
+    .replace(/[\x00-\x1F\x7F]/g, '')
+    .replace(/[/\\?*<>:"|]/g, '_')
+    .trim()
+    .slice(0, 255);
+  if (cleaned.length > 0) {
+    const lastCode = cleaned.charCodeAt(cleaned.length - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdfff) {
+      cleaned = cleaned.slice(0, -1);
+    }
+  }
+  if (cleaned === '.' || cleaned === '..') {
+    cleaned = '_';
+  }
+  return cleaned.length > 0 ? cleaned : '_';
+}
+
+// Convert Confluence's rendered HTML to plain text. RAG runs no HTML extraction
+// (it decodes and chunks bytes verbatim), so storing markup would pollute
+// embeddings with tags and CSS. This pass keeps prose readable: drop
+// script/style outright, turn block boundaries into newlines, strip remaining
+// tags, decode the entities Confluence emits, and collapse whitespace.
+function htmlToText(html: string): string {
+  if (!html) {
+    return '';
+  }
+  let s = html;
+  s = s.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  s = s.replace(
+    /<\/(p|div|li|tr|h[1-6]|blockquote|section|article|header|footer|table|ul|ol|pre)\s*>/gi,
+    '\n',
+  );
+  s = s.replace(/<br\s*\/?>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/gi, "'");
+  s = s.replace(/&#(\d+);/g, function (_m: string, dec: string) {
+    return String.fromCharCode(parseInt(dec, 10));
+  });
+  // Ampersand last so a literal "&amp;lt;" doesn't double-decode into "<".
+  s = s.replace(/&amp;/gi, '&');
+  s = s.replace(/[ \t\f\v]+/g, ' ');
+  s = s.replace(/ *\n */g, '\n');
+  s = s.replace(/\n{3,}/g, '\n\n');
+  return s.trim();
+}
+
+interface ConfluencePageRef {
+  id: string;
+  type?: string;
+  title: string;
+  version?: { number?: number; when?: string };
+  ancestors?: Array<{ title?: string }>;
+  space?: { key?: string };
+  _links?: { webui?: string };
+}
+
+interface ConfluenceSearchPage {
+  results?: ConfluencePageRef[];
+  _links?: { base?: string; next?: string };
+}
+
+interface OutputPage {
+  id: string;
+  title: string;
+  version: number;
+  modifiedAt: string | undefined;
+  spaceKey: string | undefined;
+  ancestorPath: string;
+  webUrl: string | undefined;
+}
+
+function toOutputPage(
+  r: ConfluencePageRef,
+  base: string | undefined,
+): OutputPage {
+  const ancestors = Array.isArray(r.ancestors) ? r.ancestors : [];
+  const ancestorPath = ancestors
+    .map((a) => sanitizeFolderName(a && a.title ? a.title : ''))
+    .join('/');
+  return {
+    id: r.id,
+    title: r.title,
+    version: r.version && r.version.number ? r.version.number : 0,
+    modifiedAt: r.version ? r.version.when : undefined,
+    spaceKey: r.space ? r.space.key : undefined,
+    ancestorPath: ancestorPath,
+    webUrl:
+      base && r._links && r._links.webui ? base + r._links.webui : undefined,
+  };
+}
+
+function listPages(
+  http: HttpApi,
+  auth: ConfluenceAuth,
+  params: Record<string, unknown>,
+) {
+  const spaceKey = params.spaceKey as string | undefined;
+  if (!spaceKey) {
+    throw new Error('spaceKey is required.');
+  }
+  const label =
+    typeof params.label === 'string' && params.label ? params.label : undefined;
+
+  const cql = buildCql(spaceKey, label);
+  let url =
+    auth.apiBase +
+    '/content/search?cql=' +
+    encodeURIComponent(cql) +
+    '&expand=version,ancestors,space&limit=' +
+    PAGE_LIMIT;
+
+  const pages: OutputPage[] = [];
+  let truncated = false;
+  let fetched = 0;
+
+  while (true) {
+    const response = http.get(url, { headers: auth.headers });
+    handleError(response, 'list pages');
+
+    const data = response.json() as ConfluenceSearchPage;
+    const results = Array.isArray(data.results) ? data.results : [];
+    const base = data._links ? data._links.base : undefined;
+    for (let i = 0; i < results.length; i++) {
+      pages.push(toOutputPage(results[i], base));
+    }
+    fetched++;
+
+    const next = data._links ? data._links.next : undefined;
+    if (!next) {
+      break;
+    }
+    if (fetched >= MAX_LIST_PAGES) {
+      // Stop before the sandbox pass budget bites. The page set is incomplete,
+      // so flag it: the workflow skips delete-style cleanup on a truncated list
+      // (and v1 is additive-only regardless).
+      truncated = true;
+      break;
+    }
+    // `next` is relative to `_links.base` (e.g. "/rest/api/content/search?...")
+    // and omits the "/wiki" prefix that base carries. Resolve against base
+    // verbatim; do NOT prepend apiBase (doubles "/rest/api") or origin (drops
+    // "/wiki").
+    if (base) {
+      url = base + next;
+    } else {
+      url = auth.origin + '/wiki' + next;
+    }
+  }
+
+  console.log(
+    'Listed Confluence pages: count=' +
+      pages.length +
+      ', requests=' +
+      fetched +
+      ', truncated=' +
+      truncated,
+  );
+
+  return {
+    success: true,
+    operation: 'list_pages',
+    data: {
+      pages: pages,
+      truncated: truncated,
+    },
+    count: pages.length,
+    timestamp: Date.now(),
+  };
+}
+
+function getPage(
+  http: HttpApi,
+  files: FilesApi | undefined,
+  auth: ConfluenceAuth,
+  params: Record<string, unknown>,
+) {
+  const pageId = params.pageId as string | undefined;
+  const title = params.title as string | undefined;
+  if (!pageId) {
+    throw new Error('pageId is required.');
+  }
+  if (!title) {
+    throw new Error('title is required.');
+  }
+  if (!files) {
+    throw new Error(
+      'File storage is not available. The ctx.files API is required to store page content.',
+    );
+  }
+
+  const url =
+    auth.apiBase +
+    '/content/' +
+    encodeURIComponent(pageId) +
+    '?expand=body.export_view,body.storage';
+  const response = http.get(url, { headers: auth.headers });
+
+  // A page listed in one run can be deleted, archived, or restricted before we
+  // fetch it. Treat those as skip-with-warning: throw a clear message so the
+  // loop's continueOnError moves to the next page instead of aborting the batch
+  // or creating an empty document.
+  if (response.status === 404 || response.status === 410) {
+    throw new Error(
+      'Confluence page ' +
+        pageId +
+        ' no longer exists (deleted between listing and fetch) — skipping.',
+    );
+  }
+  if (response.status === 403) {
+    throw new Error(
+      'Confluence page ' +
+        pageId +
+        ' is restricted for this account — skipping.',
+    );
+  }
+  handleError(response, 'get page');
+
+  const body = response.json() as {
+    body?: {
+      export_view?: { value?: string };
+      storage?: { value?: string };
+    };
+  };
+  const exportHtml =
+    body.body && body.body.export_view ? body.body.export_view.value || '' : '';
+  let text = htmlToText(exportHtml);
+  if (text.length < NEAR_EMPTY_TEXT) {
+    const storageHtml =
+      body.body && body.body.storage ? body.body.storage.value || '' : '';
+    const fallback = htmlToText(storageHtml);
+    if (fallback.length > text.length) {
+      text = fallback;
+    }
+  }
+
+  const stored = files.store(text, {
+    encoding: 'utf-8',
+    contentType: 'text/plain',
+    fileName: title + '.txt',
+  });
+
+  return {
+    success: true,
+    operation: 'get_page',
+    data: {
+      fileId: stored.fileId,
+      fileName: stored.fileName,
+      contentType: stored.contentType,
+      size: stored.size,
+      url: stored.url,
+    },
+    count: 1,
+    timestamp: Date.now(),
+  };
+}
+
+const connector = {
+  operations: ['list_pages', 'get_page'],
+
+  testConnection: function (ctx: TestConnectionContext) {
+    const auth = buildAuth(ctx);
+    const response = ctx.http.get(auth.apiBase + '/space?limit=1', {
+      headers: auth.headers,
+    });
+
+    if (response.status === 401) {
+      throw new Error(
+        'Authentication failed. Check the Atlassian account email and API token.',
+      );
+    }
+    if (response.status === 403) {
+      throw new Error(
+        'Access denied. Verify the Atlassian account has access to Confluence on this site.',
+      );
+    }
+    if (response.status !== 200) {
+      throw new Error(
+        'Confluence connection failed (' +
+          response.status +
+          '): ' +
+          response.text(),
+      );
+    }
+
+    return { status: 'ok' };
+  },
+
+  execute: function (ctx: ConnectorContext) {
+    const auth = buildAuth(ctx);
+
+    if (ctx.operation === 'list_pages') {
+      return listPages(ctx.http, auth, ctx.params);
+    }
+    if (ctx.operation === 'get_page') {
+      return getPage(ctx.http, ctx.files, auth, ctx.params);
+    }
+
+    throw new Error('Unknown operation: ' + ctx.operation);
+  },
+};

--- a/examples/default/integrations/confluence/connector.ts
+++ b/examples/default/integrations/confluence/connector.ts
@@ -70,6 +70,11 @@ interface TestConnectionContext {
 // result. Spaces larger than this need workflow-layer pagination (see plan).
 const PAGE_LIMIT = 100;
 const MAX_LIST_PAGES = 40;
+// Archived pages are fetched id-only in a second pass to keep them in the
+// present-id set (so delete-reconcile preserves them). Kept small — the
+// combined current+archived request count must stay under the sandbox pass
+// budget (MAX_PASSES=50): 40 + 8 leaves margin.
+const MAX_ARCHIVED_PAGES = 8;
 
 // Below this many characters of extracted text we treat `export_view` as having
 // rendered to a husk (a page that is mostly dynamic/Connect macros — Jira issue
@@ -300,6 +305,58 @@ function toOutputPage(
   };
 }
 
+interface SearchResult {
+  results: ConfluencePageRef[];
+  base: string | undefined;
+  truncated: boolean;
+}
+
+// Run a paginated /content/search, following `_links.next` until exhausted or
+// `maxRequests` is hit (which sets truncated). `next` is relative to
+// `_links.base` (which carries the "/wiki" prefix) — resolve against base
+// verbatim; do NOT prepend apiBase (doubles "/rest/api") or origin (drops
+// "/wiki"). Capping below the sandbox pass budget keeps a thrown-incomplete
+// pass from surfacing as a silent empty result.
+function paginateContentSearch(
+  http: HttpApi,
+  auth: ConfluenceAuth,
+  startUrl: string,
+  maxRequests: number,
+): SearchResult {
+  const results: ConfluencePageRef[] = [];
+  let base: string | undefined;
+  let truncated = false;
+  let fetched = 0;
+  let url = startUrl;
+
+  while (true) {
+    const response = http.get(url, { headers: auth.headers });
+    handleError(response, 'list pages');
+
+    const data = response.json() as ConfluenceSearchPage;
+    const page = Array.isArray(data.results) ? data.results : [];
+    if (base === undefined && data._links) {
+      base = data._links.base;
+    }
+    for (let i = 0; i < page.length; i++) {
+      results.push(page[i]);
+    }
+    fetched++;
+
+    const next = data._links ? data._links.next : undefined;
+    if (!next) {
+      break;
+    }
+    if (fetched >= maxRequests) {
+      truncated = true;
+      break;
+    }
+    url = base ? base + next : auth.origin + '/wiki' + next;
+  }
+
+  return { results: results, base: base, truncated: truncated };
+}
+
 function listPages(
   http: HttpApi,
   auth: ConfluenceAuth,
@@ -313,62 +370,22 @@ function listPages(
     typeof params.label === 'string' && params.label ? params.label : undefined;
 
   const cql = buildCql(spaceKey, label);
-  let url =
+
+  // Pass 1 — current pages, fully expanded. These become Tale documents.
+  const currentUrl =
     auth.apiBase +
     '/content/search?cql=' +
     encodeURIComponent(cql) +
     '&expand=version,ancestors,space&limit=' +
     PAGE_LIMIT;
-
-  // First pass: collect the raw refs (paginated). We can only decide which
-  // pages are containers once the whole set is known, so map to OutputPage in a
-  // second pass below.
-  const rawPages: ConfluencePageRef[] = [];
-  let base: string | undefined;
-  let truncated = false;
-  let fetched = 0;
-
-  while (true) {
-    const response = http.get(url, { headers: auth.headers });
-    handleError(response, 'list pages');
-
-    const data = response.json() as ConfluenceSearchPage;
-    const results = Array.isArray(data.results) ? data.results : [];
-    if (base === undefined && data._links) {
-      base = data._links.base;
-    }
-    for (let i = 0; i < results.length; i++) {
-      rawPages.push(results[i]);
-    }
-    fetched++;
-
-    const next = data._links ? data._links.next : undefined;
-    if (!next) {
-      break;
-    }
-    if (fetched >= MAX_LIST_PAGES) {
-      // Stop before the sandbox pass budget bites. The page set is incomplete,
-      // so flag it: the workflow skips delete-style cleanup on a truncated list
-      // (and v1 is additive-only regardless).
-      truncated = true;
-      break;
-    }
-    // `next` is relative to `_links.base` (e.g. "/rest/api/content/search?...")
-    // and omits the "/wiki" prefix that base carries. Resolve against base
-    // verbatim; do NOT prepend apiBase (doubles "/rest/api") or origin (drops
-    // "/wiki").
-    if (base) {
-      url = base + next;
-    } else {
-      url = auth.origin + '/wiki' + next;
-    }
-  }
+  const current = paginateContentSearch(http, auth, currentUrl, MAX_LIST_PAGES);
+  const base = current.base;
 
   // A page is a container (becomes a folder) iff it is an ancestor of another
   // page in the set.
   const parentIds: Record<string, boolean> = {};
-  for (let i = 0; i < rawPages.length; i++) {
-    const anc = rawPages[i].ancestors;
+  for (let i = 0; i < current.results.length; i++) {
+    const anc = current.results[i].ancestors;
     if (Array.isArray(anc)) {
       for (let j = 0; j < anc.length; j++) {
         const a = anc[j];
@@ -380,15 +397,59 @@ function listPages(
   }
 
   const pages: OutputPage[] = [];
-  for (let i = 0; i < rawPages.length; i++) {
-    pages.push(toOutputPage(rawPages[i], base, parentIds));
+  for (let i = 0; i < current.results.length; i++) {
+    pages.push(toOutputPage(current.results[i], base, parentIds));
   }
 
+  // Pass 2 — archived page ids only. Archived pages are NOT materialized as
+  // documents, but their ids must remain in `presentIds` so delete-reconcile
+  // PRESERVES their documents (archive != delete) and only removes pages that
+  // are genuinely gone (trashed/purged → absent from both passes). CQL has no
+  // `status` field (HTTP 400); the supported mechanism is the cqlcontext param.
+  const archivedUrl =
+    auth.apiBase +
+    '/content/search?cql=' +
+    encodeURIComponent(cql) +
+    '&cqlcontext=' +
+    encodeURIComponent(JSON.stringify({ contentStatuses: ['archived'] })) +
+    '&limit=' +
+    PAGE_LIMIT;
+  const archived = paginateContentSearch(
+    http,
+    auth,
+    archivedUrl,
+    MAX_ARCHIVED_PAGES,
+  );
+
+  // presentIds = current ∪ archived (deduped). The reconcile step deletes docs
+  // whose page id is absent from this set.
+  const presentSeen: Record<string, boolean> = {};
+  const presentIds: string[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const id = pages[i].id;
+    if (id && !presentSeen[id]) {
+      presentSeen[id] = true;
+      presentIds.push(id);
+    }
+  }
+  for (let i = 0; i < archived.results.length; i++) {
+    const id = archived.results[i].id;
+    if (id && !presentSeen[id]) {
+      presentSeen[id] = true;
+      presentIds.push(id);
+    }
+  }
+
+  // If either pass truncated, presentIds is incomplete → reconcile must skip.
+  const truncated = current.truncated || archived.truncated;
+
   console.log(
-    'Listed Confluence pages: count=' +
+    'Listed Confluence pages: current=' +
       pages.length +
-      ', requests=' +
-      fetched +
+      ', archived=' +
+      archived.results.length +
+      ', present=' +
+      presentIds.length +
       ', truncated=' +
       truncated,
   );
@@ -398,6 +459,7 @@ function listPages(
     operation: 'list_pages',
     data: {
       pages: pages,
+      presentIds: presentIds,
       truncated: truncated,
     },
     count: pages.length,

--- a/examples/default/integrations/confluence/connector.ts
+++ b/examples/default/integrations/confluence/connector.ts
@@ -244,7 +244,7 @@ interface ConfluencePageRef {
   type?: string;
   title: string;
   version?: { number?: number; when?: string };
-  ancestors?: Array<{ title?: string }>;
+  ancestors?: Array<{ id?: string; title?: string }>;
   space?: { key?: string };
   _links?: { webui?: string };
 }
@@ -261,17 +261,31 @@ interface OutputPage {
   modifiedAt: string | undefined;
   spaceKey: string | undefined;
   ancestorPath: string;
+  hasChildren: boolean;
+  // Path under the space folder where this page's document lives. A container
+  // page (one that has children) nests into a folder named after itself, so its
+  // own content and its children share that folder — instead of the page doc
+  // colliding with a same-named sibling folder.
+  folderSubPath: string;
   webUrl: string | undefined;
 }
 
 function toOutputPage(
   r: ConfluencePageRef,
   base: string | undefined,
+  parentIds: Record<string, boolean>,
 ): OutputPage {
   const ancestors = Array.isArray(r.ancestors) ? r.ancestors : [];
   const ancestorPath = ancestors
     .map((a) => sanitizeFolderName(a && a.title ? a.title : ''))
     .join('/');
+  const hasChildren = !!(r.id && parentIds[r.id]);
+  const selfSegment = sanitizeFolderName(r.title);
+  const folderSubPath = hasChildren
+    ? ancestorPath
+      ? ancestorPath + '/' + selfSegment
+      : selfSegment
+    : ancestorPath;
   return {
     id: r.id,
     title: r.title,
@@ -279,6 +293,8 @@ function toOutputPage(
     modifiedAt: r.version ? r.version.when : undefined,
     spaceKey: r.space ? r.space.key : undefined,
     ancestorPath: ancestorPath,
+    hasChildren: hasChildren,
+    folderSubPath: folderSubPath,
     webUrl:
       base && r._links && r._links.webui ? base + r._links.webui : undefined,
   };
@@ -304,7 +320,11 @@ function listPages(
     '&expand=version,ancestors,space&limit=' +
     PAGE_LIMIT;
 
-  const pages: OutputPage[] = [];
+  // First pass: collect the raw refs (paginated). We can only decide which
+  // pages are containers once the whole set is known, so map to OutputPage in a
+  // second pass below.
+  const rawPages: ConfluencePageRef[] = [];
+  let base: string | undefined;
   let truncated = false;
   let fetched = 0;
 
@@ -314,9 +334,11 @@ function listPages(
 
     const data = response.json() as ConfluenceSearchPage;
     const results = Array.isArray(data.results) ? data.results : [];
-    const base = data._links ? data._links.base : undefined;
+    if (base === undefined && data._links) {
+      base = data._links.base;
+    }
     for (let i = 0; i < results.length; i++) {
-      pages.push(toOutputPage(results[i], base));
+      rawPages.push(results[i]);
     }
     fetched++;
 
@@ -340,6 +362,26 @@ function listPages(
     } else {
       url = auth.origin + '/wiki' + next;
     }
+  }
+
+  // A page is a container (becomes a folder) iff it is an ancestor of another
+  // page in the set.
+  const parentIds: Record<string, boolean> = {};
+  for (let i = 0; i < rawPages.length; i++) {
+    const anc = rawPages[i].ancestors;
+    if (Array.isArray(anc)) {
+      for (let j = 0; j < anc.length; j++) {
+        const a = anc[j];
+        if (a && a.id) {
+          parentIds[a.id] = true;
+        }
+      }
+    }
+  }
+
+  const pages: OutputPage[] = [];
+  for (let i = 0; i < rawPages.length; i++) {
+    pages.push(toOutputPage(rawPages[i], base, parentIds));
   }
 
   console.log(

--- a/examples/default/integrations/confluence/icon.svg
+++ b/examples/default/integrations/confluence/icon.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="confluence-a" x1="23" y1="19.5" x2="8.5" y2="13.3" gradientUnits="userSpaceOnUse">
+      <stop offset="0.18" stop-color="#0052CC" />
+      <stop offset="1" stop-color="#2684FF" />
+    </linearGradient>
+    <linearGradient id="confluence-b" x1="1" y1="4.5" x2="15.5" y2="10.7" gradientUnits="userSpaceOnUse">
+      <stop offset="0.18" stop-color="#0052CC" />
+      <stop offset="1" stop-color="#2684FF" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#confluence-a)" d="M.87 18.26c-.25.38-.53.87-.76 1.24a.76.76 0 0 0 .25 1.04l4.97 3.06a.76.76 0 0 0 1.06-.26c.2-.33.45-.77.73-1.22 1.97-3.25 3.95-2.85 7.51-1.15l4.96 2.34a.76.76 0 0 0 1.03-.38l2.36-5.35a.76.76 0 0 0-.38-1c-1.05-.49-3.13-1.47-5-2.36C9.54 9.76 4.83 9.99.87 18.26z" />
+  <path fill="url(#confluence-b)" d="M23.13 5.74c.25-.38.53-.87.76-1.24a.76.76 0 0 0-.25-1.04L18.67.4a.76.76 0 0 0-1.06.26c-.2.33-.45.77-.73 1.22-1.97 3.25-3.95 2.85-7.51 1.15L4.42.69a.76.76 0 0 0-1.03.38L1.03 6.42a.76.76 0 0 0 .38 1c1.05.49 3.13 1.47 5 2.36 7.39 3.55 12.1 3.33 16.06-4.94z" />
+</svg>

--- a/examples/default/workflows/confluence/sync.json
+++ b/examples/default/workflows/confluence/sync.json
@@ -163,8 +163,6 @@
             "spaceKey": "{{input.spaceKey}}",
             "version": "{{loop.item.version}}",
             "size": "{{steps.get_page.output.data.result.data.size}}",
-            "extension": "txt",
-            "mimeType": "text/plain",
             "sourceModifiedAt": "{{loop.item.modifiedAt}}",
             "ancestorPath": "{{loop.item.ancestorPath}}",
             "webUrl": "{{loop.item.webUrl}}",

--- a/examples/default/workflows/confluence/sync.json
+++ b/examples/default/workflows/confluence/sync.json
@@ -1,6 +1,6 @@
 {
   "name": "Confluence Sync",
-  "description": "Sync pages from a Confluence space into Tale documents and RAG. Each scheduled run lists every current page in the configured space (mirroring the page hierarchy under targetFolderPath/<spaceKey>), fetches any that are new or whose version changed, converts them to plain text, and upserts documents by page ID. This sync is additive: pages removed or archived in Confluence are NOT deleted from Tale — remove them in the Tale UI if needed. (Archiving a page in Confluence keeps its ID but hides it from the page listing, so automatic deletion would wrongly purge archived pages.)",
+  "description": "Sync pages from a Confluence space into Tale documents and RAG. Each scheduled run lists the space's current pages (mirroring the page hierarchy under targetFolderPath/<spaceKey>), fetches new or changed pages, converts them to plain text, and upserts documents by page ID. Moves and renames are reflected: a page whose computed folder path drifts (it was reparented, or an ancestor was renamed/moved) is re-homed without re-indexing — this catches descendants of a moved parent even though their own version is unchanged. Deletions are reflected too: documents for pages deleted or trashed in Confluence are removed (RAG entry included). Archived pages are PRESERVED — list_pages collects archived page IDs in a second pass so they remain in the present-set and are never mistaken for deletions; only genuinely removed pages are reconciled away.",
   "version": "1.0.0",
   "config": {
     "timeout": 600000,
@@ -73,11 +73,11 @@
       "stepType": "condition",
       "config": {
         "expression": "(steps.list_pages.output.data.result.data.pages | length) > 0",
-        "description": "Loop steps throw on an empty items array, and the throw isn't covered by continueOnError, so an empty listing would abort the workflow. Route the empty case straight to done."
+        "description": "Loop steps throw on an empty items array, and the throw isn't covered by continueOnError, so an empty listing would abort the workflow. Route the empty case to check_truncated → reconcile_deletes, which has its own empty-source guard (an empty listing is more often an auth/scope failure than a genuinely empty space, so reconcile will not delete on it)."
       },
       "nextSteps": {
         "true": "loop_pages",
-        "false": "noop"
+        "false": "check_truncated"
       }
     },
     {
@@ -90,7 +90,7 @@
         "items": "{{steps.list_pages.output.data.result.data.pages}}"
       },
       "nextSteps": {
-        "done": "noop",
+        "done": "check_truncated",
         "loop": "lookup_existing"
       }
     },
@@ -117,11 +117,46 @@
       "stepType": "condition",
       "config": {
         "expression": "steps.lookup_existing.output.data.exists == true && steps.lookup_existing.output.data.contentHash == (loop.item.version | string)",
-        "description": "If a document with the same page id and version already exists in the target folder, skip the fetch. A Confluence rename or edit bumps version.number, so it falls through to get_page and the upsert rewrites title + content."
+        "description": "If a document with the same page id and version already exists, the content is unchanged — but the page may still have MOVED, so route to check_drifted rather than skipping outright. A Confluence rename or edit bumps version.number, so those fall through to get_page and the upsert rewrites title + content."
       },
       "nextSteps": {
-        "true": "loop_pages",
+        "true": "check_drifted",
         "false": "get_page"
+      }
+    },
+    {
+      "stepSlug": "check_drifted",
+      "name": "Detect Move / Reparent",
+      "stepType": "condition",
+      "config": {
+        "description": "Content version is unchanged, but the page (or an ancestor) may have moved or been renamed, so its computed folder path differs from the stored one. Folder drift is independent of content version, so this catches descendants of a moved/renamed parent whose own version did not bump. On drift, route to move_document. No drift → skip.",
+        "expression": "steps.lookup_existing.output.data.folderPath != ((input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.folderSubPath ? '/' + loop.item.folderSubPath : ''))"
+      },
+      "nextSteps": {
+        "true": "move_document",
+        "false": "loop_pages"
+      }
+    },
+    {
+      "stepSlug": "move_document",
+      "name": "Re-home Moved Document",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "create",
+          "sourceProvider": "confluence",
+          "externalItemId": "{{loop.item.id}}",
+          "title": "{{loop.item.title}}",
+          "fileId": "{{steps.lookup_existing.output.data.fileId}}",
+          "contentHash": "{{loop.item.version | string}}",
+          "driveId": "{{input.spaceKey}}",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.folderSubPath ? '/' + loop.item.folderSubPath : '')}}",
+          "folderPathPrefix": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}"
+        }
+      },
+      "nextSteps": {
+        "success": "loop_pages"
       }
     },
     {
@@ -217,6 +252,38 @@
       },
       "nextSteps": {
         "success": "loop_pages"
+      }
+    },
+    {
+      "stepSlug": "check_truncated",
+      "name": "Skip Reconcile If Listing Truncated",
+      "stepType": "condition",
+      "config": {
+        "description": "If list_pages hit the pagination cap on either the current or archived pass, presentIds is incomplete and reconcile could delete legitimate docs (including archived ones). Skip cleanup this run; the next complete run reconciles correctly.",
+        "expression": "steps.list_pages.output.data.result.data.truncated == true"
+      },
+      "nextSteps": {
+        "true": "noop",
+        "false": "reconcile_deletes"
+      }
+    },
+    {
+      "stepSlug": "reconcile_deletes",
+      "name": "Remove Documents for Deleted Pages",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "reconcile_deletes",
+          "sourceProvider": "confluence",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}",
+          "driveId": "{{input.spaceKey}}",
+          "presentExternalIds": "{{steps.list_pages.output.data.result.data.presentIds}}",
+          "truncated": "{{steps.list_pages.output.data.result.data.truncated}}"
+        }
+      },
+      "nextSteps": {
+        "success": "noop"
       }
     },
     {

--- a/examples/default/workflows/confluence/sync.json
+++ b/examples/default/workflows/confluence/sync.json
@@ -1,0 +1,232 @@
+{
+  "name": "Confluence Sync",
+  "description": "Sync pages from a Confluence space into Tale documents and RAG. Each scheduled run lists every current page in the configured space (mirroring the page hierarchy under targetFolderPath/<spaceKey>), fetches any that are new or whose version changed, converts them to plain text, and upserts documents by page ID. This sync is additive: pages removed or archived in Confluence are NOT deleted from Tale — remove them in the Tale UI if needed. (Archiving a page in Confluence keeps its ID but hides it from the page listing, so automatic deletion would wrongly purge archived pages.)",
+  "version": "1.0.0",
+  "config": {
+    "timeout": 600000,
+    "retryPolicy": {
+      "maxRetries": 2,
+      "backoffMs": 2000
+    },
+    "variables": {
+      "workflowId": "confluence_sync"
+    }
+  },
+  "requires": {
+    "integrations": [
+      {
+        "name": "confluence",
+        "operations": ["list_pages", "get_page"]
+      }
+    ]
+  },
+  "steps": [
+    {
+      "stepSlug": "start",
+      "name": "start",
+      "stepType": "start",
+      "config": {
+        "inputSchema": {
+          "properties": {
+            "spaceKey": {
+              "description": "Confluence space key — the <KEY> in https://<site>.atlassian.net/wiki/spaces/<KEY>/overview (e.g. ENG), not the display name.",
+              "type": "string"
+            },
+            "label": {
+              "description": "Optional label to filter pages (CQL label). Leave empty to sync every page in the space.",
+              "type": "string"
+            },
+            "targetFolderPath": {
+              "description": "Tale documents path where synced pages land. Pages are placed under \"<targetFolderPath>/<spaceKey>\" mirroring their ancestor hierarchy. Defaults to \"Confluence\" if omitted.",
+              "type": "string"
+            }
+          },
+          "required": ["spaceKey"]
+        }
+      },
+      "nextSteps": {
+        "success": "list_pages"
+      }
+    },
+    {
+      "stepSlug": "list_pages",
+      "name": "List Confluence Pages",
+      "stepType": "action",
+      "config": {
+        "parameters": {
+          "name": "confluence",
+          "operation": "list_pages",
+          "params": {
+            "spaceKey": "{{input.spaceKey}}",
+            "label": "{{input.label}}"
+          }
+        },
+        "type": "integration"
+      },
+      "nextSteps": {
+        "success": "check_has_pages"
+      }
+    },
+    {
+      "stepSlug": "check_has_pages",
+      "name": "Skip Loop If Space Listing Is Empty",
+      "stepType": "condition",
+      "config": {
+        "expression": "(steps.list_pages.output.data.result.data.pages | length) > 0",
+        "description": "Loop steps throw on an empty items array, and the throw isn't covered by continueOnError, so an empty listing would abort the workflow. Route the empty case straight to done."
+      },
+      "nextSteps": {
+        "true": "loop_pages",
+        "false": "noop"
+      }
+    },
+    {
+      "stepSlug": "loop_pages",
+      "name": "Loop Through Pages",
+      "stepType": "loop",
+      "config": {
+        "continueOnError": true,
+        "itemVariable": "page",
+        "items": "{{steps.list_pages.output.data.result.data.pages}}"
+      },
+      "nextSteps": {
+        "done": "noop",
+        "loop": "lookup_existing"
+      }
+    },
+    {
+      "stepSlug": "lookup_existing",
+      "name": "Look Up Existing Document",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "find_by_external_id",
+          "externalItemId": "{{loop.item.id}}",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.ancestorPath ? '/' + loop.item.ancestorPath : '')}}",
+          "folderPathPrefix": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}"
+        }
+      },
+      "nextSteps": {
+        "success": "check_unchanged"
+      }
+    },
+    {
+      "stepSlug": "check_unchanged",
+      "name": "Skip If Unchanged",
+      "stepType": "condition",
+      "config": {
+        "expression": "steps.lookup_existing.output.data.exists == true && steps.lookup_existing.output.data.contentHash == (loop.item.version | string)",
+        "description": "If a document with the same page id and version already exists in the target folder, skip the fetch. A Confluence rename or edit bumps version.number, so it falls through to get_page and the upsert rewrites title + content."
+      },
+      "nextSteps": {
+        "true": "loop_pages",
+        "false": "get_page"
+      }
+    },
+    {
+      "stepSlug": "get_page",
+      "name": "Fetch Page Content",
+      "stepType": "action",
+      "config": {
+        "parameters": {
+          "name": "confluence",
+          "operation": "get_page",
+          "params": {
+            "pageId": "{{loop.item.id}}",
+            "title": "{{loop.item.title}}"
+          }
+        },
+        "type": "integration"
+      },
+      "nextSteps": {
+        "success": "create_document"
+      }
+    },
+    {
+      "stepSlug": "create_document",
+      "name": "Create or Update Document",
+      "stepType": "action",
+      "config": {
+        "parameters": {
+          "operation": "create",
+          "sourceProvider": "confluence",
+          "externalItemId": "{{loop.item.id}}",
+          "title": "{{loop.item.title}}",
+          "fileId": "{{steps.get_page.output.data.result.data.fileId}}",
+          "contentHash": "{{loop.item.version | string}}",
+          "driveId": "{{input.spaceKey}}",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.ancestorPath ? '/' + loop.item.ancestorPath : '')}}",
+          "folderPathPrefix": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}",
+          "metadata": {
+            "confluencePageId": "{{loop.item.id}}",
+            "spaceKey": "{{input.spaceKey}}",
+            "version": "{{loop.item.version}}",
+            "size": "{{steps.get_page.output.data.result.data.size}}",
+            "extension": "txt",
+            "mimeType": "text/plain",
+            "sourceModifiedAt": "{{loop.item.modifiedAt}}",
+            "ancestorPath": "{{loop.item.ancestorPath}}",
+            "webUrl": "{{loop.item.webUrl}}",
+            "syncedAt": "{{now}}"
+          }
+        },
+        "type": "document"
+      },
+      "nextSteps": {
+        "success": "check_doc_changed"
+      }
+    },
+    {
+      "stepSlug": "check_doc_changed",
+      "name": "Skip RAG If Unchanged",
+      "stepType": "condition",
+      "config": {
+        "description": "Re-index only when the page's content actually changed. A metadata-only patch (e.g. an ancestor moved) returns action='updated' with contentChanged=false and must not re-upload to RAG.",
+        "expression": "steps.create_document.output.data.contentChanged == true"
+      },
+      "nextSteps": {
+        "false": "loop_pages",
+        "true": "index_in_rag"
+      }
+    },
+    {
+      "stepSlug": "index_in_rag",
+      "name": "Index in RAG",
+      "stepType": "action",
+      "config": {
+        "parameters": {
+          "documentId": "{{steps.create_document.output.data.documentId}}",
+          "operation": "index_in_rag"
+        },
+        "type": "document"
+      },
+      "nextSteps": {
+        "success": "finalize_content_hash"
+      }
+    },
+    {
+      "stepSlug": "finalize_content_hash",
+      "name": "Commit Content Hash",
+      "stepType": "action",
+      "config": {
+        "type": "document",
+        "parameters": {
+          "operation": "update",
+          "fileId": "{{steps.get_page.output.data.result.data.fileId}}",
+          "contentHash": "{{loop.item.version | string}}"
+        }
+      },
+      "nextSteps": {
+        "success": "loop_pages"
+      }
+    },
+    {
+      "stepSlug": "noop",
+      "name": "Done",
+      "stepType": "output",
+      "config": {},
+      "nextSteps": {}
+    }
+  ]
+}

--- a/examples/default/workflows/confluence/sync.json
+++ b/examples/default/workflows/confluence/sync.json
@@ -103,7 +103,7 @@
         "parameters": {
           "operation": "find_by_external_id",
           "externalItemId": "{{loop.item.id}}",
-          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.ancestorPath ? '/' + loop.item.ancestorPath : '')}}",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.folderSubPath ? '/' + loop.item.folderSubPath : '')}}",
           "folderPathPrefix": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}"
         }
       },
@@ -156,7 +156,7 @@
           "fileId": "{{steps.get_page.output.data.result.data.fileId}}",
           "contentHash": "{{loop.item.version | string}}",
           "driveId": "{{input.spaceKey}}",
-          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.ancestorPath ? '/' + loop.item.ancestorPath : '')}}",
+          "folderPath": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey + (loop.item.folderSubPath ? '/' + loop.item.folderSubPath : '')}}",
           "folderPathPrefix": "{{(input.targetFolderPath || 'Confluence') + '/' + input.spaceKey}}",
           "metadata": {
             "confluencePageId": "{{loop.item.id}}",

--- a/services/platform/app/components/ui/data-display/document-icon.test.tsx
+++ b/services/platform/app/components/ui/data-display/document-icon.test.tsx
@@ -31,4 +31,33 @@ describe('DocumentIcon', () => {
       expect(container.querySelector('svg')).toBeInTheDocument();
     });
   });
+
+  describe('icon resolution', () => {
+    it('derives the extension from mimeType when the title has none', () => {
+      const { getByTestId } = render(
+        <DocumentIcon
+          fileName="Getting started in Confluence"
+          mimeType="text/plain"
+        />,
+      );
+      expect(getByTestId('file-icon')).toHaveTextContent('txt');
+    });
+
+    it('prefers mimeType over the filename suffix', () => {
+      const { getByTestId } = render(
+        <DocumentIcon fileName="report.txt" mimeType="application/pdf" />,
+      );
+      expect(getByTestId('file-icon')).toHaveTextContent('pdf');
+    });
+
+    it('falls back to the filename suffix when mimeType is generic/absent', () => {
+      const { getByTestId } = render(
+        <DocumentIcon
+          fileName="report.pdf"
+          mimeType="application/octet-stream"
+        />,
+      );
+      expect(getByTestId('file-icon')).toHaveTextContent('pdf');
+    });
+  });
 });

--- a/services/platform/app/components/ui/data-display/document-icon.tsx
+++ b/services/platform/app/components/ui/data-display/document-icon.tsx
@@ -3,11 +3,17 @@
 import type { DefaultExtensionType } from 'react-file-icon';
 import { FileIcon, defaultStyles } from 'react-file-icon';
 
-import { extractExtension } from '@/lib/shared/file-types';
+import { extractExtension, mimeToExtension } from '@/lib/shared/file-types';
 import { cn } from '@/lib/utils/cn';
 
 interface DocumentIconProps {
   fileName: string;
+  /**
+   * Authoritative content type. Preferred over the filename suffix so that
+   * synced documents with clean, extension-less titles (e.g. a Confluence page
+   * "Overview" stored as text/plain) still get the right file-type icon.
+   */
+  mimeType?: string;
   className?: string;
   isFolder?: boolean;
 }
@@ -34,6 +40,7 @@ function OneDriveFolderIcon({ className }: { className?: string }) {
 
 export function DocumentIcon({
   fileName,
+  mimeType,
   className = '',
   isFolder = false,
 }: DocumentIconProps) {
@@ -45,7 +52,12 @@ export function DocumentIcon({
     );
   }
 
-  const ext = extractExtension(fileName) ?? '';
+  // Resolve from the mimeType first (authoritative), then the filename suffix
+  // as a fallback for when the mime is generic/absent.
+  const ext =
+    (mimeType ? mimeToExtension(mimeType) : undefined) ??
+    extractExtension(fileName) ??
+    '';
   const styles =
     ext in defaultStyles
       ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Guarded by `in` check above

--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -122,7 +122,11 @@ function DetailsSidebar({
       >
         <SidebarRow label={t('preview.sidebar.document')}>
           <HStack gap={2} className="items-center">
-            <DocumentIcon fileName={doc?.name ?? ''} className="w-4" />
+            <DocumentIcon
+              fileName={doc?.name ?? ''}
+              mimeType={doc?.mimeType}
+              className="w-4"
+            />
             <span className="truncate">
               <SkeletonBox>{doc?.name ?? PLACEHOLDER_NAME}</SkeletonBox>
             </span>
@@ -323,7 +327,11 @@ export function DocumentPreviewDialog({
         <div className="flex h-full min-h-0 gap-5 px-5 pb-5">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             {resolvedUrl ? (
-              <DocumentPreview url={resolvedUrl} fileName={displayName} />
+              <DocumentPreview
+                url={resolvedUrl}
+                fileName={displayName}
+                mimeType={doc?.mimeType}
+              />
             ) : (
               <PreviewPaneSkeleton />
             )}

--- a/services/platform/app/features/documents/components/document-preview-routing.test.tsx
+++ b/services/platform/app/features/documents/components/document-preview-routing.test.tsx
@@ -130,4 +130,28 @@ describe('DocumentPreview routing', () => {
 
     expect(screen.getByTestId('image-preview')).toBeInTheDocument();
   });
+
+  it('routes an extension-less title to text preview via mimeType', () => {
+    render(
+      <DocumentPreview
+        url="https://example.com/blob"
+        fileName="Getting started in Confluence"
+        mimeType="text/plain"
+      />,
+    );
+
+    expect(screen.getByTestId('text-preview')).toBeInTheDocument();
+  });
+
+  it('prefers mimeType over an unhelpful filename', () => {
+    render(
+      <DocumentPreview
+        url="https://example.com/blob"
+        fileName="report"
+        mimeType="application/pdf"
+      />,
+    );
+
+    expect(screen.getByTestId('pdf-preview')).toBeInTheDocument();
+  });
 });

--- a/services/platform/app/features/documents/components/document-preview.tsx
+++ b/services/platform/app/features/documents/components/document-preview.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo } from 'react';
 
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
+import { mimeToExtension } from '@/lib/shared/file-types';
 import { getFileExtension } from '@/lib/utils/document-helpers';
 import { lazyComponent } from '@/lib/utils/lazy-component';
 import { isTextBasedFile } from '@/lib/utils/text-file-types';
@@ -78,16 +79,27 @@ const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
 export interface DocumentPreviewProps {
   url: string;
   fileName?: string;
+  /** Authoritative content type, preferred over the filename suffix so that
+   * synced documents with clean, extension-less titles still route correctly. */
+  mimeType?: string;
 }
 
-export function DocumentPreview({ url, fileName }: DocumentPreviewProps) {
+export function DocumentPreview({
+  url,
+  fileName,
+  mimeType,
+}: DocumentPreviewProps) {
   const [isDownloading, setIsDownloading] = useState(false);
   const { toast } = useToast();
   const { t } = useT('documents');
 
+  // Prefer the authoritative mimeType (synced docs keep clean, extension-less
+  // titles), falling back to the filename suffix when the mime is generic.
   const extension = useMemo(() => {
+    const fromMime = mimeType ? mimeToExtension(mimeType) : undefined;
+    if (fromMime) return fromMime.toUpperCase();
     return getFileExtension(fileName || url);
-  }, [fileName, url]);
+  }, [fileName, url, mimeType]);
 
   const handleDownload = async () => {
     try {
@@ -145,7 +157,7 @@ export function DocumentPreview({ url, fileName }: DocumentPreviewProps) {
     return <DocumentPreviewImage url={url} fileName={fileName} />;
   }
 
-  if (isTextBasedFile(fileName || url)) {
+  if (isTextBasedFile(fileName || url, mimeType)) {
     return <DocumentPreviewText url={url} fileName={fileName} />;
   }
 

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -104,6 +104,7 @@ export function useDocumentsTableConfig({
             <HStack gap={3}>
               <DocumentIcon
                 fileName={fileName}
+                mimeType={row.original.mimeType}
                 isFolder={row.original.type === 'folder'}
               />
               <button

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -48,6 +48,21 @@ function getSourceInfo(
       title: t('sourceType.uploaded'),
     };
   }
+  if (sourceProvider === 'confluence') {
+    return {
+      title: t('sourceType.confluence'),
+    };
+  }
+  if (sourceProvider === 'google_drive') {
+    return {
+      title: t('sourceType.googleDrive'),
+    };
+  }
+  if (sourceProvider === 'webdav') {
+    return {
+      title: t('sourceType.webDav'),
+    };
+  }
   return null;
 }
 

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -315,6 +315,7 @@ import type * as file_metadata_internal_queries from "../file_metadata/internal_
 import type * as file_metadata_mutations from "../file_metadata/mutations.js";
 import type * as file_metadata_paragraphize from "../file_metadata/paragraphize.js";
 import type * as file_metadata_queries from "../file_metadata/queries.js";
+import type * as file_metadata_source_from_provider from "../file_metadata/source_from_provider.js";
 import type * as file_metadata_transcribe_audio from "../file_metadata/transcribe_audio.js";
 import type * as file_metadata_transcribe_dictation from "../file_metadata/transcribe_dictation.js";
 import type * as files_mutations from "../files/mutations.js";
@@ -644,6 +645,7 @@ import type * as migrations_backfill_wf_installations from "../migrations/backfi
 import type * as migrations_backfill_workflow_schedules from "../migrations/backfill_workflow_schedules.js";
 import type * as migrations_merge_audit_retention from "../migrations/merge_audit_retention.js";
 import type * as migrations_migrate_org_creators from "../migrations/migrate_org_creators.js";
+import type * as migrations_relabel_synced_file_metadata_source from "../migrations/relabel_synced_file_metadata_source.js";
 import type * as migrations_remove_deprecated_llm_fields from "../migrations/remove_deprecated_llm_fields.js";
 import type * as migrations_seed_applied_bounds from "../migrations/seed_applied_bounds.js";
 import type * as migrations_split_personalization_toggle from "../migrations/split_personalization_toggle.js";
@@ -1530,6 +1532,7 @@ declare const fullApi: ApiFromModules<{
   "file_metadata/mutations": typeof file_metadata_mutations;
   "file_metadata/paragraphize": typeof file_metadata_paragraphize;
   "file_metadata/queries": typeof file_metadata_queries;
+  "file_metadata/source_from_provider": typeof file_metadata_source_from_provider;
   "file_metadata/transcribe_audio": typeof file_metadata_transcribe_audio;
   "file_metadata/transcribe_dictation": typeof file_metadata_transcribe_dictation;
   "files/mutations": typeof files_mutations;
@@ -1859,6 +1862,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/backfill_workflow_schedules": typeof migrations_backfill_workflow_schedules;
   "migrations/merge_audit_retention": typeof migrations_merge_audit_retention;
   "migrations/migrate_org_creators": typeof migrations_migrate_org_creators;
+  "migrations/relabel_synced_file_metadata_source": typeof migrations_relabel_synced_file_metadata_source;
   "migrations/remove_deprecated_llm_fields": typeof migrations_remove_deprecated_llm_fields;
   "migrations/seed_applied_bounds": typeof migrations_seed_applied_bounds;
   "migrations/split_personalization_toggle": typeof migrations_split_personalization_toggle;

--- a/services/platform/convex/documents/internal_mutations.ts
+++ b/services/platform/convex/documents/internal_mutations.ts
@@ -244,6 +244,7 @@ export const upsertDocumentByExternalId = internalMutation({
     title: v.string(),
     fileId: v.optional(v.id('_storage')),
     mimeType: v.optional(v.string()),
+    extension: v.optional(v.string()),
     sourceProvider: v.optional(v.string()),
     contentHash: v.optional(v.string()),
     metadata: v.optional(jsonRecordValidator),

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -35,6 +35,10 @@ export interface UpsertDocumentByExternalIdArgs {
   title: string;
   fileId?: Id<'_storage'>;
   mimeType?: string;
+  /** File extension for the document row. Sync titles are kept clean (no
+   * extension), so callers derive this from the stored blob's filename and
+   * pass it explicitly; falls back to the title's extension when omitted. */
+  extension?: string;
   sourceProvider?: string;
   contentHash?: string;
   metadata?: Record<string, unknown>;
@@ -133,7 +137,7 @@ export async function upsertDocumentByExternalId(
     // reach prior revisions.
     if (contentChanged) {
       patch.fileId = args.fileId;
-      patch.extension = extractExtension(args.title);
+      patch.extension = args.extension ?? extractExtension(args.title);
       if (existing.fileId && existing.fileId !== args.fileId) {
         patch.historyFiles = [
           ...(existing.historyFiles ?? []),
@@ -184,7 +188,7 @@ export async function upsertDocumentByExternalId(
     title: args.title,
     fileId: args.fileId,
     mimeType: args.mimeType,
-    extension: extractExtension(args.title),
+    extension: args.extension ?? extractExtension(args.title),
     sourceProvider: args.sourceProvider,
     externalItemId: args.externalItemId,
     driveId: args.driveId,

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -38,7 +38,10 @@ vi.mock('../_generated/api', () => ({
   },
 }));
 
-function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
+function createMockCtx(
+  existingDoc: Record<string, unknown> | null = null,
+  linkedDoc: Record<string, unknown> | null = null,
+) {
   const builder = {
     withIndex: vi.fn().mockReturnThis(),
     first: vi.fn().mockResolvedValue(existingDoc),
@@ -47,6 +50,7 @@ function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
   const ctx = {
     db: {
       query: vi.fn().mockReturnValue(builder),
+      get: vi.fn().mockResolvedValue(linkedDoc),
       insert: vi.fn().mockResolvedValue('fm_new'),
       patch: vi.fn().mockResolvedValue(undefined),
     },
@@ -230,5 +234,35 @@ describe('linkDocumentToFile', () => {
     await handler(ctx, { storageId: 'storage_1', documentId: 'doc_1' });
 
     expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("records the linked document's connector provider as source", async () => {
+    const { ctx } = createMockCtx(
+      { _id: 'fm_existing', storageId: 'storage_1' },
+      { sourceProvider: 'confluence' },
+    );
+    const handler = await getLinkHandler();
+
+    await handler(ctx, { storageId: 'storage_1', documentId: 'doc_1' });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_existing', {
+      documentId: 'doc_1',
+      source: 'confluence',
+    });
+  });
+
+  it("maps an 'upload' document provider to source 'user'", async () => {
+    const { ctx } = createMockCtx(
+      { _id: 'fm_existing', storageId: 'storage_1' },
+      { sourceProvider: 'upload' },
+    );
+    const handler = await getLinkHandler();
+
+    await handler(ctx, { storageId: 'storage_1', documentId: 'doc_1' });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_existing', {
+      documentId: 'doc_1',
+      source: 'user',
+    });
   });
 });

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -6,6 +6,7 @@ import {
   RateLimitExceededError,
   checkOrganizationRateLimit,
 } from '../lib/rate_limiter/helpers';
+import { sourceFromProvider } from './source_from_provider';
 
 export const saveFileMetadata = internalMutation({
   args: {
@@ -15,9 +16,9 @@ export const saveFileMetadata = internalMutation({
     contentType: v.string(),
     size: v.number(),
     documentId: v.optional(v.id('documents')),
-    source: v.optional(
-      v.union(v.literal('user'), v.literal('agent'), v.literal('video_link')),
-    ),
+    // Open provenance string (see fileMetadata schema): 'user' | 'agent' |
+    // 'video_link' | a connector slug ('confluence', 'onedrive', 'webdav', …).
+    source: v.optional(v.string()),
     uploadedBy: v.optional(v.string()),
     /** Chat-bound files (audio uploads, video-link transcripts) carry the
      * thread id so the soft-delete cascade + RAG thread-scope auth chain
@@ -525,8 +526,14 @@ export const linkDocumentToFile = internalMutation({
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
-    if (metadata) {
-      await ctx.db.patch(metadata._id, { documentId: args.documentId });
+    if (!metadata) {
+      return;
     }
+    const document = await ctx.db.get(args.documentId);
+    const source = sourceFromProvider(document?.sourceProvider);
+    await ctx.db.patch(metadata._id, {
+      documentId: args.documentId,
+      ...(source ? { source } : {}),
+    });
   },
 });

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -18,7 +18,8 @@ export const saveFileMetadata = mutation({
     contentType: v.string(),
     size: v.number(),
     documentId: v.optional(v.id('documents')),
-    source: v.optional(v.union(v.literal('user'), v.literal('agent'))),
+    // Open provenance string (see fileMetadata schema); the UI passes 'user'.
+    source: v.optional(v.string()),
     /**
      * For chat-uploaded files only. Binds the row to a chat thread so the
      * thread's lifecycle (trash → grace → hard-delete + restore) cascades

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -7,16 +7,20 @@ export const fileMetadataTable = defineTable({
   organizationId: v.string(),
   storageId: v.id('_storage'),
   documentId: v.optional(v.id('documents')),
-  source: v.optional(
-    v.union(
-      v.literal('user'),
-      v.literal('agent'),
-      // Video-link synthetic rows — transcript text originated from a
-      // third-party site fetched via yt-dlp. Trust-distinct from
-      // user-authored uploads (R2 prompt-injection review).
-      v.literal('video_link'),
-    ),
-  ),
+  // Open provenance string (no hard enum, so a new channel needs no schema
+  // change — mirrors documents.sourceProvider). Reserved values:
+  //   'user'       — member-uploaded via the UI
+  //   'agent'      — model / automation-generated
+  //   'video_link' — yt-dlp transcript; TRUST-DISTINCT, wrapped in
+  //                  <untrusted_source> on RAG retrieval (R2 review)
+  //   <connector>  — external import: the connector slug verbatim, e.g.
+  //                  'confluence', 'google_drive', 'onedrive', 'sharepoint',
+  //                  'webdav', or any integration slug. Set by
+  //                  linkDocumentToFile from the linked document's
+  //                  sourceProvider when a blob is promoted to a document.
+  // Only 'user' and 'agent' participate in the temp-retention GC lanes; import
+  // slugs (and undefined) are never reclaimed by the sweep.
+  source: v.optional(v.string()),
   fileName: v.string(),
   contentType: v.string(),
   size: v.number(),

--- a/services/platform/convex/file_metadata/source_from_provider.test.ts
+++ b/services/platform/convex/file_metadata/source_from_provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { sourceFromProvider } from './source_from_provider';
+
+describe('sourceFromProvider', () => {
+  it("maps the document 'upload' provider to fileMetadata 'user'", () => {
+    expect(sourceFromProvider('upload')).toBe('user');
+  });
+
+  it("returns undefined (leave unchanged) for 'agent' and missing provider", () => {
+    expect(sourceFromProvider('agent')).toBeUndefined();
+    expect(sourceFromProvider(undefined)).toBeUndefined();
+    expect(sourceFromProvider('')).toBeUndefined();
+  });
+
+  it('records external-import connector slugs verbatim', () => {
+    for (const slug of [
+      'confluence',
+      'google_drive',
+      'onedrive',
+      'sharepoint',
+      'webdav',
+      'some_custom_integration',
+    ]) {
+      expect(sourceFromProvider(slug)).toBe(slug);
+    }
+  });
+});

--- a/services/platform/convex/file_metadata/source_from_provider.ts
+++ b/services/platform/convex/file_metadata/source_from_provider.ts
@@ -1,0 +1,27 @@
+/**
+ * Map a document's `sourceProvider` to the fileMetadata `source` provenance,
+ * used when a raw blob is promoted to a document (linkDocumentToFile) and by the
+ * backfill migration that repairs pre-existing rows.
+ *
+ *  - 'upload'            → 'user'   (document layer says 'upload'; fileMetadata
+ *                                    records member uploads as 'user')
+ *  - 'agent' / undefined → undefined ("leave the existing source untouched":
+ *                                    model-generated, or provenance unknown)
+ *  - anything else       → the connector slug verbatim ('confluence',
+ *                          'google_drive', 'onedrive', 'sharepoint', 'webdav',
+ *                          any integration slug) — an external import
+ *
+ * Only 'user'/'agent' are swept by the temp-retention GC, so import slugs are
+ * inherently retention-safe. Returning undefined means "do not change source".
+ */
+export function sourceFromProvider(
+  sourceProvider: string | undefined,
+): string | undefined {
+  if (sourceProvider === 'upload') {
+    return 'user';
+  }
+  if (!sourceProvider || sourceProvider === 'agent') {
+    return undefined;
+  }
+  return sourceProvider;
+}

--- a/services/platform/convex/migrations/backfill_file_metadata_document_id.ts
+++ b/services/platform/convex/migrations/backfill_file_metadata_document_id.ts
@@ -7,72 +7,66 @@
  *
  * Idempotent: skips records that already have documentId set.
  *
+ * Convex allows only ONE paginated query per function call, so this processes a
+ * single batch and self-schedules the next — a single `convex run` walks the
+ * whole table.
+ *
  * Usage:
  *   bunx convex run migrations/backfill_file_metadata_document_id:backfillFileMetadataDocumentId
  */
 
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
 import { internalMutation } from '../_generated/server';
 
 const BATCH_SIZE = 200;
 
 export const backfillFileMetadataDocumentId = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    let totalUpdated = 0;
-    let totalSkipped = 0;
-    let cursor: string | null = null;
-    let isDone = false;
+  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query('fileMetadata')
+      .paginate({ cursor: args.cursor ?? null, numItems: BATCH_SIZE });
 
-    while (!isDone) {
-      let updated = 0;
-      let skipped = 0;
+    let updated = 0;
+    let skipped = 0;
 
-      const result = await ctx.db
-        .query('fileMetadata')
-        .paginate({ cursor, numItems: BATCH_SIZE });
-
-      for (const fm of result.page) {
-        if (fm.documentId) {
-          skipped++;
-          continue;
-        }
-
-        try {
-          const doc = await ctx.db
-            .query('documents')
-            .withIndex('by_organizationId_and_fileId', (q) =>
-              q
-                .eq('organizationId', fm.organizationId)
-                .eq('fileId', fm.storageId),
-            )
-            .first();
-
-          if (!doc) {
-            skipped++;
-            continue;
-          }
-
-          await ctx.db.patch(fm._id, { documentId: doc._id });
-          updated++;
-        } catch (error) {
-          console.error(
-            `[backfillFileMetadataDocumentId] Error for ${String(fm._id)}:`,
-            error,
-          );
-          skipped++;
-        }
+    for (const fm of result.page) {
+      if (fm.documentId) {
+        skipped++;
+        continue;
       }
 
-      console.log(
-        `[backfillFileMetadataDocumentId] Batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
-      );
+      const doc = await ctx.db
+        .query('documents')
+        .withIndex('by_organizationId_and_fileId', (q) =>
+          q.eq('organizationId', fm.organizationId).eq('fileId', fm.storageId),
+        )
+        .first();
 
-      totalUpdated += updated;
-      totalSkipped += skipped;
-      cursor = result.continueCursor;
-      isDone = result.isDone;
+      if (!doc) {
+        skipped++;
+        continue;
+      }
+
+      await ctx.db.patch(fm._id, { documentId: doc._id });
+      updated++;
     }
 
-    return { updated: totalUpdated, skipped: totalSkipped };
+    console.log(
+      `[backfillFileMetadataDocumentId] batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
+    );
+
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfill_file_metadata_document_id
+          .backfillFileMetadataDocumentId,
+        { cursor: result.continueCursor },
+      );
+    }
+
+    return { updated, skipped, isDone: result.isDone };
   },
 });

--- a/services/platform/convex/migrations/relabel_synced_file_metadata_source.ts
+++ b/services/platform/convex/migrations/relabel_synced_file_metadata_source.ts
@@ -1,0 +1,79 @@
+/**
+ * Migration: backfill fileMetadata.source from the linked document's provenance.
+ *
+ * Historically the integration sandbox stamped connector-stored blobs
+ * (Confluence, Google Drive, any rest_api file op) as source 'agent', OneDrive/
+ * SharePoint imports as 'user', and WebDAV imports as undefined. We now record
+ * the specific provenance (the connector slug) via linkDocumentToFile; this
+ * repairs pre-existing rows so they match.
+ *
+ * For each fileMetadata with a linked document (by org + fileId == storageId),
+ * derive the source from the document's sourceProvider exactly as
+ * linkDocumentToFile does:
+ *   'upload'  -> 'user'
+ *   'agent' / undefined -> leave unchanged
+ *   else -> the connector slug verbatim ('confluence', 'onedrive', 'webdav', …)
+ * Only rows whose derived source DIFFERS from the current value are patched.
+ *
+ * (The companion documentId back-fill already removed synced rows from the
+ * retention GC selector, so this is provenance hardening, not a data-loss fix.)
+ *
+ * Idempotent. ONE paginated query per invocation (Convex forbids multiple);
+ * self-schedules the next batch.
+ *
+ * Usage:
+ *   bunx convex run migrations/relabel_synced_file_metadata_source:relabelSyncedFileMetadataSource
+ */
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import { internalMutation } from '../_generated/server';
+import { sourceFromProvider } from '../file_metadata/source_from_provider';
+
+const BATCH_SIZE = 200;
+
+export const relabelSyncedFileMetadataSource = internalMutation({
+  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query('fileMetadata')
+      .paginate({ cursor: args.cursor ?? null, numItems: BATCH_SIZE });
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const fm of result.page) {
+      const doc = await ctx.db
+        .query('documents')
+        .withIndex('by_organizationId_and_fileId', (q) =>
+          q.eq('organizationId', fm.organizationId).eq('fileId', fm.storageId),
+        )
+        .first();
+
+      const desired = sourceFromProvider(doc?.sourceProvider);
+      if (!desired || desired === fm.source) {
+        skipped++;
+        continue;
+      }
+
+      await ctx.db.patch(fm._id, { source: desired });
+      updated++;
+    }
+
+    console.log(
+      `[relabelSyncedFileMetadataSource] batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
+    );
+
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.relabel_synced_file_metadata_source
+          .relabelSyncedFileMetadataSource,
+        { cursor: result.continueCursor },
+      );
+    }
+
+    return { updated, skipped, isDone: result.isDone };
+  },
+});

--- a/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
+++ b/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
@@ -143,6 +143,65 @@ describe('Confluence connector', () => {
     });
   });
 
+  it('list_pages nests a container page into its own folder (page-as-folder)', async () => {
+    const base = 'https://mysite.atlassian.net/wiki';
+    const ver = { number: 1, when: '2026-01-01T00:00:00Z' };
+    seqFetch([
+      json({
+        results: [
+          // Parent page "10" (Overview) — referenced as an ancestor by "11".
+          {
+            id: '10',
+            title: 'Overview',
+            version: ver,
+            ancestors: [],
+            space: { key: 'ENG' },
+            _links: { webui: '/spaces/ENG/pages/10' },
+          },
+          // Leaf child "11" lists Overview (id 10) as its ancestor.
+          {
+            id: '11',
+            title: 'Child',
+            version: ver,
+            ancestors: [{ id: '10', title: 'Overview' }],
+            space: { key: 'ENG' },
+            _links: { webui: '/spaces/ENG/pages/11' },
+          },
+        ],
+        _links: { base },
+      }),
+    ]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'list_pages',
+      params: { spaceKey: 'ENG' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+    });
+
+    expect(out.success).toBe(true);
+    const result = out.result as {
+      data: {
+        pages: Array<{
+          id: string;
+          hasChildren: boolean;
+          folderSubPath: string;
+        }>;
+      };
+    };
+    const overview = result.data.pages.find((p) => p.id === '10');
+    const child = result.data.pages.find((p) => p.id === '11');
+    // The container page becomes a folder named after itself — its own content
+    // and its children both live under "Overview/" (no same-named sibling).
+    expect(overview?.hasChildren).toBe(true);
+    expect(overview?.folderSubPath).toBe('Overview');
+    expect(child?.hasChildren).toBe(false);
+    expect(child?.folderSubPath).toBe('Overview');
+  });
+
   it('get_page converts rendered HTML to plain text and returns the Drive-shaped envelope', async () => {
     seqFetch([
       json({

--- a/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
+++ b/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
@@ -100,6 +100,8 @@ describe('Confluence connector', () => {
     const calls = seqFetch([
       json({ results: [page('1', 3)], _links: { base, next } }),
       json({ results: [page('2', 7)], _links: { base } }),
+      // Second pass: archived-page ids (empty here).
+      json({ results: [], _links: { base } }),
     ]);
 
     const out = await executeIntegrationImpl({
@@ -113,16 +115,20 @@ describe('Confluence connector', () => {
     });
 
     expect(out.success).toBe(true);
-    expect(calls).toHaveLength(2);
+    // 2 current-pass requests (cursor pagination) + 1 archived-pass request.
+    expect(calls).toHaveLength(3);
     expect(calls[0]).toContain('/wiki/rest/api/content/search?cql=');
     // CQL must NOT carry a `status` field — Confluence rejects it with HTTP 400.
     const cql = decodeURIComponent(calls[0].split('cql=')[1].split('&')[0]);
     expect(cql).toBe('space="ENG" and type=page');
     expect(calls[1]).toBe(base + next);
+    // The archived pass selects status via the cqlcontext param, not a CQL field.
+    expect(calls[2]).toContain('cqlcontext=');
 
     const result = out.result as {
       data: {
         truncated: boolean;
+        presentIds: string[];
         pages: Array<{
           id: string;
           version: number;
@@ -134,6 +140,7 @@ describe('Confluence connector', () => {
     };
     expect(result.data.truncated).toBe(false);
     expect(result.data.pages).toHaveLength(2);
+    expect(result.data.presentIds).toEqual(['1', '2']);
     expect(result.data.pages[0]).toMatchObject({
       id: '1',
       version: 3,
@@ -170,6 +177,8 @@ describe('Confluence connector', () => {
         ],
         _links: { base },
       }),
+      // Archived pass (empty).
+      json({ results: [], _links: { base } }),
     ]);
 
     const out = await executeIntegrationImpl({
@@ -200,6 +209,47 @@ describe('Confluence connector', () => {
     expect(overview?.folderSubPath).toBe('Overview');
     expect(child?.hasChildren).toBe(false);
     expect(child?.folderSubPath).toBe('Overview');
+  });
+
+  it('presentIds = current ∪ archived; archived pages are not materialized as documents', async () => {
+    const base = 'https://mysite.atlassian.net/wiki';
+    const ver = { number: 1, when: '2026-01-01T00:00:00Z' };
+    seqFetch([
+      // Current pass: one live page "1".
+      json({ results: [page('1', 1)], _links: { base } }),
+      // Archived pass: one archived page "9".
+      json({
+        results: [
+          {
+            id: '9',
+            title: 'Archived page',
+            version: ver,
+            space: { key: 'ENG' },
+            _links: { webui: '/spaces/ENG/pages/9' },
+          },
+        ],
+        _links: { base },
+      }),
+    ]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'list_pages',
+      params: { spaceKey: 'ENG' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+    });
+
+    expect(out.success).toBe(true);
+    const result = out.result as {
+      data: { pages: Array<{ id: string }>; presentIds: string[] };
+    };
+    // Only the live page becomes a document...
+    expect(result.data.pages.map((p) => p.id)).toEqual(['1']);
+    // ...but the archived id stays in presentIds so reconcile won't delete it.
+    expect(result.data.presentIds.sort()).toEqual(['1', '9']);
   });
 
   it('get_page converts rendered HTML to plain text and returns the Drive-shaped envelope', async () => {

--- a/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
+++ b/services/platform/convex/node_only/integration_sandbox/confluence_connector.test.ts
@@ -1,0 +1,242 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { transform } from 'sucrase';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { executeIntegrationImpl } from './execute_integration_impl';
+import type { StorageProvider } from './types';
+
+// Load and transpile the real shipped connector, exactly as the sandbox does.
+const connectorCode = transform(
+  fs.readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../../examples/default/integrations/confluence/connector.ts',
+    ),
+    'utf-8',
+  ),
+  { transforms: ['typescript'], disableESTransforms: true },
+).code;
+
+const SECRETS = {
+  username: 'me@example.com',
+  password: 'tok',
+  domain: 'mysite',
+};
+const ALLOWED = ['atlassian.net'];
+
+// Feed the sandbox a fixed sequence of HTTP responses and record requested URLs.
+function seqFetch(responses: Array<() => Response>): string[] {
+  let i = 0;
+  const calls: string[] = [];
+  globalThis.fetch = Object.assign(
+    vi.fn().mockImplementation((url: string) => {
+      calls.push(url);
+      const factory = responses[i++];
+      if (!factory) throw new Error('Unexpected fetch: ' + url);
+      return Promise.resolve(factory());
+    }),
+    { preconnect: vi.fn() },
+  );
+  return calls;
+}
+
+function json(data: unknown, status = 200): () => Response {
+  return () =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+function page(id: string, version: number) {
+  return {
+    id,
+    title: 'Page ' + id,
+    version: { number: version, when: '2026-01-01T00:00:00Z' },
+    ancestors: [{ title: 'Home' }],
+    space: { key: 'ENG' },
+    _links: { webui: '/spaces/ENG/pages/' + id },
+  };
+}
+
+let stored: Array<{ data: string; fileName: string; contentType: string }>;
+function mockStorage(): StorageProvider {
+  stored = [];
+  return {
+    download() {
+      return Promise.reject(new Error('download is not used by Confluence'));
+    },
+    store(args) {
+      stored.push({
+        data: args.data,
+        fileName: args.fileName,
+        contentType: args.contentType,
+      });
+      return Promise.resolve({
+        fileId: 'stor_' + stored.length,
+        url: 'https://storage.example.com/' + stored.length,
+        fileName: args.fileName,
+        contentType: args.contentType,
+        size: args.data.length,
+      });
+    },
+  };
+}
+
+describe('Confluence connector', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('list_pages follows _links.next cursor pagination and maps page fields', async () => {
+    const base = 'https://mysite.atlassian.net/wiki';
+    // Real shape verified against the live API: `next` is relative to `base`,
+    // carries a cursor, and omits the `/wiki` prefix that `base` provides.
+    const next =
+      '/rest/api/content/search?next=true&cursor=X3RfW10&limit=100&start=100&cql=type%3Dpage';
+    const calls = seqFetch([
+      json({ results: [page('1', 3)], _links: { base, next } }),
+      json({ results: [page('2', 7)], _links: { base } }),
+    ]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'list_pages',
+      params: { spaceKey: 'ENG' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+    });
+
+    expect(out.success).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain('/wiki/rest/api/content/search?cql=');
+    // CQL must NOT carry a `status` field — Confluence rejects it with HTTP 400.
+    const cql = decodeURIComponent(calls[0].split('cql=')[1].split('&')[0]);
+    expect(cql).toBe('space="ENG" and type=page');
+    expect(calls[1]).toBe(base + next);
+
+    const result = out.result as {
+      data: {
+        truncated: boolean;
+        pages: Array<{
+          id: string;
+          version: number;
+          spaceKey: string;
+          ancestorPath: string;
+          webUrl: string;
+        }>;
+      };
+    };
+    expect(result.data.truncated).toBe(false);
+    expect(result.data.pages).toHaveLength(2);
+    expect(result.data.pages[0]).toMatchObject({
+      id: '1',
+      version: 3,
+      spaceKey: 'ENG',
+      ancestorPath: 'Home',
+      webUrl: base + '/spaces/ENG/pages/1',
+    });
+  });
+
+  it('get_page converts rendered HTML to plain text and returns the Drive-shaped envelope', async () => {
+    seqFetch([
+      json({
+        body: {
+          export_view: { value: '<h1>Title</h1><p>Hello <b>world</b></p>' },
+          storage: { value: '' },
+        },
+      }),
+    ]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'get_page',
+      params: { pageId: '42', title: 'Guide' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+      storageProvider: mockStorage(),
+    });
+
+    expect(out.success).toBe(true);
+    // The sync workflow reads fileId, size, and contentType off this envelope.
+    const result = out.result as {
+      data: { fileId: string; size: number; contentType: string };
+    };
+    expect(result.data.fileId).toBe('stor_1');
+    expect(result.data.contentType).toBe('text/plain');
+    expect(result.data.size).toBeGreaterThan(0);
+    expect(stored[0]).toMatchObject({
+      fileName: 'Guide.txt',
+      contentType: 'text/plain',
+      data: 'Title\nHello world',
+    });
+  });
+
+  it('get_page falls back to storage format when export_view is a near-empty husk', async () => {
+    seqFetch([
+      json({
+        body: {
+          export_view: { value: '<p></p>' },
+          storage: { value: '<p>Macro body text that survived</p>' },
+        },
+      }),
+    ]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'get_page',
+      params: { pageId: '7', title: 'Macro Page' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+      storageProvider: mockStorage(),
+    });
+
+    expect(out.success).toBe(true);
+    expect(stored[0].data).toBe('Macro body text that survived');
+  });
+
+  it('get_page skips a restricted (403) page without storing anything', async () => {
+    seqFetch([json({ message: 'forbidden' }, 403)]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'get_page',
+      params: { pageId: '99', title: 'Secret' },
+      variables: {},
+      secrets: SECRETS,
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+      storageProvider: mockStorage(),
+    });
+
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/restricted/);
+    expect(stored).toHaveLength(0);
+  });
+
+  it('rejects a malformed site domain with a clear setup error', async () => {
+    seqFetch([]);
+
+    const out = await executeIntegrationImpl({
+      code: connectorCode,
+      operation: 'list_pages',
+      params: { spaceKey: 'ENG' },
+      variables: {},
+      secrets: { username: 'a@b.com', password: 't', domain: 'evil.com/@x' },
+      allowedHosts: ALLOWED,
+      timeoutMs: 5000,
+    });
+
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/not configured or is invalid/);
+  });
+});

--- a/services/platform/convex/node_only/integration_sandbox/helpers/create_convex_storage_provider.ts
+++ b/services/platform/convex/node_only/integration_sandbox/helpers/create_convex_storage_provider.ts
@@ -55,6 +55,11 @@ export function createConvexStorageProvider(
           fileName,
           contentType,
           size: blob.size,
+          // Write-time default for raw integration blobs. When the workflow
+          // promotes one to a document, linkDocumentToFile rewrites this to the
+          // connector's provenance (e.g. 'confluence') from the document's
+          // sourceProvider; transient blobs that never become a document stay
+          // 'agent' and remain eligible for the agent-temp retention sweep.
           source: 'agent',
         },
       );
@@ -91,6 +96,11 @@ export function createConvexStorageProvider(
           fileName,
           contentType,
           size: blob.size,
+          // Write-time default for raw integration blobs. When the workflow
+          // promotes one to a document, linkDocumentToFile rewrites this to the
+          // connector's provenance (e.g. 'confluence') from the document's
+          // sourceProvider; transient blobs that never become a document stay
+          // 'agent' and remain eligible for the agent-temp retention sweep.
           source: 'agent',
         },
       );

--- a/services/platform/convex/onedrive/import_files_deps.ts
+++ b/services/platform/convex/onedrive/import_files_deps.ts
@@ -54,6 +54,8 @@ export function createImportFilesDeps(
           fileName,
           contentType,
           size,
+          // Provenance is finalized by linkDocumentToFile from the document's
+          // sourceProvider ('onedrive' / 'sharepoint').
           source: 'user',
         },
       );

--- a/services/platform/convex/onedrive/upload_and_create_document_deps.ts
+++ b/services/platform/convex/onedrive/upload_and_create_document_deps.ts
@@ -49,6 +49,8 @@ export function createUploadAndCreateDocDeps(
           fileName,
           contentType,
           size,
+          // Provenance is finalized by linkDocumentToFile from the document's
+          // sourceProvider ('onedrive' / 'sharepoint').
           source: 'user',
         },
       );

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -16,6 +16,7 @@ import type { Doc, Id } from '../../../_generated/dataModel';
 import type { ActionCtx } from '../../../_generated/server';
 import { fetchDocumentComparisonByUrls } from '../../../agent_tools/documents/helpers/fetch_document_comparison';
 import { fetchDocumentContent } from '../../../agent_tools/documents/helpers/fetch_document_content';
+import { extractExtension } from '../../../documents/extract_extension';
 import { getDocumentEffectiveDate } from '../../../documents/transform_to_document_item';
 import type { DocumentMetadata } from '../../../documents/types';
 import { orgSlugFromId } from '../../../lib/helpers/org_slug';
@@ -520,6 +521,10 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
         }
 
         const docTitle = params.title ?? fileMetadata.fileName;
+        // Sync titles are kept clean (no extension), so derive the document's
+        // extension from the stored blob's filename (e.g. "Overview.txt" -> "txt").
+        const extension =
+          extractExtension(fileMetadata.fileName) ?? extractExtension(docTitle);
         const organizationId =
           typeof _variables.organizationId === 'string'
             ? _variables.organizationId
@@ -563,6 +568,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
               title: docTitle,
               fileId: storageId,
               mimeType: fileMetadata.contentType,
+              extension,
               sourceProvider,
               contentHash: params.contentHash,
               metadata: params.metadata,
@@ -610,6 +616,7 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             title: docTitle,
             fileId: storageId,
             mimeType: fileMetadata.contentType,
+            extension,
             sourceProvider,
             contentHash: params.contentHash,
             createdBy: userId,

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action.ts
@@ -572,6 +572,18 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             },
           );
 
+          // Back-fill the reverse fileMetadata -> document link. Sync flows
+          // store the blob in an earlier step (source 'agent', no documentId),
+          // so without this the row matches the retention sweep's orphaned
+          // agent-temp-file selector (source 'agent' AND documentId undefined)
+          // and its blob + RAG entry can be hard-deleted out from under a live
+          // document. A content re-sync may swap to a new storageId, so link
+          // the current one on every run. Mirrors the upload/OneDrive paths.
+          await ctx.runMutation(
+            internal.file_metadata.internal_mutations.linkDocumentToFile,
+            { storageId, documentId: result.documentId },
+          );
+
           return {
             success: true,
             fileId: params.fileId,
@@ -604,6 +616,14 @@ export const documentAction: ActionDefinition<DocumentActionParams> = {
             ...folderIdPatch,
             ...metadataPatch,
           },
+        );
+
+        // Back-fill the reverse fileMetadata -> document link (see the upsert
+        // branch above) so a connector-stored blob isn't garbage-collected as
+        // an orphaned agent temp file.
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.linkDocumentToFile,
+          { storageId, documentId },
         );
 
         return {

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action_link_file.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action_link_file.test.ts
@@ -1,0 +1,106 @@
+import { getFunctionName } from 'convex/server';
+import { describe, expect, it } from 'vitest';
+
+import type { ActionCtx } from '../../../_generated/server';
+import { documentAction } from './document_action';
+
+// Regression guard for the fileMetadata <- document back-fill. Connector-sync
+// flows store the blob (source 'agent', no documentId) in an earlier step, then
+// create the document here. Without linkDocumentToFile the row stays orphaned
+// (documentId undefined) and the retention sweep can hard-delete it as an agent
+// temp file. These tests assert the create op links the blob on BOTH branches.
+//
+// Convex's generated `internal` api is a proxy that returns a fresh reference on
+// every access, so dispatch/assert by getFunctionName(), not `===`.
+
+interface RunMutationCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+function createMockCtx() {
+  const runMutationCalls: RunMutationCall[] = [];
+  const ctx = {
+    runQuery: (fn: Parameters<typeof getFunctionName>[0]) => {
+      if (getFunctionName(fn).includes('getByStorageId')) {
+        return Promise.resolve({
+          fileName: 'Overview.txt',
+          contentType: 'text/plain',
+          size: 915,
+        });
+      }
+      return Promise.resolve(null);
+    },
+    runMutation: (
+      fn: Parameters<typeof getFunctionName>[0],
+      args: Record<string, unknown>,
+    ) => {
+      const name = getFunctionName(fn);
+      runMutationCalls.push({ name, args });
+      if (name.includes('upsertDocumentByExternalId')) {
+        return Promise.resolve({
+          documentId: 'doc_synced',
+          action: 'created',
+          contentChanged: true,
+        });
+      }
+      if (name.includes('createDocument')) {
+        return Promise.resolve('doc_adhoc');
+      }
+      return Promise.resolve(null);
+    },
+  };
+  return { ctx, runMutationCalls };
+}
+
+function linkCall(calls: RunMutationCall[]): RunMutationCall | undefined {
+  return calls.find((c) => c.name.includes('linkDocumentToFile'));
+}
+
+describe('documentAction create — fileMetadata back-fill', () => {
+  it('links fileMetadata.documentId after a sync upsert (externalItemId present)', async () => {
+    const { ctx, runMutationCalls } = createMockCtx();
+
+    await documentAction.execute(
+      ctx as unknown as ActionCtx,
+      {
+        operation: 'create',
+        fileId: 'stor_sync',
+        externalItemId: '163939',
+        title: 'Overview',
+        sourceProvider: 'confluence',
+        contentHash: '1',
+      },
+      { organizationId: 'org_1', userId: 'user_1' },
+    );
+
+    const link = linkCall(runMutationCalls);
+    expect(link).toBeDefined();
+    expect(link?.args).toEqual({
+      storageId: 'stor_sync',
+      documentId: 'doc_synced',
+    });
+  });
+
+  it('links fileMetadata.documentId after an ad-hoc create (no externalItemId)', async () => {
+    const { ctx, runMutationCalls } = createMockCtx();
+
+    await documentAction.execute(
+      ctx as unknown as ActionCtx,
+      {
+        operation: 'create',
+        fileId: 'stor_adhoc',
+        title: 'Scratch',
+        sourceProvider: 'agent',
+      },
+      { organizationId: 'org_1', userId: 'user_1' },
+    );
+
+    const link = linkCall(runMutationCalls);
+    expect(link).toBeDefined();
+    expect(link?.args).toEqual({
+      storageId: 'stor_adhoc',
+      documentId: 'doc_adhoc',
+    });
+  });
+});

--- a/services/platform/convex/workflow_engine/action_defs/document/document_action_link_file.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/document/document_action_link_file.test.ts
@@ -80,6 +80,13 @@ describe('documentAction create — fileMetadata back-fill', () => {
       storageId: 'stor_sync',
       documentId: 'doc_synced',
     });
+
+    // extension is derived from the stored blob's filename ('Overview.txt'),
+    // since sync titles are kept clean — and passed to the upsert.
+    const upsert = runMutationCalls.find((c) =>
+      c.name.includes('upsertDocumentByExternalId'),
+    );
+    expect(upsert?.args.extension).toBe('txt');
   });
 
   it('links fileMetadata.documentId after an ad-hoc create (no externalItemId)', async () => {
@@ -102,5 +109,10 @@ describe('documentAction create — fileMetadata back-fill', () => {
       storageId: 'stor_adhoc',
       documentId: 'doc_adhoc',
     });
+
+    const create = runMutationCalls.find((c) =>
+      c.name.includes('createDocument'),
+    );
+    expect(create?.args.extension).toBe('txt');
   });
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2015,6 +2015,9 @@
       }
     },
     "sourceType": {
+      "confluence": "Confluence",
+      "googleDrive": "Google Drive",
+      "webDav": "WebDAV",
       "oneDrive": "OneDrive",
       "oneDriveSynced": "OneDrive (synchronisiert)",
       "sharePoint": "SharePoint",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2015,6 +2015,9 @@
       }
     },
     "sourceType": {
+      "confluence": "Confluence",
+      "googleDrive": "Google Drive",
+      "webDav": "WebDAV",
       "oneDrive": "OneDrive",
       "oneDriveSynced": "OneDrive (synced)",
       "sharePoint": "SharePoint",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2016,6 +2016,9 @@
       }
     },
     "sourceType": {
+      "confluence": "Confluence",
+      "googleDrive": "Google Drive",
+      "webDav": "WebDAV",
       "oneDrive": "OneDrive",
       "oneDriveSynced": "OneDrive (synchronisé)",
       "sharePoint": "SharePoint",

--- a/services/platform/types/documents.ts
+++ b/services/platform/types/documents.ts
@@ -12,6 +12,10 @@ export interface DocumentItem {
   name?: string;
   type: 'file' | 'folder';
   size?: number;
+  /** Authoritative content type, e.g. 'text/plain', 'application/pdf'. */
+  mimeType?: string;
+  /** File extension without the dot, e.g. 'txt', 'pdf'. */
+  extension?: string;
   folderId?: string;
   /**
    * Source provider — integration slug for integration-sourced docs


### PR DESCRIPTION
## Summary

Adds a **Confluence Cloud → Tale read-only sync** integration: a data-driven connector + sync workflow that pulls Confluence pages into Documents + RAG, with move/rename/delete sync. Building it surfaced and fixed several cross-cutting provenance/UI gaps in the shared document pipeline (which also benefit Google Drive / OneDrive / WebDAV).

## Confluence integration (data-only, under `examples/default/`)

- `integrations/confluence/{config.json,connector.ts,icon.svg}` + `workflows/confluence/sync.json`.
- **Auth:** Confluence Cloud API token (Basic auth) — same family as Circuly/Twilio, no backend changes.
- **Plain-text storage:** the connector converts page HTML → text, so RAG indexes clean prose and document titles stay extension-free.
- **Page-as-folder:** a page with children becomes a folder containing its own content + children (no same-named folder/doc collision).
- **Move/rename sync:** version-independent folder-drift detection re-homes reparented pages and the descendants of a moved parent, using the stored blob (no re-download, no orphaned blob, RAG untouched).
- **Delete sync (archive-safe):** reconcile removes docs for deleted/trashed/purged pages; a second archived-ids pass (`cqlcontext` `contentStatuses=archived`) keeps archived pages in the present-set so they are preserved. Reuses the existing truncated/empty/mass-delete guards.
- Cursor pagination (`_links.next`), CQL verified against the live API.

## Shared document-pipeline fixes (`services/platform`)

Surfaced by the sync; these fix Google Drive / OneDrive / WebDAV too:

- **`fileMetadata.documentId` back-fill** on connector-synced docs — closes a latent retention-GC data-loss path (synced blobs looked like orphaned agent temp files) + repair migration.
- **Specific `fileMetadata.source` provenance** per channel (enum relaxed to an open string; `linkDocumentToFile` derives it from the document's `sourceProvider`).
- **`document.extension`** populated for synced docs (was only in `metadata`).
- **Source column** labels Confluence / Google Drive / WebDAV (+ en/de/fr i18n).
- **Icon and preview resolve from `mimeType`**, not just the filename — extension-less synced docs (e.g. a `text/plain` Confluence page) get the right file-type icon and preview inline instead of a generic icon / "Preview not available".

## Notes / follow-ups

- Verified end-to-end against a live Confluence Cloud tenant (auth, CQL pagination, `body.export_view`, HTML→text). The archived-pages `cqlcontext` query is per Atlassian docs — worth confirming on a space that has archived pages.
- One-shot repair migrations (`backfillFileMetadataDocumentId`, `relabelSyncedFileMetadataSource`) repair pre-existing synced rows.
- Deferred (documented in code): OAuth 3LO, Server/Data Center, attachments/images, workflow-layer pagination for very large (>~4000-page) spaces.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests) — green (71,473 tests).
- [x] No hand-rolled skeletons — N/A.
- [x] Updated `services/platform/messages/{en,de,fr}.json` (`sourceType.confluence/googleDrive/webDav`).
- [x] `/docs/{en,de,fr}/` — N/A (integrations are not documented per-integration; no user-facing docs page changed).
- [x] Docs opening/closing + loanword tests — N/A (no docs touched).
- [x] `@tale/docs` lint/test — N/A (no docs touched).
- [x] README — N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Confluence Cloud integration for syncing pages as documents
  * Enhanced document type detection using MIME types for more accurate file icons and preview routing
  * Added support for Confluence, Google Drive, and WebDAV document sources

* **Improvements**
  * Improved file extension handling across various document sources

* **Localization**
  * Added translated labels for new source types in supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->