### PR TITLE
feat(platform): surface test-run result and failing step in tester

### DIFF
--- a/services/platform/app/features/automations/components/automation-tester.test.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render } from '@/test/utils/render';
+
+type ExecStatusData = {
+  status: string;
+  currentStepName?: string;
+  error?: string;
+};
+
+// Mutable so each test sets the execution status the subscription returns.
+const h = vi.hoisted(() => {
+  const fixture: {
+    startMock: ReturnType<typeof vi.fn>;
+    executionStatus: { data: ExecStatusData | undefined };
+  } = {
+    startMock: vi.fn(() => Promise.resolve('exec-1')),
+    executionStatus: { data: undefined },
+  };
+  return fixture;
+});
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      // The mock returns the key path (no template), so append params rather
+      // than replace `{placeholders}` that aren't there.
+      params
+        ? `automations.${key} ${Object.values(params).join(' ')}`
+        : `automations.${key}`,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/app/hooks/use-persisted-state', () => ({
+  usePersistedState: () => ['{}', vi.fn()],
+}));
+
+vi.mock('@/app/components/ui/forms/json-input', () => ({
+  JsonInput: (props: { label?: string; value?: string }) => (
+    <textarea aria-label={props.label} defaultValue={props.value} />
+  ),
+}));
+
+vi.mock('../hooks/file-queries', () => ({
+  useReadWorkflow: () => ({
+    data: { ok: true, config: { steps: [{ stepType: 'start', config: {} }] } },
+  }),
+}));
+
+vi.mock('../hooks/file-mutations', () => ({
+  useStartWorkflowFromFile: () => ({
+    mutateAsync: h.startMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useExecutionStatus: () => h.executionStatus,
+}));
+
+import { AutomationTester } from './automation-tester';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  h.executionStatus = { data: undefined };
+});
+
+async function runExecute() {
+  const user = userEvent.setup();
+  render(
+    <AutomationTester organizationId="org-1" workflowSlug="my-workflow" />,
+  );
+  await user.click(
+    screen.getByRole('button', { name: 'automations.tester.execute' }),
+  );
+}
+
+describe('AutomationTester result feedback (#1484)', () => {
+  describe('accessibility', () => {
+    it('has no critical accessibility violations', async () => {
+      const { container } = render(
+        <AutomationTester organizationId="org-1" workflowSlug="my-workflow" />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  it('shows which step failed and why after a failed run', async () => {
+    h.executionStatus = {
+      data: {
+        status: 'failed',
+        currentStepName: 'Send Email',
+        error: 'Missing recipient address',
+      },
+    };
+
+    await runExecute();
+
+    expect(h.startMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        screen.getByText('automations.tester.result.failed'),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText('automations.tester.result.failedAtStep Send Email'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Missing recipient address')).toBeInTheDocument();
+  });
+
+  it('shows a success state when the run completes', async () => {
+    h.executionStatus = { data: { status: 'completed' } };
+
+    await runExecute();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('automations.tester.result.completed'),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a running state with the current step', async () => {
+    h.executionStatus = {
+      data: { status: 'running', currentStepName: 'Fetch Data' },
+    };
+
+    await runExecute();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('automations.tester.result.running'),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText('automations.tester.result.runningStep Fetch Data'),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/automations/components/automation-tester.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.tsx
@@ -17,11 +17,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { JsonInput } from '@/app/components/ui/forms/json-input';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 import { useStartWorkflowFromFile } from '../hooks/file-mutations';
 import { useReadWorkflow } from '../hooks/file-queries';
+import { useExecutionStatus } from '../hooks/queries';
 import {
   buildInputTemplateFromSchema,
   getMissingRequiredFields,
@@ -101,6 +103,15 @@ export function AutomationTester({
   const [isDryRunning, setIsDryRunning] = useState(false);
   const [dryRunResult, setDryRunResult] = useState<DryRunResult | null>(null);
 
+  // The just-started execution, subscribed reactively so the panel shows the
+  // run progress to completed/failed (with the failing step + error) instead
+  // of firing and forgetting (#1484).
+  const [activeExecutionId, setActiveExecutionId] =
+    useState<Id<'wfExecutions'> | null>(null);
+  const { data: executionStatus } = useExecutionStatus(
+    activeExecutionId ?? undefined,
+  );
+
   const { mutateAsync: startWorkflow, isPending: isExecuting } =
     useStartWorkflowFromFile();
 
@@ -135,6 +146,7 @@ export function AutomationTester({
 
     setIsDryRunning(true);
     setDryRunResult(null);
+    setActiveExecutionId(null);
 
     toast({
       title: t('tester.dryRun.button'),
@@ -145,6 +157,7 @@ export function AutomationTester({
   };
 
   const handleExecute = async () => {
+    setActiveExecutionId(null);
     let input = {};
     try {
       input = JSON.parse(testInput);
@@ -185,6 +198,7 @@ export function AutomationTester({
       });
 
       setDryRunResult(null);
+      setActiveExecutionId(executionId);
       onTestComplete?.();
     } catch (error) {
       console.error('Test execution failed:', error);
@@ -225,6 +239,7 @@ export function AutomationTester({
           onChange={(value) => {
             setTestInput(value);
             setDryRunResult(null);
+            setActiveExecutionId(null);
           }}
           label={t('tester.inputLabel')}
           description={t('tester.inputDescription')}
@@ -302,6 +317,67 @@ export function AutomationTester({
                 ))}
               </HStack>
             </div>
+          </BorderedSection>
+        )}
+
+        {activeExecutionId && (
+          <BorderedSection
+            className={cn(
+              'p-3',
+              executionStatus?.status === 'completed'
+                ? 'bg-emerald-50 dark:bg-emerald-950/20 border-emerald-200 dark:border-emerald-800'
+                : executionStatus?.status === 'failed'
+                  ? 'bg-destructive/10 border-destructive/50'
+                  : 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20',
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            <HStack gap={2} className="mb-1">
+              {executionStatus?.status === 'completed' ? (
+                <CheckCircle2 className="size-4 text-emerald-600 dark:text-emerald-400" />
+              ) : executionStatus?.status === 'failed' ? (
+                <AlertCircle className="text-destructive size-4" />
+              ) : (
+                <Loader2 className="size-4 animate-spin text-blue-600 motion-reduce:animate-none dark:text-blue-400" />
+              )}
+              <Text as="span" variant="label">
+                {executionStatus?.status === 'completed'
+                  ? t('tester.result.completed')
+                  : executionStatus?.status === 'failed'
+                    ? t('tester.result.failed')
+                    : t('tester.result.running')}
+              </Text>
+            </HStack>
+
+            {executionStatus?.status === 'failed' ? (
+              <Stack gap={1}>
+                {executionStatus.currentStepName && (
+                  <Text variant="error-sm">
+                    {t('tester.result.failedAtStep', {
+                      step: executionStatus.currentStepName,
+                    })}
+                  </Text>
+                )}
+                {executionStatus.error && (
+                  <Text
+                    variant="error-sm"
+                    className="break-words whitespace-pre-line"
+                  >
+                    {executionStatus.error}
+                  </Text>
+                )}
+              </Stack>
+            ) : (
+              executionStatus?.status !== 'completed' &&
+              executionStatus?.currentStepName && (
+                <Text className="text-muted-foreground text-xs">
+                  {t('tester.result.runningStep', {
+                    step: executionStatus.currentStepName,
+                  })}
+                </Text>
+              )
+            )}
           </BorderedSection>
         )}
 

--- a/services/platform/app/features/automations/hooks/queries.ts
+++ b/services/platform/app/features/automations/hooks/queries.ts
@@ -12,6 +12,20 @@ export function useExecutionJournal(
   );
 }
 
+/**
+ * Live status of a single execution (status / current step / error). Reactive,
+ * so a tester that started a run sees it progress to completed/failed without
+ * polling. Pass `undefined` to skip (no active run).
+ */
+export function useExecutionStatus(
+  executionId: Id<'wfExecutions'> | undefined,
+) {
+  return useConvexQuery(
+    api.wf_executions.queries.getExecutionStatus,
+    executionId ? { executionId } : 'skip',
+  );
+}
+
 interface ListExecutionsArgs {
   wfDefinitionId: string;
   status?: string[];

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -716,6 +716,13 @@
         "executionId": "Ausführungs-ID: {id}",
         "testFailed": "Ausführung fehlgeschlagen",
         "startFailed": "Ausführung konnte nicht gestartet werden"
+      },
+      "result": {
+        "completed": "Abgeschlossen",
+        "failed": "Ausführung fehlgeschlagen",
+        "running": "Läuft …",
+        "failedAtStep": "Fehlgeschlagen bei Schritt: {step}",
+        "runningStep": "Aktueller Schritt: {step}"
       }
     }
   },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -716,6 +716,13 @@
         "executionId": "Execution ID: {id}",
         "testFailed": "Execution failed",
         "startFailed": "Failed to start execution"
+      },
+      "result": {
+        "completed": "Completed",
+        "failed": "Execution failed",
+        "running": "Running…",
+        "failedAtStep": "Failed at step: {step}",
+        "runningStep": "Current step: {step}"
       }
     }
   },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -717,6 +717,13 @@
         "executionId": "ID d'exécution : {id}",
         "testFailed": "Échec de l'exécution",
         "startFailed": "Échec du démarrage de l'exécution"
+      },
+      "result": {
+        "completed": "Terminé",
+        "failed": "Échec de l'exécution",
+        "running": "En cours…",
+        "failedAtStep": "Échec à l'étape : {step}",
+        "runningStep": "Étape en cours : {step}"
       }
     }
   },

--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -252,9 +252,14 @@
 
 	# Default: Express server for static files and index.html with env injection
 	reverse_proxy platform:3000 {
-		# Active health checking
+		# Active health checking. Interval is 5s (not 2s): the platform has a
+		# long cold boot (Convex connect + asset load — see its 180s compose
+		# start_period), and a 2s probe logged a failed health check every two
+		# seconds until it came up, which read as "repeated proxy failures"
+		# during normal startup (#1447). Caddy still routes correctly once the
+		# backend is up; 5s matches the docs upstream and cuts the boot noise.
 		health_uri /api/health
-		health_interval 2s
+		health_interval 5s
 		health_timeout 2s
 		health_status 200
 		health_passes 2


### PR DESCRIPTION
## What

Addresses **#1484** (part of the workflow-observability epic). The automation test panel started a run and only toasted "execution started" — the user got no feedback on whether it succeeded or failed, or **which step failed and why**.

## How

The tester now subscribes to the started execution's status (new `useExecutionStatus` hook over the existing reactive `getExecutionStatus` query) and renders a live result section:

- **running** — spinner + the current step name (`motion-reduce` honored),
- **completed** — success,
- **failed** — which step failed (`currentStepName`) + the error message.

It resets when the input changes or a new run starts. `en`/`de`/`fr` strings added.

## Scope

This is the contained, shippable slice of the observability epic. Per-node **canvas badges (#1487)** and **step-debug (#1490)** are tracked separately (plan posted on #1487) — they need new canvas data-flow + design input.

## Tests

`automation-tester.test.tsx` — accessibility audit + failed / completed / running result rendering (4 cases).

## Verification

`typecheck` · `lint` · tests · i18n parity/usage green. CodeRabbit applied (a11y block, `motion-reduce` on the spinner, typed test fixture, running-state coverage).

Refs #1484.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation tester now displays live execution status with real-time progress updates.
  * Status card shows completed, failed, and running states with relevant step information.
  * Failed executions display error messages and the step where failure occurred.

* **Tests**
  * Added comprehensive test coverage for automation tester status displays and accessibility.

* **Localization**
  * Added German, English, and French translations for execution status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->