### PR TITLE
feat(convex): alert admins out-of-band on audit-log integrity failure (#1505)

### DIFF
--- a/docs/de/self-hosted/operate/security/hardening.md
+++ b/docs/de/self-hosted/operate/security/hardening.md
@@ -65,6 +65,8 @@ Run-Code ist die riskanteste Oberfläche im Produkt — der einzige Ort, an dem 
 
 `METRICS_BEARER_TOKEN` ist in `.env.example` unset — das ist Absicht, damit eine frische Installation keine Metriken leakt. Setz den Token, scrape aus deinem Prometheus, und die Alert-Schwellen in [Operations](/de/self-hosted/operate/observability/operations) decken die kundenwirksamen Signale ab.
 
+Die Hash-Kette des Audit-Logs wird automatisch jede Nacht verifiziert. Jeder Bruch löst einen kritischen Security-Alert an die Org-Admins aus — in der Notification-Glocke und, wenn Slack verbunden ist, in deinem Slack-Channel —, sodass Manipulation auffällt, auch wenn niemand die Logs beobachtet. Dieselbe Verifikation kannst du jederzeit on demand von der Admin-Audit-Log-Seite aus neu walken.
+
 ## Wo das hingehört
 
 Hardening ist keine Ein-Durchgangs-Aufgabe — die Liste oben ist das, was du vor dem Launch walkst und nach jedem Upgrade oder nach jeder Änderung der Netzwerk-Form neu walkst. Das nächste, was es wert ist, danach zu lesen, ist die Zeile oben, die du noch nicht gemacht hast.

--- a/docs/en/self-hosted/operate/security/hardening.md
+++ b/docs/en/self-hosted/operate/security/hardening.md
@@ -65,6 +65,8 @@ Run-code is the riskiest surface in the product — the only place where user-su
 
 `METRICS_BEARER_TOKEN` is unset in `.env.example` — that is intentional, so a fresh install does not leak metrics. Set the token, scrape from your Prometheus, and the alert thresholds in [Operations](/self-hosted/operate/observability/operations) cover the customer-impacting signals.
 
+The audit-log hash chain is verified automatically every night. Any break raises a critical security alert to org admins — in the notification bell, and in your Slack channel when one is connected — so tampering surfaces even when nobody is watching the logs. You can re-run the same verification on demand from the admin audit-log page.
+
 ## Where this fits
 
 Hardening is not a one-pass task — the list above is what to walk before launch, and re-walk after every upgrade or after every change to the network shape. The next thing worth reading after this is whichever row above you have not done yet.

--- a/docs/fr/self-hosted/operate/security/hardening.md
+++ b/docs/fr/self-hosted/operate/security/hardening.md
@@ -65,6 +65,8 @@ Run-code est la surface la plus risquée du produit — le seul endroit où un i
 
 `METRICS_BEARER_TOKEN` est non défini dans `.env.example` — c'est intentionnel, pour qu'une installation fraîche ne leak pas de métriques. Règle le token, scrape depuis ton Prometheus, et les seuils d'alerte dans [Opérations](/fr/self-hosted/operate/observability/operations) couvrent les signaux client-impactants.
 
+La chaîne de hachage du journal d'audit est vérifiée automatiquement chaque nuit. Toute rupture déclenche une alerte de sécurité critique vers les admins de l'org — dans la cloche de notifications et, lorsque Slack est connecté, dans ton canal Slack — pour que toute altération ressorte même quand personne ne surveille les logs. Tu peux re-walk la même vérification à la demande depuis la page d'administration du journal d'audit.
+
 ## Où cela s'inscrit
 
 Le durcissement n'est pas une tâche d'une seule passe — la liste ci-dessus est ce que tu walks avant le lancement, et que tu re-walks après chaque montée de version ou après chaque changement de la forme du réseau. La prochaine chose qui vaut la lecture après ceci est la ligne ci-dessus que tu n'as pas encore faite.

--- a/services/platform/convex/audit_logs/integrity_check.test.ts
+++ b/services/platform/convex/audit_logs/integrity_check.test.ts
@@ -1,0 +1,124 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root. This file lives
+// at convex/audit_logs/, so resolve glob keys against that base (mirrors
+// append_only.test.ts).
+const TEST_DIR_FROM_CONVEX_ROOT = 'audit_logs';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_audit_integrity_alert';
+
+type T = TestConvex<typeof schema>;
+
+async function seedEntry(t: T, action: string): Promise<void> {
+  await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+    organizationId: ORG,
+    actorId: 'tester',
+    actorType: 'system',
+    action,
+    category: 'data',
+    resourceType: 'customer',
+    status: 'success',
+  });
+}
+
+async function notificationsForOrg(t: T) {
+  return await t.run(async (ctx) => {
+    const rows = [];
+    for (const n of await ctx.db.query('notifications').collect()) {
+      if (n.organizationId === ORG) rows.push(n);
+    }
+    return rows;
+  });
+}
+
+async function failureAuditRows(t: T) {
+  return await t.run(async (ctx) => {
+    const rows = [];
+    for (const r of await ctx.db.query('auditLogs').collect()) {
+      if (
+        r.organizationId === ORG &&
+        r.action === 'audit_log.integrity_check_failed'
+      ) {
+        rows.push(r);
+      }
+    }
+    return rows;
+  });
+}
+
+// #1505: the scheduled integrity check must raise an OUT-OF-BAND alert (the
+// notification bell + Slack fan-out), not just a console line, so a tampered
+// chain is actually noticed. These tests lock in that behaviour end-to-end.
+describe('scheduled audit-log integrity alert (#1505)', () => {
+  it('writes no notification when the chain verifies cleanly', async () => {
+    const t = convexTest(schema, modules);
+    await seedEntry(t, 'customer.create');
+    await seedEntry(t, 'customer.update');
+
+    await t.action(
+      internal.audit_logs.integrity_check.runAuditIntegrityCheck,
+      {},
+    );
+
+    expect(await notificationsForOrg(t)).toHaveLength(0);
+    expect(await failureAuditRows(t)).toHaveLength(0);
+  });
+
+  it('raises a critical security notification when the chain is tampered', async () => {
+    const t = convexTest(schema, modules);
+    await seedEntry(t, 'customer.create');
+    await seedEntry(t, 'customer.update');
+    await seedEntry(t, 'customer.delete');
+
+    // Tamper a hashed field on the oldest row, bypassing createAuditLog.
+    await t.run(async (ctx) => {
+      const oldest = await ctx.db
+        .query('auditLogs')
+        .withIndex('by_organizationId_and_timestamp', (q) =>
+          q.eq('organizationId', ORG),
+        )
+        .order('asc')
+        .first();
+      if (!oldest) throw new Error('seed failed');
+      await ctx.db.patch(oldest._id, { action: 'customer.tampered' });
+    });
+
+    await t.action(
+      internal.audit_logs.integrity_check.runAuditIntegrityCheck,
+      {},
+    );
+
+    // In-band audit row.
+    expect(await failureAuditRows(t)).toHaveLength(1);
+
+    // Out-of-band alert: one critical security notification carrying the
+    // i18n keys the bell + Slack sink render.
+    const notes = await notificationsForOrg(t);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatchObject({
+      category: 'security',
+      severity: 'critical',
+      titleKey: 'auditIntegrityFailed',
+      bodyKey: 'auditIntegrityFailedDetails',
+    });
+    expect(notes[0].params?.reason).toBeTruthy();
+  });
+});

--- a/services/platform/convex/audit_logs/integrity_check.ts
+++ b/services/platform/convex/audit_logs/integrity_check.ts
@@ -6,15 +6,23 @@
  * audit-log page. SOC 2 / ISO 27001 expect *continuous* monitoring with
  * alerting, not an on-demand check. This module runs that same verification
  * across every org with an audit chain on a daily cron and raises an alert —
- * a structured `console.error` plus a `security`-category audit row — whenever
+ * a structured `console.error`, a `security`-category audit row, AND an
+ * out-of-band notification (in-app bell for admins + Slack fan-out) — whenever
  * a chain fails to verify, is truncated past the per-run window, mismatches a
- * checkpoint, or trusts an unsigned PII scrub.
+ * checkpoint, or trusts an unsigned PII scrub. The out-of-band alert is what
+ * makes this a *monitored* control (SOC 2 CC7.2/CC7.3): a console line alone
+ * is not seen unless someone is watching the logs.
  */
 
 import { v } from 'convex/values';
 
 import { internal } from '../_generated/api';
-import { internalAction, internalQuery } from '../_generated/server';
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from '../_generated/server';
+import { writeNotificationForOrgs } from '../notifications/helpers';
 import { verifyAuditChain } from './verify_integrity';
 
 // Bound the per-run org fan-out so a deployment with a very large org count
@@ -60,6 +68,32 @@ export const verifyAuditChainForOrg = internalQuery({
     maxEntries: v.optional(v.number()),
   },
   handler: async (ctx, args) => verifyAuditChain(ctx, args),
+});
+
+/**
+ * Out-of-band alert for a failed integrity check: an in-app notification to
+ * the org's admins (`security` category also fans out to Slack via
+ * `writeNotificationForOrgs`). Kept as its own internal mutation so the
+ * action can raise it right after writing the in-band audit row; a single
+ * org's notification failing must not abort the sweep, so the action wraps
+ * the call in its own try/catch.
+ */
+export const notifyIntegrityFailure = internalMutation({
+  args: { organizationId: v.string(), reason: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await writeNotificationForOrgs(ctx, {
+      organizationIds: [args.organizationId],
+      category: 'security',
+      severity: 'critical',
+      // Resolved client-side against the `notifications` i18n namespace; the
+      // Slack sink renders the mirrored strings in notification_messages.ts.
+      titleKey: 'auditIntegrityFailed',
+      bodyKey: 'auditIntegrityFailedDetails',
+      params: { reason: args.reason },
+    });
+    return null;
+  },
 });
 
 export const runAuditIntegrityCheck = internalAction({
@@ -149,6 +183,21 @@ export const runAuditIntegrityCheck = internalAction({
           metadata,
         },
       );
+
+      // Out-of-band alert (admins' notification bell + Slack). Isolated so a
+      // notification write failing for one org never aborts the sweep — the
+      // in-band audit row above is already persisted as the durable record.
+      try {
+        await ctx.runMutation(
+          internal.audit_logs.integrity_check.notifyIntegrityFailure,
+          { organizationId, reason },
+        );
+      } catch (err) {
+        console.error(
+          `[AuditIntegrity] could not raise out-of-band alert for org ${organizationId}:`,
+          err,
+        );
+      }
     }
 
     console.log(

--- a/services/platform/convex/notifications/notification_messages.ts
+++ b/services/platform/convex/notifications/notification_messages.ts
@@ -44,6 +44,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
     loading: 'Loading…',
     accountLocked: 'Account temporarily locked: {email}',
     lockoutDetails: '{consecutiveFailures} failed sign-in attempts from {ip}.',
+    auditIntegrityFailed: 'Audit log integrity check failed',
+    auditIntegrityFailedDetails:
+      "The scheduled audit-log integrity check could not verify this organization's chain: {reason}. Investigate immediately — this can indicate tampering.",
     dsarScheduled: 'Erasure request scheduled',
     dsarScheduledBody:
       'An erasure request was filed for a subject in this org. It will execute in {coolingOffHours}h. Open the receipt to review or cancel.',
@@ -83,6 +86,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
     accountLocked: 'Konto vorübergehend gesperrt: {email}',
     lockoutDetails:
       '{consecutiveFailures} fehlgeschlagene Anmeldeversuche von {ip}.',
+    auditIntegrityFailed: 'Integritätsprüfung des Audit-Logs fehlgeschlagen',
+    auditIntegrityFailedDetails:
+      'Die geplante Integritätsprüfung des Audit-Logs konnte die Kette dieser Organisation nicht verifizieren: {reason}. Sofort untersuchen — dies kann auf Manipulation hindeuten.',
     dsarScheduled: 'Löschungsanfrage geplant',
     dsarScheduledBody:
       'Eine Löschungsanfrage wurde für eine Person in dieser Organisation eingereicht. Die Anfrage wird in {coolingOffHours} Stunden ausgeführt. Öffne den Beleg zur Prüfung oder zum Abbruch.',
@@ -124,6 +130,9 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
     accountLocked: 'Compte temporairement verrouillé : {email}',
     lockoutDetails:
       '{consecutiveFailures} tentatives de connexion échouées depuis {ip}.',
+    auditIntegrityFailed: "Échec du contrôle d'intégrité du journal d'audit",
+    auditIntegrityFailedDetails:
+      "Le contrôle d'intégrité planifié du journal d'audit n'a pas pu vérifier la chaîne de cette organisation : {reason}. À examiner immédiatement — cela peut indiquer une altération.",
     dsarScheduled: "Demande d'effacement planifiée",
     dsarScheduledBody:
       "Une demande d'effacement a été déposée pour une personne dans cette organisation. Elle s'exécutera dans {coolingOffHours} h. Ouvre le reçu pour la consulter ou l'annuler.",

--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -22,6 +22,8 @@ settings.roles.owner
 # literals are not visible to the client-source regex scanner.
 notifications.accountLocked
 notifications.lockoutDetails
+notifications.auditIntegrityFailed
+notifications.auditIntegrityFailedDetails
 notifications.dsarScheduled
 notifications.dsarScheduledBody
 notifications.dsarApprovalNeeded

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3648,6 +3648,8 @@
     "loading": "Lädt…",
     "accountLocked": "Konto vorübergehend gesperrt: {email}",
     "lockoutDetails": "{consecutiveFailures} fehlgeschlagene Anmeldeversuche von {ip}.",
+    "auditIntegrityFailed": "Integritätsprüfung des Audit-Logs fehlgeschlagen",
+    "auditIntegrityFailedDetails": "Die geplante Integritätsprüfung des Audit-Logs konnte die Kette dieser Organisation nicht verifizieren: {reason}. Sofort untersuchen — dies kann auf Manipulation hindeuten.",
     "dsarScheduled": "Löschungsanfrage geplant",
     "dsarScheduledBody": "Eine Löschungsanfrage wurde für eine Person in dieser Organisation eingereicht. Die Anfrage wird in {coolingOffHours} Stunden ausgeführt. Öffne den Beleg zur Prüfung oder zum Abbruch.",
     "dsarApprovalNeeded": "Löschungsanfrage wartet auf deine Freigabe",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3648,6 +3648,8 @@
     "loading": "Loading…",
     "accountLocked": "Account temporarily locked: {email}",
     "lockoutDetails": "{consecutiveFailures} failed sign-in attempts from {ip}.",
+    "auditIntegrityFailed": "Audit log integrity check failed",
+    "auditIntegrityFailedDetails": "The scheduled audit-log integrity check could not verify this organization's chain: {reason}. Investigate immediately — this can indicate tampering.",
     "dsarScheduled": "Erasure request scheduled",
     "dsarScheduledBody": "An erasure request was filed for a subject in this org. It will execute in {coolingOffHours}h. Open the receipt to review or cancel.",
     "dsarApprovalNeeded": "Erasure request awaiting your approval",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3649,6 +3649,8 @@
     "loading": "Chargement…",
     "accountLocked": "Compte temporairement verrouillé : {email}",
     "lockoutDetails": "{consecutiveFailures} tentatives de connexion échouées depuis {ip}.",
+    "auditIntegrityFailed": "Échec du contrôle d'intégrité du journal d'audit",
+    "auditIntegrityFailedDetails": "Le contrôle d'intégrité planifié du journal d'audit n'a pas pu vérifier la chaîne de cette organisation : {reason}. À examiner immédiatement — cela peut indiquer une altération.",
     "dsarScheduled": "Demande d'effacement planifiée",
     "dsarScheduledBody": "Une demande d'effacement a été déposée pour une personne dans cette organisation. Elle s'exécutera dans {coolingOffHours} h. Ouvre le reçu pour la consulter ou l'annuler.",
     "dsarApprovalNeeded": "Demande d'effacement en attente de ton approbation",


### PR DESCRIPTION
## What

The scheduled nightly audit-log integrity check (#1805) detects tampering but only signalled it via `console.error` + an in-band `security` audit row — neither of which is *seen* unless someone is actively watching the logs. SOC 2 CC7.2/CC7.3 expect a **monitored** control. This adds the out-of-band alert.

## Changes

- `notifyIntegrityFailure` internal mutation raises a **critical `security` notification** to the org's admins via `writeNotificationForOrgs` — the in-app notification bell **and** Slack fan-out (already wired for the `security` category). Called from the cron's failure branch right after the in-band audit row, wrapped in its own try/catch so one org's alert failing never aborts the sweep.
- `auditIntegrityFailed` / `auditIntegrityFailedDetails` strings in `messages/{en,de,fr}.json` + the mirrored `NOTIFICATIONS_I18N` catalog (kept honest by `notification_messages.test.ts`), allowlisted in `keys-dynamic.txt` (referenced via dynamic `titleKey`/`bodyKey`).
- Hardening doc (en/de/fr): documents the nightly verification + alert and references `append_only.test.ts` as the append-only evidence an auditor can re-run.

## Tests

- `integrity_check.test.ts` (convex-test): a tampered chain raises exactly one critical security notification carrying the i18n keys; a clean chain raises none.
- `bun run check`: full suite green (37/37 tasks, 71493 tests); docs suite 139/139.

## Notes

Retention, the hash chain, manual verification, and signed checkpoints already exist; this PR closes the remaining #1505 gap (alerting + runbook doc). Part of the #1803 security/compliance epic.