### PR TITLE
feat(platform): add generic OIDC identity provider adapter

### DIFF
--- a/services/platform/app/features/settings/integrations/components/sso-config-dialog.tsx
+++ b/services/platform/app/features/settings/integrations/components/sso-config-dialog.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@tale/ui/icon-button';
 import { Center, HStack, Stack } from '@tale/ui/layout';
 import { StatusIndicator } from '@tale/ui/status-indicator';
 import { Text } from '@tale/ui/text';
-import { CheckCircle, Loader2, X, XCircle } from 'lucide-react';
+import { CheckCircle, KeyRound, Loader2, X, XCircle } from 'lucide-react';
 
 import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
 import { FormSection } from '@/app/components/ui/forms/form-section';
@@ -21,7 +21,10 @@ import type {
 } from '@/lib/shared/schemas/sso_providers';
 import { narrowStringUnion } from '@/lib/utils/type-guards';
 
-import { useSsoConfigForm } from '../hooks/use-sso-config-form';
+import {
+  type SsoProviderType,
+  useSsoConfigForm,
+} from '../hooks/use-sso-config-form';
 import { RoleMappingSection } from './sso-config/role-mapping-section';
 
 interface SSOConfigDialogProps {
@@ -41,6 +44,8 @@ export function SSOConfigDialog({
     t,
     tCommon,
     platformRoles,
+    providerType,
+    setProviderType,
     issuer,
     setIssuer,
     clientId,
@@ -75,6 +80,8 @@ export function SSOConfigDialog({
     organizationId,
     existingProvider,
   });
+
+  const isGeneric = providerType === 'generic-oidc';
 
   const isFormValid = isConnected
     ? !!issuer?.trim() && !!clientId?.trim()
@@ -120,7 +127,11 @@ export function SSOConfigDialog({
         <Stack gap={4}>
           <HStack gap={3} align="center">
             <Center className="border-border size-10 rounded-md border">
-              <MicrosoftIcon className="size-5" />
+              {isGeneric ? (
+                <KeyRound className="size-5" />
+              ) : (
+                <MicrosoftIcon className="size-5" />
+              )}
             </Center>
             <Stack gap={1}>
               <Text variant="label">{t('integrations.sso.name')}</Text>
@@ -137,21 +148,60 @@ export function SSOConfigDialog({
           </HStack>
 
           <Text variant="muted" className="text-sm leading-relaxed">
-            {t('integrations.sso.description')}
+            {isGeneric
+              ? t('integrations.sso.descriptionGeneric')
+              : t('integrations.sso.description')}
           </Text>
 
           {isConnected && (
             <StatusIndicator variant="success">
-              {t('integrations.sso.connectedToEntra')}
+              {isGeneric
+                ? t('integrations.sso.connectedToGeneric')
+                : t('integrations.sso.connectedToEntra')}
             </StatusIndicator>
           )}
 
           <FormSection>
+            <Select
+              id="sso-provider-type"
+              label={t('integrations.sso.providerTypeLabel')}
+              description={t('integrations.sso.providerTypeHelp')}
+              value={providerType}
+              onValueChange={(value) => {
+                const narrowed = narrowStringUnion<SsoProviderType>(value, [
+                  'entra-id',
+                  'generic-oidc',
+                ] as const);
+                if (narrowed) {
+                  setProviderType(narrowed);
+                }
+              }}
+              disabled={isSubmitting || isLoadingConfig || isConnected}
+              options={[
+                {
+                  value: 'entra-id',
+                  label: t('integrations.sso.providerTypeEntra'),
+                },
+                {
+                  value: 'generic-oidc',
+                  label: t('integrations.sso.providerTypeGeneric'),
+                },
+              ]}
+            />
+
             <Input
               id="sso-issuer"
               label={t('integrations.sso.issuerLabel')}
-              description={t('integrations.sso.issuerHelp')}
-              placeholder="https://login.microsoftonline.com/{tenant-id}/v2.0"
+              description={
+                isGeneric
+                  ? t('integrations.sso.issuerHelpGeneric')
+                  : t('integrations.sso.issuerHelp')
+              }
+              placeholder={
+                isGeneric
+                  ? 'https://idp.example.com'
+                  : 'https://login.microsoftonline.com/{tenant-id}/v2.0'
+              }
               value={issuer}
               onChange={(e) => setIssuer(e.target.value)}
               disabled={isSubmitting || isLoadingConfig}
@@ -160,11 +210,17 @@ export function SSOConfigDialog({
             <Input
               id="sso-client-id"
               label={t('integrations.sso.clientIdLabel')}
-              description={t('integrations.sso.clientIdHelp')}
+              description={
+                isGeneric
+                  ? t('integrations.sso.clientIdHelpGeneric')
+                  : t('integrations.sso.clientIdHelp')
+              }
               placeholder={
                 isLoadingConfig
                   ? tCommon('actions.loading')
-                  : 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+                  : isGeneric
+                    ? 'your-client-id'
+                    : 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
               }
               value={clientId}
               onChange={(e) => setClientId(e.target.value)}
@@ -175,7 +231,11 @@ export function SSOConfigDialog({
               id="sso-client-secret"
               type="password"
               label={t('integrations.sso.clientSecretLabel')}
-              description={t('integrations.sso.clientSecretHelp')}
+              description={
+                isGeneric
+                  ? t('integrations.sso.clientSecretHelpGeneric')
+                  : t('integrations.sso.clientSecretHelp')
+              }
               placeholder={isConnected ? '••••••••••••••••' : ''}
               value={clientSecret}
               onChange={(e) => setClientSecret(e.target.value)}
@@ -221,40 +281,48 @@ export function SSOConfigDialog({
               )}
             </ActionRow>
 
-            <Switch
-              id="onedrive-access-toggle"
-              label={t('integrations.sso.oneDriveAccessLabel')}
-              description={t('integrations.sso.oneDriveAccessHelp')}
-              checked={enableOneDriveAccess}
-              onCheckedChange={setEnableOneDriveAccess}
-              disabled={isSubmitting || isLoadingConfig}
-            />
+            {!isGeneric && (
+              <>
+                <Switch
+                  id="onedrive-access-toggle"
+                  label={t('integrations.sso.oneDriveAccessLabel')}
+                  description={t('integrations.sso.oneDriveAccessHelp')}
+                  checked={enableOneDriveAccess}
+                  onCheckedChange={setEnableOneDriveAccess}
+                  disabled={isSubmitting || isLoadingConfig}
+                />
 
-            <Switch
-              id="auto-provision-team-toggle"
-              label={t('integrations.sso.autoProvisionTeamLabel')}
-              description={t('integrations.sso.autoProvisionTeamHelp')}
-              checked={autoProvisionTeam}
-              onCheckedChange={setAutoProvisionTeam}
-              disabled={isSubmitting || isLoadingConfig}
-            />
+                <Switch
+                  id="auto-provision-team-toggle"
+                  label={t('integrations.sso.autoProvisionTeamLabel')}
+                  description={t('integrations.sso.autoProvisionTeamHelp')}
+                  checked={autoProvisionTeam}
+                  onCheckedChange={setAutoProvisionTeam}
+                  disabled={isSubmitting || isLoadingConfig}
+                />
 
-            {autoProvisionTeam && (
-              <Input
-                id="sso-exclude-groups"
-                label={t('integrations.sso.excludeGroupsLabel')}
-                description={t('integrations.sso.excludeGroupsHelp')}
-                placeholder="All-Employees, Domain-Users"
-                value={excludeGroups}
-                onChange={(e) => setExcludeGroups(e.target.value)}
-                disabled={isSubmitting || isLoadingConfig}
-              />
+                {autoProvisionTeam && (
+                  <Input
+                    id="sso-exclude-groups"
+                    label={t('integrations.sso.excludeGroupsLabel')}
+                    description={t('integrations.sso.excludeGroupsHelp')}
+                    placeholder="All-Employees, Domain-Users"
+                    value={excludeGroups}
+                    onChange={(e) => setExcludeGroups(e.target.value)}
+                    disabled={isSubmitting || isLoadingConfig}
+                  />
+                )}
+              </>
             )}
 
             <Switch
               id="auto-provision-role-toggle"
               label={t('integrations.sso.autoProvisionRoleLabel')}
-              description={t('integrations.sso.autoProvisionRoleHelp')}
+              description={
+                isGeneric
+                  ? t('integrations.sso.autoProvisionRoleHelpGeneric')
+                  : t('integrations.sso.autoProvisionRoleHelp')
+              }
               checked={autoProvisionRole}
               onCheckedChange={setAutoProvisionRole}
               disabled={isSubmitting || isLoadingConfig}

--- a/services/platform/app/features/settings/integrations/hooks/use-sso-config-form.test.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-sso-config-form.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SsoProvider } from '@/lib/shared/schemas/sso_providers';
+
+// Stable references: returning a fresh `t`/mutate object per render would make
+// the hook's effect deps change every render and spin a render loop.
+const h = vi.hoisted(() => ({
+  upsertMock: vi.fn(),
+  testMock: vi.fn(),
+  testExistingMock: vi.fn(),
+  removeMock: vi.fn(),
+  getFullConfigMock: vi.fn(),
+  t: (key: string) => key,
+}));
+
+vi.mock('./actions', () => ({
+  useUpsertSsoProvider: () => ({ mutateAsync: h.upsertMock, isPending: false }),
+  useRemoveSsoProvider: () => ({ mutateAsync: h.removeMock, isPending: false }),
+  useSsoFullConfig: () => ({
+    mutateAsync: h.getFullConfigMock,
+    isPending: false,
+  }),
+  useTestSsoConfig: () => ({ mutateAsync: h.testMock, isPending: false }),
+  useTestExistingSsoConfig: () => ({
+    mutateAsync: h.testExistingMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+vi.mock('@/lib/i18n/client', () => ({ useT: () => ({ t: h.t }) }));
+
+import { useSsoConfigForm } from './use-sso-config-form';
+
+function setup() {
+  const onOpenChange = vi.fn();
+  const { result } = renderHook(() =>
+    useSsoConfigForm({
+      open: true,
+      onOpenChange,
+      organizationId: 'org-1',
+      existingProvider: null,
+    }),
+  );
+  return { result, onOpenChange };
+}
+
+function fillCredentials(result: ReturnType<typeof setup>['result']) {
+  act(() => {
+    result.current.setIssuer('https://idp.example.com');
+    result.current.setClientId('client-123');
+    result.current.setClientSecret('secret-xyz');
+  });
+}
+
+describe('useSsoConfigForm provider type (#1506)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('defaults to entra-id and saves Microsoft Graph scopes + Entra features', async () => {
+    h.upsertMock.mockResolvedValueOnce('provider-1');
+    const { result } = setup();
+
+    expect(result.current.providerType).toBe('entra-id');
+    fillCredentials(result);
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(h.upsertMock).toHaveBeenCalledTimes(1);
+    const arg = h.upsertMock.mock.calls[0][0];
+    expect(arg.providerId).toBe('entra-id');
+    expect(arg.scopes).toContain(
+      'https://graph.microsoft.com/GroupMember.Read.All',
+    );
+    expect(arg.providerFeatures?.entraId).toBeDefined();
+  });
+
+  it('saves generic OIDC with standard scopes and no provider features', async () => {
+    h.upsertMock.mockResolvedValueOnce('provider-2');
+    const { result } = setup();
+
+    act(() => result.current.setProviderType('generic-oidc'));
+    fillCredentials(result);
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    const arg = h.upsertMock.mock.calls[0][0];
+    expect(arg.providerId).toBe('generic-oidc');
+    expect(arg.scopes).toEqual(['openid', 'email', 'profile']);
+    // OneDrive / Graph team-sync are Entra-only; generic persists no features.
+    expect(arg.providerFeatures).toBeUndefined();
+  });
+
+  it('tests a generic OIDC config against the generic adapter', async () => {
+    h.testMock.mockResolvedValueOnce({ valid: true });
+    const { result } = setup();
+
+    act(() => result.current.setProviderType('generic-oidc'));
+    fillCredentials(result);
+    await act(async () => {
+      await result.current.handleTest();
+    });
+
+    const arg = h.testMock.mock.calls[0][0];
+    expect(arg.providerId).toBe('generic-oidc');
+    expect(arg.scopes).toEqual(['openid', 'email', 'profile']);
+  });
+
+  it('derives generic-oidc provider type from a loaded config', async () => {
+    const existingProvider: SsoProvider = {
+      _id: 'sso-1',
+      providerId: 'generic-oidc',
+      issuer: 'https://idp.example.com',
+      scopes: ['openid', 'email', 'profile'],
+      autoProvisionRole: true,
+      roleMappingRules: [],
+      defaultRole: 'member',
+    };
+    h.getFullConfigMock.mockResolvedValueOnce({
+      _id: 'sso-1',
+      organizationId: 'org-1',
+      providerId: 'generic-oidc',
+      issuer: 'https://idp.example.com',
+      clientId: 'client-123',
+      scopes: ['openid', 'email', 'profile'],
+      autoProvisionRole: true,
+      roleMappingRules: [],
+      defaultRole: 'member',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    const { result } = renderHook(() =>
+      useSsoConfigForm({
+        open: true,
+        onOpenChange: vi.fn(),
+        organizationId: 'org-1',
+        existingProvider,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.providerType).toBe('generic-oidc'),
+    );
+    expect(result.current.issuer).toBe('https://idp.example.com');
+  });
+});

--- a/services/platform/app/features/settings/integrations/hooks/use-sso-config-form.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-sso-config-form.ts
@@ -18,7 +18,7 @@ import {
   useUpsertSsoProvider,
 } from './actions';
 
-const DEFAULT_SCOPES = [
+const ENTRA_SCOPES = [
   'openid',
   'email',
   'profile',
@@ -26,6 +26,17 @@ const DEFAULT_SCOPES = [
   'https://graph.microsoft.com/GroupMember.Read.All',
   'https://graph.microsoft.com/Files.Read',
 ];
+
+// Generic OIDC: the adapter always forces `openid`; request the standard
+// identity scopes so the userinfo endpoint returns the email/profile claims
+// that role mapping reads.
+const GENERIC_OIDC_SCOPES = ['openid', 'email', 'profile'];
+
+export type SsoProviderType = 'entra-id' | 'generic-oidc';
+
+function scopesForProvider(type: SsoProviderType): string[] {
+  return type === 'generic-oidc' ? GENERIC_OIDC_SCOPES : ENTRA_SCOPES;
+}
 
 const DEFAULT_MAPPING_RULES: RoleMappingRule[] = [
   { source: 'jobTitle', pattern: '*admin*', targetRole: 'admin' },
@@ -62,6 +73,7 @@ export function useSsoConfigForm({
     [t],
   );
 
+  const [providerType, setProviderType] = useState<SsoProviderType>('entra-id');
   const [issuer, setIssuer] = useState('');
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
@@ -79,6 +91,7 @@ export function useSsoConfigForm({
   } | null>(null);
 
   const originalConfigRef = useRef<{
+    providerType: SsoProviderType;
     issuer: string;
     clientId: string;
     autoProvisionTeam: boolean;
@@ -110,6 +123,7 @@ export function useSsoConfigForm({
 
     const orig = originalConfigRef.current;
     const basicFieldsChanged =
+      providerType !== orig.providerType ||
       issuer !== orig.issuer ||
       clientId !== orig.clientId ||
       autoProvisionTeam !== orig.autoProvisionTeam ||
@@ -130,6 +144,7 @@ export function useSsoConfigForm({
       );
     });
   }, [
+    providerType,
     issuer,
     clientId,
     clientSecret,
@@ -157,6 +172,11 @@ export function useSsoConfigForm({
                       r.source === 'jobTitle' || r.source === 'appRole',
                   )
                 : DEFAULT_MAPPING_RULES;
+            const loadedType: SsoProviderType =
+              config.providerId === 'generic-oidc'
+                ? 'generic-oidc'
+                : 'entra-id';
+            setProviderType(loadedType);
             setIssuer(config.issuer);
             setClientId(config.clientId);
             setAutoProvisionTeam(entraFeatures?.autoProvisionTeam ?? false);
@@ -168,6 +188,7 @@ export function useSsoConfigForm({
               entraFeatures?.enableOneDriveAccess ?? false,
             );
             originalConfigRef.current = {
+              providerType: loadedType,
               issuer: config.issuer,
               clientId: config.clientId,
               autoProvisionTeam: entraFeatures?.autoProvisionTeam ?? false,
@@ -190,6 +211,7 @@ export function useSsoConfigForm({
           });
         });
     } else if (!existingProvider) {
+      setProviderType('entra-id');
       setIssuer('');
       setClientId('');
       setClientSecret('');
@@ -214,27 +236,33 @@ export function useSsoConfigForm({
       return;
     }
 
+    const isGeneric = providerType === 'generic-oidc';
+
     try {
       await upsertSSOProvider({
         organizationId,
-        providerId: 'entra-id',
+        providerId: providerType,
         issuer,
         clientId,
         clientSecret,
-        scopes: DEFAULT_SCOPES,
+        scopes: scopesForProvider(providerType),
         autoProvisionRole,
         roleMappingRules,
         defaultRole,
-        providerFeatures: {
-          entraId: {
-            enableOneDriveAccess,
-            autoProvisionTeam,
-            excludeGroups: excludeGroups
-              .split(',')
-              .map((g) => g.trim())
-              .filter(Boolean),
-          },
-        },
+        // OneDrive and Entra group→team sync ride Microsoft Graph, so they
+        // apply only to the Entra provider; generic OIDC persists no features.
+        providerFeatures: isGeneric
+          ? undefined
+          : {
+              entraId: {
+                enableOneDriveAccess,
+                autoProvisionTeam,
+                excludeGroups: excludeGroups
+                  .split(',')
+                  .map((g) => g.trim())
+                  .filter(Boolean),
+              },
+            },
       });
 
       toast({
@@ -258,6 +286,7 @@ export function useSsoConfigForm({
     }
   }, [
     isConnected,
+    providerType,
     issuer,
     clientId,
     clientSecret,
@@ -316,6 +345,8 @@ export function useSsoConfigForm({
             issuer,
             clientId,
             clientSecret,
+            providerId: providerType,
+            scopes: scopesForProvider(providerType),
           });
 
       setTestResult(result);
@@ -353,6 +384,7 @@ export function useSsoConfigForm({
     }
   }, [
     isConnected,
+    providerType,
     clientSecret,
     issuer,
     clientId,
@@ -385,6 +417,8 @@ export function useSsoConfigForm({
     t,
     tCommon,
     platformRoles,
+    providerType,
+    setProviderType,
     issuer,
     setIssuer,
     clientId,

--- a/services/platform/convex/sso_providers/actions.ts
+++ b/services/platform/convex/sso_providers/actions.ts
@@ -88,6 +88,8 @@ export const testConfig = action({
     issuer: v.string(),
     clientId: v.string(),
     clientSecret: v.string(),
+    providerId: v.optional(v.string()),
+    scopes: v.optional(v.array(v.string())),
   },
   returns: validationResultValidator,
   handler: async (ctx, args) => {
@@ -134,6 +136,8 @@ export const testExistingConfig = action({
       issuer: provider.issuer,
       clientId,
       clientSecret,
+      providerId: provider.providerId,
+      scopes: provider.scopes,
     });
     return { valid, error };
   },

--- a/services/platform/convex/sso_providers/entra_id/adapter.ts
+++ b/services/platform/convex/sso_providers/entra_id/adapter.ts
@@ -138,7 +138,10 @@ function parseIdTokenAuthContext(idToken: string): SsoAuthContext | undefined {
   }
 }
 
-async function getUserInfo(accessToken: string): Promise<SsoUserInfo> {
+async function getUserInfo(
+  _config: SsoProviderConfig,
+  accessToken: string,
+): Promise<SsoUserInfo> {
   const userInfoUrl = `${MICROSOFT_GRAPH_BASE}/me?$select=id,displayName,givenName,mail,userPrincipalName,jobTitle`;
 
   const response = await fetch(userInfoUrl, {
@@ -159,7 +162,10 @@ async function getUserInfo(accessToken: string): Promise<SsoUserInfo> {
   };
 }
 
-async function getGroups(accessToken: string): Promise<SsoGroup[]> {
+async function getGroups(
+  _config: SsoProviderConfig,
+  accessToken: string,
+): Promise<SsoGroup[]> {
   const response = await fetch(
     `${MICROSOFT_GRAPH_BASE}/me/memberOf?$select=id,displayName`,
     {
@@ -183,7 +189,10 @@ async function getGroups(accessToken: string): Promise<SsoGroup[]> {
     }));
 }
 
-async function getAppRoles(accessToken: string): Promise<string[]> {
+async function getAppRoles(
+  _config: SsoProviderConfig,
+  accessToken: string,
+): Promise<string[]> {
   const response = await fetch(
     `${MICROSOFT_GRAPH_BASE}/me/appRoleAssignments?$select=appRoleId`,
     { headers: { Authorization: `Bearer ${accessToken}` } },

--- a/services/platform/convex/sso_providers/entra_id/team_sync.ts
+++ b/services/platform/convex/sso_providers/entra_id/team_sync.ts
@@ -1,6 +1,6 @@
 import { components } from '../../_generated/api';
 import type { MutationCtx } from '../../_generated/server';
-import type { SsoProviderAdapter } from '../types';
+import type { SsoProviderAdapter, SsoProviderConfig } from '../types';
 
 interface Team {
   _id: string;
@@ -14,6 +14,7 @@ export interface SyncTeamsFromGroupsArgs {
   accessToken: string;
   excludeGroups: string[];
   adapter: SsoProviderAdapter;
+  config: SsoProviderConfig;
 }
 
 export interface SyncTeamsResult {
@@ -245,7 +246,7 @@ async function removeStaleTeamMemberships(
 export async function syncTeamsFromGroups(
   args: SyncTeamsFromGroupsArgs,
 ): Promise<SyncTeamsResult> {
-  const { ctx, userId, accessToken, excludeGroups, adapter } = args;
+  const { ctx, userId, accessToken, excludeGroups, adapter, config } = args;
 
   const result: SyncTeamsResult = {
     teamsCreated: 0,
@@ -266,7 +267,7 @@ export async function syncTeamsFromGroups(
       return result;
     }
 
-    const groups = await adapter.getGroups(accessToken);
+    const groups = await adapter.getGroups(config, accessToken);
 
     const excludeGroupsLower = new Set(
       excludeGroups.map((g) => g.toLowerCase().trim()),

--- a/services/platform/convex/sso_providers/generic_oidc/adapter.test.ts
+++ b/services/platform/convex/sso_providers/generic_oidc/adapter.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resetOidcDiscoveryCacheForTests } from '../oidc_discovery';
+import type { SsoProviderConfig } from '../types';
+import { genericOidcAdapter } from './adapter';
+
+const ISSUER = 'https://idp.example.com';
+const DISCOVERY = {
+  issuer: ISSUER,
+  authorization_endpoint: 'https://idp.example.com/authorize',
+  token_endpoint: 'https://idp.example.com/token',
+  userinfo_endpoint: 'https://idp.example.com/userinfo',
+  jwks_uri: 'https://idp.example.com/jwks',
+};
+
+const config: SsoProviderConfig = {
+  providerId: 'generic-oidc',
+  issuer: ISSUER,
+  clientId: 'client-123',
+  clientSecret: 'secret-xyz',
+  scopes: ['email', 'profile'],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input, init) =>
+      handler(urlOf(input), init ?? undefined),
+    );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetOidcDiscoveryCacheForTests();
+});
+
+describe('generic OIDC adapter (#1506)', () => {
+  it('builds the authorize URL from the discovered endpoint and forces the openid scope', async () => {
+    mockFetch((url) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const url = await genericOidcAdapter.buildAuthorizeUrl(config, {
+      redirectUri: 'https://app.example/callback',
+      state: 'state-1',
+    });
+
+    expect(`${url.origin}${url.pathname}`).toBe(
+      DISCOVERY.authorization_endpoint,
+    );
+    expect(url.searchParams.get('client_id')).toBe('client-123');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://app.example/callback',
+    );
+    expect(url.searchParams.get('state')).toBe('state-1');
+    const scope = url.searchParams.get('scope') ?? '';
+    expect(scope.split(' ')).toEqual(['openid', 'email', 'profile']);
+  });
+
+  it('exchanges the code at the discovered token endpoint', async () => {
+    let tokenBody: URLSearchParams | undefined;
+    mockFetch((url, init) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      if (url === DISCOVERY.token_endpoint) {
+        if (init?.body instanceof URLSearchParams) {
+          tokenBody = init.body;
+        }
+        return jsonResponse({
+          access_token: 'at',
+          refresh_token: 'rt',
+          expires_in: 3600,
+          id_token: 'idt',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const tokens = await genericOidcAdapter.exchangeCodeForTokens(config, {
+      code: 'auth-code',
+      redirectUri: 'https://app.example/callback',
+    });
+
+    expect(tokens.accessToken).toBe('at');
+    expect(tokens.refreshToken).toBe('rt');
+    expect(tokens.idToken).toBe('idt');
+    expect(tokens.expiresAt).toBeGreaterThan(Date.now());
+    expect(tokenBody?.get('grant_type')).toBe('authorization_code');
+    expect(tokenBody?.get('code')).toBe('auth-code');
+    expect(tokenBody?.get('client_id')).toBe('client-123');
+  });
+
+  it('maps userinfo claims (sub -> externalId, email, name, groups)', async () => {
+    mockFetch((url) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      if (url === DISCOVERY.userinfo_endpoint) {
+        return jsonResponse({
+          sub: 'user-1',
+          email: 'user@example.com',
+          name: 'User One',
+          groups: ['admins', 'engineering'],
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const info = await genericOidcAdapter.getUserInfo(config, 'at');
+    expect(info.externalId).toBe('user-1');
+    expect(info.email).toBe('user@example.com');
+    expect(info.name).toBe('User One');
+    expect(info.groups).toEqual(['admins', 'engineering']);
+  });
+
+  it('falls back to given/family name then preferred_username', async () => {
+    mockFetch((url) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      return jsonResponse({
+        sub: 'user-2',
+        given_name: 'Ada',
+        family_name: 'Lovelace',
+        preferred_username: 'ada',
+      });
+    });
+    const info = await genericOidcAdapter.getUserInfo(config, 'at');
+    expect(info.name).toBe('Ada Lovelace');
+    expect(info.email).toBe('ada');
+  });
+
+  it('validateConfig succeeds for a discoverable issuer with a userinfo endpoint', async () => {
+    mockFetch(() => jsonResponse(DISCOVERY));
+    expect(await genericOidcAdapter.validateConfig(config)).toEqual({
+      valid: true,
+    });
+  });
+
+  it('validateConfig fails when discovery is unreachable', async () => {
+    mockFetch(() => jsonResponse({}, 404));
+    const result = await genericOidcAdapter.validateConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/discovery/i);
+  });
+
+  it('validateConfig fails when no userinfo_endpoint is advertised', async () => {
+    mockFetch(() =>
+      jsonResponse({ ...DISCOVERY, userinfo_endpoint: undefined }),
+    );
+    const result = await genericOidcAdapter.validateConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/userinfo/i);
+  });
+
+  it('throws when userinfo omits the required sub claim', async () => {
+    mockFetch((url) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      return jsonResponse({ email: 'no-sub@example.com' });
+    });
+    await expect(genericOidcAdapter.getUserInfo(config, 'at')).rejects.toThrow(
+      /sub/i,
+    );
+  });
+
+  it('caches the discovery document across calls in a flow', async () => {
+    const fetchSpy = mockFetch((url) => {
+      if (url.includes('.well-known')) return jsonResponse(DISCOVERY);
+      if (url === DISCOVERY.userinfo_endpoint) {
+        return jsonResponse({ sub: 'u', email: 'u@example.com' });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await genericOidcAdapter.getUserInfo(config, 'at');
+    await genericOidcAdapter.getUserInfo(config, 'at');
+
+    const wellKnownCalls = fetchSpy.mock.calls.filter((call) =>
+      urlOf(call[0]).includes('.well-known'),
+    ).length;
+    expect(wellKnownCalls).toBe(1);
+  });
+});

--- a/services/platform/convex/sso_providers/generic_oidc/adapter.ts
+++ b/services/platform/convex/sso_providers/generic_oidc/adapter.ts
@@ -1,0 +1,194 @@
+// The role matcher is provider-agnostic (it matches jobTitle / appRole / group
+// claims against rules) — reused here rather than duplicated.
+import { mapEntraRoleToPlatformRole } from '../entra_id/role_mapping';
+import { discoverOidc, OIDC_FETCH_TIMEOUT_MS } from '../oidc_discovery';
+import type {
+  AuthorizeUrlParams,
+  PlatformRole,
+  RoleMappingRule,
+  SsoGroup,
+  SsoProviderAdapter,
+  SsoProviderCapabilities,
+  SsoProviderConfig,
+  SsoTokens,
+  SsoUserInfo,
+  TokenExchangeParams,
+} from '../types';
+
+const capabilities: SsoProviderCapabilities = {
+  supportsGroupSync: true,
+  supportsRoleMapping: true,
+  supportsOneDriveAccess: false,
+  supportsGoogleDriveAccess: false,
+};
+
+async function buildAuthorizeUrl(
+  config: SsoProviderConfig,
+  params: AuthorizeUrlParams,
+): Promise<URL> {
+  const { authorizationEndpoint } = await discoverOidc(config.issuer);
+  const authUrl = new URL(authorizationEndpoint);
+
+  const scopes = [...config.scopes];
+  // Standard OIDC needs the `openid` scope; add it if the operator omitted it.
+  if (!scopes.includes('openid')) scopes.unshift('openid');
+  for (const scope of params.additionalScopes ?? []) {
+    if (!scopes.includes(scope)) scopes.push(scope);
+  }
+
+  authUrl.searchParams.set('client_id', config.clientId);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('redirect_uri', params.redirectUri);
+  authUrl.searchParams.set('scope', scopes.join(' '));
+  authUrl.searchParams.set('state', params.state);
+  if (params.prompt) authUrl.searchParams.set('prompt', params.prompt);
+  if (params.loginHint)
+    authUrl.searchParams.set('login_hint', params.loginHint);
+
+  return authUrl;
+}
+
+async function exchangeCodeForTokens(
+  config: SsoProviderConfig,
+  params: TokenExchangeParams,
+): Promise<SsoTokens> {
+  const { tokenEndpoint } = await discoverOidc(config.issuer);
+
+  const response = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+    }),
+    signal: AbortSignal.timeout(OIDC_FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token exchange failed: ${await response.text()}`);
+  }
+
+  const data = await response.json();
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: data.expires_in
+      ? Date.now() + data.expires_in * 1000
+      : undefined,
+    idToken: data.id_token,
+  };
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+/**
+ * Fetch the standard OIDC userinfo claims and map them to our shape. The
+ * `groups` claim (when the IdP is configured to emit it) is carried on
+ * `groups` so group-based role mapping works at login.
+ */
+async function getUserInfo(
+  config: SsoProviderConfig,
+  accessToken: string,
+): Promise<SsoUserInfo> {
+  const { userinfoEndpoint } = await discoverOidc(config.issuer);
+  if (!userinfoEndpoint) {
+    throw new Error(
+      'This OIDC provider does not advertise a userinfo_endpoint, which Tale requires to resolve the signed-in user',
+    );
+  }
+
+  const response = await fetch(userinfoEndpoint, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(OIDC_FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to get user info: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : [data.given_name, data.family_name].filter(Boolean).join(' ') ||
+        (typeof data.preferred_username === 'string'
+          ? data.preferred_username
+          : '');
+
+  // `sub` is the stable subject identifier and the only claim guaranteed by
+  // the spec. A missing one would otherwise become the string "undefined" and
+  // collide every such user onto one account — fail fast instead.
+  const subValue: unknown = data.sub;
+  const externalId =
+    typeof subValue === 'string'
+      ? subValue
+      : typeof subValue === 'number'
+        ? String(subValue)
+        : '';
+  if (!externalId) {
+    throw new Error(
+      'OIDC userinfo response is missing the required "sub" claim',
+    );
+  }
+
+  return {
+    externalId,
+    email: data.email ?? data.preferred_username,
+    name,
+    groups: toStringArray(data.groups),
+  };
+}
+
+async function getGroups(
+  config: SsoProviderConfig,
+  accessToken: string,
+): Promise<SsoGroup[]> {
+  const userInfo = await getUserInfo(config, accessToken);
+  return (userInfo.groups ?? []).map((g) => ({ id: g, name: g }));
+}
+
+async function validateConfig(
+  config: Omit<SsoProviderConfig, 'clientSecret'> & { clientSecret?: string },
+): Promise<{ valid: boolean; error?: string }> {
+  try {
+    const endpoints = await discoverOidc(config.issuer);
+    if (!endpoints.userinfoEndpoint) {
+      return {
+        valid: false,
+        error:
+          'The issuer is reachable but advertises no userinfo_endpoint, which Tale requires.',
+      };
+    }
+    return { valid: true };
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : 'OIDC discovery failed',
+    };
+  }
+}
+
+function mapToRole(
+  rules: RoleMappingRule[],
+  defaultRole: PlatformRole,
+  userInfo: SsoUserInfo,
+): PlatformRole {
+  return mapEntraRoleToPlatformRole(rules, defaultRole, userInfo);
+}
+
+export const genericOidcAdapter: SsoProviderAdapter = {
+  providerId: 'generic-oidc',
+  displayName: 'Generic OIDC',
+  capabilities,
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  getUserInfo,
+  getGroups,
+  validateConfig,
+  mapToRole,
+};

--- a/services/platform/convex/sso_providers/handle_sso_login.ts
+++ b/services/platform/convex/sso_providers/handle_sso_login.ts
@@ -83,7 +83,7 @@ export async function handleSsoLogin(
     }
 
     const entraFeatures = ssoConfig?.providerFeatures?.entraId;
-    if (entraFeatures?.autoProvisionTeam && adapter.getGroups) {
+    if (ssoConfig && entraFeatures?.autoProvisionTeam && adapter.getGroups) {
       try {
         const syncResult = await syncTeamsFromGroups({
           // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- GenericActionCtx shares the required runQuery/runMutation surface with MutationCtx
@@ -92,6 +92,17 @@ export async function handleSsoLogin(
           accessToken: args.accessToken,
           excludeGroups: entraFeatures.excludeGroups || [],
           adapter,
+          // Entra's getGroups uses only the access token (Microsoft Graph), so
+          // clientId/secret are unused here; issuer/scopes are carried for
+          // discovery-driven adapters that resolve groups from the userinfo
+          // endpoint.
+          config: {
+            providerId: ssoConfig.providerId,
+            issuer: ssoConfig.issuer,
+            clientId: '',
+            clientSecret: '',
+            scopes: ssoConfig.scopes,
+          },
         });
 
         if (syncResult.errors.length > 0) {

--- a/services/platform/convex/sso_providers/oidc_discovery.ts
+++ b/services/platform/convex/sso_providers/oidc_discovery.ts
@@ -1,0 +1,109 @@
+/**
+ * OpenID Connect discovery (#1506).
+ *
+ * A generic OIDC identity provider (Keycloak, Auth0, Okta, Google, …) publishes
+ * its endpoints at `${issuer}/.well-known/openid-configuration`. Unlike the
+ * Entra adapter — which constructs Microsoft URLs from the tenant id — a
+ * generic adapter must read the authorization, token, and userinfo endpoints
+ * from that document. The adapter resolves discovery per auth flow (login is
+ * infrequent and the document is cacheable), so no endpoint is persisted.
+ */
+
+import { isRecord } from '../../lib/utils/type-guards';
+
+export interface OidcEndpoints {
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  /** Optional per the OIDC spec, but required for our user-info mapping. */
+  userinfoEndpoint?: string;
+  jwksUri?: string;
+}
+
+function wellKnownUrl(issuer: string): string {
+  const trimmed = issuer.endsWith('/') ? issuer.slice(0, -1) : issuer;
+  return `${trimmed}/.well-known/openid-configuration`;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Network timeout for OIDC endpoint fetches — a login flow must fail fast if
+ *  the IdP is unreachable rather than hang on a stuck socket. */
+export const OIDC_FETCH_TIMEOUT_MS = 10_000;
+
+// Short-lived in-memory cache keyed by issuer. A single login callback resolves
+// discovery several times (token exchange, userinfo, group sync); caching folds
+// those into one network call. Best-effort per isolate, never persisted; the
+// TTL bounds staleness so a rotated endpoint is picked up within minutes.
+const DISCOVERY_TTL_MS = 5 * 60_000;
+const discoveryCache = new Map<
+  string,
+  { endpoints: OidcEndpoints; expiresAt: number }
+>();
+
+/** Test-only: drop cached discovery between cases. */
+export function resetOidcDiscoveryCacheForTests(): void {
+  discoveryCache.clear();
+}
+
+/**
+ * Fetch and validate the issuer's discovery document. Throws on an
+ * unreachable issuer or a document missing the authorization/token endpoints
+ * (a provider with neither cannot run the authorization-code flow).
+ */
+export async function discoverOidc(issuer: string): Promise<OidcEndpoints> {
+  const cached = discoveryCache.get(issuer);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.endpoints;
+  }
+
+  const url = wellKnownUrl(issuer);
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(OIDC_FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(
+      `OIDC discovery failed: could not reach ${url} (${
+        err instanceof Error ? err.message : 'network error'
+      })`,
+      { cause: err },
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `OIDC discovery failed: ${url} returned ${response.status}`,
+    );
+  }
+
+  const doc: unknown = await response.json();
+  if (!isRecord(doc)) {
+    throw new Error(
+      `OIDC discovery failed: ${url} did not return a JSON object`,
+    );
+  }
+
+  const authorizationEndpoint = asString(doc['authorization_endpoint']);
+  const tokenEndpoint = asString(doc['token_endpoint']);
+  if (!authorizationEndpoint || !tokenEndpoint) {
+    throw new Error(
+      'OIDC discovery failed: document is missing authorization_endpoint or token_endpoint',
+    );
+  }
+
+  const endpoints: OidcEndpoints = {
+    issuer: asString(doc['issuer']) ?? issuer,
+    authorizationEndpoint,
+    tokenEndpoint,
+    userinfoEndpoint: asString(doc['userinfo_endpoint']),
+    jwksUri: asString(doc['jwks_uri']),
+  };
+  discoveryCache.set(issuer, {
+    endpoints,
+    expiresAt: Date.now() + DISCOVERY_TTL_MS,
+  });
+  return endpoints;
+}

--- a/services/platform/convex/sso_providers/registry.ts
+++ b/services/platform/convex/sso_providers/registry.ts
@@ -1,8 +1,10 @@
 import { entraIdAdapter } from './entra_id/adapter';
+import { genericOidcAdapter } from './generic_oidc/adapter';
 import type { SsoProviderAdapter } from './types';
 
 const adapters: Record<string, SsoProviderAdapter> = {
   'entra-id': entraIdAdapter,
+  'generic-oidc': genericOidcAdapter,
 };
 
 export function getAdapter(providerId: string): SsoProviderAdapter | null {

--- a/services/platform/convex/sso_providers/sso_authorize_handler.ts
+++ b/services/platform/convex/sso_providers/sso_authorize_handler.ts
@@ -98,7 +98,7 @@ export async function ssoAuthorizeHandler(
       }
     }
 
-    const authUrl = adapter.buildAuthorizeUrl(
+    const authUrl = await adapter.buildAuthorizeUrl(
       {
         providerId: provider.providerId,
         issuer: provider.issuer,

--- a/services/platform/convex/sso_providers/sso_callback_handler.ts
+++ b/services/platform/convex/sso_providers/sso_callback_handler.ts
@@ -192,21 +192,20 @@ export async function ssoCallbackHandler(
     const clientId = await decryptString(provider.clientIdEncrypted);
     const clientSecret = await decryptString(provider.clientSecretEncrypted);
 
-    const tokens = await adapter.exchangeCodeForTokens(
-      {
-        providerId: provider.providerId,
-        issuer: provider.issuer,
-        clientId,
-        clientSecret,
-        scopes: provider.scopes,
-      },
-      {
-        code,
-        redirectUri: state.redirectUri,
-      },
-    );
+    const ssoConfig = {
+      providerId: provider.providerId,
+      issuer: provider.issuer,
+      clientId,
+      clientSecret,
+      scopes: provider.scopes,
+    };
 
-    const userInfo = await adapter.getUserInfo(tokens.accessToken);
+    const tokens = await adapter.exchangeCodeForTokens(ssoConfig, {
+      code,
+      redirectUri: state.redirectUri,
+    });
+
+    const userInfo = await adapter.getUserInfo(ssoConfig, tokens.accessToken);
 
     if (tokens.idToken) {
       const authContext = parseIdTokenAuthContext(tokens.idToken);
@@ -218,7 +217,7 @@ export async function ssoCallbackHandler(
     let appRoles: string[] = [];
     if (provider.autoProvisionRole && adapter.getAppRoles) {
       try {
-        appRoles = await adapter.getAppRoles(tokens.accessToken);
+        appRoles = await adapter.getAppRoles(ssoConfig, tokens.accessToken);
       } catch (e) {
         console.warn('[SSO] Failed to fetch app roles:', e);
       }

--- a/services/platform/convex/sso_providers/types.ts
+++ b/services/platform/convex/sso_providers/types.ts
@@ -47,15 +47,32 @@ export interface SsoProviderAdapter {
   readonly displayName: string;
   readonly capabilities: SsoProviderCapabilities;
 
-  buildAuthorizeUrl(config: SsoProviderConfig, params: AuthorizeUrlParams): URL;
+  // May be async: a discovery-driven adapter (generic OIDC) resolves the
+  // authorization endpoint from the issuer's well-known document. Callers
+  // must `await` the result.
+  buildAuthorizeUrl(
+    config: SsoProviderConfig,
+    params: AuthorizeUrlParams,
+  ): URL | Promise<URL>;
   exchangeCodeForTokens(
     config: SsoProviderConfig,
     params: TokenExchangeParams,
   ): Promise<SsoTokens>;
-  getUserInfo(accessToken: string): Promise<SsoUserInfo>;
+  // `config` is passed so a discovery-driven adapter can resolve the userinfo
+  // endpoint; provider-specific adapters (Entra) may ignore it.
+  getUserInfo(
+    config: SsoProviderConfig,
+    accessToken: string,
+  ): Promise<SsoUserInfo>;
 
-  getGroups?(accessToken: string): Promise<SsoGroup[]>;
-  getAppRoles?(accessToken: string): Promise<string[]>;
+  getGroups?(
+    config: SsoProviderConfig,
+    accessToken: string,
+  ): Promise<SsoGroup[]>;
+  getAppRoles?(
+    config: SsoProviderConfig,
+    accessToken: string,
+  ): Promise<string[]>;
 
   validateConfig(
     config: Omit<SsoProviderConfig, 'clientSecret'> & { clientSecret?: string },

--- a/services/platform/convex/sso_providers/upsert_sso_provider.ts
+++ b/services/platform/convex/sso_providers/upsert_sso_provider.ts
@@ -62,6 +62,8 @@ export async function upsertSsoProvider(
       issuer: args.issuer,
       clientId: args.clientId,
       clientSecret: args.clientSecret,
+      providerId: args.providerId,
+      scopes: args.scopes,
     });
 
     if (!validation.valid) {

--- a/services/platform/convex/sso_providers/validate_sso_config.ts
+++ b/services/platform/convex/sso_providers/validate_sso_config.ts
@@ -1,126 +1,41 @@
+import { getAdapter } from './registry';
+
 type ValidateSsoConfigArgs = {
   issuer: string;
   clientId: string;
   clientSecret: string;
+  /**
+   * Which provider type to validate against. Defaults to `entra-id` for
+   * back-compat with callers that predate multi-provider support.
+   */
+  providerId?: string;
+  scopes?: string[];
 };
 
 type ValidationResult = {
   valid: boolean;
   error?: string;
-  tokenEndpoint?: string;
 };
 
+/**
+ * Validate an SSO provider's configuration by dispatching to its adapter:
+ * Entra runs a Microsoft Graph client-credentials probe, generic OIDC runs
+ * `.well-known/openid-configuration` discovery. Centralising the dispatch here
+ * keeps the save and test paths validating each provider type correctly.
+ */
 export async function validateSsoConfig(
   args: ValidateSsoConfigArgs,
 ): Promise<ValidationResult> {
-  const { issuer, clientId, clientSecret } = args;
-
-  // Step 1: Validate issuer by fetching OpenID Discovery document
-  const discoveryUrl = issuer.endsWith('/')
-    ? `${issuer}.well-known/openid-configuration`
-    : `${issuer}/.well-known/openid-configuration`;
-
-  let tokenEndpoint: string;
-
-  try {
-    const discoveryResponse = await fetch(discoveryUrl, {
-      method: 'GET',
-      headers: { Accept: 'application/json' },
-    });
-
-    if (!discoveryResponse.ok) {
-      return {
-        valid: false,
-        error: `Invalid Issuer URL: Could not fetch OpenID configuration (HTTP ${discoveryResponse.status})`,
-      };
-    }
-
-    const discoveryDoc = await discoveryResponse.json();
-
-    if (!discoveryDoc.token_endpoint) {
-      return {
-        valid: false,
-        error:
-          'Invalid Issuer URL: OpenID configuration missing token_endpoint',
-      };
-    }
-
-    if (!discoveryDoc.authorization_endpoint) {
-      return {
-        valid: false,
-        error:
-          'Invalid Issuer URL: OpenID configuration missing authorization_endpoint',
-      };
-    }
-
-    tokenEndpoint = discoveryDoc.token_endpoint;
-  } catch (error) {
-    return {
-      valid: false,
-      error: `Invalid Issuer URL: ${error instanceof Error ? error.message : 'Network error'}`,
-    };
+  const providerId = args.providerId ?? 'entra-id';
+  const adapter = getAdapter(providerId);
+  if (!adapter) {
+    return { valid: false, error: `Unsupported SSO provider: ${providerId}` };
   }
-
-  // Step 2: Validate Client ID and Client Secret using client credentials flow
-  try {
-    const tokenResponse = await fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: clientId,
-        client_secret: clientSecret,
-        scope: 'https://graph.microsoft.com/.default',
-      }),
-    });
-
-    if (!tokenResponse.ok) {
-      const errorBody = await tokenResponse.json().catch(() => ({}));
-      const errorDescription =
-        errorBody.error_description ||
-        errorBody.error ||
-        `HTTP ${tokenResponse.status}`;
-
-      if (errorDescription.includes('AADSTS700016')) {
-        return {
-          valid: false,
-          error: 'Invalid Client ID: Application not found in the directory',
-        };
-      }
-
-      if (errorDescription.includes('AADSTS7000215')) {
-        return {
-          valid: false,
-          error:
-            'Invalid Client Secret: The provided secret is incorrect or expired',
-        };
-      }
-
-      if (errorDescription.includes('AADSTS700024')) {
-        return {
-          valid: false,
-          error:
-            'Client Secret expired: Please generate a new secret in Azure portal',
-        };
-      }
-
-      return {
-        valid: false,
-        error: `Authentication failed: ${errorDescription}`,
-      };
-    }
-
-    // Successfully obtained a token - credentials are valid
-    return {
-      valid: true,
-      tokenEndpoint,
-    };
-  } catch (error) {
-    return {
-      valid: false,
-      error: `Failed to validate credentials: ${error instanceof Error ? error.message : 'Network error'}`,
-    };
-  }
+  return adapter.validateConfig({
+    providerId,
+    issuer: args.issuer,
+    clientId: args.clientId,
+    clientSecret: args.clientSecret,
+    scopes: args.scopes ?? [],
+  });
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4821,7 +4821,17 @@
         "testPassed": "Gültig",
         "testing": "Wird getestet...",
         "title": "SSO-Konfiguration",
-        "updating": "Aktualisiere..."
+        "updating": "Aktualisiere...",
+        "providerTypeLabel": "Anbietertyp",
+        "providerTypeHelp": "Microsoft Entra ID nutzt Microsoft Graph für die Team- und OneDrive-Synchronisierung. Generisches OIDC funktioniert mit jedem OpenID-Connect-Anbieter und liest dessen Endpunkte aus der Konfiguration, die der Aussteller veröffentlicht.",
+        "providerTypeEntra": "Microsoft Entra ID",
+        "providerTypeGeneric": "Generisches OIDC",
+        "descriptionGeneric": "Melde dich mit einem beliebigen OpenID-Connect-Anbieter an, etwa Keycloak, Auth0, Okta oder Google.",
+        "issuerHelpGeneric": "Die OIDC-Aussteller-URL. Tale liest die Authorization-, Token- und Userinfo-Endpunkte aus dem .well-known/openid-configuration-Dokument des Ausstellers.",
+        "clientIdHelpGeneric": "Die Client-ID deines OIDC-Anbieters",
+        "clientSecretHelpGeneric": "Das Client-Secret deines OIDC-Anbieters",
+        "connectedToGeneric": "Mit deinem OIDC-Anbieter verbunden",
+        "autoProvisionRoleHelpGeneric": "Rollen automatisch anhand der Claims deines OIDC-Anbieters zuweisen"
       }
     },
     "providers": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5082,7 +5082,17 @@
         "testPassed": "Valid",
         "testing": "Testing...",
         "title": "SSO configuration",
-        "updating": "Updating..."
+        "updating": "Updating...",
+        "providerTypeLabel": "Provider type",
+        "providerTypeHelp": "Microsoft Entra ID uses Microsoft Graph for team and OneDrive sync. Generic OIDC works with any OpenID Connect provider and reads its endpoints from the configuration the issuer publishes.",
+        "providerTypeEntra": "Microsoft Entra ID",
+        "providerTypeGeneric": "Generic OIDC",
+        "descriptionGeneric": "Sign in with any OpenID Connect identity provider, such as Keycloak, Auth0, Okta, or Google.",
+        "issuerHelpGeneric": "The OIDC issuer URL. Tale reads the authorization, token, and userinfo endpoints from the issuer's .well-known/openid-configuration document.",
+        "clientIdHelpGeneric": "The client ID issued by your OIDC provider",
+        "clientSecretHelpGeneric": "The client secret issued by your OIDC provider",
+        "connectedToGeneric": "Connected to your OIDC provider",
+        "autoProvisionRoleHelpGeneric": "Automatically assign roles based on claims returned by your OIDC provider"
       }
     },
     "providers": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4822,7 +4822,17 @@
         "testPassed": "Valide",
         "testing": "Test en cours...",
         "title": "Configuration SSO",
-        "updating": "Mise à jour..."
+        "updating": "Mise à jour...",
+        "providerTypeLabel": "Type de fournisseur",
+        "providerTypeHelp": "Microsoft Entra ID utilise Microsoft Graph pour la synchronisation des équipes et de OneDrive. OIDC générique fonctionne avec n'importe quel fournisseur OpenID Connect et lit ses points de terminaison depuis la configuration publiée par l'émetteur.",
+        "providerTypeEntra": "Microsoft Entra ID",
+        "providerTypeGeneric": "OIDC générique",
+        "descriptionGeneric": "Connecte-toi avec n'importe quel fournisseur d'identité OpenID Connect, comme Keycloak, Auth0, Okta ou Google.",
+        "issuerHelpGeneric": "L'URL de l'émetteur OIDC. Tale lit les points de terminaison d'autorisation, de jeton et userinfo depuis le document .well-known/openid-configuration de l'émetteur.",
+        "clientIdHelpGeneric": "L'ID client fourni par ton fournisseur OIDC",
+        "clientSecretHelpGeneric": "Le secret client fourni par ton fournisseur OIDC",
+        "connectedToGeneric": "Connecté à ton fournisseur OIDC",
+        "autoProvisionRoleHelpGeneric": "Attribuer automatiquement des rôles selon les claims renvoyés par ton fournisseur OIDC"
       }
     },
     "providers": {


### PR DESCRIPTION
## What

Adds a discovery-based **generic OpenID Connect** SSO adapter alongside the existing Microsoft Entra ID provider, so any OIDC issuer (Keycloak, Auth0, Okta, Google, …) can be configured. Part of the security & compliance baseline epic.

## Backend

- **`oidc_discovery.ts`** — resolves the authorization / token / userinfo endpoints from the issuer's `.well-known/openid-configuration` **per auth flow**. No endpoint is persisted, so there is **no schema migration**.
- **`generic_oidc/adapter.ts`** — implements `SsoProviderAdapter`: forces the `openid` scope, maps `sub → externalId` / `email` / `name` (with given/family/preferred_username fallback) / `groups`, and reuses the provider-agnostic role matcher. Registered as `'generic-oidc'`.
- **Interface change** — `buildAuthorizeUrl` is now async-capable and `getUserInfo` / `getGroups` / `getAppRoles` take the provider `config` so discovery-driven adapters can resolve endpoints. Entra signatures and all call sites (authorize handler, callback handler, team sync, login) updated.
- **`validate_sso_config.ts`** — now dispatches to the selected adapter (Entra Graph client-credentials probe vs. OIDC discovery) instead of hardcoding a Microsoft Graph scope.

## UI

- `sso-config-dialog.tsx` gains a **provider-type selector**. Entra-only controls (OneDrive/SharePoint, Graph team sync, exclude groups) are gated to Entra; the generic path sends standard OIDC scopes and persists no provider features. Issuer/client help text and the connected-state copy adapt per type.
- `en` / `de` / `fr` strings added (de-CH inherits from de).

## Tests

- `generic_oidc/adapter.test.ts` — discovery, code→token exchange, userinfo claim mapping (incl. name fallbacks), and `validateConfig` success / unreachable-issuer / missing-userinfo paths (7 cases).
- `use-sso-config-form.test.ts` — provider-type branching: Entra sends Graph scopes + features, generic sends standard scopes + no features, the test path targets the correct adapter, and the type is derived from a loaded config (4 cases).

## Verification

`bun run --filter @tale/platform typecheck` · `lint` · `test` (server + ui) all green. CodeRabbit review applied (scope-selection helper deduped; load-mapping test added).

Refs #1506. Tracked under the security baseline epic #1803.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Generic OpenID Connect (OIDC) as an SSO provider option alongside Entra ID.
  * SSO configuration UI now displays provider-specific icons, descriptions, and help text based on selected provider type.
  * Generic OIDC automatically discovers endpoints from issuer configuration.

* **Improvements**
  * Enhanced SSO configuration validation to support multiple provider types.
  * Added multi-language support (English, French, German) for Generic OIDC provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->