### PR TITLE
feat(platform): warn and sign out idle sessions client-side

### DIFF
--- a/services/platform/app/hooks/use-session-idle-watchdog.test.tsx
+++ b/services/platform/app/hooks/use-session-idle-watchdog.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stable mock refs — a fresh object/function per render would change the
+// effect deps and reset the idle timer every render.
+const h = vi.hoisted(() => ({
+  getEnv: vi.fn(),
+  signOut: vi.fn(() => Promise.resolve()),
+  toast: vi.fn((_props: { title?: string; description?: string }) => ({
+    id: '1',
+    dismiss: vi.fn(),
+    update: vi.fn(),
+  })),
+  t: (key: string) => key,
+}));
+
+vi.mock('@/lib/env', () => ({ getEnv: h.getEnv }));
+vi.mock('@/lib/auth-client', () => ({ authClient: { signOut: h.signOut } }));
+vi.mock('@/app/hooks/use-toast', () => ({ toast: h.toast }));
+vi.mock('@/lib/i18n/client', () => ({ useT: () => ({ t: h.t }) }));
+
+import { useSessionIdleWatchdog } from './use-session-idle-watchdog';
+
+const MINUTE = 60_000;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  localStorage.clear();
+  // jsdom's Location.href is non-configurable; replace the whole object so the
+  // watchdog's redirect is observable instead of triggering a navigation.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { href: '' },
+  });
+  h.getEnv.mockImplementation((key: string) =>
+    key === 'SESSION_IDLE_TIMEOUT_MINUTES'
+      ? 10
+      : key === 'BASE_PATH'
+        ? ''
+        : undefined,
+  );
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+function fireActivity() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+  });
+}
+
+describe('useSessionIdleWatchdog (#1502)', () => {
+  it('is a no-op when no idle timeout is configured', async () => {
+    h.getEnv.mockImplementation((key: string) =>
+      key === 'BASE_PATH' ? '' : undefined,
+    );
+
+    renderHook(() => useSessionIdleWatchdog());
+    await advance(30 * MINUTE);
+
+    expect(h.toast).not.toHaveBeenCalled();
+    expect(h.signOut).not.toHaveBeenCalled();
+  });
+
+  it('warns before the window elapses, then signs out', async () => {
+    renderHook(() => useSessionIdleWatchdog());
+
+    // 10-min window, 1-min warning lead → warning fires after 9 min idle.
+    await advance(9 * MINUTE + 30_000);
+    expect(h.toast).toHaveBeenCalledTimes(1);
+    expect(h.toast.mock.calls[0][0]).toMatchObject({
+      title: 'sessionIdle.warningTitle',
+    });
+    expect(h.signOut).not.toHaveBeenCalled();
+
+    // Cross the hard cut-off.
+    await advance(MINUTE);
+    expect(h.signOut).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe('/log-in?reason=idle');
+  });
+
+  it('resets the timer on user activity', async () => {
+    renderHook(() => useSessionIdleWatchdog());
+
+    await advance(8 * MINUTE);
+    fireActivity();
+    // 8 more minutes — only 8 min idle since the keypress, under the window.
+    await advance(8 * MINUTE);
+
+    expect(h.signOut).not.toHaveBeenCalled();
+
+    // …but it still fires once genuinely idle past the window.
+    await advance(3 * MINUTE);
+    expect(h.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses the warning when the user returns', async () => {
+    renderHook(() => useSessionIdleWatchdog());
+
+    await advance(9 * MINUTE + 30_000);
+    expect(h.toast).toHaveBeenCalledTimes(1);
+    const dismiss = h.toast.mock.results[0].value.dismiss;
+
+    fireActivity();
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/app/hooks/use-session-idle-watchdog.tsx
+++ b/services/platform/app/hooks/use-session-idle-watchdog.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { useEffect, useRef } from 'react';
+
+import { toast } from '@/app/hooks/use-toast';
+import { authClient } from '@/lib/auth-client';
+import { getEnv } from '@/lib/env';
+import { useT } from '@/lib/i18n/client';
+
+// Cross-tab shared "last activity" timestamp (ms). Activity in any tab keeps
+// every tab alive, mirroring the server's sliding window — otherwise an idle
+// background tab would sign you out while you work in another.
+const ACTIVITY_STORAGE_KEY = 'tale:session-idle:last-activity';
+
+// Genuine user input. mousemove is chatty, so the localStorage write is
+// throttled; the in-memory timestamp updates on every event.
+const ACTIVITY_EVENTS = [
+  'mousemove',
+  'mousedown',
+  'keydown',
+  'touchstart',
+  'scroll',
+  'wheel',
+] as const;
+
+const WARNING_LEAD_MS = 60_000; // warn this long before the hard cut-off
+const ACTIVITY_WRITE_THROTTLE_MS = 10_000;
+const CHECK_INTERVAL_MS = 5_000;
+
+/**
+ * Session idle watchdog (#1502, client side).
+ *
+ * The server is the control: Better Auth rejects an over-idle session on the
+ * next request when `SESSION_IDLE_TIMEOUT_MINUTES` is set (see
+ * `lib/shared/session-idle.ts`). This hook is the matching UX — it watches
+ * local input, warns shortly before the window elapses, and signs the user
+ * out proactively instead of letting their next action 401. No-op unless the
+ * timeout is configured.
+ *
+ * Mount once inside the authenticated layout.
+ */
+export function useSessionIdleWatchdog(): void {
+  const { t } = useT('common');
+  // Read translations fresh at toast time without re-running the effect (and
+  // resetting the idle timer) on every render or locale change.
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  useEffect(() => {
+    const minutes = getEnv('SESSION_IDLE_TIMEOUT_MINUTES');
+    if (!minutes || !Number.isFinite(minutes) || minutes <= 0) {
+      return undefined;
+    }
+
+    const idleMs = minutes * 60_000;
+    const warnMs = Math.min(WARNING_LEAD_MS, Math.floor(idleMs / 2));
+
+    let lastActivity = Date.now();
+    let lastWrite = 0;
+    let dismissWarning: (() => void) | null = null;
+
+    const readShared = (): number => {
+      try {
+        const raw = localStorage.getItem(ACTIVITY_STORAGE_KEY);
+        const parsed = raw === null ? NaN : Number(raw);
+        return Number.isFinite(parsed) ? parsed : 0;
+      } catch {
+        return 0;
+      }
+    };
+
+    const writeShared = (ts: number): void => {
+      try {
+        localStorage.setItem(ACTIVITY_STORAGE_KEY, String(ts));
+      } catch (err) {
+        // Storage can throw in private mode / when full; the in-memory
+        // timestamp still drives this tab, only cross-tab sync is lost.
+        console.warn('[session-idle] could not persist activity', err);
+      }
+    };
+
+    const clearWarning = (): void => {
+      if (dismissWarning) {
+        dismissWarning();
+        dismissWarning = null;
+      }
+    };
+
+    const recordActivity = (persist: boolean): void => {
+      const now = Date.now();
+      lastActivity = now;
+      clearWarning();
+      if (persist && now - lastWrite > ACTIVITY_WRITE_THROTTLE_MS) {
+        lastWrite = now;
+        writeShared(now);
+      }
+    };
+
+    // Seed from any tab that was already active.
+    lastActivity = Math.max(lastActivity, readShared());
+    writeShared(lastActivity);
+
+    const onActivity = (): void => recordActivity(true);
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'visible') recordActivity(true);
+    };
+    const onStorage = (event: StorageEvent): void => {
+      if (event.key !== ACTIVITY_STORAGE_KEY || !event.newValue) return;
+      const ts = Number(event.newValue);
+      if (Number.isFinite(ts) && ts > lastActivity) {
+        lastActivity = ts;
+        clearWarning();
+      }
+    };
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, onActivity, { passive: true });
+    }
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('storage', onStorage);
+
+    let signingOut = false;
+    const signOutForIdle = async (): Promise<void> => {
+      if (signingOut) return;
+      signingOut = true;
+      try {
+        await authClient.signOut();
+      } catch (err) {
+        console.error('[session-idle] sign-out failed', err);
+      }
+      // Intentional hard navigation (not the router): a full reload tears
+      // down the Convex client, React Query cache, and any in-memory auth
+      // state on sign-out. Same precedent as user-button and dashboard.tsx.
+      const basePath = getEnv('BASE_PATH');
+      window.location.href = `${basePath}/log-in?reason=idle`;
+    };
+
+    const interval = window.setInterval(() => {
+      // The storage event never fires in the tab that wrote it and can be
+      // missed under throttling, so re-read the shared value each tick.
+      lastActivity = Math.max(lastActivity, readShared());
+      const idleFor = Date.now() - lastActivity;
+
+      if (idleFor >= idleMs) {
+        window.clearInterval(interval);
+        clearWarning();
+        void signOutForIdle();
+        return;
+      }
+
+      if (idleFor >= idleMs - warnMs && !dismissWarning) {
+        const handle = toast({
+          duration: warnMs + CHECK_INTERVAL_MS * 2,
+          title: tRef.current('sessionIdle.warningTitle'),
+          description: tRef.current('sessionIdle.warningDescription'),
+          action: (
+            <ToastPrimitives.Action
+              altText={tRef.current('sessionIdle.staySignedIn')}
+              asChild
+              onClick={() => recordActivity(true)}
+            >
+              <button
+                type="button"
+                className="bg-foreground text-background focus-visible:ring-ring inline-flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-medium transition-colors hover:opacity-90 focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
+              >
+                {tRef.current('sessionIdle.staySignedIn')}
+              </button>
+            </ToastPrimitives.Action>
+          ),
+        });
+        dismissWarning = handle.dismiss;
+      }
+    }, CHECK_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+      clearWarning();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, onActivity);
+      }
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+}

--- a/services/platform/app/routes/dashboard.tsx
+++ b/services/platform/app/routes/dashboard.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 
 import { useConvexAuth } from '@/app/hooks/use-convex-auth';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { useSessionIdleWatchdog } from '@/app/hooks/use-session-idle-watchdog';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { getEnv } from '@/lib/env';
@@ -33,6 +34,12 @@ export const Route = createFileRoute('/dashboard')({
 function DashboardRedirect() {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading } = useConvexAuth();
+
+  // Idle-timeout UX: warn and sign out proactively when the deployment sets
+  // SESSION_IDLE_TIMEOUT_MINUTES. The authenticated layout is the right mount
+  // point — it wraps every signed-in page and is gated on a live session.
+  useSessionIdleWatchdog();
+
   const [sessionVerified, setSessionVerified] = useState(false);
   const [hasValidSession, setHasValidSession] = useState(true);
 

--- a/services/platform/lib/env.ts
+++ b/services/platform/lib/env.ts
@@ -9,6 +9,7 @@ declare global {
       SENTRY_DSN?: string;
       SENTRY_TRACES_SAMPLE_RATE?: number;
       TALE_VERSION?: string;
+      SESSION_IDLE_TIMEOUT_MINUTES?: number;
     };
     __ACCEPT_LANGUAGE__?: string;
   }
@@ -22,6 +23,7 @@ export function getEnv(key: 'FILE_EVENTS_ENABLED'): boolean;
 export function getEnv(key: 'SENTRY_DSN'): string | undefined;
 export function getEnv(key: 'SENTRY_TRACES_SAMPLE_RATE'): number;
 export function getEnv(key: 'TALE_VERSION'): string | undefined;
+export function getEnv(key: 'SESSION_IDLE_TIMEOUT_MINUTES'): number | undefined;
 export function getEnv(
   key:
     | 'SITE_URL'
@@ -31,7 +33,8 @@ export function getEnv(
     | 'FILE_EVENTS_ENABLED'
     | 'SENTRY_DSN'
     | 'SENTRY_TRACES_SAMPLE_RATE'
-    | 'TALE_VERSION',
+    | 'TALE_VERSION'
+    | 'SESSION_IDLE_TIMEOUT_MINUTES',
 ): string | boolean | number | undefined {
   const value = window.__ENV__?.[key];
   if (value === undefined) {
@@ -45,7 +48,11 @@ export function getEnv(
     ) {
       return false;
     }
-    if (key === 'SENTRY_DSN' || key === 'TALE_VERSION') {
+    if (
+      key === 'SENTRY_DSN' ||
+      key === 'TALE_VERSION' ||
+      key === 'SESSION_IDLE_TIMEOUT_MINUTES'
+    ) {
       return undefined;
     }
     if (key === 'SENTRY_TRACES_SAMPLE_RATE') {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1493,6 +1493,11 @@
     "loading": {
       "navigating": "Seite wird geladen",
       "label": "Wird geladen"
+    },
+    "sessionIdle": {
+      "warningTitle": "Du wirst bald abgemeldet",
+      "warningDescription": "Deine Sitzung endet nach einer Phase der Inaktivität. Interagiere mit der Seite oder nutze die Schaltfläche, um weiterzuarbeiten.",
+      "staySignedIn": "Angemeldet bleiben"
     }
   },
   "composer": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1493,6 +1493,11 @@
     "loading": {
       "navigating": "Loading page",
       "label": "Loading"
+    },
+    "sessionIdle": {
+      "warningTitle": "You'll be signed out soon",
+      "warningDescription": "Your session ends after a period of inactivity. Interact with the page or use the button below to keep working.",
+      "staySignedIn": "Stay signed in"
     }
   },
   "composer": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1494,6 +1494,11 @@
     "loading": {
       "navigating": "Chargement de la page",
       "label": "Chargement"
+    },
+    "sessionIdle": {
+      "warningTitle": "Tu vas bientôt être déconnecté",
+      "warningDescription": "Ta session prend fin après une période d'inactivité. Interagis avec la page ou utilise le bouton pour continuer.",
+      "staySignedIn": "Rester connecté"
     }
   },
   "composer": {

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -12,6 +12,7 @@ import {
   wrapCanvasPreviewHtml,
 } from './lib/canvas-preview-shell';
 import { createConfigWatcher } from './lib/config-watcher';
+import { parseSessionIdleTimeoutMinutes } from './lib/shared/session-idle';
 import { fetchAdapter as webdavFetchAdapter } from './lib/webdav/adapters/fetch';
 import { makeWebdavCtx } from './lib/webdav/ctx';
 import {
@@ -166,6 +167,7 @@ interface EnvConfig {
   SENTRY_DSN: string | undefined;
   SENTRY_TRACES_SAMPLE_RATE: number;
   TALE_VERSION: string | undefined;
+  SESSION_IDLE_TIMEOUT_MINUTES?: number;
   CANVAS_PREVIEW_CSP_EXTRA_ORIGINS: readonly string[];
 }
 
@@ -212,6 +214,9 @@ function getEnvConfig(): EnvConfig {
       process.env.SENTRY_TRACES_SAMPLE_RATE || '1.0',
     ),
     TALE_VERSION: process.env.TALE_VERSION,
+    // Idle-timeout window for the client watchdog (#1502). Validated/clamped
+    // server-side; `undefined` (omitted from __ENV__) when the feature is off.
+    SESSION_IDLE_TIMEOUT_MINUTES: parseSessionIdleTimeoutMinutes() ?? undefined,
     // Whitespace-separated origin list, e.g.
     // `CANVAS_PREVIEW_CSP_EXTRA_ORIGINS="https://cdn.jsdelivr.net https://unpkg.com"`.
     // Validated and appended to the canvas-preview CSP — see the policy

--- a/services/platform/vite-plugins/inject-env.ts
+++ b/services/platform/vite-plugins/inject-env.ts
@@ -1,5 +1,7 @@
 import { type Plugin } from 'vite';
 
+import { parseSessionIdleTimeoutMinutes } from '../lib/shared/session-idle';
+
 interface EnvConfig {
   SITE_URL: string;
   BASE_PATH: string;
@@ -8,6 +10,7 @@ interface EnvConfig {
   SENTRY_DSN?: string;
   SENTRY_TRACES_SAMPLE_RATE: number;
   TALE_VERSION?: string;
+  SESSION_IDLE_TIMEOUT_MINUTES?: number;
 }
 
 function getEnvConfig(): EnvConfig {
@@ -24,6 +27,7 @@ function getEnvConfig(): EnvConfig {
       process.env.SENTRY_TRACES_SAMPLE_RATE || '1.0',
     ),
     TALE_VERSION: process.env.TALE_VERSION,
+    SESSION_IDLE_TIMEOUT_MINUTES: parseSessionIdleTimeoutMinutes() ?? undefined,
   };
 }
 


### PR DESCRIPTION
## What

Completes the **session idle timeout** (#1502) with its client-side UX. The server enforcement merged in #1808 — Better Auth rejects an over-idle session on the next request when `SESSION_IDLE_TIMEOUT_MINUTES` is set. This adds the matching watchdog so a user is **warned and signed out proactively** instead of silently 401-ing on their next action. Part of the security baseline epic.

## How

- **`useSessionIdleWatchdog`** watches local input (`mousemove`, `mousedown`, `keydown`, `touchstart`, `scroll`, `wheel`, plus `visibilitychange`), shows a warning toast one minute before the cut-off with a **Stay signed in** action, and at the window calls `authClient.signOut()` then hard-redirects to `/log-in` (full reload to flush Convex/React-Query/auth state, matching the existing sign-out precedent).
- **Cross-tab**: the last-activity timestamp is shared via `localStorage` and re-read each tick, so an idle background tab doesn't sign out a user who is active in another tab — mirroring the server's sliding window.
- **No-op** unless the timeout is configured.
- The validated window is exposed to the client via `window.__ENV__` (`server.ts` + the dev `inject-env` plugin) and read through a typed `getEnv` overload; it is **omitted entirely** when the feature is off.
- Mounted once in the authenticated dashboard layout. `en`/`de`/`fr` strings added.

## Tests

`use-session-idle-watchdog.test.tsx` — fake-timer coverage for: no-op when unconfigured, warn-then-sign-out at the thresholds, activity resets the timer, and the warning is dismissed when the user returns (4 cases).

## Verification

`typecheck` · `lint` · `test` (ui + server) · i18n parity/usage all green. CodeRabbit applied (documented the intentional hard reload; added a focus-visible ring + `motion-reduce` to the toast action).

Refs #1502. Tracked under the security baseline epic #1803.