### PR TITLE
fix(platform): vite dep-optimizer 404s + tab underline alignment

### DIFF
--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -83,6 +83,10 @@ export function TabNavigation({
   // to the right while only the tabs scroll. All measurement/scroll logic reads
   // this element, so the <nav> itself needs no ref.
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // The <nav> owns the bottom border, so the active indicator is anchored to it
+  // (not to `scrollRef`) — see the indicator's JSX comment for why.
+  const navRef = useRef<HTMLElement | null>(null);
+  const indicatorRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 0, left: 0 });
   // Track if we should animate (only after initial render)
@@ -123,24 +127,33 @@ export function TabNavigation({
   // each cycle, and a parent that produces a fresh `items` array per render
   // would feed that cycle into a max-update-depth loop.
   const updateIndicator = useCallback(() => {
-    if (activeIndex !== -1 && itemRefs.current[activeIndex]) {
-      const activeElement = itemRefs.current[activeIndex];
-      if (activeElement) {
-        const nextWidth = activeElement.offsetWidth;
-        const nextLeft = activeElement.offsetLeft;
-        setIndicatorStyle((prev) =>
-          prev.width === nextWidth && prev.left === nextLeft
-            ? prev
-            : { width: nextWidth, left: nextLeft },
-        );
+    const navElement = navRef.current;
+    const activeElement =
+      activeIndex !== -1 ? itemRefs.current[activeIndex] : null;
+    if (navElement && activeElement) {
+      // Measure with bounding rects relative to the <nav>, not `offsetLeft`.
+      // The indicator now lives in the <nav> while the active tab lives in the
+      // horizontally-scrolling inner container, so they no longer share an
+      // offset parent. The tab's on-screen `left` already reflects the
+      // scroller's `scrollLeft`; subtracting the nav's `left` maps it into the
+      // indicator's containing block. (Assumes the <nav> has no horizontal
+      // padding/border — the component keeps `px-*` on the inner scroller.)
+      const navRect = navElement.getBoundingClientRect();
+      const itemRect = activeElement.getBoundingClientRect();
+      const nextWidth = itemRect.width;
+      const nextLeft = itemRect.left - navRect.left;
+      setIndicatorStyle((prev) =>
+        prev.width === nextWidth && prev.left === nextLeft
+          ? prev
+          : { width: nextWidth, left: nextLeft },
+      );
 
-        // Enable animations after first position is set
-        if (!hasInitialized.current) {
-          hasInitialized.current = true;
-          requestAnimationFrame(() => {
-            setShouldAnimate(true);
-          });
-        }
+      // Enable animations after first position is set
+      if (!hasInitialized.current) {
+        hasInitialized.current = true;
+        requestAnimationFrame(() => {
+          setShouldAnimate(true);
+        });
       }
     }
   }, [activeIndex]);
@@ -200,6 +213,34 @@ export function TabNavigation({
     });
   }, [activeIndex]);
 
+  // Keep the indicator pinned to the active tab while the strip scrolls
+  // horizontally. The indicator sits in the <nav> (so it can rest on the bottom
+  // border, which the overflow-clipped scroller can't reach), so unlike the old
+  // in-scroller indicator it does NOT move with the tabs for free — we
+  // re-measure on scroll. The slide transition is suppressed during the scroll
+  // so the underline tracks the tab 1:1 instead of lagging 200ms behind it, and
+  // restored once scrolling settles so tab switches still animate.
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return undefined;
+    let restoreTimer: ReturnType<typeof setTimeout> | undefined;
+    const onScroll = () => {
+      const indicator = indicatorRef.current;
+      if (indicator) indicator.style.transition = 'none';
+      updateIndicator();
+      if (restoreTimer) clearTimeout(restoreTimer);
+      restoreTimer = setTimeout(() => {
+        const settled = indicatorRef.current;
+        if (settled) settled.style.transition = '';
+      }, 150);
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+      if (restoreTimer) clearTimeout(restoreTimer);
+    };
+  }, [updateIndicator]);
+
   // Combine refs for resize observation. The scroll container's width drives
   // both the indicator measurement and the active-tab scroll-into-view.
   const allRefs = useMemo(() => {
@@ -218,6 +259,7 @@ export function TabNavigation({
 
   return (
     <nav
+      ref={navRef}
       className={cn(
         'relative border-b border-border min-h-11 flex items-stretch shrink-0',
         standalone && 'bg-background z-10',
@@ -267,24 +309,31 @@ export function TabNavigation({
             </Link>
           );
         })}
-
-        {/* Animated indicator */}
-        {activeIndex !== -1 && (
-          <div
-            className={cn(
-              'absolute bottom-0 h-0.5',
-              !accentColor && 'bg-foreground',
-              shouldAnimate &&
-                'transition-all duration-200 ease-out motion-reduce:transition-none',
-            )}
-            style={{
-              width: `${indicatorStyle.width}px`,
-              left: `${indicatorStyle.left}px`,
-              backgroundColor: accentColor || undefined,
-            }}
-          />
-        )}
       </div>
+
+      {/* Animated active indicator. Rendered as a child of the <nav> rather than
+          the scroll container so it can sit flush on the nav's bottom border:
+          the scroll container is `overflow-x: auto` (which forces `overflow-y`
+          to clip too), so a child anchored to `bottom-0` there floats above the
+          border by the nav's bottom padding. Its position is measured in JS
+          relative to the nav and re-synced on scroll. */}
+      {activeIndex !== -1 && (
+        <div
+          ref={indicatorRef}
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute bottom-0 h-0.5',
+            !accentColor && 'bg-foreground',
+            shouldAnimate &&
+              'transition-all duration-200 ease-out motion-reduce:transition-none',
+          )}
+          style={{
+            width: `${indicatorStyle.width}px`,
+            left: `${indicatorStyle.left}px`,
+            backgroundColor: accentColor || undefined,
+          }}
+        />
+      )}
 
       {/* Trailing action group — pinned to the right, outside the scroll area,
           so it stays in view while the tabs scroll under it. The left shadow +

--- a/services/platform/vite.config.ts
+++ b/services/platform/vite.config.ts
@@ -97,6 +97,20 @@ export default defineConfig({
       'remark-gfm',
       'rehype-raw',
       'rehype-sanitize',
+      // Custom markdown plugins (@tale/ui) reach *past* react-markdown and
+      // import these micromark/unist internals directly, so each becomes its
+      // own optimized entry that the react-markdown pre-bundle above does not
+      // cover. Discovered only when a markdown route mounts a plugin, they
+      // re-bundle the shared micromark chunk mid-session and 404 the in-flight
+      // `dev-*.js` request. Listing them keeps that chunk stable from cold start.
+      'micromark-core-commonmark',
+      'micromark-util-classify-character',
+      'unist-util-visit',
+      // Charting stack (analytics + automation metrics) is behind lazy routes,
+      // so the cold-start scanner never sees `recharts`. First chart mount
+      // discovers it plus its transitive prop-types -> react-is, forcing a
+      // re-optimization that 404s the in-flight `react-is-*.js` chunk.
+      'recharts',
     ],
     exclude: [
       '@tanstack/react-start/server',


### PR DESCRIPTION
Two unrelated dev/UI fixes surfaced this session.

## 1. Vite dep-optimizer `Pre-transform error` 404s

The client dev server was throwing:

> Pre-transform error: The file does not exist at `.../.vite/deps/dev-CQ-cgh4x.js` … / `react-is-BfRvF5um.js`

Root cause: two dependency clusters are reached **only via lazy routes / direct bare imports** that Vite's cold-start scanner never sees, so the first navigation that hits them forces a mid-session re-optimization. That rewrites the hashed chunk names and 404s any in-flight request for the old ones.

- **`react-is-*.js`** — `recharts` (analytics + automation-metrics charts) is behind lazy routes; first chart mount drags in `prop-types` → `react-is`.
- **`dev-*.js`** — the custom `@tale/ui` markdown plugins import `micromark-core-commonmark`, `micromark-util-classify-character`, and `unist-util-visit` **directly**, forming their own optimized entries the pre-bundled `react-markdown` doesn't cover, so they re-bundle the shared micromark chunk.

Fix: pre-include all of them in `optimizeDeps.include`, extending the existing markdown-pre-bundling block in `vite.config.ts`. They now bundle on the first optimize pass, so no mid-session re-optimization is triggered.

## 2. Active tab underline floating above the nav border

The recent tab-nav refactor moved the animated indicator **inside** the inner scroll container (`overflow-x: auto`, which forces `overflow-y` to clip too). Anchored to `bottom-0` there, the indicator floats above the nav's bottom border by the consumer's vertical padding (e.g. settings' `py-3` = 12px) — so the underline hugged the text instead of sitting on the hairline border. This affected every nav that pads the strip (settings, knowledge, conversations, automations).

Fix: render the indicator as a child of the `<nav>` (which owns the border) so `bottom-0` lands on the actual border regardless of padding, measure its position with `getBoundingClientRect` relative to the nav, and re-sync on horizontal scroll with the slide transition suppressed so it tracks the active tab 1:1 instead of smearing. No call-site changes; every consumer's designed height is preserved.

## Test plan

- `oxfmt --check`, `tsc --noEmit` (all files), `oxlint --type-aware`, `tab-navigation` test — all green.
- Verified the underline fix analytically against the CSS box model (the indicator now resolves to the nav's padding-box bottom = inner border edge). Visual confirmation in-app pending (settings page needs auth).
- Vite fix: dev server re-optimizes cleanly from the changed `include`; confirmed serving HTTP 200 after restart.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests). 71,498 tests pass; the only 2 failures are pre-existing **flaky 5s timeouts** in unrelated Convex backend suites (`governance/erasure_collab_passes`, `slack/http_actions`) caused by concurrent load — both pass in isolation (12/12, 1.15s) and are untouched by this PR.
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no skeleton changes).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no user-facing strings added/changed).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change — N/A (build-config + pixel-alignment fix, no documented behavior change).
- [x] Every touched docs page has a real opening/closing — N/A (no docs touched).
- [x] Ran `bun run --filter @tale/docs lint` and `test` — N/A.
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active tab indicator positioning and stability during horizontal scrolling.

* **Performance**
  * Optimized application startup time through enhanced dependency pre-bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->