### PR TITLE
fix(platform): ignore spurious empty Radix Select change on org settings

### DIFF
--- a/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { useFormEditor } from '@/app/components/ui/editor';
+import { fireEvent, render, waitFor } from '@/test/utils/render';
+
+import { OrganizationSettingsView } from './organization-settings';
+
+interface Form {
+  name: string;
+  defaultLocale: string;
+}
+
+const save = vi.fn(async (_v: Form) => {});
+
+const holder: { current: ReturnType<typeof useFormEditor<Form>> | null } = {
+  current: null,
+};
+
+function Harness() {
+  const editor = useFormEditor<Form>({
+    data: { name: 'Acme', defaultLocale: 'en' },
+    save,
+  });
+  holder.current = editor;
+  return (
+    <OrganizationSettingsView
+      controller={editor}
+      organization={{ _id: 'org1', name: 'Acme' }}
+      onSave={save}
+    />
+  );
+}
+
+describe('OrganizationSettingsView locale select', () => {
+  it('does not mark the form dirty on a spurious empty change', async () => {
+    render(<Harness />);
+    // Baseline applied → not dirty.
+    await waitFor(() => expect(holder.current?.isLoading).toBe(false));
+    expect(holder.current?.isDirty).toBe(false);
+
+    // Radix renders a hidden native <select> for form integration; a spurious
+    // empty value propagates through it as `onValueChange('')` during the
+    // cold-load window. Simulate that — the guard must drop it.
+    const native = document.querySelector('select');
+    expect(native).not.toBeNull();
+    fireEvent.change(native as HTMLSelectElement, { target: { value: '' } });
+
+    expect(holder.current?.isDirty).toBe(false);
+    expect(holder.current?.form.getValues('defaultLocale')).toBe('en');
+  });
+
+  it('marks the form dirty when a real locale is selected', async () => {
+    render(<Harness />);
+    await waitFor(() => expect(holder.current?.isLoading).toBe(false));
+
+    const native = document.querySelector('select');
+    fireEvent.change(native as HTMLSelectElement, { target: { value: 'de' } });
+
+    await waitFor(() => expect(holder.current?.isDirty).toBe(true));
+    expect(holder.current?.form.getValues('defaultLocale')).toBe('de');
+  });
+});

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -109,10 +109,23 @@ export function OrganizationSettingsView({
             <Select
               id="default-locale"
               label={tSettings('organization.defaultLocale')}
-              value={defaultLocale}
-              onValueChange={(value) =>
-                setValue('defaultLocale', value, { shouldDirty: true })
-              }
+              // Default to '' so the Radix Select is controlled from the first
+              // render — `watch('defaultLocale')` is `undefined` until the form
+              // resets to server data, and `value={undefined}` makes Radix
+              // uncontrolled (empty trigger + "uncontrolled to controlled"
+              // warning when the real value lands).
+              value={defaultLocale ?? ''}
+              onValueChange={(value) => {
+                // Ignore empty / no-op changes. Radix Select emits a spurious
+                // `onValueChange('')` while its controlled value and options
+                // are still settling during the cold-load window; without this
+                // guard that turns into `setValue('defaultLocale', '', {
+                // shouldDirty })`, falsely marking the form dirty (Save
+                // enabled + blocker) on a page the user only opened. `''` is
+                // never a valid locale, so dropping it is always correct.
+                if (!value || value === defaultLocale) return;
+                setValue('defaultLocale', value, { shouldDirty: true });
+              }}
               disabled={isSaving || isLoading}
               options={localeOptions}
               wrapperClassName="max-w-sm"

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -804,6 +804,7 @@ import type * as sso_providers_entra_id_error_codes from "../sso_providers/entra
 import type * as sso_providers_entra_id_role_mapping from "../sso_providers/entra_id/role_mapping.js";
 import type * as sso_providers_entra_id_team_sync from "../sso_providers/entra_id/team_sync.js";
 import type * as sso_providers_find_or_create_sso_user from "../sso_providers/find_or_create_sso_user.js";
+import type * as sso_providers_generic_oidc_adapter from "../sso_providers/generic_oidc/adapter.js";
 import type * as sso_providers_get from "../sso_providers/get.js";
 import type * as sso_providers_get_auth_user from "../sso_providers/get_auth_user.js";
 import type * as sso_providers_get_caller_role from "../sso_providers/get_caller_role.js";
@@ -817,6 +818,7 @@ import type * as sso_providers_internal_actions from "../sso_providers/internal_
 import type * as sso_providers_internal_mutations from "../sso_providers/internal_mutations.js";
 import type * as sso_providers_internal_queries from "../sso_providers/internal_queries.js";
 import type * as sso_providers_is_sso_configured from "../sso_providers/is_sso_configured.js";
+import type * as sso_providers_oidc_discovery from "../sso_providers/oidc_discovery.js";
 import type * as sso_providers_queries from "../sso_providers/queries.js";
 import type * as sso_providers_registry from "../sso_providers/registry.js";
 import type * as sso_providers_remove_provider from "../sso_providers/remove_provider.js";
@@ -2022,6 +2024,7 @@ declare const fullApi: ApiFromModules<{
   "sso_providers/entra_id/role_mapping": typeof sso_providers_entra_id_role_mapping;
   "sso_providers/entra_id/team_sync": typeof sso_providers_entra_id_team_sync;
   "sso_providers/find_or_create_sso_user": typeof sso_providers_find_or_create_sso_user;
+  "sso_providers/generic_oidc/adapter": typeof sso_providers_generic_oidc_adapter;
   "sso_providers/get": typeof sso_providers_get;
   "sso_providers/get_auth_user": typeof sso_providers_get_auth_user;
   "sso_providers/get_caller_role": typeof sso_providers_get_caller_role;
@@ -2035,6 +2038,7 @@ declare const fullApi: ApiFromModules<{
   "sso_providers/internal_mutations": typeof sso_providers_internal_mutations;
   "sso_providers/internal_queries": typeof sso_providers_internal_queries;
   "sso_providers/is_sso_configured": typeof sso_providers_is_sso_configured;
+  "sso_providers/oidc_discovery": typeof sso_providers_oidc_discovery;
   "sso_providers/queries": typeof sso_providers_queries;
   "sso_providers/registry": typeof sso_providers_registry;
   "sso_providers/remove_provider": typeof sso_providers_remove_provider;


### PR DESCRIPTION
## Problem

Entering **Organization settings** without editing anything could enable **Save**, render the "Default language (for agents)" dropdown **empty**, and trigger the **"Unsaved changes"** blocker dialog on navigation.

## Root cause

A cold-load race (reproducible on slow/cold Convex, or right after org creation). During the load window the locale `Select`'s controlled value is in flux, and **Radix emits a spurious `onValueChange('')`** (confirmed live — stack runs through `@radix-ui/react-select`'s hidden native `<select>`). The handler ran `setValue('defaultLocale', '', { shouldDirty: true })`, so the form went genuinely dirty against the `'en'` baseline:

```
values:        { name: 'test2', defaultLocale: '' }   ← Radix set it to ''
defaultValues: { name: 'test2', defaultLocale: 'en' }
dirtyFields:   { defaultLocale: true }
```

On fast/warm loads the window is sub-frame and self-heals, which is why it looked intermittent.

## Fix

In `organization-settings.tsx`:
- **Guard the handler** — `if (!value || value === defaultLocale) return;` before `setValue`. `''` is never a valid locale, so dropping it is always correct.
- **Controlled from first render** — `value={defaultLocale ?? ''}` (also clears the separate "uncontrolled to controlled" console warning).

Scope is intentionally minimal: the shared `useFormEditor` hook is untouched (its `data !== undefined && isDirty` window is not the cause — RHF doesn't recompute dirty without a field event).

## Testing

- New regression test `organization-settings.test.tsx` simulates the spurious empty change via Radix's hidden native `<select>` — **fails without the guard, passes with it** — plus asserts a real selection still marks dirty.
- Verified live: **12 cold-load cycles, all clean** (locale always "English", Save always disabled, no warnings).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests). 71,487 passed; the only 3 failures are pre-existing turbo-load timeout flakes in unrelated convexTest specs (`governance/erasure_collab_passes`, `integrations/slack/http_actions`, `users/set_member_password`) — all pass in isolation. This change is frontend-only and touches no Convex code.
- [x] No hand-rolled skeletons or magic `h-[…]` — N/A (no skeleton changes).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no string changes).
- [x] Updated `/docs/{en,de,fr}/` — N/A (bug fix, no user-visible behavior/config/API change).
- [x] Touched docs pages have real opening/closing — N/A (no docs touched).
- [x] Ran `@tale/docs` lint/test — N/A (no docs touched).
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.

> Includes a second commit regenerating `convex/_generated/api.d.ts` for the `sso_providers/generic_oidc/*` modules — codegen drift left after #1809, unrelated to the fix itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the organization settings locale selector could incorrectly mark the form as modified during loading or when selecting duplicate values.

* **Tests**
  * Added test coverage for locale selector dirty-state behavior in organization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->