### PR TITLE
fix(platform): highlight a duplicated agent as a new row

### DIFF
--- a/services/platform/app/features/agents/components/agent-row-actions.test.tsx
+++ b/services/platform/app/features/agents/components/agent-row-actions.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/test/utils/a11y';
 import { render } from '@/test/utils/render';
+
+const h = vi.hoisted(() => ({
+  duplicateMock: vi.fn(() => Promise.resolve({ newAgentName: 'my-agent-1' })),
+}));
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: (ns: string) => ({
@@ -28,13 +34,34 @@ vi.mock('@/lib/shared/constants/agents', () => ({
 }));
 
 vi.mock('../hooks/mutations', () => ({
-  useDuplicateAgent: () => ({ mutateAsync: vi.fn() }),
+  useDuplicateAgent: () => ({ mutateAsync: h.duplicateMock }),
   useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
 }));
 
 import { AgentRowActions } from './agent-row-actions';
 
 describe('AgentRowActions', () => {
+  it('reports the new agent name to onDuplicated after duplicating', async () => {
+    const onDuplicated = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AgentRowActions
+        agentName="my-agent"
+        organizationId="test-org-id"
+        onDuplicated={onDuplicated}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'common.actions.openMenu' }),
+    );
+    await user.click(screen.getByText('common.duplicate'));
+
+    await waitFor(() =>
+      expect(onDuplicated).toHaveBeenCalledWith('my-agent-1'),
+    );
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(

--- a/services/platform/app/features/agents/components/agent-row-actions.tsx
+++ b/services/platform/app/features/agents/components/agent-row-actions.tsx
@@ -18,7 +18,7 @@ import { AgentDeleteDialog } from './agent-delete-dialog';
 interface AgentRowActionsProps {
   agentName: string;
   organizationId: string;
-  onDuplicated?: () => void;
+  onDuplicated?: (newAgentName: string) => void;
   onDeleted?: () => void;
 }
 
@@ -50,7 +50,7 @@ export function AgentRowActions({
     if (isDuplicating) return;
     setIsDuplicating(true);
     try {
-      await duplicateAgent({
+      const { newAgentName } = await duplicateAgent({
         organizationId,
         agentName,
       });
@@ -58,7 +58,7 @@ export function AgentRowActions({
         title: t('agents.agentDuplicated'),
         variant: 'success',
       });
-      onDuplicated?.();
+      onDuplicated?.(newAgentName);
     } catch (error) {
       console.error(error);
       toast({

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import type { Row } from '@tanstack/react-table';
 import { Bot } from 'lucide-react';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
@@ -69,6 +69,28 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
     void queryClient.invalidateQueries({ queryKey: ['config', 'agents'] });
   }, [queryClient]);
 
+  // Briefly highlight a freshly-duplicated row so it reads as a new, separate
+  // agent in the list rather than something tied to the menu it came from
+  // (#1354).
+  const [highlightedName, setHighlightedName] = useState<string | null>(null);
+  const highlightTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (highlightTimer.current) clearTimeout(highlightTimer.current);
+    },
+    [],
+  );
+
+  const handleDuplicated = useCallback(
+    (newAgentName: string) => {
+      invalidateAgents();
+      setHighlightedName(newAgentName);
+      if (highlightTimer.current) clearTimeout(highlightTimer.current);
+      highlightTimer.current = setTimeout(() => setHighlightedName(null), 2500);
+    },
+    [invalidateAgents],
+  );
+
   const teamNameMap = useMemo(() => {
     const map = new Map();
     if (teams) {
@@ -83,7 +105,7 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
     useAgentsTableConfig({
       organizationId,
       teamNameMap,
-      onDuplicated: invalidateAgents,
+      onDuplicated: handleDuplicated,
       onDeleted: invalidateAgents,
     });
 
@@ -119,6 +141,11 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
       {...list.tableProps}
       columns={columns}
       stickyLayout={stickyLayout}
+      rowClassName={(row) =>
+        row.original.name === highlightedName
+          ? 'bg-primary/10 transition-colors duration-500 motion-reduce:transition-none'
+          : ''
+      }
       onRowClick={handleRowClick}
       actionMenu={<AgentsActionMenu organizationId={organizationId} />}
       emptyState={{

--- a/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
+++ b/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
@@ -22,7 +22,7 @@ interface AgentsTableConfig {
 interface AgentsTableConfigOptions {
   organizationId: string;
   teamNameMap: Map<string, string>;
-  onDuplicated?: () => void;
+  onDuplicated?: (newAgentName: string) => void;
   onDeleted?: () => void;
 }
 


### PR DESCRIPTION
## What

Fixes #1354. Duplicating an agent from its three-dot menu gave no clear signal that the copy was a separate new agent, so it read as if it were tied to the menu that opened it.

## How

- `duplicateAgent` already returns `{ newAgentName }`; the row action now threads that name up through `onDuplicated(newAgentName)`.
- `AgentsTable` briefly highlights the matching row (`bg-primary/10`, 2.5s, with `motion-reduce:transition-none`) via the existing `DataTable` `rowClassName` hook, so the new agent reads unmistakably as a separate new row. The menu already closed on selection — this supplies the missing visual anchor.

## Tests

`agent-row-actions.test.tsx` — opening the menu and choosing Duplicate calls `onDuplicated` with the new agent name.

## Verification

`typecheck` · `lint` · tests green. CodeRabbit clean (added `motion-reduce`).

Refs #1354.