### PR TITLE
fix(platform): keep translation requests one-off in reply language

### DIFF
--- a/services/platform/convex/lib/agent_response/build_system_prompt.test.ts
+++ b/services/platform/convex/lib/agent_response/build_system_prompt.test.ts
@@ -24,6 +24,12 @@ describe('responseLanguageDirective', () => {
     }
   });
 
+  it('states that a translation/explicit-language request is one-off (#1622)', () => {
+    const d = responseLanguageDirective('de-DE');
+    expect(d).toContain('one-off');
+    expect(d).toContain('does not carry over');
+  });
+
   it('uses the resolved fallback locale in rule 3 when known', () => {
     const d = responseLanguageDirective('de-DE');
     expect(d).toContain('`de-DE`');

--- a/services/platform/convex/lib/agent_response/build_system_prompt.ts
+++ b/services/platform/convex/lib/agent_response/build_system_prompt.ts
@@ -12,6 +12,11 @@ import type { UserPersonalization } from './build_user_personalization';
  * browser locale → org default — and only feeds rule 3. Appended last in the
  * system prompt so it's the strongest, most recent instruction on output
  * language.
+ *
+ * The rules are evaluated per-message and a translation/explicit-language
+ * request is one-off (#1622): without that, the model tends to keep replying
+ * in the language of a previous one-shot translation instead of mirroring the
+ * user's next message.
  */
 export function responseLanguageDirective(
   fallbackLocale: string | undefined,
@@ -27,6 +32,8 @@ export function responseLanguageDirective(
     '1. **Explicit request.** If the user\'s latest message explicitly asks for a language (e.g. "reply in German", "auf Deutsch", "répondez en français", "translate to French"), use that language.',
     "2. **Message language.** Otherwise, detect the natural language of the user's latest message and reply in that language.",
     `3. **Fallback.** Only if the latest message has no detectable natural language — code-only, a bare URL, pure numbers, a single emoji, or a one- or two-character ambiguous token — ${rule3}.`,
+    '',
+    'Apply these rules fresh to every message. An explicit language request or a translation (rule 1) is one-off: it sets the language for that one reply and does not carry over. When the next message is in another language, rule 2 applies again — reply in the language of that message, not the one you were previously asked to translate into.',
     '',
     'Never use timezone, IP, or geolocation to choose the reply language; only rule 3 uses the fallback.',
   ].join('\n');


### PR DESCRIPTION
## What

Fixes #1622. After a one-off "translate this to French" request, the model kept replying in French for subsequent messages.

## Why

The centralized response-language directive (#1795) evaluates the *latest* message (rule 1 explicit request → rule 2 message language → rule 3 fallback), but never told the model that an explicit-language / translation request is **scoped to that turn**. With a French assistant turn sitting in the history, the model mirrored it instead of re-detecting the user's next (English) message.

## Fix

A clause added to `responseLanguageDirective` makes per-message evaluation explicit and rule 1 one-off:

> Apply these rules fresh to every message. An explicit language request or a translation (rule 1) is one-off: it sets the language for that one reply and does not carry over. When the next message is in another language, rule 2 applies again…

Prompt-only change — no behaviour-code change. Test added asserting the one-off guidance is present.

## Verification

`typecheck` · `lint` · `build_system_prompt.test.ts` (6) green. CodeRabbit: no findings.

Refs #1622.