### PR TITLE
fix(platform): keep tooltips clear of viewport edges and controls

### DIFF
--- a/services/platform/app/components/ui/overlays/tooltip.tsx
+++ b/services/platform/app/components/ui/overlays/tooltip.tsx
@@ -10,6 +10,13 @@ interface TooltipProps {
   children: ReactNode;
   side?: 'top' | 'right' | 'bottom' | 'left';
   sideOffset?: number;
+  /**
+   * Minimum gap (px) kept between the tooltip and the viewport edge when Radix
+   * flips/shifts it to avoid a collision. Without this the tooltip can sit
+   * flush against an edge and visually overlap adjacent controls in cramped
+   * toolbars (e.g. the composer's attach button) — #1461.
+   */
+  collisionPadding?: number;
   delayDuration?: number;
   contentClassName?: string;
   open?: boolean;
@@ -21,6 +28,7 @@ export function Tooltip({
   children,
   side,
   sideOffset = 4,
+  collisionPadding = 8,
   delayDuration = 300,
   contentClassName,
   open,
@@ -36,6 +44,7 @@ export function Tooltip({
           <TooltipPrimitive.Content
             side={side}
             sideOffset={sideOffset}
+            collisionPadding={collisionPadding}
             className={cn(
               'z-[60] overflow-hidden rounded-lg border bg-foreground p-2 py-1 text-xs text-background shadow-md animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
               contentClassName,


### PR DESCRIPTION
## What

Fixes #1461 ("Attach tooltip overlaps and does not align properly with icon").

## Why

The shared `Tooltip` wrapper set a `sideOffset` but no `collisionPadding`. Radix avoids collisions by default, but with zero padding a shifted/flipped tooltip can sit flush against the viewport edge and visually overlap adjacent controls — most visibly the attach button in the cramped assistant composer toolbar.

## Fix

Adds a `collisionPadding` default of **8px** (overridable per-call) on the shared `Tooltip`, so every tooltip keeps a small gap from the edge instead of overlapping neighbours. Centered alignment on the trigger is already Radix's default.

Note: the standalone attach button in the **main** chat composer was previously refactored into the "+" menu (a menu item, no tooltip); this change covers the remaining attach tooltip in the automation assistant and every other tooltip app-wide.

## Verification

`typecheck` · `lint` · `tooltip.test.tsx` (2) green. CodeRabbit: no findings.

Refs #1461.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltip component now supports customizable padding to control spacing between tooltips and viewport edges when repositioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->