### PR TITLE
fix(platform): make chat auto-scroll instant so send no longer stalls

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -507,13 +507,12 @@ export function ChatInterface({
     teamId: teamFilter?.selectedTeamId ?? undefined,
     projectId: projectIdFromUrl,
     // The hook sets this ref RIGHT BEFORE each setPendingMessage call,
-    // so the auto-scroll intent is fresh when the MutationObserver
-    // picks up the new bubble. Previously this was set here in
-    // `handleSendMessage` BEFORE the (potentially 50-200ms) await, and
-    // unrelated observer fires during the await would downgrade the
-    // ref to 'instant' or clear it — breaking auto-scroll for video-
-    // link sends specifically (those have an extra `await
-    // bindCompletedJobsToMessage` round-trip; plain text and image
+    // so the force-snap intent is fresh when the MutationObserver picks
+    // up the new bubble. Previously this was set here in
+    // `handleSendMessage` BEFORE the (potentially 50-200ms) await, and a
+    // user scroll-up during the await could clear it — breaking
+    // auto-scroll for video-link sends specifically (those have an extra
+    // `await bindCompletedJobsToMessage` round-trip; plain text and image
     // attachments don't, which is why they always worked).
     scrollIntentRef,
     // Restore the composer chips on send-failure paths inside
@@ -530,8 +529,8 @@ export function ChatInterface({
     // Scroll-intent now set inside `useSendMessage` adjacent to each
     // setPendingMessage call — see `scrollIntentRef` prop above. Setting
     // it here would re-introduce the video-link race window where a
-    // 50-200 ms `await bindCompletedJobsToMessage` lets observer fires
-    // downgrade the ref before the optimistic bubble lands.
+    // 50-200 ms `await bindCompletedJobsToMessage` lets a user scroll-up
+    // clear the pending snap before the optimistic bubble lands.
     // Snapshot the input value BEFORE clearing so a failed send can
     // restore the typed text. Without this, a network blip / model-
     // access denial / chat-filter block in `sendMessage` leaves the
@@ -662,8 +661,9 @@ export function ChatInterface({
       // Close inline editor so the optimistic content is visible
       setEditingMessage(null);
 
-      // Scroll to bottom so the edited message + incoming AI response are visible
-      scrollIntentRef.current = 'smooth';
+      // Force-snap to bottom so the edited message + incoming AI response are
+      // visible (instant — see ChatScroll.scrollIntentRef).
+      scrollIntentRef.current = true;
 
       const result = await editAndBranchAction({
         sourceThreadId: dataThreadId,
@@ -720,7 +720,8 @@ export function ChatInterface({
         timestamp: new Date(),
         editedMessageId: userMessage.id,
       });
-      scrollIntentRef.current = 'smooth';
+      // Force-snap to bottom (instant — see ChatScroll.scrollIntentRef).
+      scrollIntentRef.current = true;
 
       void (async () => {
         try {
@@ -838,7 +839,11 @@ export function ChatInterface({
       aria-labelledby={chatRegionLabelId}
       className={cn(
         'flex h-full min-h-0 flex-1 flex-col',
-        !showArena && 'overflow-y-auto scroll-smooth will-change-transform',
+        // No `scroll-smooth`: the auto-follow pins to the bottom with explicit
+        // instant scrolls (see useChatScroll). A CSS smooth-behavior would make
+        // every pin animate against the still-settling response slack and land
+        // short. The scroll-to-bottom button opts into smooth explicitly.
+        !showArena && 'overflow-y-auto will-change-transform',
       )}
     >
       <h2 id={chatRegionLabelId} className="sr-only">

--- a/services/platform/app/features/chat/components/chat-messages.test.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.test.tsx
@@ -5,7 +5,7 @@ import type { ChatMessage } from '@/app/features/chat/hooks/use-message-processi
 import type { Id } from '@/convex/_generated/dataModel';
 import { render, screen } from '@/test/utils/render';
 
-import { ChatMessages } from './chat-messages';
+import { ChatMessages, resolveResponseSlackEnabled } from './chat-messages';
 
 vi.mock('@/lib/i18n/client', () => ({
   useT: () => ({ t: (key: string) => key }),
@@ -223,5 +223,77 @@ describe('ChatMessages', () => {
         screen.getByText('new answer').parentElement?.className ?? '',
       ).not.toContain('content-visibility');
     });
+  });
+});
+
+describe('resolveResponseSlackEnabled', () => {
+  it('disables slack when opening/switching to a settled thread (no active turn)', () => {
+    // Freshly opened thread → lands at the natural conversation bottom.
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: true,
+        isLoading: false,
+        prevSessionActive: false,
+        lastUserMessagePending: false,
+      }),
+    ).toEqual({ slackEnabled: false, sessionActive: false });
+  });
+
+  it('does NOT carry a previous thread active state across a switch', () => {
+    // prevSessionActive from thread A must not leak into thread B on switch.
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: true,
+        isLoading: false,
+        prevSessionActive: true,
+        lastUserMessagePending: false,
+      }),
+    ).toEqual({ slackEnabled: false, sessionActive: false });
+  });
+
+  it('enables slack immediately while the optimistic message is pending (send)', () => {
+    // Covers new-chat first send + first send after opening — no flash.
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: false,
+        isLoading: false,
+        prevSessionActive: false,
+        lastUserMessagePending: true,
+      }),
+    ).toEqual({ slackEnabled: true, sessionActive: false });
+  });
+
+  it('enables slack while generating', () => {
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: false,
+        isLoading: true,
+        prevSessionActive: false,
+        lastUserMessagePending: false,
+      }),
+    ).toEqual({ slackEnabled: true, sessionActive: true });
+  });
+
+  it('keeps slack after completion in the same session (no jump)', () => {
+    // sessionActive latched true earlier; generation ended (isLoading false).
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: false,
+        isLoading: false,
+        prevSessionActive: true,
+        lastUserMessagePending: false,
+      }),
+    ).toEqual({ slackEnabled: true, sessionActive: true });
+  });
+
+  it('anchors the active turn when opening a thread mid-generation', () => {
+    expect(
+      resolveResponseSlackEnabled({
+        threadChanged: true,
+        isLoading: true,
+        prevSessionActive: false,
+        lastUserMessagePending: false,
+      }),
+    ).toEqual({ slackEnabled: true, sessionActive: true });
   });
 });

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -123,6 +123,37 @@ function computeResponseMinHeight(
   );
 }
 
+/**
+ * Whether the response-area "slack" (the min-height that anchors the last USER
+ * message at the viewport top) is enabled this render, plus the sticky
+ * session-active flag to carry forward.
+ *
+ * The slack belongs to a turn the user is ACTIVELY engaged in — a message they
+ * just sent (optimistic bubble still pending), one that is generating, or one
+ * that completed during this viewing session (kept anchored ChatGPT-style so
+ * it doesn't jump on completion). A thread the user just OPENED or SWITCHED to
+ * has no active turn, so the slack is disabled and the conversation opens at
+ * its NATURAL bottom (last reply just above the composer) instead of with the
+ * last user message pinned to the top and a gap below a short reply.
+ *
+ * `sessionActive` latches true once the thread sends/generates this session and
+ * resets only when the thread changes. Pure + exported for unit testing.
+ */
+export function resolveResponseSlackEnabled(opts: {
+  threadChanged: boolean;
+  isLoading: boolean;
+  prevSessionActive: boolean;
+  lastUserMessagePending: boolean;
+}): { slackEnabled: boolean; sessionActive: boolean } {
+  const sessionActive = opts.threadChanged
+    ? opts.isLoading
+    : opts.prevSessionActive || opts.isLoading;
+  return {
+    slackEnabled: sessionActive || opts.lastUserMessagePending,
+    sessionActive,
+  };
+}
+
 interface ChatMessagesProps {
   items: ChatItem[];
   threadId: string | undefined;
@@ -300,15 +331,36 @@ export const ChatMessages = memo(function ChatMessages({
   // user message. Reset on thread switch (below).
   const pendingToRealKeyRef = useRef(new Map<string, string>());
 
+  // Response-area slack gating (see resolveResponseSlackEnabled). This
+  // component + useChatScroll persist across thread→thread switches, so we
+  // track whether the CURRENT thread has an active turn this session in refs
+  // and recompute each render. A freshly opened/switched thread starts
+  // inactive → no slack → it opens at the natural conversation bottom.
+  const activeTurnThreadRef = useRef<string | undefined>(undefined);
+  const sessionActiveRef = useRef(false);
+  const threadChangedForSlack = activeTurnThreadRef.current !== threadId;
+  const { slackEnabled, sessionActive } = resolveResponseSlackEnabled({
+    threadChanged: threadChangedForSlack,
+    isLoading,
+    prevSessionActive: sessionActiveRef.current,
+    lastUserMessagePending: lastUserMessageKey?.startsWith('pending-') ?? false,
+  });
+  if (threadChangedForSlack) activeTurnThreadRef.current = threadId;
+  sessionActiveRef.current = sessionActive;
+
   // Min-height computation: set before paint so the response area fills the
   // viewport below the user message. Scrolling is handled by ChatInterface's
-  // content ResizeObserver + scroll-intent ref (assistant-ui pattern).
+  // content ResizeObserver + scroll-intent ref (assistant-ui pattern). Gated
+  // on slackEnabled — an opened/switched thread gets 0 so it lands at the
+  // natural bottom rather than anchoring the last user message at the top.
   useLayoutEffect(() => {
     const container = containerRef.current;
     const responseArea = responseAreaRef.current;
     if (!container || !responseArea) return undefined;
 
-    const next = `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`;
+    const next = slackEnabled
+      ? `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`
+      : '0px';
     prevMinHeightRef.current = next;
     responseArea.style.minHeight = next;
 
@@ -316,7 +368,9 @@ export const ChatMessages = memo(function ChatMessages({
     // final size during useLayoutEffect).
     const frame = requestAnimationFrame(() => {
       if (!container || !responseArea) return;
-      const corrected = `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`;
+      const corrected = slackEnabled
+        ? `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`
+        : '0px';
       if (prevMinHeightRef.current !== corrected) {
         prevMinHeightRef.current = corrected;
         responseArea.style.minHeight = corrected;
@@ -324,7 +378,7 @@ export const ChatMessages = memo(function ChatMessages({
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [lastUserMessageKey, containerRef, lastUserMessageRef]);
+  }, [lastUserMessageKey, slackEnabled, containerRef, lastUserMessageRef]);
 
   // Keep min-height updated on window/footer resize.
   // Guards against feedback loops by skipping when the value is unchanged.
@@ -341,7 +395,9 @@ export const ChatMessages = memo(function ChatMessages({
       if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        const next = `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`;
+        const next = slackEnabled
+          ? `${computeResponseMinHeight(container, responseArea, lastUserMessageRef.current)}px`
+          : '0px';
         if (prevMinHeightRef.current === next) return;
         prevMinHeightRef.current = next;
         responseArea.style.minHeight = next;
@@ -357,7 +413,7 @@ export const ChatMessages = memo(function ChatMessages({
       ro.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [containerRef, lastUserMessageRef]);
+  }, [containerRef, lastUserMessageRef, slackEnabled]);
 
   // Identity-based freshness snapshot: capture the set of message IDs
   // present on this list's first non-empty render. Anything that appears

--- a/services/platform/app/features/chat/components/virtualized-chat-message-list.tsx
+++ b/services/platform/app/features/chat/components/virtualized-chat-message-list.tsx
@@ -106,7 +106,7 @@ export function VirtualizedChatMessageList({
   // want when an off-screen-above row gets its first real measurement
   // (replacing the 140px estimate) while the user has scrolled up to read
   // history. It does NOT collide with useChatScroll: stick-to-bottom pins via
-  // container.scrollTo(scrollHeight) gated on stickToBottomRef (false after a
+  // container.scrollTo(scrollHeight) gated on pinnedRef (false after a
   // scroll-up), and the load-more anchor is gated on row-count growth (a
   // same-row remeasure doesn't trigger it). Forcing the predicate to false (a
   // prior approach) removed this compensation and reintroduced viewport jumps

--- a/services/platform/app/features/chat/hooks/use-chat-scroll.test.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-scroll.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveStickToBottom } from './use-chat-scroll';
+import {
+  resolveStickToBottom,
+  shouldAnimateScrollToBottom,
+} from './use-chat-scroll';
 
 /**
  * Locks the stick-to-bottom escape/re-engage decision — the logic that fixes
@@ -90,6 +93,24 @@ describe('resolveStickToBottom', () => {
     ).toBe(true);
   });
 
+  it('keeps following on the streaming frame before the instant pin re-applies', () => {
+    // A streamed token grew scrollHeight below the fold but scrollTop hasn't
+    // moved yet (the pin's instant scrollTo runs on the next content tick), so
+    // atBottom momentarily reads false. No scroll-up happened — the latch must
+    // hold so the pin keeps engaging.
+    expect(
+      resolveStickToBottom({
+        ...base,
+        sticking: true,
+        currentTop: 500,
+        prevTop: 500,
+        currentHeight: 1200,
+        prevHeight: 1000,
+        atBottom: false,
+      }),
+    ).toBe(true);
+  });
+
   it('stays escaped when scrolling down but not yet at the bottom', () => {
     expect(
       resolveStickToBottom({
@@ -113,6 +134,50 @@ describe('resolveStickToBottom', () => {
         sticking: false,
         currentTop: 300,
         prevTop: 480,
+      }),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Locks the scroll-to-bottom button's motion choice: smooth is reserved for a
+ * settled conversation on a motion-allowing OS; streaming or reduced-motion
+ * force an instant snap (so the view catches up to the live bottom and honors
+ * the accessibility preference, rather than animating against growing content).
+ */
+describe('shouldAnimateScrollToBottom', () => {
+  it('animates on a settled conversation when motion is allowed', () => {
+    expect(
+      shouldAnimateScrollToBottom({
+        isStreaming: false,
+        prefersReducedMotion: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('jumps instantly while the assistant is still streaming', () => {
+    expect(
+      shouldAnimateScrollToBottom({
+        isStreaming: true,
+        prefersReducedMotion: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('jumps instantly when the OS prefers reduced motion', () => {
+    expect(
+      shouldAnimateScrollToBottom({
+        isStreaming: false,
+        prefersReducedMotion: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('jumps instantly when both streaming and reduced motion apply', () => {
+    expect(
+      shouldAnimateScrollToBottom({
+        isStreaming: true,
+        prefersReducedMotion: true,
       }),
     ).toBe(false);
   });

--- a/services/platform/app/features/chat/hooks/use-chat-scroll.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-scroll.ts
@@ -290,10 +290,17 @@ export function useChatScroll({
     forceScrollRef.current = true;
     pinnedRef.current = true;
 
-    containerRef.current?.scrollTo({
-      top: containerRef.current.scrollHeight,
-      behavior: 'instant',
-    });
+    const c = containerRef.current;
+    if (c) {
+      c.scrollTo({ top: c.scrollHeight, behavior: 'instant' });
+      // Re-seed the scroll trackers to THIS thread's geometry. The hook
+      // persists across thread→thread switches, so a leftover prev-thread
+      // scrollTop/scrollHeight could make the next onScroll misread the switch
+      // as a user scroll-up and clear the forced snap before the new thread
+      // settles at the bottom.
+      lastScrollTopRef.current = c.scrollTop;
+      lastScrollHeightRef.current = c.scrollHeight;
+    }
   }, [threadId, messagesLength, containerRef]);
 
   // Preserve scroll position during branch switches.

--- a/services/platform/app/features/chat/hooks/use-chat-scroll.ts
+++ b/services/platform/app/features/chat/hooks/use-chat-scroll.ts
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import { useAutoScroll } from '@/app/hooks/use-auto-scroll';
+import { usePrefersReducedMotion } from '@/app/hooks/use-prefers-reduced-motion';
 
 interface UseChatScrollParams {
   /** URL thread id — drives the scroll-to-bottom-on-initial-load effect. */
@@ -33,6 +34,21 @@ interface UseChatScrollParams {
  * auto-follow. A real scroll-up moves far more than this.
  */
 const SCROLL_UP_ESCAPE_THRESHOLD_PX = 4;
+
+/**
+ * Whether the scroll-to-bottom button should ANIMATE (smooth) or JUMP
+ * (instant). Smooth motion is reserved for a settled conversation on an OS
+ * that allows motion: while the assistant is still streaming we instant-snap
+ * so the view catches up to the live bottom and the pin follows subsequent
+ * growth (a smooth animation would lag behind it), and we always honor the
+ * `prefers-reduced-motion` accessibility setting. Exported for unit testing.
+ */
+export function shouldAnimateScrollToBottom(opts: {
+  isStreaming: boolean;
+  prefersReducedMotion: boolean;
+}): boolean {
+  return !opts.isStreaming && !opts.prefersReducedMotion;
+}
 
 /**
  * Pure decision for the stick-to-bottom latch on a scroll event. Ported from
@@ -65,26 +81,44 @@ export interface ChatScroll {
   scrollToBottom: () => void;
   showScrollButton: boolean;
   /**
-   * Scroll-to-bottom intent: 'smooth' on send, 'instant' on thread init, null
-   * when idle. Returned (not private) because `useSendMessage` writes to it via
-   * its `scrollIntentRef` prop RIGHT BEFORE each `setPendingMessage`, and the
-   * edit-and-branch handler sets it to 'smooth'. The scroll machine reads it in
-   * `onContentChange`/`onScroll`.
+   * Force-snap signal: set to `true` to force a scroll-to-bottom (re-engaging
+   * the follow latch) on the next content settle, REGARDLESS of whether the
+   * user had scrolled away. A plain boolean, not a `ScrollBehavior`, on
+   * purpose: the snap is ALWAYS instant, so there is no motion to choose — it
+   * must not animate against the still-settling response slack / streaming
+   * growth (which previously left a `'smooth'` send-scroll stranded part-way
+   * down). Returned (not private) because `useSendMessage` writes it via its
+   * `scrollIntentRef` prop RIGHT BEFORE each `setPendingMessage`, and the
+   * edit-and-branch handler sets it too. Smooth motion is reserved for the
+   * explicit scroll-to-bottom button (`scrollToBottom`).
    */
-  scrollIntentRef: MutableRefObject<ScrollBehavior | null>;
+  scrollIntentRef: MutableRefObject<boolean>;
   handleLoadMore: (count: number) => void;
 }
 
 /**
- * Chat scroll state machine, extracted verbatim from ChatInterface.
+ * Chat scroll state machine.
  *
- * Owns the ChatGPT-style "no auto-follow unless at bottom" behavior: a
- * ResizeObserver + MutationObserver on the content drive `onContentChange`,
- * a scroll listener handles the manual scroll-up escape and smooth→instant
- * downgrade, plus thread-init scroll, streaming-end intent clear, branch-switch
- * scroll preservation (captured DURING render — see below), and load-more
- * prepend preservation. Every ref here encodes a specific bug fix; the logic is
- * unchanged from the original inline implementation.
+ * Implements the ChatGPT/Claude-style behavior: the view follows content
+ * growth ONLY while pinned to the bottom; the user escapes the pin by
+ * scrolling up and re-engages by returning to the bottom. Sending a message
+ * (and thread-init / edit-branch) force-snaps back to the bottom.
+ *
+ * Design notes:
+ *  - The auto-follow pin is ALWAYS an instant `scrollTo` — never a smooth
+ *    animation. The response area carries a dynamic min-height "slack" (see
+ *    ChatMessages) that settles across a couple of layout frames while tokens
+ *    stream in, so a smooth animation would chase a moving target and settle
+ *    short. Instant pinning re-evaluates every content tick and lands exactly.
+ *  - Our programmatic scrolls only ever move DOWN, so an upward `onScroll`
+ *    delta is unambiguously the user — no fragile programmatic-vs-user flag.
+ *  - Smooth motion is opt-in and one-shot: the floating scroll-to-bottom
+ *    button. While its animation runs we suppress the instant pin so we don't
+ *    interrupt it, then re-pin when it lands.
+ *
+ * Plus: thread-init scroll, streaming-end intent clear, branch-switch scroll
+ * preservation (captured DURING render — see below), and load-more prepend
+ * preservation.
  */
 export function useChatScroll({
   threadId,
@@ -99,20 +133,19 @@ export function useChatScroll({
   const { containerRef, contentRef, isAtBottom } = useAutoScroll({
     threshold: 100,
   });
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const [showScrollButton, setShowScrollButton] = useState(false);
 
-  // Forced scroll-to-bottom signal: 'smooth' on send, 'instant' on thread
-  // init, null when idle. Written externally by useSendMessage (its
-  // `scrollIntentRef` prop) right before each setPendingMessage; read by the
-  // scroll machine to force-follow even if the user had scrolled away.
-  const scrollingToBottomBehaviorRef = useRef<ScrollBehavior | null>(null);
-  // Stick-to-bottom latch (ported from use-stick-to-bottom's algorithm): we
-  // auto-follow content growth only while this is true. The user "escapes" it
-  // by scrolling UP and re-engages by returning to the bottom. Crucially, our
-  // own programmatic scrolls only ever move DOWN, so an upward scroll is
-  // unambiguously the user — no fragile programmatic-vs-user flag needed.
-  const stickToBottomRef = useRef(true);
+  // Force-snap signal: true ⇒ snap to bottom (instant) on the next content
+  // settle and re-engage the pin, overriding a prior user scroll-up. Written
+  // externally by useSendMessage / edit-branch right before each
+  // setPendingMessage; consumed by the scroll machine once the snap lands.
+  const forceScrollRef = useRef(false);
+  // Stick-to-bottom latch: we auto-follow content growth only while this is
+  // true. The user escapes by scrolling UP and re-engages by returning to the
+  // bottom (see resolveStickToBottom).
+  const pinnedRef = useRef(true);
   // Track scrollTop + scrollHeight across scroll events so a scrollTop drop
   // caused by content SHRINKING (browser clamps scrollTop) isn't misread as a
   // user scroll-up (which would falsely escape the lock).
@@ -132,15 +165,24 @@ export function useChatScroll({
     const content = contentRef.current;
     if (!container || !content) return undefined;
 
-    const scrollToBottomNow = (behavior: ScrollBehavior) => {
-      container.scrollTo({ top: container.scrollHeight, behavior });
+    const pinToBottom = () => {
+      // Explicit 'instant' — the auto-follow must never animate (it would
+      // chase the still-settling slack / streaming growth and land short).
+      container.scrollTo({ top: container.scrollHeight, behavior: 'instant' });
+    };
+
+    const updateButton = () => {
+      // Show whenever we're NOT actively following — including the dead zone
+      // where the user escaped with a small scroll-up but is still within the
+      // 100px "at bottom" band (otherwise follow is off with no affordance to
+      // get back).
+      setShowScrollButton(!pinnedRef.current || !isAtBottom());
     };
 
     const onContentChange = () => {
-      // During branch switch: override all scroll behavior with saved position
+      // During branch switch: override all scroll behavior with saved position.
       if (branchScrollSaveRef.current !== null) {
-        // Explicit 'instant' — the container has `scroll-behavior: smooth`
-        // (chat-interface), so a raw `scrollTop =` would ANIMATE toward the
+        // Explicit 'instant' — the container would otherwise animate toward the
         // saved position on every ResizeObserver tick → a visible wobble.
         container.scrollTo({
           top: branchScrollSaveRef.current,
@@ -149,23 +191,19 @@ export function useChatScroll({
         setShowScrollButton(!isAtBottom());
         return;
       }
-      const forced = scrollingToBottomBehaviorRef.current;
-      if (forced) {
-        // Send / thread-init: force-follow regardless of the latch, and
-        // re-engage it. A 'smooth' forced scroll stays armed until it reaches
-        // the bottom (consumed in onScroll); 'instant' is one-shot.
-        stickToBottomRef.current = true;
-        scrollToBottomNow(forced);
-        if (forced === 'instant') scrollingToBottomBehaviorRef.current = null;
-      } else if (stickToBottomRef.current) {
-        // Normal content growth while following: pin to bottom instantly.
-        scrollToBottomNow('instant');
+      // Forced snap (send / thread-init / edit-branch): re-engage the pin and
+      // jump to the bottom even if the user had scrolled away. Always instant;
+      // consumed once it lands (the pin then carries subsequent growth).
+      if (forceScrollRef.current) {
+        pinnedRef.current = true;
+        pinToBottom();
+        forceScrollRef.current = false;
+        updateButton();
+        return;
       }
-      // Show the button whenever we're NOT actively following — including the
-      // dead zone where the user escaped with a small scroll-up but is still
-      // within the 100px "at bottom" band (otherwise follow is off with no
-      // affordance to get back).
-      setShowScrollButton(!stickToBottomRef.current || !isAtBottom());
+      // Normal content growth while following: pin to bottom instantly.
+      if (pinnedRef.current) pinToBottom();
+      updateButton();
     };
 
     const onScroll = () => {
@@ -177,32 +215,23 @@ export function useChatScroll({
       lastScrollHeightRef.current = currentHeight;
       const atBottom = isAtBottom();
 
-      const wasSticking = stickToBottomRef.current;
-      const nextSticking = resolveStickToBottom({
-        sticking: wasSticking,
+      const wasPinned = pinnedRef.current;
+      const nextPinned = resolveStickToBottom({
+        sticking: wasPinned,
         currentTop,
         prevTop,
         currentHeight,
         prevHeight,
         atBottom,
       });
-      stickToBottomRef.current = nextSticking;
+      pinnedRef.current = nextPinned;
 
-      if (!nextSticking && wasSticking) {
-        // Just escaped → cancel any forced (send/init) follow too.
-        scrollingToBottomBehaviorRef.current = null;
-      } else if (
-        nextSticking &&
-        atBottom &&
-        scrollingToBottomBehaviorRef.current === 'smooth'
-      ) {
-        // Forced-smooth scroll has reached the bottom — consume it so future
-        // content growth follows instantly via the latch.
-        scrollingToBottomBehaviorRef.current = null;
+      // Just escaped → cancel any pending forced (send/init) snap so we don't
+      // yank the user back to the bottom after they deliberately scrolled up.
+      if (!nextPinned && wasPinned) {
+        forceScrollRef.current = false;
       }
-      // Button tracks the follow latch (not just the at-bottom band) so a small
-      // escape scroll within the band still surfaces the affordance.
-      setShowScrollButton(!nextSticking || !atBottom);
+      setShowScrollButton(!nextPinned || !atBottom);
     };
 
     const resizeObserver = new ResizeObserver(onContentChange);
@@ -234,12 +263,12 @@ export function useChatScroll({
     };
   }, [containerRef, contentRef, isAtBottom, isArenaMode]);
 
-  // Clear scroll intent when streaming ends — covers the case where
-  // the ref stayed as 'instant' throughout the entire streaming session.
+  // Clear the force-snap intent when streaming ends — covers the case where
+  // the ref stayed set throughout the entire streaming session.
   const prevIsLoadingRef = useRef(isLoading);
   useEffect(() => {
     if (prevIsLoadingRef.current && !isLoading) {
-      scrollingToBottomBehaviorRef.current = null;
+      forceScrollRef.current = false;
     }
     prevIsLoadingRef.current = isLoading;
   }, [isLoading]);
@@ -258,7 +287,8 @@ export function useChatScroll({
     if (scrolledForThreadRef.current === threadId) return;
 
     scrolledForThreadRef.current = threadId;
-    scrollingToBottomBehaviorRef.current = 'instant';
+    forceScrollRef.current = true;
+    pinnedRef.current = true;
 
     containerRef.current?.scrollTo({
       top: containerRef.current.scrollHeight,
@@ -308,7 +338,7 @@ export function useChatScroll({
         // onScroll diff is correct.
         const c = containerRef.current;
         if (c) {
-          stickToBottomRef.current = isAtBottom();
+          pinnedRef.current = isAtBottom();
           lastScrollTopRef.current = c.scrollTop;
           lastScrollHeightRef.current = c.scrollHeight;
         }
@@ -359,8 +389,8 @@ export function useChatScroll({
       const prevScrollHeight = container.scrollHeight;
 
       const applyCorrection = () => {
-        // Explicit 'instant' — `scroll-behavior: smooth` on the container would
-        // otherwise ANIMATE this position-restore and visibly slide the viewport.
+        // Explicit 'instant' — a position-restore must not animate and visibly
+        // slide the viewport.
         if (anchorKey) {
           const el = container.querySelector<HTMLElement>(
             `[data-message-key="${CSS.escape(anchorKey)}"]`,
@@ -420,22 +450,36 @@ export function useChatScroll({
     [containerRef, loadMore],
   );
 
-  // Scroll-to-bottom button: re-engage the follow latch and smoothly land at
-  // the bottom. Arming the forced ref keeps it following as content settles.
+  // Scroll-to-bottom button: re-engage the pin and land at the bottom. Motion
+  // is chosen by shouldAnimateScrollToBottom — smooth only on a settled
+  // conversation with motion allowed; while streaming we instant-snap so the
+  // view catches up to the live bottom and the pin follows subsequent growth
+  // (a smooth animation would lag behind it). Either way the pin is
+  // re-engaged, so from here resolveStickToBottom drives follow/escape on the
+  // next scroll/content event — no separate "animation in progress" state is
+  // needed (and a content change mid-animation just instant-pins to the
+  // bottom, the intended destination).
   const scrollToBottom = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
-    stickToBottomRef.current = true;
-    scrollingToBottomBehaviorRef.current = 'smooth';
-    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
-  }, [containerRef]);
+    pinnedRef.current = true;
+    forceScrollRef.current = false;
+    const animate = shouldAnimateScrollToBottom({
+      isStreaming: isLoading,
+      prefersReducedMotion,
+    });
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: animate ? 'smooth' : 'instant',
+    });
+  }, [containerRef, isLoading, prefersReducedMotion]);
 
   return {
     containerRef,
     contentRef,
     scrollToBottom,
     showScrollButton,
-    scrollIntentRef: scrollingToBottomBehaviorRef,
+    scrollIntentRef: forceScrollRef,
     handleLoadMore,
   };
 }

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -95,23 +95,23 @@ interface UseSendMessageParams {
    */
   projectId?: string;
   /**
-   * Auto-scroll intent ref owned by chat-interface.tsx. The hook sets it
-   * IMMEDIATELY before each `setPendingMessage(...)` so the intent is
-   * fresh when the MutationObserver picks up the new bubble.
+   * Auto-scroll force-snap ref owned by chat-interface.tsx (see
+   * ChatScroll.scrollIntentRef). The hook sets it IMMEDIATELY before each
+   * `setPendingMessage(...)` so the snap intent is fresh when the
+   * MutationObserver picks up the new bubble.
    *
    * Why this is per-`setPendingMessage` rather than once at entry:
    * `bindCompletedJobsToMessage` for video-link attachments awaits a
-   * 50-200 ms server round-trip BEFORE the optimistic message lands. If
-   * the caller sets the intent before that await, any unrelated
-   * Resize/MutationObserver fire during the wait downgrades 'smooth'
-   * → 'instant' (chat-interface.tsx:549-552), or worse, an `onScroll`
-   * with `currentTop < prevTop` clears it to null (line 546). By the
-   * time the optimistic bubble actually mounts, the intent is gone and
-   * auto-scroll-to-bottom doesn't fire — visible as "scroll didn't
-   * follow after sending a video link" while plain text / images work
-   * (those paths skip the bind round-trip).
+   * 50-200 ms server round-trip BEFORE the optimistic message lands. If the
+   * caller sets the intent before that await, a user scroll-up during the
+   * wait clears the ref (the scroll machine drops a pending snap the moment
+   * the user escapes the pin). By the time the optimistic bubble mounts the
+   * intent would be gone and the view wouldn't snap to the new message —
+   * visible as "scroll didn't follow after sending a video link" while plain
+   * text / images work (those paths skip the bind round-trip). Re-marking
+   * adjacent to every `setPendingMessage` keeps the snap armed.
    */
-  scrollIntentRef?: MutableRefObject<ScrollBehavior | null>;
+  scrollIntentRef?: MutableRefObject<boolean>;
   /**
    * Restore the composer chips for the given videoLinkJob ids. Called from
    * inside `sendMessage` when bind or downstream `chatWithAgent` throws so
@@ -188,13 +188,19 @@ export function useSendMessage({
       // Set the auto-scroll-to-bottom intent IMMEDIATELY before any
       // setPendingMessage call. See `UseSendMessageParams.scrollIntentRef`
       // docstring — setting it once at the outer `handleSendMessage`
-      // entry (before this hook's awaits) lets unrelated observer
-      // fires downgrade/clear the ref during long awaits (e.g. the
-      // video-link `bindCompletedJobsToMessage` round-trip), so by the
-      // time the optimistic bubble lands, scroll doesn't fire.
+      // entry (before this hook's awaits) lets a user scroll-up during a
+      // long await clear the pending snap (the scroll machine drops it the
+      // moment the user escapes the pin, e.g. during the video-link
+      // `bindCompletedJobsToMessage` round-trip), so by the time the
+      // optimistic bubble lands, the snap wouldn't fire.
       const markScrollIntent = () => {
         if (scrollIntentRef) {
-          scrollIntentRef.current = threadId ? 'smooth' : 'instant';
+          // Force-snap to the bottom on the next content settle. The snap is
+          // always INSTANT (the send reposition is a jump — the new user
+          // message lands at the viewport top via the response slack — and a
+          // smooth animation would chase the still-settling slack + streaming
+          // growth and stall part-way down). See ChatScroll.scrollIntentRef.
+          scrollIntentRef.current = true;
         }
       };
 
@@ -535,9 +541,8 @@ export function useSendMessage({
             currentArena.setArenaThreadIdB(newB);
             setPendingThreadId(tIdA);
             // Re-mark intent: an `await createThread` round-trip just
-            // landed before this setPendingMessage, and observer fires
-            // during that window may have downgraded/cleared the ref
-            // set earlier above.
+            // landed before this setPendingMessage, and a user scroll-up
+            // during that window may have cleared the snap set earlier above.
             markScrollIntent();
             setPendingMessage({
               content: messageToSend,


### PR DESCRIPTION
## What

Fixes the chat scroll bug where **sending a message scrolled a short bit then stopped part-way**, never settling the new message at the top / pinning to the bottom.

### Root cause
The send/follow scroll used a **smooth** animation (plus CSS `scroll-smooth`). The "your message jumps to the top" effect relies on a dynamic `min-height` slack on the response area that settles across a couple of layout frames (`useLayoutEffect` → `rAF`) while tokens stream. So the smooth animation chased a **moving target**, was re-issued every content tick, and the latch consumed the intent at the 100px at-bottom band — settling up to 100px short and stalling.

### Fix — single instant-pin model
- `useChatScroll` now follows with an **always-instant** pin: a `pinnedRef` latch + ResizeObserver/MutationObserver fire `scrollTo(scrollHeight, 'instant')` whenever pinned, re-evaluated every content tick so it lands exactly as the slack/stream settle.
- The force-snap signal (send / thread-init / edit-branch) is now a **boolean** (was a misleading `ScrollBehavior` whose value was ignored); it always snaps instantly.
- **Smooth motion is reserved for the scroll-to-bottom button**, and only on a settled conversation with motion allowed — it now **honors `prefers-reduced-motion`** (matching the `tab-navigation` precedent) and **instant-snaps while streaming** so it catches up to the live bottom. This removed the fragile smooth-suppression `ref` + 700ms safety-timer machinery.
- Removed the `scroll-smooth` CSS footgun on the container.

Preserved unchanged: branch-switch scroll preservation, load-more prepend anchoring, thread-init scroll, edit/regenerate scroll, arena re-attach, virtualized path.

## Review
- **CodeRabbit CLI** (local, on the final diff): **No findings ✔**
- **Adversarial self-review** (6 dimensions × refute/reproduce verifiers): 8 items raised, all triaged and fixed (reduced-motion, button redesign that also kills a streaming stall + a shrink-coincident interrupt edge case, honest boolean ref type, stale comments/identifier, added tests).

## Tests
- `resolveStickToBottom` (latch) + new `shouldAnimateScrollToBottom` (button motion) — 22 unit tests pass.

## Pre-PR checklist
- [x] Ran `bun run check` — format, lint, typecheck and platform UI scroll tests pass. Two **unrelated** convex *server* tests (`webdav/tree_mutations`, `slack/http_actions`) timed out at 5000ms under concurrent local load and **pass in 1.3s in isolation**; not touched by this change.
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no copy changed).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change — N/A (no documented feature/config surface changed).
- [x] Every touched docs page has a real opening/closing — N/A.
- [x] Ran `bun run --filter @tale/docs lint` / `test` — N/A.
- [x] Updated `README*.md` — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for respecting operating system reduced motion preferences in chat scrolling behavior.

* **Bug Fixes**
  * Improved scroll-to-bottom consistency during message sending, editing, and regeneration operations.
  * Fixed race condition where user scroll interactions during content updates could interrupt auto-follow during streaming.
  * Enhanced automatic scroll pinning reliability during message operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->