### PR TITLE
fix(proxy): relax platform health-check interval to cut boot noise

### DIFF
--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -252,9 +252,14 @@
 
 	# Default: Express server for static files and index.html with env injection
 	reverse_proxy platform:3000 {
-		# Active health checking
+		# Active health checking. Interval is 5s (not 2s): the platform has a
+		# long cold boot (Convex connect + asset load — see its 180s compose
+		# start_period), and a 2s probe logged a failed health check every two
+		# seconds until it came up, which read as "repeated proxy failures"
+		# during normal startup (#1447). Caddy still routes correctly once the
+		# backend is up; 5s matches the docs upstream and cuts the boot noise.
 		health_uri /api/health
-		health_interval 2s
+		health_interval 5s
 		health_timeout 2s
 		health_status 200
 		health_passes 2


### PR DESCRIPTION
## What

Fixes #1447 ("repeated proxy health-check failures during startup").

## Root cause

Caddy actively probes the platform upstream's `/api/health` (`services/proxy/Caddyfile`) — but the interval was **2s**. The platform has a long cold boot (Convex connect + asset load; its compose healthcheck uses a 180s `start_period`), so until the platform process starts listening, Caddy logged a failed health check **every 2 seconds**. That stream of failures read as "startup instability."

It was never a functional problem: the platform `depends_on` the proxy, and Caddy marks the upstream up and routes correctly once the backend is ready (passive circuit breaker + retry already handle the gap).

## Fix

Relax the active probe to **5s** (matching the docs upstream), cutting boot-time failed-health-check log volume ~2.5× without meaningfully slowing failover detection. Passive health checking (`fail_duration`/`max_fails`/`unhealthy_status`) is unchanged.

## Verification

Single-value config change in a well-formed `reverse_proxy` block; CodeRabbit: no findings. Full runtime validation (log volume during `tale start --fresh`) needs a stack boot.

Refs #1447.