### PR TITLE
perf(platform): make warm dashboard page transitions near-instant

### DIFF
--- a/services/platform/app/features/agents/components/agents-table.test.tsx
+++ b/services/platform/app/features/agents/components/agents-table.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/lib/i18n/client', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
+  useRouter: () => ({ preloadRoute: vi.fn() }),
   useParams: () => ({ id: 'test-org-id' }),
   Link: ({
     children,

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { useListPage } from '@/app/hooks/use-list-page';
+import { usePreloadRoute } from '@/app/hooks/use-preload-route';
 import { useTeamFilter } from '@/app/hooks/use-team-filter';
 import { useT } from '@/lib/i18n/client';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
@@ -38,6 +39,7 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
   const { t: tSettings } = useT('settings');
   const { teams } = useTeamFilter();
   const navigate = useNavigate();
+  const preloadRoute = usePreloadRoute();
   const queryClient = useQueryClient();
   const { agents: rawAgents, isLoading } = useListAgents(organizationId);
   const { i18n: i18nCtx } = useTranslation();
@@ -122,6 +124,18 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
     [navigate, organizationId],
   );
 
+  const handleRowMouseEnter = useCallback(
+    (row: Row<AgentRow>) => {
+      // Warm the detail route (runs its loader → readAgent) on hover so the
+      // click lands on already-fetched data.
+      preloadRoute({
+        to: '/dashboard/$id/agents/$agentId',
+        params: { id: organizationId, agentId: row.original.name },
+      });
+    },
+    [preloadRoute, organizationId],
+  );
+
   const list = useListPage<AgentRow>({
     dataSource: {
       type: 'query',
@@ -147,6 +161,7 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
           : ''
       }
       onRowClick={handleRowClick}
+      onRowMouseEnter={handleRowMouseEnter}
       actionMenu={<AgentsActionMenu organizationId={organizationId} />}
       emptyState={{
         icon: Bot,

--- a/services/platform/app/features/automations/hooks/file-queries.ts
+++ b/services/platform/app/features/automations/hooks/file-queries.ts
@@ -9,12 +9,21 @@ import { api } from '@/convex/_generated/api';
 
 type WorkflowFilter = 'installed' | 'templates' | 'all';
 
+/**
+ * Query key for the workflows list. Exported so a route loader can prefetch the
+ * exact key useListWorkflows reads (keeps loader and hook drift-proof).
+ */
+export const workflowListKey = (
+  organizationId: string,
+  filter?: WorkflowFilter,
+) => [...configKeys.list('workflows', organizationId), filter] as const;
+
 export function useListWorkflows(
   organizationId: string,
   filter?: WorkflowFilter,
 ) {
   const { data, isLoading, error, refetch } = useActionQuery(
-    ['config', 'workflows', organizationId, '_list', filter],
+    workflowListKey(organizationId, filter),
     api.workflows.file_actions.listWorkflows,
     { organizationId, filter },
   );

--- a/services/platform/app/features/documents/components/documents-table.test.tsx
+++ b/services/platform/app/features/documents/components/documents-table.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@tanstack/react-router', () => ({
   useLocation: () => ({ pathname: '/dashboard/test-org/documents' }),
 }));
 
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ prefetchQuery: vi.fn() }),
+}));
+
 vi.mock('@/app/hooks/use-team-filter', () => ({
   useTeamFilter: () => ({ teams: [], selectedTeamId: undefined }),
 }));

--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { convexQuery } from '@convex-dev/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { type Row } from '@tanstack/react-table';
 import { FileText } from 'lucide-react';
@@ -11,6 +13,8 @@ import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useDebounce } from '@/app/hooks/use-debounce';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useTeamFilter } from '@/app/hooks/use-team-filter';
+import { api } from '@/convex/_generated/api';
+import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 import type { DocumentItem, RagStatus } from '@/types/documents';
 
@@ -42,6 +46,7 @@ export function DocumentsTable({
   hasMicrosoftAccount = false,
 }: DocumentsTableProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { t: tDocuments } = useT('documents');
 
   const { data: docCount } = useApproxDocumentCount(organizationId);
@@ -273,6 +278,20 @@ export function DocumentsTable({
     [navigateToFolder, openPreview],
   );
 
+  const handleRowMouseEnter = useCallback(
+    (row: Row<DocumentItem>) => {
+      // Warm the preview's point query on hover (cheap single-doc read) so the
+      // preview dialog opens without a loading flash on click.
+      if (row.original.type !== 'file') return;
+      void queryClient.prefetchQuery(
+        convexQuery(api.documents.queries.getDocumentById, {
+          documentId: toId<'documents'>(row.original.id),
+        }),
+      );
+    },
+    [queryClient],
+  );
+
   const closePreview = useCallback(() => {
     void navigate({
       to: '/dashboard/$id/documents',
@@ -357,6 +376,7 @@ export function DocumentsTable({
       <DataTable
         columns={columns}
         onRowClick={handleRowClick}
+        onRowMouseEnter={handleRowMouseEnter}
         rowClassName={getRowClassName}
         stickyLayout={stickyLayout}
         actionMenu={

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -10,6 +10,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { useListPage } from '@/app/hooks/use-list-page';
+import { usePreloadRoute } from '@/app/hooks/use-preload-route';
 import { useT } from '@/lib/i18n/client';
 
 import { useProjects, type ProjectListItem } from '../hooks/queries';
@@ -37,6 +38,7 @@ function formatRelative(timestamp: number, locale: string): string {
 export function ProjectsTable({ organizationId }: ProjectsTableProps) {
   const { t } = useT('projects');
   const navigate = useNavigate();
+  const preloadRoute = usePreloadRoute();
   const [includeArchived, setIncludeArchived] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const { projects, isLoading } = useProjects(organizationId, {
@@ -53,6 +55,18 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       });
     },
     [navigate, organizationId],
+  );
+
+  const handleRowMouseEnter = useCallback(
+    (row: Row<ProjectListItem>) => {
+      // Warm the detail route (runs its loader → getProject) on hover so the
+      // click lands on already-fetched data.
+      preloadRoute({
+        to: '/dashboard/$id/projects/$projectId',
+        params: { id: organizationId, projectId: String(row.original._id) },
+      });
+    },
+    [preloadRoute, organizationId],
   );
 
   const locale =
@@ -158,6 +172,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
         {...list.tableProps}
         columns={columns}
         onRowClick={handleRowClick}
+        onRowMouseEnter={handleRowMouseEnter}
         filtersContent={
           <Checkbox
             id="projects-show-archived"

--- a/services/platform/app/hooks/use-cached-paginated-query.test.ts
+++ b/services/platform/app/hooks/use-cached-paginated-query.test.ts
@@ -1,0 +1,65 @@
+import type { ConvexReactClient } from 'convex/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { api } from '@/convex/_generated/api';
+
+import { primeCachedPaginatedQuery } from './use-cached-paginated-query';
+
+const LIST = api.customers.queries.listCustomersPaginated;
+
+// Expose the mock fn separately so assertions don't reference an unbound method.
+function makeClient(query: ReturnType<typeof vi.fn>): ConvexReactClient {
+  return { query } as unknown as ConvexReactClient;
+}
+
+describe('primeCachedPaginatedQuery', () => {
+  it('fetches page 0 with injected paginationOpts and resolves', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValue({ page: [{ _id: 'a' }], isDone: true });
+
+    await primeCachedPaginatedQuery(
+      makeClient(query),
+      LIST,
+      { organizationId: 'org-prime-1' },
+      { initialNumItems: 20 },
+    );
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(LIST, {
+      organizationId: 'org-prime-1',
+      paginationOpts: { numItems: 20, cursor: null },
+    });
+  });
+
+  it('skips the fetch when the same key is already cached', async () => {
+    const query = vi.fn().mockResolvedValue({ page: [], isDone: true });
+    const args = { organizationId: 'org-prime-2' };
+
+    await primeCachedPaginatedQuery(makeClient(query), LIST, args, {
+      initialNumItems: 20,
+    });
+    await primeCachedPaginatedQuery(makeClient(query), LIST, args, {
+      initialNumItems: 20,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows query errors instead of rejecting', async () => {
+    const query = vi.fn().mockRejectedValue(new Error('boom'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      primeCachedPaginatedQuery(
+        makeClient(query),
+        LIST,
+        { organizationId: 'org-prime-3' },
+        { initialNumItems: 20 },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/services/platform/app/hooks/use-cached-paginated-query.ts
+++ b/services/platform/app/hooks/use-cached-paginated-query.ts
@@ -1,4 +1,5 @@
-import { getFunctionName } from 'convex/server';
+import type { ConvexReactClient } from 'convex/react';
+import { getFunctionName, type OptionalRestArgs } from 'convex/server';
 
 import {
   useConvexPaginatedQuery,
@@ -62,4 +63,58 @@ export function useCachedPaginatedQuery<Query extends PaginatedQueryReference>(
   }
 
   return result;
+}
+
+/**
+ * Prime {@link useCachedPaginatedQuery}'s cache from a route `loader` so the
+ * first page paints instantly on the *first* navigation to a list — not just on
+ * re-nav. Fetches page 0 once and writes it under the same cache key the hook
+ * reads, sidestepping Convex `usePaginatedQuery`'s per-mount `paginationOpts.id`
+ * (which makes a plain `convexQuery` loader prefetch miss the subscription).
+ *
+ * `args` MUST equal the hook's `queryArgs` (everything it passes besides
+ * `initialNumItems`) so the key matches — pass the same leading args the
+ * component will use (e.g. `{ organizationId }` for an unfiltered list). The
+ * `numItems` is not part of the key, so it only sets how many rows paint
+ * instantly before the live subscription fills the rest.
+ *
+ * Client-only (the cache and WS client are per-browser) and fire-and-forget:
+ * always `void` it in a loader so a slow/failed prime never stalls the
+ * transition. Skips the fetch when the key is already cached.
+ */
+export async function primeCachedPaginatedQuery<
+  Query extends PaginatedQueryReference,
+>(
+  convexClient: ConvexReactClient,
+  query: Query,
+  args: PaginatedQueryArgs<Query>,
+  options: { initialNumItems: number },
+): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const cacheKey = buildCacheKey(query, args);
+  if (paginatedQueryCache.has(cacheKey)) return;
+  try {
+    // Convex's generic `OptionalRestArgs<Query>` is an unresolved conditional
+    // type, so it can't see that spreading `PaginatedQueryArgs` (FunctionArgs
+    // minus paginationOpts) back with paginationOpts reconstitutes the call
+    // args — a third-party typing gap, so assert the reconstructed tuple.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generic OptionalRestArgs<Query> conditional can't be satisfied structurally; the reconstructed page-0 args are correct
+    const queryArgs = [
+      {
+        ...args,
+        paginationOpts: { numItems: options.initialNumItems, cursor: null },
+      },
+    ] as unknown as OptionalRestArgs<Query>;
+    const result = await convexClient.query(query, ...queryArgs);
+    paginatedQueryCache.set(cacheKey, {
+      results: result.page,
+      wasExhausted: result.isDone,
+    });
+    if (paginatedQueryCache.size > MAX_CACHE_ENTRIES) {
+      const oldestKey = paginatedQueryCache.keys().next().value;
+      if (oldestKey) paginatedQueryCache.delete(oldestKey);
+    }
+  } catch (error) {
+    console.warn('Failed to prime paginated query cache', error);
+  }
 }

--- a/services/platform/app/hooks/use-table-config-factory.ts
+++ b/services/platform/app/hooks/use-table-config-factory.ts
@@ -10,6 +10,12 @@ import type { Namespace } from '@/lib/i18n/types';
 
 type TranslationFn = (key: string) => string;
 
+/**
+ * Default first-page size for entity list tables. Exported so route loaders can
+ * prime the paginated cache with the same count the table renders.
+ */
+export const DEFAULT_TABLE_PAGE_SIZE = 20;
+
 interface TableConfigMetadata {
   searchPlaceholder: string;
   stickyLayout: boolean;
@@ -32,7 +38,7 @@ interface CreateTableConfigOptions<TTableName extends TableNames> {
   defaultSort: keyof Doc<TTableName> | (string & {});
   /** Sort descending by default (default: true) */
   defaultSortDesc?: boolean;
-  /** Page size (default: 10) */
+  /** Page size (default: {@link DEFAULT_TABLE_PAGE_SIZE}) */
   pageSize?: number;
   /** Enable sticky layout (default: true) */
   stickyLayout?: boolean;
@@ -92,7 +98,7 @@ export function createTableConfigHook<TTableName extends TableNames>(
     additionalNamespaces = [],
     defaultSort,
     defaultSortDesc = true,
-    pageSize = 20,
+    pageSize = DEFAULT_TABLE_PAGE_SIZE,
     stickyLayout = true,
     infiniteScroll = true,
   } = options;

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -33,6 +33,12 @@ export const queryClient = new QueryClient({
       // expires with zero observers). Aligned with the codebase's 5min staleTime
       // and TanStack defaults.
       gcTime: 15 * 60 * 1000,
+      // Convex keeps subscribed queries live over the WS (setQueryData on each
+      // update) regardless of staleTime, so this only suppresses redundant
+      // one-shot refetches on mount/focus — it never serves stale Convex data.
+      // useActionQuery overrides to Infinity; the session query sets its own.
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -1,3 +1,4 @@
+import { convexQuery } from '@convex-dev/react-query';
 import { FullPageCenter } from '@tale/ui/full-page-center';
 import { VStack } from '@tale/ui/layout';
 import { SkeletonBox, SkeletonCircle } from '@tale/ui/skeleton';
@@ -48,6 +49,13 @@ export const Route = createFileRoute('/dashboard/$id')({
   // transition — the component renders a skeleton while the live subscription
   // catches up.
   loader: ({ context, params }) => {
+    // The team filter (TeamFilterProvider) reads getMyTeams on every dashboard
+    // page; warm it alongside the gating member context.
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.members.queries.getMyTeams, {
+        organizationId: params.id,
+      }),
+    );
     const preload = ensureConvexQuery(
       context,
       api.members.queries.getCurrentMemberContext,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/customers.tsx
@@ -3,6 +3,8 @@ import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { CustomersTable } from '@/app/features/customers/components/customers-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
@@ -24,10 +26,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/customers')({
         organizationId: params.id,
       }),
     );
-    void context.queryClient.prefetchQuery(
-      convexQuery(api.customers.queries.listCustomers, {
-        organizationId: params.id,
-      }),
+    // Prime the paginated list cache so the first page paints without a
+    // skeleton flash on first nav. Args mirror useListCustomersPaginated's base
+    // args (no in-page filters — those resolve via the live subscription).
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.customers.queries.listCustomersPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
     );
   },
   component: CustomersPage,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/documents.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/documents.tsx
@@ -4,6 +4,8 @@ import { z } from 'zod';
 
 import { useHasMicrosoftAccount } from '@/app/features/auth/hooks/queries';
 import { DocumentsTable } from '@/app/features/documents/components/documents-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
@@ -18,9 +20,28 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/documents')({
     meta: seo('documents'),
   }),
   validateSearch: searchSchema,
-  loader: ({ context }) => {
+  loader: ({ context, params }) => {
     void context.queryClient.prefetchQuery(
       convexQuery(api.accounts.queries.hasMicrosoftAccount, {}),
+    );
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.documents.queries.approxCountDocuments, {
+        organizationId: params.id,
+      }),
+    );
+    // Root folder list — matches useFolders(orgId) with no parentId.
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.folders.queries.listFolders, {
+        organizationId: params.id,
+      }),
+    );
+    // Prime the paginated document list (root folder, no filters) so the table
+    // paints without a skeleton flash on first nav.
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.documents.queries.listDocumentsPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
     );
   },
   component: DocumentsPage,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/products.tsx
@@ -3,6 +3,8 @@ import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { ProductsTable } from '@/app/features/products/components/products-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
@@ -23,10 +25,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/products')({
         organizationId: params.id,
       }),
     );
-    void context.queryClient.prefetchQuery(
-      convexQuery(api.products.queries.listProducts, {
-        organizationId: params.id,
-      }),
+    // Prime the paginated list cache so the first page paints without a
+    // skeleton flash on first nav. Args mirror useListProductsPaginated's base
+    // args (no in-page filters — those resolve via the live subscription).
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.products.queries.listProductsPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
     );
   },
   component: ProductsPage,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/vendors.tsx
@@ -3,6 +3,8 @@ import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { VendorsTable } from '@/app/features/vendors/components/vendors-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
@@ -23,10 +25,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/vendors')({
         organizationId: params.id,
       }),
     );
-    void context.queryClient.prefetchQuery(
-      convexQuery(api.vendors.queries.listVendors, {
-        organizationId: params.id,
-      }),
+    // Prime the paginated list cache so the first page paints without a
+    // skeleton flash on first nav. Args mirror useListVendorsPaginated's base
+    // args (no in-page filters — those resolve via the live subscription).
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.vendors.queries.listVendorsPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
     );
   },
   component: VendorsPage,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/websites.tsx
@@ -3,6 +3,8 @@ import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { WebsitesTable } from '@/app/features/websites/components/websites-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
@@ -23,10 +25,14 @@ export const Route = createFileRoute('/dashboard/$id/_knowledge/websites')({
         organizationId: params.id,
       }),
     );
-    void context.queryClient.prefetchQuery(
-      convexQuery(api.websites.queries.listWebsites, {
-        organizationId: params.id,
-      }),
+    // Prime the paginated list cache so the first page paints without a
+    // skeleton flash on first nav. Args mirror useListWebsitesPaginated's base
+    // args (no in-page filters — those resolve via the live subscription).
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.websites.queries.listWebsitesPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
     );
   },
   component: WebsitesPage,

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -17,6 +17,8 @@ import {
 import { AgentNavigation } from '@/app/features/agents/components/agent-navigation';
 import { useReadAgent } from '@/app/features/agents/hooks/queries';
 import { AgentConfigProvider } from '@/app/features/agents/hooks/use-agent-config-context';
+import { configKeys } from '@/app/hooks/config-query-keys';
+import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 import { cn } from '@/lib/utils/cn';
@@ -26,6 +28,22 @@ export const Route = createFileRoute('/dashboard/$id/agents/$agentId')({
   head: () => ({
     meta: seo('agent'),
   }),
+  loader: ({ context, params }) => {
+    const { id: organizationId, agentId: agentName } = params;
+    // Warm the agent config (filesystem-backed action) so the detail paints
+    // without a skeleton — also runs on the agents list's row-hover preload.
+    // Mirrors useReadAgent's key + args so the component reads it warm.
+    void context.queryClient.prefetchQuery({
+      queryKey: configKeys.detail('agents', organizationId, agentName),
+      queryFn: () =>
+        context.convexQueryClient.convexClient.action(
+          api.agents.file_actions.readAgent,
+          { organizationId, agentName },
+        ),
+      staleTime: Infinity,
+      retry: false,
+    });
+  },
   component: AgentDetailLayout,
 });
 

--- a/services/platform/app/routes/dashboard/$id/agents/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/index.tsx
@@ -1,12 +1,28 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { AgentsTable } from '@/app/features/agents/components/agents-table';
+import { configKeys } from '@/app/hooks/config-query-keys';
+import { api } from '@/convex/_generated/api';
 import { seo } from '@/lib/utils/seo';
 
 export const Route = createFileRoute('/dashboard/$id/agents/')({
   head: () => ({
     meta: seo('agents'),
   }),
+  loader: ({ context, params }) => {
+    // Warm the agents list (filesystem-backed action) so the table paints
+    // without a skeleton on first nav. Mirrors useListAgents's key + args.
+    void context.queryClient.prefetchQuery({
+      queryKey: configKeys.list('agents', params.id),
+      queryFn: () =>
+        context.convexQueryClient.convexClient.action(
+          api.agents.file_actions.listAgents,
+          { organizationId: params.id },
+        ),
+      staleTime: Infinity,
+      retry: false,
+    });
+  },
   component: AgentsPage,
 });
 

--- a/services/platform/app/routes/dashboard/$id/automations/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/index.tsx
@@ -7,8 +7,10 @@ import { SearchInput } from '@/app/components/ui/forms/search-input';
 import { AutomationsActionMenu } from '@/app/features/automations/components/automations-action-menu';
 import { AutomationsTable } from '@/app/features/automations/components/automations-table';
 import type { AutomationTableItem } from '@/app/features/automations/components/automations-table';
+import { workflowListKey } from '@/app/features/automations/hooks/file-queries';
 import { useAutomationsTableConfig } from '@/app/features/automations/hooks/use-automations-table-config';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
+import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
@@ -21,6 +23,21 @@ export const Route = createFileRoute('/dashboard/$id/automations/')({
     meta: seo('automations'),
   }),
   validateSearch: searchSchema,
+  loader: ({ context, params }) => {
+    // Warm the workflows list (filesystem-backed action) so the table paints
+    // without a skeleton on first nav. AutomationsTable mounts
+    // useListWorkflows(orgId, 'installed'); match that key + args.
+    void context.queryClient.prefetchQuery({
+      queryKey: workflowListKey(params.id, 'installed'),
+      queryFn: () =>
+        context.convexQueryClient.convexClient.action(
+          api.workflows.file_actions.listWorkflows,
+          { organizationId: params.id, filter: 'installed' },
+        ),
+      staleTime: Infinity,
+      retry: false,
+    });
+  },
   component: AutomationsPage,
 });
 

--- a/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
@@ -7,8 +7,11 @@ import {
   useApproxConversationCountByStatus,
   useListConversationsPaginated,
 } from '@/app/features/conversations/hooks/queries';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
 import { api } from '@/convex/_generated/api';
 import type { Doc } from '@/convex/_generated/dataModel';
+
+const INITIAL_NUM_ITEMS = 30;
 
 const VALID_STATUSES = ['open', 'closed', 'archived', 'spam'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
@@ -39,21 +42,24 @@ export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
   },
   loader: ({ context, params }) => {
     if (isValidStatus(params.status)) {
-      void context.queryClient.prefetchQuery(
-        convexQuery(api.conversations.queries.listConversationsPaginated, {
-          organizationId: params.id,
-          status: params.status,
-          paginationOpts: { numItems: 30, cursor: null },
-        }),
-      );
+      const status = params.status;
       void context.queryClient.prefetchQuery(
         convexQuery(
           api.conversations.queries.approxCountConversationsByStatus,
           {
             organizationId: params.id,
-            status: params.status,
+            status,
           },
         ),
+      );
+      // Prime the paginated list cache so the first page paints without a
+      // skeleton flash on first nav. Args mirror useListConversationsPaginated's
+      // base args (priority/search are in-page filters — live subscription).
+      void primeCachedPaginatedQuery(
+        context.convexQueryClient.convexClient,
+        api.conversations.queries.listConversationsPaginated,
+        { organizationId: params.id, status },
+        { initialNumItems: INITIAL_NUM_ITEMS },
       );
     }
   },
@@ -87,7 +93,7 @@ function ConversationsStatusPage() {
     organizationId,
     status: mappedStatus,
     priority: priority && priority.length > 0 ? priority : undefined,
-    initialNumItems: 30,
+    initialNumItems: INITIAL_NUM_ITEMS,
   });
 
   return (

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -1,3 +1,4 @@
+import { convexQuery } from '@convex-dev/react-query';
 import { Heading } from '@tale/ui/heading';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
@@ -19,10 +20,20 @@ import {
 } from '@/app/components/ui/navigation/tab-navigation';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
+import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 export const Route = createFileRoute('/dashboard/$id/projects/$projectId')({
+  loader: ({ context, params }) => {
+    // Warm the gating project query so the detail header/content paint without
+    // a skeleton — also runs on the projects list's row-hover preload.
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.projects.queries.getProject, {
+        projectId: asProjectId(params.projectId),
+      }),
+    );
+  },
   component: ProjectDetailLayout,
 });
 

--- a/services/platform/app/routes/dashboard/$id/projects/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/index.tsx
@@ -1,3 +1,4 @@
+import { convexQuery } from '@convex-dev/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
 import {
@@ -6,6 +7,7 @@ import {
 } from '@/app/components/layout/adaptive-header';
 import { PageLayout } from '@/app/components/layout/page-layout';
 import { ProjectsTable } from '@/app/features/projects/components/projects-table';
+import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
@@ -13,6 +15,17 @@ export const Route = createFileRoute('/dashboard/$id/projects/')({
   head: () => ({
     meta: seo('projects'),
   }),
+  loader: ({ context, params }) => {
+    // Warm the projects list so the table paints without a skeleton on first
+    // nav. ProjectsTable mounts useProjects with includeArchived:false, so the
+    // args must match that exactly or the cache key misses.
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.projects.queries.listProjects, {
+        organizationId: params.id,
+        includeArchived: false,
+      }),
+    );
+  },
   component: ProjectsPage,
 });
 


### PR DESCRIPTION
## Why

Navigating between dashboard pages flashed a skeleton on nearly every transition. The route loaders that were *meant* to warm list data didn't work: Convex's `usePaginatedQuery` keys its first page with a fresh **per-mount `paginationOpts.id`**, so a `convexQuery` loader prefetch never matches the subscription the table actually reads — and `usePaginatedQuery` reads the Convex client store, not the react-query cache that `convexQuery` warms. The four `_knowledge` routes were worse: they prefetched the **non-paginated** `listX` (a full-collection scan) that the tables never read — firing on every nav *and* every intent-hover.

This makes warm transitions near-instant by warming exactly what each page reads.

## What changed

- **`primeCachedPaginatedQuery`** (`app/hooks/use-cached-paginated-query.ts`) — a loader does a one-shot page-0 query and writes it into the **same module cache** `useCachedPaginatedQuery` reads on remount, sidestepping the `id` mismatch entirely. Wired into the customers / products / vendors / websites / documents / conversations loaders, replacing the broken prefetches. Keyed on each list's base args (in-page filters ride the live subscription).
- **Effective `convexQuery` prefetch** for non-paginated reads that *do* warm correctly: projects list (matching the table's `includeArchived: false`), documents count + root folders, and `getMyTeams` in the `$id` shell loader.
- **Action-backed prefetch** for agents & automations lists/detail via shared query-key factories (`configKeys`, new `workflowListKey`) so the loader and hook can't drift.
- **Row-hover preload** — wired the already-present-but-unused `onRowMouseEnter` + `usePreloadRoute` on the projects & agents tables (with detail-route loaders for `getProject` / `readAgent`); documents rows hover-prefetch the cheap `getDocumentById` point query.
- **Global query defaults** (`app/router.tsx`): `staleTime: 5min` + `refetchOnWindowFocus: false` — safe because Convex keeps subscribed data live over the WS; this only drops redundant one-shot refetches on mount/focus.

## Deferred (follow-ups, intentionally out of scope)

- Trimming documents' per-row `storage.getUrl()` in the list transform (backend change; needs tracing the URL consumers in preview/download).
- The `loadMore(200)` / `pageSize*3` client-side eager-load and server-side search (the eager-load is load-bearing for client-side team filtering).
- Paginating the unbounded conversation-detail message load (why conversation rows are **not** hover-prefetched here — it would amplify that fetch).

## Note to reviewers

Sidebar links use `preload="render"`, so these loaders run on dashboard entry. Net backend work is **lower** than before (page-0 primes replace full-collection scans), but if aggregate load looks chatty in practice, downgrade the heaviest list links to `preload="intent"` or raise `defaultPreloadDelay`.

## Verification

- [x] Ran `bun run check` (format, lint, typecheck, all 71,533 server+pii tests) — green.
- [x] Affected UI tests (`test:ui`) pass, incl. a new test for `primeCachedPaginatedQuery`; updated two existing tests for the new provider deps (`useRouter`, `useQueryClient`).
- [x] CodeRabbit review — 0 findings.
- [x] No hand-rolled skeletons — N/A (this removes skeleton flashes via the existing cache).
- [x] `messages/{en,de,fr}.json` — N/A (no user-facing strings; comments only).
- [x] `/docs/{en,de,fr}/` — N/A (perf-only; no new/changed UI elements or copy).
- [x] READMEs — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Table rows now preload data on hover for faster navigation.
  * Routes prefetch page data during navigation to improve loading times.

* **Performance**
  * Optimized paginated query caching to reduce initial loading UI.
  * Updated query client configuration for better WebSocket subscription handling.

* **Tests**
  * Added test coverage for paginated query caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->