### PR TITLE
refactor(platform): collapse RAG indexing status onto fileMetadata.ragStatus

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -292,6 +292,7 @@ import type * as documents_get_agent_scoped_file_ids from "../documents/get_agen
 import type * as documents_get_document_by_id from "../documents/get_document_by_id.js";
 import type * as documents_get_document_by_id_transformed from "../documents/get_document_by_id_transformed.js";
 import type * as documents_get_document_by_path from "../documents/get_document_by_path.js";
+import type * as documents_get_document_rag_projection from "../documents/get_document_rag_projection.js";
 import type * as documents_get_documents from "../documents/get_documents.js";
 import type * as documents_get_documents_cursor from "../documents/get_documents_cursor.js";
 import type * as documents_get_onedrive_sync_configs from "../documents/get_onedrive_sync_configs.js";
@@ -656,6 +657,7 @@ import type * as message_metadata_queries from "../message_metadata/queries.js";
 import type * as migrations from "../migrations.js";
 import type * as migrations_backfill_apikey_reference_id from "../migrations/backfill_apikey_reference_id.js";
 import type * as migrations_backfill_file_metadata_document_id from "../migrations/backfill_file_metadata_document_id.js";
+import type * as migrations_backfill_filemetadata_rag_status from "../migrations/backfill_filemetadata_rag_status.js";
 import type * as migrations_backfill_folder_path from "../migrations/backfill_folder_path.js";
 import type * as migrations_backfill_folders from "../migrations/backfill_folders.js";
 import type * as migrations_backfill_ledger_granularity from "../migrations/backfill_ledger_granularity.js";
@@ -1534,6 +1536,7 @@ declare const fullApi: ApiFromModules<{
   "documents/get_document_by_id": typeof documents_get_document_by_id;
   "documents/get_document_by_id_transformed": typeof documents_get_document_by_id_transformed;
   "documents/get_document_by_path": typeof documents_get_document_by_path;
+  "documents/get_document_rag_projection": typeof documents_get_document_rag_projection;
   "documents/get_documents": typeof documents_get_documents;
   "documents/get_documents_cursor": typeof documents_get_documents_cursor;
   "documents/get_onedrive_sync_configs": typeof documents_get_onedrive_sync_configs;
@@ -1898,6 +1901,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   "migrations/backfill_apikey_reference_id": typeof migrations_backfill_apikey_reference_id;
   "migrations/backfill_file_metadata_document_id": typeof migrations_backfill_file_metadata_document_id;
+  "migrations/backfill_filemetadata_rag_status": typeof migrations_backfill_filemetadata_rag_status;
   "migrations/backfill_folder_path": typeof migrations_backfill_folder_path;
   "migrations/backfill_folders": typeof migrations_backfill_folders;
   "migrations/backfill_ledger_granularity": typeof migrations_backfill_ledger_granularity;

--- a/services/platform/convex/agent_tools/rag/helpers/list_indexed_documents.ts
+++ b/services/platform/convex/agent_tools/rag/helpers/list_indexed_documents.ts
@@ -19,14 +19,28 @@ export async function listIndexedDocuments(
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolCtx from @convex-dev/agent lacks our agent knowledge properties injected at runtime
   const extended = ctx as AgentKnowledgeCtx;
 
-  return ctx.runQuery(internal.documents.internal_queries.listIndexedForAgent, {
-    organizationId,
-    agentTeamId: extended.agentTeamId,
-    agentTeamIds: extended.agentTeamIds,
-    includeTeamKnowledge: extended.includeTeamKnowledge,
-    includeOrgKnowledge: extended.includeOrgKnowledge,
-    knowledgeFileIds: extended.knowledgeFileIds,
-    limit: args.limit,
-    cursor: args.cursor,
-  });
+  try {
+    return await ctx.runQuery(
+      internal.documents.internal_queries.listIndexedForAgent,
+      {
+        organizationId,
+        agentTeamId: extended.agentTeamId,
+        agentTeamIds: extended.agentTeamIds,
+        includeTeamKnowledge: extended.includeTeamKnowledge,
+        includeOrgKnowledge: extended.includeOrgKnowledge,
+        knowledgeFileIds: extended.knowledgeFileIds,
+        limit: args.limit,
+        cursor: args.cursor,
+      },
+    );
+  } catch (err) {
+    // Defense-in-depth: a very large knowledge corpus can push this past the
+    // Convex transaction read cap. Degrade to an empty listing rather than
+    // throwing an opaque tool error to the agent.
+    console.warn(
+      '[rag_search list_indexed] listIndexedForAgent failed; returning empty listing',
+      err instanceof Error ? err.message : err,
+    );
+    return { documents: [], totalCount: null, hasMore: false, cursor: null };
+  }
 }

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -106,18 +106,29 @@ export async function resolveFileIds(
     knowledgeFileIds: extended.knowledgeFileIds?.length,
   });
 
-  return ctx.runQuery(
-    internal.documents.internal_queries.getAgentScopedFileIds,
-    {
-      organizationId,
-      agentTeamId: extended.agentTeamId,
-      agentTeamIds: extended.agentTeamIds,
-      includeTeamKnowledge: extended.includeTeamKnowledge,
-      includeOrgKnowledge: extended.includeOrgKnowledge,
-      knowledgeFileIds: extended.knowledgeFileIds,
-      agentProjectIds: extended.agentProjectIds,
-    },
-  );
+  try {
+    return await ctx.runQuery(
+      internal.documents.internal_queries.getAgentScopedFileIds,
+      {
+        organizationId,
+        agentTeamId: extended.agentTeamId,
+        agentTeamIds: extended.agentTeamIds,
+        includeTeamKnowledge: extended.includeTeamKnowledge,
+        includeOrgKnowledge: extended.includeOrgKnowledge,
+        knowledgeFileIds: extended.knowledgeFileIds,
+        agentProjectIds: extended.agentProjectIds,
+      },
+    );
+  } catch (err) {
+    // A very large knowledge corpus can push this scope query past the Convex
+    // transaction read cap. Degrade to an empty scope (the tool reports no
+    // results) rather than throwing an opaque tool error to the agent.
+    console.warn(
+      '[rag_search] getAgentScopedFileIds failed; resolving to empty scope',
+      err instanceof Error ? err.message : err,
+    );
+    return [];
+  }
 }
 
 const ragToolArgs = z.discriminatedUnion('operation', [

--- a/services/platform/convex/documents/actions.ts
+++ b/services/platform/convex/documents/actions.ts
@@ -4,6 +4,7 @@ import { v } from 'convex/values';
 
 import { isRecord, getBoolean, getString } from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
 import { action } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
@@ -19,6 +20,9 @@ export const retryRagIndexing = action({
     error: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
+    // RAG status is canonical on fileMetadata.ragStatus; hoist storageId so the
+    // catch can mark failure after the document is resolved.
+    let storageId: Id<'_storage'> | null = null;
     try {
       const authUser = await getAuthUserIdentity(ctx);
       if (!authUser) {
@@ -48,6 +52,7 @@ export const retryRagIndexing = action({
       if (!document.fileId) {
         return { success: false, error: 'Document has no file' };
       }
+      storageId = document.fileId;
 
       const rawResult = await ragAction.execute(
         ctx,
@@ -64,29 +69,25 @@ export const retryRagIndexing = action({
 
       if (success) {
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: {
-              status: 'queued',
-            },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'queued' },
         );
         await ctx.scheduler.runAfter(
           INITIAL_POLLING_DELAY_MS,
-          internal.documents.internal_actions.checkRagDocumentStatus,
-          { documentId: args.documentId, attempt: 1 },
+          internal.file_metadata.internal_actions.pollFileRagStatus,
+          {
+            storageId: document.fileId,
+            organizationId: document.organizationId,
+            attempt: 1,
+          },
         );
       } else {
         const error =
           (result ? getString(result, 'error') : undefined) ??
           'Upload to RAG failed';
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: { status: 'failed', error },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'failed', ragError: error },
         );
       }
 
@@ -95,19 +96,18 @@ export const retryRagIndexing = action({
       const message =
         error instanceof Error ? error.message : 'Failed to retry RAG indexing';
       console.error('[retryRagIndexing] Error:', error);
-      try {
-        await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: { status: 'failed', error: message },
-          },
-        );
-      } catch (updateError) {
-        console.error(
-          '[retryRagIndexing] Failed to update document status:',
-          updateError,
-        );
+      if (storageId) {
+        try {
+          await ctx.runMutation(
+            internal.file_metadata.internal_mutations.updateFileRagStatus,
+            { storageId, ragStatus: 'failed', ragError: message },
+          );
+        } catch (updateError) {
+          console.error(
+            '[retryRagIndexing] Failed to update document status:',
+            updateError,
+          );
+        }
       }
       return { success: false, error: message };
     }

--- a/services/platform/convex/documents/actions.ts
+++ b/services/platform/convex/documents/actions.ts
@@ -54,6 +54,22 @@ export const retryRagIndexing = action({
       }
       storageId = document.fileId;
 
+      // Self-heal the canonical RAG-status home before writing status:
+      // updateFileRagStatus below no-ops when the blob has no fileMetadata row
+      // (e.g. a UI upload without fileSize, or a legacy file-backed doc), which
+      // would leave this retry silently stuck. Does not schedule another upload
+      // — this action pushes the blob itself just below.
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.ensureFileMetadataForDocument,
+        {
+          organizationId: document.organizationId,
+          storageId: document.fileId,
+          documentId: args.documentId,
+          fileName: document.title ?? 'document',
+          contentType: document.mimeType,
+        },
+      );
+
       const rawResult = await ragAction.execute(
         ctx,
         {

--- a/services/platform/convex/documents/get_agent_scoped_file_ids.test.ts
+++ b/services/platform/convex/documents/get_agent_scoped_file_ids.test.ts
@@ -39,7 +39,7 @@ function createMockCtx(docs: Array<Record<string, unknown>>) {
     withIndex: (indexName: string) => {
       if (
         table === 'fileMetadata' &&
-        indexName === 'by_organizationId_and_ragStatus'
+        indexName === 'by_organizationId_and_ragStatus_and_documentId'
       ) {
         return makeAsyncIterator(completedFms);
       }
@@ -350,5 +350,76 @@ describe('getAgentScopedFileIds', () => {
     });
 
     expect(ids).toEqual(['file2']);
+  });
+
+  // SSOT skip branches: with the canonical fileMetadata-keyed query, three
+  // classes of completed rows must be dropped from agent scope. The index range
+  // already excludes documentId-absent rows, but the in-loop guards backstop
+  // each case — exercise them with explicit fileMetadata rows + a docs map.
+  describe('SSOT skip branches', () => {
+    function createScopedCtx(
+      fms: Array<Record<string, unknown>>,
+      docsById: Record<string, Record<string, unknown>>,
+    ) {
+      const makeAsyncIterator = (rows: Array<Record<string, unknown>>) => ({
+        [Symbol.asyncIterator]() {
+          let i = 0;
+          return {
+            async next() {
+              return i < rows.length
+                ? { value: rows[i++], done: false }
+                : { value: undefined, done: true };
+            },
+          };
+        },
+      });
+      const query = (table: string) => ({
+        withIndex: (indexName: string) =>
+          table === 'fileMetadata' &&
+          indexName === 'by_organizationId_and_ragStatus_and_documentId'
+            ? makeAsyncIterator(fms)
+            : makeAsyncIterator([]),
+      });
+      const get = async (id: unknown) => docsById[id as string] ?? null;
+      return { db: { query, get } } as unknown as Parameters<
+        typeof getAgentScopedFileIds
+      >[0];
+    }
+
+    const orgArgs = {
+      organizationId: 'org1',
+      includeTeamKnowledge: false,
+      includeOrgKnowledge: true,
+    };
+
+    it('skips a completed row whose documentId is unset (defensive guard)', async () => {
+      const ctx = createScopedCtx(
+        [
+          { storageId: 'blob-x', ragStatus: 'completed' }, // no documentId
+          { storageId: 'blob-y', documentId: 'docY', ragStatus: 'completed' },
+        ],
+        { docY: { _id: 'docY', fileId: 'blob-y' } },
+      );
+      const ids = await getAgentScopedFileIds(ctx, orgArgs);
+      expect(ids).toEqual(['blob-y']);
+    });
+
+    it('skips a stale completed row on a doc whose current blob differs', async () => {
+      const ctx = createScopedCtx(
+        [{ storageId: 'old-blob', documentId: 'docZ', ragStatus: 'completed' }],
+        { docZ: { _id: 'docZ', fileId: 'new-blob' } }, // re-indexed: current blob moved
+      );
+      const ids = await getAgentScopedFileIds(ctx, orgArgs);
+      expect(ids).toEqual([]);
+    });
+
+    it('skips trashed / soft-deleted documents', async () => {
+      const ctx = createScopedCtx(
+        [{ storageId: 'blob-t', documentId: 'docT', ragStatus: 'completed' }],
+        { docT: { _id: 'docT', fileId: 'blob-t', lifecycleStatus: 'trashed' } },
+      );
+      const ids = await getAgentScopedFileIds(ctx, orgArgs);
+      expect(ids).toEqual([]);
+    });
   });
 });

--- a/services/platform/convex/documents/get_agent_scoped_file_ids.test.ts
+++ b/services/platform/convex/documents/get_agent_scoped_file_ids.test.ts
@@ -17,16 +17,39 @@ function createMockCtx(docs: Array<Record<string, unknown>>) {
     },
   });
 
-  const query = () => ({
+  // RAG completion is canonical on fileMetadata.ragStatus now. Derive the
+  // completed fileMetadata rows from the doc fixtures (a doc is RAG-complete
+  // when its ragInfo.status === 'completed'), and resolve documents by _id via
+  // ctx.db.get — mirroring getAgentScopedFileIds' new query path.
+  const completedFms = docs
+    .filter(
+      (d) =>
+        (d.ragInfo as { status?: string } | undefined)?.status === 'completed',
+    )
+    .map((d) => ({
+      storageId: d.fileId,
+      documentId: d._id,
+      ragStatus: 'completed',
+      organizationId: 'org1',
+    }));
+
+  const docsById = new Map(docs.map((d) => [d._id, d]));
+
+  const query = (table: string) => ({
     withIndex: (indexName: string) => {
-      if (indexName === 'by_organizationId_and_indexed') {
-        return makeAsyncIterator(docs.filter((d) => d.indexed === true));
+      if (
+        table === 'fileMetadata' &&
+        indexName === 'by_organizationId_and_ragStatus'
+      ) {
+        return makeAsyncIterator(completedFms);
       }
-      return makeAsyncIterator(docs);
+      return makeAsyncIterator([]);
     },
   });
 
-  return { db: { query } } as unknown as Parameters<
+  const get = async (id: unknown) => docsById.get(id) ?? null;
+
+  return { db: { query, get } } as unknown as Parameters<
     typeof getAgentScopedFileIds
   >[0];
 }

--- a/services/platform/convex/documents/get_agent_scoped_file_ids.ts
+++ b/services/platform/convex/documents/get_agent_scoped_file_ids.ts
@@ -12,7 +12,8 @@ import { isActiveDocument } from './_helpers';
  *    Per the projects mutual-exclusivity rule, a project doc has projectId set and
  *    teamId cleared — so this branch never double-counts with the team layer.
  *
- * Only returns documents with ragInfo.status === 'completed' and a valid fileId.
+ * Only returns documents whose current blob is RAG-completed
+ * (fileMetadata.ragStatus === 'completed') and that have a valid fileId.
  */
 export async function getAgentScopedFileIds(
   ctx: QueryCtx,
@@ -51,22 +52,30 @@ export async function getAgentScopedFileIds(
     return [...fileIdSet];
   }
 
-  const query = ctx.db
-    .query('documents')
-    .withIndex('by_organizationId_and_indexed', (q) =>
-      q.eq('organizationId', args.organizationId).eq('indexed', true),
+  // RAG completion now lives on fileMetadata.ragStatus (canonical). Enumerate
+  // completed fileMetadata for the org and resolve each to its Document-Hub
+  // document to apply lifecycle + team/project/org scoping. fileMetadata rows
+  // without a documentId (chat uploads, transcripts) are not Document-Hub
+  // knowledge and are excluded here.
+  const completedFiles = ctx.db
+    .query('fileMetadata')
+    .withIndex('by_organizationId_and_ragStatus', (q) =>
+      q.eq('organizationId', args.organizationId).eq('ragStatus', 'completed'),
     );
 
-  for await (const doc of query) {
-    if (!doc.fileId) continue;
-    // Skip trashed/soft-deleted docs (e.g. WebDAV DELETE) — they must not
-    // remain in agent RAG retrieval scope. The `indexed` index doesn't
-    // filter lifecycle, so an out-of-scope deleted file would otherwise
-    // still be retrievable by the agent.
-    if (!isActiveDocument(doc)) continue;
-
-    const fileId = String(doc.fileId);
+  for await (const fm of completedFiles) {
+    if (!fm.documentId) continue;
+    const fileId = String(fm.storageId);
     if (fileIdSet.has(fileId)) continue;
+
+    const doc = await ctx.db.get(fm.documentId);
+    if (!doc || !doc.fileId) continue;
+    // Only the document's CURRENT blob counts — a re-indexed doc can leave a
+    // stale completed fileMetadata on its previous blob.
+    if (String(doc.fileId) !== fileId) continue;
+    // Skip trashed/soft-deleted docs (e.g. WebDAV DELETE) — they must not
+    // remain in agent RAG retrieval scope.
+    if (!isActiveDocument(doc)) continue;
 
     if (
       needsProjectDocs &&

--- a/services/platform/convex/documents/get_agent_scoped_file_ids.ts
+++ b/services/platform/convex/documents/get_agent_scoped_file_ids.ts
@@ -53,17 +53,22 @@ export async function getAgentScopedFileIds(
   }
 
   // RAG completion now lives on fileMetadata.ragStatus (canonical). Enumerate
-  // completed fileMetadata for the org and resolve each to its Document-Hub
-  // document to apply lifecycle + team/project/org scoping. fileMetadata rows
-  // without a documentId (chat uploads, transcripts) are not Document-Hub
-  // knowledge and are excluded here.
+  // completed Document-Hub fileMetadata for the org and resolve each to its
+  // document to apply lifecycle + team/project/org scoping. The `.gt(documentId,
+  // undefined)` bound seeks past chat-upload / transcript rows (documentId
+  // absent), so the scan stays bounded by Hub-doc count instead of the org's
+  // whole completed corpus.
   const completedFiles = ctx.db
     .query('fileMetadata')
-    .withIndex('by_organizationId_and_ragStatus', (q) =>
-      q.eq('organizationId', args.organizationId).eq('ragStatus', 'completed'),
+    .withIndex('by_organizationId_and_ragStatus_and_documentId', (q) =>
+      q
+        .eq('organizationId', args.organizationId)
+        .eq('ragStatus', 'completed')
+        .gt('documentId', undefined),
     );
 
   for await (const fm of completedFiles) {
+    // Defensive — the index range already excludes documentId-absent rows.
     if (!fm.documentId) continue;
     const fileId = String(fm.storageId);
     if (fileIdSet.has(fileId)) continue;

--- a/services/platform/convex/documents/get_document_rag_projection.ts
+++ b/services/platform/convex/documents/get_document_rag_projection.ts
@@ -1,0 +1,95 @@
+/**
+ * Read-side projection of a document's RAG indexing status.
+ *
+ * RAG status lives canonically on `fileMetadata.ragStatus` (join:
+ * `documents.fileId == fileMetadata.storageId`, 1:1). The retired
+ * `documents.ragInfo`/`indexed` fields are no longer written — every read that
+ * used to consume them goes through this helper instead, so the projected shape
+ * stays identical and the frontend is unchanged.
+ *
+ * A document with no `fileId`, or whose blob has no fileMetadata row, projects
+ * as `{ indexed: false, status: undefined }` — the UI renders that as
+ * `not_indexed`.
+ */
+
+import type { Doc, Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+
+export interface DocumentRagProjection {
+  status?: 'queued' | 'running' | 'completed' | 'failed';
+  indexedAt?: number;
+  error?: string;
+  indexed: boolean;
+}
+
+const NOT_INDEXED: DocumentRagProjection = { indexed: false };
+
+function projectFromFileMetadata(
+  fm: Doc<'fileMetadata'> | null,
+): DocumentRagProjection {
+  if (!fm) return NOT_INDEXED;
+  return {
+    status: fm.ragStatus,
+    indexedAt: fm.ragIndexedAt,
+    error: fm.ragError,
+    indexed: fm.ragStatus === 'completed',
+  };
+}
+
+/** Single-document projection. */
+export async function getDocumentRagProjection(
+  ctx: QueryCtx,
+  doc: Pick<Doc<'documents'>, 'fileId'>,
+): Promise<DocumentRagProjection> {
+  const fileId = doc.fileId;
+  if (!fileId) return NOT_INDEXED;
+  const fm = await ctx.db
+    .query('fileMetadata')
+    .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+    .first();
+  return projectFromFileMetadata(fm);
+}
+
+/**
+ * Batch projection keyed by document `_id`. Looks up each distinct `fileId`
+ * once on `by_storageId`. Mirrors the `batchGetStorageUrls` pattern in
+ * `transform_to_document_item.ts`.
+ */
+export async function getDocumentRagProjectionBatch(
+  ctx: QueryCtx,
+  docs: Array<Pick<Doc<'documents'>, '_id' | 'fileId'>>,
+): Promise<Map<string, DocumentRagProjection>> {
+  const result = new Map<string, DocumentRagProjection>();
+  if (docs.length === 0) return result;
+
+  // Deduplicate fileIds so a blob shared by multiple docs is fetched once.
+  const seen = new Set<string>();
+  const uniqueFileIds: Id<'_storage'>[] = [];
+  for (const d of docs) {
+    if (!d.fileId) continue;
+    const key = String(d.fileId);
+    if (!seen.has(key)) {
+      seen.add(key);
+      uniqueFileIds.push(d.fileId);
+    }
+  }
+
+  const byFileId = new Map<string, DocumentRagProjection>();
+  await Promise.all(
+    uniqueFileIds.map(async (fileId) => {
+      const fm = await ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+        .first();
+      byFileId.set(String(fileId), projectFromFileMetadata(fm));
+    }),
+  );
+
+  for (const d of docs) {
+    const proj = d.fileId
+      ? (byFileId.get(String(d.fileId)) ?? NOT_INDEXED)
+      : NOT_INDEXED;
+    result.set(String(d._id), proj);
+  }
+  return result;
+}

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -180,6 +180,13 @@ export const getPollingInterval = (attempt: number): number => {
   return (15 + (attempt - 30) * 6) * MINUTE;
 };
 
+/**
+ * @deprecated Retired by the RAG-status collapse onto fileMetadata.ragStatus.
+ * No longer scheduled — uploaders now schedule
+ * `internal.file_metadata.internal_actions.pollFileRagStatus` (keyed by
+ * storageId). Kept defined only so any invocation scheduled before the cutover
+ * resolves instead of erroring; it writes the now-unread documents.ragInfo.
+ */
 export const checkRagDocumentStatus = internalAction({
   args: {
     documentId: v.id('documents'),
@@ -616,6 +623,12 @@ export const uploadDocumentToRag = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
+    // RAG status is canonical on fileMetadata.ragStatus. This documents-pipeline
+    // action keeps its synchronous upload but writes status + schedules the
+    // server poll on the fileMetadata row (keyed by the document's storageId).
+    // storageId is hoisted so the catch can still mark failure when the upload
+    // throws after the document is resolved.
+    let storageId: Id<'_storage'> | null = null;
     try {
       const document = await ctx.runQuery(
         internal.documents.internal_queries.getDocumentByIdRaw,
@@ -628,6 +641,7 @@ export const uploadDocumentToRag = internalAction({
       if (!document.fileId) {
         throw new Error(`Document has no file: ${args.documentId}`);
       }
+      storageId = document.fileId;
 
       const rawResult = await ragAction.execute(
         ctx,
@@ -646,18 +660,17 @@ export const uploadDocumentToRag = internalAction({
 
       if (success) {
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: {
-              status: 'queued',
-            },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'queued' },
         );
         await ctx.scheduler.runAfter(
           INITIAL_POLLING_DELAY_MS,
-          internal.documents.internal_actions.checkRagDocumentStatus,
-          { documentId: args.documentId, attempt: 1 },
+          internal.file_metadata.internal_actions.pollFileRagStatus,
+          {
+            storageId: document.fileId,
+            organizationId: document.organizationId,
+            attempt: 1,
+          },
         );
       } else {
         const error =
@@ -667,11 +680,8 @@ export const uploadDocumentToRag = internalAction({
           `[uploadDocumentToRag] Failed to upload document ${args.documentId}: ${error}`,
         );
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: { status: 'failed', error },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'failed', ragError: error },
         );
       }
     } catch (error) {
@@ -680,13 +690,12 @@ export const uploadDocumentToRag = internalAction({
       console.error(
         `[uploadDocumentToRag] Error uploading document ${args.documentId}: ${message}`,
       );
-      await ctx.runMutation(
-        internal.documents.internal_mutations.updateDocumentRagInfo,
-        {
-          documentId: args.documentId,
-          ragInfo: { status: 'failed', error: message },
-        },
-      );
+      if (storageId) {
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId, ragStatus: 'failed', ragError: message },
+        );
+      }
       throw error;
     }
 
@@ -786,29 +795,25 @@ export const reindexDocumentInRag = internalAction({
       if (success) {
         uploadSuccess = true;
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: {
-              status: 'queued',
-            },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'queued' },
         );
         await ctx.scheduler.runAfter(
           INITIAL_POLLING_DELAY_MS,
-          internal.documents.internal_actions.checkRagDocumentStatus,
-          { documentId: args.documentId, attempt: 1 },
+          internal.file_metadata.internal_actions.pollFileRagStatus,
+          {
+            storageId: document.fileId,
+            organizationId: document.organizationId,
+            attempt: 1,
+          },
         );
       } else {
         const error =
           (resultRec ? getString(resultRec, 'error') : undefined) ??
           'Re-index upload failed';
         await ctx.runMutation(
-          internal.documents.internal_mutations.updateDocumentRagInfo,
-          {
-            documentId: args.documentId,
-            ragInfo: { status: 'failed', error },
-          },
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: document.fileId, ragStatus: 'failed', ragError: error },
         );
       }
     } catch (error) {
@@ -818,11 +823,8 @@ export const reindexDocumentInRag = internalAction({
         `[reindexDocumentInRag] Error re-indexing document ${args.documentId}: ${message}`,
       );
       await ctx.runMutation(
-        internal.documents.internal_mutations.updateDocumentRagInfo,
-        {
-          documentId: args.documentId,
-          ragInfo: { status: 'failed', error: message },
-        },
+        internal.file_metadata.internal_mutations.updateFileRagStatus,
+        { storageId: document.fileId, ragStatus: 'failed', ragError: message },
       );
     }
 

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -643,6 +643,21 @@ export const uploadDocumentToRag = internalAction({
       }
       storageId = document.fileId;
 
+      // Self-heal the canonical RAG-status home before writing status:
+      // updateFileRagStatus below no-ops when the blob has no fileMetadata row
+      // (e.g. a workflow-created or legacy file-backed doc), which would leave
+      // status stuck. Schedules no extra upload — this action uploads below.
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.ensureFileMetadataForDocument,
+        {
+          organizationId: document.organizationId,
+          storageId: document.fileId,
+          documentId: args.documentId,
+          fileName: document.title ?? 'document',
+          contentType: document.mimeType,
+        },
+      );
+
       const rawResult = await ragAction.execute(
         ctx,
         {

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
@@ -12,15 +12,26 @@ interface MockDoc {
 }
 
 function createMockCtx(docs: MockDoc[]) {
+  // Completion is canonical on fileMetadata.ragStatus now: the query paginates
+  // completed fileMetadata (one per doc), then resolves each to its document
+  // via ctx.db.get(documentId).
+  const fms = docs.map((d) => ({
+    storageId: d.fileId,
+    documentId: d._id,
+    ragStatus: 'completed' as const,
+    organizationId: 'org1',
+  }));
+  const docsById = new Map(docs.map((d) => [d._id, d]));
+
   const queryFn = () => ({
     withIndex: () => ({
       order: () => ({
         paginate: async (opts: { cursor: string | null; numItems: number }) => {
-          // Simulate Convex .paginate() behavior
+          // Simulate Convex .paginate() behavior over the fileMetadata rows
           const startIndex = opts.cursor ? Number(opts.cursor) : 0;
-          const page = docs.slice(startIndex, startIndex + opts.numItems);
+          const page = fms.slice(startIndex, startIndex + opts.numItems);
           const endIndex = startIndex + page.length;
-          const isDone = endIndex >= docs.length;
+          const isDone = endIndex >= fms.length;
           return {
             page,
             isDone,
@@ -31,7 +42,9 @@ function createMockCtx(docs: MockDoc[]) {
     }),
   });
 
-  return { db: { query: queryFn } } as unknown as Parameters<
+  const get = async (id: unknown) => docsById.get(id as string) ?? null;
+
+  return { db: { query: queryFn, get } } as unknown as Parameters<
     typeof listIndexedDocumentsForAgent
   >[0];
 }
@@ -288,18 +301,26 @@ describe('listIndexedDocumentsForAgent', () => {
       title: `Doc ${i}`,
     }));
 
+    const fms = docs.map((d) => ({
+      storageId: d.fileId,
+      documentId: d._id,
+      ragStatus: 'completed' as const,
+      organizationId: 'org1',
+    }));
+    const docsById = new Map(docs.map((d) => [d._id, d]));
     const queryFn = () => ({
       withIndex: () => ({
         order: () => ({
           paginate: async () => ({
-            page: docs,
+            page: fms,
             isDone: true,
             continueCursor: 'end',
           }),
         }),
       }),
     });
-    const ctx = { db: { query: queryFn } } as unknown as Parameters<
+    const get = async (id: unknown) => docsById.get(id as string) ?? null;
+    const ctx = { db: { query: queryFn, get } } as unknown as Parameters<
       typeof listIndexedDocumentsForAgent
     >[0];
 

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.test.ts
@@ -397,4 +397,69 @@ describe('listIndexedDocumentsForAgent', () => {
     const uniqueFileIds = new Set(allDocs.map((d) => d.fileId));
     expect(uniqueFileIds.size).toBe(10);
   });
+
+  // SSOT skip branches: the index range excludes documentId-absent rows, but the
+  // stale-blob (doc.fileId !== fm.storageId) and inactive-doc guards backstop
+  // re-indexed and trashed docs. Inject explicit fileMetadata rows + a docs map.
+  describe('SSOT skip branches', () => {
+    function createRawCtx(
+      fms: Array<Record<string, unknown>>,
+      docsById: Record<string, Record<string, unknown>>,
+    ) {
+      const queryFn = () => ({
+        withIndex: () => ({
+          order: () => ({
+            paginate: async () => ({
+              page: fms,
+              isDone: true,
+              continueCursor: 'end',
+            }),
+          }),
+        }),
+      });
+      const get = async (id: unknown) => docsById[id as string] ?? null;
+      return { db: { query: queryFn, get } } as unknown as Parameters<
+        typeof listIndexedDocumentsForAgent
+      >[0];
+    }
+
+    const orgArgs = { organizationId: 'org1', includeOrgKnowledge: true };
+
+    it('skips a completed row whose documentId is unset (defensive guard)', async () => {
+      const ctx = createRawCtx(
+        [
+          { storageId: 'blob-x', ragStatus: 'completed' }, // no documentId
+          { storageId: 'blob-y', documentId: 'docY', ragStatus: 'completed' },
+        ],
+        { docY: { _id: 'docY', fileId: 'blob-y', title: 'Y' } },
+      );
+      const result = await listIndexedDocumentsForAgent(ctx, orgArgs);
+      expect(result.documents.map((d) => d.fileId)).toEqual(['blob-y']);
+    });
+
+    it('skips a stale completed row on a re-indexed doc (current blob differs)', async () => {
+      const ctx = createRawCtx(
+        [{ storageId: 'old-blob', documentId: 'docZ', ragStatus: 'completed' }],
+        { docZ: { _id: 'docZ', fileId: 'new-blob', title: 'Z' } },
+      );
+      const result = await listIndexedDocumentsForAgent(ctx, orgArgs);
+      expect(result.documents).toEqual([]);
+    });
+
+    it('skips trashed / soft-deleted documents', async () => {
+      const ctx = createRawCtx(
+        [{ storageId: 'blob-t', documentId: 'docT', ragStatus: 'completed' }],
+        {
+          docT: {
+            _id: 'docT',
+            fileId: 'blob-t',
+            title: 'T',
+            lifecycleStatus: 'trashed',
+          },
+        },
+      );
+      const result = await listIndexedDocumentsForAgent(ctx, orgArgs);
+      expect(result.documents).toEqual([]);
+    });
+  });
 });

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.ts
@@ -115,19 +115,28 @@ export async function listIndexedDocumentsForAgent(
     prevDbCursor = dbCursor;
     matchesSeenOnLastPage = 0;
 
+    // RAG completion is canonical on fileMetadata.ragStatus. Paginate completed
+    // fileMetadata for the org and resolve each to its Document-Hub document for
+    // scoping. Rows without a documentId (chat uploads, transcripts) are not
+    // Document-Hub knowledge and are skipped.
     const result = await ctx.db
-      .query('documents')
-      .withIndex('by_organizationId_and_indexed', (q) =>
-        q.eq('organizationId', args.organizationId).eq('indexed', true),
+      .query('fileMetadata')
+      .withIndex('by_organizationId_and_ragStatus', (q) =>
+        q
+          .eq('organizationId', args.organizationId)
+          .eq('ragStatus', 'completed'),
       )
       .order('desc')
       .paginate({ cursor: dbCursor ?? null, numItems: limit * 2 });
 
-    for (const doc of result.page) {
-      if (!hasFileId(doc)) continue;
-      // Exclude trashed/soft-deleted docs (e.g. WebDAV DELETE) from the
-      // agent's indexed-document listing — the `indexed` index doesn't
-      // filter lifecycle status.
+    for (const fm of result.page) {
+      if (!fm.documentId) continue;
+      const doc = await ctx.db.get(fm.documentId);
+      if (!doc || !hasFileId(doc)) continue;
+      // Only the document's CURRENT blob counts — a re-indexed doc can leave a
+      // stale completed fileMetadata on its previous blob.
+      if (String(doc.fileId) !== String(fm.storageId)) continue;
+      // Exclude trashed/soft-deleted docs (e.g. WebDAV DELETE).
       if (!isActiveDocument(doc)) continue;
 
       const fileId = String(doc.fileId);

--- a/services/platform/convex/documents/list_indexed_documents_for_agent.ts
+++ b/services/platform/convex/documents/list_indexed_documents_for_agent.ts
@@ -19,7 +19,11 @@ import type { QueryCtx } from '../_generated/server';
 import { isActiveDocument } from './_helpers';
 
 const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 500;
+// Caps the per-call read fan-out (numItems = limit*2 per page × MAX_PAGES ×
+// per-row ctx.db.get). The dense Hub-only index means pages rarely hit
+// MAX_PAGES now, but keep MAX_LIMIT modest so a single call stays well under
+// the Convex transaction read cap even on a large org.
+const MAX_LIMIT = 100;
 const MAX_PAGES = 20;
 
 export interface AgentIndexedDocumentItem {
@@ -116,20 +120,26 @@ export async function listIndexedDocumentsForAgent(
     matchesSeenOnLastPage = 0;
 
     // RAG completion is canonical on fileMetadata.ragStatus. Paginate completed
-    // fileMetadata for the org and resolve each to its Document-Hub document for
-    // scoping. Rows without a documentId (chat uploads, transcripts) are not
-    // Document-Hub knowledge and are skipped.
+    // Document-Hub fileMetadata for the org and resolve each to its document for
+    // scoping. The `.gt(documentId, undefined)` bound seeks past chat-upload /
+    // transcript rows (documentId absent) at the index level, so pages stay
+    // dense with Hub docs. (Pages are ordered by documentId desc within the
+    // (org, completed) group — stable for the cursor; this is an LLM listing
+    // tool that carries sourceModifiedAt per item, so chronological order is
+    // not relied upon.)
     const result = await ctx.db
       .query('fileMetadata')
-      .withIndex('by_organizationId_and_ragStatus', (q) =>
+      .withIndex('by_organizationId_and_ragStatus_and_documentId', (q) =>
         q
           .eq('organizationId', args.organizationId)
-          .eq('ragStatus', 'completed'),
+          .eq('ragStatus', 'completed')
+          .gt('documentId', undefined),
       )
       .order('desc')
       .paginate({ cursor: dbCursor ?? null, numItems: limit * 2 });
 
     for (const fm of result.page) {
+      // Defensive — the index range already excludes documentId-absent rows.
       if (!fm.documentId) continue;
       const doc = await ctx.db.get(fm.documentId);
       if (!doc || !hasFileId(doc)) continue;

--- a/services/platform/convex/documents/rest_api.ts
+++ b/services/platform/convex/documents/rest_api.ts
@@ -68,6 +68,37 @@ export const createDocument = withRestAuth('rest:api', async (rc, request) => {
     },
   );
 
+  // Coverage: a REST-created document with a backing blob must have a
+  // fileMetadata row so its RAG indexing status has a canonical home
+  // (documents.ragInfo is being retired in favor of fileMetadata.ragStatus).
+  // Every other creation path (UI upload, connectors, WebDAV, agent writes)
+  // already does this; REST was the one gap. Mirrors createDocumentFromUpload:
+  // saveFileMetadata (idempotent on by_storageId, schedules RAG upload) then
+  // linkDocumentToFile (sets source from the doc's provider).
+  if (body.fileId) {
+    const storageId = toId<'_storage'>(body.fileId);
+    const meta = await rc.ctx.runQuery(
+      internal.file_metadata.internal_queries.getStorageMetadata,
+      { storageId },
+    );
+    await rc.ctx.runMutation(
+      internal.file_metadata.internal_mutations.saveFileMetadata,
+      {
+        organizationId: rc.org.organizationId,
+        storageId,
+        fileName: body.title ?? 'document',
+        contentType:
+          body.mimeType ?? meta?.contentType ?? 'application/octet-stream',
+        size: meta?.size ?? 0,
+        uploadedBy: rc.user.userId,
+      },
+    );
+    await rc.ctx.runMutation(
+      internal.file_metadata.internal_mutations.linkDocumentToFile,
+      { storageId, documentId },
+    );
+  }
+
   return jsonCreated({ id: documentId });
 });
 

--- a/services/platform/convex/documents/schema.ts
+++ b/services/platform/convex/documents/schema.ts
@@ -34,6 +34,12 @@ export const documentsTable = defineTable({
    * RAG retrieval unions project docs via `getAgentScopedFileIds`.
    */
   projectId: v.optional(v.id('projects')),
+  /**
+   * @deprecated RAG indexing status is now canonical on
+   * `fileMetadata.ragStatus` (join: `documents.fileId == fileMetadata.storageId`).
+   * No longer written; read via `getDocumentRagProjection`. Kept optional for
+   * backward compatibility with existing rows.
+   */
   ragInfo: v.optional(
     v.object({
       status: v.union(
@@ -50,6 +56,10 @@ export const documentsTable = defineTable({
       jobId: v.optional(v.string()),
     }),
   ),
+  /**
+   * @deprecated Use `fileMetadata.ragStatus === 'completed'` (projected via
+   * `getDocumentRagProjection`). No longer written.
+   */
   indexed: v.optional(v.boolean()),
   scannedPagesDetected: v.optional(v.number()),
   ocrApplied: v.optional(v.boolean()),
@@ -92,6 +102,9 @@ export const documentsTable = defineTable({
   // .DS_Store, index.html) makes the (org,title) collect O(all-same-name).
   .index('by_org_title_folder', ['organizationId', 'title', 'folderId'])
   .index('by_organizationId_and_fileId', ['organizationId', 'fileId'])
+  // @deprecated unused — RAG completion is now queried via fileMetadata
+  // `by_organizationId_and_ragStatus`. Kept (deprecate-don't-delete) so
+  // existing data + any in-flight code referencing it stays valid.
   .index('by_organizationId_and_indexed', ['organizationId', 'indexed'])
   .index('by_organizationId_and_folderPath', ['organizationId', 'folderPath'])
   // Projects feature: list documents attached to a project.

--- a/services/platform/convex/documents/transform_to_document_item.test.ts
+++ b/services/platform/convex/documents/transform_to_document_item.test.ts
@@ -234,4 +234,51 @@ describe('transformToDocumentItem', () => {
       expect(result.teamIds).toEqual([]);
     });
   });
+
+  describe('RAG projection mapping (canonical fileMetadata.ragStatus)', () => {
+    it('maps ragStatus/ragIndexedAt/ragError from the projection map by document _id', () => {
+      const doc = createMockDocument();
+      const ragProjectionMap = new Map([
+        [
+          'doc1',
+          {
+            status: 'completed' as const,
+            indexedAt: 1_700_000_000,
+            error: undefined,
+            indexed: true,
+          },
+        ],
+      ]);
+      const result = transformToDocumentItem(doc, { ragProjectionMap });
+      expect(result.ragStatus).toBe('completed');
+      expect(result.ragIndexedAt).toBe(1_700_000_000);
+      expect(result.ragError).toBeUndefined();
+    });
+
+    it('surfaces a failed projection with its error', () => {
+      const doc = createMockDocument();
+      const ragProjectionMap = new Map([
+        ['doc1', { status: 'failed' as const, error: 'boom', indexed: false }],
+      ]);
+      const result = transformToDocumentItem(doc, { ragProjectionMap });
+      expect(result.ragStatus).toBe('failed');
+      expect(result.ragError).toBe('boom');
+    });
+
+    it('projects as not-indexed (undefined fields) when no map is provided', () => {
+      const doc = createMockDocument();
+      const result = transformToDocumentItem(doc);
+      expect(result.ragStatus).toBeUndefined();
+      expect(result.ragIndexedAt).toBeUndefined();
+      expect(result.ragError).toBeUndefined();
+    });
+
+    it('projects as not-indexed when the map has no entry for this doc', () => {
+      const doc = createMockDocument();
+      const result = transformToDocumentItem(doc, {
+        ragProjectionMap: new Map(),
+      });
+      expect(result.ragStatus).toBeUndefined();
+    });
+  });
 });

--- a/services/platform/convex/documents/transform_to_document_item.ts
+++ b/services/platform/convex/documents/transform_to_document_item.ts
@@ -6,6 +6,10 @@ import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
 import { toPublicUrl } from '../lib/helpers/public_storage_url';
 import { extractExtension } from './extract_extension';
+import {
+  type DocumentRagProjection,
+  getDocumentRagProjectionBatch,
+} from './get_document_rag_projection';
 import { getUserNamesBatch } from './get_user_names_batch';
 import type { DocumentItemResponse, DocumentMetadata } from './types';
 
@@ -44,6 +48,13 @@ export interface TransformOptions {
    * When provided, avoids individual storage.getUrl calls
    */
   storageUrlsMap?: Map<string, string>;
+  /**
+   * Pre-fetched RAG status projection map (document _id -> projection).
+   * RAG status lives on fileMetadata.ragStatus now (not documents.ragInfo);
+   * the batch transform populates this so per-doc projection is a map lookup.
+   * Absent → the doc projects as not-indexed.
+   */
+  ragProjectionMap?: Map<string, DocumentRagProjection>;
 }
 
 /**
@@ -82,6 +93,9 @@ export function transformToDocumentItem(
     ? options?.userNamesMap?.get(document.createdBy)
     : undefined;
 
+  // RAG status projected from fileMetadata.ragStatus (canonical owner).
+  const ragProjection = options?.ragProjectionMap?.get(String(document._id));
+
   return {
     id: document._id,
     name: document.title ?? metadata?.name ?? 'Untitled',
@@ -103,10 +117,10 @@ export function transformToDocumentItem(
     syncConfigId: metadata?.syncConfigId,
     isDirectlySelected: metadata?.isDirectlySelected,
     url,
-    // RAG status from database (if available)
-    ragStatus: document.ragInfo?.status,
-    ragIndexedAt: document.ragInfo?.indexedAt,
-    ragError: document.ragInfo?.error,
+    // RAG status projected from fileMetadata (canonical), not documents.ragInfo
+    ragStatus: ragProjection?.status,
+    ragIndexedAt: ragProjection?.indexedAt,
+    ragError: ragProjection?.error,
     scannedPagesDetected: document.scannedPagesDetected,
     ocrApplied: document.ocrApplied,
     teamId: document.teamId ?? null,
@@ -145,15 +159,20 @@ export async function transformDocumentsBatch(
     .map((doc) => doc.fileId)
     .filter((id): id is NonNullable<Doc<'documents'>['fileId']> => !!id);
 
-  // Batch fetch user names and storage URLs in parallel
-  const [userNamesMap, storageUrlsMap] = await Promise.all([
+  // Batch fetch user names, storage URLs, and RAG status projections in parallel
+  const [userNamesMap, storageUrlsMap, ragProjectionMap] = await Promise.all([
     getUserNamesBatch(ctx, userIds),
     batchGetStorageUrls(ctx, fileIds),
+    getDocumentRagProjectionBatch(ctx, documents),
   ]);
 
   // Transform all documents using pre-fetched data
   return documents.map((doc) =>
-    transformToDocumentItem(doc, { userNamesMap, storageUrlsMap }),
+    transformToDocumentItem(doc, {
+      userNamesMap,
+      storageUrlsMap,
+      ragProjectionMap,
+    }),
   );
 }
 

--- a/services/platform/convex/documents/types.ts
+++ b/services/platform/convex/documents/types.ts
@@ -20,6 +20,11 @@ import {
 // =============================================================================
 
 export type RagStatus = Infer<typeof ragStatusValidator>;
+/**
+ * @deprecated Mirrors the retired `documents.ragInfo` field. RAG status is
+ * canonical on `fileMetadata.ragStatus`; project it via
+ * `getDocumentRagProjection`.
+ */
 export type RagInfo = Infer<typeof ragInfoValidator>;
 export type SourceProvider = Infer<typeof sourceProviderValidator>;
 export type SourceMode = Infer<typeof sourceModeValidator>;

--- a/services/platform/convex/documents/update_document_internal.test.ts
+++ b/services/platform/convex/documents/update_document_internal.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateDocumentInternal } from './update_document_internal';
+
+type Doc = Record<string, unknown> & { _id: string; fileId?: string };
+
+/**
+ * Mock ctx for the reindex gate. The gate reads canonical RAG status from
+ * `fileMetadata` (`by_storageId` .first()) for the doc's CURRENT blob and only
+ * schedules `reindexDocumentInRag` when that blob is completed AND the file or
+ * title changed.
+ */
+function createMockCtx(document: Doc, fm: Record<string, unknown> | null) {
+  const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+  const scheduled: Array<{ args: Record<string, unknown> }> = [];
+
+  const ctx = {
+    db: {
+      get: async (id: unknown) => (id === document._id ? document : null),
+      query: () => {
+        let storageId: unknown;
+        const q = {
+          eq: (field: string, value: unknown) => {
+            if (field === 'storageId') storageId = value;
+            return q;
+          },
+        };
+        return {
+          withIndex: (_idx: string, cb: (qq: unknown) => unknown) => {
+            cb(q);
+            return {
+              first: async () => (storageId === document.fileId ? fm : null),
+            };
+          },
+        };
+      },
+      patch: async (id: string, data: Record<string, unknown>) => {
+        patches.push({ id, data });
+      },
+    },
+    scheduler: {
+      runAfter: async (
+        _delay: number,
+        _ref: unknown,
+        args: Record<string, unknown>,
+      ) => {
+        scheduled.push({ args });
+      },
+    },
+  } as unknown as Parameters<typeof updateDocumentInternal>[0];
+
+  return { ctx, patches, scheduled };
+}
+
+const baseDoc: Doc = {
+  _id: 'd1',
+  fileId: 's1',
+  organizationId: 'org1',
+  title: 'Old title',
+  contentHash: 'oldhash',
+};
+
+describe('updateDocumentInternal reindex gate', () => {
+  it('schedules content reindex when hash + file changed on a completed blob', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'completed' },
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      contentHash: 'newhash',
+      fileId: 's2' as never,
+    });
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].args).toEqual({
+      documentId: 'd1',
+      oldFileId: 's1',
+      oldOrganizationId: 'org1',
+    });
+  });
+
+  it('schedules title reindex on a title-only rename of a completed blob', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'completed' },
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      title: 'New title',
+    });
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].args).toMatchObject({
+      documentId: 'd1',
+      oldFileId: 's1',
+    });
+  });
+
+  it('does NOT reindex when the current blob is not completed', async () => {
+    const { ctx, scheduled, patches } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'queued' },
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      contentHash: 'newhash',
+      fileId: 's2' as never,
+    });
+
+    expect(scheduled).toHaveLength(0);
+    expect(patches).toHaveLength(1); // patch still happens
+  });
+
+  it('does NOT reindex a legacy completed doc with no fileMetadata row (migration window)', async () => {
+    const { ctx, scheduled } = createMockCtx({ ...baseDoc }, null);
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      title: 'New title',
+    });
+
+    expect(scheduled).toHaveLength(0);
+  });
+
+  it('does NOT reindex when neither file content nor title changed', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'completed' },
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      mimeType: 'application/pdf',
+    });
+
+    expect(scheduled).toHaveLength(0);
+  });
+});

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -78,27 +78,27 @@ export async function updateDocumentInternal(
   const titleChanged =
     updateData.title !== undefined && document.title !== updateData.title;
 
-  // If file changed and document was RAG-indexed, mark as queued for re-indexing
+  // Re-index gate reads canonical fileMetadata.ragStatus for the doc's current
+  // blob (documents.ragInfo is retired). The fileMetadata pipeline owns the
+  // flip to 'queued' when reindexDocumentInRag re-uploads, so status is not
+  // written here.
+  const currentFileId = document.fileId;
+  const currentFm = currentFileId
+    ? await ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', currentFileId))
+        .first()
+    : null;
+  const wasIndexed = currentFm?.ragStatus === 'completed';
+
+  // If file/title changed and the document was RAG-indexed, re-index.
   const needsContentReindex =
-    hashChanged &&
-    hasNewFile &&
-    document.ragInfo?.status === 'completed' &&
-    document.fileId;
+    hashChanged && hasNewFile && wasIndexed && document.fileId;
 
   const needsTitleReindex =
-    titleChanged &&
-    !hashChanged &&
-    document.ragInfo?.status === 'completed' &&
-    document.fileId;
+    titleChanged && !hashChanged && wasIndexed && document.fileId;
 
   const needsReindex = needsContentReindex || needsTitleReindex;
-
-  if (needsReindex) {
-    finalUpdateData.ragInfo = {
-      ...document.ragInfo,
-      status: 'queued',
-    };
-  }
 
   // Remove undefined values
   const cleanUpdateData = Object.fromEntries(

--- a/services/platform/convex/documents/update_document_rag_info.ts
+++ b/services/platform/convex/documents/update_document_rag_info.ts
@@ -1,5 +1,10 @@
 /**
- * Update document RAG info (internal helper)
+ * Update document RAG info (internal helper).
+ *
+ * @deprecated RAG status is canonical on `fileMetadata.ragStatus`. This writes
+ * the retired `documents.ragInfo`/`indexed` fields and is only reachable from
+ * the deprecated `checkRagDocumentStatus` poller (kept for pre-cutover drain).
+ * New code writes status via `internal.file_metadata.internal_mutations.updateFileRagStatus`.
  */
 
 import type { Id } from '../_generated/dataModel';

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -63,6 +63,10 @@ function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
             [Symbol.asyncIterator]: async function* () {
               for (const m of matched) yield m;
             },
+            // The RAG-status reindex gate queries fileMetadata `by_storageId`
+            // and calls .first(); these fixtures have no fileMetadata, so the
+            // gate stays inactive (matched is empty for that lookup).
+            first: async () => matched[0] ?? null,
           };
         },
       }),

--- a/services/platform/convex/documents/upsert_document_by_external_id.test.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.test.ts
@@ -22,7 +22,13 @@ interface MockFolder {
   organizationId: string;
 }
 
-function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
+function createMockCtx(
+  initial: MockDoc[],
+  initialFolders: MockFolder[] = [],
+  // Maps an existing blob storageId → its canonical RAG status row. Drives the
+  // reindex gate (`fileMetadata by_storageId .first()`); empty → gate inert.
+  fmByStorageId: Record<string, { ragStatus?: string }> = {},
+) {
   const docs = new Map<string, MockDoc>();
   for (const doc of initial) docs.set(doc._id, doc);
   const folders = new Map<string, MockFolder>();
@@ -30,6 +36,7 @@ function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
   let counter = initial.length;
   const inserts: MockDoc[] = [];
   const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const scheduled: Array<{ args: Record<string, unknown> }> = [];
 
   const ctx = {
     db: {
@@ -42,14 +49,24 @@ function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
         ) => {
           let orgFilter: string | undefined;
           let externalFilter: string | undefined;
+          let storageIdFilter: string | undefined;
           const qb = {
             eq: (field: string, value: unknown) => {
               if (field === 'organizationId') orgFilter = value as string;
               if (field === 'externalItemId') externalFilter = value as string;
+              if (field === 'storageId') storageIdFilter = value as string;
               return qb;
             },
           };
           cb(qb);
+          // fileMetadata reindex-gate lookup (keyed on storageId only).
+          if (storageIdFilter !== undefined) {
+            const sid = storageIdFilter;
+            return {
+              [Symbol.asyncIterator]: async function* () {},
+              first: async () => fmByStorageId[sid] ?? null,
+            };
+          }
           const matched: MockDoc[] = [];
           for (const doc of docs.values()) {
             if (
@@ -63,9 +80,6 @@ function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
             [Symbol.asyncIterator]: async function* () {
               for (const m of matched) yield m;
             },
-            // The RAG-status reindex gate queries fileMetadata `by_storageId`
-            // and calls .first(); these fixtures have no fileMetadata, so the
-            // gate stays inactive (matched is empty for that lookup).
             first: async () => matched[0] ?? null,
           };
         },
@@ -98,9 +112,19 @@ function createMockCtx(initial: MockDoc[], initialFolders: MockFolder[] = []) {
       get: (id: string) =>
         Promise.resolve(folders.get(id) ?? docs.get(id) ?? null),
     },
+    scheduler: {
+      runAfter: (
+        _delay: number,
+        _ref: unknown,
+        args: Record<string, unknown>,
+      ) => {
+        scheduled.push({ args });
+        return Promise.resolve(undefined);
+      },
+    },
   };
 
-  return { ctx, docs, inserts, patches };
+  return { ctx, docs, inserts, patches, scheduled };
 }
 
 const ORG = 'org1';
@@ -387,5 +411,74 @@ describe('upsertDocumentByExternalId', () => {
     );
     expect(result.action).toBe('created');
     expect(inserts).toHaveLength(1);
+  });
+
+  describe('reindex gate (canonical fileMetadata.ragStatus)', () => {
+    const indexedDoc: MockDoc = {
+      _id: 'd1',
+      organizationId: ORG,
+      externalItemId: 'gd-1',
+      contentHash: 'h1',
+      fileId: 'old-blob',
+    };
+
+    it('schedules reindex when a RAG-completed doc swaps to a new blob with changed content', async () => {
+      const { ctx, scheduled } = createMockCtx([{ ...indexedDoc }], [], {
+        'old-blob': { ragStatus: 'completed' },
+      });
+
+      const result = await upsertDocumentByExternalId(
+        ctx as unknown as MutationCtx,
+        {
+          organizationId: ORG,
+          externalItemId: 'gd-1',
+          title: 'file.txt',
+          contentHash: 'h2',
+          fileId: 'new-blob' as never,
+        },
+      );
+
+      expect(result.action).toBe('updated');
+      expect(result.contentChanged).toBe(true);
+      expect(scheduled).toEqual([
+        {
+          args: {
+            documentId: 'd1',
+            oldFileId: 'old-blob',
+            oldOrganizationId: ORG,
+          },
+        },
+      ]);
+    });
+
+    it('does NOT schedule reindex when the existing blob is not RAG-completed', async () => {
+      const { ctx, scheduled } = createMockCtx([{ ...indexedDoc }], [], {
+        'old-blob': { ragStatus: 'queued' },
+      });
+
+      await upsertDocumentByExternalId(ctx as unknown as MutationCtx, {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h2',
+        fileId: 'new-blob' as never,
+      });
+
+      expect(scheduled).toHaveLength(0);
+    });
+
+    it('does NOT schedule reindex when no fileMetadata row exists (migration window)', async () => {
+      const { ctx, scheduled } = createMockCtx([{ ...indexedDoc }], [], {});
+
+      await upsertDocumentByExternalId(ctx as unknown as MutationCtx, {
+        organizationId: ORG,
+        externalItemId: 'gd-1',
+        title: 'file.txt',
+        contentHash: 'h2',
+        fileId: 'new-blob' as never,
+      });
+
+      expect(scheduled).toHaveLength(0);
+    });
   });
 });

--- a/services/platform/convex/documents/upsert_document_by_external_id.ts
+++ b/services/platform/convex/documents/upsert_document_by_external_id.ts
@@ -158,12 +158,23 @@ export async function upsertDocumentByExternalId(
     // re-uploads) is the main producer of this state. `reindexDocumentInRag`
     // dedup-skips a re-upload when the new content already exists in RAG,
     // so the only work it does here is the old-fileId DELETE.
+    // Re-index gate reads canonical fileMetadata.ragStatus for the existing
+    // blob (documents.ragInfo is retired).
+    const existingFileId = existing.fileId;
+    const existingFm = existingFileId
+      ? await ctx.db
+          .query('fileMetadata')
+          .withIndex('by_storageId', (q) => q.eq('storageId', existingFileId))
+          .first()
+      : null;
+    const existingIndexed = existingFm?.ragStatus === 'completed';
+
     if (
       contentChanged &&
       existing.fileId &&
       args.fileId &&
       existing.fileId !== args.fileId &&
-      existing.ragInfo?.status === 'completed'
+      existingIndexed
     ) {
       await ctx.scheduler.runAfter(
         0,

--- a/services/platform/convex/documents/validators.ts
+++ b/services/platform/convex/documents/validators.ts
@@ -41,6 +41,11 @@ export const ragInfoStatusValidator = v.union(
   v.literal('failed'),
 );
 
+/**
+ * @deprecated RAG status is canonical on `fileMetadata.ragStatus`. This shape
+ * mirrors the retired `documents.ragInfo` field; read status via
+ * `getDocumentRagProjection` instead.
+ */
 export const ragInfoValidator = v.object({
   status: ragInfoStatusValidator,
   indexedAt: v.optional(v.number()),

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -3,22 +3,37 @@
 import { v } from 'convex/values';
 
 import { extractExtension } from '../../lib/shared/file-types';
-import { isRecord, getNumber } from '../../lib/utils/type-guards';
+import {
+  isRecord,
+  getNumber,
+  getString,
+  getBoolean,
+} from '../../lib/utils/type-guards';
 import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
 import { getCrawlerUrl } from '../documents/generate_document_helpers';
+import { getPollingInterval } from '../documents/internal_actions';
 import {
   isUpstreamHttpError,
   UpstreamHttpError,
 } from '../lib/errors/upstream_http_error';
 import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { ragFetch } from '../lib/helpers/rag_config';
 import { ragAction } from '../workflow_engine/action_defs/rag/rag_action';
 
+const INITIAL_POLLING_DELAY_MS = 10_000;
+const MAX_POLL_ATTEMPTS = 50;
+
 /**
- * Upload a file to the RAG service for indexing.
+ * Upload a file to the RAG service for indexing, then start a server-driven
+ * status poll.
  *
- * Triggered by saveFileMetadata on new inserts. Only uploads — status
- * polling is driven by the client via checkFileRagStatus.
+ * Triggered by saveFileMetadata on new inserts. The chat UI's
+ * checkFileRagStatuses still polls while a chat is open, but it is the only
+ * client poller — so this schedules pollFileRagStatus to advance status to
+ * 'completed' server-side even when no client is watching (e.g. a Document-Hub
+ * upload). Both pollers hit the same RAG /statuses endpoint and write the same
+ * canonical fileMetadata.ragStatus.
  */
 export const uploadFileToRag = internalAction({
   args: {
@@ -40,6 +55,15 @@ export const uploadFileToRag = internalAction({
         },
         { organizationId: args.organizationId },
       );
+      await ctx.scheduler.runAfter(
+        INITIAL_POLLING_DELAY_MS,
+        internal.file_metadata.internal_actions.pollFileRagStatus,
+        {
+          storageId: args.storageId,
+          organizationId: args.organizationId,
+          attempt: 1,
+        },
+      );
     } catch (error) {
       console.error(
         `[uploadFileToRag] Failed to upload file ${args.storageId}: ${error instanceof Error ? error.message : String(error)}`,
@@ -54,6 +78,184 @@ export const uploadFileToRag = internalAction({
       );
     }
 
+    return null;
+  },
+});
+
+/**
+ * Server-driven RAG status poller for a single fileMetadata row.
+ *
+ * Scheduled by uploadFileToRag after the blob is pushed to RAG. Self-reschedules
+ * (progressive backoff via getPollingInterval) until ragStatus is terminal,
+ * writing the canonical fileMetadata.ragStatus via updateFileRagStatus. This is
+ * the server-side counterpart to the chat UI's checkFileRagStatuses poll — both
+ * hit the same RAG /statuses endpoint and write the same field — so every
+ * upload reaches 'completed' even with no client polling. Source dates / OCR are
+ * handled separately by extractFileMetadata, so this only advances status.
+ */
+export const pollFileRagStatus = internalAction({
+  args: {
+    storageId: v.id('_storage'),
+    organizationId: v.string(),
+    attempt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const metadata = await ctx.runQuery(
+      internal.file_metadata.internal_queries.getByStorageId,
+      { storageId: args.storageId },
+    );
+    // Row gone, never RAG-queued (audio → transcript pipeline), or already
+    // terminal → nothing to advance.
+    if (
+      !metadata ||
+      metadata.ragStatus === undefined ||
+      metadata.ragStatus === 'completed' ||
+      metadata.ragStatus === 'failed'
+    ) {
+      return null;
+    }
+
+    if (args.attempt > MAX_POLL_ATTEMPTS) {
+      console.warn(
+        `[pollFileRagStatus] Max attempts (${MAX_POLL_ATTEMPTS}) reached for ${args.storageId}`,
+      );
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileRagStatus,
+        {
+          storageId: args.storageId,
+          ragStatus: 'failed',
+          ragError: `Status check timed out after ${MAX_POLL_ATTEMPTS} attempts`,
+        },
+      );
+      return null;
+    }
+
+    // A missing/unresolvable slug is terminal — retrying just re-throws.
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+    if (orgSlug === null) {
+      console.warn(
+        `[pollFileRagStatus] org ${args.organizationId} unresolvable for ${args.storageId}; marking failed (no retry)`,
+      );
+      await ctx.runMutation(
+        internal.file_metadata.internal_mutations.updateFileRagStatus,
+        {
+          storageId: args.storageId,
+          ragStatus: 'failed',
+          ragError: 'Organization unresolvable (deleted or missing slug).',
+        },
+      );
+      return null;
+    }
+
+    const reschedule = () =>
+      ctx.scheduler.runAfter(
+        getPollingInterval(args.attempt),
+        internal.file_metadata.internal_actions.pollFileRagStatus,
+        {
+          storageId: args.storageId,
+          organizationId: args.organizationId,
+          attempt: args.attempt + 1,
+        },
+      );
+
+    try {
+      const response = await ragFetch('/api/v1/documents/statuses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_ids: [args.storageId] }),
+        timeoutMs: 10_000,
+        orgSlug,
+      });
+
+      if (response.status === 429 || (!response.ok && response.status >= 500)) {
+        await reschedule();
+        return null;
+      }
+      if (response.status >= 400 && response.status < 500) {
+        console.error(
+          `[pollFileRagStatus] RAG returned ${response.status} for ${args.storageId}, not retrying`,
+        );
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          {
+            storageId: args.storageId,
+            ragStatus: 'failed',
+            ragError: `RAG service returned ${response.status}`,
+          },
+        );
+        return null;
+      }
+      if (!response.ok) {
+        await reschedule();
+        return null;
+      }
+
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        await reschedule();
+        return null;
+      }
+      if (!isRecord(body) || !isRecord(body.statuses)) {
+        await reschedule();
+        return null;
+      }
+
+      const docStatus = body.statuses[args.storageId];
+      if (!isRecord(docStatus)) {
+        // RAG hasn't ingested it yet — keep polling.
+        await reschedule();
+        return null;
+      }
+
+      const status = getString(docStatus, 'status');
+      const error = getString(docStatus, 'error');
+      const progressPhase = getString(docStatus, 'progress_phase');
+      const progressDetail = getString(docStatus, 'progress_detail');
+      const ragProgress =
+        progressPhase && progressDetail
+          ? `${progressPhase} ${progressDetail}`
+          : progressPhase || undefined;
+
+      if (status === 'completed') {
+        const ocrApplied = getBoolean(docStatus, 'ocr_applied');
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          {
+            storageId: args.storageId,
+            ragStatus: 'completed',
+            ...(ocrApplied != null && { ocrApplied }),
+          },
+        );
+        return null;
+      }
+      if (status === 'failed') {
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          {
+            storageId: args.storageId,
+            ragStatus: 'failed',
+            ragError: error || 'Unknown error',
+          },
+        );
+        return null;
+      }
+      if (status === 'processing') {
+        await ctx.runMutation(
+          internal.file_metadata.internal_mutations.updateFileRagStatus,
+          { storageId: args.storageId, ragStatus: 'running', ragProgress },
+        );
+      }
+      await reschedule();
+    } catch (error) {
+      console.error(
+        `[pollFileRagStatus] Error (attempt ${args.attempt}/${MAX_POLL_ATTEMPTS}):`,
+        error,
+      );
+      await reschedule();
+    }
     return null;
   },
 });

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -41,6 +41,7 @@ vi.mock('../_generated/api', () => ({
 function createMockCtx(
   existingDoc: Record<string, unknown> | null = null,
   linkedDoc: Record<string, unknown> | null = null,
+  systemMeta: Record<string, unknown> | null = null,
 ) {
   const builder = {
     withIndex: vi.fn().mockReturnThis(),
@@ -53,6 +54,9 @@ function createMockCtx(
       get: vi.fn().mockResolvedValue(linkedDoc),
       insert: vi.fn().mockResolvedValue('fm_new'),
       patch: vi.fn().mockResolvedValue(undefined),
+      system: {
+        get: vi.fn().mockResolvedValue(systemMeta),
+      },
     },
     scheduler: {
       runAfter: vi.fn().mockResolvedValue(undefined),
@@ -70,6 +74,18 @@ async function getSaveHandler() {
 async function getLinkHandler() {
   const { linkDocumentToFile } = await import('./internal_mutations');
   return (linkDocumentToFile as unknown as { handler: Function }).handler;
+}
+
+async function getUpdateRagStatusHandler() {
+  const { updateFileRagStatus } = await import('./internal_mutations');
+  return (updateFileRagStatus as unknown as { handler: Function }).handler;
+}
+
+async function getEnsureHandler() {
+  const { ensureFileMetadataForDocument } =
+    await import('./internal_mutations');
+  return (ensureFileMetadataForDocument as unknown as { handler: Function })
+    .handler;
 }
 
 const baseArgs = {
@@ -264,5 +280,135 @@ describe('linkDocumentToFile', () => {
       documentId: 'doc_1',
       source: 'user',
     });
+  });
+});
+
+describe('updateFileRagStatus ragIndexedAt units', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression guard: the completion timestamp must be Unix SECONDS, not ms.
+  // The RagStatusBadge renders `new Date(indexedAt * 1000)`, and both the
+  // legacy ragInfo.indexedAt writer and the backfill store seconds — writing
+  // Date.now() (ms) here renders a ~year-58000 date.
+  it('stamps ragIndexedAt in SECONDS on completion (not ms)', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      storageId: 'storage_1',
+      ragStatus: 'running',
+      ragQueuedAt: 1,
+    });
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, { storageId: 'storage_1', ragStatus: 'completed' });
+
+    const patchArg = ctx.db.patch.mock.calls[0][1] as { ragIndexedAt: number };
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    // In seconds range (~1.7e9), decisively below the ms range (~1.7e12).
+    expect(patchArg.ragIndexedAt).toBeGreaterThan(1_000_000_000);
+    expect(patchArg.ragIndexedAt).toBeLessThan(100_000_000_000);
+    expect(Math.abs(patchArg.ragIndexedAt - nowSeconds)).toBeLessThanOrEqual(5);
+  });
+
+  it('preserves prior ragIndexedAt for non-completed transitions', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      storageId: 'storage_1',
+      ragStatus: 'queued',
+      ragIndexedAt: 1_700_000_000,
+    });
+    const handler = await getUpdateRagStatusHandler();
+
+    await handler(ctx, { storageId: 'storage_1', ragStatus: 'running' });
+
+    const patchArg = ctx.db.patch.mock.calls[0][1] as { ragIndexedAt: number };
+    expect(patchArg.ragIndexedAt).toBe(1_700_000_000);
+  });
+});
+
+describe('ensureFileMetadataForDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const ensureArgs = {
+    organizationId: 'org_1',
+    storageId: 'storage_1',
+    documentId: 'doc_1',
+    fileName: 'test.pdf',
+    contentType: 'application/pdf',
+  };
+
+  it('creates a minimal linked row when none exists, reading size/contentType from the storage system table', async () => {
+    const { ctx } = createMockCtx(null, null, {
+      size: 2048,
+      contentType: 'application/pdf',
+    });
+    const handler = await getEnsureHandler();
+
+    const result = await handler(ctx, {
+      ...ensureArgs,
+      contentType: undefined,
+    });
+
+    expect(result).toBe('fm_new');
+    expect(ctx.db.insert).toHaveBeenCalledWith('fileMetadata', {
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+      documentId: 'doc_1',
+      fileName: 'test.pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+    });
+    // Must NOT schedule another RAG upload/poll — the caller already uploaded.
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it('defaults contentType/size when the blob has no system metadata', async () => {
+    const { ctx } = createMockCtx(null, null, null);
+    const handler = await getEnsureHandler();
+
+    await handler(ctx, { ...ensureArgs, contentType: undefined });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith('fileMetadata', {
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+      documentId: 'doc_1',
+      fileName: 'test.pdf',
+      contentType: 'application/octet-stream',
+      size: 0,
+    });
+  });
+
+  it('links documentId on an existing-but-unlinked row without inserting', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_existing',
+      storageId: 'storage_1',
+    });
+    const handler = await getEnsureHandler();
+
+    const result = await handler(ctx, ensureArgs);
+
+    expect(result).toBe('fm_existing');
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_existing', {
+      documentId: 'doc_1',
+    });
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the row already has a documentId', async () => {
+    const { ctx } = createMockCtx({
+      _id: 'fm_existing',
+      storageId: 'storage_1',
+      documentId: 'doc_existing',
+    });
+    const handler = await getEnsureHandler();
+
+    const result = await handler(ctx, ensureArgs);
+
+    expect(result).toBe('fm_existing');
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -193,9 +193,14 @@ export const updateFileRagStatus = internalMutation({
             ? undefined
             : metadata.ragQueuedAt,
       // Canonical completion timestamp (replaces documents.ragInfo.indexedAt).
-      // Stamp on completion; preserve the prior value otherwise.
+      // Stamp on completion; preserve the prior value otherwise. Unix SECONDS
+      // to match every other consumer: the legacy ragInfo.indexedAt writer and
+      // the backfill store seconds, and the RagStatusBadge renders it as
+      // `new Date(indexedAt * 1000)`. Writing ms here renders a far-future date.
       ragIndexedAt:
-        args.ragStatus === 'completed' ? Date.now() : metadata.ragIndexedAt,
+        args.ragStatus === 'completed'
+          ? Math.floor(Date.now() / 1000)
+          : metadata.ragIndexedAt,
       ...(args.ocrApplied != null && { ocrApplied: args.ocrApplied }),
     });
 
@@ -208,6 +213,54 @@ export const updateFileRagStatus = internalMutation({
         });
       }
     }
+  },
+});
+
+/**
+ * Ensure the canonical `fileMetadata` row exists for a document blob that the
+ * documents pipeline RAG-indexes directly via `ragAction` (`retryRagIndexing`,
+ * `uploadDocumentToRag`). Those actions push the blob themselves and then write
+ * status via `updateFileRagStatus`, which silently no-ops when the row is
+ * missing — so a file-backed document that never got a `fileMetadata` row (e.g.
+ * a UI upload with no `fileSize`, or a legacy pre-`fileMetadata` doc) would
+ * report success while its status stayed stuck on `not_indexed`.
+ *
+ * Creates the row when absent (reading size/contentType straight from the
+ * `_storage` system table) and links the `documentId`, but schedules NO RAG
+ * upload or poll — the caller already uploaded and owns the status/poll, so
+ * routing through `saveFileMetadata` here would double-index. No-op beyond
+ * linking an absent `documentId` when the row already exists.
+ */
+export const ensureFileMetadataForDocument = internalMutation({
+  args: {
+    organizationId: v.string(),
+    storageId: v.id('_storage'),
+    documentId: v.id('documents'),
+    fileName: v.string(),
+    contentType: v.optional(v.string()),
+  },
+  async handler(ctx, args) {
+    const existing = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
+      .first();
+    if (existing) {
+      if (!existing.documentId) {
+        await ctx.db.patch(existing._id, { documentId: args.documentId });
+      }
+      return existing._id;
+    }
+
+    const sys = await ctx.db.system.get(args.storageId);
+    return await ctx.db.insert('fileMetadata', {
+      organizationId: args.organizationId,
+      storageId: args.storageId,
+      documentId: args.documentId,
+      fileName: args.fileName,
+      contentType:
+        args.contentType ?? sys?.contentType ?? 'application/octet-stream',
+      size: sys?.size ?? 0,
+    });
   },
 });
 

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -192,6 +192,10 @@ export const updateFileRagStatus = internalMutation({
           : isTerminal
             ? undefined
             : metadata.ragQueuedAt,
+      // Canonical completion timestamp (replaces documents.ragInfo.indexedAt).
+      // Stamp on completion; preserve the prior value otherwise.
+      ragIndexedAt:
+        args.ragStatus === 'completed' ? Date.now() : metadata.ragIndexedAt,
       ...(args.ocrApplied != null && { ocrApplied: args.ocrApplied }),
     });
 

--- a/services/platform/convex/file_metadata/internal_queries.ts
+++ b/services/platform/convex/file_metadata/internal_queries.ts
@@ -200,6 +200,34 @@ export const getStorageSha256 = internalQuery({
 });
 
 /**
+ * Read Convex-computed blob metadata (size + contentType) for a storage id.
+ * Exists because `ctx.db.system.get(...)` is unavailable in actions — the
+ * REST `POST /api/v1/documents` handler calls this to size the fileMetadata
+ * row it creates for an externally-supplied `fileId`. Returns null when the
+ * blob is missing.
+ */
+export const getStorageMetadata = internalQuery({
+  args: {
+    storageId: v.id('_storage'),
+  },
+  returns: v.union(
+    v.object({
+      size: v.number(),
+      contentType: v.optional(v.string()),
+    }),
+    v.null(),
+  ),
+  async handler(ctx, args) {
+    const meta = await ctx.db.system.get(args.storageId);
+    if (!meta) return null;
+    return {
+      size: meta.size,
+      ...(meta.contentType != null && { contentType: meta.contentType }),
+    };
+  },
+});
+
+/**
  * Find a prior completed audio transcription with identical content (same
  * SHA-256 hash) within the same org. Used by `transcribeAudio` to short-
  * circuit duplicate uploads: user drags the same `meeting.mp3` twice, we

--- a/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
+++ b/services/platform/convex/file_metadata/poll_file_rag_status.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Unwrap the registered action so `.handler` is directly callable.
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    internalAction: (config: Record<string, unknown>) => config,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+// Minimal api refs the poller hands to runQuery/runMutation/scheduler.
+vi.mock('../_generated/api', () => ({
+  internal: {
+    file_metadata: {
+      internal_queries: { getByStorageId: 'getByStorageId' },
+      internal_mutations: { updateFileRagStatus: 'updateFileRagStatus' },
+      internal_actions: { pollFileRagStatus: 'pollFileRagStatus' },
+    },
+  },
+}));
+
+// Neutralize heavy / network imports the module pulls at load time.
+vi.mock('../lib/helpers/rag_config', () => ({ ragFetch: vi.fn() }));
+vi.mock('../lib/helpers/org_slug', () => ({ orgSlugFromIdOrNull: vi.fn() }));
+vi.mock('../documents/internal_actions', () => ({
+  getPollingInterval: vi.fn(() => 1000),
+}));
+vi.mock('../documents/generate_document_helpers', () => ({
+  getCrawlerUrl: vi.fn(),
+}));
+vi.mock('../workflow_engine/action_defs/rag/rag_action', () => ({
+  ragAction: {},
+}));
+
+import { orgSlugFromIdOrNull } from '../lib/helpers/org_slug';
+import { ragFetch } from '../lib/helpers/rag_config';
+import { pollFileRagStatus } from './internal_actions';
+
+const handler = (
+  pollFileRagStatus as unknown as {
+    handler: (
+      ctx: unknown,
+      args: { storageId: string; organizationId: string; attempt: number },
+    ) => Promise<unknown>;
+  }
+).handler;
+const ragFetchMock = ragFetch as unknown as ReturnType<typeof vi.fn>;
+const orgSlugMock = orgSlugFromIdOrNull as unknown as ReturnType<typeof vi.fn>;
+
+function createCtx(metadata: Record<string, unknown> | null) {
+  const runMutation = vi.fn().mockResolvedValue(undefined);
+  const runQuery = vi.fn().mockResolvedValue(metadata);
+  const runAfter = vi.fn().mockResolvedValue(undefined);
+  return {
+    ctx: { runQuery, runMutation, scheduler: { runAfter } },
+    runMutation,
+    runAfter,
+  };
+}
+
+function makeResp(opts: {
+  status?: number;
+  ok?: boolean;
+  body?: unknown;
+  jsonThrows?: boolean;
+}) {
+  const status = opts.status ?? 200;
+  return {
+    status,
+    ok: opts.ok ?? (status >= 200 && status < 300),
+    json: async () => {
+      if (opts.jsonThrows) throw new Error('bad json');
+      return opts.body;
+    },
+  };
+}
+
+const baseArgs = { storageId: 's1', organizationId: 'org1', attempt: 1 };
+const statusBody = (s: Record<string, unknown>) => ({ statuses: { s1: s } });
+
+describe('pollFileRagStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orgSlugMock.mockResolvedValue('org-slug');
+  });
+
+  it('short-circuits on a terminal/absent canonical status (no fetch, no write)', async () => {
+    for (const ragStatus of ['completed', 'failed', undefined]) {
+      const { ctx, runMutation, runAfter } = createCtx(
+        ragStatus === undefined ? { _id: 'fm1' } : { _id: 'fm1', ragStatus },
+      );
+      const res = await handler(ctx, baseArgs);
+      expect(res).toBeNull();
+      expect(ragFetchMock).not.toHaveBeenCalled();
+      expect(runMutation).not.toHaveBeenCalled();
+      expect(runAfter).not.toHaveBeenCalled();
+    }
+  });
+
+  it('returns early when the row is gone', async () => {
+    const { ctx, runMutation } = createCtx(null);
+    const res = await handler(ctx, baseArgs);
+    expect(res).toBeNull();
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it('marks failed (no fetch) past MAX_POLL_ATTEMPTS', async () => {
+    const { ctx, runMutation } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'running',
+    });
+    await handler(ctx, { ...baseArgs, attempt: 51 });
+    expect(ragFetchMock).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith('updateFileRagStatus', {
+      storageId: 's1',
+      ragStatus: 'failed',
+      ragError: expect.stringContaining('timed out'),
+    });
+  });
+
+  it('marks failed (no fetch, no retry) when the org slug is unresolvable', async () => {
+    orgSlugMock.mockResolvedValue(null);
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(ragFetchMock).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith(
+      'updateFileRagStatus',
+      expect.objectContaining({ ragStatus: 'failed' }),
+    );
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it('reschedules on 429 without writing status', async () => {
+    ragFetchMock.mockResolvedValue(makeResp({ status: 429, ok: false }));
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).toHaveBeenCalledWith(1000, 'pollFileRagStatus', {
+      storageId: 's1',
+      organizationId: 'org1',
+      attempt: 2,
+    });
+  });
+
+  it('reschedules on 5xx', async () => {
+    ragFetchMock.mockResolvedValue(makeResp({ status: 503, ok: false }));
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks failed (no retry) on a 4xx', async () => {
+    ragFetchMock.mockResolvedValue(makeResp({ status: 404, ok: false }));
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).toHaveBeenCalledWith(
+      'updateFileRagStatus',
+      expect.objectContaining({
+        ragStatus: 'failed',
+        ragError: expect.stringContaining('404'),
+      }),
+    );
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it('reschedules when the JSON body fails to parse', async () => {
+    ragFetchMock.mockResolvedValue(makeResp({ status: 200, jsonThrows: true }));
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).toHaveBeenCalledTimes(1);
+  });
+
+  it('reschedules when RAG has not ingested the file yet (no statuses entry)', async () => {
+    ragFetchMock.mockResolvedValue(
+      makeResp({ status: 200, body: { statuses: {} } }),
+    );
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes completed (with ocrApplied) and stops on a completed status', async () => {
+    ragFetchMock.mockResolvedValue(
+      makeResp({
+        status: 200,
+        body: statusBody({ status: 'completed', ocr_applied: true }),
+      }),
+    );
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'running',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).toHaveBeenCalledWith('updateFileRagStatus', {
+      storageId: 's1',
+      ragStatus: 'completed',
+      ocrApplied: true,
+    });
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it('writes failed and stops on a failed status', async () => {
+    ragFetchMock.mockResolvedValue(
+      makeResp({
+        status: 200,
+        body: statusBody({ status: 'failed', error: 'extract error' }),
+      }),
+    );
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'running',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).toHaveBeenCalledWith('updateFileRagStatus', {
+      storageId: 's1',
+      ragStatus: 'failed',
+      ragError: 'extract error',
+    });
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it('writes running and reschedules on a processing status', async () => {
+    ragFetchMock.mockResolvedValue(
+      makeResp({
+        status: 200,
+        body: statusBody({
+          status: 'processing',
+          progress_phase: 'embedding',
+          progress_detail: '3/10',
+        }),
+      }),
+    );
+    const { ctx, runMutation, runAfter } = createCtx({
+      _id: 'fm1',
+      ragStatus: 'queued',
+    });
+    await handler(ctx, baseArgs);
+    expect(runMutation).toHaveBeenCalledWith('updateFileRagStatus', {
+      storageId: 's1',
+      ragStatus: 'running',
+      ragProgress: 'embedding 3/10',
+    });
+    expect(runAfter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -43,6 +43,10 @@ export const fileMetadataTable = defineTable({
   // (e.g. scheduled action silently failed before hitting the service).
   // Falls back to _creationTime when absent on older rows.
   ragQueuedAt: v.optional(v.number()),
+  // Unix ms when ragStatus most recently reached 'completed'. Canonical
+  // replacement for the retired documents.ragInfo.indexedAt — stamped by
+  // updateFileRagStatus on completion, read by getDocumentRagProjection.
+  ragIndexedAt: v.optional(v.number()),
   // Audio transcription (populated when contentType starts with 'audio/').
   transcript: v.optional(v.string()),
   transcriptionStatus: v.optional(
@@ -160,6 +164,11 @@ export const fileMetadataTable = defineTable({
   // thread's bound files in O(1) per thread. Same shape as the soft-delete
   // composite index for status-narrowed sweeps.
   .index('by_organizationId_and_threadId', ['organizationId', 'threadId'])
+  // Canonical "list indexed files in this org" lookup — replaces the
+  // documents-side by_organizationId_and_indexed index after RAG status
+  // collapsed onto fileMetadata. Used by getAgentScopedFileIds +
+  // listIndexedDocumentsForAgent (ragStatus === 'completed').
+  .index('by_organizationId_and_ragStatus', ['organizationId', 'ragStatus'])
   // Watchdog sweep: the `recoverStuckTranscriptions` cron runs every 5
   // minutes and only cares about rows whose `transcriptionStatus` is
   // `'running'`. The vast majority of rows are `'completed'` /

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -43,9 +43,11 @@ export const fileMetadataTable = defineTable({
   // (e.g. scheduled action silently failed before hitting the service).
   // Falls back to _creationTime when absent on older rows.
   ragQueuedAt: v.optional(v.number()),
-  // Unix ms when ragStatus most recently reached 'completed'. Canonical
+  // Unix SECONDS when ragStatus most recently reached 'completed'. Canonical
   // replacement for the retired documents.ragInfo.indexedAt — stamped by
-  // updateFileRagStatus on completion, read by getDocumentRagProjection.
+  // updateFileRagStatus on completion, read by getDocumentRagProjection. Seconds
+  // (not ms) to match the legacy writer, the backfill, and the RagStatusBadge's
+  // `new Date(indexedAt * 1000)` render.
   ragIndexedAt: v.optional(v.number()),
   // Audio transcription (populated when contentType starts with 'audio/').
   transcript: v.optional(v.string()),

--- a/services/platform/convex/file_metadata/schema.ts
+++ b/services/platform/convex/file_metadata/schema.ts
@@ -166,11 +166,20 @@ export const fileMetadataTable = defineTable({
   // thread's bound files in O(1) per thread. Same shape as the soft-delete
   // composite index for status-narrowed sweeps.
   .index('by_organizationId_and_threadId', ['organizationId', 'threadId'])
-  // Canonical "list indexed files in this org" lookup — replaces the
-  // documents-side by_organizationId_and_indexed index after RAG status
+  // Canonical "list indexed Document-Hub files in this org" lookup — replaces
+  // the documents-side by_organizationId_and_indexed index after RAG status
   // collapsed onto fileMetadata. Used by getAgentScopedFileIds +
-  // listIndexedDocumentsForAgent (ragStatus === 'completed').
-  .index('by_organizationId_and_ragStatus', ['organizationId', 'ragStatus'])
+  // listIndexedDocumentsForAgent, queried as
+  // `.eq(org).eq('ragStatus','completed').gt('documentId', undefined)`: the
+  // documentId third field lets the range bound SEEK past chat-upload /
+  // transcript rows (documentId absent → ordered as `undefined`, the least
+  // value), so the scan stays dense with Hub docs instead of being inflated by
+  // the org's chat corpus. (Convex orders: undefined < null < … < string.)
+  .index('by_organizationId_and_ragStatus_and_documentId', [
+    'organizationId',
+    'ragStatus',
+    'documentId',
+  ])
   // Watchdog sweep: the `recoverStuckTranscriptions` cron runs every 5
   // minutes and only cares about rows whose `transcriptionStatus` is
   // `'running'`. The vast majority of rows are `'completed'` /

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -781,18 +781,30 @@ export async function generateAgentResponse(
         >
       | undefined;
     if (needsKnowledgeContext && organizationId && promptMessage) {
-      const accessibleFileIds: string[] = await ctx.runQuery(
-        internal.documents.internal_queries.getAgentScopedFileIds,
-        {
-          organizationId,
-          agentTeamId,
-          agentTeamIds,
-          includeTeamKnowledge,
-          includeOrgKnowledge,
-          knowledgeFileIds,
-          agentProjectIds,
-        },
-      );
+      // Resolve the agent's RAG scope defensively: on a very large knowledge
+      // corpus this query can hit the Convex transaction read cap and throw.
+      // Degrade to "no knowledge context this turn" (logged) rather than abort
+      // the whole response — same guardrail as the orgSlugFromId resolve below.
+      let accessibleFileIds: string[] = [];
+      try {
+        accessibleFileIds = await ctx.runQuery(
+          internal.documents.internal_queries.getAgentScopedFileIds,
+          {
+            organizationId,
+            agentTeamId,
+            agentTeamIds,
+            includeTeamKnowledge,
+            includeOrgKnowledge,
+            knowledgeFileIds,
+            agentProjectIds,
+          },
+        );
+      } catch (err) {
+        console.warn(
+          '[generateAgentResponse] getAgentScopedFileIds failed; skipping knowledge context',
+          err instanceof Error ? err.message : err,
+        );
+      }
       if (accessibleFileIds.length === 0) {
         debugLog('No accessible RAG documents, skipping knowledge context');
       } else {

--- a/services/platform/convex/migrations.ts
+++ b/services/platform/convex/migrations.ts
@@ -31,23 +31,28 @@ export const runAll = internalAction({
       internal.migrations.split_personalization_toggle.apply,
       {},
     );
+    // Both backfills below are independent and idempotent. The documentId
+    // backfill keys on (organizationId, fileId); the rag-status backfill keys on
+    // storageId and has NO documentId dependency — so call order is cosmetic.
+    // Each runs only its first batch synchronously here and self-schedules its
+    // tail, so the two walks interleave regardless. Agent RAG retrieval requires
+    // BOTH documentId set AND ragStatus === 'completed', so a legacy
+    // completed-but-unlinked blob is transiently invisible until both chains
+    // drain, then converges. (The rag-status backfill self-heals missing rows it
+    // creates with documentId already set; the documentId backfill skips those.)
+    //
     // Links fileMetadata.documentId from the matching (organizationId, fileId)
-    // document. Runs BEFORE the rag-status backfill: getAgentScopedFileIds and
-    // listIndexedDocumentsForAgent skip completed fileMetadata rows whose
-    // documentId is unset, so an unlinked-but-completed blob would silently drop
-    // out of agent RAG retrieval after the SSOT cutover. Self-scheduling,
-    // idempotent (skips rows that already have documentId). Both backfills are
-    // independent and idempotent, so the self-scheduled tails may overlap; agent
-    // scope converges once both drain.
+    // document. Self-scheduling, idempotent (skips rows that already have
+    // documentId).
     await ctx.runMutation(
       internal.migrations.backfill_file_metadata_document_id
         .backfillFileMetadataDocumentId,
       {},
     );
-    // Copies legacy documents.ragInfo.{status,error,indexedAt} onto the now-
-    // canonical fileMetadata.{ragStatus,ragError,ragIndexedAt}. Self-scheduling
-    // (one paginated batch per call), idempotent, fills holes only — safe to
-    // re-run on every deploy. Keys on storageId.
+    // Mirrors TERMINAL legacy documents.ragInfo.{status,error,indexedAt} onto the
+    // canonical fileMetadata.{ragStatus,ragError,ragIndexedAt}, creating the row
+    // when missing. Self-scheduling (one paginated batch per call), idempotent —
+    // safe to re-run on every deploy.
     await ctx.runMutation(
       internal.migrations.backfill_filemetadata_rag_status
         .backfillFilemetadataRagStatus,

--- a/services/platform/convex/migrations.ts
+++ b/services/platform/convex/migrations.ts
@@ -31,11 +31,23 @@ export const runAll = internalAction({
       internal.migrations.split_personalization_toggle.apply,
       {},
     );
+    // Links fileMetadata.documentId from the matching (organizationId, fileId)
+    // document. Runs BEFORE the rag-status backfill: getAgentScopedFileIds and
+    // listIndexedDocumentsForAgent skip completed fileMetadata rows whose
+    // documentId is unset, so an unlinked-but-completed blob would silently drop
+    // out of agent RAG retrieval after the SSOT cutover. Self-scheduling,
+    // idempotent (skips rows that already have documentId). Both backfills are
+    // independent and idempotent, so the self-scheduled tails may overlap; agent
+    // scope converges once both drain.
+    await ctx.runMutation(
+      internal.migrations.backfill_file_metadata_document_id
+        .backfillFileMetadataDocumentId,
+      {},
+    );
     // Copies legacy documents.ragInfo.{status,error,indexedAt} onto the now-
     // canonical fileMetadata.{ragStatus,ragError,ragIndexedAt}. Self-scheduling
     // (one paginated batch per call), idempotent, fills holes only — safe to
-    // re-run on every deploy. Keys on storageId, so it does not depend on the
-    // documentId backfill.
+    // re-run on every deploy. Keys on storageId.
     await ctx.runMutation(
       internal.migrations.backfill_filemetadata_rag_status
         .backfillFilemetadataRagStatus,

--- a/services/platform/convex/migrations.ts
+++ b/services/platform/convex/migrations.ts
@@ -31,5 +31,15 @@ export const runAll = internalAction({
       internal.migrations.split_personalization_toggle.apply,
       {},
     );
+    // Copies legacy documents.ragInfo.{status,error,indexedAt} onto the now-
+    // canonical fileMetadata.{ragStatus,ragError,ragIndexedAt}. Self-scheduling
+    // (one paginated batch per call), idempotent, fills holes only — safe to
+    // re-run on every deploy. Keys on storageId, so it does not depend on the
+    // documentId backfill.
+    await ctx.runMutation(
+      internal.migrations.backfill_filemetadata_rag_status
+        .backfillFilemetadataRagStatus,
+      {},
+    );
   },
 });

--- a/services/platform/convex/migrations/backfill_filemetadata_rag_status.test.ts
+++ b/services/platform/convex/migrations/backfill_filemetadata_rag_status.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Unwrap the registered mutation so `.handler` is directly callable (mirrors
+// file_metadata/internal_mutations.test.ts).
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+import { backfillFilemetadataRagStatus } from './backfill_filemetadata_rag_status';
+
+type Doc = Record<string, unknown>;
+type Fm = Record<string, unknown> & { _id: string; ragStatus?: string };
+
+/**
+ * Mock ctx for the backfill mutation. `documents` resolves to a paginated page;
+ * `fileMetadata` resolves to a `by_storageId` `.first()` lookup keyed by the
+ * provided map. Tracks inserts, patches, and self-scheduling.
+ */
+function createMockCtx(opts: {
+  docs: Doc[];
+  fmByStorageId?: Record<string, Fm>;
+  sysByStorageId?: Record<string, { size: number; contentType?: string }>;
+  isDone?: boolean;
+}) {
+  const fmByStorageId = opts.fmByStorageId ?? {};
+  const sysByStorageId = opts.sysByStorageId ?? {};
+  const inserts: Array<{ table: string; doc: Doc }> = [];
+  const patches: Array<{ id: string; patch: Doc }> = [];
+  const scheduled: Array<{ delay: number; args: Doc }> = [];
+
+  const ctx = {
+    db: {
+      query: (table: string) => {
+        if (table === 'documents') {
+          return {
+            paginate: async () => ({
+              page: opts.docs,
+              isDone: opts.isDone ?? true,
+              continueCursor: 'next-cursor',
+            }),
+          };
+        }
+        // fileMetadata by_storageId .first()
+        let storageId: string | undefined;
+        const builder = {
+          withIndex: (_idx: string, cb: (q: unknown) => unknown) => {
+            const q = {
+              eq: (field: string, value: unknown) => {
+                if (field === 'storageId') storageId = value as string;
+                return q;
+              },
+            };
+            cb(q);
+            return builder;
+          },
+          first: async () =>
+            storageId ? (fmByStorageId[storageId] ?? null) : null,
+        };
+        return builder;
+      },
+      system: {
+        get: async (id: unknown) => sysByStorageId[id as string] ?? null,
+      },
+      insert: async (table: string, doc: Doc) => {
+        inserts.push({ table, doc });
+        return `fm_inserted_${inserts.length}`;
+      },
+      patch: async (id: string, patch: Doc) => {
+        patches.push({ id, patch });
+      },
+    },
+    scheduler: {
+      runAfter: async (delay: number, _ref: unknown, args: Doc) => {
+        scheduled.push({ delay, args });
+      },
+    },
+  };
+
+  return { ctx, inserts, patches, scheduled };
+}
+
+const handler = (
+  backfillFilemetadataRagStatus as unknown as {
+    handler: (
+      ctx: unknown,
+      args: { cursor?: string | null },
+    ) => Promise<{
+      patched: number;
+      inserted: number;
+      skipped: number;
+      isDone: boolean;
+    }>;
+  }
+).handler;
+
+describe('backfillFilemetadataRagStatus', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('M1: skips non-terminal legacy statuses (queued/running) — no write', async () => {
+    const { ctx, inserts, patches } = createMockCtx({
+      docs: [
+        {
+          _id: 'd1',
+          organizationId: 'org1',
+          fileId: 's1',
+          ragInfo: { status: 'queued' },
+        },
+        {
+          _id: 'd2',
+          organizationId: 'org1',
+          fileId: 's2',
+          ragInfo: { status: 'running' },
+        },
+      ],
+      // even though a hole exists, non-terminal must not be copied
+      fmByStorageId: { s1: { _id: 'fm1' }, s2: { _id: 'fm2' } },
+    });
+
+    const res = await handler(ctx, {});
+
+    expect(inserts).toHaveLength(0);
+    expect(patches).toHaveLength(0);
+    expect(res).toMatchObject({ patched: 0, inserted: 0, skipped: 2 });
+  });
+
+  it('patches the hole on an existing fileMetadata row for a terminal status', async () => {
+    const { ctx, patches, inserts } = createMockCtx({
+      docs: [
+        {
+          _id: 'd1',
+          organizationId: 'org1',
+          fileId: 's1',
+          ragInfo: {
+            status: 'completed',
+            indexedAt: 1_700_000_000,
+            error: undefined,
+          },
+        },
+      ],
+      fmByStorageId: { s1: { _id: 'fm1' } }, // exists, ragStatus unset
+    });
+
+    const res = await handler(ctx, {});
+
+    expect(inserts).toHaveLength(0);
+    expect(patches).toEqual([
+      {
+        id: 'fm1',
+        patch: { ragStatus: 'completed', ragIndexedAt: 1_700_000_000 },
+      },
+    ]);
+    expect(res).toMatchObject({ patched: 1, inserted: 0 });
+  });
+
+  it('idempotent: never overwrites an already-set canonical ragStatus', async () => {
+    const { ctx, patches, inserts } = createMockCtx({
+      docs: [
+        {
+          _id: 'd1',
+          organizationId: 'org1',
+          fileId: 's1',
+          ragInfo: { status: 'failed', error: 'boom' },
+        },
+      ],
+      fmByStorageId: { s1: { _id: 'fm1', ragStatus: 'completed' } }, // already canonical
+    });
+
+    const res = await handler(ctx, {});
+
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+    expect(res).toMatchObject({ patched: 0, inserted: 0, skipped: 1 });
+  });
+
+  it('M2: creates the canonical row when missing, reading size/contentType from _storage', async () => {
+    const { ctx, inserts, patches } = createMockCtx({
+      docs: [
+        {
+          _id: 'd1',
+          organizationId: 'org1',
+          fileId: 's1',
+          title: 'Report.pdf',
+          mimeType: undefined,
+          ragInfo: { status: 'completed', indexedAt: 1_700_000_000 },
+        },
+      ],
+      fmByStorageId: {}, // no row → must insert
+      sysByStorageId: { s1: { size: 2048, contentType: 'application/pdf' } },
+    });
+
+    const res = await handler(ctx, {});
+
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toEqual({
+      table: 'fileMetadata',
+      doc: {
+        organizationId: 'org1',
+        storageId: 's1',
+        documentId: 'd1',
+        fileName: 'Report.pdf',
+        contentType: 'application/pdf',
+        size: 2048,
+        ragStatus: 'completed',
+        ragIndexedAt: 1_700_000_000,
+      },
+    });
+    expect(res).toMatchObject({ inserted: 1, patched: 0 });
+  });
+
+  it('M2: defaults contentType/size when the blob has no system metadata', async () => {
+    const { ctx, inserts } = createMockCtx({
+      docs: [
+        {
+          _id: 'd1',
+          organizationId: 'org1',
+          fileId: 's1',
+          title: undefined,
+          mimeType: undefined,
+          ragInfo: { status: 'failed', error: 'nope' },
+        },
+      ],
+      fmByStorageId: {},
+      sysByStorageId: {}, // no system metadata
+    });
+
+    await handler(ctx, {});
+
+    expect(inserts[0].doc).toMatchObject({
+      fileName: 'document',
+      contentType: 'application/octet-stream',
+      size: 0,
+      ragStatus: 'failed',
+      ragError: 'nope',
+    });
+  });
+
+  it('skips docs with no ragInfo.status or no fileId', async () => {
+    const { ctx, inserts, patches, scheduled } = createMockCtx({
+      docs: [
+        { _id: 'd1', organizationId: 'org1', fileId: 's1' }, // no ragInfo
+        { _id: 'd2', organizationId: 'org1', ragInfo: { status: 'completed' } }, // no fileId
+      ],
+    });
+
+    const res = await handler(ctx, {});
+
+    expect(inserts).toHaveLength(0);
+    expect(patches).toHaveLength(0);
+    expect(scheduled).toHaveLength(0);
+    expect(res).toMatchObject({ skipped: 2, isDone: true });
+  });
+
+  it('self-schedules the next batch when not done', async () => {
+    const { ctx, scheduled } = createMockCtx({
+      docs: [],
+      isDone: false,
+    });
+
+    await handler(ctx, {});
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toMatchObject({
+      delay: 0,
+      args: { cursor: 'next-cursor' },
+    });
+  });
+});

--- a/services/platform/convex/migrations/backfill_filemetadata_rag_status.ts
+++ b/services/platform/convex/migrations/backfill_filemetadata_rag_status.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration: Backfill RAG indexing status onto fileMetadata.
+ *
+ * RAG status collapsed onto `fileMetadata.ragStatus` as the single source of
+ * truth; `documents.ragInfo` is retired. For each document whose legacy
+ * `ragInfo.status` predates a fileMetadata status, copy it across so completed/
+ * failed history survives the cutover:
+ *   documents.ragInfo.{status,error,indexedAt} → fileMetadata.{ragStatus,ragError,ragIndexedAt}
+ *
+ * Idempotent + non-destructive: only fills holes — never overwrites a
+ * fileMetadata.ragStatus that is already set (fileMetadata is canonical).
+ *
+ * Convex allows only ONE paginated query per function call, so this processes a
+ * single batch and self-schedules the next — a single invocation walks the
+ * whole `documents` table.
+ *
+ * Usage:
+ *   bunx convex run migrations/backfill_filemetadata_rag_status:backfillFilemetadataRagStatus
+ */
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import { internalMutation } from '../_generated/server';
+
+const BATCH_SIZE = 200;
+
+export const backfillFilemetadataRagStatus = internalMutation({
+  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query('documents')
+      .paginate({ cursor: args.cursor ?? null, numItems: BATCH_SIZE });
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const doc of result.page) {
+      const status = doc.ragInfo?.status;
+      const fileId = doc.fileId;
+      if (!status || !fileId) {
+        skipped++;
+        continue;
+      }
+
+      const fm = await ctx.db
+        .query('fileMetadata')
+        .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+        .first();
+      if (!fm) {
+        // No canonical owner (legacy coverage gap; new REST creates are fixed).
+        skipped++;
+        continue;
+      }
+      if (fm.ragStatus) {
+        // Canonical already set — never overwrite.
+        skipped++;
+        continue;
+      }
+
+      await ctx.db.patch(fm._id, {
+        ragStatus: status,
+        ...(doc.ragInfo?.error ? { ragError: doc.ragInfo.error } : {}),
+        ...(doc.ragInfo?.indexedAt
+          ? { ragIndexedAt: doc.ragInfo.indexedAt }
+          : {}),
+      });
+      updated++;
+    }
+
+    console.log(
+      `[backfillFilemetadataRagStatus] batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
+    );
+
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfill_filemetadata_rag_status
+          .backfillFilemetadataRagStatus,
+        { cursor: result.continueCursor },
+      );
+    }
+
+    return { updated, skipped, isDone: result.isDone };
+  },
+});

--- a/services/platform/convex/migrations/backfill_filemetadata_rag_status.ts
+++ b/services/platform/convex/migrations/backfill_filemetadata_rag_status.ts
@@ -2,13 +2,28 @@
  * Migration: Backfill RAG indexing status onto fileMetadata.
  *
  * RAG status collapsed onto `fileMetadata.ragStatus` as the single source of
- * truth; `documents.ragInfo` is retired. For each document whose legacy
- * `ragInfo.status` predates a fileMetadata status, copy it across so completed/
- * failed history survives the cutover:
+ * truth; `documents.ragInfo` is retired. For each file-backed document carrying
+ * a TERMINAL legacy `ragInfo.status` (`completed`/`failed`), mirror it onto the
+ * canonical fileMetadata row so that history survives the cutover:
  *   documents.ragInfo.{status,error,indexedAt} → fileMetadata.{ragStatus,ragError,ragIndexedAt}
  *
- * Idempotent + non-destructive: only fills holes — never overwrites a
- * fileMetadata.ragStatus that is already set (fileMetadata is canonical).
+ * Two cases:
+ *  - fileMetadata row exists → fill the hole (never overwrite a set ragStatus).
+ *  - fileMetadata row missing → CREATE it (mirrors `ensureFileMetadataForDocument`'s
+ *    shape, reading size/contentType from the `_storage` system table). Without
+ *    this, a legacy completed document whose blob never got a fileMetadata row
+ *    would project as `not_indexed` and silently drop out of agent RAG retrieval.
+ *
+ * NON-terminal legacy statuses (`queued`/`running`) are intentionally NOT copied:
+ * nothing advances a backfilled non-terminal canonical status server-side (the
+ * poller is only scheduled at fresh-upload time, and `expireStaleRagQueue` only
+ * rescues `queued`), so copying one would pin the row forever. Leaving it unset
+ * projects as `not_indexed` and stays re-driveable via re-index.
+ *
+ * Idempotent + non-destructive: only fills holes / creates missing rows — never
+ * overwrites a fileMetadata.ragStatus that is already set. A re-run finds the
+ * row it created (set ragStatus) and skips it; overlapping self-scheduled chains
+ * are serialized by Convex OCC. Safe to re-run on every deploy.
  *
  * Convex allows only ONE paginated query per function call, so this processes a
  * single batch and self-schedules the next — a single invocation walks the
@@ -23,7 +38,10 @@ import { v } from 'convex/values';
 import { internal } from '../_generated/api';
 import { internalMutation } from '../_generated/server';
 
-const BATCH_SIZE = 200;
+// 100 (not 200): each batch may now also do up to BATCH_SIZE system.get + insert
+// on top of the paginate + by_storageId reads, so keep transaction read/write
+// bytes comfortably under the cap. Free — the walk self-schedules.
+const BATCH_SIZE = 100;
 
 export const backfillFilemetadataRagStatus = internalMutation({
   args: { cursor: v.optional(v.union(v.string(), v.null())) },
@@ -32,7 +50,8 @@ export const backfillFilemetadataRagStatus = internalMutation({
       .query('documents')
       .paginate({ cursor: args.cursor ?? null, numItems: BATCH_SIZE });
 
-    let updated = 0;
+    let patched = 0;
+    let inserted = 0;
     let skipped = 0;
 
     for (const doc of result.page) {
@@ -42,34 +61,59 @@ export const backfillFilemetadataRagStatus = internalMutation({
         skipped++;
         continue;
       }
+      // Terminal-only: a non-terminal status has no server-side advancer here
+      // and would pin the canonical row. Leave it unset (→ not_indexed).
+      if (status !== 'completed' && status !== 'failed') {
+        skipped++;
+        continue;
+      }
 
       const fm = await ctx.db
         .query('fileMetadata')
         .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
         .first();
+
+      const ragExtras = {
+        ...(doc.ragInfo?.error ? { ragError: doc.ragInfo.error } : {}),
+        ...(doc.ragInfo?.indexedAt
+          ? { ragIndexedAt: doc.ragInfo.indexedAt }
+          : {}),
+      };
+
       if (!fm) {
-        // No canonical owner (legacy coverage gap; new REST creates are fixed).
-        skipped++;
+        // No canonical row yet (legacy blob predating fileMetadata). Create it so
+        // the document keeps its indexed status + stays in agent RAG scope.
+        // On a shared blob the first document the walk reaches claims documentId
+        // (same first-writer non-determinism as the documentId backfill's
+        // `by_organizationId_and_fileId .first()`).
+        const sys = await ctx.db.system.get(fileId);
+        await ctx.db.insert('fileMetadata', {
+          organizationId: doc.organizationId,
+          storageId: fileId,
+          documentId: doc._id,
+          fileName: doc.title ?? 'document',
+          contentType:
+            doc.mimeType ?? sys?.contentType ?? 'application/octet-stream',
+          size: sys?.size ?? 0,
+          ragStatus: status,
+          ...ragExtras,
+        });
+        inserted++;
         continue;
       }
+
       if (fm.ragStatus) {
         // Canonical already set — never overwrite.
         skipped++;
         continue;
       }
 
-      await ctx.db.patch(fm._id, {
-        ragStatus: status,
-        ...(doc.ragInfo?.error ? { ragError: doc.ragInfo.error } : {}),
-        ...(doc.ragInfo?.indexedAt
-          ? { ragIndexedAt: doc.ragInfo.indexedAt }
-          : {}),
-      });
-      updated++;
+      await ctx.db.patch(fm._id, { ragStatus: status, ...ragExtras });
+      patched++;
     }
 
     console.log(
-      `[backfillFilemetadataRagStatus] batch: updated=${updated}, skipped=${skipped}, done=${result.isDone}`,
+      `[backfillFilemetadataRagStatus] batch: patched=${patched}, inserted=${inserted}, skipped=${skipped}, done=${result.isDone}`,
     );
 
     if (!result.isDone) {
@@ -81,6 +125,6 @@ export const backfillFilemetadataRagStatus = internalMutation({
       );
     }
 
-    return { updated, skipped, isDone: result.isDone };
+    return { patched, inserted, skipped, isDone: result.isDone };
   },
 });

--- a/services/platform/convex/projects/queries.ts
+++ b/services/platform/convex/projects/queries.ts
@@ -10,6 +10,7 @@ import { v } from 'convex/values';
 
 import type { Doc, Id } from '../_generated/dataModel';
 import { query, type QueryCtx } from '../_generated/server';
+import { getDocumentRagProjectionBatch } from '../documents/get_document_rag_projection';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
@@ -221,7 +222,12 @@ export const getProjectStats = query({
       .take(PROJECT_STATS_CAP + 1);
     const docsTruncated = docs.length > PROJECT_STATS_CAP;
     const docsPage = docsTruncated ? docs.slice(0, PROJECT_STATS_CAP) : docs;
-    const indexedFileCount = docsPage.filter((d) => d.indexed === true).length;
+    // Indexed state is projected from fileMetadata.ragStatus (canonical), not
+    // the retired documents.indexed flag.
+    const ragProjections = await getDocumentRagProjectionBatch(ctx, docsPage);
+    const indexedFileCount = docsPage.filter(
+      (d) => ragProjections.get(String(d._id))?.indexed === true,
+    ).length;
 
     const threads = await ctx.db
       .query('threadMetadata')
@@ -291,30 +297,32 @@ export const listProjectDocuments = query({
     const auth = await getAuthContext(ctx, project.organizationId);
     if (!hasProjectAccess(project, auth.teamIds, auth.role)) return [];
 
-    const docsQuery = ctx.db
+    const rawDocs = await ctx.db
       .query('documents')
       .withIndex('by_organizationId_and_projectId', (q) =>
         q
           .eq('organizationId', project.organizationId)
           .eq('projectId', args.projectId),
       )
-      .order('desc');
+      .order('desc')
+      .collect();
 
-    const docs = [];
-    for await (const d of docsQuery) {
-      docs.push({
+    // RAG status/indexed projected from fileMetadata.ragStatus (canonical).
+    const ragProjections = await getDocumentRagProjectionBatch(ctx, rawDocs);
+    return rawDocs.map((d) => {
+      const proj = ragProjections.get(String(d._id));
+      return {
         _id: d._id,
         _creationTime: d._creationTime,
         title: d.title,
         fileId: d.fileId,
         mimeType: d.mimeType,
         extension: d.extension,
-        indexed: d.indexed,
-        ragStatus: d.ragInfo?.status ?? null,
+        indexed: proj?.indexed ?? false,
+        ragStatus: proj?.status ?? null,
         createdBy: d.createdBy,
-      });
-    }
-    return docs;
+      };
+    });
   },
 });
 


### PR DESCRIPTION
## Context

RAG indexing status was stored in **three** places that drift: `documents.ragInfo` + `documents.indexed`, `fileMetadata.ragStatus`, and the RAG service's own Postgres row — kept loosely in sync by polling, with two independent writers inside Convex. This makes `fileMetadata.ragStatus` the **single source of truth** within Convex and projects it on reads. It's a **Convex-internal** change: the RAG Python service, the synchronous search/retrieval path, and the receive-only boundary are untouched; vectors stay in RAG's Postgres.

## What changed

**Single canonical owner**
- `documents.ragInfo` / `documents.indexed` are no longer written (kept `@deprecated` + optional for existing rows). Every reader projects status through one helper, `getDocumentRagProjection` (join `documents.fileId == fileMetadata.storageId`), so the response shape and the **frontend are unchanged** and drift becomes structurally impossible. This also resolves the within-Convex asymmetry (chat uploads have no `documents` row) by keying on `storageId`, which both upload kinds share.

**Schema + index swap**
- Add `fileMetadata.ragIndexedAt` (canonical completion timestamp) and a `by_organizationId_and_ragStatus` index. `getAgentScopedFileIds` and `listIndexedDocumentsForAgent` query that index and resolve to documents, replacing the retired `documents.by_organizationId_and_indexed` (kept, deprecate-don't-delete).

**Server-driven status advancement**
- New `pollFileRagStatus` (storageId-keyed, self-scheduling), scheduled by `uploadFileToRag`, so **Document-Hub uploads reach `completed` even with no chat open** — previously the only server-driven poller was the documents pipeline, and `checkFileRagStatuses` is polled only by the chat UI. The documents-pipeline uploaders (`uploadDocumentToRag`, `reindexDocumentInRag`, `retryRagIndexing`) now write `fileMetadata` status and schedule this poller. `checkRagDocumentStatus` is retired-but-kept (`@deprecated`) so any pre-deploy scheduled job drains harmlessly.

**Coverage + backfill**
- REST `POST /api/v1/documents` with a `fileId` now creates the `fileMetadata` row (the one creation path that didn't).
- One-time backfill `backfill_filemetadata_rag_status` copies legacy `documents.ragInfo` → `fileMetadata` (fill-holes-only, idempotent), registered in migrations `runAll`.

## Verification

- `tsc --noEmit`, `oxlint --type-aware`, and `format:check` all clean.
- 286 server tests pass (`documents` / `file_metadata` / `projects`); updated the mocks in `get_agent_scoped_file_ids`, `list_indexed_documents_for_agent`, and `upsert_document_by_external_id` for the fileMetadata-driven query path.
- `convex dev --once` pushed successfully — schema validated against existing local data and the new index built.
- **Manual app E2E still recommended** (needs the live RAG service): upload a doc with no chat open → badge advances to `completed`; agent retrieval; chat upload; an integration sync re-queue; REST create with `fileId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server-side polling for RAG indexing status provides more reliable tracking of document indexing progress

* **Improvements**
  * Enhanced metadata tracking to ensure accurate RAG indexing status across document updates
  * Better handling of file replacements to prevent stale indexed state
  * Added timestamps for document indexing completion events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->