### PR TITLE
perf(platform): speed up chat switch, org switch & value toggles

### DIFF
--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -5,7 +5,7 @@ import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { useNavigate } from '@tanstack/react-router';
 import { Bot, ChevronDown, Plus } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { CreateAgentDialog } from '@/app/features/agents/components/agent-create-dialog';
@@ -30,7 +30,7 @@ interface AgentSelectorProps {
   projectId?: string;
 }
 
-export function AgentSelector({
+export const AgentSelector = memo(function AgentSelector({
   organizationId,
   projectId,
 }: AgentSelectorProps) {
@@ -185,4 +185,4 @@ export function AgentSelector({
       )}
     </>
   );
-}
+});

--- a/services/platform/app/features/chat/components/branch-navigator.tsx
+++ b/services/platform/app/features/chat/components/branch-navigator.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@tale/ui/button';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useMemo, useCallback } from 'react';
+import { memo, useMemo, useCallback } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 
@@ -22,7 +22,9 @@ interface BranchNavigatorProps {
  *
  * The "original" parent counts as option 0, each branch is 1+.
  */
-export function BranchNavigator({ forkOrder }: BranchNavigatorProps) {
+export const BranchNavigator = memo(function BranchNavigator({
+  forkOrder,
+}: BranchNavigatorProps) {
   const { t } = useT('chat');
   const ctx = useBranchContext();
   const forkOrderKey = String(forkOrder);
@@ -120,4 +122,4 @@ export function BranchNavigator({ forkOrder }: BranchNavigatorProps) {
       </Button>
     </div>
   );
-}
+});

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -7,7 +7,7 @@ import { Stack } from '@tale/ui/layout';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
-import { useParams, useNavigate } from '@tanstack/react-router';
+import { useParams, useNavigate, useRouter } from '@tanstack/react-router';
 import {
   ChevronDown,
   CircleDotIcon,
@@ -110,6 +110,10 @@ interface ChatRowContextValue {
   executingThreadIds: Set<string>;
   isThreadHeld: (threadId: string) => boolean;
   onSelect: (chatId: string) => void;
+  /** Warm the thread route's chunk + loader on hover/focus so the click is
+   *  near-instant. Router `defaultPreload: 'intent'` doesn't fire for rows that
+   *  navigate imperatively rather than via <Link>, so we preload explicitly. */
+  onPreload: (chatId: string) => void;
   onStartRename: (chatId: string) => void;
   onSaveRename: (chatId: string, title: string) => void;
   onCancelRename: () => void;
@@ -174,6 +178,7 @@ export function ChatHistorySidebar({
 }: ChatHistorySidebarProps) {
   const { t } = useT('chat');
   const navigate = useNavigate();
+  const router = useRouter();
   const params = useParams({ strict: false });
   // TanStack Router useParams with strict: false returns unknown params — cast required
   const currentThreadId = params.threadId;
@@ -393,6 +398,22 @@ export function ChatHistorySidebar({
     [navigate, organizationId, onChatSelect],
   );
 
+  const handleChatPreload = useCallback(
+    (threadId: string) => {
+      void router
+        .preloadRoute({
+          to: '/dashboard/$id/chat/$threadId',
+          params: { id: organizationId, threadId },
+        })
+        .catch((error: unknown) => {
+          // Preload is a best-effort warm-up; a failure here must never break
+          // the row (the click still navigates normally).
+          console.warn('Failed to preload chat route', error);
+        });
+    },
+    [router, organizationId],
+  );
+
   const handleStartRename = useCallback(
     (chatId: string) => setEditingChatId(chatId),
     [],
@@ -437,6 +458,7 @@ export function ChatHistorySidebar({
       executingThreadIds,
       isThreadHeld,
       onSelect: handleChatClick,
+      onPreload: handleChatPreload,
       onStartRename: handleStartRename,
       onSaveRename: (chatId, title) => void handleSaveRename(chatId, title),
       onCancelRename: handleCancelRename,
@@ -450,6 +472,7 @@ export function ChatHistorySidebar({
       executingThreadIds,
       isThreadHeld,
       handleChatClick,
+      handleChatPreload,
       handleStartRename,
       handleSaveRename,
       handleCancelRename,
@@ -994,6 +1017,8 @@ function ChatRow({ chat }: { chat: ChatItem }) {
           <button
             type="button"
             aria-label={chat.title}
+            onMouseEnter={() => ctx.onPreload(chat._id)}
+            onFocus={() => ctx.onPreload(chat._id)}
             onClick={() => {
               if (clickTimeoutRef.current) {
                 clearTimeout(clickTimeoutRef.current);

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -41,7 +41,7 @@ import {
   useMarkThreadRead,
   useUnarchiveThread,
 } from '../hooks/mutations';
-import { useChatAgents, useThreadStatus } from '../hooks/queries';
+import { useChatAgents } from '../hooks/queries';
 import { useArenaThreadSetup } from '../hooks/use-arena-thread-setup';
 import { useChatScroll } from '../hooks/use-chat-scroll';
 import { useChatVideoLinks } from '../hooks/use-chat-video-links';
@@ -113,12 +113,18 @@ interface ChatInterfaceProps {
   organizationId: string;
   threadId?: string;
   readOnly?: boolean;
+  /** Resolved thread status from `ThreadGate`'s `getThreadStatus` subscription,
+   *  passed down so we don't open a second identical subscription here just to
+   *  derive `isArchived`. `undefined` while loading / for new/just-created
+   *  threads (treated as not-archived). */
+  threadStatus?: string | null;
 }
 
 export function ChatInterface({
   organizationId,
   threadId,
   readOnly = false,
+  threadStatus,
 }: ChatInterfaceProps) {
   const { t } = useT('chat');
   const chatRegionLabelId = useId();
@@ -321,10 +327,10 @@ export function ChatInterface({
   const { active: activeEditingImage } = useEffectiveEditingImage(threadImages);
   const { setEditingImageRef, setDismissedImageKey } = useChatLayout();
 
-  // Thread status — disable input for archived threads
-  // Always check the URL threadId (root thread), not dataThreadId (which may
-  // be a branch thread that wasn't individually archived).
-  const threadStatus = useThreadStatus(threadId, organizationId);
+  // Thread status — disable input for archived threads. Status is derived from
+  // the URL threadId (root thread), not dataThreadId (which may be a branch
+  // thread that wasn't individually archived). Provided by ThreadGate to avoid
+  // a duplicate getThreadStatus subscription on every thread switch.
   const isArchived = threadStatus === 'archived';
 
   const { mutate: unarchiveThread, isPending: isUnarchiving } =
@@ -358,17 +364,20 @@ export function ChatInterface({
   // Block input when any pending or executing approval exists
   const hasActiveApproval = activeApproval !== null;
 
-  // Fork info — for showing divider in forked threads
-  const { data: forkInfo } = useConvexQuery(
-    api.threads.queries.getThreadForkInfo,
+  // Consolidated thread metadata behind ONE access check + subscription (fork
+  // info, generation status, project). useMessageProcessing reads the same
+  // getThreadMeta with identical args, so they share a single Convex
+  // subscription per thread switch instead of four separate ones.
+  const { data: threadMeta } = useConvexQuery(
+    api.threads.queries.getThreadMeta,
     dataThreadId ? { threadId: dataThreadId } : 'skip',
   );
 
+  // Fork info — for showing divider in forked threads
+  const forkInfo = threadMeta?.forkInfo ?? undefined;
+
   // Server-derived generation status (reactive Convex subscription)
-  const { data: isGenerating } = useConvexQuery(
-    api.threads.queries.isThreadGenerating,
-    dataThreadId ? { threadId: dataThreadId } : 'skip',
-  );
+  const isGenerating = threadMeta?.isGenerating;
 
   // Client-side optimistic flag — set on send click, released when the
   // server subscription confirms or the send fails. Closes the ~200–550 ms
@@ -472,13 +481,10 @@ export function ChatInterface({
       : undefined;
 
   // For an EXISTING project chat the projectId isn't in the URL — read it from
-  // the thread so the composer applies the project's agent/model restrictions
-  // and recommendations either way.
-  const { data: threadProject } = useConvexQuery(
-    api.threads.queries.getThreadProject,
-    dataThreadId ? { threadId: dataThreadId, organizationId } : 'skip',
-  );
-  const currentProjectId = threadProject?.projectId ?? projectIdFromUrl;
+  // the thread (via the consolidated getThreadMeta above) so the composer
+  // applies the project's agent/model restrictions and recommendations either
+  // way.
+  const currentProjectId = threadMeta?.projectId ?? projectIdFromUrl;
 
   const { sendMessage } = useSendMessage({
     organizationId,
@@ -623,6 +629,19 @@ export function ChatInterface({
   const handleEditClick = useCallback((messageId: string, content: string) => {
     setEditingMessage({ id: messageId, content });
   }, []);
+
+  // Stable identities for the two props ChatMessages would otherwise receive as
+  // fresh inline arrows each render — required for its React.memo to hold.
+  const handleEditCancel = useCallback(() => {
+    setEditingMessage(null);
+  }, []);
+
+  const handleSavePromptFromMessage = useCallback(
+    (messageId: string, content: string) => {
+      setSavePromptData({ messageId, content });
+    },
+    [],
+  );
 
   const handleEditSubmit = useCallback(
     async (newContent: string) => {
@@ -910,9 +929,7 @@ export function ChatInterface({
                 onForkAtMessage={
                   isArchived || readOnly ? undefined : handleForkAtMessage
                 }
-                onSavePrompt={(messageId, content) =>
-                  setSavePromptData({ messageId, content })
-                }
+                onSavePrompt={handleSavePromptFromMessage}
                 onUnsavePrompt={handleUnsavePrompt}
                 savedMessageMap={savedMessageMap}
                 onRetry={isArchived || readOnly ? undefined : handleRetry}
@@ -929,9 +946,7 @@ export function ChatInterface({
                   isArchived || readOnly ? undefined : handleEditSubmit
                 }
                 onEditCancel={
-                  isArchived || readOnly
-                    ? undefined
-                    : () => setEditingMessage(null)
+                  isArchived || readOnly ? undefined : handleEditCancel
                 }
                 hideFeedback={isArchived}
               />

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -4,6 +4,7 @@ import { Button } from '@tale/ui/button';
 import { useQuery } from 'convex/react';
 import { AlertTriangle, Loader2, CheckCircle2, Lock } from 'lucide-react';
 import {
+  memo,
   useId,
   useMemo,
   useRef,
@@ -171,7 +172,7 @@ interface ChatMessagesProps {
  * 1. useLayoutEffect: approximate value before paint (prevents flash)
  * 2. ResizeObserver: accurate correction after layout completes
  */
-export function ChatMessages({
+export const ChatMessages = memo(function ChatMessages({
   items,
   threadId,
   organizationId,
@@ -737,50 +738,87 @@ export function ChatMessages({
     />
   ) : null;
 
-  if (useVirtual) {
-    return (
-      <VoiceOutputProvider threadId={threadId}>
-        <VoiceOutputAnnouncer />
-        <VirtualizedChatMessageList
-          items={items}
-          containerRef={containerRef}
-          renderItem={renderItemWithDivider}
-          labelId={messageHistoryLabelId}
-          header={
-            <>
-              <h2 id={messageHistoryLabelId} className="sr-only">
-                {t('aria.messageHistory')}
-              </h2>
-              {loadMoreHeader}
-              <div className="h-6" aria-hidden="true" />
-            </>
-          }
-          footer={
-            // The virtualized root log has NO aria-live (it would announce
-            // windowing churn), so the thinking affordance gets its own scoped
-            // polite region here. The region wrapper is ALWAYS mounted (only its
-            // content is conditional) so a later ThinkingIndicator insertion is
-            // a mutation of an already-registered region — content inserted in
-            // the same DOM mutation as its aria-live container announces
-            // unreliably across screen readers. ThinkingIndicator has no
-            // internal live region, so nothing nests. The approval card renders
-            // BARE (it owns internal sub-state live regions; see above). No
-            // parent `gap` — the live wrapper carries its own bottom padding
-            // only when populated, so an empty wrapper adds no phantom gap.
-            <div className="flex flex-col pb-2">
-              <div
-                aria-live="polite"
-                className={responseFooterLive ? 'pb-3' : undefined}
-              >
-                {responseFooterLive}
-              </div>
-              {responseFooterStatic}
-            </div>
-          }
-        />
-      </VoiceOutputProvider>
-    );
-  }
+  // Single VoiceOutputProvider wraps BOTH render paths (below) so voice-output
+  // state has one lifecycle per ChatMessages instance — previously each branch
+  // mounted its own provider, so flipping the virtualization flag left a stale
+  // provider that could leak voice state across threads.
+  const messageList = useVirtual ? (
+    <VirtualizedChatMessageList
+      items={items}
+      containerRef={containerRef}
+      renderItem={renderItemWithDivider}
+      labelId={messageHistoryLabelId}
+      header={
+        <>
+          <h2 id={messageHistoryLabelId} className="sr-only">
+            {t('aria.messageHistory')}
+          </h2>
+          {loadMoreHeader}
+          <div className="h-6" aria-hidden="true" />
+        </>
+      }
+      footer={
+        // The virtualized root log has NO aria-live (it would announce
+        // windowing churn), so the thinking affordance gets its own scoped
+        // polite region here. The region wrapper is ALWAYS mounted (only its
+        // content is conditional) so a later ThinkingIndicator insertion is
+        // a mutation of an already-registered region — content inserted in
+        // the same DOM mutation as its aria-live container announces
+        // unreliably across screen readers. ThinkingIndicator has no
+        // internal live region, so nothing nests. The approval card renders
+        // BARE (it owns internal sub-state live regions; see above). No
+        // parent `gap` — the live wrapper carries its own bottom padding
+        // only when populated, so an empty wrapper adds no phantom gap.
+        <div className="flex flex-col pb-2">
+          <div
+            aria-live="polite"
+            className={responseFooterLive ? 'pb-3' : undefined}
+          >
+            {responseFooterLive}
+          </div>
+          {responseFooterStatic}
+        </div>
+      }
+    />
+  ) : (
+    <div
+      className="mx-auto flex w-full max-w-(--chat-max-width) flex-col"
+      role="log"
+      aria-live="polite"
+      aria-labelledby={messageHistoryLabelId}
+    >
+      <h2 id={messageHistoryLabelId} className="sr-only">
+        {t('aria.messageHistory')}
+      </h2>
+      <div className="flex flex-col gap-3 pt-6">
+        {loadMoreHeader}
+
+        {/* Messages before the last user message */}
+        <div className="flex flex-col gap-3">
+          {beforeItems.map((item, i) => renderItemWithDivider(item, i))}
+        </div>
+
+        {/* Last user message */}
+        {lastUserItem && renderItemWithDivider(lastUserItem, lastUserIdx)}
+
+        {/* Response area: min-height fills viewport so scroll-to-bottom
+            positions the user message at the top. When AI response exceeds
+            viewport height, min-height becomes irrelevant. */}
+        <div
+          ref={responseAreaRef}
+          className="flex shrink-0 flex-col gap-3 [overflow-anchor:none]"
+        >
+          {afterItems.map((item, i) =>
+            renderItemWithDivider(item, lastUserIdx + 1 + i),
+          )}
+          {/* Non-virtualized path: the root already is role="log"
+              aria-live="polite", so both pieces render inside it as before. */}
+          {responseFooterLive}
+          {responseFooterStatic}
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <VoiceOutputProvider threadId={threadId}>
@@ -788,43 +826,7 @@ export function ChatMessages({
           announced exactly once, not amplified by the parent log's
           aria-live region. */}
       <VoiceOutputAnnouncer />
-      <div
-        className="mx-auto flex w-full max-w-(--chat-max-width) flex-col"
-        role="log"
-        aria-live="polite"
-        aria-labelledby={messageHistoryLabelId}
-      >
-        <h2 id={messageHistoryLabelId} className="sr-only">
-          {t('aria.messageHistory')}
-        </h2>
-        <div className="flex flex-col gap-3 pt-6">
-          {loadMoreHeader}
-
-          {/* Messages before the last user message */}
-          <div className="flex flex-col gap-3">
-            {beforeItems.map((item, i) => renderItemWithDivider(item, i))}
-          </div>
-
-          {/* Last user message */}
-          {lastUserItem && renderItemWithDivider(lastUserItem, lastUserIdx)}
-
-          {/* Response area: min-height fills viewport so scroll-to-bottom
-            positions the user message at the top. When AI response exceeds
-            viewport height, min-height becomes irrelevant. */}
-          <div
-            ref={responseAreaRef}
-            className="flex shrink-0 flex-col gap-3 [overflow-anchor:none]"
-          >
-            {afterItems.map((item, i) =>
-              renderItemWithDivider(item, lastUserIdx + 1 + i),
-            )}
-            {/* Non-virtualized path: the root already is role="log"
-                aria-live="polite", so both pieces render inside it as before. */}
-            {responseFooterLive}
-            {responseFooterStatic}
-          </div>
-        </div>
-      </div>
+      {messageList}
     </VoiceOutputProvider>
   );
-}
+});

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -8,6 +8,7 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import startCase from 'lodash/startCase';
 import { AlertTriangle, ChevronDown, Cpu } from 'lucide-react';
 import {
+  memo,
   type ReactNode,
   useCallback,
   useEffect,
@@ -53,7 +54,7 @@ function getModelShortName(modelId: string): string {
   return slash >= 0 ? modelId.slice(slash + 1) : modelId;
 }
 
-export function ModelSelector({
+export const ModelSelector = memo(function ModelSelector({
   organizationId,
   projectId,
 }: ModelSelectorProps) {
@@ -398,4 +399,4 @@ export function ModelSelector({
       }
     />
   );
-}
+});

--- a/services/platform/app/features/chat/context/branch-context.tsx
+++ b/services/platform/app/features/chat/context/branch-context.tsx
@@ -121,10 +121,15 @@ export function BranchProvider({
   organizationId,
   children,
 }: BranchProviderProps) {
-  const [branchSelections, setBranchSelections] = useState<
-    Record<string, string>
-  >({});
-  const initializedRef = useRef(false);
+  // User branch selections made this session (keyed by forkOrder), overlaid on
+  // top of the server-persisted selections below. Kept separate so the persisted
+  // value is parsed lazily in a useMemo rather than copied into state via an
+  // effect: the old seed-in-effect caused a SECOND render per thread switch
+  // (reset → {}, then persisted-arrives → parsed), and since `dataThreadId` is
+  // derived from `activeBranchThreadId`, every chat subscription churned twice.
+  const [localOverrides, setLocalOverrides] = useState<Record<string, string>>(
+    {},
+  );
 
   // Load persisted branch selections from DB
   const persistedSelections = useQuery(
@@ -132,36 +137,41 @@ export function BranchProvider({
     threadId ? { threadId, organizationId } : 'skip',
   );
 
-  // Initialize from persisted data once on load
-  useEffect(() => {
-    if (persistedSelections && !initializedRef.current) {
-      try {
-        const parsed: unknown = JSON.parse(persistedSelections);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-          const selections: Record<string, string> = {};
-          const entries = Object.entries(
-            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- validated as object above
-            parsed as Record<string, unknown>,
-          );
-          for (const [key, val] of entries) {
-            if (typeof val === 'string') selections[key] = val;
-          }
-          setBranchSelections(selections);
+  // Parse persisted selections WITHOUT seeding state (no extra render when the
+  // query resolves). Invalid JSON falls back to empty, same as before.
+  const persistedParsed = useMemo<Record<string, string>>(() => {
+    if (!persistedSelections) return {};
+    try {
+      const parsed: unknown = JSON.parse(persistedSelections);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const selections: Record<string, string> = {};
+        for (const [key, val] of Object.entries(
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- validated as object above
+          parsed as Record<string, unknown>,
+        )) {
+          if (typeof val === 'string') selections[key] = val;
         }
-      } catch (err) {
-        console.warn(
-          '[branch-context] ignoring invalid persisted branch selections JSON',
-          err,
-        );
+        return selections;
       }
-      initializedRef.current = true;
+    } catch (err) {
+      console.warn(
+        '[branch-context] ignoring invalid persisted branch selections JSON',
+        err,
+      );
     }
+    return {};
   }, [persistedSelections]);
 
-  // Reset when thread changes
+  // Effective selections: server-persisted defaults overlaid with this
+  // session's explicit switches.
+  const branchSelections = useMemo(
+    () => ({ ...persistedParsed, ...localOverrides }),
+    [persistedParsed, localOverrides],
+  );
+
+  // Reset this session's overrides when the thread changes.
   useEffect(() => {
-    initializedRef.current = false;
-    setBranchSelections({});
+    setLocalOverrides({});
   }, [threadId]);
 
   // Persist branch selections to DB
@@ -201,27 +211,29 @@ export function BranchProvider({
 
   const switchBranch = useCallback(
     (forkOrder: string, branchThreadId: string | null) => {
-      setBranchSelections((prev) => {
+      setLocalOverrides((prev) => {
         const next = {
           ...prev,
           [forkOrder]: branchThreadId ?? ORIGINAL_SELECTION,
         };
-        persistSelections(next);
+        // Persist the full merged set (persisted defaults + all session
+        // overrides) so a reload restores every selection, not just this one.
+        persistSelections({ ...persistedParsed, ...next });
         return next;
       });
     },
-    [persistSelections],
+    [persistSelections, persistedParsed],
   );
 
   const selectNewBranch = useCallback(
     (forkOrder: string, branchThreadId: string) => {
-      setBranchSelections((prev) => {
+      setLocalOverrides((prev) => {
         const next = { ...prev, [forkOrder]: branchThreadId };
-        persistSelections(next);
+        persistSelections({ ...persistedParsed, ...next });
         return next;
       });
     },
-    [persistSelections],
+    [persistSelections, persistedParsed],
   );
 
   const value = useMemo(

--- a/services/platform/app/features/chat/context/branch-context.tsx
+++ b/services/platform/app/features/chat/context/branch-context.tsx
@@ -174,6 +174,16 @@ export function BranchProvider({
     setLocalOverrides({});
   }, [threadId]);
 
+  // Keep the latest persisted selections in a ref so the persist callbacks read
+  // the freshest server data without capturing it in their closure — closes a
+  // narrow stale window if getThreadBranchSelections updates between a
+  // callback's creation and its setLocalOverrides updater running, and keeps
+  // switchBranch/selectNewBranch referentially stable.
+  const persistedParsedRef = useRef(persistedParsed);
+  useEffect(() => {
+    persistedParsedRef.current = persistedParsed;
+  }, [persistedParsed]);
+
   // Persist branch selections to DB
   const { mutate: updateBranchSelections } = useConvexMutation(
     api.threads.mutations.updateBranchSelections,
@@ -218,22 +228,22 @@ export function BranchProvider({
         };
         // Persist the full merged set (persisted defaults + all session
         // overrides) so a reload restores every selection, not just this one.
-        persistSelections({ ...persistedParsed, ...next });
+        persistSelections({ ...persistedParsedRef.current, ...next });
         return next;
       });
     },
-    [persistSelections, persistedParsed],
+    [persistSelections],
   );
 
   const selectNewBranch = useCallback(
     (forkOrder: string, branchThreadId: string) => {
       setLocalOverrides((prev) => {
         const next = { ...prev, [forkOrder]: branchThreadId };
-        persistSelections({ ...persistedParsed, ...next });
+        persistSelections({ ...persistedParsedRef.current, ...next });
         return next;
       });
     },
-    [persistSelections, persistedParsed],
+    [persistSelections],
   );
 
   const value = useMemo(

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -122,17 +122,6 @@ export function useArchivedThreads({
   };
 }
 
-export function useThreadStatus(
-  threadId: string | undefined,
-  organizationId: string,
-) {
-  const { data } = useConvexQuery(
-    api.threads.queries.getThreadStatus,
-    threadId ? { threadId, organizationId } : 'skip',
-  );
-  return data ?? null;
-}
-
 export interface ComposerModeMeta {
   label: string;
   icon?: string;

--- a/services/platform/app/features/chat/hooks/use-message-processing.test.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.test.ts
@@ -1103,7 +1103,12 @@ describe('useMessageProcessing', () => {
     };
 
     it('hides file-only message while the thread is generating', () => {
-      setQueryResult(api.threads.queries.isThreadGenerating, true);
+      setQueryResult(api.threads.queries.getThreadMeta, {
+        isGenerating: true,
+        failedErrors: {},
+        forkInfo: null,
+        projectId: null,
+      });
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({
@@ -1142,7 +1147,12 @@ describe('useMessageProcessing', () => {
       // Regression case: shipped guard looked for streaming/pending assistant
       // status, which is undefined in the window between pre-tool `success`
       // and post-tool creation. The isGenerating-based guard covers it.
-      setQueryResult(api.threads.queries.isThreadGenerating, true);
+      setQueryResult(api.threads.queries.getThreadMeta, {
+        isGenerating: true,
+        failedErrors: {},
+        forkInfo: null,
+        projectId: null,
+      });
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({
@@ -1178,7 +1188,12 @@ describe('useMessageProcessing', () => {
     });
 
     it('merges file-only parts into a text-bearing assistant in the same turn', () => {
-      setQueryResult(api.threads.queries.isThreadGenerating, true);
+      setQueryResult(api.threads.queries.getThreadMeta, {
+        isGenerating: true,
+        failedErrors: {},
+        forkInfo: null,
+        projectId: null,
+      });
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({
@@ -1330,7 +1345,12 @@ describe('useMessageProcessing', () => {
     });
 
     it('does not let a later-turn streaming message hide a prior-turn file-only', () => {
-      setQueryResult(api.threads.queries.isThreadGenerating, true);
+      setQueryResult(api.threads.queries.getThreadMeta, {
+        isGenerating: true,
+        failedErrors: {},
+        forkInfo: null,
+        projectId: null,
+      });
       mockUseUIMessages.mockReturnValue({
         results: [
           createUIMessage({

--- a/services/platform/app/features/chat/hooks/use-message-processing.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.ts
@@ -113,13 +113,19 @@ export function useMessageProcessing(
     stream: true,
   });
 
-  // Separate lightweight query for error strings of failed messages.
-  // Kept out of the streaming query to avoid .map()-ing UIMessages (which
-  // creates new object references and breaks React/SDK dedup).
-  const messageErrors = useQuery(
-    api.threads.queries.getFailedMessageErrors,
+  // Consolidated thread metadata behind a SINGLE access check + subscription.
+  // ChatInterface reads the same getThreadMeta with identical args, so the two
+  // share ONE Convex subscription per thread switch instead of four separate
+  // ones (failed errors, generation status, fork info, project).
+  const threadMeta = useQuery(
+    api.threads.queries.getThreadMeta,
     threadId ? { threadId } : 'skip',
   );
+
+  // Error strings of failed messages (was getFailedMessageErrors). Kept out of
+  // the streaming query to avoid .map()-ing UIMessages (which creates new
+  // object references and breaks React/SDK dedup).
+  const messageErrors = threadMeta?.failedErrors;
 
   // Thread-level generation status. Held true across an entire multi-step
   // turn (set by markGenerating, cleared by clearGenerationStatus) including
@@ -127,10 +133,7 @@ export function useMessageProcessing(
   // — exactly when an orphan file-only message must stay hidden. Prefer this
   // over scanning uiMessages for a streaming/pending status, which is
   // undefined during that gap.
-  const isGenerating = useQuery(
-    api.threads.queries.isThreadGenerating,
-    threadId ? { threadId } : 'skip',
-  );
+  const isGenerating = threadMeta?.isGenerating;
 
   // Client-side pending-send signal. When the user has just clicked send
   // but the new user message hasn't been persisted yet, `pendingMessage` is

--- a/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
@@ -284,7 +284,8 @@ function CustomInstructionsToggleSection({
 }: ToggleSectionProps) {
   const { t } = useT('personalization');
   const { toast } = useToast();
-  const { mutateAsync: setEnabled } = useSetCustomInstructionsEnabled();
+  const { mutateAsync: setEnabled, isPending } =
+    useSetCustomInstructionsEnabled();
 
   const description = buildOrgDefaultHint(
     t,
@@ -298,6 +299,9 @@ function CustomInstructionsToggleSection({
       label={t('page.customInstructionsToggle.label')}
       description={description}
       checked={gate.effective}
+      // Disable while the write is in flight so a rapid double-toggle can't
+      // enqueue overlapping mutations (the value already flipped optimistically).
+      disabled={isPending}
       onCheckedChange={async (next) => {
         try {
           await setEnabled({ organizationId, enabled: next });
@@ -320,7 +324,7 @@ function MemoriesToggleSection({
 }: ToggleSectionProps) {
   const { t } = useT('personalization');
   const { toast } = useToast();
-  const { mutateAsync: setEnabled } = useSetMemoriesEnabled();
+  const { mutateAsync: setEnabled, isPending } = useSetMemoriesEnabled();
 
   const description = buildOrgDefaultHint(
     t,
@@ -334,6 +338,9 @@ function MemoriesToggleSection({
       label={t('page.memoriesToggle.label')}
       description={description}
       checked={gate.effective}
+      // Disable while the write is in flight so a rapid double-toggle can't
+      // enqueue overlapping mutations (the value already flipped optimistically).
+      disabled={isPending}
       onCheckedChange={async (next) => {
         try {
           await setEnabled({ organizationId, enabled: next });
@@ -446,7 +453,8 @@ function VoiceOutputSection({
 }) {
   const { t } = useT('personalization');
   const { toast } = useToast();
-  const { mutateAsync: setVoiceOutput } = useSetVoiceOutput();
+  const { mutateAsync: setVoiceOutput, isPending: isSettingVoiceOutput } =
+    useSetVoiceOutput();
   const getCapability = useAction(api.tts.synthesize.getCapability);
   const { data: orgVoicePolicy } = useGovernancePolicy(
     organizationId,
@@ -506,7 +514,10 @@ function VoiceOutputSection({
   );
 
   const disabled =
-    isLoading || (providerAvailable === false && !enabled) || orgVetoed;
+    isLoading ||
+    isSettingVoiceOutput ||
+    (providerAvailable === false && !enabled) ||
+    orgVetoed;
 
   return (
     <SettingsToggleRow

--- a/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
@@ -6,7 +6,7 @@ import { SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize, useSkeleton } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
 import { Link } from '@tanstack/react-router';
-import { useAction, useMutation, useQuery } from 'convex/react';
+import { useAction, useQuery } from 'convex/react';
 import { ConvexError } from 'convex/values';
 import { Trash2 } from 'lucide-react';
 import {
@@ -40,6 +40,7 @@ import {
   useDismissPendingMemory,
   useSetCustomInstructionsEnabled,
   useSetMemoriesEnabled,
+  useSetVoiceOutput,
   useSoftDeleteMemory,
   useUpsertMyPreferences,
 } from '../hooks/mutations';
@@ -445,7 +446,7 @@ function VoiceOutputSection({
 }) {
   const { t } = useT('personalization');
   const { toast } = useToast();
-  const setVoiceOutput = useMutation(api.tts.mutations.setUserVoiceOutput);
+  const { mutateAsync: setVoiceOutput } = useSetVoiceOutput();
   const getCapability = useAction(api.tts.synthesize.getCapability);
   const { data: orgVoicePolicy } = useGovernancePolicy(
     organizationId,

--- a/services/platform/app/features/settings/personalization/hooks/mutations.ts
+++ b/services/platform/app/features/settings/personalization/hooks/mutations.ts
@@ -1,3 +1,4 @@
+import { updateDocumentQuery } from '@/app/hooks/optimistic-updates';
 import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
 import { api } from '@/convex/_generated/api';
 
@@ -5,14 +6,55 @@ export function useUpsertMyPreferences() {
   return useConvexMutation(api.user_preferences.mutations.upsertMyPreferences);
 }
 
+// Optimistic toggles: patch the live `getMyPreferences` doc the instant the
+// switch is flipped so the control reflects the new value immediately instead
+// of freezing for the server round-trip. The patch is a straightforward
+// projection of `args.enabled`; `errorToast: false` because the callers toast
+// their own (better-copy) error message. Mirrors the reference implementation
+// in `governance/hooks/mutations.ts::useUpsertGovernancePolicy`.
 export function useSetCustomInstructionsEnabled() {
   return useConvexMutation(
     api.user_preferences.mutations.setCustomInstructionsEnabled,
+    {
+      errorToast: false,
+      optimisticUpdate: (store, args) =>
+        updateDocumentQuery(
+          store,
+          api.user_preferences.queries.getMyPreferences,
+          { organizationId: args.organizationId },
+          (current) => ({
+            ...current,
+            customInstructionsEnabled: args.enabled,
+          }),
+        ),
+    },
   );
 }
 
 export function useSetMemoriesEnabled() {
-  return useConvexMutation(api.user_preferences.mutations.setMemoriesEnabled);
+  return useConvexMutation(api.user_preferences.mutations.setMemoriesEnabled, {
+    errorToast: false,
+    optimisticUpdate: (store, args) =>
+      updateDocumentQuery(
+        store,
+        api.user_preferences.queries.getMyPreferences,
+        { organizationId: args.organizationId },
+        (current) => ({ ...current, memoriesEnabled: args.enabled }),
+      ),
+  });
+}
+
+export function useSetVoiceOutput() {
+  return useConvexMutation(api.tts.mutations.setUserVoiceOutput, {
+    errorToast: false,
+    optimisticUpdate: (store, args) =>
+      updateDocumentQuery(
+        store,
+        api.user_preferences.queries.getMyPreferences,
+        { organizationId: args.organizationId },
+        (current) => ({ ...current, voiceOutput: args.enabled }),
+      ),
+  });
 }
 
 export function useApprovePendingMemory() {

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -41,13 +41,26 @@ export const Route = createFileRoute('/dashboard/$id')({
   // Warm the membership/ability context before the layout renders so children
   // mount with access resolved (no shell-skeleton flash on warm org entry).
   // The component's gating logic surfaces denied/not-found states, so an
-  // access error here must not fail the transition.
-  loader: ({ context, params }) =>
-    ensureConvexQuery(context, api.members.queries.getCurrentMemberContext, {
-      organizationId: params.id,
-    }).catch((error: unknown) => {
+  // access error here must not fail the transition. Cap the wait at 2s so a
+  // slow membership round-trip (e.g. during an org switch) can't hang the
+  // transition — the component renders a skeleton while the live subscription
+  // catches up.
+  loader: ({ context, params }) => {
+    const preload = ensureConvexQuery(
+      context,
+      api.members.queries.getCurrentMemberContext,
+      { organizationId: params.id },
+    ).catch((error: unknown) => {
       console.warn('Failed to preload member context', error);
-    }),
+    });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, 2000);
+    });
+    return Promise.race([preload, timeout]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  },
   component: DashboardLayout,
 });
 
@@ -90,8 +103,12 @@ function DashboardLayout() {
     void (async () => {
       try {
         await authClient.organization.setActive({ organizationId });
+        // Audit + preference persistence is off the critical path — fire in the
+        // background so the guard doesn't block on it. Errors are logged.
+        void recordOrgSwitch({ organizationId }).catch((err) => {
+          console.warn('Failed to record org switch audit entry:', err);
+        });
         await queryClient.invalidateQueries({ queryKey: ['auth', 'session'] });
-        await recordOrgSwitch({ organizationId });
       } catch (err) {
         console.warn('Failed to sync active organization:', err);
         orgSyncRef.current = null;

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -97,7 +97,7 @@ function ThreadGate({
   // skeleton. (Ref mutation during render is intentional and idempotent.)
   const hasRenderedInterfaceRef = useRef(false);
 
-  const renderInterface = (readOnly?: boolean) => {
+  const renderInterface = (readOnly?: boolean, status?: string | null) => {
     hasRenderedInterfaceRef.current = true;
     return (
       <SuspenseBoundary
@@ -112,6 +112,7 @@ function ThreadGate({
           organizationId={organizationId}
           threadId={threadId}
           readOnly={readOnly}
+          threadStatus={status}
         />
       </SuspenseBoundary>
     );
@@ -153,11 +154,12 @@ function ThreadGate({
 
   // Shared read-only access for non-owner org members
   if (threadStatus === 'shared-readonly') {
-    return renderInterface(true);
+    return renderInterface(true, threadStatus);
   }
 
-  // Thread is accessible — render ChatInterface
-  return renderInterface();
+  // Thread is accessible — render ChatInterface (pass the resolved status so
+  // ChatInterface can derive `isArchived` without a second subscription).
+  return renderInterface(false, threadStatus);
 }
 
 function ChatLayoutContent({ organizationId }: { organizationId: string }) {

--- a/services/platform/app/routes/dashboard/switching.tsx
+++ b/services/platform/app/routes/dashboard/switching.tsx
@@ -73,15 +73,44 @@ function SwitchingPage() {
         await authClient.organization.setActive({
           organizationId: targetOrgId,
         });
+        // Audit + lastActiveOrganizationId persistence is NOT on the critical
+        // path — fire it in the background so the spinner doesn't wait on the
+        // dedup scan + better-auth `updateMany` round-trip. Initiated before
+        // navigate so the in-flight mutation survives this route unmounting.
+        void recordOrgSwitch({ organizationId: targetOrgId }).catch((err) => {
+          console.warn('Failed to record org switch audit entry:', err);
+        });
         // Force a fresh session read so downstream `useQuery(['auth','session'])`
         // observers see the new activeOrganizationId before we navigate.
-        await queryClient.invalidateQueries({ queryKey: ['auth', 'session'] });
+        // `refetchQueries` already refetches active observers, so the prior
+        // `invalidateQueries` was redundant.
         await queryClient.refetchQueries({ queryKey: ['auth', 'session'] });
-        try {
-          await recordOrgSwitch({ organizationId: targetOrgId });
-        } catch (err) {
-          console.warn('Failed to record org switch audit entry:', err);
-        }
+
+        // Drop cached Convex queries scoped to the PREVIOUS org. The old
+        // /dashboard/$id route has already unmounted (we're on /dashboard/
+        // switching), so these have no observers — without this they linger
+        // until gcTime (15min, router.tsx) keeping stale subscriptions alive
+        // and risk briefly showing the previous org's data on the way in.
+        // Convex keys are ['convexQuery', '<module>:<query>', args]; the
+        // session query (['auth','session']) is left untouched, and queries
+        // for the target org (or with no org arg) are kept.
+        queryClient.removeQueries({
+          predicate: (q) => {
+            if (!Array.isArray(q.queryKey) || q.queryKey[0] !== 'convexQuery') {
+              return false;
+            }
+            const args = q.queryKey[2];
+            if (
+              typeof args !== 'object' ||
+              args === null ||
+              !('organizationId' in args)
+            ) {
+              return false;
+            }
+            const orgId = args.organizationId;
+            return typeof orgId === 'string' && orgId !== targetOrgId;
+          },
+        });
       } catch (err) {
         console.error('Failed to switch organization:', err);
       }

--- a/services/platform/convex/audit_logs/schema.ts
+++ b/services/platform/convex/audit_logs/schema.ts
@@ -119,6 +119,16 @@ export const auditLogsTable = defineTable({
     'category',
     'timestamp',
   ])
+  // Dedup lookups that target a single actor (e.g. recordOrgSwitch's
+  // "did THIS user already sign in to THIS org recently?") — lets the query
+  // range on timestamp for one actor instead of scanning every actor's rows
+  // in the org+category+time window.
+  .index('by_org_category_actorId_timestamp', [
+    'organizationId',
+    'category',
+    'actorId',
+    'timestamp',
+  ])
   .index('by_org_resourceType_timestamp', [
     'organizationId',
     'resourceType',

--- a/services/platform/convex/lib/rls/organization/get_user_organizations.ts
+++ b/services/platform/convex/lib/rls/organization/get_user_organizations.ts
@@ -43,28 +43,44 @@ export async function getUserOrganizations(
   // Check if we're in trusted headers mode (role from JWT)
   const trustedData = await getTrustedAuthData(ctx);
 
-  // Query Better Auth's member table for all memberships
-  const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-    model: 'member',
-    paginationOpts: {
-      cursor: null,
-      numItems: 100, // Reasonable limit for user's organizations
-    },
-    where: [
-      {
-        field: 'userId',
-        value: authUser.userId ?? null,
-        operator: 'eq',
-      },
-    ],
-  });
+  // Query Better Auth's member table for ALL memberships, paginating until the
+  // adapter reports done. The previous single 100-item page silently dropped
+  // the tail for users in >100 orgs (and could strand the org switcher); most
+  // users fit in one page, so the common case is still a single round-trip.
+  const memberRows: OrganizationMember[] = [];
+  let cursor: string | null = null;
+  for (;;) {
+    // Explicit type breaks the otherwise-circular inference (result depends on
+    // `cursor`, which is reassigned from `result.continueCursor`).
+    const result: {
+      page: OrganizationMember[];
+      isDone?: boolean;
+      continueCursor?: string;
+    } = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+      model: 'member',
+      paginationOpts: { cursor, numItems: 100 },
+      where: [
+        {
+          field: 'userId',
+          value: authUser.userId ?? null,
+          operator: 'eq',
+        },
+      ],
+    });
+    if (!result || result.page.length === 0) break;
+    memberRows.push(...result.page);
+    // Stop on done, or if the cursor stops advancing (defensive against a
+    // non-terminating adapter response).
+    if (result.isDone || result.continueCursor === cursor) break;
+    cursor = result.continueCursor ?? null;
+  }
 
-  if (!result || result.page.length === 0) {
+  if (memberRows.length === 0) {
     return [];
   }
 
-  return result.page
-    .map((member: { organizationId: string; role?: string }) => {
+  return memberRows
+    .map((member) => {
       // Get role from trusted headers if available, otherwise from database
       const rawRole = trustedData?.trustedRole || member.role || 'member';
       const normalizedRole = rawRole.toLowerCase();

--- a/services/platform/convex/members/queries.test.ts
+++ b/services/platform/convex/members/queries.test.ts
@@ -460,9 +460,9 @@ describe('listByOrganizationHandler', () => {
       ],
     });
 
+    // Single batched user lookup (findMany with `in`) returns a page.
     ctx.runQuery.mockResolvedValueOnce({
-      name: 'Alice',
-      email: 'alice@example.com',
+      page: [{ _id: 'u_1', name: 'Alice', email: 'alice@example.com' }],
     });
 
     const result = await listByOrganizationHandler(ctx as unknown as QueryCtx, {
@@ -483,7 +483,7 @@ describe('listByOrganizationHandler', () => {
     ]);
   });
 
-  it('returns member without name/email when user lookup fails', async () => {
+  it('returns member without name/email when its user is absent from the batch lookup', async () => {
     mockedGetAuthUser.mockResolvedValue({ userId: 'user_1' });
     mockedGetOrgMember.mockResolvedValue({
       _id: 'om_1',
@@ -513,9 +513,11 @@ describe('listByOrganizationHandler', () => {
       ],
     });
 
-    ctx.runQuery
-      .mockRejectedValueOnce(new Error('lookup failed'))
-      .mockResolvedValueOnce({ name: 'Bob', email: 'bob@example.com' });
+    // Batched user lookup returns only u_2 — u_1 is missing, so m_1 gets no
+    // user details while m_2 is enriched.
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'u_2', name: 'Bob', email: 'bob@example.com' }],
+    });
 
     const result = await listByOrganizationHandler(ctx as unknown as QueryCtx, {
       organizationId: 'org_1',

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -1,7 +1,6 @@
 import { v } from 'convex/values';
 
 import type { MemberRole } from '../../lib/shared/schemas/organizations';
-import { getString, isRecord } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { query, QueryCtx } from '../_generated/server';
 import {
@@ -11,7 +10,12 @@ import {
 } from '../lib/rls';
 import { UnauthorizedError } from '../lib/rls/errors';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
-import type { BetterAuthFindManyResult, BetterAuthMember } from './types';
+import type {
+  BetterAuthFindManyResult,
+  BetterAuthMember,
+  BetterAuthOrganization,
+  BetterAuthUser,
+} from './types';
 import { memberRoleValidator } from './validators';
 
 interface BetterAuthTeam {
@@ -144,46 +148,41 @@ export async function listByOrganizationHandler(
     return [];
   }
 
-  return Promise.all(
-    result.page.map(async (member) => {
-      let displayName: string | undefined;
-      let email: string | undefined;
-      let twoFactorEnabled = false;
-      try {
-        const userResult = await ctx.runQuery(
-          components.betterAuth.adapter.findOne,
-          {
-            model: 'user',
-            where: [{ field: '_id', value: member.userId, operator: 'eq' }],
-          },
-        );
-        displayName = userResult?.name;
-        email = userResult?.email;
-        twoFactorEnabled = userResult?.twoFactorEnabled === true;
-      } catch (error) {
-        console.warn(
-          '[Members] Failed to fetch user details',
-          member.userId,
-          error,
-        );
+  // Batch-fetch every member's user record in ONE `in` query + a Map join,
+  // replacing the previous findOne-per-member N+1.
+  const userIds = [...new Set(result.page.map((member) => member.userId))];
+  const usersById = new Map<string, BetterAuthUser>();
+  if (userIds.length > 0) {
+    try {
+      const usersResult: BetterAuthFindManyResult<BetterAuthUser> =
+        await ctx.runQuery(components.betterAuth.adapter.findMany, {
+          model: 'user',
+          paginationOpts: { cursor: null, numItems: userIds.length },
+          where: [{ field: '_id', value: userIds, operator: 'in' }],
+        });
+      for (const user of usersResult?.page ?? []) {
+        usersById.set(user._id, user);
       }
+    } catch (error) {
+      console.warn('[Members] Failed to batch-fetch user details', error);
+    }
+  }
 
-      const role: MemberRole = isValidRole(member.role)
-        ? member.role
-        : 'member';
+  return result.page.map((member) => {
+    const user = usersById.get(member.userId);
+    const role: MemberRole = isValidRole(member.role) ? member.role : 'member';
 
-      return {
-        _id: member._id,
-        organizationId: member.organizationId,
-        userId: member.userId,
-        role,
-        createdAt: member.createdAt,
-        displayName,
-        email,
-        twoFactorEnabled,
-      };
-    }),
-  );
+    return {
+      _id: member._id,
+      organizationId: member.organizationId,
+      userId: member.userId,
+      role,
+      createdAt: member.createdAt,
+      displayName: user?.name,
+      email: user?.email,
+      twoFactorEnabled: user?.twoFactorEnabled === true,
+    };
+  });
 }
 
 export const listByOrganization = query({
@@ -268,27 +267,35 @@ export const getUserOrganizationsWithDetails = query({
 
     const orgs = await getUserOrganizations(ctx, authUser);
 
-    const enriched = await Promise.all(
-      orgs.map(async (o) => {
-        const org = await ctx.runQuery(components.betterAuth.adapter.findOne, {
-          model: 'organization',
-          where: [{ field: '_id', value: o.organizationId, operator: 'eq' }],
-        });
-        const record = isRecord(org) ? org : undefined;
-        const name = record
-          ? (getString(record, 'name') ?? o.organizationId)
-          : o.organizationId;
-        const slug = record ? getString(record, 'slug') : undefined;
-        return {
-          organizationId: o.organizationId,
-          role: o.role,
-          name,
-          slug,
-        };
-      }),
-    );
+    // Batch-fetch every org record in ONE `in` query + a Map join, replacing
+    // the previous findOne-per-org N+1.
+    const orgIds = [...new Set(orgs.map((o) => o.organizationId))];
+    const orgsById = new Map<string, BetterAuthOrganization>();
+    if (orgIds.length > 0) {
+      try {
+        const orgsResult: BetterAuthFindManyResult<BetterAuthOrganization> =
+          await ctx.runQuery(components.betterAuth.adapter.findMany, {
+            model: 'organization',
+            paginationOpts: { cursor: null, numItems: orgIds.length },
+            where: [{ field: '_id', value: orgIds, operator: 'in' }],
+          });
+        for (const org of orgsResult?.page ?? []) {
+          orgsById.set(org._id, org);
+        }
+      } catch (error) {
+        console.warn('[Members] Failed to batch-fetch org details', error);
+      }
+    }
 
-    return enriched;
+    return orgs.map((o) => {
+      const org = orgsById.get(o.organizationId);
+      return {
+        organizationId: o.organizationId,
+        role: o.role,
+        name: org?.name ?? o.organizationId,
+        slug: org?.slug,
+      };
+    });
   },
 });
 

--- a/services/platform/convex/organizations/record_org_switch.test.ts
+++ b/services/platform/convex/organizations/record_org_switch.test.ts
@@ -55,14 +55,43 @@ type AuditEntry = {
 };
 
 function createMockCtx(recentEntries: AuditEntry[] = []) {
+  // The handler now scopes the dedup scan via the
+  // `by_org_category_actorId_timestamp` index (eq actorId + gte timestamp) and
+  // no longer filters actorId in JS. Simulate that here: capture the bounds the
+  // handler builds in its index callback and only yield matching entries, the
+  // way the real index would.
+  let filterActorId: string | undefined;
+  let cutoff = Number.NEGATIVE_INFINITY;
+
   const order = vi.fn().mockImplementation(() => ({
     [Symbol.asyncIterator]: async function* () {
       for (const entry of recentEntries) {
+        if (filterActorId !== undefined && entry.actorId !== filterActorId) {
+          continue;
+        }
+        if (entry.timestamp < cutoff) continue;
         yield entry;
       }
     },
   }));
-  const withIndex = vi.fn().mockReturnValue({ order });
+  const withIndex = vi
+    .fn()
+    .mockImplementation((_name: string, fn?: (q: unknown) => unknown) => {
+      if (typeof fn === 'function') {
+        const q = {
+          eq: (field: string, value: unknown) => {
+            if (field === 'actorId') filterActorId = value as string;
+            return q;
+          },
+          gte: (_field: string, value: number) => {
+            cutoff = value;
+            return q;
+          },
+        };
+        fn(q);
+      }
+      return { order };
+    });
   const query = vi.fn().mockReturnValue({ withIndex });
 
   return {
@@ -202,7 +231,7 @@ describe('recordOrgSwitch', () => {
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('queries by_org_category_timestamp scoped to last 30 minutes', async () => {
+  it('queries by_org_category_actorId_timestamp scoped to this user + last 30 minutes', async () => {
     const ctx = createMockCtx([]);
     const handler = await getHandler();
     const before = Date.now();
@@ -211,7 +240,7 @@ describe('recordOrgSwitch', () => {
 
     expect(ctx._builders.query).toHaveBeenCalledWith('auditLogs');
     expect(ctx._builders.withIndex).toHaveBeenCalledWith(
-      'by_org_category_timestamp',
+      'by_org_category_actorId_timestamp',
       expect.any(Function),
     );
     expect(ctx._builders.order).toHaveBeenCalledWith('desc');
@@ -225,6 +254,7 @@ describe('recordOrgSwitch', () => {
 
     expect(eq).toHaveBeenNthCalledWith(1, 'organizationId', 'org_1');
     expect(eq).toHaveBeenNthCalledWith(2, 'category', 'auth');
+    expect(eq).toHaveBeenNthCalledWith(3, 'actorId', 'user_1');
     expect(gte).toHaveBeenCalledTimes(1);
     const cutoff = gte.mock.calls[0][1] as number;
     expect(cutoff).toBeGreaterThanOrEqual(before - 30 * 60 * 1000);

--- a/services/platform/convex/organizations/record_org_switch.ts
+++ b/services/platform/convex/organizations/record_org_switch.ts
@@ -53,20 +53,24 @@ export const recordOrgSwitch = mutation({
     const actorId = String(authUser._id);
     const cutoff = Date.now() - DEDUP_WINDOW_MS;
     let hasRecentEntry = false;
+    // Scope the scan to THIS actor via the actorId index, so we walk only this
+    // user's recent auth entries (typically 0-1 in the window) instead of every
+    // actor's. The action check stays in JS — the matching set per actor is
+    // tiny, not worth another index column.
     for await (const entry of ctx.db
       .query('auditLogs')
-      .withIndex('by_org_category_timestamp', (q) =>
+      .withIndex('by_org_category_actorId_timestamp', (q) =>
         q
           .eq('organizationId', args.organizationId)
           .eq('category', 'auth')
+          .eq('actorId', actorId)
           .gte('timestamp', cutoff),
       )
       .order('desc')) {
       if (
-        entry.actorId === actorId &&
         // TODO: drop `entered_organization` branch after demo data purge.
-        (entry.action === 'signed_in_to_organization' ||
-          entry.action === 'entered_organization')
+        entry.action === 'signed_in_to_organization' ||
+        entry.action === 'entered_organization'
       ) {
         hasRecentEntry = true;
         break;

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -262,6 +262,66 @@ export const getThreadProject = query({
   },
 });
 
+/**
+ * Consolidated per-thread metadata for the chat surface: project, fork info,
+ * live generation status, and failed-message error strings — all behind a
+ * SINGLE canAccessThread check. ChatInterface + useMessageProcessing read this
+ * one query instead of four separate subscriptions (getThreadProject,
+ * getThreadForkInfo, isThreadGenerating, getFailedMessageErrors), each of which
+ * independently re-ran the access check on every thread switch. Returns null
+ * when the thread is inaccessible. (Arena split view and the automations chat
+ * still use the granular queries directly.)
+ */
+export const getThreadMeta = query({
+  args: { threadId: v.string() },
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return null;
+
+    const metadata = await canAccessThread(ctx, args.threadId, authUser);
+    if (!metadata) return null;
+
+    // Live generation status (mirrors isThreadGenerating, incl. stale guard).
+    let isGenerating = false;
+    if (metadata.generationStatus === 'generating') {
+      isGenerating =
+        !metadata.generationStartTime ||
+        Date.now() - metadata.generationStartTime <=
+          GENERATION_STALE_THRESHOLD_MS;
+    }
+
+    // Fork info — owner-only, forked threads only (mirrors getThreadForkInfo).
+    const forkInfo =
+      metadata.userId === authUser.userId && metadata.forkedFrom
+        ? {
+            forkedFrom: metadata.forkedFrom,
+            forkedFromShare: metadata.forkedFromShare ?? false,
+            forkedMessageCount: metadata.forkedMessageCount ?? null,
+            lastForkedMessageOrder: metadata.lastForkedMessageOrder ?? null,
+            forkedAt: metadata.forkedAt ?? null,
+          }
+        : null;
+
+    // Failed-message error strings (mirrors getFailedMessageErrors).
+    const failedResult = await listMessages(ctx, components.agent, {
+      threadId: args.threadId,
+      paginationOpts: { cursor: null, numItems: 10 },
+      statuses: ['failed'],
+    });
+    const failedErrors: Record<string, string> = {};
+    for (const msg of failedResult.page) {
+      if (msg.error) failedErrors[msg._id] = msg.error;
+    }
+
+    return {
+      projectId: metadata.projectId ?? null,
+      isGenerating,
+      forkInfo,
+      failedErrors,
+    };
+  },
+});
+
 export { getSharedThread } from './get_shared_thread';
 
 export const getThreadBranches = query({

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -274,6 +274,24 @@ export const getThreadProject = query({
  */
 export const getThreadMeta = query({
   args: { threadId: v.string() },
+  returns: v.union(
+    v.null(),
+    v.object({
+      projectId: v.union(v.id('projects'), v.null()),
+      isGenerating: v.boolean(),
+      forkInfo: v.union(
+        v.null(),
+        v.object({
+          forkedFrom: v.string(),
+          forkedFromShare: v.boolean(),
+          forkedMessageCount: v.union(v.number(), v.null()),
+          lastForkedMessageOrder: v.union(v.number(), v.null()),
+          forkedAt: v.union(v.number(), v.null()),
+        }),
+      ),
+      failedErrors: v.record(v.string(), v.string()),
+    }),
+  ),
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return null;


### PR DESCRIPTION
## Context

Switching chats, switching orgs, and flipping setting toggles were all noticeably slow. A focused investigation traced this to per-switch subscription churn, a serial org-switch waterfall, server-side N+1/unindexed queries, and toggles missing optimistic updates. This PR addresses all three symptoms.

## Chat switch
- **Consolidated four per-thread queries into one `getThreadMeta`** (`getThreadProject` + `getThreadForkInfo` + `isThreadGenerating` + `getFailedMessageErrors`) behind a **single `canAccessThread`** check. `ChatInterface` and `useMessageProcessing` read it with identical args → one shared subscription per switch instead of four (each previously re-ran the access check). Granular queries kept for arena/automations.
- **Deduped the `getThreadStatus` subscription** — `ThreadGate` passes the resolved status to `ChatInterface` instead of a second identical sub.
- **Removed the branch-context double render** — persisted branch selections are parsed in a `useMemo` (overlaid with session overrides) instead of seeded via `useEffect`+`setState`, which churned `activeBranchThreadId` (and thus every chat subscription) twice per switch.
- **Hover/intent preload** on chat-history rows so the click isn't a cold chunk+loader fetch.
- **Memoized** `ChatMessages` (+ stabilized its two inline-arrow props), `ModelSelector`, `AgentSelector`, `BranchNavigator`; **hoisted** the duplicated `VoiceOutputProvider` to a single lifecycle.

## Org switch
- **`recordOrgSwitch` now fires in the background** (off the spinner-visible critical path); dropped the redundant `invalidateQueries`-then-`refetchQueries`.
- **Indexed the audit dedup scan** (`by_org_category_actorId_timestamp`) so it scans 0-1 rows instead of 50-200.
- **Batched the member/org N+1** — `getUserOrganizationsWithDetails` and `listByOrganization` do one `in` query + Map join instead of a `findOne` per row.
- **Fully paginate `getUserOrganizations`** (was a single 100-item page that silently dropped the tail and could strand the switcher).
- **Evict stale cross-org Convex queries** on switch; **2s timeout guard** on the dashboard loader so a slow membership read can't hang the transition.

## Value toggles
- Added `optimisticUpdate` to the **custom-instructions, memories, and voice-output** preference toggles (voice output migrated off raw `useMutation`) so the switch flips instantly instead of waiting on the round-trip.

## Deferred (measure-gated)
Per the plan, the structural render refactors (full memoized `MessageRow` extraction, `ChatLayoutContext` split, per-thread scroll restore) are deferred: `MessageBubble` already has a field-based memo so the expensive markdown path is protected; `ChatLayoutContext` holds no per-keystroke state; and scroll restore needs cursor-resume + real-browser validation against `useChatScroll`.

## Deploy note
The new `auditLogs` index (`by_org_category_actorId_timestamp`) must be built by a **Convex deploy** before `record_org_switch` runs against it.

## Verification
- `tsc --noEmit` (platform) ✅, `oxlint --type-aware` ✅, `oxfmt --check` ✅
- Targeted suites pass: `use-message-processing` (49), `record_org_switch` (10, mock updated for the new index), `chat-messages`/`model-selector`/`agent-selector`/`chat-header` (27), `audit_logs` (14), `optimistic-updates` (13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimistic UI updates for voice output and custom instructions toggle settings.

* **Bug Fixes**
  * Fixed organization membership display for users with more than 100 memberships.

* **Performance**
  * Optimized route preloading and consolidated thread metadata queries for faster chat interface loading.
  * Improved query efficiency by eliminating N+1 database calls for member and organization lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->