### PR TITLE
fix(platform): polish list header, mobile header, chat toolbar, skeletons & tab nav

### DIFF
--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { Check } from 'lucide-react';
 import { type ComponentType, Fragment, type ReactNode } from 'react';
 
 import { cn } from '../../lib/cn';
+import { TooltipContent } from './tooltip';
 
 export interface DropdownMenuActionItem {
   type: 'item';
@@ -89,6 +91,15 @@ interface DropdownMenuProps {
   contentClassName?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Optional hover/focus tooltip for the trigger. When set, the trigger is
+   * composed with a Radix tooltip (both triggers share the same DOM node via
+   * `asChild`), so the menu still opens on click while the tooltip explains it
+   * on hover. Handy for icon-only triggers in dense toolbars.
+   */
+  tooltip?: ReactNode;
+  /** Side the tooltip opens on. @default 'top' */
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
 function RadioIndicator() {
@@ -291,15 +302,38 @@ export function DropdownMenu({
   contentClassName,
   open,
   onOpenChange,
+  tooltip,
+  tooltipSide = 'top',
 }: DropdownMenuProps) {
+  const triggerEl = (
+    <DropdownMenuPrimitive.Trigger asChild onClick={(e) => e.stopPropagation()}>
+      {trigger}
+    </DropdownMenuPrimitive.Trigger>
+  );
+
   return (
     <DropdownMenuPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuPrimitive.Trigger
-        asChild
-        onClick={(e) => e.stopPropagation()}
-      >
-        {trigger}
-      </DropdownMenuPrimitive.Trigger>
+      {tooltip ? (
+        // Radix's documented composition for "tooltip on a menu trigger":
+        // both `asChild` triggers collapse onto the same button so the menu
+        // still opens on click while the tooltip shows on hover/focus.
+        <TooltipPrimitive.Provider delayDuration={300}>
+          <TooltipPrimitive.Root>
+            <TooltipPrimitive.Trigger asChild>
+              {triggerEl}
+            </TooltipPrimitive.Trigger>
+            <TooltipPrimitive.Portal>
+              {/* collisionPadding keeps the tooltip off the viewport edge so it
+                  can't visually overlap adjacent controls in dense toolbars. */}
+              <TooltipContent side={tooltipSide} collisionPadding={8}>
+                {tooltip}
+              </TooltipContent>
+            </TooltipPrimitive.Portal>
+          </TooltipPrimitive.Root>
+        </TooltipPrimitive.Provider>
+      ) : (
+        triggerEl
+      )}
       <DropdownMenuPrimitive.Portal>
         <DropdownMenuPrimitive.Content
           sideOffset={4}

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -179,6 +179,13 @@ export interface DataTableProps<TData, TValue = unknown> {
   onClearFilters?: () => void;
   /** Header action menu element (use DataTableActionMenu component) */
   actionMenu?: ReactNode;
+  /**
+   * Extra content rendered inside the filter bar (left side, alongside the
+   * search input) — e.g. an inline toggle like "show archived". Keeps the
+   * `actionMenu` slot reserved for the primary right-aligned action so the
+   * header matches the other list pages.
+   */
+  filtersContent?: ReactNode;
   /** Footer content */
   footer?: ReactNode;
   /** Enable sticky layout with header at top and pagination at bottom */
@@ -228,6 +235,7 @@ export function DataTable<TData, TValue = unknown>({
   isFiltersLoading = false,
   onClearFilters,
   actionMenu,
+  filtersContent,
   footer,
   stickyLayout = false,
   infiniteScroll,
@@ -414,7 +422,11 @@ export function DataTable<TData, TValue = unknown>({
 
   // Determine if we should render header
   const hasHeader =
-    search || (filters && filters.length > 0) || dateRange || actionMenu;
+    search ||
+    (filters && filters.length > 0) ||
+    dateRange ||
+    actionMenu ||
+    filtersContent;
 
   // Build the header content
   const headerContent = hasHeader ? (
@@ -425,7 +437,9 @@ export function DataTable<TData, TValue = unknown>({
         dateRange={dateRange}
         isLoading={isFiltersLoading}
         onClearAll={onClearFilters}
-      />
+      >
+        {filtersContent}
+      </DataTableFilters>
       {actionMenu}
     </div>
   ) : null;

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { Description } from '@tale/ui/description';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { useSkeleton } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
+import { TooltipContent } from '@tale/ui/tooltip';
 import { Check, ChevronDown, Circle, Search } from 'lucide-react';
 import {
   type KeyboardEvent,
@@ -90,6 +92,15 @@ export interface SearchableSelectProps {
   showRadio?: boolean;
   /** Optional action element rendered on the right side of each option */
   optionAction?: (option: SearchableSelectOption) => ReactNode;
+  /**
+   * Optional hover/focus tooltip for the trigger. When set, the trigger is
+   * composed with a Radix tooltip (both triggers collapse onto the same DOM
+   * node via `asChild`), so the popover still opens on click while the tooltip
+   * explains the control on hover. Useful for compact toolbar triggers.
+   */
+  tooltip?: ReactNode;
+  /** Side the tooltip opens on. @default 'top' */
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
 const CONTENT_CLASSES =
@@ -148,6 +159,8 @@ function SearchableSelectBase({
   filterFn,
   showRadio,
   optionAction,
+  tooltip,
+  tooltipSide = 'top',
 }: SearchableSelectProps) {
   const instanceId = useId();
   const listboxId = `${instanceId}-listbox`;
@@ -290,11 +303,35 @@ function SearchableSelectBase({
     [filteredOptions, highlightedIndex, handleSelect],
   );
 
+  const popoverTrigger = (
+    <PopoverPrimitive.Trigger asChild>
+      {defaultTrigger}
+    </PopoverPrimitive.Trigger>
+  );
+
   const popover = (
     <PopoverPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <PopoverPrimitive.Trigger asChild>
-        {defaultTrigger}
-      </PopoverPrimitive.Trigger>
+      {tooltip ? (
+        // Radix's documented "tooltip on a popover trigger" composition: both
+        // `asChild` triggers collapse onto the same node, so the popover opens
+        // on click while the tooltip shows on hover/focus.
+        <TooltipPrimitive.Provider delayDuration={300}>
+          <TooltipPrimitive.Root>
+            <TooltipPrimitive.Trigger asChild>
+              {popoverTrigger}
+            </TooltipPrimitive.Trigger>
+            <TooltipPrimitive.Portal>
+              {/* collisionPadding keeps the tooltip off the viewport edge so it
+                  can't visually overlap adjacent controls in dense toolbars. */}
+              <TooltipContent side={tooltipSide} collisionPadding={8}>
+                {tooltip}
+              </TooltipContent>
+            </TooltipPrimitive.Portal>
+          </TooltipPrimitive.Root>
+        </TooltipPrimitive.Provider>
+      ) : (
+        popoverTrigger
+      )}
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
           align={align}

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -78,10 +78,10 @@ export function TabNavigation({
   const pathname = location.pathname;
   const ability = useAbility();
   const { accentColor } = useBrandingContext();
-  const navRef = useRef<HTMLElement | null>(null);
   // The horizontally-scrolling tab list. Kept separate from the outer <nav> so
   // the trailing button group can sit outside the scroll area and stay pinned
-  // to the right while only the tabs scroll.
+  // to the right while only the tabs scroll. All measurement/scroll logic reads
+  // this element, so the <nav> itself needs no ref.
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 0, left: 0 });
@@ -196,7 +196,6 @@ export function TabNavigation({
 
   return (
     <nav
-      ref={navRef}
       className={cn(
         'relative border-b border-border min-h-11 flex items-stretch shrink-0',
         standalone && 'bg-background z-10',
@@ -253,7 +252,8 @@ export function TabNavigation({
             className={cn(
               'absolute bottom-0 h-0.5',
               !accentColor && 'bg-foreground',
-              shouldAnimate && 'transition-all duration-200 ease-out',
+              shouldAnimate &&
+                'transition-all duration-200 ease-out motion-reduce:transition-none',
             )}
             style={{
               width: `${indicatorStyle.width}px`,

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -79,6 +79,10 @@ export function TabNavigation({
   const ability = useAbility();
   const { accentColor } = useBrandingContext();
   const navRef = useRef<HTMLElement | null>(null);
+  // The horizontally-scrolling tab list. Kept separate from the outer <nav> so
+  // the trailing button group can sit outside the scroll area and stay pinned
+  // to the right while only the tabs scroll.
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 0, left: 0 });
   // Track if we should animate (only after initial render)
@@ -152,32 +156,33 @@ export function TabNavigation({
   // can leave the active tab hidden off the right edge. Adjusts `scrollLeft`
   // directly so we never scroll an outer container.
   useEffect(() => {
-    const nav = navRef.current;
+    const scroller = scrollRef.current;
     const active = itemRefs.current[activeIndex];
-    if (!nav || !active) return;
-    if (nav.scrollWidth <= nav.clientWidth) return;
+    if (!scroller || !active) return;
+    if (scroller.scrollWidth <= scroller.clientWidth) return;
 
     const target =
-      active.offsetLeft + active.offsetWidth / 2 - nav.clientWidth / 2;
-    const max = nav.scrollWidth - nav.clientWidth;
+      active.offsetLeft + active.offsetWidth / 2 - scroller.clientWidth / 2;
+    const max = scroller.scrollWidth - scroller.clientWidth;
     const clamped = Math.max(0, Math.min(target, max));
-    if (Math.abs(nav.scrollLeft - clamped) < 1) return;
+    if (Math.abs(scroller.scrollLeft - clamped) < 1) return;
 
     const prefersReducedMotion =
       typeof window !== 'undefined' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    nav.scrollTo({
+    scroller.scrollTo({
       left: clamped,
       behavior:
         prefersReducedMotion || !hasInitialized.current ? 'auto' : 'smooth',
     });
   }, [activeIndex]);
 
-  // Combine refs for resize observation
+  // Combine refs for resize observation. The scroll container's width drives
+  // both the indicator measurement and the active-tab scroll-into-view.
   const allRefs = useMemo(() => {
     const refs: (HTMLElement | null)[] = [
-      navRef.current,
+      scrollRef.current,
       ...itemRefs.current.slice(0, accessibleItems.length),
     ];
     return { current: refs };
@@ -193,69 +198,79 @@ export function TabNavigation({
     <nav
       ref={navRef}
       className={cn(
-        'scrollbar-hide relative border-b border-border min-h-11 flex items-center gap-4 shrink-0 overflow-x-auto px-4',
+        'relative border-b border-border min-h-11 flex items-stretch shrink-0',
         standalone && 'bg-background z-10',
         className,
       )}
       aria-label={ariaLabel}
     >
-      {accessibleItems.map((item, index) => {
-        const isActive = isPathActive(item);
-        const [path, queryString] = item.href.split('?');
-        const hrefSearch = queryString
-          ? Object.fromEntries(new URLSearchParams(queryString))
-          : undefined;
-        const isItemDirty =
-          dirtyKeys !== undefined &&
-          (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false);
+      <div
+        ref={scrollRef}
+        className="scrollbar-hide relative flex min-w-0 flex-1 items-center gap-4 overflow-x-auto px-4"
+      >
+        {accessibleItems.map((item, index) => {
+          const isActive = isPathActive(item);
+          const [path, queryString] = item.href.split('?');
+          const hrefSearch = queryString
+            ? Object.fromEntries(new URLSearchParams(queryString))
+            : undefined;
+          const isItemDirty =
+            dirtyKeys !== undefined &&
+            (item.dirtyKeys?.some((k) => dirtyKeys.has(k)) ?? false);
 
-        return (
-          <Link
-            key={item.href}
-            ref={(el) => {
-              itemRefs.current[index] = el;
-            }}
-            to={path}
-            search={item.search ?? hrefSearch}
-            preload={prefetch ? 'render' : false}
-            aria-current={isActive ? 'page' : undefined}
+          return (
+            <Link
+              key={item.href}
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              to={path}
+              search={item.search ?? hrefSearch}
+              preload={prefetch ? 'render' : false}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                "relative h-full flex items-center gap-1.5 py-1 text-sm font-medium transition-colors whitespace-nowrap shrink-0 rounded-sm focus-visible:outline-none focus-visible:after:content-[''] focus-visible:after:absolute focus-visible:after:-inset-x-1 focus-visible:after:inset-y-0.5 focus-visible:after:rounded-sm focus-visible:after:ring-2 focus-visible:after:ring-ring focus-visible:after:ring-inset focus-visible:after:pointer-events-none justify-center",
+                isActive
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {isItemDirty && (
+                <span
+                  aria-hidden="true"
+                  className="inline-block size-1.5 rounded-full bg-amber-500"
+                />
+              )}
+              {item.label}
+              {item.trailing}
+            </Link>
+          );
+        })}
+
+        {/* Animated indicator */}
+        {activeIndex !== -1 && (
+          <div
             className={cn(
-              "relative h-full flex items-center gap-1.5 py-1 text-sm font-medium transition-colors whitespace-nowrap shrink-0 rounded-sm focus-visible:outline-none focus-visible:after:content-[''] focus-visible:after:absolute focus-visible:after:-inset-x-1 focus-visible:after:inset-y-0.5 focus-visible:after:rounded-sm focus-visible:after:ring-2 focus-visible:after:ring-ring focus-visible:after:ring-inset focus-visible:after:pointer-events-none justify-center",
-              isActive
-                ? 'text-foreground'
-                : 'text-muted-foreground hover:text-foreground',
+              'absolute bottom-0 h-0.5',
+              !accentColor && 'bg-foreground',
+              shouldAnimate && 'transition-all duration-200 ease-out',
             )}
-          >
-            {isItemDirty && (
-              <span
-                aria-hidden="true"
-                className="inline-block size-1.5 rounded-full bg-amber-500"
-              />
-            )}
-            {item.label}
-            {item.trailing}
-          </Link>
-        );
-      })}
+            style={{
+              width: `${indicatorStyle.width}px`,
+              left: `${indicatorStyle.left}px`,
+              backgroundColor: accentColor || undefined,
+            }}
+          />
+        )}
+      </div>
 
-      {/* Animated indicator */}
-      {activeIndex !== -1 && (
-        <div
-          className={cn(
-            'absolute bottom-0 h-0.5',
-            !accentColor && 'bg-foreground',
-            shouldAnimate && 'transition-all duration-200 ease-out',
-          )}
-          style={{
-            width: `${indicatorStyle.width}px`,
-            left: `${indicatorStyle.left}px`,
-            backgroundColor: accentColor || undefined,
-          }}
-        />
-      )}
-
+      {/* Trailing action group — pinned to the right, outside the scroll area,
+          so it stays in view while the tabs scroll under it. The left shadow +
+          background fade make the scrolling tabs visibly slide beneath it. */}
       {children && (
-        <div className="ml-auto flex items-center gap-2">{children}</div>
+        <div className="bg-background relative z-[1] flex shrink-0 items-center gap-2 self-stretch pr-4 pl-3 shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.18)] dark:shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.6)]">
+          {children}
+        </div>
       )}
     </nav>
   );

--- a/services/platform/app/features/chat/components/agent-selector.test.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.test.tsx
@@ -178,7 +178,7 @@ describe('AgentSelector', () => {
     // Trigger has a min-width pin (from `sm` up) so loading→loaded never
     // reflows for the common label range. Mobile drops the pin so the
     // composer toolbar fits — see the source comment in agent-selector.tsx.
-    expect(trigger).toHaveClass('sm:min-w-40');
+    expect(trigger).toHaveClass('sm:min-w-32');
   });
 
   it('shows "Add agent" button when user has write permission', async () => {

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -132,18 +132,20 @@ export function AgentSelector({
         side="top"
         sideOffset={8}
         contentClassName="w-[16.25rem]"
+        tooltip={t('agentSelector.label')}
+        tooltipSide="top"
         searchPlaceholder={t('agentSelector.searchPlaceholder')}
         emptyText={t('agentSelector.noResults')}
         aria-label={t('agentSelector.label')}
         trigger={
-          // min-w-40 (160 px) pins the trigger so the loading→loaded swap
-          // doesn't reflow for common labels. Names longer than ~160 px
-          // (rare, e.g. "Research Agent") still grow on resolve. On
-          // narrow mobile viewports the pin is dropped so the composer
-          // toolbar fits without overflowing the send/mic cluster.
+          // min-w-32 (128 px) pins the trigger so the loading→loaded swap
+          // doesn't reflow for common labels. Names longer than ~128 px
+          // still grow on resolve. On narrow mobile viewports the pin is
+          // dropped so the composer toolbar fits without overflowing the
+          // send/mic cluster.
           <Button
             type="button"
-            className="gap-2 sm:min-w-40"
+            className="gap-1.5 sm:min-w-32"
             size="icon"
             variant="ghost"
             aria-label={t('agentSelector.label')}

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -860,7 +860,7 @@ export function ChatInput({
             className="flex-1 gap-2 pb-3 sm:gap-4"
           >
             <HStack
-              gap={0}
+              gap={1}
               align="center"
               className="scrollbar-hide min-w-0 flex-1 overflow-x-auto"
             >
@@ -886,7 +886,7 @@ export function ChatInput({
               {isArenaMode ? (
                 <ArenaModelSelector organizationId={organizationId} />
               ) : (
-                <HStack gap={0} align="center">
+                <HStack gap={1} align="center">
                   <AgentSelector
                     organizationId={organizationId}
                     projectId={projectId}

--- a/services/platform/app/features/chat/components/composer-mode-menu.tsx
+++ b/services/platform/app/features/chat/components/composer-mode-menu.tsx
@@ -373,6 +373,8 @@ export function ComposerModeMenu({
 
   return (
     <DropdownMenu
+      tooltip={t('openMenu')}
+      tooltipSide="top"
       trigger={
         <Button
           variant="ghost"

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -378,6 +378,8 @@ export function ModelSelector({
       side="top"
       sideOffset={8}
       contentClassName="w-[22rem]"
+      tooltip={t('modelSelector.label')}
+      tooltipSide="top"
       searchPlaceholder={t('modelSelector.searchPlaceholder')}
       emptyText={t('modelSelector.noResults')}
       aria-label={t('modelSelector.label')}
@@ -386,7 +388,7 @@ export function ModelSelector({
       trigger={
         <Button
           type="button"
-          className="gap-2"
+          className="gap-1.5"
           size="icon"
           variant="ghost"
           aria-label={t('modelSelector.label')}

--- a/services/platform/app/features/chat/components/save-prompt-menu.tsx
+++ b/services/platform/app/features/chat/components/save-prompt-menu.tsx
@@ -41,6 +41,8 @@ export function SavePromptMenu({
 
   return (
     <DropdownMenu
+      tooltip={tChat('savePromptMenu')}
+      tooltipSide="top"
       trigger={
         <Button
           variant="ghost"

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -158,20 +158,20 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         {...list.tableProps}
         columns={columns}
         onRowClick={handleRowClick}
+        filtersContent={
+          <Checkbox
+            id="projects-show-archived"
+            checked={includeArchived}
+            onCheckedChange={(v) => setIncludeArchived(Boolean(v))}
+            label={t('list.showArchived')}
+          />
+        }
         actionMenu={
-          <div className="flex items-center gap-3">
-            <Checkbox
-              id="projects-show-archived"
-              checked={includeArchived}
-              onCheckedChange={(v) => setIncludeArchived(Boolean(v))}
-              label={t('list.showArchived')}
-            />
-            <DataTableActionMenu
-              label={t('list.createButton')}
-              icon={Plus}
-              onClick={() => setCreateOpen(true)}
-            />
-          </div>
+          <DataTableActionMenu
+            label={t('list.createButton')}
+            icon={Plus}
+            onClick={() => setCreateOpen(true)}
+          />
         }
         emptyState={{
           icon: Folder,

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -189,7 +189,7 @@ function DashboardLayout() {
           <DirtyBlockerProvider>
             <AdaptiveHeaderProvider>
               <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
-                <header className="bg-background border-border flex items-center gap-2 border-b px-4 pt-(--safe-top) pb-2 md:hidden">
+                <header className="bg-background border-border flex items-center gap-2 border-b px-4 pt-[calc(var(--safe-top)+0.5rem)] pb-2 md:hidden">
                   <MobileBackButton organizationId={organizationId} />
                   <div className="min-w-0 flex-1">
                     <AdaptiveHeaderSlot />

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -284,7 +284,7 @@ export function DashboardShellFrame() {
   return (
     <div className="flex h-dvh w-full flex-col overflow-hidden md:flex-row">
       {/* Mobile top bar */}
-      <div className="bg-background border-border flex items-center gap-2 border-b p-2 pt-[calc(var(--safe-top)+0.75rem)] md:hidden">
+      <div className="bg-background border-border flex items-center gap-2 border-b p-2 pt-[calc(var(--safe-top)+0.5rem)] md:hidden">
         <Skeletonize loading>
           <SkeletonBox>
             <div className="size-8" />

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/delegation.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/delegation.tsx
@@ -95,15 +95,19 @@ function DelegationTab() {
   // placeholder MUST include a `description` — real delegate rows have one, so
   // omitting it here renders the single-line checkbox variant and the masked
   // row loses the description's height (visible jump when data resolves).
+  // Masked placeholder rows (hidden behind `<Skeletonize loading>`); they only
+  // reserve the real row's height. Route through the translation layer rather
+  // than hardcoding English — reuse existing translated keys so we don't add
+  // never-visible strings to every locale.
   const placeholderOptions = useMemo(
     () =>
       Array.from({ length: 4 }, (_, i) => ({
         value: `__placeholder_${i}`,
-        label: 'Delegate agent',
-        description: 'Delegate agent description placeholder',
+        label: t('agents.delegation.title'),
+        description: t('agents.delegation.description'),
         disabled: true,
       })),
-    [],
+    [t],
   );
 
   return (

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/delegation.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/delegation.tsx
@@ -91,12 +91,16 @@ function DelegationTab() {
   const selectedValues = config.delegates ?? [];
 
   // While loading, feed the real CheckboxGroup a few placeholder rows so the
-  // same tree renders in both states; `<Skeletonize loading>` masks them.
+  // same tree renders in both states; `<Skeletonize loading>` masks them. The
+  // placeholder MUST include a `description` — real delegate rows have one, so
+  // omitting it here renders the single-line checkbox variant and the masked
+  // row loses the description's height (visible jump when data resolves).
   const placeholderOptions = useMemo(
     () =>
       Array.from({ length: 4 }, (_, i) => ({
         value: `__placeholder_${i}`,
         label: 'Delegate agent',
+        description: 'Delegate agent description placeholder',
         disabled: true,
       })),
     [],

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -440,7 +440,7 @@ function AutomationDetailInner({
                 // SAME step-card placeholder as the route-level loading state
                 // instead of a generic text skeleton. Otherwise the skeleton
                 // visibly "blinks": canvas placeholder → text lines → canvas.
-                <Skeletonize loading>
+                <Skeletonize loading className="contents">
                   <AutomationCanvasSkeleton />
                 </Skeletonize>
               }

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@tale/ui/badge';
 import { Heading } from '@tale/ui/heading';
 import { Center } from '@tale/ui/layout';
-import { SkeletonBox, SkeletonText } from '@tale/ui/skeleton';
+import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
 import {
@@ -68,6 +68,86 @@ const PLACEHOLDER_STEPS = [
   },
   { name: 'Finish', description: 'Return the result', type: 'Output' },
 ] as const;
+
+/**
+ * Static canvas placeholder shared by the route-level loading state and the
+ * Suspense fallback for the lazily code-split ReactFlow canvas. Reusing one
+ * placeholder for both is what removes the skeleton "blink": once the workflow
+ * data resolves but the canvas chunk is still downloading, the user keeps
+ * seeing the identical step-card placeholder instead of a generic text
+ * skeleton flashing in for a frame. Callers wrap it in `<Skeletonize loading>`.
+ */
+function AutomationCanvasSkeleton() {
+  return (
+    <div className="relative flex w-full flex-1 justify-stretch overflow-auto">
+      <div className="bg-background relative min-h-0 flex-[1_1_0]">
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle, hsl(var(--muted-foreground)) 1px, transparent 1px)',
+            backgroundSize: '20px 20px',
+          }}
+        />
+        <Center className="absolute inset-0">
+          <div className="flex flex-col items-center">
+            {PLACEHOLDER_STEPS.map((step, index) => (
+              <div key={step.name}>
+                {index > 0 && (
+                  <div className="border-muted-foreground/30 mx-auto h-8 w-0 border-l-2" />
+                )}
+                {/* Real step-card shape (mirrors AutomationStep):
+                    icon, heading, caption, trailing type badge. */}
+                <div className="border-border bg-card w-[18.75rem] rounded-lg border shadow-sm">
+                  <div className="flex gap-3 px-2.5 py-2">
+                    <SkeletonBox>
+                      <div className="size-5 shrink-0 rounded-sm" />
+                    </SkeletonBox>
+                    <div className="min-w-0 flex-1">
+                      <Heading level={3} size="sm">
+                        <SkeletonBox>{step.name}</SkeletonBox>
+                      </Heading>
+                      <Text variant="caption" className="mt-1 line-clamp-2">
+                        <SkeletonBox>{step.description}</SkeletonBox>
+                      </Text>
+                    </div>
+                    <Badge
+                      variant="outline"
+                      className="text-muted-foreground h-fit px-1 py-0.5 text-xs"
+                    >
+                      <SkeletonBox>{step.type}</SkeletonBox>
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Center>
+        <div className="absolute right-4 bottom-4">
+          <SkeletonBox>
+            <div className="border-border h-[128px] w-[192px] rounded-lg border shadow-sm" />
+          </SkeletonBox>
+        </div>
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+          <div className="ring-border bg-background flex items-center gap-2 rounded-lg p-1 shadow-sm ring-1">
+            <SkeletonBox>
+              <div className="size-8 rounded-md" />
+            </SkeletonBox>
+            <SkeletonBox>
+              <div className="size-8 rounded-md" />
+            </SkeletonBox>
+            <SkeletonBox>
+              <div className="size-8 rounded-md" />
+            </SkeletonBox>
+            <SkeletonBox>
+              <div className="size-8 rounded-md" />
+            </SkeletonBox>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function AutomationDetailLayout() {
   const { id: organizationId, amId } = Route.useParams();
@@ -162,76 +242,7 @@ function AutomationDetailLayout() {
         <Skeletonize loading className="contents">
           <div className="relative flex min-h-0 flex-1">
             <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
-              <div className="relative flex w-full flex-1 justify-stretch overflow-auto">
-                <div className="bg-background relative min-h-0 flex-[1_1_0]">
-                  <div
-                    className="absolute inset-0 opacity-20"
-                    style={{
-                      backgroundImage:
-                        'radial-gradient(circle, hsl(var(--muted-foreground)) 1px, transparent 1px)',
-                      backgroundSize: '20px 20px',
-                    }}
-                  />
-                  <Center className="absolute inset-0">
-                    <div className="flex flex-col items-center">
-                      {PLACEHOLDER_STEPS.map((step, index) => (
-                        <div key={step.name}>
-                          {index > 0 && (
-                            <div className="border-muted-foreground/30 mx-auto h-8 w-0 border-l-2" />
-                          )}
-                          {/* Real step-card shape (mirrors AutomationStep):
-                              icon, heading, caption, trailing type badge. */}
-                          <div className="border-border bg-card w-[18.75rem] rounded-lg border shadow-sm">
-                            <div className="flex gap-3 px-2.5 py-2">
-                              <SkeletonBox>
-                                <div className="size-5 shrink-0 rounded-sm" />
-                              </SkeletonBox>
-                              <div className="min-w-0 flex-1">
-                                <Heading level={3} size="sm">
-                                  <SkeletonBox>{step.name}</SkeletonBox>
-                                </Heading>
-                                <Text
-                                  variant="caption"
-                                  className="mt-1 line-clamp-2"
-                                >
-                                  <SkeletonBox>{step.description}</SkeletonBox>
-                                </Text>
-                              </div>
-                              <Badge
-                                variant="outline"
-                                className="text-muted-foreground h-fit px-1 py-0.5 text-xs"
-                              >
-                                <SkeletonBox>{step.type}</SkeletonBox>
-                              </Badge>
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </Center>
-                  <div className="absolute right-4 bottom-4">
-                    <SkeletonBox>
-                      <div className="border-border h-[128px] w-[192px] rounded-lg border shadow-sm" />
-                    </SkeletonBox>
-                  </div>
-                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
-                    <div className="ring-border bg-background flex items-center gap-2 rounded-lg p-1 shadow-sm ring-1">
-                      <SkeletonBox>
-                        <div className="size-8 rounded-md" />
-                      </SkeletonBox>
-                      <SkeletonBox>
-                        <div className="size-8 rounded-md" />
-                      </SkeletonBox>
-                      <SkeletonBox>
-                        <div className="size-8 rounded-md" />
-                      </SkeletonBox>
-                      <SkeletonBox>
-                        <div className="size-8 rounded-md" />
-                      </SkeletonBox>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <AutomationCanvasSkeleton />
             </div>
             {/* Real AI-panel aside (mounts open by default once loaded): same
                 fixed-width bordered column with a masked header. */}
@@ -424,13 +435,13 @@ function AutomationDetailInner({
           {isExactAutomationPage ? (
             <SuspenseBoundary
               fallback={
-                // Genuine code-split chunk (ReactFlow canvas): its code isn't
-                // loaded yet, so the cardinal-rule exception applies — keep the
-                // fallback minimal rather than reconstructing the real canvas.
+                // The ReactFlow canvas is a genuine code-split chunk, so a
+                // fallback is unavoidable while it downloads — but reuse the
+                // SAME step-card placeholder as the route-level loading state
+                // instead of a generic text skeleton. Otherwise the skeleton
+                // visibly "blinks": canvas placeholder → text lines → canvas.
                 <Skeletonize loading>
-                  <div className="flex-1 p-4">
-                    <SkeletonText lines={3} />
-                  </div>
+                  <AutomationCanvasSkeleton />
                 </Skeletonize>
               }
             >


### PR DESCRIPTION
## Summary

UI polish across several surfaces. Each fix is small and self-contained; two add an **additive** prop to a shared component (no behavior change for existing callers).

### 1. Projects list header layout
The "show archived" toggle was crammed into the `actionMenu` slot next to the create button, which broke the header's responsive layout. Moved the toggle into the filter bar (left, beside search) and left only the create button in `actionMenu`, so the header now matches the other list pages (customers/products/…). Added an additive `filtersContent` slot to `DataTable` (forwarded to the existing `DataTableFilters` children slot).

### 2. Mobile header / user profile not centered
The mobile top bar used `pt-(--safe-top) pb-2`; with no notch the top padding collapses to 0 while the bottom stays 8px, so the avatar + title sat too high. Changed to `pb-2 pt-[calc(var(--safe-top)+0.5rem)]` so content is vertically centered below the safe-area inset (matching the shell-frame pattern).

### 3 & 4. Chat composer toolbar — compact + tooltips
- Unified the toolbar gaps to a consistent `gap-1` (the left cluster was `gap-0`) and tightened the agent/model selectors (`gap-2`→`gap-1.5`, agent `min-w-40`→`min-w-32`).
- Added hover/focus tooltips to the four triggers that lacked them (composer-menu, save-prompt, agent, model). This required additive `tooltip`/`tooltipSide` props on the shared `DropdownMenu` and `SearchableSelect`, using Radix's documented "tooltip on a menu/popover trigger" composition (`collisionPadding` set so the tooltip can't overlap adjacent controls in the dense toolbar).

### 5. Automation editor skeleton blink
The lazily code-split ReactFlow canvas had a `<SkeletonText lines={3}>` Suspense fallback, so after data resolved you briefly saw: step-card skeleton → text skeleton → canvas. Extracted a single `AutomationCanvasSkeleton` and reuse it for both the route-level loading state and the Suspense fallback — the placeholder is now identical throughout, so no blink.

### 6. Tab navigation — pinned action group
The trailing action group lived inside the scrolling `<nav>` with `ml-auto`, so it scrolled out of view when the tabs overflowed. Split the tabs into an inner `overflow-x-auto` scroller and pinned the action group outside it (`shrink-0`) with a left edge shadow so the tabs visibly slide beneath it. This is the shared `TabNavigation`, so it fixes the automation editor and every other tab strip.

### 7. Checkbox skeleton missing description height
On the agent **delegation** settings page, the loading placeholder rows had a label but no `description`, so they rendered the single-line checkbox variant while real rows (with agent descriptions) are two-line — the masked skeleton dropped the description's height. Gave the placeholder a description so the same tree renders in both states.

## Review & verification

- **Self-reviewed** the full diff.
- **CodeRabbit** reviewed (2 passes). Fixed: dropped a now-unused `navRef`, and honored `prefers-reduced-motion` on the active-tab indicator transition. Two further nitpicks were intentionally **not** taken:
  - *Per-instance `TooltipPrimitive.Provider`* — required, not optional: there is no root-level provider, and the app's existing `Tooltip`/`UserButton` use the same per-instance pattern. Removing it would break the tooltips.
  - *Dirty-dot `aria-hidden`* — pre-existing behavior; a proper fix needs a new localized "unsaved changes" string across all locales, better as a focused a11y follow-up.
- `bun run format:check` ✅, `turbo run lint typecheck` ✅ (29/29), and all touched component tests pass (data-table, data-table-filters, dropdown-menu, searchable-select, tab-navigation, agent-selector, model-selector, checkbox, checkbox-group).

## Note on visual verification

No platform dev server was available in this environment, so these were verified by code/convention rather than in a running browser. The structural fixes (1, 5, 6, 7) and the additive props are well-grounded; the subjective tuning (toolbar gap values in #3, the centering padding in #2) are sensible defaults and one-line tweaks if anything looks off on device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tooltip support to dropdown menus, searchable select dropdowns, and various action buttons throughout the interface.
  * Enhanced data table filter organization with flexible content placement options.

* **Improvements**
  * Refined tab navigation scrolling to keep the active tab visible and accessible.
  * Improved loading placeholders to maintain consistent layout during data loading, reducing visual jumps.
  * Optimized spacing and alignment across chat components for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->