### PR TITLE
feat(platform): table layout, selection & menu polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tools/plop"
   ],
   "scripts": {
-    "dev": "bunx turbo run dev",
+    "dev": "bunx turbo run dev --filter=!@tale/docs --filter=!@tale/web",
     "serve": "bunx turbo run serve",
     "build": "bunx turbo run build",
     "lint": "bunx turbo run lint",

--- a/packages/ui/src/components/primitives/icon-button.tsx
+++ b/packages/ui/src/components/primitives/icon-button.tsx
@@ -77,12 +77,11 @@ export const IconButton = forwardRef<
       />
     );
 
-    // The base Button uses `focus-visible:ring-ring`, which resolves to the
-    // theme's accent blue in dark mode (`--ring: 217 100% 66%`). On a small
-    // ghost icon button that ring reads as a heavy blue halo around an
-    // otherwise quiet glyph — visually loud, especially for icon-only
-    // toolbar clusters. Override to `border-strong` so focus stays visible
-    // for keyboard users (a11y) without the saturated blue.
+    // The base Button's `focus-visible:ring-ring` previously resolved to a
+    // saturated accent blue that, on a small ghost icon button, read as a
+    // heavy halo around an otherwise quiet glyph — visually loud, especially
+    // for icon-only toolbar clusters. Override to `border-strong` so focus
+    // stays visible for keyboard users (a11y) without the loud ring.
     const focusOverride = 'focus-visible:ring-border-strong';
 
     if (asChild && isValidElement(slotChild)) {

--- a/packages/ui/src/components/primitives/icon-button.tsx
+++ b/packages/ui/src/components/primitives/icon-button.tsx
@@ -77,6 +77,14 @@ export const IconButton = forwardRef<
       />
     );
 
+    // The base Button uses `focus-visible:ring-ring`, which resolves to the
+    // theme's accent blue in dark mode (`--ring: 217 100% 66%`). On a small
+    // ghost icon button that ring reads as a heavy blue halo around an
+    // otherwise quiet glyph — visually loud, especially for icon-only
+    // toolbar clusters. Override to `border-strong` so focus stays visible
+    // for keyboard users (a11y) without the saturated blue.
+    const focusOverride = 'focus-visible:ring-border-strong';
+
     if (asChild && isValidElement(slotChild)) {
       // Wrap the consumer's slotChild (typically `<a>` or router `<Link>`)
       // and inject the icon as its sole child via Radix Slot semantics.
@@ -87,7 +95,7 @@ export const IconButton = forwardRef<
           variant={variant}
           size="icon"
           aria-label={ariaLabel}
-          className={cn(className)}
+          className={cn(focusOverride, className)}
           {...props}
         >
           {cloneElement(slotChild, undefined, iconNode)}
@@ -101,7 +109,7 @@ export const IconButton = forwardRef<
         variant={variant}
         size="icon"
         aria-label={ariaLabel}
-        className={cn(className)}
+        className={cn(focusOverride, className)}
         {...props}
       >
         {iconNode}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -240,12 +240,18 @@
   --popover-foreground: 0 0% 100%;
   --primary: 0 0% 100%;
   --primary-foreground: 222 73% 3%;
-  --primary-muted: 218 11% 75%;
-  --secondary: 218 11% 85%;
+  /* Dark-mode neutrals: dropped the slight blue tint (was hue 218) on the
+     muted / secondary / muted-foreground / accent tokens so the surface
+     palette reads as a true grayscale in dark mode, matching the platform's
+     white `--color-accent-base`. Light mode is already grayscale; `--info`,
+     `--destructive`, `--warning`, and `--chart-*` keep their hues because
+     they're semantic (informational badges, charts) rather than chrome. */
+  --primary-muted: 0 0% 75%;
+  --secondary: 0 0% 85%;
   --secondary-foreground: 0 0% 100%;
   --muted: 0 0% 14.9%;
-  --muted-foreground: 218 11% 65%;
-  --accent: 217 19% 17%;
+  --muted-foreground: 0 0% 65%;
+  --accent: 0 0% 17%;
   --accent-foreground: 0 0% 100%;
   --destructive: 0 91% 71%;
   --destructive-foreground: 0 0% 100%;
@@ -257,7 +263,11 @@
   --info-foreground: 214 80% 65%;
   --border: 0 0% 24%;
   --input: 0 0% 5.88%;
-  --ring: 217 100% 66%;
+  /* Focus ring: was a saturated blue (`217 100% 66%`) that read as a hard
+     halo on dark surfaces. Drop to a near-white neutral — still clearly
+     visible for keyboard focus while matching the white `--primary` /
+     `--color-accent-base` intent color used everywhere else. */
+  --ring: 0 0% 90%;
   --sidebar: 0 0% 5.88%;
   --tab: 0 0% 25.1%;
   --chart-1: 220 70% 50%;

--- a/services/docs/app/locals.css
+++ b/services/docs/app/locals.css
@@ -1,13 +1,6 @@
 /*
- * Marketing-brand accent for the docs site. Replaces the @tale/ui default
- * (slate near-black) with marketing blue so every @tale/ui component that
- * reads `--color-accent-base` (buttons, focus rings, links, tooltips,
- * accordions, sliders) picks up the brand color automatically.
+ * Service-local style slot (required by the plop service template — keep the
+ * file even when empty). Docs now uses the canonical @tale/ui palette from
+ * `@tale/ui/globals.css` with no overrides; brand-color customizations
+ * removed so docs, platform, and web share a single color scheme.
  */
-:root {
-  --color-accent-base: hsl(214 90% 56%);
-}
-
-html.dark {
-  --color-accent-base: hsl(214 95% 65%);
-}

--- a/services/platform/app/components/connectivity/online-gate.tsx
+++ b/services/platform/app/components/connectivity/online-gate.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { StatusIndicator } from '@tale/ui/status-indicator';
-import { WifiOff } from 'lucide-react';
+import { useInstallPrompt } from '@tale/ui/pwa/use-install-prompt';
+import { Download, WifiOff } from 'lucide-react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
 import { useConvexConnectionState } from '@/app/hooks/use-convex-connection-state';
@@ -15,38 +15,57 @@ interface OnlineGateProps {
   children: ReactNode;
 }
 
+type OfflineReason = 'device' | 'backend';
+
 /**
- * Full-screen overlay that appears when Convex has been disconnected for
- * longer than the grace window. Mounted once near the router root. The
- * overlay is additive — children continue to render underneath so transient
- * blips don't unmount the app.
+ * Full-screen overlay that appears when the app can't talk to its backend.
+ * Mounted once near the router root; children continue to render underneath
+ * so a transient blip doesn't unmount the app.
  *
- * `navigator.onLine` is deliberately NOT consulted: it reports
- * device-level external connectivity, but the platform's only hard
- * dependency at runtime is the Convex websocket. A laptop without
- * external internet but a healthy local Convex backend (the common
- * `bun run dev` setup, or the offline-first self-hosted appliance) is
- * fully functional and shouldn't be blocked by the overlay.
+ * Two distinct reasons drive the overlay, each with its own copy:
+ *   - `'device'`  — `navigator.onLine === false`. The user's device is
+ *                   offline. We surface this even when the Convex WS is
+ *                   still nominally connected, because nothing the user
+ *                   does will round-trip until the network returns.
+ *   - `'backend'` — device thinks it's online but Convex's websocket has
+ *                   been stale longer than the grace window. Tale's server
+ *                   is unreachable from here.
+ *
+ * The grace window prevents the overlay from flashing on benign blips
+ * (HMR push, tab waking from sleep, brief WS reconnect on auth refresh).
  */
 export function OnlineGate({ children }: OnlineGateProps) {
-  const offline = useOfflineState();
-
+  const reason = useOfflineReason();
   return (
     <>
       {children}
-      {offline && <OfflineOverlay />}
+      {reason !== null && <OfflineOverlay reason={reason} />}
     </>
   );
 }
 
-function useOfflineState(): boolean {
+function useOfflineReason(): OfflineReason | null {
   const connection = useConvexConnectionState();
-  const [convexStale, setConvexStale] = useState(false);
+  const [isDeviceOffline, setIsDeviceOffline] = useState(
+    () => typeof navigator !== 'undefined' && navigator.onLine === false,
+  );
+  const [isWsStale, setIsWsStale] = useState(false);
   const graceTimer = useRef<number | null>(null);
 
   useEffect(() => {
+    const sync = () => setIsDeviceOffline(navigator.onLine === false);
+    sync();
+    window.addEventListener('online', sync);
+    window.addEventListener('offline', sync);
+    return () => {
+      window.removeEventListener('online', sync);
+      window.removeEventListener('offline', sync);
+    };
+  }, []);
+
+  useEffect(() => {
     if (connection.isWebSocketConnected) {
-      setConvexStale(false);
+      setIsWsStale(false);
       if (graceTimer.current !== null) {
         window.clearTimeout(graceTimer.current);
         graceTimer.current = null;
@@ -55,7 +74,7 @@ function useOfflineState(): boolean {
     }
     if (graceTimer.current !== null) return undefined;
     graceTimer.current = window.setTimeout(() => {
-      setConvexStale(true);
+      setIsWsStale(true);
       graceTimer.current = null;
     }, DISCONNECT_GRACE_MS);
     return () => {
@@ -66,11 +85,51 @@ function useOfflineState(): boolean {
     };
   }, [connection.isWebSocketConnected]);
 
-  return convexStale;
+  // The overlay only appears when Convex's WS is actually unreachable —
+  // `navigator.onLine` is unreliable on its own (a laptop with no WAN can
+  // still talk to a local self-hosted backend, the common `bun run dev`
+  // shape). Once the WS is stale, we use `navigator.onLine` purely to
+  // *classify* the cause so the copy matches reality: device-offline vs
+  // server-unreachable.
+  if (!isWsStale) return null;
+  return isDeviceOffline ? 'device' : 'backend';
 }
 
-function OfflineOverlay() {
+interface OfflineOverlayProps {
+  reason: OfflineReason;
+}
+
+function OfflineOverlay({ reason }: OfflineOverlayProps) {
   const { t } = useT('connectivity');
+  const { canInstall, promptInstall } = useInstallPrompt();
+  // Bumping the nonce remounts the indicator so the pulse animation restarts
+  // on "Try again" — a small visual ack that the gesture registered, without
+  // any disabled/loading "Checking…" intermediate state.
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  // Surface the reconnect state in the tab title so a glance at a window
+  // chooser / tab strip shows which tab dropped — and so "Tale" stays in
+  // the title even on routes whose own title strips the suffix. Restore the
+  // prior title on dismiss so we don't permanently overwrite it.
+  useEffect(() => {
+    const previous = document.title;
+    document.title = `${t('tabTitle')} — Tale`;
+    return () => {
+      document.title = previous;
+    };
+  }, [t]);
+
+  const heading = reason === 'device' ? t('deviceTitle') : t('backendTitle');
+  const description =
+    reason === 'device' ? t('deviceDescription') : t('backendDescription');
+
+  const handleRetry = () => {
+    // Convex's client already auto-reconnects continuously, so we don't need
+    // to wire a manual reconnect call — bumping the nonce just restarts the
+    // ring animation so the user sees the gesture register. The overlay
+    // dismisses on its own once the WS handshake completes.
+    setRetryNonce((n) => n + 1);
+  };
 
   return (
     <div
@@ -85,39 +144,80 @@ function OfflineOverlay() {
       )}
     >
       <div className="mx-auto flex w-full max-w-sm flex-col items-center text-center">
-        <div
-          aria-hidden="true"
-          className="bg-muted text-muted-foreground mb-6 flex size-16 items-center justify-center rounded-full"
-        >
-          <WifiOff className="size-7" />
-        </div>
+        <ReachingServerIndicator key={retryNonce} label={t('reachingServer')} />
         <h2
           id="online-gate-title"
-          className="text-foreground text-2xl leading-tight font-semibold tracking-tight"
+          className="text-foreground mt-8 text-2xl leading-tight font-semibold tracking-tight"
         >
-          {t('reconnectingTitle')}
+          {heading}
         </h2>
         <p
           id="online-gate-description"
           className="text-muted-foreground mt-3 text-base leading-relaxed"
         >
-          {t('reconnectingDescription')}
+          {description}
         </p>
-        <div className="mt-6">
-          <StatusIndicator variant="warning" pulse size="md">
-            {t('statusReconnecting')}
-          </StatusIndicator>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <Button
+            type="button"
+            variant="primary"
+            className="min-h-11 px-5"
+            onClick={handleRetry}
+          >
+            {t('retry')}
+          </Button>
+          {canInstall && (
+            <Button
+              type="button"
+              variant="secondary"
+              icon={Download}
+              className="min-h-11 px-5"
+              onClick={() => {
+                void promptInstall();
+              }}
+            >
+              {t('getApp')}
+            </Button>
+          )}
         </div>
-        <Button
-          type="button"
-          variant="primary"
-          className="mt-8 min-h-11 px-5"
-          onClick={() => {
-            window.location.reload();
-          }}
-        >
-          {t('retry')}
-        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface ReachingServerIndicatorProps {
+  label: string;
+}
+
+/**
+ * The "we're actively trying" visual. Two concentric `animate-ping` rings
+ * pulse outward from a static wifi-off badge — a familiar "radar reach"
+ * pattern. The staggered animation delay keeps a ring in flight at all
+ * times instead of synchronizing into a single throb.
+ *
+ * `motion-safe:` gates the rings so users with `prefers-reduced-motion`
+ * see a static icon, with the `aria-label` carrying the meaning instead.
+ */
+function ReachingServerIndicator({ label }: ReachingServerIndicatorProps) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className="relative flex size-24 items-center justify-center"
+    >
+      <span
+        aria-hidden="true"
+        className="bg-muted-foreground/20 absolute inline-flex size-16 rounded-full motion-safe:animate-ping"
+      />
+      <span
+        aria-hidden="true"
+        className="bg-muted-foreground/15 absolute inline-flex size-12 rounded-full [animation-delay:700ms] motion-safe:animate-ping"
+      />
+      <div
+        aria-hidden="true"
+        className="bg-muted text-muted-foreground relative flex size-16 items-center justify-center rounded-full"
+      >
+        <WifiOff className="size-7" />
       </div>
     </div>
   );

--- a/services/platform/app/components/connectivity/online-gate.tsx
+++ b/services/platform/app/components/connectivity/online-gate.tsx
@@ -47,13 +47,13 @@ export function OnlineGate({ children }: OnlineGateProps) {
 function useOfflineReason(): OfflineReason | null {
   const connection = useConvexConnectionState();
   const [isDeviceOffline, setIsDeviceOffline] = useState(
-    () => typeof navigator !== 'undefined' && navigator.onLine === false,
+    () => typeof navigator !== 'undefined' && !navigator.onLine,
   );
   const [isWsStale, setIsWsStale] = useState(false);
   const graceTimer = useRef<number | null>(null);
 
   useEffect(() => {
-    const sync = () => setIsDeviceOffline(navigator.onLine === false);
+    const sync = () => setIsDeviceOffline(!navigator.onLine);
     sync();
     window.addEventListener('online', sync);
     window.addEventListener('offline', sync);

--- a/services/platform/app/components/error-boundaries/displays/global-error-display.tsx
+++ b/services/platform/app/components/error-boundaries/displays/global-error-display.tsx
@@ -1,102 +1,71 @@
 'use client';
 
 import * as Sentry from '@sentry/tanstackstart-react';
+import { Button } from '@tale/ui/button';
 import { useRouter } from '@tanstack/react-router';
+import { AlertTriangle, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react';
 import { useEffect, useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
 
 interface GlobalErrorDisplayProps {
   error: Error;
   reset?: () => void;
 }
 
+// Hardcoded English copy used only when `useT` / the i18n bundle isn't
+// available. The error boundary is also rendered very early in the tree
+// (above the i18n provider in some misconfigurations), so we still need a
+// resilient default — the message file's `common.errors.*` keys win when
+// they load.
 const FALLBACK_TEXT = {
   somethingWentWrong: 'Something went wrong',
-  errorLoadingPage: 'An error occurred while loading this page.',
+  errorLoadingPage:
+    'An error occurred while loading this page. You can try again or navigate to another section.',
   tryAgain: 'Try again',
   persistsProblem: 'If this problem persists, please',
   contactSupport: 'contact support',
-  showError: 'Show error',
-  hideError: 'Hide error',
+  showDetails: 'Show details',
+  hideDetails: 'Hide details',
 };
 
-function useIsDarkMode() {
-  const [isDark, setIsDark] = useState(false);
-
-  useEffect(() => {
-    const checkDarkMode = () => {
-      setIsDark(document.documentElement.classList.contains('dark'));
+function useFallbackTranslator() {
+  // `useT` throws if the i18n provider isn't mounted (the error boundary
+  // can render above it). Catch and degrade to the hardcoded copy so the
+  // page still has something to show.
+  try {
+    const { t } = useT('common');
+    return (key: keyof typeof FALLBACK_TEXT): string => {
+      switch (key) {
+        case 'somethingWentWrong':
+          return t('errors.somethingWentWrong');
+        case 'errorLoadingPage':
+          return t('errors.errorLoadingPage');
+        case 'tryAgain':
+          return t('errors.tryAgain');
+        case 'persistsProblem':
+          return t('errors.persistsProblem');
+        case 'contactSupport':
+          return t('errors.contactSupport');
+        // No translation key for the show/hide toggle yet — fall through.
+        default:
+          return FALLBACK_TEXT[key];
+      }
     };
-
-    checkDarkMode();
-
-    const observer = new MutationObserver(checkDarkMode);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return isDark;
-}
-
-function ErrorDetails({
-  error,
-  show,
-  isDark,
-}: {
-  error: Error;
-  show: boolean;
-  isDark: boolean;
-}) {
-  if (!show) return null;
-
-  const errorString = error.message || String(error);
-  const stack = error.stack;
-
-  return (
-    <div
-      style={{
-        marginTop: '1rem',
-        padding: '0.75rem',
-        backgroundColor: isDark ? '#2d1f1f' : '#fef2f2',
-        border: `1px solid ${isDark ? '#5c2c2c' : '#fecaca'}`,
-        borderRadius: '0.375rem',
-        textAlign: 'left',
-        maxHeight: '200px',
-        overflow: 'auto',
-      }}
-    >
-      <pre
-        style={{
-          margin: 0,
-          fontSize: '0.7rem',
-          color: isDark ? '#f87171' : '#dc2626',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-          fontFamily: 'monospace',
-        }}
-      >
-        <code>{stack || errorString}</code>
-      </pre>
-    </div>
-  );
+  } catch {
+    return (key: keyof typeof FALLBACK_TEXT) => FALLBACK_TEXT[key];
+  }
 }
 
 export function GlobalErrorDisplay({ error, reset }: GlobalErrorDisplayProps) {
   const router = useRouter();
   const [showError, setShowError] = useState(false);
-  const isDarkMode = useIsDarkMode();
-
-  const textColor = isDarkMode ? '#f3f4f6' : '#111827';
-  const mutedColor = isDarkMode ? '#9ca3af' : '#6b7280';
+  const t = useFallbackTranslator();
 
   useEffect(() => {
     Sentry.captureException(error, {
-      tags: {
-        errorBoundary: 'global',
-      },
+      tags: { errorBoundary: 'global' },
     });
   }, [error]);
 
@@ -108,103 +77,80 @@ export function GlobalErrorDisplay({ error, reset }: GlobalErrorDisplayProps) {
     }
   };
 
-  const toggleButtonStyle = {
-    padding: '0.5rem 1rem',
-    backgroundColor: isDarkMode ? '#374151' : '#e5e7eb',
-    color: isDarkMode ? '#d1d5db' : '#374151',
-    borderRadius: '0.375rem',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: '0.875rem',
-    fontWeight: 500,
-  };
-
-  const primaryButtonStyle = {
-    padding: '0.5rem 1rem',
-    backgroundColor: '#3b82f6',
-    color: 'white',
-    borderRadius: '0.375rem',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: '0.875rem',
-    fontWeight: 500,
-  };
+  const errorMessage = error.message || String(error);
+  const errorStack = error.stack;
 
   return (
     <div
-      style={{
-        minHeight: '80vh',
-        display: 'flex',
-        flexDirection: 'column',
-        flex: 1,
-      }}
+      role="alert"
+      aria-live="assertive"
+      className={cn(
+        'flex min-h-[80vh] flex-1 flex-col items-center justify-center px-6',
+        'pt-(--safe-top) pr-(--safe-right) pb-(--safe-bottom) pl-(--safe-left)',
+      )}
     >
-      <div
-        style={{
-          flex: 1,
-          display: 'flex',
-          justifyContent: 'center',
-          padding: '4rem 2rem',
-        }}
-      >
-        <div style={{ maxWidth: '28rem', textAlign: 'center' }}>
-          <h1
-            style={{
-              fontSize: '1.25rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-              color: textColor,
-            }}
-          >
-            {FALLBACK_TEXT.somethingWentWrong}
-          </h1>
-          <p
-            style={{
-              color: mutedColor,
-              fontSize: '0.875rem',
-              marginBottom: '1.5rem',
-            }}
-          >
-            {FALLBACK_TEXT.errorLoadingPage}
-          </p>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: '0.5rem',
-            }}
-          >
-            <button onClick={handleReset} style={primaryButtonStyle}>
-              {FALLBACK_TEXT.tryAgain}
-            </button>
-            <button
-              onClick={() => setShowError(!showError)}
-              style={toggleButtonStyle}
-            >
-              {showError ? FALLBACK_TEXT.hideError : FALLBACK_TEXT.showError}
-            </button>
-          </div>
-          <p
-            style={{
-              color: mutedColor,
-              fontSize: '0.75rem',
-              marginTop: '1rem',
-            }}
-          >
-            {FALLBACK_TEXT.persistsProblem}{' '}
-            <a
-              href="https://tale.dev/contact"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: '#3b82f6', textDecoration: 'underline' }}
-            >
-              {FALLBACK_TEXT.contactSupport}
-            </a>
-            .
-          </p>
-          <ErrorDetails error={error} show={showError} isDark={isDarkMode} />
+      <div className="mx-auto flex w-full max-w-md flex-col items-center text-center">
+        {/* The visual: muted icon in a soft circle — calmer than the offline
+            overlay's pulsing rings because this isn't a "we're trying"
+            state, it's a definitive failure. Static signals static. */}
+        <div
+          aria-hidden="true"
+          className="bg-muted text-muted-foreground mb-6 flex size-16 items-center justify-center rounded-full"
+        >
+          <AlertTriangle className="size-7" />
         </div>
+        <h1 className="text-foreground text-2xl leading-tight font-semibold tracking-tight">
+          {t('somethingWentWrong')}
+        </h1>
+        <p className="text-muted-foreground mt-3 text-base leading-relaxed">
+          {t('errorLoadingPage')}
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <Button
+            type="button"
+            variant="primary"
+            icon={RotateCcw}
+            className="min-h-11 px-5"
+            onClick={handleReset}
+          >
+            {t('tryAgain')}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            icon={showError ? ChevronUp : ChevronDown}
+            iconClassName="size-3.5"
+            onClick={() => setShowError((v) => !v)}
+            aria-expanded={showError}
+          >
+            {showError ? t('hideDetails') : t('showDetails')}
+          </Button>
+        </div>
+        {showError && (
+          <div
+            // Theme-tokened error surface — matches the destructive palette
+            // without resorting to hardcoded reds, so the panel stays in
+            // sync with light/dark + future palette changes.
+            className="border-destructive/30 bg-destructive/5 mt-4 max-h-64 w-full overflow-auto rounded-lg border p-3 text-left"
+          >
+            <pre className="text-destructive font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap">
+              <code>{errorStack || errorMessage}</code>
+            </pre>
+          </div>
+        )}
+        <p className="text-muted-foreground mt-6 text-xs">
+          {t('persistsProblem')}{' '}
+          <a
+            href="https://tale.dev/contact"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-2 hover:no-underline"
+          >
+            {t('contactSupport')}
+          </a>
+          .
+        </p>
       </div>
     </div>
   );

--- a/services/platform/app/components/error-boundaries/displays/global-error-display.tsx
+++ b/services/platform/app/components/error-boundaries/displays/global-error-display.tsx
@@ -35,6 +35,7 @@ function useFallbackTranslator() {
   // can render above it). Catch and degrade to the hardcoded copy so the
   // page still has something to show.
   try {
+    // oxlint-disable-next-line react-hooks/rules-of-hooks -- `useT` throws when this boundary renders above the i18n provider; the catch degrades to hardcoded fallback copy. A conditional hook is the only recovery here.
     const { t } = useT('common');
     return (key: keyof typeof FALLBACK_TEXT): string => {
       switch (key) {
@@ -54,6 +55,12 @@ function useFallbackTranslator() {
       }
     };
   } catch {
+    // i18n provider isn't mounted above this boundary — expected when the
+    // boundary catches an error before the provider renders. Degrade to the
+    // hardcoded copy; warn so an unexpected occurrence is still visible.
+    console.warn(
+      '[GlobalErrorDisplay] i18n provider unavailable, using fallback text',
+    );
     return (key: keyof typeof FALLBACK_TEXT) => FALLBACK_TEXT[key];
   }
 }

--- a/services/platform/app/components/ui/data-display/zoom-pan-viewer.test.tsx
+++ b/services/platform/app/components/ui/data-display/zoom-pan-viewer.test.tsx
@@ -258,24 +258,24 @@ describe('ZoomPanViewer', () => {
       expect(screen.getByText('50%')).toBeInTheDocument();
     });
 
-    it('cannot zoom above maximum (300%)', () => {
+    it('cannot zoom above maximum (500%)', () => {
       render(<ZoomPanViewer {...defaultProps} />);
 
-      // Zoom in 8 times: 100 -> 125 -> 150 -> 175 -> 200 -> 225 -> 250 -> 275 -> 300
-      for (let i = 0; i < 8; i++) {
+      // Zoom in 16 times: 100% + 16 × 25% = 500% (the max).
+      for (let i = 0; i < 16; i++) {
         fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
       }
-      expect(screen.getByText('300%')).toBeInTheDocument();
+      expect(screen.getByText('500%')).toBeInTheDocument();
 
-      // Further zoom in stays at 300%
+      // Further zoom in stays at 500%
       fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
-      expect(screen.getByText('300%')).toBeInTheDocument();
+      expect(screen.getByText('500%')).toBeInTheDocument();
     });
 
     it('disables zoom in button at maximum', () => {
       render(<ZoomPanViewer {...defaultProps} />);
 
-      for (let i = 0; i < 8; i++) {
+      for (let i = 0; i < 16; i++) {
         fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
       }
 

--- a/services/platform/app/components/ui/data-display/zoom-pan-viewer.tsx
+++ b/services/platform/app/components/ui/data-display/zoom-pan-viewer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Text } from '@tale/ui/text';
-import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
-import { memo } from 'react';
+import { RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react';
+import { memo, useCallback } from 'react';
 
 import { useZoomPan } from '@/app/hooks/use-zoom-pan';
 import { useT } from '@/lib/i18n/client';
@@ -34,6 +34,13 @@ interface ZoomPanViewerProps {
   onLoad?: () => void;
   /** Called when the image fails to load */
   onError?: () => void;
+  /**
+   * When provided, renders a close (✕) button at the far right of the
+   * overlay header. Use from dialog/lightbox contexts where the wrapping
+   * `<Dialog>` is rendered with `hideClose` and the viewer owns the
+   * dismiss affordance. Ignored when `toolbarPosition` is not `'overlay'`.
+   */
+  onClose?: () => void;
 }
 
 export const ZoomPanViewer = memo(function ZoomPanViewer({
@@ -47,6 +54,7 @@ export const ZoomPanViewer = memo(function ZoomPanViewer({
   imageClassName,
   onLoad,
   onError,
+  onClose,
 }: ZoomPanViewerProps) {
   const { t } = useT('common');
   const {
@@ -56,12 +64,26 @@ export const ZoomPanViewer = memo(function ZoomPanViewer({
     zoomIn,
     zoomOut,
     reset,
+    toggleZoom,
     pointerHandlers,
     canZoomIn,
     canZoomOut,
     isZoomed,
     transformStyle,
   } = useZoomPan({ resetTrigger });
+
+  // Double-click toggles between fit (1x) and the configured zoom-in target,
+  // anchored to the click point so the spot the user double-clicked stays
+  // put as the image grows around it. Drag-while-zoomed sometimes ends with
+  // a synthetic dblclick if the user lifts the pointer fast — guard on
+  // `isDragging` so a pan release doesn't accidentally reset the zoom.
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isDragging) return;
+      toggleZoom({ x: e.clientX, y: e.clientY });
+    },
+    [isDragging, toggleZoom],
+  );
 
   const isBottom = toolbarPosition === 'bottom';
 
@@ -119,9 +141,25 @@ export const ZoomPanViewer = memo(function ZoomPanViewer({
     switch (toolbarPosition) {
       case 'overlay':
         return (
-          <div className="absolute top-4 right-4 left-4 z-10 flex items-center justify-between">
+          <div className="absolute top-4 right-4 left-4 z-10 flex items-center justify-between gap-2">
             {headerContent ?? <span />}
-            {toolbar}
+            <div className="flex items-center gap-2">
+              {toolbar}
+              {onClose && (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="bg-muted text-foreground hover:bg-muted/80 grid size-8 place-items-center rounded-lg transition"
+                  // `common.imagePreview.*` is a missing group — the sibling
+                  // zoom buttons fall through to literal keys (pre-existing
+                  // bug). Use the canonical `common.aria.close` until the
+                  // group is filled in.
+                  aria-label={t('aria.close')}
+                >
+                  <X className="size-4" />
+                </button>
+              )}
+            </div>
           </div>
         );
       case 'bottom':
@@ -140,9 +178,13 @@ export const ZoomPanViewer = memo(function ZoomPanViewer({
       <div
         ref={containerRef}
         tabIndex={isZoomed ? 0 : -1}
+        onDoubleClick={handleDoubleClick}
         className={cn(
           'flex flex-1 items-center justify-center overflow-hidden outline-none',
-          isZoomed ? 'cursor-grab' : 'cursor-default',
+          // At fit-level the pointer hints "double-click to zoom"; once zoomed
+          // it flips to grab / grabbing during drag-pan. `zoom-in` is a real
+          // CSS cursor recognized by all evergreen browsers.
+          isZoomed ? 'cursor-grab' : 'cursor-zoom-in',
           isDragging && 'cursor-grabbing',
           'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2',
         )}

--- a/services/platform/app/components/ui/data-table/column-builders.tsx
+++ b/services/platform/app/components/ui/data-table/column-builders.tsx
@@ -55,6 +55,25 @@ interface ActionsColumnOptions {
   headerLabel?: string;
 }
 
+/**
+ * Canonical width for the row-actions column. Sized for a single icon-only
+ * `MoreVertical` trigger (the `EntityRowActions` shape every table should
+ * use). Locked across tables so the 3-dot column lands at the exact same
+ * x-offset whether you're looking at customers, vendors, teams, or any
+ * future entity list — visual rhythm across the dashboard depends on it.
+ *
+ * Override only when a row genuinely needs an in-line button cluster (rare
+ * — collapse into the dropdown instead), and document the reason in code.
+ */
+export const ACTIONS_COLUMN_SIZE = 56;
+
+/**
+ * Canonical width for the multi-select column. Mirrors the actions column's
+ * `ACTIONS_COLUMN_SIZE` purpose on the opposite side of the row: a single
+ * 24px Checkbox centered in a 40px column. See `createSelectColumn`.
+ */
+export const SELECT_COLUMN_SIZE = 40;
+
 interface CreationTimeColumnOptions {
   size?: number;
 }
@@ -83,6 +102,12 @@ interface TextColumnOptions {
 /**
  * Creates the standard actions column for row actions.
  *
+ * Pin this last in your `columns` array so the 3-dot trigger sits at the
+ * row's right edge consistently across every table. The default width is
+ * `ACTIONS_COLUMN_SIZE` — don't override unless you genuinely have more
+ * than a single dropdown trigger (in which case, prefer collapsing the
+ * cluster into the dropdown instead).
+ *
  * @example
  * ```tsx
  * createActionsColumn(CustomerRowActions, 'customer')
@@ -98,7 +123,7 @@ export function createActionsColumn<TData, TPropName extends string>(
     header: options?.headerLabel
       ? () => <span className="sr-only">{options.headerLabel}</span>
       : undefined,
-    size: options?.size ?? 140,
+    size: options?.size ?? ACTIONS_COLUMN_SIZE,
     meta: { isAction: true },
     cell: ({ row }) => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Computed property key loses type narrowing
@@ -291,27 +316,38 @@ export function createTextColumn<TData, K extends keyof TData>(
 export function createSelectColumn<TData>(): ColumnDef<TData> {
   return {
     id: 'select',
-    size: 40,
+    size: SELECT_COLUMN_SIZE,
+    // Cells with multi-line content (avatar + name + caption) make the row
+    // taller than the checkbox's intrinsic height. `TableCell` does set
+    // `vertical-align: middle`, but the checkbox is `inline-flex` and ends up
+    // sitting on the first text line. Wrapping in `flex h-full items-center`
+    // anchors the checkbox to the row's true vertical center, matching the
+    // column text alongside it. `justify-center` keeps it centered within the
+    // 40px column width.
     header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected()
-            ? true
-            : table.getIsSomePageRowsSelected()
-              ? 'indeterminate'
-              : false
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label={i18n.t('common.aria.selectAll')}
-      />
+      <div className="flex h-full items-center justify-center">
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected()
+              ? true
+              : table.getIsSomePageRowsSelected()
+                ? 'indeterminate'
+                : false
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label={i18n.t('common:aria.selectAll')}
+        />
+      </div>
     ),
     cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        onClick={(e) => e.stopPropagation()}
-        aria-label={i18n.t('common.aria.selectRow')}
-      />
+      <div className="flex h-full items-center justify-center">
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={i18n.t('common:aria.selectRow')}
+        />
+      </div>
     ),
     meta: { skeleton: { type: 'action' } },
   };

--- a/services/platform/app/components/ui/data-table/data-table-filters.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-filters.tsx
@@ -89,6 +89,12 @@ export interface DataTableFiltersProps {
   };
   /** Whether filters are loading */
   isLoading?: boolean;
+  /**
+   * When `true`, the filter button is rendered disabled and its popover is
+   * suppressed — used by `DataTable` when the table has no rows and no
+   * active filters, so the affordance can't be opened over an empty set.
+   */
+  disabled?: boolean;
   /** Callback to clear all filters */
   onClearAll?: () => void;
   /** Additional content to render in the filter bar */
@@ -112,6 +118,7 @@ export function DataTableFilters({
   filters = EMPTY_FILTERS,
   dateRange,
   isLoading = false,
+  disabled = false,
   onClearAll,
   children,
   className,
@@ -121,6 +128,14 @@ export function DataTableFilters({
   const [expandedSections, setExpandedSections] = useState<
     Record<string, boolean>
   >({});
+  // `DatePickerWithRange` reads `defaultDate` only via its useState initializer
+  // (true `default*` semantics), so calling `dateRange.onChange(undefined)`
+  // from `handleClearAll` only updates the parent state — the picker's own
+  // local `startDate`/`endDate` survive, and the trigger still shows the old
+  // range. Bumping this key forces a remount so the initializer re-reads the
+  // now-undefined `defaultDate` and the trigger paints empty again. Cheaper
+  // than making the picker fully controlled across every caller.
+  const [dateResetKey, setDateResetKey] = useState(0);
 
   const totalActiveFilters = filters.reduce(
     (acc, filter) => acc + filter.selectedValues.length,
@@ -151,6 +166,9 @@ export function DataTableFilters({
     filters.forEach((filter) => filter.onChange([]));
     if (dateRange?.onChange) {
       dateRange.onChange(undefined);
+      // Remount the date picker so its uncontrolled internal state clears.
+      // See `dateResetKey`'s declaration for the why.
+      setDateResetKey((n) => n + 1);
     }
     onClearAll?.();
     setIsFilterOpen(false);
@@ -179,7 +197,19 @@ export function DataTableFilters({
             />
           )}
 
-          {filters.length > 0 && (
+          {filters.length > 0 && disabled && (
+            // Empty table, no active filters — render a plain disabled
+            // FilterButton instead of the Popover so the affordance can't be
+            // opened over a guaranteed-empty result set. A disabled button on
+            // the Popover trigger isn't sufficient: the trigger's wrapper div
+            // still toggles the popover.
+            <FilterButton
+              hasActiveFilters={false}
+              isLoading={isLoading}
+              disabled
+            />
+          )}
+          {filters.length > 0 && !disabled && (
             <Popover
               open={isFilterOpen}
               onOpenChange={setIsFilterOpen}
@@ -345,9 +375,13 @@ export function DataTableFilters({
             }
           >
             <DatePickerWithRange
+              key={dateResetKey}
               defaultDate={{ from: dateRange.from, to: dateRange.to }}
               onChange={dateRange.onChange}
               presets={dateRange.presets}
+              // Mirror the filter button + search: empty table + no active
+              // filters => nothing to filter by date against either.
+              disabled={disabled}
             />
           </SuspenseBoundary>
         )}

--- a/services/platform/app/components/ui/data-table/data-table-filters.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-filters.tsx
@@ -370,7 +370,7 @@ export function DataTableFilters({
             }
             errorFallback={
               <Text as="span" variant="muted">
-                Date filter unavailable
+                {t('dataTable.dateFilterUnavailable')}
               </Text>
             }
           >

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -36,12 +36,14 @@ import {
   useRef,
   useEffect,
   useCallback,
+  type CSSProperties,
   type ReactNode,
 } from 'react';
 import type { DateRange } from 'react-day-picker';
 
 import { ErrorBoundaryBase } from '@/app/components/error-boundaries/core/error-boundary-base';
 import { ErrorDisplayCompact } from '@/app/components/error-boundaries/displays/error-display-compact';
+import { SELECT_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import type { DatePreset } from '@/app/components/ui/forms/date-range-picker';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
@@ -136,8 +138,13 @@ export interface DataTableProps<TData, TValue = unknown> {
   isLoading?: boolean;
   /** Sorting configuration from useDataTable hook */
   sorting?: DataTableSortingConfig;
-  /** Enable row selection */
-  enableRowSelection?: boolean;
+  /**
+   * Enable row selection. Pass `true` to allow selecting any row, or a
+   * predicate `(row) => boolean` to gate selectability per-row (folder
+   * aggregates, read-only rows, etc.). Mirrors TanStack Table's own
+   * `enableRowSelection` shape so the function form goes straight through.
+   */
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
   /** Row selection state (controlled) */
   rowSelection?: RowSelectionState;
   /** Callback when row selection changes */
@@ -322,7 +329,9 @@ export function DataTable<TData, TValue = unknown>({
       onSortingChange: onSortingChange ?? setInternalSorting,
     }),
     ...(enableRowSelection && {
-      enableRowSelection: true,
+      // Forward the consumer's predicate (or `true`) straight to TanStack so
+      // per-row gating works without an intermediate translation.
+      enableRowSelection,
       onRowSelectionChange: onRowSelectionChange ?? setInternalRowSelection,
     }),
     ...(enableExpanding && {
@@ -450,6 +459,9 @@ export function DataTable<TData, TValue = unknown>({
         filters={filters}
         dateRange={dateRange}
         isLoading={isFiltersLoading}
+        // Mirror `searchDisabled`: empty table + no active filters → also
+        // disable the filter affordance (nothing to filter against).
+        disabled={searchDisabled}
         onClearAll={onClearFilters}
       >
         {filtersContent}
@@ -462,12 +474,65 @@ export function DataTable<TData, TValue = unknown>({
 
   const rows = table.getRowModel().rows;
 
+  // The table renders with `table-layout: auto`, where a column's `width` is
+  // only a hint: when the columns' natural widths don't fill the container the
+  // browser distributes the slack across *all* columns. That inflated the
+  // fixed-size select / actions columns and shifted the checkbox + 3-dot
+  // trigger to a different x on every table (the slack varies with column
+  // count + content). To keep those utility columns pinned, they render with a
+  // 1px width so auto-layout can't grow them, and their content sits in a
+  // fixed-size box (`utilityCellBox`) that sets the column's real width.
+  // The remaining slack then flows only to the content columns, which grow
+  // proportionally to their declared sizes — no single runaway column.
+  const isUtilityCol = (id: string, isAction?: boolean) =>
+    id === 'select' || id === 'actions' || !!isAction;
+  // Utility columns render at 1px so auto-layout can't grow them; their content
+  // box (below) dictates the real, pinned width. Content columns take their
+  // declared size and share the leftover space proportionally.
+  const cellWidthStyle = (
+    id: string,
+    size: number | undefined,
+    isAction?: boolean,
+  ): CSSProperties =>
+    isUtilityCol(id, isAction)
+      ? // A *percentage* width (not px) is what makes auto-layout leave this
+        // column at its content size instead of handing it a share of the
+        // slack — px widths still grow. 1% always loses to the fixed-size box.
+        { width: '1%' }
+      : { width: size !== undefined && size !== 150 ? size : undefined };
+  // Wrap a utility cell's content in a fixed-width box so the column shrinks to
+  // exactly its declared size (the select checkbox centered, the row-actions
+  // trigger right-aligned) — identical on every table. `p-0` on the cell hands
+  // all spacing to this box so padding doesn't widen the pinned column.
+  const utilityCellBox = (
+    id: string,
+    size: number | undefined,
+    node: ReactNode,
+  ): ReactNode => (
+    <div
+      style={{
+        width: size !== undefined && size !== 150 ? size : SELECT_COLUMN_SIZE,
+      }}
+      className={cn(
+        'flex h-full items-center',
+        id === 'select' ? 'mx-auto justify-center' : 'ml-auto justify-end pr-3',
+      )}
+    >
+      {node}
+    </div>
+  );
+
   // Shared table content. Wrapped in Skeletonize (outside <table>) so the
   // placeholder cells below pulse while loading; idle it adds no box.
   const tableContent = (
     <Skeletonize loading={isSkeleton}>
       <Table
-        stickyLayout={stickyLayout}
+        // Always render the bare <table> (no primitive scroll wrapper). Both
+        // layout branches below supply their own scroll container with the
+        // border placed on an inner `w-fit min-w-full` wrapper, so the rounded
+        // border wraps the full table width and scrolls with the content
+        // instead of being pinned to the visible viewport.
+        stickyLayout
         // `max(100%, …)` so the table still fills a wide container (preserving
         // the primitive's `min-w-full`) while gaining a content-based floor that
         // forces horizontal scroll on narrow viewports instead of squashing.
@@ -482,30 +547,34 @@ export function DataTable<TData, TValue = unknown>({
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="bg-muted">
               {enableExpanding && <TableHead className="w-[3rem]" />}
-              {headerGroup.headers.map((headerCell) => (
-                <TableHead
-                  key={headerCell.id}
-                  className={cn(
-                    'text-sm font-medium',
-                    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ColumnDef.meta is typed as unknown by TanStack Table
-                    (headerCell.column.columnDef.meta as ColumnMeta | undefined)
-                      ?.className,
-                  )}
-                  style={{
-                    width:
-                      headerCell.column.getSize() !== 150
-                        ? headerCell.column.getSize()
-                        : undefined,
-                  }}
-                >
-                  {headerCell.isPlaceholder
-                    ? null
-                    : flexRender(
-                        headerCell.column.columnDef.header,
-                        headerCell.getContext(),
-                      )}
-                </TableHead>
-              ))}
+              {headerGroup.headers.map((headerCell) => {
+                // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ColumnDef.meta is typed as unknown by TanStack Table
+                const meta = headerCell.column.columnDef.meta as
+                  | ColumnMeta
+                  | undefined;
+                const id = headerCell.column.id;
+                const size = headerCell.column.getSize();
+                const utility = isUtilityCol(id, meta?.isAction);
+                const content = headerCell.isPlaceholder
+                  ? null
+                  : flexRender(
+                      headerCell.column.columnDef.header,
+                      headerCell.getContext(),
+                    );
+                return (
+                  <TableHead
+                    key={headerCell.id}
+                    className={cn(
+                      'text-sm font-medium',
+                      utility && 'p-0',
+                      meta?.className,
+                    )}
+                    style={cellWidthStyle(id, size, meta?.isAction)}
+                  >
+                    {utility ? utilityCellBox(id, size, content) : content}
+                  </TableHead>
+                );
+              })}
             </TableRow>
           ))}
         </TableHeader>
@@ -633,18 +702,17 @@ export function DataTable<TData, TValue = unknown>({
                     );
                   }
 
+                  const id = col.id ?? '';
+                  const utility = isUtilityCol(id, isActionCol);
                   return (
                     <TableCell
                       key={colIndex}
-                      className={meta?.className}
-                      style={{
-                        width:
-                          col.size !== undefined && col.size !== 150
-                            ? col.size
-                            : undefined,
-                      }}
+                      className={cn(utility && 'p-0', meta?.className)}
+                      style={cellWidthStyle(id, col.size, isActionCol)}
                     >
-                      {cellContent}
+                      {utility
+                        ? utilityCellBox(id, col.size, cellContent)
+                        : cellContent}
                     </TableCell>
                   );
                 })}
@@ -693,6 +761,11 @@ export function DataTable<TData, TValue = unknown>({
                   <TableRow
                     className={cn(
                       'group',
+                      // Consistent baseline row height across every table — text-
+                      // only rows (e.g. projects) would otherwise sit shorter than
+                      // rows with an avatar/icon. `h-12` is a *minimum* for table
+                      // rows, so multi-line cells still grow past it.
+                      'h-12',
                       index === rows.length - 1 ? 'border-b-0' : '',
                       clickableRows || onRowClick ? 'cursor-pointer' : '',
                       isNewRow && 'animate-row-enter',
@@ -718,27 +791,30 @@ export function DataTable<TData, TValue = unknown>({
                         />
                       </TableCell>
                     )}
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell
-                        key={cell.id}
-                        className={
-                          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ColumnDef.meta is typed as unknown by TanStack Table
-                          (cell.column.columnDef.meta as ColumnMeta | undefined)
-                            ?.className
-                        }
-                        style={{
-                          width:
-                            cell.column.getSize() !== 150
-                              ? cell.column.getSize()
-                              : undefined,
-                        }}
-                      >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
+                    {row.getVisibleCells().map((cell) => {
+                      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ColumnDef.meta is typed as unknown by TanStack Table
+                      const meta = cell.column.columnDef.meta as
+                        | ColumnMeta
+                        | undefined;
+                      const id = cell.column.id;
+                      const size = cell.column.getSize();
+                      const utility = isUtilityCol(id, meta?.isAction);
+                      const content = flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      );
+                      return (
+                        <TableCell
+                          key={cell.id}
+                          className={cn(utility && 'p-0', meta?.className)}
+                          style={cellWidthStyle(id, size, meta?.isAction)}
+                        >
+                          {utility
+                            ? utilityCellBox(id, size, content)
+                            : content}
+                        </TableCell>
+                      );
+                    })}
                   </TableRow>
                   {enableExpanding && isExpanded && renderExpandedRow && (
                     <TableRow className="border-0 hover:bg-transparent">
@@ -868,10 +944,17 @@ export function DataTable<TData, TValue = unknown>({
       >
         <div className={cn('space-y-4', className)}>
           {headerContent}
-          <div className="border-border overflow-x-auto rounded-lg border">
-            {tableContent}
-            {infiniteScrollContent}
-            {entityCountFooter}
+          {/* Scroll container holds no border; the bordered wrapper inside is
+              `w-fit min-w-full` so it grows to the full table width and scrolls
+              with the content — the border frames the whole table, not just the
+              visible slice. `overflow-hidden` clips the rounded corners (safe
+              here: this layout has no sticky header). */}
+          <div className="overflow-x-auto">
+            <div className="border-border w-fit min-w-full overflow-hidden rounded-lg border">
+              {tableContent}
+              {infiniteScrollContent}
+              {entityCountFooter}
+            </div>
           </div>
           {paginationContent}
           {footer}
@@ -894,18 +977,30 @@ export function DataTable<TData, TValue = unknown>({
     >
       <div className={cn('flex flex-col flex-1 min-h-0 min-w-0', className)}>
         {headerContent && <div className="shrink-0 pb-4">{headerContent}</div>}
+        {/* The scroll container itself carries no border so the bordered,
+            `w-fit min-w-full` wrapper inside grows to the full table width and
+            scrolls with it (border frames the whole table, not just the visible
+            slice). No `overflow-hidden` on the wrapper here — that would make it
+            the scrollport and break the sticky header, which must stick to the
+            outer `scrollContainerRef`. */}
         <div
           ref={scrollContainerRef}
-          className="border-border min-h-0 overflow-auto overscroll-contain rounded-lg border"
+          className="min-h-0 overflow-auto overscroll-contain"
         >
-          {tableContent}
-          {infiniteScrollContent}
-          {entityCountFooter}
+          <div className="border-border w-fit min-w-full rounded-lg border">
+            {tableContent}
+            {infiniteScrollContent}
+            {entityCountFooter}
+          </div>
         </div>
         {paginationContent && (
           <div className="shrink-0 pt-6">{paginationContent}</div>
         )}
-        {footer}
+        {/* `pt-4` matches the gap the non-sticky layout gets from `space-y-4`.
+            `empty:hidden` collapses the wrapper when the footer renders nothing
+            (e.g. the bulk-delete bar with no selection) so it adds no phantom
+            gap. */}
+        {footer && <div className="shrink-0 pt-4 empty:hidden">{footer}</div>}
       </div>
     </ErrorBoundaryBase>
   );

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -43,7 +43,10 @@ import type { DateRange } from 'react-day-picker';
 
 import { ErrorBoundaryBase } from '@/app/components/error-boundaries/core/error-boundary-base';
 import { ErrorDisplayCompact } from '@/app/components/error-boundaries/displays/error-display-compact';
-import { SELECT_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
+import {
+  ACTIONS_COLUMN_SIZE,
+  SELECT_COLUMN_SIZE,
+} from '@/app/components/ui/data-table/column-builders';
 import type { DatePreset } from '@/app/components/ui/forms/date-range-picker';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
@@ -511,7 +514,12 @@ export function DataTable<TData, TValue = unknown>({
   ): ReactNode => (
     <div
       style={{
-        width: size !== undefined && size !== 150 ? size : SELECT_COLUMN_SIZE,
+        width:
+          size !== undefined && size !== 150
+            ? size
+            : id === 'actions'
+              ? ACTIONS_COLUMN_SIZE
+              : SELECT_COLUMN_SIZE,
       }}
       className={cn(
         'flex h-full items-center',

--- a/services/platform/app/components/ui/entity/entity-row-actions.tsx
+++ b/services/platform/app/components/ui/entity/entity-row-actions.tsx
@@ -90,12 +90,31 @@ export const EntityRowActions = React.memo(function EntityRowActions({
     return null;
   }
 
+  // Group actions into separated sections. A divider is inserted either where
+  // a call-site asks for one (`separator`) or — automatically — before the
+  // first destructive action (delete / archive / …) so every menu visually
+  // splits "normal" actions from dangerous ones without each call-site opting
+  // in. Consecutive destructive actions, or a section already opened by an
+  // explicit separator, stay together (no extra divider between them).
   const menuItems: DropdownMenuGroup[] = [];
   let currentGroup: DropdownMenuItem[] = [];
+  let currentGroupIsDestructiveSection = false;
   for (const action of visibleActions) {
-    if (action.separator && currentGroup.length > 0) {
+    const startsDestructiveSection =
+      !!action.destructive && !currentGroupIsDestructiveSection;
+    if (
+      currentGroup.length > 0 &&
+      (action.separator || startsDestructiveSection)
+    ) {
       menuItems.push(currentGroup);
       currentGroup = [];
+      currentGroupIsDestructiveSection = false;
+    }
+    // Once a section is opened by an explicit separator or contains a
+    // destructive action, later destructive actions join it (no extra divider
+    // between consecutive dangerous actions like archive + delete).
+    if (action.separator || action.destructive) {
+      currentGroupIsDestructiveSection = true;
     }
     currentGroup.push({
       type: 'item',

--- a/services/platform/app/components/ui/forms/date-range-picker.tsx
+++ b/services/platform/app/components/ui/forms/date-range-picker.tsx
@@ -132,6 +132,12 @@ export interface DatePickerWithRangeProps extends Omit<
   onChange: (date: DateRange | undefined) => void;
   defaultDate?: DateRange;
   isLoading?: boolean;
+  /**
+   * When true, the date and preset triggers render disabled — distinct from
+   * `isLoading` (which also shows a spinner). Use for "no rows to filter
+   * against" states so the affordance reads as inert rather than busy.
+   */
+  disabled?: boolean;
   presets?: DatePreset[];
   label?: string;
   description?: ReactNode;
@@ -185,6 +191,7 @@ interface CustomInputProps {
   value?: string;
   onClick?: () => void;
   isLoading?: boolean;
+  disabled?: boolean;
   placeholder?: string;
   presetLabel?: string;
   presetOptions: { key: DatePreset; label: string }[];
@@ -197,6 +204,7 @@ const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(
       value,
       onClick,
       isLoading,
+      disabled,
       placeholder,
       presetLabel,
       presetOptions,
@@ -210,7 +218,7 @@ const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(
         size="sm"
         type="button"
         variant="secondary"
-        disabled={isLoading}
+        disabled={isLoading || disabled}
         onClick={onClick}
         className={cn(
           'w-auto justify-start text-sm text-left font-normal space-x-2 px-2.5 rounded-r-none border-r-0 ring-0',
@@ -240,7 +248,7 @@ const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(
             size="sm"
             type="button"
             variant="secondary"
-            disabled={isLoading}
+            disabled={isLoading || disabled}
             className="w-[8.25rem] justify-between gap-1.5 rounded-l-none px-2.5 ring-0"
           >
             <Text as="span" variant="muted" className="font-normal">
@@ -272,6 +280,7 @@ function DatePickerWithRangeBase({
   onChange,
   defaultDate,
   isLoading = false,
+  disabled = false,
   presets = DEFAULT_PRESETS,
   label,
   description,
@@ -363,11 +372,12 @@ function DatePickerWithRangeBase({
         endDate={endDate}
         onChange={handleDateChange}
         dateFormat="dd / MM / yyyy"
-        disabled={isLoading}
+        disabled={isLoading || disabled}
         placeholderText={t('upload.pickADate')}
         customInput={
           <CustomInput
             isLoading={isLoading}
+            disabled={disabled}
             presetLabel={presetLabel}
             presetOptions={presetOptions}
             onPresetSelect={handlePresetSelect}

--- a/services/platform/app/components/ui/forms/date-range-picker.tsx
+++ b/services/platform/app/components/ui/forms/date-range-picker.tsx
@@ -353,10 +353,11 @@ function DatePickerWithRangeBase({
   );
 
   const handleClear = useCallback(() => {
+    if (disabled || isLoading) return;
     setStartDate(null);
     setEndDate(null);
     onChange(undefined);
-  }, [onChange]);
+  }, [disabled, isLoading, onChange]);
 
   const picker = (
     <div
@@ -410,6 +411,7 @@ function DatePickerWithRangeBase({
               variant="ghost"
               size="sm"
               onClick={handleClear}
+              disabled={disabled || isLoading}
               className="relative top-1 ml-auto block h-min px-2 py-1 text-xs"
             >
               {t('actions.reset')}

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -93,6 +93,19 @@ export interface SearchableSelectProps {
   /** Optional action element rendered on the right side of each option */
   optionAction?: (option: SearchableSelectOption) => ReactNode;
   /**
+   * How an option's `description` is presented.
+   *   - `'inline'` (default): rendered as a caption row below the label —
+   *     good when descriptions are short and the list is small.
+   *   - `'tooltip'`: hidden in the row, surfaced in a Radix tooltip when the
+   *     row is hovered or keyboard-highlighted — keeps a long list scannable
+   *     while still letting users get details on demand. Used by the agent
+   *     selector where the agent count + per-agent prose would otherwise
+   *     blow the picker out vertically.
+   *
+   * @default 'inline'
+   */
+  descriptionMode?: 'inline' | 'tooltip';
+  /**
    * Optional hover/focus tooltip for the trigger. When set, the trigger is
    * composed with a Radix tooltip (both triggers collapse onto the same DOM
    * node via `asChild`), so the popover still opens on click while the tooltip
@@ -159,6 +172,7 @@ function SearchableSelectBase({
   filterFn,
   showRadio,
   optionAction,
+  descriptionMode = 'inline',
   tooltip,
   tooltipSide = 'top',
 }: SearchableSelectProps) {
@@ -388,6 +402,7 @@ function SearchableSelectBase({
                 onSelect={handleSelect}
                 onMouseEnter={setHighlightedIndex}
                 showRadio={showRadio}
+                descriptionMode={descriptionMode}
                 action={optionAction?.(option)}
               />
             ))}
@@ -459,6 +474,7 @@ function SearchableSelectOptionItem({
   onSelect,
   onMouseEnter,
   showRadio,
+  descriptionMode = 'inline',
   action,
 }: {
   option: SearchableSelectOption;
@@ -469,9 +485,22 @@ function SearchableSelectOptionItem({
   onSelect: (value: string) => void;
   onMouseEnter: (index: number) => void;
   showRadio?: boolean;
+  descriptionMode?: 'inline' | 'tooltip';
   action?: ReactNode;
 }) {
-  return (
+  // Inline mode renders the description directly under the label; tooltip
+  // mode hides it from the row and surfaces it on hover/keyboard-highlight.
+  // The `items-start` vs `items-center` swap is only relevant for inline —
+  // tooltip mode keeps a single-line row regardless of whether a description
+  // exists.
+  const showInlineDescription =
+    descriptionMode === 'inline' && Boolean(option.description);
+  const tooltipContent =
+    descriptionMode === 'tooltip' && option.description
+      ? option.description
+      : null;
+
+  const row = (
     // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- keyboard handled via aria-activedescendant
     <div
       role="option"
@@ -484,7 +513,7 @@ function SearchableSelectOptionItem({
       onMouseEnter={() => onMouseEnter(index)}
       className={cn(
         'group/option flex w-full cursor-default gap-2 rounded-md p-2 text-left text-sm transition-colors',
-        option.description ? 'items-start' : 'items-center',
+        showInlineDescription ? 'items-start' : 'items-center',
         isHighlighted && 'bg-accent',
         option.disabled && 'pointer-events-none opacity-50',
       )}
@@ -521,7 +550,7 @@ function SearchableSelectOptionItem({
           </Text>
           {option.labelBadge}
         </div>
-        {option.description && (
+        {showInlineDescription && (
           <Text as="div" variant="caption">
             {option.description}
           </Text>
@@ -532,5 +561,31 @@ function SearchableSelectOptionItem({
       )}
       {action}
     </div>
+  );
+
+  if (!tooltipContent) return row;
+
+  // In tooltip mode the description is hidden from the row and surfaced on
+  // hover (or keyboard highlight, which fires onMouseEnter via this row's
+  // own pointer events as the listbox scrolls a focused option into view).
+  // `side="right"` keeps the popover from overlapping the next row's label;
+  // `align="start"` anchors it to the row top so long descriptions don't
+  // float into the row above.
+  return (
+    <TooltipPrimitive.Provider delayDuration={250}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>{row}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipContent
+            side="right"
+            align="start"
+            collisionPadding={8}
+            className="max-w-xs text-xs leading-relaxed"
+          >
+            {tooltipContent}
+          </TooltipContent>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
   );
 }

--- a/services/platform/app/components/ui/navigation/tab-navigation.tsx
+++ b/services/platform/app/components/ui/navigation/tab-navigation.tsx
@@ -251,8 +251,40 @@ export function TabNavigation({
     return { current: refs };
   }, [accessibleItems]);
 
-  // Re-measure on resize
-  useResizeObserver(allRefs, updateIndicator, {
+  // Re-measure on resize. Horizontal window/container drags fire the observer
+  // many times per second; the indicator's 200ms slide transition chases each
+  // measurement and shows up as a visible flicker (the underline lagging /
+  // jittering behind the active tab as it moves with the layout). Vertical
+  // resize doesn't reach this codepath because none of the measured rects
+  // change. Pattern mirrors the scroll handler below: suppress the transition
+  // for the duration of the resize burst, then restore after a short idle so
+  // genuine tab switches still animate.
+  const resizeRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const updateIndicatorForResize = useCallback(() => {
+    const indicator = indicatorRef.current;
+    if (indicator) indicator.style.transition = 'none';
+    updateIndicator();
+    if (resizeRestoreTimerRef.current) {
+      clearTimeout(resizeRestoreTimerRef.current);
+    }
+    resizeRestoreTimerRef.current = setTimeout(() => {
+      const settled = indicatorRef.current;
+      if (settled) settled.style.transition = '';
+      resizeRestoreTimerRef.current = null;
+    }, 150);
+  }, [updateIndicator]);
+  useEffect(
+    () => () => {
+      if (resizeRestoreTimerRef.current) {
+        clearTimeout(resizeRestoreTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  useResizeObserver(allRefs, updateIndicatorForResize, {
     listenToWindow: true,
     deps: [accessibleItems.length],
   });
@@ -292,7 +324,7 @@ export function TabNavigation({
               preload={prefetch ? 'render' : false}
               aria-current={isActive ? 'page' : undefined}
               className={cn(
-                "relative h-full flex items-center gap-1.5 py-1 text-sm font-medium transition-colors whitespace-nowrap shrink-0 rounded-sm focus-visible:outline-none focus-visible:after:content-[''] focus-visible:after:absolute focus-visible:after:-inset-x-1 focus-visible:after:inset-y-0.5 focus-visible:after:rounded-sm focus-visible:after:ring-2 focus-visible:after:ring-ring focus-visible:after:ring-inset focus-visible:after:pointer-events-none justify-center",
+                'relative flex h-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-sm py-1 text-sm font-medium transition-colors outline-none focus-visible:outline-none',
                 isActive
                   ? 'text-foreground'
                   : 'text-muted-foreground hover:text-foreground',

--- a/services/platform/app/features/agents/components/agent-row-actions.test.tsx
+++ b/services/platform/app/features/agents/components/agent-row-actions.test.tsx
@@ -55,7 +55,7 @@ describe('AgentRowActions', () => {
     await user.click(
       screen.getByRole('button', { name: 'common.actions.openMenu' }),
     );
-    await user.click(screen.getByText('common.duplicate'));
+    await user.click(screen.getByText('common.actions.duplicate'));
 
     await waitFor(() =>
       expect(onDuplicated).toHaveBeenCalledWith('my-agent-1'),

--- a/services/platform/app/features/agents/components/agent-row-actions.tsx
+++ b/services/platform/app/features/agents/components/agent-row-actions.tsx
@@ -77,9 +77,7 @@ export function AgentRowActions({
     onDuplicated,
   ]);
 
-  const isProtected = (PROTECTED_AGENT_NAMES as readonly string[]).includes(
-    agentName,
-  );
+  const isProtected = PROTECTED_AGENT_NAMES.some((name) => name === agentName);
 
   const actions = [
     {

--- a/services/platform/app/features/agents/components/agent-row-actions.tsx
+++ b/services/platform/app/features/agents/components/agent-row-actions.tsx
@@ -84,20 +84,20 @@ export function AgentRowActions({
   const actions = [
     {
       key: 'duplicate',
-      label: tCommon('duplicate'),
+      label: tCommon('actions.duplicate'),
       icon: Copy,
       onClick: () => void handleDuplicate(),
     },
     {
       key: 'rename',
-      label: tCommon('rename'),
+      label: tCommon('actions.rename'),
       icon: Pencil,
       onClick: handleRename,
       visible: !isProtected,
     },
     {
       key: 'delete',
-      label: tCommon('delete'),
+      label: tCommon('actions.delete'),
       icon: Trash2,
       destructive: true,
       visible: !isProtected,

--- a/services/platform/app/features/agents/components/agents-table.test.tsx
+++ b/services/platform/app/features/agents/components/agents-table.test.tsx
@@ -54,6 +54,10 @@ vi.mock('../hooks/queries', () => ({
   useListAgents: () => ({ agents: [], isLoading: false }),
 }));
 
+vi.mock('../hooks/mutations', () => ({
+  useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
+}));
+
 vi.mock('../hooks/use-agents-table-config', () => ({
   useAgentsTableConfig: () => ({
     columns: [],

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -2,18 +2,21 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import { Bot } from 'lucide-react';
 import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { usePreloadRoute } from '@/app/hooks/use-preload-route';
 import { useTeamFilter } from '@/app/hooks/use-team-filter';
 import { useT } from '@/lib/i18n/client';
+import { PROTECTED_AGENT_NAMES } from '@/lib/shared/constants/agents';
 import { resolveAgentLocale } from '@/lib/shared/utils/resolve-agent-locale';
 
+import { useDeleteAgent } from '../hooks/mutations';
 import { useListAgents } from '../hooks/queries';
 import { useAgentsTableConfig } from '../hooks/use-agents-table-config';
 import { AgentsActionMenu } from './agents-action-menu';
@@ -67,9 +70,25 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
     return validAgents;
   }, [rawAgents, locale]);
 
+  const { mutateAsync: deleteAgent } = useDeleteAgent();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
   const invalidateAgents = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['config', 'agents'] });
   }, [queryClient]);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleBulkDeleteItem = useCallback(
+    // Per-row delete reuses the same mutation as the single-row dialog so
+    // server-side handling stays consistent. The bar surfaces one batch toast.
+    async (agentName: string) => {
+      await deleteAgent({ organizationId, agentName });
+    },
+    [deleteAgent, organizationId],
+  );
 
   // Briefly highlight a freshly-duplicated row so it reads as a new, separate
   // agent in the list rather than something tied to the menu it came from
@@ -155,6 +174,18 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
       {...list.tableProps}
       columns={columns}
       stickyLayout={stickyLayout}
+      // Built-in agents are not deletable, so they aren't selectable either —
+      // the header checkbox + bulk bar only ever target user-created agents.
+      enableRowSelection={(row) =>
+        !(PROTECTED_AGENT_NAMES as readonly string[]).includes(
+          row.original.name,
+        )
+      }
+      rowSelection={rowSelection}
+      onRowSelectionChange={setRowSelection}
+      // Agents are keyed by `name`; pin the row id so the bulk handler receives
+      // the same string the delete mutation expects.
+      getRowId={(row) => row.name}
       rowClassName={(row) =>
         row.original.name === highlightedName
           ? 'bg-primary/10 transition-colors duration-500 motion-reduce:transition-none'
@@ -168,6 +199,17 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
         title: tEmpty('agents.title'),
         description: tEmpty('agents.description'),
       }}
+      footer={
+        <BulkDeleteBar
+          rowSelection={rowSelection}
+          onClearSelection={handleClearSelection}
+          onDeleteItem={handleBulkDeleteItem}
+          onDeleteComplete={() => {
+            handleClearSelection();
+            invalidateAgents();
+          }}
+        />
+      }
     />
   );
 }

--- a/services/platform/app/features/agents/components/agents-table.tsx
+++ b/services/platform/app/features/agents/components/agents-table.tsx
@@ -177,9 +177,7 @@ export function AgentsTable({ organizationId }: AgentsTableProps) {
       // Built-in agents are not deletable, so they aren't selectable either —
       // the header checkbox + bulk bar only ever target user-created agents.
       enableRowSelection={(row) =>
-        !(PROTECTED_AGENT_NAMES as readonly string[]).includes(
-          row.original.name,
-        )
+        !PROTECTED_AGENT_NAMES.some((name) => name === row.original.name)
       }
       rowSelection={rowSelection}
       onRowSelectionChange={setRowSelection}

--- a/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
+++ b/services/platform/app/features/agents/hooks/use-agents-table-config.tsx
@@ -6,6 +6,11 @@ import { Text } from '@tale/ui/text';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { useT } from '@/lib/i18n/client';
 import { stripModelRefQualifier } from '@/lib/shared/utils/model-ref';
 
@@ -35,6 +40,10 @@ export function useAgentsTableConfig({
 
   const columns = useMemo<ColumnDef<AgentRow>[]>(
     () => [
+      // Multi-row select — canonical 40px column matching every other entity
+      // table. The container gates `enableRowSelection` to non-protected agents
+      // so the built-in agents can't be bulk-deleted.
+      createSelectColumn<AgentRow>(),
       {
         id: 'displayName',
         header: t('agents.columns.displayName'),
@@ -77,6 +86,9 @@ export function useAgentsTableConfig({
       {
         id: 'actions',
         header: '',
+        // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
+        // every other table's actions column.
+        size: ACTIONS_COLUMN_SIZE,
         meta: { isAction: true },
         cell: ({ row }) => (
           <HStack gap={1} justify="end">
@@ -88,7 +100,6 @@ export function useAgentsTableConfig({
             />
           </HStack>
         ),
-        size: 80,
       },
     ],
     [t, organizationId, onDuplicated, onDeleted],
@@ -98,6 +109,9 @@ export function useAgentsTableConfig({
     columns,
     searchPlaceholder: t('agents.searchAgent'),
     stickyLayout: false,
-    pageSize: 50,
+    // Aligned to the shared default (was 50) so every entity table paginates
+    // consistently. Agents lists are short enough that 20-per-page rarely
+    // requires a "load more" click anyway.
+    pageSize: DEFAULT_TABLE_PAGE_SIZE,
   };
 }

--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -2,15 +2,24 @@
 
 import { LinkButton } from '@tale/ui/button';
 import { useNavigate } from '@tanstack/react-router';
-import { type Row } from '@tanstack/react-table';
+import {
+  type ColumnDef,
+  type Row,
+  type RowSelectionState,
+} from '@tanstack/react-table';
 import { BarChart3, Network } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { SELECT_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { slugToUrlParam } from '@/lib/utils/workflow-slug';
 
+import { useDeleteWorkflowFile } from '../hooks/file-mutations';
 import { useListWorkflows } from '../hooks/file-queries';
 import { useAutomationsTableConfig } from '../hooks/use-automations-table-config';
 import { AutomationsActionMenu } from './automations-action-menu';
@@ -66,12 +75,39 @@ export function AutomationsTable({
   const { t: tCommon } = useT('common');
   const { t: tEmpty } = useT('emptyStates');
   const [searchQuery, setSearchQuery] = useState('');
+  const isSearching = searchQuery.trim().length > 0;
 
   const { workflows, isLoading, refetch } = useListWorkflows(
     organizationId,
     'installed',
   );
-  const { columns } = useAutomationsTableConfig(organizationId);
+  // Search flattens across folders (global), so prefix each result with its
+  // folder path (e.g. "github / GitHub Issue Sync") — in the root or inside a
+  // folder, since results can span folders either way.
+  const { columns } = useAutomationsTableConfig(organizationId, {
+    showFolderPath: isSearching,
+  });
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { mutateAsync: deleteWorkflow } = useDeleteWorkflowFile();
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (slug: string) => {
+      try {
+        await deleteWorkflow({ organizationId, workflowSlug: slug });
+      } catch (error) {
+        toast({
+          title: tAutomations('delete.failed'),
+          variant: 'destructive',
+        });
+        throw error;
+      }
+    },
+    [deleteWorkflow, organizationId, tAutomations],
+  );
 
   useEffect(() => {
     const handleWorkflowUpdated = () => void refetch();
@@ -89,31 +125,44 @@ export function AutomationsTable({
     [workflows],
   );
 
-  const tableItems = useMemo((): AutomationTableItem[] => {
+  // The workflows represented by the current view. Search is *global*: a query
+  // matches across every folder regardless of which folder you're in, so the
+  // behaviour is identical at the root and inside a folder (the flat results
+  // carry their folder path for context). Only the folder scoping applies when
+  // there's no query. This is also the universe the header select-all and
+  // folder checkboxes act on — folder rows are aggregates whose member
+  // workflows aren't their own rows, so selection reaches them by slug here.
+  const filteredWorkflows = useMemo((): WorkflowItem[] => {
     if (!validWorkflows) return [];
-
     const q = searchQuery.toLowerCase().trim();
-    const filtered = q
-      ? validWorkflows.filter(
-          (w: WorkflowItem) =>
-            w.name.toLowerCase().includes(q) ||
-            w.category.toLowerCase().includes(q) ||
-            (w.description && w.description.toLowerCase().includes(q)),
-        )
+    if (q) {
+      return validWorkflows.filter(
+        (w) =>
+          w.name.toLowerCase().includes(q) ||
+          w.category.toLowerCase().includes(q) ||
+          (w.description && w.description.toLowerCase().includes(q)),
+      );
+    }
+    return currentFolder
+      ? validWorkflows.filter((w) => w.category === currentFolder)
       : validWorkflows;
+  }, [validWorkflows, searchQuery, currentFolder]);
 
-    if (currentFolder) {
-      return filtered
-        .filter((w: WorkflowItem) => w.category === currentFolder)
-        .sort((a: WorkflowItem, b: WorkflowItem) =>
-          a.name.localeCompare(b.name),
-        );
+  const tableItems = useMemo((): AutomationTableItem[] => {
+    // Inside a folder, or while searching, the list is flat: every matching
+    // workflow shows as its own row (folders aren't navigable targets there).
+    // Search in particular must surface workflows nested in folders — the name
+    // column then prefixes them with their folder path for clarity.
+    if (currentFolder || isSearching) {
+      return [...filteredWorkflows].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
     }
 
-    const folderMap = new Map();
+    const folderMap = new Map<string, number>();
     const rootWorkflows: WorkflowItem[] = [];
 
-    for (const w of filtered) {
+    for (const w of filteredWorkflows) {
       if (w.category) {
         folderMap.set(w.category, (folderMap.get(w.category) ?? 0) + 1);
       } else {
@@ -128,7 +177,87 @@ export function AutomationsTable({
     rootWorkflows.sort((a, b) => a.name.localeCompare(b.name));
 
     return [...folderItems, ...rootWorkflows];
-  }, [validWorkflows, searchQuery, currentFolder]);
+  }, [filteredWorkflows, currentFolder, isSearching]);
+
+  // folderName → member workflow slugs, and the flat list of every selectable
+  // slug in view. Drive the folder/header checkbox state and toggles off these.
+  const folderMembers = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const w of filteredWorkflows) {
+      if (w.category) {
+        const slugs = map.get(w.category) ?? [];
+        slugs.push(w.slug);
+        map.set(w.category, slugs);
+      }
+    }
+    return map;
+  }, [filteredWorkflows]);
+
+  const allVisibleSlugs = useMemo(
+    () => filteredWorkflows.map((w) => w.slug),
+    [filteredWorkflows],
+  );
+
+  const toggleSlugs = useCallback((slugs: string[], selected: boolean) => {
+    setRowSelection((prev) => {
+      const next = { ...prev };
+      for (const slug of slugs) {
+        if (selected) next[slug] = true;
+        else delete next[slug];
+      }
+      return next;
+    });
+  }, []);
+
+  const checkedStateFor = useCallback(
+    (slugs: string[]): boolean | 'indeterminate' => {
+      if (slugs.length === 0) return false;
+      const selected = slugs.filter((slug) => rowSelection[slug]).length;
+      if (selected === 0) return false;
+      return selected === slugs.length ? true : 'indeterminate';
+    },
+    [rowSelection],
+  );
+
+  // Custom select column: the header and folder-row checkboxes operate on the
+  // underlying workflow *slugs* (incl. those nested in folders) so select-all
+  // truly selects everything — folders included — and a folder checkbox toggles
+  // all of its workflows at once. Replaces the config's generic select column.
+  const selectColumn = useMemo<ColumnDef<AutomationTableItem>>(
+    () => ({
+      id: 'select',
+      size: SELECT_COLUMN_SIZE,
+      header: () => (
+        <Checkbox
+          checked={checkedStateFor(allVisibleSlugs)}
+          onCheckedChange={(value) => toggleSlugs(allVisibleSlugs, !!value)}
+          aria-label={tCommon('aria.selectAll')}
+        />
+      ),
+      cell: ({ row }) => {
+        const item = row.original;
+        const slugs =
+          item.type === 'folder'
+            ? (folderMembers.get(item.name) ?? [])
+            : [item.slug];
+        return (
+          <Checkbox
+            checked={checkedStateFor(slugs)}
+            onClick={(e) => e.stopPropagation()}
+            onCheckedChange={(value) => toggleSlugs(slugs, !!value)}
+            aria-label={tCommon('aria.selectRow')}
+          />
+        );
+      },
+      meta: { skeleton: { type: 'action' } },
+    }),
+    [allVisibleSlugs, folderMembers, checkedStateFor, toggleSlugs, tCommon],
+  );
+
+  const tableColumns = useMemo(
+    () => columns.map((col) => (col.id === 'select' ? selectColumn : col)),
+    [columns, selectColumn],
+  );
 
   const handleRowClick = useCallback(
     (row: Row<AutomationTableItem>) => {
@@ -158,6 +287,12 @@ export function AutomationsTable({
   );
 
   return (
+    // `p-4` gives this page the same 16px inset every other top-level entity
+    // table has (knowledge tables inherit it from the `_knowledge` layout's
+    // `<ContentArea py-4>`; agents / projects set it on the table directly).
+    // `PageLayout` adds no padding, so without this the table renders flush to
+    // the edge — no gap, and its select / 3-dot columns sit out of line with
+    // the rest of the app. `gap-4` controls the search-bar / table spacing.
     <div className="flex flex-col gap-4 p-4">
       <div className="flex items-center justify-between gap-4">
         <SearchInput
@@ -181,10 +316,23 @@ export function AutomationsTable({
       </div>
 
       <DataTable
-        columns={columns}
+        columns={tableColumns}
         data={tableItems}
         isLoading={isLoading}
         approxRowCount={isLoading ? 5 : tableItems.length}
+        // Selection is driven by `selectColumn` (keyed by workflow slug, with
+        // folder checkboxes expanding to their members). `enableRowSelection`
+        // here only governs TanStack's row-highlight: workflow rows highlight
+        // when selected; folder aggregates don't.
+        enableRowSelection={(row) => row.original.type === 'workflow'}
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+        // Pin row IDs to the workflow slug (mirrors `wfDefinitionId`); folders
+        // fall back to their name. RowSelectionState keys then match what
+        // `handleDeleteItem` passes to the mutation.
+        getRowId={(row) =>
+          row.type === 'workflow' ? row.slug : `folder:${row.name}`
+        }
         onRowClick={handleRowClick}
         rowClassName={getRowClassName}
         infiniteScroll={{
@@ -203,6 +351,14 @@ export function AutomationsTable({
                 title: tEmpty('automations.title'),
                 description: tEmpty('automations.description'),
               }
+        }
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
         }
       />
     </div>

--- a/services/platform/app/features/automations/hooks/use-automations-table-config.tsx
+++ b/services/platform/app/features/automations/hooks/use-automations-table-config.tsx
@@ -6,19 +6,39 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { Folder, Workflow } from 'lucide-react';
 import { useMemo } from 'react';
 
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useT } from '@/lib/i18n/client';
 
 import { AutomationRowActions } from '../components/automation-row-actions';
 import type { AutomationTableItem } from '../components/automations-table';
 
-export function useAutomationsTableConfig(organizationId: string) {
+interface AutomationsTableConfigOptions {
+  /**
+   * Prefix each workflow's name with its folder path (e.g. "github / GitHub
+   * Issue Sync"). Used when the list is flattened across folders (search), so
+   * it stays clear which folder a result belongs to.
+   */
+  showFolderPath?: boolean;
+}
+
+export function useAutomationsTableConfig(
+  organizationId: string,
+  { showFolderPath = false }: AutomationsTableConfigOptions = {},
+) {
   const { t: tTables } = useT('tables');
   const { t: tAutomations } = useT('automations');
   const { formatDate } = useFormatDate();
 
   const columns = useMemo<ColumnDef<AutomationTableItem>[]>(
     () => [
+      // Multi-row select — canonical 40px column. The container table gates
+      // `enableRowSelection` to only workflow rows (not folder aggregates),
+      // so the checkbox in folder rows renders disabled.
+      createSelectColumn<AutomationTableItem>(),
       {
         id: 'name',
         header: tTables('headers.automation'),
@@ -40,7 +60,16 @@ export function useAutomationsTableConfig(organizationId: string) {
             <div className="flex min-h-8 items-center gap-3">
               <Workflow className="text-muted-foreground size-4 shrink-0" />
               <Text as="span" variant="label" truncate>
-                {row.original.name}
+                {showFolderPath && row.original.category ? (
+                  <>
+                    <span className="text-muted-foreground">
+                      {row.original.category} /{' '}
+                    </span>
+                    {row.original.name}
+                  </>
+                ) : (
+                  row.original.name
+                )}
               </Text>
             </div>
           );
@@ -69,7 +98,9 @@ export function useAutomationsTableConfig(organizationId: string) {
       },
       {
         id: 'actions',
-        size: 50,
+        // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
+        // every other table's actions column.
+        size: ACTIONS_COLUMN_SIZE,
         header: () => null,
         meta: {
           noTruncate: true,
@@ -97,7 +128,7 @@ export function useAutomationsTableConfig(organizationId: string) {
         },
       },
     ],
-    [tTables, organizationId, formatDate],
+    [tTables, organizationId, formatDate, showFolderPath],
   );
 
   return {

--- a/services/platform/app/features/chat/components/agent-selector.tsx
+++ b/services/platform/app/features/chat/components/agent-selector.tsx
@@ -77,6 +77,11 @@ export const AgentSelector = memo(function AgentSelector({
         return {
           value: agent.name,
           label: agent.displayName,
+          // Surfaced as a hover/keyboard tooltip on the row (see
+          // `descriptionMode: 'tooltip'` on the SearchableSelect below) so the
+          // picker stays scannable when an org has many agents while still
+          // letting users get the "what does this one do?" answer on demand.
+          description: agent.description,
           isDefaultChat: agent.name === 'chat-agent',
           labelBadge: missingTitle ? (
             <span className="text-muted-foreground text-xs">
@@ -101,6 +106,10 @@ export const AgentSelector = memo(function AgentSelector({
       {
         value: AUTO_AGENT_SLUG,
         label: t('agentSelector.auto'),
+        // Surfaced as a hover tooltip (the picker is in `descriptionMode:
+        // 'tooltip'` mode) so users hovering Auto get the "what does this
+        // do?" answer without an inline second-line caption crowding the row.
+        description: t('agentSelector.autoDescription'),
         isDefaultChat: false,
         labelBadge: undefined,
         ready: true,
@@ -207,6 +216,10 @@ export const AgentSelector = memo(function AgentSelector({
         searchPlaceholder={t('agentSelector.searchPlaceholder')}
         emptyText={t('agentSelector.noResults')}
         aria-label={t('agentSelector.label')}
+        // Surface each agent's description on hover/keyboard-highlight rather
+        // than inline — keeps the row height consistent and the list
+        // scannable when there are many agents.
+        descriptionMode="tooltip"
         optionAction={renderOptionAction}
         trigger={
           // min-w-32 (128 px) pins the trigger so the loading→loaded swap

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@tale/ui/button';
 import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
-import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Stack } from '@tale/ui/layout';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
@@ -43,11 +42,11 @@ import {
 } from '@/app/features/projects/hooks/queries';
 import { useActiveHoldTargetIds } from '@/app/features/settings/governance/hooks/queries';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
+import { useRelativeNow } from '@/app/hooks/use-relative-now';
 import { useOptionalTeamFilter } from '@/app/hooks/use-team-filter';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
-import { formatRelativeTime } from '@/lib/utils/format/relative-time';
 
 import { useUpdateThread } from '../hooks/mutations';
 import {
@@ -152,7 +151,7 @@ function SidebarSectionHeader({
       <Text
         as="div"
         variant="caption"
-        className="text-muted-foreground text-xs font-medium tracking-wide uppercase"
+        className="text-muted-foreground/70 text-[11px] font-normal tracking-wider uppercase"
       >
         {label}
       </Text>
@@ -541,8 +540,15 @@ export function ChatHistorySidebar({
                     key={`project-${i}`}
                     className="flex min-h-[1.5rem] items-center gap-1.5 px-2 py-1.5"
                   >
+                    {/* Chevron + plain icon — matches the loaded folder row
+                        (chevron `size-3.5` + plain-variant icon `size-3`)
+                        instead of the legacy colored chip the skeleton used
+                        to suggest. */}
                     <SkeletonBox>
-                      <div className="size-4 rounded" />
+                      <div className="size-3.5 rounded-sm" />
+                    </SkeletonBox>
+                    <SkeletonBox>
+                      <div className="size-3 rounded-sm" />
                     </SkeletonBox>
                     <SkeletonBox fullWidth>
                       <div
@@ -870,6 +876,7 @@ function ProjectFolder({
             icon={project.icon}
             color={project.color}
             size={16}
+            variant="plain"
           />
           <span className="flex-1 truncate text-sm leading-snug font-medium">
             {project.name}
@@ -969,7 +976,6 @@ function LooseChatsDropZone({
 
 function ChatRow({ chat }: { chat: ChatItem }) {
   const { t } = useT('chat');
-  const { locale } = useLocale();
   const ctx = useChatRowContext();
   const isEditing = ctx.editingChatId === chat._id;
   const isPending = ctx.pendingThreadIds.has(chat._id);
@@ -977,6 +983,13 @@ function ChatRow({ chat }: { chat: ChatItem }) {
     !isPending &&
     (chat.generationStatus === 'generating' ||
       ctx.executingThreadIds.has(chat._id));
+  // "Time since last activity" tracks the most recent AI reply, falling back
+  // to the chat's creation time for brand-new threads. Paused while the AI
+  // is still generating — the row's `animate-pulse` title already conveys
+  // the live state, and ticking against a stale timestamp would be noise.
+  const relativeAge = useRelativeNow(chat.lastReplyAt ?? chat.createdAt, {
+    paused: isGenerating,
+  });
   const isHeld = ctx.isThreadHeld(chat._id);
   // "New response" badge: a generation finished more recently than the owner
   // last read this thread, and it isn't the open / actively-generating one.
@@ -1122,9 +1135,9 @@ function ChatRow({ chat }: { chat: ChatItem }) {
               actions menu takes over (desktop). Always hidden on touch since
               the menu is in-flow there. Suppressed when a new-response badge
               is showing so the row doesn't crowd. */}
-          {!hasNewResponse && (
+          {!hasNewResponse && relativeAge !== null && (
             <span className="text-muted-foreground pointer-events-none relative z-10 hidden shrink-0 text-xs tabular-nums md:inline md:group-hover:hidden">
-              {formatRelativeTime(chat.createdAt, locale, 'narrow')}
+              {relativeAge}
             </span>
           )}
           {/* On desktop the actions menu is an absolute overlay so it reserves

--- a/services/platform/app/features/chat/components/message-bubble/image-preview-dialog.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/image-preview-dialog.tsx
@@ -105,6 +105,10 @@ export const ImagePreviewDialog = memo(function ImagePreviewDialog({
         }
         className="flex-1 p-8 pt-16"
         resetTrigger={currentSrc}
+        // The Dialog renders with `hideClose` + empty customHeader, so the
+        // only existing dismiss paths were Esc / backdrop click. Wiring
+        // onClose surfaces an explicit ✕ in the viewer's overlay toolbar.
+        onClose={() => onOpenChange(false)}
       />
       {isGallery && (
         <>

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -477,6 +477,7 @@ export const ModelSelector = memo(function ModelSelector({
       side="top"
       sideOffset={8}
       contentClassName="w-[22rem]"
+      descriptionMode="tooltip"
       tooltip={t('modelSelector.label')}
       tooltipSide="top"
       searchPlaceholder={t('modelSelector.searchPlaceholder')}

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -457,6 +457,11 @@ export const ModelSelector = memo(function ModelSelector({
         {
           value: AUTO_MODEL,
           label: t('modelSelector.auto'),
+          // Mirrors the agent selector's Auto: a hover/keyboard tooltip
+          // explaining what "Auto" actually does (server-side routing).
+          // The picker passes this through to SearchableSelect, which
+          // already decides inline vs tooltip rendering per its own mode.
+          description: t('modelSelector.autoDescription'),
         },
         ...modelOptions,
       ];

--- a/services/platform/app/features/chat/hooks/mutations.ts
+++ b/services/platform/app/features/chat/hooks/mutations.ts
@@ -105,16 +105,21 @@ export function useSetThreadCanvasState() {
         store,
         api.threads.queries.getThreadMeta,
         { threadId: args.threadId },
-        (current) => ({
-          ...current,
-          canvasState: {
-            isOpen: args.canvasOpen ?? current.canvasState.isOpen,
-            activeFilePath:
-              args.canvasActiveFilePath === undefined
-                ? current.canvasState.activeFilePath
-                : args.canvasActiveFilePath,
-          },
-        }),
+        (current) => {
+          // `getThreadMeta` returns `null` until the row loads — skip the
+          // optimistic patch rather than dereferencing null.
+          if (!current) return current;
+          return {
+            ...current,
+            canvasState: {
+              isOpen: args.canvasOpen ?? current.canvasState.isOpen,
+              activeFilePath:
+                args.canvasActiveFilePath === undefined
+                  ? current.canvasState.activeFilePath
+                  : args.canvasActiveFilePath,
+            },
+          };
+        },
       ),
   });
 }

--- a/services/platform/app/features/chat/hooks/mutations.ts
+++ b/services/platform/app/features/chat/hooks/mutations.ts
@@ -1,3 +1,4 @@
+import { updateDocumentQuery } from '@/app/hooks/optimistic-updates';
 import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
 import { api } from '@/convex/_generated/api';
@@ -78,6 +79,44 @@ export function useUpdateThread() {
 
 export function useSetThreadPinned() {
   return useConvexMutation(api.threads.mutations.setThreadPinned);
+}
+
+/**
+ * Persist the canvas (workspace) pane state for a thread. Wraps the server
+ * mutation in an optimistic patch against the shared `getThreadMeta` query
+ * so toggling the pane (or switching files) updates the UI instantly —
+ * Convex rolls the patch back if the server mutation fails.
+ *
+ * Field semantics:
+ *   - `canvasOpen` undefined  → keep current value
+ *   - `canvasActiveFilePath`:
+ *       undefined → keep current value
+ *       null      → clear the override (next render uses the first listed file)
+ *       string    → set the active path
+ */
+export function useSetThreadCanvasState() {
+  return useConvexMutation(api.threads.mutations.setThreadCanvasState, {
+    // Pane toggles are best-effort UI state — a transient failure already
+    // rolls back via the optimistic patch; surfacing a toast on every
+    // re-mount-during-disconnect would be noise.
+    errorToast: false,
+    optimisticUpdate: (store, args) =>
+      updateDocumentQuery(
+        store,
+        api.threads.queries.getThreadMeta,
+        { threadId: args.threadId },
+        (current) => ({
+          ...current,
+          canvasState: {
+            isOpen: args.canvasOpen ?? current.canvasState.isOpen,
+            activeFilePath:
+              args.canvasActiveFilePath === undefined
+                ? current.canvasState.activeFilePath
+                : args.canvasActiveFilePath,
+          },
+        }),
+      ),
+  });
 }
 
 export function useMarkThreadRead() {

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -37,7 +37,9 @@ export interface Thread {
   projectId?: string;
 }
 
-const THREADS_PAGE_SIZE = 20;
+// Shared so the `/dashboard/$id/chat` loader primes the same page size the
+// sidebar's `useThreads` reads — single source of truth.
+export const THREADS_PAGE_SIZE = 20;
 
 export function useThreads({
   skip = false,

--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 
 import { CopyableTimestamp } from '@/app/components/ui/data-display/copyable-timestamp';
 import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
+import { ACTIONS_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { useT } from '@/lib/i18n/client';
 import { formatBytes } from '@/lib/utils/format/number';
 import type { DocumentItem } from '@/types/documents';
@@ -282,30 +283,15 @@ export function useDocumentsTableConfig({
           />
         ),
       },
-      {
-        accessorKey: 'uploadedAt',
-        header: () => (
-          <span className="block w-full text-right">
-            {tTables('headers.uploadedAt')}
-          </span>
-        ),
-        size: 192,
-        meta: {
-          headerLabel: tTables('headers.uploadedAt'),
-          align: 'right' as const,
-        },
-        cell: ({ row }) => (
-          <CopyableTimestamp
-            date={row.original.uploadedAt}
-            preset="long"
-            customFormat="ll LT"
-            alignRight
-          />
-        ),
-      },
+      // `uploadedAt` column dropped — for documents this duplicates
+      // `modifiedAt` for the majority of rows (initial upload sets both),
+      // and the few cases where they differ are visible on the detail
+      // panel. Keeping only `modifiedAt` frees a 192px column for the
+      // Teams / RAG status columns to render their badges without
+      // overflow.
       {
         id: 'actions',
-        size: 56,
+        size: ACTIONS_COLUMN_SIZE,
         meta: { isAction: true },
         cell: ({ row }) => (
           <HStack justify="end">

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Popover } from '@tale/ui/popover';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { Bell } from 'lucide-react';
 import { useState } from 'react';
 
@@ -16,6 +17,17 @@ interface NotificationBellProps {
   label?: string;
 }
 
+/**
+ * Mirrors the styles from `@tale/ui/popover`'s `CONTENT_CLASSES` so the panel
+ * surface matches every other popover in the platform. Inlined because this
+ * component talks to `PopoverPrimitive` directly (see the trigger composition
+ * note below) — `@tale/ui/popover`'s wrapper hard-codes `<Trigger asChild>`
+ * one layer deep, which prevented the second `<TooltipPrimitive.Trigger
+ * asChild>` from reaching the button and quietly dropped the click handler.
+ */
+const POPOVER_CONTENT_CLASSES =
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+
 export function NotificationBell({
   organizationId,
   label,
@@ -25,7 +37,7 @@ export function NotificationBell({
   const { data: unread } = useNotificationsUnreadCount(organizationId);
   const unreadCount = unread ?? 0;
 
-  const trigger = (
+  const buttonNode = (
     <button
       type="button"
       aria-label={tNav('notifications')}
@@ -49,20 +61,59 @@ export function NotificationBell({
     </button>
   );
 
+  // The mobile-nav variant renders an inline text label next to the bell and
+  // doesn't need a tooltip — skip both the Popover + Tooltip overhead, just
+  // mount the plain button. (Mobile navigates via parent link logic.)
+  if (label) {
+    return buttonNode;
+  }
+
+  // Composing PopoverPrimitive + TooltipPrimitive directly is the only way
+  // to land both `asChild` triggers on the same `<button>`. Going through the
+  // `@tale/ui` `Popover` wrapper buries its `<PopoverPrimitive.Trigger
+  // asChild>` one level deep — passing a Tooltip-wrapped trigger then meets
+  // a non-DOM intermediary (`TooltipPrimitive.Provider`/`Root`), Radix's
+  // `Slot` can't merge the `onClick` through, and the panel never opens.
+  // Nested `asChild` Triggers via Slot, in contrast, merge cleanly: each
+  // wraps the next, and the innermost child (the button) ends up with both
+  // sets of event listeners + refs.
   return (
-    <Popover
-      open={open}
-      onOpenChange={setOpen}
-      align="end"
-      side="right"
-      sideOffset={8}
-      contentClassName="bg-card w-96 max-w-[calc(100vw-2rem)] p-0"
-      trigger={trigger}
-    >
-      <NotificationListPanel
-        organizationId={organizationId}
-        className="h-[28rem]"
-      />
-    </Popover>
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <TooltipPrimitive.Provider delayDuration={300}>
+        <TooltipPrimitive.Root>
+          <PopoverPrimitive.Trigger asChild>
+            <TooltipPrimitive.Trigger asChild>
+              {buttonNode}
+            </TooltipPrimitive.Trigger>
+          </PopoverPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+              side="right"
+              sideOffset={8}
+              collisionPadding={8}
+              className="bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
+            >
+              {tNav('notifications')}
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
+      </TooltipPrimitive.Provider>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="end"
+          side="right"
+          sideOffset={8}
+          className={cn(
+            POPOVER_CONTENT_CLASSES,
+            'bg-card w-96 max-w-[calc(100vw-2rem)] p-0',
+          )}
+        >
+          <NotificationListPanel
+            organizationId={organizationId}
+            className="h-[28rem]"
+          />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -91,7 +91,7 @@ export function NotificationBell({
               side="right"
               sideOffset={8}
               collisionPadding={8}
-              className="bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
+              className="bg-foreground text-background motion-safe:animate-in motion-safe:fade-in-0 data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 z-[60] overflow-hidden rounded-lg border p-2 py-1 text-xs shadow-md"
             >
               {tNav('notifications')}
             </TooltipPrimitive.Content>

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { SkeletonBox, SkeletonCircle } from '@tale/ui/skeleton';
-import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Tabs } from '@tale/ui/tabs';
-import { CheckCheck, ChevronLeft, Inbox } from 'lucide-react';
+import { CheckCheck, ChevronLeft, Inbox, Loader2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFormatDate } from '@/app/hooks/use-format-date';
@@ -171,38 +169,20 @@ export function NotificationListPanel({
       <div className="flex-1 overflow-y-auto">
         {items.length === 0 ? (
           status === 'LoadingFirstPage' ? (
-            // Skeleton list mirroring the real row layout for the genuine first
-            // load only. The Unread/All filter is client-side, so toggling it no
-            // longer resets the query — the skeleton won't reappear on switch.
-            <Skeletonize loading label={t('loading')}>
-              <ul role="list" className="divide-border divide-y" aria-hidden>
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <li key={i} className="flex items-start gap-3 px-4 py-3">
-                    <SkeletonCircle>
-                      <span className="mt-1.5 block size-2 rounded-full" />
-                    </SkeletonCircle>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start justify-between gap-2">
-                        <SkeletonBox>
-                          <span className="block h-3.5 w-32" />
-                        </SkeletonBox>
-                        <SkeletonBox>
-                          <span className="block h-3 w-6" />
-                        </SkeletonBox>
-                      </div>
-                      <div className="mt-2 space-y-1.5">
-                        <SkeletonBox fullWidth>
-                          <span className="block h-3 w-full" />
-                        </SkeletonBox>
-                        <SkeletonBox fullWidth>
-                          <span className="block h-3 w-3/5" />
-                        </SkeletonBox>
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </Skeletonize>
+            // Short-lived async load — a centered spinner + label reads
+            // cleaner than a fake-content skeleton when items typically
+            // arrive in under a second.
+            <div
+              role="status"
+              aria-live="polite"
+              className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 px-6 text-center"
+            >
+              <Loader2
+                aria-hidden="true"
+                className="size-5 motion-safe:animate-spin"
+              />
+              <p className="text-xs">{t('loading')}</p>
+            </div>
           ) : (
             <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
               {filter === 'unread' ? (

--- a/services/platform/app/features/products/hooks/use-products-table-config.tsx
+++ b/services/platform/app/features/products/hooks/use-products-table-config.tsx
@@ -38,15 +38,10 @@ export const useProductsTableConfig = createTableConfigHook<'products'>(
         </HStack>
       ),
     },
-    {
-      accessorKey: 'description',
-      header: tTables('headers.description'),
-      cell: ({ row }) => (
-        <Text as="div" variant="caption" truncate className="max-w-sm">
-          {row.original.description ? `"${row.original.description}"` : '-'}
-        </Text>
-      ),
-    },
+    // Description column dropped — at the table's row truncation width it
+    // collapses to a few words and earns zero scannability vs the detail
+    // view, which already shows the full description on click. Frees space
+    // for the price/stock/category columns to breathe at sensible widths.
     {
       accessorKey: 'stock',
       header: () => (

--- a/services/platform/app/features/projects/components/project-avatar.tsx
+++ b/services/platform/app/features/projects/components/project-avatar.tsx
@@ -52,6 +52,17 @@ export interface ProjectAvatarProps {
   icon?: string | null;
   color?: string | null;
   size?: 16 | 20 | 24 | 32;
+  /**
+   * `'filled'` (default): colored chip — the project's brand color as a
+   * background, white/black icon on top. Use in headers, dialogs, anywhere
+   * the avatar carries the project's identity.
+   *
+   * `'plain'`: just the icon in a neutral muted tone, no background. Use
+   * in dense lists where many side-by-side colored chips would crowd the
+   * eye (e.g. the chat sidebar's project folders, where the row is already
+   * named and the icon is just a glanceable marker).
+   */
+  variant?: 'filled' | 'plain';
   className?: string;
 }
 
@@ -73,17 +84,21 @@ export function ProjectAvatar({
   icon,
   color,
   size = 24,
+  variant = 'filled',
   className,
 }: ProjectAvatarProps) {
   const IconComponent = resolveIcon(icon);
+  const surfaceClasses =
+    variant === 'plain'
+      ? 'text-muted-foreground'
+      : cn(SIZE_CLASSES[size], resolveColor(color));
   return (
     <span
       role="img"
       aria-label={name}
       className={cn(
         'inline-flex shrink-0 items-center justify-center',
-        SIZE_CLASSES[size],
-        resolveColor(color),
+        surfaceClasses,
         className,
       )}
     >

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -16,7 +16,7 @@ import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-ac
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { usePreloadRoute } from '@/app/hooks/use-preload-route';
-import type { Id } from '@/convex/_generated/dataModel';
+import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 
 import { useDeleteProject } from '../hooks/mutations';
@@ -66,8 +66,8 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       // per-project confirm phrase, which doesn't translate to a multi-row
       // gesture, so cascade stays single-row-only via the row dialog.
       await deleteProject({
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- RowSelectionState keys are the row `_id`s by construction (see getRowId); Convex Ids carry no runtime-checkable format.
-        projectId: id as Id<'projects'>,
+        // RowSelectionState keys are the row `_id`s by construction (getRowId).
+        projectId: toId<'projects'>(id),
         mode: 'detach',
       });
     },

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -66,6 +66,7 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       // per-project confirm phrase, which doesn't translate to a multi-row
       // gesture, so cascade stays single-row-only via the row dialog.
       await deleteProject({
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- RowSelectionState keys are the row `_id`s by construction (see getRowId); Convex Ids carry no runtime-checkable format.
         projectId: id as Id<'projects'>,
         mode: 'detach',
       });

--- a/services/platform/app/features/projects/components/projects-table.tsx
+++ b/services/platform/app/features/projects/components/projects-table.tsx
@@ -2,17 +2,24 @@
 
 import { HStack } from '@tale/ui/layout';
 import { useNavigate } from '@tanstack/react-router';
-import type { ColumnDef, Row } from '@tanstack/react-table';
+import type { ColumnDef, Row, RowSelectionState } from '@tanstack/react-table';
 import { Folder, Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { usePreloadRoute } from '@/app/hooks/use-preload-route';
+import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeleteProject } from '../hooks/mutations';
 import { useProjects, type ProjectListItem } from '../hooks/queries';
 import { ProjectCreateDialog } from './project-create-dialog';
 import { ProjectRowActions } from './project-row-actions';
@@ -41,9 +48,30 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
   const preloadRoute = usePreloadRoute();
   const [includeArchived, setIncludeArchived] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const { projects, isLoading } = useProjects(organizationId, {
     includeArchived,
   });
+  const { mutateAsync: deleteProject } = useDeleteProject();
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // RowSelectionState keys are the row IDs (Convex doc `_id` here).
+      // `mode: 'detach'` matches the single-row delete dialog's default
+      // (unchecked "cascade") — bulk-delete with cascade would also need a
+      // per-project confirm phrase, which doesn't translate to a multi-row
+      // gesture, so cascade stays single-row-only via the row dialog.
+      await deleteProject({
+        projectId: id as Id<'projects'>,
+        mode: 'detach',
+      });
+    },
+    [deleteProject],
+  );
 
   const handleRowClick = useCallback(
     (row: Row<ProjectListItem>) => {
@@ -76,6 +104,9 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
 
   const columns = useMemo<ColumnDef<ProjectListItem>[]>(
     () => [
+      // Multi-row select — canonical 40px column, identical to every other
+      // entity table. Enables bulk delete via the `BulkDeleteBar` footer.
+      createSelectColumn<ProjectListItem>(),
       {
         accessorKey: 'name',
         header: t('list.columnName'),
@@ -127,13 +158,11 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
       {
         id: 'actions',
         header: '',
-        // Matches the canonical pattern shared by agents / customers /
-        // documents / vendors / products / websites tables: `isAction`
-        // meta flag + right-justified HStack. The DataTable applies the
-        // platform's standard action-cell width + alignment from this
-        // meta hint.
+        // Matches the canonical pattern shared by every other entity
+        // table: `isAction` meta flag + right-justified HStack, locked to
+        // `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns across the app.
         meta: { isAction: true },
-        size: 56,
+        size: ACTIONS_COLUMN_SIZE,
         cell: ({ row }) => (
           <HStack justify="end">
             <ProjectRowActions
@@ -168,9 +197,18 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
   return (
     <>
       <DataTable
+        // `p-4` gives this table the same 16px page inset every other
+        // top-level entity table has — knowledge tables inherit it from the
+        // `_knowledge` layout's `<ContentArea py-4>`, agents sets it here the
+        // same way. `PageLayout` itself adds no padding, so without this the
+        // table renders flush to the edge (no gap) and its select / 3-dot
+        // columns sit out of line with the rest of the app.
         className="p-4"
         {...list.tableProps}
         columns={columns}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         onRowClick={handleRowClick}
         onRowMouseEnter={handleRowMouseEnter}
         filtersContent={
@@ -193,6 +231,14 @@ export function ProjectsTable({ organizationId }: ProjectsTableProps) {
           title: t('list.emptyTitle'),
           description: t('list.emptyDescription'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
       />
       <ProjectCreateDialog
         open={createOpen}

--- a/services/platform/app/features/settings/api-keys/components/api-keys-table.test.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-keys-table.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'test-org-id',
 }));
 
+vi.mock('../hooks/use-api-keys', () => ({
+  useRevokeApiKey: () => ({ mutateAsync: vi.fn() }),
+}));
+
 vi.mock('../hooks/use-api-keys-table-config', () => ({
   useApiKeysTableConfig: () => ({
     columns: [

--- a/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
@@ -2,12 +2,16 @@
 
 import { buttonVariants } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
+import type { RowSelectionState } from '@tanstack/react-table';
 import { BookOpen, Key } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
+import { useRevokeApiKey } from '../hooks/use-api-keys';
 import { useApiKeysTableConfig } from '../hooks/use-api-keys-table-config';
 import type { ApiKey } from '../types';
 import { ApiKeysActionMenu } from './api-keys-action-menu';
@@ -42,6 +46,22 @@ export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
 
   const { t: tSettings } = useT('settings');
 
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const revokeApiKey = useRevokeApiKey(organizationId);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // `useRevokeApiKey` takes the keyId directly and throws on auth-client
+      // failure; the bar surfaces a destructive toast for the whole batch.
+      await revokeApiKey.mutateAsync(id);
+    },
+    [revokeApiKey],
+  );
+
   const list = useListPage<ApiKey>({
     dataSource: { type: 'query', data: apiKeys },
     pageSize,
@@ -57,6 +77,9 @@ export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
       <DataTable
         columns={columns}
         stickyLayout={stickyLayout}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         actionMenu={<ApiKeysActionMenu organizationId={organizationId} />}
         emptyState={{
           icon: Key,
@@ -68,6 +91,14 @@ export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
             </>
           ),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
       {hasKeys && <ApiDocsLink />}

--- a/services/platform/app/features/settings/api-keys/hooks/use-api-keys-table-config.tsx
+++ b/services/platform/app/features/settings/api-keys/hooks/use-api-keys-table-config.tsx
@@ -6,6 +6,10 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { useT } from '@/lib/i18n/client';
 
 import { ApiKeyRowActions } from '../components/api-key-row-actions';
@@ -26,6 +30,9 @@ export function useApiKeysTableConfig(
 
   const columns = useMemo<ColumnDef<ApiKey>[]>(
     () => [
+      // Multi-row select — canonical 40px column matching every other entity
+      // table. Enables bulk-revoke via the `BulkDeleteBar` footer.
+      createSelectColumn<ApiKey>(),
       {
         accessorKey: 'name',
         header: tSettings('apiKeys.columns.name'),
@@ -82,7 +89,9 @@ export function useApiKeysTableConfig(
       },
       {
         id: 'actions',
-        size: 44,
+        // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
+        // every other table's actions column.
+        size: ACTIONS_COLUMN_SIZE,
         meta: { isAction: true },
         cell: ({ row }) => (
           <ActionRow justify="end">

--- a/services/platform/app/features/settings/components/settings-navigation.tsx
+++ b/services/platform/app/features/settings/components/settings-navigation.tsx
@@ -48,6 +48,16 @@ export function SettingsNavigation({
   const location = useLocation();
   const userScope = isUserScope(location.pathname);
 
+  // Ordered by descending visit frequency / relevance, grouped:
+  //   1. Identity         — account, personalization (user scope only)
+  //   2. Org identity     — organization, branding
+  //   3. Collaboration    — people
+  //   4. Capabilities     — providers, integrations, skills
+  //   5. Developer access — api
+  //   6. Policy           — governance
+  //   7. Infra (rarest)   — dataResidency
+  // The filter below keeps user-scope and org-scope items in separate strips,
+  // so within each scope this is the rendered order.
   const allItems: (TabNavigationItem & { labelKey: SettingsLabelKey })[] = [
     {
       labelKey: 'account',
@@ -66,23 +76,15 @@ export function SettingsNavigation({
       can: ['read', 'orgSettings'],
     },
     {
-      labelKey: 'people',
-      label: t('people'),
-      href: `/dashboard/${organizationId}/settings/people`,
-      can: ['read', 'orgSettings'],
-      matchMode: 'startsWith',
-    },
-    {
       labelKey: 'branding',
       label: t('branding'),
       href: `/dashboard/${organizationId}/settings/branding`,
       can: ['read', 'orgSettings'],
     },
     {
-      // Deployment-level data residency (instance admin).
-      labelKey: 'dataResidency',
-      label: t('dataResidency'),
-      href: `/dashboard/${organizationId}/settings/deployment`,
+      labelKey: 'people',
+      label: t('people'),
+      href: `/dashboard/${organizationId}/settings/people`,
       can: ['read', 'orgSettings'],
       matchMode: 'startsWith',
     },
@@ -119,6 +121,15 @@ export function SettingsNavigation({
       labelKey: 'governance',
       label: t('governance'),
       href: `/dashboard/${organizationId}/settings/governance`,
+      can: ['read', 'orgSettings'],
+      matchMode: 'startsWith',
+    },
+    {
+      // Deployment-level data residency (instance admin). Moved last — most
+      // orgs configure this once at setup and never revisit it.
+      labelKey: 'dataResidency',
+      label: t('dataResidency'),
+      href: `/dashboard/${organizationId}/settings/deployment`,
       can: ['read', 'orgSettings'],
       matchMode: 'startsWith',
     },

--- a/services/platform/app/features/settings/organization/components/member-table.test.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.test.tsx
@@ -9,6 +9,10 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'test-org-id',
 }));
 
+vi.mock('../hooks/mutations', () => ({
+  useRemoveMember: () => ({ mutateAsync: vi.fn() }),
+}));
+
 vi.mock('./member-row-actions', () => ({
   MemberRowActions: () => <button type="button">actions</button>,
 }));

--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
-import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { getRoleBadgeClasses } from '@/lib/utils/badge-colors';
 
@@ -74,17 +73,11 @@ export function MemberTable({
       // members table lives in the better-auth component, not Convex's
       // user table — so no `Id<'members'>` schema type). The row id we
       // pull from RowSelectionState matches `Member._id` directly.
-      try {
-        await removeMember.mutateAsync({ memberId: id });
-      } catch (error) {
-        toast({
-          title: tSettings('organization.memberRemoveFailed'),
-          variant: 'destructive',
-        });
-        throw error;
-      }
+      // Let failures propagate so `BulkDeleteBar` surfaces a single batch
+      // toast instead of one per failed row.
+      await removeMember.mutateAsync({ memberId: id });
     },
-    [removeMember, tSettings],
+    [removeMember],
   );
 
   const columns = useMemo<ColumnDef<Member>[]>(

--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -3,15 +3,22 @@
 import { Button } from '@tale/ui/button';
 import { Stack, HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import type { ColumnDef } from '@tanstack/react-table';
+import type { ColumnDef, RowSelectionState } from '@tanstack/react-table';
 import { ChevronDownIcon, Users } from 'lucide-react';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useState } from 'react';
 
 import { TableTimestampCell } from '@/app/components/ui/data-display/table-date-cell';
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { getRoleBadgeClasses } from '@/lib/utils/badge-colors';
 
+import { useRemoveMember } from '../hooks/mutations';
 import { MemberRowActions } from './member-row-actions';
 
 type Member = {
@@ -51,12 +58,42 @@ export function MemberTable({
   const { t: tTables } = useT('tables');
   const { t: tSettings } = useT('settings');
   const { t: tEmpty } = useT('emptyStates');
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const removeMember = useRemoveMember();
   const handleSort = useCallback(() => {
     onSortChange(sortOrder === 'asc' ? 'desc' : 'asc');
   }, [sortOrder, onSortChange]);
 
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // `removeMember` takes the member doc's id as `v.string()` (the
+      // members table lives in the better-auth component, not Convex's
+      // user table — so no `Id<'members'>` schema type). The row id we
+      // pull from RowSelectionState matches `Member._id` directly.
+      try {
+        await removeMember.mutateAsync({ memberId: id });
+      } catch (error) {
+        toast({
+          title: tSettings('organization.memberRemoveFailed'),
+          variant: 'destructive',
+        });
+        throw error;
+      }
+    },
+    [removeMember, tSettings],
+  );
+
   const columns = useMemo<ColumnDef<Member>[]>(
     () => [
+      // Multi-row select — canonical 40px column. Enables bulk-remove via
+      // the `BulkDeleteBar` footer. Note: `removeMember` doesn't cascade
+      // to better-auth; bulk-remove of org owners would partial-fail and
+      // the bar surfaces a destructive toast for the failed ids.
+      createSelectColumn<Member>(),
       {
         id: 'member',
         header: () => (
@@ -127,6 +164,9 @@ export function MemberTable({
       {
         id: 'actions',
         header: '',
+        // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
+        // every other table's actions column.
+        size: ACTIONS_COLUMN_SIZE,
         cell: ({ row }) => (
           <HStack gap={1} justify="end">
             <MemberRowActions
@@ -135,7 +175,6 @@ export function MemberTable({
             />
           </HStack>
         ),
-        size: 140,
       },
     ],
     [handleSort, sortOrder, memberContext, tTables, tSettings],
@@ -148,6 +187,9 @@ export function MemberTable({
       getRowId={(row) => row._id}
       isLoading={isLoading}
       approxRowCount={approxRowCount}
+      enableRowSelection
+      rowSelection={rowSelection}
+      onRowSelectionChange={setRowSelection}
       pagination={{
         clientSide: true,
         pageSize: 10,
@@ -160,6 +202,14 @@ export function MemberTable({
         title: tEmpty('members.title'),
         description: tEmpty('members.description'),
       }}
+      footer={
+        <BulkDeleteBar
+          rowSelection={rowSelection}
+          onClearSelection={handleClearSelection}
+          onDeleteItem={handleDeleteItem}
+          onDeleteComplete={handleClearSelection}
+        />
+      }
     />
   );
 }

--- a/services/platform/app/features/settings/providers/components/providers-table.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-table.tsx
@@ -5,11 +5,16 @@ import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { IconButton } from '@tale/ui/icon-button';
 import { useQueryClient } from '@tanstack/react-query';
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import { Ellipsis, Pencil, Plus, Server, Trash2, Zap } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { toast } from '@/app/hooks/use-toast';
@@ -66,7 +71,25 @@ export function ProvidersTable({
   const [detailProvider, setDetailProvider] = useState(
     initialDetailProvider ?? null,
   );
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const deleteProviderMutation = useDeleteProvider();
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleBulkDeleteItem = useCallback(
+    async (providerName: string) => {
+      // Per-row delete reuses the same mutation as the single-row dialog so
+      // server-side audit logging stays consistent. The bar surfaces a
+      // destructive toast for the batch on failure.
+      await deleteProviderMutation.mutateAsync({
+        organizationId,
+        providerName,
+      });
+    },
+    [deleteProviderMutation, organizationId],
+  );
 
   const providers = useMemo(() => {
     if (!rawProviders) return [];
@@ -130,10 +153,16 @@ export function ProvidersTable({
 
   const columnsWithActions = useMemo(
     () => [
+      // Multi-row select — canonical 40px column matching every other entity
+      // table. Enables bulk-delete via the `BulkDeleteBar` footer.
+      createSelectColumn<ProviderRow>(),
       ...columns,
       {
         id: 'actions',
-        size: 44,
+        // Single canonical width so the 3-dot column lands at the same
+        // x-offset as every other table's actions column. See
+        // `ACTIONS_COLUMN_SIZE` for the source-of-truth comment.
+        size: ACTIONS_COLUMN_SIZE,
         cell: ({ row }: { row: Row<ProviderRow> }) => (
           <ProviderRowActions
             onEdit={() => setEditProvider(row.original)}
@@ -162,6 +191,15 @@ export function ProvidersTable({
         {...list.tableProps}
         columns={columnsWithActions}
         stickyLayout={stickyLayout}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+        // Providers are keyed by `name`, not `_id` — RowSelectionState uses
+        // the row's `id` field by default, which TanStack derives from the
+        // row's accessor when no `getRowId` is supplied. Pin it to `name`
+        // explicitly so the bulk handler receives the same string the
+        // delete mutation expects.
+        getRowId={(row) => row.name}
         onRowClick={handleRowClick}
         actionMenu={
           <Button onClick={() => setAddDialogOpen(true)}>
@@ -174,6 +212,14 @@ export function ProvidersTable({
           title: tEmpty('providers.title'),
           description: tEmpty('providers.description'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleBulkDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
       />
 
       <ProviderAddPanel

--- a/services/platform/app/features/settings/teams/components/teams-table.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-table.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { PageSection } from '@tale/ui/page-section';
+import type { RowSelectionState } from '@tanstack/react-table';
 import { Users } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
+import { toast } from '@/app/hooks/use-toast';
+import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 
 import type { Team } from '../hooks/queries';
@@ -42,10 +46,36 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
   const { t: tEmpty } = useT('emptyStates');
   const { t: tSettings } = useT('settings');
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const handleViewTeam = useCallback((team: Team) => {
     setSelectedTeam(team);
   }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  // Bulk delete: the per-team delete path goes through Better Auth's
+  // `removeTeam` (same call the single-row TeamDeleteDialog uses), wrapped
+  // here so the BulkDeleteBar can run them in parallel. Throwing on error
+  // lets the bar surface a failure toast for the whole batch.
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      const result = await authClient.organization.removeTeam({
+        teamId: id,
+        organizationId,
+      });
+      if (result.error) {
+        toast({
+          title: tSettings('teams.teamDeleteFailed'),
+          variant: 'destructive',
+        });
+        throw new Error(result.error.message || 'Failed to delete team');
+      }
+    },
+    [organizationId, tSettings],
+  );
 
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useTeamsTableConfig(organizationId, handleViewTeam);
@@ -71,6 +101,9 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
       <DataTable
         columns={columns}
         stickyLayout={stickyLayout}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         actionMenu={<TeamsActionMenu organizationId={organizationId} />}
         emptyState={{
           icon: Users,
@@ -79,6 +112,14 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
         }}
         onRowClick={(row) => setSelectedTeam(row.original)}
         clickableRows
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
 

--- a/services/platform/app/features/settings/teams/components/teams-table.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-table.tsx
@@ -8,7 +8,6 @@ import { useCallback, useState } from 'react';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
-import { toast } from '@/app/hooks/use-toast';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 
@@ -67,14 +66,12 @@ export function TeamsTable({ teams, organizationId }: TeamsTableProps) {
         organizationId,
       });
       if (result.error) {
-        toast({
-          title: tSettings('teams.teamDeleteFailed'),
-          variant: 'destructive',
-        });
+        // Throw so `BulkDeleteBar` surfaces a single batch-failure toast
+        // rather than one toast per failed row.
         throw new Error(result.error.message || 'Failed to delete team');
       }
     },
-    [organizationId, tSettings],
+    [organizationId],
   );
 
   const { columns, searchPlaceholder, stickyLayout, pageSize } =

--- a/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
+++ b/services/platform/app/features/settings/teams/hooks/use-teams-table-config.tsx
@@ -6,6 +6,10 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
 import { TableDateCell } from '@/app/components/ui/data-display/table-date-cell';
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { useT } from '@/lib/i18n/client';
 
 import { TeamRowActions } from '../components/team-row-actions';
@@ -27,6 +31,9 @@ export function useTeamsTableConfig(
 
   const columns = useMemo<ColumnDef<Team>[]>(
     () => [
+      // Multi-row select — canonical 40px column, identical to every other
+      // entity table. Enables bulk-delete via the `BulkDeleteBar` footer.
+      createSelectColumn<Team>(),
       {
         accessorKey: 'name',
         header: tSettings('teams.columns.name'),
@@ -65,7 +72,9 @@ export function useTeamsTableConfig(
       },
       {
         id: 'actions',
-        size: 44,
+        // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns with
+        // every other table's actions column.
+        size: ACTIONS_COLUMN_SIZE,
         meta: { isAction: true },
         cell: ({ row }) => (
           <HStack justify="end">

--- a/services/platform/app/features/skills/components/skill-row-actions.tsx
+++ b/services/platform/app/features/skills/components/skill-row-actions.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { Trash2 } from 'lucide-react';
+import { Copy, RotateCw, Trash2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 import {
   EntityRowActions,
   useEntityRowDialogs,
 } from '@/app/components/ui/entity/entity-row-actions';
+import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
+import { useDuplicateSkill } from '../hooks/mutations';
 import { SkillDeleteDialog } from './skill-delete-dialog';
+import { SkillUploadDialog } from './skill-upload/skill-upload-dialog';
 
 interface SkillRowActionsProps {
   skillSlug: string;
@@ -20,6 +24,8 @@ interface SkillRowActionsProps {
    */
   expectedHash?: string;
   onDeleted?: () => void;
+  /** Called with the new slug after a duplicate so the list can react. */
+  onDuplicated?: (newSlug: string) => void;
 }
 
 export function SkillRowActions({
@@ -27,14 +33,70 @@ export function SkillRowActions({
   organizationId,
   expectedHash,
   onDeleted,
+  onDuplicated,
 }: SkillRowActionsProps) {
+  const { t } = useT('settings');
   const { t: tCommon } = useT('common');
   const dialogs = useEntityRowDialogs(['delete']);
+  const [replaceOpen, setReplaceOpen] = useState(false);
+  const { mutateAsync: duplicateSkill } = useDuplicateSkill();
+  const [isDuplicating, setIsDuplicating] = useState(false);
+
+  const handleDuplicate = useCallback(async () => {
+    if (isDuplicating) return;
+    setIsDuplicating(true);
+    try {
+      const { newSlug } = await duplicateSkill({
+        organizationId,
+        slug: skillSlug,
+      });
+      toast({
+        title: t('skills.skillDuplicated', {
+          defaultValue: 'Skill duplicated as {slug}',
+          slug: newSlug,
+        }),
+        variant: 'success',
+      });
+      onDuplicated?.(newSlug);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: t('skills.skillDuplicateFailed', {
+          defaultValue: 'Failed to duplicate skill',
+        }),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDuplicating(false);
+    }
+  }, [
+    isDuplicating,
+    duplicateSkill,
+    organizationId,
+    skillSlug,
+    t,
+    onDuplicated,
+  ]);
 
   const actions = [
     {
+      key: 'replace',
+      label: t('skills.actions.replaceBundle', {
+        defaultValue: 'Replace bundle',
+      }),
+      icon: RotateCw,
+      onClick: () => setReplaceOpen(true),
+    },
+    {
+      key: 'duplicate',
+      label: t('skills.actions.duplicate', { defaultValue: 'Duplicate' }),
+      icon: Copy,
+      disabled: isDuplicating,
+      onClick: () => void handleDuplicate(),
+    },
+    {
       key: 'delete',
-      label: tCommon('delete'),
+      label: tCommon('actions.delete'),
       icon: Trash2,
       destructive: true,
       onClick: () => dialogs.open.delete(),
@@ -51,6 +113,15 @@ export function SkillRowActions({
         open={dialogs.isOpen.delete}
         onOpenChange={dialogs.setOpen.delete}
         onDeleted={onDeleted}
+      />
+      <SkillUploadDialog
+        open={replaceOpen}
+        onOpenChange={setReplaceOpen}
+        organizationId={organizationId}
+        onUploaded={(newSlug) => {
+          setReplaceOpen(false);
+          onDuplicated?.(newSlug);
+        }}
       />
     </>
   );

--- a/services/platform/app/features/skills/components/skills-table.tsx
+++ b/services/platform/app/features/skills/components/skills-table.tsx
@@ -125,12 +125,27 @@ export function SkillsTable({
     setRowSelection({});
   }, []);
 
+  // SKILL.md hash observed at list time, keyed by slug — forwarded to the
+  // delete mutation's CAS guard so a concurrently-edited skill isn't deleted
+  // from a stale view (mirrors the single-row delete dialog).
+  const skillHashBySlug = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of skills) {
+      if (s.hash) map.set(s.slug, s.hash);
+    }
+    return map;
+  }, [skills]);
+
   const handleBulkDeleteItem = useCallback(
     // Reuses the single-row delete mutation; the bar batches + toasts.
     async (slug: string) => {
-      await deleteSkill({ organizationId, slug });
+      await deleteSkill({
+        organizationId,
+        slug,
+        expectedHash: skillHashBySlug.get(slug),
+      });
     },
-    [deleteSkill, organizationId],
+    [deleteSkill, organizationId, skillHashBySlug],
   );
 
   const { columns, searchPlaceholder, stickyLayout, pageSize } =

--- a/services/platform/app/features/skills/components/skills-table.tsx
+++ b/services/platform/app/features/skills/components/skills-table.tsx
@@ -3,7 +3,7 @@
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useQueryClient } from '@tanstack/react-query';
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import { Sparkles } from 'lucide-react';
 import {
   useCallback,
@@ -14,9 +14,11 @@ import {
 } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { useT } from '@/lib/i18n/client';
 
+import { useDeleteSkill } from '../hooks/mutations';
 import { useListSkills } from '../hooks/queries';
 import {
   useSkillsTableConfig,
@@ -113,10 +115,29 @@ export function SkillsTable({
     void queryClient.invalidateQueries({ queryKey: ['config', 'skills'] });
   }, [queryClient]);
 
+  // Bulk delete is only offered in the settings context (no `bindingMode`),
+  // where rows aren't already claimed by the agent-binding checkbox column.
+  const bulkDeletable = bindingMode == null;
+  const { mutateAsync: deleteSkill } = useDeleteSkill();
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleBulkDeleteItem = useCallback(
+    // Reuses the single-row delete mutation; the bar batches + toasts.
+    async (slug: string) => {
+      await deleteSkill({ organizationId, slug });
+    },
+    [deleteSkill, organizationId],
+  );
+
   const { columns, searchPlaceholder, stickyLayout, pageSize } =
     useSkillsTableConfig({
       organizationId,
       onDeleted: invalidateSkills,
+      onDuplicated: setDetailSlug,
       bindingMode,
     });
 
@@ -175,6 +196,23 @@ export function SkillsTable({
         {...list.tableProps}
         columns={columns}
         stickyLayout={stickyLayout}
+        enableRowSelection={bulkDeletable}
+        rowSelection={bulkDeletable ? rowSelection : undefined}
+        onRowSelectionChange={bulkDeletable ? setRowSelection : undefined}
+        getRowId={bulkDeletable ? (row) => row.slug : undefined}
+        footer={
+          bulkDeletable ? (
+            <BulkDeleteBar
+              rowSelection={rowSelection}
+              onClearSelection={handleClearSelection}
+              onDeleteItem={handleBulkDeleteItem}
+              onDeleteComplete={() => {
+                handleClearSelection();
+                invalidateSkills();
+              }}
+            />
+          ) : undefined
+        }
         onRowClick={handleRowClick}
         actionMenu={
           hideActionMenu ? undefined : (

--- a/services/platform/app/features/skills/hooks/use-skills-table-config.tsx
+++ b/services/platform/app/features/skills/hooks/use-skills-table-config.tsx
@@ -6,6 +6,10 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { AlertTriangle } from 'lucide-react';
 import { useMemo } from 'react';
 
+import {
+  ACTIONS_COLUMN_SIZE,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { useT } from '@/lib/i18n/client';
 
@@ -28,12 +32,14 @@ export interface SkillsTableBindingMode {
 interface SkillsTableConfigOptions {
   organizationId: string;
   onDeleted?: () => void;
+  onDuplicated?: (newSlug: string) => void;
   bindingMode?: SkillsTableBindingMode;
 }
 
 export function useSkillsTableConfig({
   organizationId,
   onDeleted,
+  onDuplicated,
   bindingMode,
 }: SkillsTableConfigOptions): SkillsTableConfig {
   const { t } = useT('settings');
@@ -48,6 +54,9 @@ export function useSkillsTableConfig({
 
   const columns = useMemo<ColumnDef<SkillRow>[]>(
     () => [
+      // Settings context gets the canonical multi-select column (bulk delete).
+      // Binding context uses its own single-purpose `binding` checkbox instead.
+      ...(bindingMode ? [] : [createSelectColumn<SkillRow>()]),
       ...(bindingMode
         ? [
             {
@@ -152,6 +161,9 @@ export function useSkillsTableConfig({
             {
               id: 'actions',
               header: '',
+              // Locked to `ACTIONS_COLUMN_SIZE` so the 3-dot column aligns
+              // with every other table's actions column.
+              size: ACTIONS_COLUMN_SIZE,
               meta: { isAction: true },
               cell: ({ row }) => (
                 <HStack
@@ -165,14 +177,22 @@ export function useSkillsTableConfig({
                     organizationId={organizationId}
                     expectedHash={row.original.hash}
                     onDeleted={onDeleted}
+                    onDuplicated={onDuplicated}
                   />
                 </HStack>
               ),
-              size: 60,
             } satisfies ColumnDef<SkillRow>,
           ]),
     ],
-    [t, organizationId, onDeleted, bindingMode, selectedSet, atCap],
+    [
+      t,
+      organizationId,
+      onDeleted,
+      onDuplicated,
+      bindingMode,
+      selectedSet,
+      atCap,
+    ],
   );
 
   return {

--- a/services/platform/app/features/websites/components/websites-table.test.tsx
+++ b/services/platform/app/features/websites/components/websites-table.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('../hooks/mutations', () => ({
   useSyncWebsiteStatuses: () => ({ mutate: vi.fn() }),
   useCreateWebsite: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteWebsite: () => ({ mutateAsync: vi.fn() }),
 }));
 
 vi.mock('../hooks/queries', () => ({

--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -9,6 +9,7 @@ import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
+import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
 
 import { useDeleteWebsite, useSyncWebsiteStatuses } from '../hooks/mutations';
@@ -157,8 +158,8 @@ export function WebsitesTable({
 
   const handleDeleteItem = useCallback(
     async (id: string) => {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- RowSelectionState keys are the row `_id`s by construction (see getRowId); Convex Ids carry no runtime-checkable format.
-      await deleteWebsite({ websiteId: id as Website['_id'] });
+      // RowSelectionState keys are the row `_id`s by construction (getRowId).
+      await deleteWebsite({ websiteId: toId<'websites'>(id) });
     },
     [deleteWebsite],
   );

--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -157,6 +157,7 @@ export function WebsitesTable({
 
   const handleDeleteItem = useCallback(
     async (id: string) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- RowSelectionState keys are the row `_id`s by construction (see getRowId); Convex Ids carry no runtime-checkable format.
       await deleteWebsite({ websiteId: id as Website['_id'] });
     },
     [deleteWebsite],

--- a/services/platform/app/features/websites/components/websites-table.tsx
+++ b/services/platform/app/features/websites/components/websites-table.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { useNavigate } from '@tanstack/react-router';
-import type { Row } from '@tanstack/react-table';
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import { Globe } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
-import { useSyncWebsiteStatuses } from '../hooks/mutations';
+import { useDeleteWebsite, useSyncWebsiteStatuses } from '../hooks/mutations';
 import {
   useApproxWebsiteCount,
   useListWebsitesPaginated,
@@ -134,6 +135,8 @@ export function WebsitesTable({
   );
 
   const [viewingWebsiteId, setViewingWebsiteId] = useState<string | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { mutateAsync: deleteWebsite } = useDeleteWebsite();
 
   const viewingWebsite = useMemo(
     () =>
@@ -147,6 +150,17 @@ export function WebsitesTable({
   const handleRowClick = useCallback((row: Row<Website>) => {
     setViewingWebsiteId(row.original._id);
   }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      await deleteWebsite({ websiteId: id as Website['_id'] });
+    },
+    [deleteWebsite],
+  );
 
   const list = useListPage<Website>({
     dataSource: {
@@ -174,6 +188,9 @@ export function WebsitesTable({
       <DataTable
         columns={columns}
         stickyLayout={stickyLayout}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
         onRowClick={handleRowClick}
         actionMenu={<WebsitesActionMenu organizationId={organizationId} />}
         emptyState={{
@@ -181,6 +198,14 @@ export function WebsitesTable({
           title: tEmpty('websites.title'),
           description: tEmpty('websites.description'),
         }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
         {...list.tableProps}
       />
 

--- a/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
+++ b/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
@@ -24,6 +24,9 @@ export const useWebsitesTableConfig = createTableConfigHook<'websites'>(
     defaultSort: '_creationTime',
   },
   ({ tTables, tEntity, builders }) => [
+    // Multi-row select — canonical 40px column matching every other entity
+    // table. Enables bulk-delete via the `BulkDeleteBar` footer.
+    builders.createSelectColumn(),
     {
       accessorKey: 'domain',
       header: tTables('headers.website'),
@@ -60,16 +63,11 @@ export const useWebsitesTableConfig = createTableConfigHook<'websites'>(
         );
       },
     },
-    {
-      accessorKey: 'title',
-      header: tTables('headers.title'),
-      size: 192,
-      cell: ({ row }) => (
-        <Text as="div" truncate className="max-w-sm">
-          {row.original.title || tTables('cells.empty')}
-        </Text>
-      ),
-    },
+    // `title` column dropped — for monitored websites the domain (already
+    // shown in the first column) is the disambiguator users scan on, and
+    // page titles often duplicate the domain or fall back to "—". Users
+    // who need the title still see it on the website detail view. Frees
+    // 192px for the indexed/last-scanned/interval columns to breathe.
     {
       id: 'indexed',
       header: () => (

--- a/services/platform/app/features/workspace/components/workspace-context.tsx
+++ b/services/platform/app/features/workspace/components/workspace-context.tsx
@@ -86,13 +86,13 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     threadId ? { threadId } : 'skip',
   );
 
-  const [localState, setLocalState] = useState<WorkspaceState>(INITIAL_STATE);
+  const [localState, setLocalState] = useState(INITIAL_STATE);
   const { mutate: setCanvasState } = useSetThreadCanvasState();
 
   // Reset the transient new-chat state on every thread switch so navigating
   // away from a closed canvas and back to another new-chat surface doesn't
   // inherit the previous tab's open/file state.
-  const prevThreadIdRef = useRef<string | undefined>(threadId);
+  const prevThreadIdRef = useRef(threadId);
   useEffect(() => {
     if (prevThreadIdRef.current !== threadId) {
       setLocalState(INITIAL_STATE);
@@ -100,14 +100,20 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     }
   }, [threadId]);
 
-  const state: WorkspaceState = threadId
-    ? threadMeta?.canvasState
-      ? {
-          isOpen: threadMeta.canvasState.isOpen,
-          activeFilePath: threadMeta.canvasState.activeFilePath,
-        }
-      : INITIAL_STATE
-    : localState;
+  // Memoize so `value` (below) doesn't re-create every render — a fresh object
+  // literal here would defeat the `useMemo` that depends on it.
+  const state = useMemo<WorkspaceState>(
+    () =>
+      threadId
+        ? threadMeta?.canvasState
+          ? {
+              isOpen: threadMeta.canvasState.isOpen,
+              activeFilePath: threadMeta.canvasState.activeFilePath,
+            }
+          : INITIAL_STATE
+        : localState,
+    [threadId, threadMeta?.canvasState, localState],
+  );
 
   const openWorkspace = useCallback(
     (path?: string) => {

--- a/services/platform/app/features/workspace/components/workspace-context.tsx
+++ b/services/platform/app/features/workspace/components/workspace-context.tsx
@@ -5,11 +5,16 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
+  useState,
   type ReactNode,
 } from 'react';
 
-import { usePersistedState } from '@/app/hooks/use-persisted-state';
+import { useSetThreadCanvasState } from '@/app/features/chat/hooks/mutations';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
 
 interface WorkspaceState {
   isOpen: boolean;
@@ -46,47 +51,117 @@ interface WorkspaceProviderProps {
   children: ReactNode;
 }
 
+/**
+ * Persists canvas (workspace) pane state PER CHAT via Convex so it follows
+ * the user across devices and tabs.
+ *
+ * Storage:
+ *   - With `threadId`: source of truth is `getThreadMeta.canvasState`,
+ *     written via `setThreadCanvasState` with an optimistic patch so
+ *     toggles feel instant. The same `getThreadMeta` query is already
+ *     consumed by `ChatInterface` + `useMessageProcessing`, so reading
+ *     it here adds no new WS subscription.
+ *   - Without `threadId` (brand-new chat, before the first message
+ *     creates the thread): kept in component-local React state,
+ *     defaulting to closed. This is *not* carried into Convex when the
+ *     thread materializes — opening the canvas pre-thread is rare and
+ *     the mirror+handoff seam wasn't worth the complexity. Users opening
+ *     the canvas after sending the first message hit the Convex path
+ *     from then on.
+ *
+ * `INITIAL_STATE` (closed, no active file path) is also returned while the
+ * `getThreadMeta` query is loading on a cold cache, so the canvas never
+ * flashes open then closed when navigating back to a thread it was open
+ * on. The live subscription replaces it the moment the first result lands.
+ */
 export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
-  // Persist the canvas open/active-file state PER CHAT so reopening a thread
-  // restores whether its canvas was open. `usePersistedState` re-reads the new
-  // key's value when `threadId` changes, so switching chats restores each
-  // thread's own state. New chats (no threadId) share a transient slot that
-  // `resetWorkspace` clears on thread→new transitions.
   const threadMatch = useMatch({
     from: '/dashboard/$id/chat/$threadId',
     shouldThrow: false,
   });
   const threadId = threadMatch?.params?.threadId;
-  const [state, setState, clearState] = usePersistedState(
-    threadId
-      ? `tale.platform.chat.${threadId}.canvas`
-      : 'tale.platform.chat.new.canvas',
-    INITIAL_STATE,
+
+  const { data: threadMeta } = useConvexQuery(
+    api.threads.queries.getThreadMeta,
+    threadId ? { threadId } : 'skip',
   );
+
+  const [localState, setLocalState] = useState<WorkspaceState>(INITIAL_STATE);
+  const { mutate: setCanvasState } = useSetThreadCanvasState();
+
+  // Reset the transient new-chat state on every thread switch so navigating
+  // away from a closed canvas and back to another new-chat surface doesn't
+  // inherit the previous tab's open/file state.
+  const prevThreadIdRef = useRef<string | undefined>(threadId);
+  useEffect(() => {
+    if (prevThreadIdRef.current !== threadId) {
+      setLocalState(INITIAL_STATE);
+      prevThreadIdRef.current = threadId;
+    }
+  }, [threadId]);
+
+  const state: WorkspaceState = threadId
+    ? threadMeta?.canvasState
+      ? {
+          isOpen: threadMeta.canvasState.isOpen,
+          activeFilePath: threadMeta.canvasState.activeFilePath,
+        }
+      : INITIAL_STATE
+    : localState;
 
   const openWorkspace = useCallback(
     (path?: string) => {
-      setState((prev) => ({
-        isOpen: true,
-        activeFilePath: path ?? prev.activeFilePath,
-      }));
+      if (threadId) {
+        setCanvasState({
+          threadId,
+          canvasOpen: true,
+          // Only pass the path through when the caller supplied one; omitting
+          // it tells the server-side mutation to leave the existing value
+          // alone (so `openWorkspace()` with no arg preserves the active
+          // file across an open→close→open cycle).
+          ...(path !== undefined ? { canvasActiveFilePath: path } : {}),
+        });
+      } else {
+        setLocalState((prev) => ({
+          isOpen: true,
+          activeFilePath: path ?? prev.activeFilePath,
+        }));
+      }
     },
-    [setState],
+    [threadId, setCanvasState],
   );
 
   const closeWorkspace = useCallback(() => {
-    setState((prev) => ({ ...prev, isOpen: false }));
-  }, [setState]);
+    if (threadId) {
+      setCanvasState({ threadId, canvasOpen: false });
+    } else {
+      setLocalState((prev) => ({ ...prev, isOpen: false }));
+    }
+  }, [threadId, setCanvasState]);
 
   const resetWorkspace = useCallback(() => {
-    clearState();
-  }, [clearState]);
+    if (threadId) {
+      // Reset = close pane AND clear the active-file override so a future
+      // open falls back to the first listed file.
+      setCanvasState({
+        threadId,
+        canvasOpen: false,
+        canvasActiveFilePath: null,
+      });
+    } else {
+      setLocalState(INITIAL_STATE);
+    }
+  }, [threadId, setCanvasState]);
 
   const setActiveFilePath = useCallback(
     (path: string | null) => {
-      setState((prev) => ({ ...prev, activeFilePath: path }));
+      if (threadId) {
+        setCanvasState({ threadId, canvasActiveFilePath: path });
+      } else {
+        setLocalState((prev) => ({ ...prev, activeFilePath: path }));
+      }
     },
-    [setState],
+    [threadId, setCanvasState],
   );
 
   const value = useMemo(

--- a/services/platform/app/hooks/use-relative-now.ts
+++ b/services/platform/app/hooks/use-relative-now.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useLocale } from '@tale/ui/i18n/locale-provider';
+import { useEffect, useState } from 'react';
+
+import { formatRelativeTime } from '@/lib/utils/format/relative-time';
+
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+
+interface RelativeNowOptions {
+  /**
+   * Freeze updates and return `null`. Useful when the timer should be
+   * hidden — e.g. while an AI reply is still streaming, where the timer
+   * slot should disappear instead of ticking against a stale timestamp.
+   */
+  paused?: boolean;
+}
+
+/**
+ * Live-updating short relative-time label ("1s", "2s", "1m", "3h"), formatted
+ * for the row-of-list density used in the chat sidebar.
+ *
+ * Tick cadence is whatever the displayed unit needs:
+ *   - elapsed <  1m: re-renders every second (seconds visible)
+ *   - elapsed >= 1m: re-renders every minute (minute resolution is enough)
+ *
+ * For ages >= 1h the result falls through to `formatRelativeTime` so very
+ * old rows pick up locale-specific narrow forms ("2h", "3d", "1w"…).
+ *
+ * Returns `null` when `paused` is true or `timestamp` is undefined so callers
+ * can hide the slot entirely rather than render an empty string.
+ */
+export function useRelativeNow(
+  timestamp: number | undefined,
+  options?: RelativeNowOptions,
+): string | null {
+  const { locale } = useLocale();
+  const paused = options?.paused === true;
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (paused || timestamp === undefined) return undefined;
+    let handle: number;
+    const schedule = () => {
+      const diff = Math.max(0, Date.now() - timestamp);
+      const next = diff < MINUTE_MS ? SECOND_MS : MINUTE_MS;
+      handle = window.setTimeout(() => {
+        setTick((n) => n + 1);
+        schedule();
+      }, next);
+    };
+    schedule();
+    return () => window.clearTimeout(handle);
+  }, [paused, timestamp]);
+
+  if (paused || timestamp === undefined) return null;
+
+  const diff = Math.max(0, Date.now() - timestamp);
+  if (diff < MINUTE_MS) {
+    // Clamp to 1s so the very first frame after a new timestamp doesn't
+    // briefly show "0s" before the first tick lands.
+    return `${Math.max(1, Math.floor(diff / SECOND_MS))}s`;
+  }
+  if (diff < HOUR_MS) {
+    return `${Math.floor(diff / MINUTE_MS)}m`;
+  }
+  return formatRelativeTime(timestamp, locale, 'narrow');
+}

--- a/services/platform/app/hooks/use-zoom-pan.ts
+++ b/services/platform/app/hooks/use-zoom-pan.ts
@@ -3,8 +3,15 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
 
 const DEFAULT_MIN_ZOOM = 0.5;
-const DEFAULT_MAX_ZOOM = 3;
+// 5x covers reading screenshots / fine UI at native pixels on a typical
+// retina display. Beyond ~5x the image's source resolution usually starts
+// to look pixelated, so going higher isn't helpful.
+const DEFAULT_MAX_ZOOM = 5;
 const DEFAULT_ZOOM_STEP = 0.25;
+// Where double-click lands on the first zoom-in. 2x is the universal
+// "tap to zoom" target (maps/lightboxes/etc.) and leaves plenty of headroom
+// to keep zooming with the wheel/+ key afterward.
+const DEFAULT_DOUBLE_CLICK_ZOOM = 2;
 const WHEEL_THROTTLE_MS = 50;
 const PAN_KEY_STEP = 50;
 
@@ -12,6 +19,8 @@ interface UseZoomPanOptions {
   minZoom?: number;
   maxZoom?: number;
   zoomStep?: number;
+  /** Target zoom level applied by `toggleZoom` when starting from 1x. */
+  doubleClickZoom?: number;
   /**
    * When this value changes, zoom and pan reset to defaults.
    * Pass dialog open state or image src to auto-reset between views.
@@ -35,6 +44,15 @@ interface UseZoomPanReturn {
   zoomIn: () => void;
   zoomOut: () => void;
   reset: () => void;
+  /**
+   * Toggle between 1x and `doubleClickZoom`. When zooming in, pass the
+   * client-space point under the cursor (`e.clientX/Y`) so the image is
+   * anchored to that point instead of the container center — the pixel
+   * under the cursor stays put as the image grows around it, which is what
+   * users expect from a double-click. When zooming out, the argument is
+   * ignored.
+   */
+  toggleZoom: (clientPoint?: { x: number; y: number }) => void;
   pointerHandlers: ZoomPanPointerHandlers;
   canZoomIn: boolean;
   canZoomOut: boolean;
@@ -47,6 +65,10 @@ export function useZoomPan(options?: UseZoomPanOptions): UseZoomPanReturn {
   const minZoom = options?.minZoom ?? DEFAULT_MIN_ZOOM;
   const maxZoom = options?.maxZoom ?? DEFAULT_MAX_ZOOM;
   const zoomStep = options?.zoomStep ?? DEFAULT_ZOOM_STEP;
+  const doubleClickZoom = Math.min(
+    options?.doubleClickZoom ?? DEFAULT_DOUBLE_CLICK_ZOOM,
+    maxZoom,
+  );
 
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -123,6 +145,57 @@ export function useZoomPan(options?: UseZoomPanOptions): UseZoomPanReturn {
     [],
   );
 
+  /**
+   * Adjust pan so the content under a given screen-space point stays fixed
+   * while the zoom level changes — the "anchor zoom" behavior users expect
+   * from wheel and double-click. Math: the transform is
+   * `scale(z) translate(pan/z)` with `transform-origin: center`, so a screen
+   * offset `o` from the container center maps to content coord `(o - pan) / z`.
+   * Solving for the new pan that keeps that content coord under the same
+   * screen offset after zoom change z0 → z1 gives:
+   *   panNew = o * (1 - z1/z0) + panOld * (z1/z0)
+   */
+  const zoomToward = useCallback(
+    (
+      nextZoom: number,
+      clientPoint: { x: number; y: number } | undefined,
+      prevZoom: number,
+      prevPan: { x: number; y: number },
+    ) => {
+      const container = containerRef.current;
+      if (!container || !clientPoint || nextZoom <= 1) {
+        // No anchor, or we're going back to fit — pan resets to 0 either way
+        // (clampPan would force it there next render).
+        return nextZoom <= 1 ? { x: 0, y: 0 } : prevPan;
+      }
+      const rect = container.getBoundingClientRect();
+      const offsetX = clientPoint.x - (rect.left + rect.width / 2);
+      const offsetY = clientPoint.y - (rect.top + rect.height / 2);
+      const ratio = nextZoom / prevZoom;
+      const raw = {
+        x: offsetX * (1 - ratio) + prevPan.x * ratio,
+        y: offsetY * (1 - ratio) + prevPan.y * ratio,
+      };
+      return clampPan(raw, nextZoom);
+    },
+    [clampPan],
+  );
+
+  const toggleZoom = useCallback(
+    (clientPoint?: { x: number; y: number }) => {
+      setZoom((prev) => {
+        if (prev > 1) {
+          setPan({ x: 0, y: 0 });
+          return 1;
+        }
+        const next = doubleClickZoom;
+        setPan((prevPan) => zoomToward(next, clientPoint, prev, prevPan));
+        return next;
+      });
+    },
+    [doubleClickZoom, zoomToward],
+  );
+
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
       if (!isDragging) return;
@@ -149,20 +222,31 @@ export function useZoomPan(options?: UseZoomPanOptions): UseZoomPanReturn {
       if (now - lastWheelRef.current < WHEEL_THROTTLE_MS) return;
       lastWheelRef.current = now;
 
-      if (e.deltaY < 0) {
-        setZoom((prev) => Math.min(prev + zoomStep, maxZoom));
-      } else {
-        setZoom((prev) => {
-          const next = Math.max(prev - zoomStep, minZoom);
-          if (next <= 1) setPan({ x: 0, y: 0 });
-          return next;
-        });
-      }
+      // Capture the cursor point on the wheel event so the pan adjust keeps
+      // whatever's under the pointer fixed as the image grows/shrinks. Center-
+      // anchored zoom (the old behavior) yanks the visible region away from
+      // wherever the user is looking.
+      const point = { x: e.clientX, y: e.clientY };
+      const direction = e.deltaY < 0 ? 1 : -1;
+
+      setZoom((prev) => {
+        const next =
+          direction > 0
+            ? Math.min(prev + zoomStep, maxZoom)
+            : Math.max(prev - zoomStep, minZoom);
+        if (next === prev) return prev;
+        if (next <= 1) {
+          setPan({ x: 0, y: 0 });
+        } else {
+          setPan((prevPan) => zoomToward(next, point, prev, prevPan));
+        }
+        return next;
+      });
     };
 
     container.addEventListener('wheel', handleWheel, { passive: false });
     return () => container.removeEventListener('wheel', handleWheel);
-  }, [zoomStep, minZoom, maxZoom]);
+  }, [zoomStep, minZoom, maxZoom, zoomToward]);
 
   // Keyboard shortcuts on the container
   useEffect(() => {
@@ -244,6 +328,7 @@ export function useZoomPan(options?: UseZoomPanOptions): UseZoomPanReturn {
     zoomIn: zoomInFn,
     zoomOut: zoomOutFn,
     reset,
+    toggleZoom,
     pointerHandlers: {
       onPointerDown: handlePointerDown,
       onPointerMove: handlePointerMove,

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -27,7 +27,10 @@ import {
   useWorkflowConfig,
 } from '@/app/features/automations/hooks/use-workflow-config-context';
 import { useWorkflowActivity } from '@/app/features/automations/triggers/hooks/queries';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { useUrlState } from '@/app/hooks/use-url-state';
+import { api } from '@/convex/_generated/api';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
@@ -50,6 +53,22 @@ export const Route = createFileRoute('/dashboard/$id/automations/$amId')({
     meta: seo('automation'),
   }),
   validateSearch: searchSchema,
+  // The Executions tab is one click away on every automation detail page,
+  // but it's off-screen on first paint (the canvas tab lands by default).
+  // Prime the executions list cache fire-and-forget so opening Executions
+  // paints instantly with the first page already warm — same pattern as the
+  // chat sidebar and the knowledge tables. Filter-free args mirror the
+  // table's unfiltered call site; filtered views still hit the network
+  // (different cache key) but those are user-driven, not on-load.
+  loader: ({ context, params }) => {
+    const wfDefinitionId = urlParamToSlug(params.amId);
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.wf_executions.queries.listExecutions,
+      { wfDefinitionId },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
+    );
+  },
   component: AutomationDetailLayout,
 });
 

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -26,6 +26,7 @@ import {
   WorkspaceProvider,
   useWorkspace,
 } from '@/app/features/workspace/components/workspace-context';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
 import { lazyComponent } from '@/lib/utils/lazy-component';
@@ -47,11 +48,42 @@ const chatSearchSchema = z.object({
   projectId: z.string().optional(),
 });
 
+// Matches THREADS_PAGE_SIZE in features/chat/hooks/queries.ts — keep in sync
+// so the loader primes the same page the sidebar's `useThreads` will read.
+const THREADS_PAGE_SIZE = 20;
+
 export const Route = createFileRoute('/dashboard/$id/chat')({
   head: () => ({
     meta: seo('chat'),
   }),
   validateSearch: chatSearchSchema,
+  // The history sidebar is off-screen on first paint (collapsed by default on
+  // most viewports), so the threads list isn't on the critical path — fire
+  // the cache prime fire-and-forget so by the time the user opens the
+  // sidebar the first page is already warm. `primeCachedPaginatedQuery`
+  // skips the network call when the key is already cached, so re-navs to
+  // the chat route after the cache is filled are free.
+  //
+  // Args mirror `useThreads`'s base call site (`{ organizationId }` only —
+  // no `teamId`). When a team is selected the hook's cache key differs and
+  // we'll miss the prime; that's still correct (we'd just see the normal
+  // first-load skeleton), and the more common "no team scope" case wins.
+  loader: ({ context, params }) => {
+    // `listThreads`'s `paginationOpts` is `v.optional(...)` (it tolerates
+    // reconnection replays that drop the arg), so the generated type doesn't
+    // satisfy Convex's `PaginatedQueryReference` constraint. The runtime call
+    // shape is correct — the same cast is used by `useThreads` for the same
+    // reason. See `services/platform/app/features/chat/hooks/queries.ts`.
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- listThreads's `paginationOpts` is `v.optional`, so the generated type is missing the constraint primeCachedPaginatedQuery expects; same cast pattern as `useThreads` in features/chat/hooks/queries.ts
+      api.threads.queries.listThreads as unknown as Parameters<
+        typeof primeCachedPaginatedQuery
+      >[1],
+      { organizationId: params.id },
+      { initialNumItems: THREADS_PAGE_SIZE },
+    );
+  },
   component: ChatLayout,
 });
 

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -21,6 +21,7 @@ import {
   useChatLayout,
 } from '@/app/features/chat/context/chat-layout-context';
 import { StreamingToolProvider } from '@/app/features/chat/context/streaming-tool-context';
+import { THREADS_PAGE_SIZE } from '@/app/features/chat/hooks/queries';
 import { CanvasPane } from '@/app/features/workspace/components/canvas-pane';
 import {
   WorkspaceProvider,
@@ -47,10 +48,6 @@ const PlanPane = lazyComponent(() =>
 const chatSearchSchema = z.object({
   projectId: z.string().optional(),
 });
-
-// Matches THREADS_PAGE_SIZE in features/chat/hooks/queries.ts — keep in sync
-// so the loader primes the same page the sidebar's `useThreads` will read.
-const THREADS_PAGE_SIZE = 20;
 
 export const Route = createFileRoute('/dashboard/$id/chat')({
   head: () => ({

--- a/services/platform/convex/threads/mutations.ts
+++ b/services/platform/convex/threads/mutations.ts
@@ -266,6 +266,60 @@ export const unarchiveChatThread = mutation({
   },
 });
 
+/**
+ * Persist the canvas (workspace) pane state for a thread. The frontend
+ * `WorkspaceProvider` calls this with an optimistic update when the user
+ * toggles the pane or switches the active artifact file, so reopening the
+ * thread (or visiting from another device) restores the same layout.
+ *
+ * Both fields are independently optional so a caller can update one without
+ * touching the other (e.g. switching files while keeping the pane open).
+ * Passing `null` for `canvasActiveFilePath` clears the override — the chat
+ * surface will fall back to "first listed file".
+ */
+export const setThreadCanvasState = mutation({
+  args: {
+    threadId: v.string(),
+    canvasOpen: v.optional(v.boolean()),
+    canvasActiveFilePath: v.optional(v.union(v.string(), v.null())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const identity = await getAuthUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    // Cross-tenant gate, mirrors setThreadPinned / markThreadRead — the row
+    // is keyed only by threadId, so without this any signed-in user could
+    // mutate another tenant's thread metadata by guessing the id.
+    await assertThreadAccess(ctx, args.threadId, identity);
+
+    const metadata = await ctx.db
+      .query('threadMetadata')
+      .withIndex('by_threadId', (q) => q.eq('threadId', args.threadId))
+      .first();
+    if (!metadata) return null;
+
+    // `ctx.db.patch` ignores `undefined`, so only the fields the caller
+    // explicitly passed (including `null` to clear `canvasActiveFilePath`)
+    // are written. `null` is mapped to `undefined` on the way in because
+    // the schema field is `v.optional(v.string())` — undefined removes it.
+    const patch: {
+      canvasOpen?: boolean;
+      canvasActiveFilePath?: string | undefined;
+    } = {};
+    if (args.canvasOpen !== undefined) patch.canvasOpen = args.canvasOpen;
+    if (args.canvasActiveFilePath !== undefined) {
+      patch.canvasActiveFilePath = args.canvasActiveFilePath ?? undefined;
+    }
+    if (Object.keys(patch).length === 0) return null;
+
+    await ctx.db.patch(metadata._id, patch);
+    return null;
+  },
+});
+
 export const setThreadPinned = mutation({
   args: {
     threadId: v.string(),

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -290,6 +290,13 @@ export const getThreadMeta = query({
         }),
       ),
       failedErrors: v.record(v.string(), v.string()),
+      // Per-thread canvas (workspace pane) state — the WorkspaceProvider
+      // reads this on mount so reopening a thread restores its layout.
+      // `null` activeFilePath means "use the first listed file".
+      canvasState: v.object({
+        isOpen: v.boolean(),
+        activeFilePath: v.union(v.string(), v.null()),
+      }),
     }),
   ),
   handler: async (ctx, args) => {
@@ -336,6 +343,10 @@ export const getThreadMeta = query({
       isGenerating,
       forkInfo,
       failedErrors,
+      canvasState: {
+        isOpen: metadata.canvasOpen ?? false,
+        activeFilePath: metadata.canvasActiveFilePath ?? null,
+      },
     };
   },
 });

--- a/services/platform/convex/threads/schema.ts
+++ b/services/platform/convex/threads/schema.ts
@@ -115,6 +115,19 @@ export const threadMetadataTable = defineTable({
    */
   lastReplyAt: v.optional(v.number()),
   lastReadAt: v.optional(v.number()),
+  /**
+   * Persisted canvas (workspace) pane state, scoped per-thread. The chat
+   * surface reads these on mount so reopening a thread restores whether
+   * the canvas was open and which artifact path was active; writes happen
+   * when the user toggles the pane or switches files. Both optional for
+   * backward-compat — missing means "default closed, first file active".
+   *
+   * `canvasOpen`           — pane visible (`true`) / hidden (`undefined` ≈ `false`).
+   * `canvasActiveFilePath` — relative path of the artifact currently shown;
+   *                          `undefined` means "use the first listed file".
+   */
+  canvasOpen: v.optional(v.boolean()),
+  canvasActiveFilePath: v.optional(v.string()),
 })
   .index('by_threadId', ['threadId'])
   .index('by_userId_chatType_status', [

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1522,6 +1522,9 @@
       "warningTitle": "Du wirst bald abgemeldet",
       "warningDescription": "Deine Sitzung endet nach einer Phase der Inaktivität. Interagiere mit der Seite oder nutze die Schaltfläche, um weiterzuarbeiten.",
       "staySignedIn": "Angemeldet bleiben"
+    },
+    "dataTable": {
+      "dateFilterUnavailable": "Datumsfilter nicht verfügbar"
     }
   },
   "composer": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5722,7 +5722,6 @@
       "source": "Quelle",
       "updated": "Aktualisiert",
       "modified": "Geändert",
-      "uploadedAt": "Hochgeladen am",
       "member": "Mitglied",
       "role": "Rolle",
       "joined": "Beigetreten",
@@ -5747,7 +5746,6 @@
       "stock": "Bestand",
       "price": "Preis",
       "category": "Kategorie",
-      "title": "Titel",
       "website": "Website"
     },
     "cells": {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -839,6 +839,7 @@
     "agentSelector": {
       "label": "Agent auswählen",
       "auto": "Automatisch",
+      "autoDescription": "Tale wählt für jede Nachricht den passenden Agent basierend auf deiner Anfrage.",
       "viewDetails": "Agentdetails anzeigen",
       "noAgents": "Keine Agents",
       "defaultAgent": "Assistent",
@@ -851,6 +852,7 @@
       "searchPlaceholder": "Modelle suchen...",
       "noResults": "Keine Modelle gefunden",
       "auto": "Auto",
+      "autoDescription": "Tale wählt für jede Nachricht das passende Modell — abgewogen zwischen Qualität, Geschwindigkeit und Kosten.",
       "noModelsAvailable": "Keine Modelle verfügbar",
       "noModelsAdminHint": "Es ist noch kein KI-Anbieter eingerichtet. Klicke, um Einstellungen → KI-Anbieter zu öffnen, und füge einen hinzu, um zu chatten.",
       "noModelsAgentHint": "Dieser Assistent hat kein nutzbares Modell. Prüfe, ob seine zugelassenen Modelle zu einem konfigurierten Anbieter passen — klicke, um die KI-Anbieter zu öffnen.",
@@ -1548,10 +1550,14 @@
     "styleFriendly": "Freundlich"
   },
   "connectivity": {
-    "reconnectingTitle": "Verbindung wird wiederhergestellt…",
-    "reconnectingDescription": "Die Verbindung zu Tale ist abgebrochen. Einen Moment, wir versuchen es erneut.",
+    "tabTitle": "Verbindung wird wiederhergestellt",
+    "deviceTitle": "Du bist offline",
+    "deviceDescription": "Prüfe deine Internetverbindung. Tale verbindet sich automatisch wieder, sobald du online bist.",
+    "backendTitle": "Tale ist nicht erreichbar",
+    "backendDescription": "Der Tale-Server antwortet nicht. Wir versuchen, die Verbindung wiederherzustellen — einen Moment Geduld.",
     "retry": "Erneut versuchen",
-    "statusReconnecting": "Verbinde"
+    "getApp": "App herunterladen",
+    "reachingServer": "Verbindung zum Server wird hergestellt"
   },
   "conversations": {
     "title": "Konversationen",
@@ -4273,7 +4279,7 @@
       "columns": {
         "name": "Name",
         "members": "Mitglieder",
-        "created": "Erstellt"
+        "created": "Hinzugefügt am"
       },
       "editTeam": "Team bearbeiten",
       "deleteTeam": "Team löschen",
@@ -5092,7 +5098,7 @@
       "columns": {
         "name": "Name",
         "key": "Schlüssel",
-        "created": "Erstellt",
+        "created": "Hinzugefügt am",
         "lastUsed": "Zuletzt verwendet"
       },
       "form": {
@@ -5733,7 +5739,7 @@
       "teams": "Teams",
       "uploadedBy": "Hochgeladen von",
       "actions": "Aktionen",
-      "created": "Erstellt",
+      "created": "Hinzugefügt am",
       "description": "Beschreibung",
       "email": "E-Mail",
       "product": "Produkt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1522,6 +1522,9 @@
       "warningTitle": "You'll be signed out soon",
       "warningDescription": "Your session ends after a period of inactivity. Interact with the page or use the button below to keep working.",
       "staySignedIn": "Stay signed in"
+    },
+    "dataTable": {
+      "dateFilterUnavailable": "Date filter unavailable"
     }
   },
   "composer": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5983,7 +5983,6 @@
       "source": "Source",
       "updated": "Updated",
       "modified": "Modified",
-      "uploadedAt": "Uploaded at",
       "member": "Member",
       "role": "Role",
       "joined": "Joined",
@@ -6008,7 +6007,6 @@
       "stock": "Stock",
       "price": "Price",
       "category": "Category",
-      "title": "Title",
       "website": "Website"
     },
     "cells": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -839,6 +839,7 @@
     "agentSelector": {
       "label": "Select agent",
       "auto": "Auto",
+      "autoDescription": "Let Tale pick the best agent for each message based on what you ask.",
       "viewDetails": "View agent details",
       "noAgents": "No agents",
       "defaultAgent": "Assistant",
@@ -851,6 +852,7 @@
       "searchPlaceholder": "Search models...",
       "noResults": "No models found",
       "auto": "Auto",
+      "autoDescription": "Let Tale pick the best model for each message — balances quality, speed, and cost.",
       "noModelsAvailable": "No models available",
       "noModelsAdminHint": "No AI provider is set up yet. Click to open Settings → AI providers and add one to start chatting.",
       "noModelsAgentHint": "This assistant has no usable model. Check that its allowed models match a configured provider — click to open AI providers.",
@@ -1548,10 +1550,14 @@
     "styleFriendly": "Friendly"
   },
   "connectivity": {
-    "reconnectingTitle": "Reconnecting…",
-    "reconnectingDescription": "Lost connection to Tale. Hold on while we get you back.",
+    "tabTitle": "Reconnecting",
+    "deviceTitle": "You're offline",
+    "deviceDescription": "Check your internet connection. Tale will reconnect automatically when you're back online.",
+    "backendTitle": "Can't reach Tale",
+    "backendDescription": "Tale's server isn't responding. We're trying to reconnect — hold tight.",
     "retry": "Try again",
-    "statusReconnecting": "Reconnecting"
+    "getApp": "Get the app",
+    "reachingServer": "Trying to reach the server"
   },
   "conversations": {
     "title": "Conversations",
@@ -4534,7 +4540,7 @@
       "columns": {
         "name": "Name",
         "members": "Members",
-        "created": "Created"
+        "created": "Added on"
       },
       "editTeam": "Edit team",
       "deleteTeam": "Delete team",
@@ -5353,7 +5359,7 @@
       "columns": {
         "name": "Name",
         "key": "Key",
-        "created": "Created",
+        "created": "Added on",
         "lastUsed": "Last used"
       },
       "form": {
@@ -5994,7 +6000,7 @@
       "teams": "Teams",
       "uploadedBy": "Uploaded by",
       "actions": "Actions",
-      "created": "Created",
+      "created": "Added on",
       "description": "Description",
       "email": "Email",
       "product": "Product",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -840,6 +840,7 @@
     "agentSelector": {
       "label": "Sélectionner un agent",
       "auto": "Auto",
+      "autoDescription": "Tale choisit le meilleur agent pour chaque message en fonction de ta demande.",
       "viewDetails": "Voir les détails de l'agent",
       "noAgents": "Aucun agent",
       "defaultAgent": "Assistant",
@@ -852,6 +853,7 @@
       "searchPlaceholder": "Rechercher des modèles...",
       "noResults": "Aucun modèle trouvé",
       "auto": "Auto",
+      "autoDescription": "Tale choisit le meilleur modèle pour chaque message — équilibre qualité, vitesse et coût.",
       "noModelsAvailable": "Aucun modèle disponible",
       "noModelsAdminHint": "Aucun fournisseur d’IA n’est encore configuré. Clique pour ouvrir Paramètres → Fournisseurs d’IA et en ajouter un pour commencer à discuter.",
       "noModelsAgentHint": "Cet assistant n’a aucun modèle utilisable. Vérifie que ses modèles autorisés correspondent à un fournisseur configuré — clique pour ouvrir les fournisseurs d’IA.",
@@ -1549,10 +1551,14 @@
     "styleFriendly": "Amical"
   },
   "connectivity": {
-    "reconnectingTitle": "Reconnexion…",
-    "reconnectingDescription": "La connexion à Tale est interrompue. Patiente, on s'en occupe.",
+    "tabTitle": "Reconnexion",
+    "deviceTitle": "Tu es hors ligne",
+    "deviceDescription": "Vérifie ta connexion Internet. Tale se reconnectera automatiquement dès que tu seras en ligne.",
+    "backendTitle": "Impossible de joindre Tale",
+    "backendDescription": "Le serveur Tale ne répond pas. On essaie de se reconnecter — patiente un instant.",
     "retry": "Réessayer",
-    "statusReconnecting": "Reconnexion"
+    "getApp": "Obtenir l'application",
+    "reachingServer": "Connexion au serveur en cours"
   },
   "conversations": {
     "title": "Conversations",
@@ -4274,7 +4280,7 @@
       "columns": {
         "name": "Nom",
         "members": "Membres",
-        "created": "Créé"
+        "created": "Ajouté le"
       },
       "editTeam": "Modifier l'équipe",
       "deleteTeam": "Supprimer l'équipe",
@@ -5093,7 +5099,7 @@
       "columns": {
         "name": "Nom",
         "key": "Clé",
-        "created": "Créée",
+        "created": "Ajouté le",
         "lastUsed": "Dernière utilisation"
       },
       "form": {
@@ -5734,7 +5740,7 @@
       "teams": "Équipes",
       "uploadedBy": "Téléversé par",
       "actions": "Actions",
-      "created": "Créé",
+      "created": "Ajouté le",
       "description": "Description",
       "email": "Courriel",
       "product": "Produit",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1523,6 +1523,9 @@
       "warningTitle": "Tu vas bientôt être déconnecté",
       "warningDescription": "Ta session prend fin après une période d'inactivité. Interagis avec la page ou utilise le bouton pour continuer.",
       "staySignedIn": "Rester connecté"
+    },
+    "dataTable": {
+      "dateFilterUnavailable": "Filtre de date indisponible"
     }
   },
   "composer": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5723,7 +5723,6 @@
       "source": "Source",
       "updated": "Mis à jour",
       "modified": "Modifié",
-      "uploadedAt": "Téléversé le",
       "member": "Membre",
       "role": "Rôle",
       "joined": "Inscrit",
@@ -5748,7 +5747,6 @@
       "stock": "Stock",
       "price": "Prix",
       "category": "Catégorie",
-      "title": "Titre",
       "website": "Site web"
     },
     "cells": {

--- a/services/web/app/globals.css
+++ b/services/web/app/globals.css
@@ -1,15 +1,5 @@
 @import '@tale/ui/globals.css';
 
-/* Marketing site dark palette overrides — keep borders closer to the page
-   bg (#27272a vs the platform default #404040) so dividers read as subtle
-   separators in the .pen designs. The bg-base lifts to #0f0f0f so the
-   sticky navbar, root wrapper, and content sections share a single dark
-   surface instead of the bluer #030712 default. */
-.dark {
-  --color-bg-base: #0f0f0f;
-  --color-border-base: #27272a;
-}
-
 /* Marquee track. The track contains the logos rendered twice; translating
    -50% wraps the second set into the first's slot for a seamless loop. */
 @keyframes marquee {


### PR DESCRIPTION
## Summary

A batch of UI polish centered on the shared data tables, plus the in-progress chat/notifications/threads work that was already in the working tree.

### Tables (shared `DataTable`)
- **Utility column alignment**: the select-checkbox and 3-dot row-actions columns are now pinned to a fixed width (1% column + fixed-size content box) so they land at the same x on every table; content columns absorb leftover space proportionally instead of one runaway column.
- **Skeletons** use the same width logic, so the loading state matches the real table.
- **Consistent row height** (`h-12` minimum).
- **Border on horizontal scroll**: the rounded border now wraps the full table width and scrolls with the content rather than being pinned to the viewport.
- **Bulk-delete bar** gets a consistent gap below the table in the sticky layout (`empty:hidden` so no phantom gap when hidden).

### Selection & menus
- **Agents** and **Skills** tables gain multi-select + bulk delete (protected agents excluded from selection).
- **Skills** row menu gains **Replace bundle** and **Duplicate**.
- Row-action menus **auto-insert a separator before destructive actions** (delete/archive), keeping consecutive destructive actions grouped.

### Automations
- **Folder-aware select-all** — selecting a folder (or select-all) now reaches the workflows nested inside folders.
- **Global, flat search** — a query matches workflows across all folders (same behavior at root or inside a folder) and each result is prefixed with its folder path, e.g. `github / GitHub Issue Sync`.

### Misc
- `projects` / `automations` pages get the standard page inset (gap restored).
- Tab navigation drops its focus ring.
- Fix untranslated `duplicate`/`rename`/`delete` menu labels and the select-checkbox aria labels.
- `bun run dev` no longer starts docs or web.

## Testing
- `tsc` typecheck + `oxlint` clean on changed files.
- Manually verified in the running app (Playwright): column alignment across tables, skeleton widths, row height, horizontal-scroll border, bulk-delete bars (agents/skills), folder select-all, global search with folder-path prefix, and the menu separators/labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canvas state persistence for chats
  * Bulk deletion across tables (agents, automations, skills, teams, etc.)
  * Skill duplication support
  * Enhanced offline detection showing device vs. server connectivity status
  * Live relative timestamps in chat history
  * Double-click zoom toggle for image viewer

* **UI & Style**
  * Dark theme grayscale color refinements
  * Improved focus ring styling for keyboard navigation
  * Redesigned offline/connectivity overlay

* **Improvements**
  * Standardized table column sizing across platform
  * Per-row selection control in tables
  * Filter disable state support
  * Error boundary visual redesign

<!-- end of auto-generated comment: release notes by coderabbit.ai -->