### PR TITLE
feat(platform): advise of lockout risk on a failed login

### DIFF
--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -107,6 +107,11 @@ export function LogInPage() {
   });
 
   const [loginError, setLoginError] = useState<string | null>(null);
+  // Standing, count-free advisory shown on a failed credential attempt. We
+  // deliberately never reveal attempts-remaining: a live counter would break
+  // the uniform "wrong email or password" response and hand an attacker both
+  // account-enumeration and a brute-force budget (#1566).
+  const [showLockoutHint, setShowLockoutHint] = useState(false);
 
   const { isSubmitting, isValid } = form.formState;
 
@@ -150,21 +155,31 @@ export function LogInPage() {
             ? errSec
             : undefined;
         setLoginError(formatLockoutMessage(retryAfterSec));
+        // Already locked — the lockout message stands on its own.
+        setShowLockoutHint(false);
         return;
       }
       setLoginError(t('login.wrongCredentials'));
+      setShowLockoutHint(true);
     },
     [formatLockoutMessage, t],
   );
 
   const handleSubmit = async (data: LogInFormData) => {
     setLoginError(null);
+    setShowLockoutHint(false);
 
     try {
+      // Track whether onError fired this attempt rather than reading the
+      // pre-await `loginError` (a stale closure value) in the fallback below.
+      let authErrorHandled = false;
       const response = await authClient.signIn.email(
         { email: data.email, password: data.password },
         {
-          onError: handleAuthError,
+          onError: (ctx) => {
+            authErrorHandled = true;
+            handleAuthError(ctx);
+          },
         },
       );
 
@@ -190,7 +205,10 @@ export function LogInPage() {
 
       if (!response.data?.user) {
         // Fallback: signIn returned without a user but onError wasn't triggered.
-        if (!loginError) setLoginError(t('login.wrongCredentials'));
+        if (!authErrorHandled) {
+          setLoginError(t('login.wrongCredentials'));
+          setShowLockoutHint(true);
+        }
         return;
       }
 
@@ -285,6 +303,12 @@ export function LogInPage() {
                 className="text-destructive flex items-center gap-1.5 text-sm"
               >
                 {loginError}
+              </p>
+            )}
+
+            {showLockoutHint && (
+              <p aria-live="polite" className="text-muted-foreground text-xs">
+                {t('login.lockoutAdvisory')}
               </p>
             )}
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -259,7 +259,8 @@
       },
       "toast": {
         "success": "Angemeldet"
-      }
+      },
+      "lockoutAdvisory": "Wiederholte Fehlversuche sperren das Konto vorübergehend."
     },
     "signup": {
       "signupTitle": "Erstelle Dein Konto",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -259,7 +259,8 @@
       },
       "toast": {
         "success": "Signed in successfully"
-      }
+      },
+      "lockoutAdvisory": "Repeated failed attempts will temporarily lock the account."
     },
     "signup": {
       "signupTitle": "Create your account",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -260,7 +260,8 @@
       },
       "toast": {
         "success": "Connecté avec succès"
-      }
+      },
+      "lockoutAdvisory": "Des échecs répétés verrouillent temporairement le compte."
     },
     "signup": {
       "signupTitle": "Crée ton compte",


### PR DESCRIPTION
## What

Addresses #1566. A failed sign-in gave the user no hint that repeated failures lock the account, so the lockout felt like it came out of nowhere — only the admin was notified.

Now a failed **credential** attempt shows a calm, muted advisory beneath the error:

> Repeated failed attempts will temporarily lock the account.

It is not shown once the account is already locked (the lockout countdown message stands on its own).

## Why not an "N attempts remaining" counter

The issue requested a progressive counter. In an audited deployment that is a security regression, so it is deliberately **not** implemented:

- A per-attempt counter only appears for real accounts, breaking the uniform "wrong email or password" response and reintroducing **account enumeration** (the very thing the existing jitter + uniform-404 mitigations remove).
- It also hands an attacker an exact **brute-force budget** per account.

The standing advisory conveys the consequence (so the user isn't surprised) without leaking either signal. An emailed owner alert was considered but the platform has no transactional-email infrastructure (`requireEmailVerification: false`, password reset is admin-managed), so it's out of scope here.

## Changes

- `log-in.tsx`: a `showLockoutHint` state, set on a failed credential attempt and cleared on lockout / new submit; muted advisory line under the error.
- `en`/`de`/`fr`: `auth.login.lockoutAdvisory`.

## Verification

`typecheck` · `lint` · i18n parity/usage green.

Refs #1566.