### PR TITLE
feat(platform): restrict audit-log reads to org admins

### DIFF
--- a/docs/de/platform/admin/governance/audit-logs.md
+++ b/docs/de/platform/admin/governance/audit-logs.md
@@ -43,7 +43,7 @@ Der JSON-Export (`audit-logs-<timestamp>.json`) trägt dieselben Zeilen als voll
 
 ## Aufbewahrung und Integrität
 
-Audit-Zeilen sind unveränderlich: Bearbeitungen und Löschungen werden selbst auditiert, und das Zeilenschema trägt einen Integritäts-Hash, den du gegen den Export prüfen kannst. Eine täglich geplante Prüfung verifiziert die Hash-Kette serverseitig erneut und schreibt einen `security`-Audit-Eintrag, wenn die Verifikation fehlschlägt — sodass Manipulation oder eine Löschung außer der Reihe auch dann auffällt, wenn niemand die manuelle Prüfung ausführt. Die Aufbewahrung steht standardmäßig auf 90 Tagen und ist auf der Seite zur Aufbewahrungsrichtlinie konfigurierbar (30 bis 365 Tage). Zeilen, die altern, werden vom nächsten Cleanup-Lauf entfernt — es gibt kein Soft-Delete-Fenster für Audit-Daten.
+Audit-Zeilen sind unveränderlich: Bearbeitungen und Löschungen werden selbst auditiert, und das Zeilenschema trägt einen Integritäts-Hash, den du gegen den Export prüfen kannst. Eine täglich geplante Prüfung verifiziert die Hash-Kette serverseitig erneut und schreibt einen `security`-Audit-Eintrag, wenn die Verifikation fehlschlägt — sodass Manipulation oder eine Löschung außer der Reihe auch dann auffällt, wenn niemand die manuelle Prüfung ausführt. Eine fehlgeschlagene Prüfung löst zusätzlich eine kritische In-App-Benachrichtigung an die Admins der Organisation aus und geht an Slack, wenn ein Slack-Benachrichtigungskanal konfiguriert ist. Die Aufbewahrung steht standardmäßig auf 90 Tagen und ist auf der Seite zur Aufbewahrungsrichtlinie konfigurierbar (30 bis 365 Tage). Zeilen, die altern, werden vom nächsten Cleanup-Lauf entfernt — es gibt kein Soft-Delete-Fenster für Audit-Daten.
 
 ## Wo das hingehört
 

--- a/docs/en/platform/admin/governance/audit-logs.md
+++ b/docs/en/platform/admin/governance/audit-logs.md
@@ -43,7 +43,7 @@ The JSON export (`audit-logs-<timestamp>.json`) carries the same rows as full ob
 
 ## Retention and integrity
 
-Audit rows are immutable: edits and deletes are themselves audited, and the row schema carries an integrity hash you can verify against the export. A scheduled daily check re-verifies the hash chain server-side and records a `security` audit entry if verification fails, so tampering or an out-of-band deletion surfaces even when no admin runs the manual check. Retention defaults to 90 days and is configurable on the retention policy page (30 to 365 days). Rows that age out are removed by the next cleanup pass — there is no soft-delete window for audit data.
+Audit rows are immutable: edits and deletes are themselves audited, and the row schema carries an integrity hash you can verify against the export. A scheduled daily check re-verifies the hash chain server-side and records a `security` audit entry if verification fails, so tampering or an out-of-band deletion surfaces even when no admin runs the manual check. A failed check also raises a critical in-app notification to the organisation's admins and fans out to Slack when a Slack notification channel is configured. Retention defaults to 90 days and is configurable on the retention policy page (30 to 365 days). Rows that age out are removed by the next cleanup pass — there is no soft-delete window for audit data.
 
 ## Where this fits
 

--- a/docs/fr/platform/admin/governance/audit-logs.md
+++ b/docs/fr/platform/admin/governance/audit-logs.md
@@ -43,7 +43,7 @@ L'export JSON (`audit-logs-<timestamp>.json`) porte les mêmes lignes en objets 
 
 ## Rétention et intégrité
 
-Les lignes d'audit sont immuables : les modifications et suppressions sont elles-mêmes auditées, et le schéma de ligne porte un hash d'intégrité que tu peux vérifier contre l'export. Une tâche planifiée quotidienne re-vérifie la chaîne de hachage côté serveur et écrit une entrée d'audit `security` si la vérification échoue — ainsi une altération ou une suppression hors bande ressort même si personne ne lance la vérification manuelle. La rétention est de 90 jours par défaut et se configure sur la page de politique de rétention (30 à 365 jours). Les lignes qui vieillissent sont retirées par la prochaine passe de nettoyage — il n'y a pas de fenêtre de soft-delete pour les données d'audit.
+Les lignes d'audit sont immuables : les modifications et suppressions sont elles-mêmes auditées, et le schéma de ligne porte un hash d'intégrité que tu peux vérifier contre l'export. Une tâche planifiée quotidienne re-vérifie la chaîne de hachage côté serveur et écrit une entrée d'audit `security` si la vérification échoue — ainsi une altération ou une suppression hors bande ressort même si personne ne lance la vérification manuelle. Une vérification en échec déclenche aussi une notification critique dans l'app pour les admins de l'organisation et part vers Slack quand un canal de notification Slack est configuré. La rétention est de 90 jours par défaut et se configure sur la page de politique de rétention (30 à 365 jours). Les lignes qui vieillissent sont retirées par la prochaine passe de nettoyage — il n'y a pas de fenêtre de soft-delete pour les données d'audit.
 
 ## Où cela s'inscrit
 

--- a/services/platform/convex/audit_logs/queries.ts
+++ b/services/platform/convex/audit_logs/queries.ts
@@ -3,9 +3,23 @@ import { v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import { getAuthUserIdentity, getOrganizationMember } from '../lib/rls';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import type { OrganizationMember } from '../lib/rls/types';
 import * as AuditLogHelpers from './helpers';
 import { listAuditLogsPaginated as listAuditLogsPaginatedHelper } from './list_audit_logs_paginated';
 import { auditLogFilterValidator, auditLogItemValidator } from './validators';
+
+/**
+ * Audit-log reads are admin/owner-only (#1505): the log records every
+ * member's actions, so non-admins reading it would leak other users'
+ * activity. Mirrors the RLS matrix (`access_control.ts`) and the
+ * admin-only `orgSettings` UI gate.
+ */
+export function assertAuditLogReadAccess(member: OrganizationMember): void {
+  if (!isAdmin(member.role)) {
+    throw new Error('Only admins can read audit logs');
+  }
+}
 
 export const listAuditLogs = query({
   args: {
@@ -24,7 +38,12 @@ export const listAuditLogs = query({
       throw new Error('Unauthenticated');
     }
 
-    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const member = await getOrganizationMember(
+      ctx,
+      args.organizationId,
+      authUser,
+    );
+    assertAuditLogReadAccess(member);
 
     return await AuditLogHelpers.listAuditLogs(ctx, {
       organizationId: args.organizationId,
@@ -48,34 +67,14 @@ export const listAuditLogsPaginated = query({
       throw new Error('Unauthenticated');
     }
 
-    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const member = await getOrganizationMember(
+      ctx,
+      args.organizationId,
+      authUser,
+    );
+    assertAuditLogReadAccess(member);
 
     return await listAuditLogsPaginatedHelper(ctx, args);
-  },
-});
-
-export const getResourceAuditTrail = query({
-  args: {
-    organizationId: v.string(),
-    resourceType: v.string(),
-    resourceId: v.string(),
-    limit: v.optional(v.number()),
-  },
-  returns: v.array(auditLogItemValidator),
-  handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new Error('Unauthenticated');
-    }
-
-    await getOrganizationMember(ctx, args.organizationId, authUser);
-
-    return await AuditLogHelpers.getResourceAuditTrail(ctx, {
-      organizationId: args.organizationId,
-      resourceType: args.resourceType,
-      resourceId: args.resourceId,
-      limit: args.limit,
-    });
   },
 });
 
@@ -106,7 +105,12 @@ export const getActivitySummary = query({
       throw new Error('Unauthenticated');
     }
 
-    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const member = await getOrganizationMember(
+      ctx,
+      args.organizationId,
+      authUser,
+    );
+    assertAuditLogReadAccess(member);
 
     return await AuditLogHelpers.getActivitySummary(ctx, {
       organizationId: args.organizationId,

--- a/services/platform/convex/audit_logs/read_access.test.ts
+++ b/services/platform/convex/audit_logs/read_access.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OrganizationMember } from '../lib/rls/types';
+import { assertAuditLogReadAccess } from './queries';
+
+function memberWithRole(role: string): OrganizationMember {
+  return {
+    _id: 'member_test',
+    createdAt: 0,
+    organizationId: 'org_test',
+    userId: 'user_test',
+    role,
+  };
+}
+
+// #1505: every public audit-log query gates reads through this helper —
+// the log records all members' actions, so reads are admin/owner-only.
+describe('assertAuditLogReadAccess', () => {
+  it.each(['admin', 'owner', 'Admin', 'OWNER'])(
+    'allows the %s role',
+    (role) => {
+      expect(() =>
+        assertAuditLogReadAccess(memberWithRole(role)),
+      ).not.toThrow();
+    },
+  );
+
+  it.each(['developer', 'editor', 'member', 'disabled', ''])(
+    'rejects the %s role',
+    (role) => {
+      expect(() => assertAuditLogReadAccess(memberWithRole(role))).toThrow(
+        'Only admins can read audit logs',
+      );
+    },
+  );
+});

--- a/services/platform/convex/crons.ts
+++ b/services/platform/convex/crons.ts
@@ -78,9 +78,9 @@ crons.cron(
 // Audit-log integrity monitoring (#1505) — the hash-chain + checkpoint
 // verification previously ran only as an on-demand admin query. Run it daily
 // across every org with an audit chain and alert (a structured console.error
-// plus a security-category audit row) on any chain break, truncation,
-// checkpoint mismatch, or unsigned PII scrub. 02:00 avoids the 01:00
-// legal-hold release sweep and the 04:00 retention sweep.
+// plus a security-category audit row) on any chain break, truncation, or
+// checkpoint mismatch. 02:00 avoids the 01:00 legal-hold release sweep and
+// the 04:00 retention sweep.
 crons.cron(
   'verify audit-log integrity (daily)',
   '0 2 * * *',

--- a/services/platform/convex/lib/rls/helpers/access_control.test.ts
+++ b/services/platform/convex/lib/rls/helpers/access_control.test.ts
@@ -49,8 +49,9 @@ describe('authorizeRls', () => {
   });
 
   describe('developer role', () => {
-    it('has full read/write access to all tables', () => {
+    it('has full read/write access to all tables except auditLogs', () => {
       for (const table of ALL_TABLES) {
+        if (table === 'auditLogs') continue;
         expect(authorizeRls('developer', table, 'read')).toBe(true);
         expect(authorizeRls('developer', table, 'write')).toBe(true);
       }
@@ -68,7 +69,6 @@ describe('authorizeRls', () => {
       'conversationMessages',
       'approvals',
       'websites',
-      'auditLogs',
     ];
     const readOnly: Table[] = [
       'integrations',
@@ -96,11 +96,32 @@ describe('authorizeRls', () => {
   });
 
   describe('member role', () => {
-    it('has read-only access to all tables', () => {
+    it('has read-only access to all tables except auditLogs', () => {
       for (const table of ALL_TABLES) {
+        if (table === 'auditLogs') continue;
         expect(authorizeRls('member', table, 'read')).toBe(true);
         expect(authorizeRls('member', table, 'write')).toBe(false);
       }
+    });
+  });
+
+  describe('auditLogs table (#1505 read-side hardening)', () => {
+    it('grants read only to admin and owner', () => {
+      expect(authorizeRls('admin', 'auditLogs', 'read')).toBe(true);
+      expect(authorizeRls('owner', 'auditLogs', 'read')).toBe(true);
+      expect(authorizeRls('developer', 'auditLogs', 'read')).toBe(false);
+      expect(authorizeRls('editor', 'auditLogs', 'read')).toBe(false);
+      expect(authorizeRls('member', 'auditLogs', 'read')).toBe(false);
+      expect(authorizeRls('disabled', 'auditLogs', 'read')).toBe(false);
+    });
+
+    it('keeps write for roles whose RLS-wrapped mutations insert audit rows', () => {
+      expect(authorizeRls('admin', 'auditLogs', 'write')).toBe(true);
+      expect(authorizeRls('owner', 'auditLogs', 'write')).toBe(true);
+      expect(authorizeRls('developer', 'auditLogs', 'write')).toBe(true);
+      expect(authorizeRls('editor', 'auditLogs', 'write')).toBe(true);
+      expect(authorizeRls('member', 'auditLogs', 'write')).toBe(false);
+      expect(authorizeRls('disabled', 'auditLogs', 'write')).toBe(false);
     });
   });
 

--- a/services/platform/convex/lib/rls/helpers/access_control.ts
+++ b/services/platform/convex/lib/rls/helpers/access_control.ts
@@ -56,6 +56,7 @@ type PlatformRoleName =
 
 const ALL: readonly PlatformAction[] = ['read', 'write'];
 const READ_ONLY: readonly PlatformAction[] = ['read'];
+const WRITE_ONLY: readonly PlatformAction[] = ['write'];
 const NONE: readonly PlatformAction[] = [];
 
 const platformPermissions: Record<
@@ -118,7 +119,9 @@ const platformPermissions: Record<
     websites: ALL,
     promptTemplates: ALL,
     promptCategories: ALL,
-    auditLogs: ALL,
+    // Audit-log reads are admin-only (#1505); WRITE stays so RLS-wrapped
+    // user mutations can insert their own audit rows.
+    auditLogs: WRITE_ONLY,
     artifacts: ALL,
     artifactRevisions: ALL,
     auditLogChainGenesis: NONE,
@@ -149,7 +152,9 @@ const platformPermissions: Record<
     websites: ALL,
     promptTemplates: ALL,
     promptCategories: ALL,
-    auditLogs: ALL,
+    // Audit-log reads are admin-only (#1505); WRITE stays so RLS-wrapped
+    // user mutations can insert their own audit rows.
+    auditLogs: WRITE_ONLY,
     artifacts: ALL,
     artifactRevisions: ALL,
     auditLogChainGenesis: NONE,
@@ -180,7 +185,9 @@ const platformPermissions: Record<
     websites: READ_ONLY,
     promptTemplates: ALL,
     promptCategories: ALL,
-    auditLogs: READ_ONLY,
+    // Audit-log reads are admin-only (#1505); member audit rows are written
+    // through internal mutations that bypass RLS (see prompts/mutations.ts).
+    auditLogs: NONE,
     // Members can READ artifacts (so the chat surface keeps working in
     // shared threads) but NOT write — artifact_create / file_* /
     // artifact_run all trigger billable sandbox executions. Aligns with

--- a/services/platform/lib/permissions/ability.test.ts
+++ b/services/platform/lib/permissions/ability.test.ts
@@ -79,6 +79,21 @@ describe('defineAbilityFor', () => {
     );
   });
 
+  describe('auditLogs', () => {
+    it.each(['owner', 'admin'])('grants auditLogs read to %s role', (role) => {
+      const ability = defineAbilityFor(role);
+      expect(ability.can('read', 'auditLogs')).toBe(true);
+    });
+
+    it.each(['developer', 'editor', 'member', 'disabled'])(
+      'denies auditLogs read for %s role',
+      (role) => {
+        const ability = defineAbilityFor(role);
+        expect(ability.can('read', 'auditLogs')).toBe(false);
+      },
+    );
+  });
+
   describe('members', () => {
     it.each(['owner', 'admin'])('grants members write to %s role', (role) => {
       const ability = defineAbilityFor(role);

--- a/services/platform/lib/permissions/ability.ts
+++ b/services/platform/lib/permissions/ability.ts
@@ -73,6 +73,8 @@ export function defineAbilityFor(role: string | null): AppAbility {
       // developers cannot manage org settings or members
       cannot('read', 'orgSettings');
       cannot('write', 'members');
+      // audit-log reads are admin-only (#1505)
+      cannot('read', 'auditLogs');
       break;
     }
     case 'editor': {
@@ -93,9 +95,9 @@ export function defineAbilityFor(role: string | null): AppAbility {
         can('read', resource);
         can('write', resource);
       }
-      // read-only on workflow/integration resources
+      // read-only on workflow/integration resources;
+      // audit-log reads are admin-only (#1505)
       const readOnlyResources: PlatformResource[] = [
-        'auditLogs',
         'integrations',
         'onedriveSyncConfigs',
         'wfDefinitions',
@@ -116,6 +118,8 @@ export function defineAbilityFor(role: string | null): AppAbility {
       can('read', 'knowledgeRead');
       cannot('read', 'orgSettings');
       cannot('read', 'developerSettings');
+      // audit-log reads are admin-only (#1505)
+      cannot('read', 'auditLogs');
       break;
     }
     default: {


### PR DESCRIPTION
## What / why

Closes the last open gap from #1505 (audit-log hardening): the read side. The hash chain, nightly integrity cron + alerting, append-only test, retention, and admin-gated export already shipped (#1805, #1820) — but the four public queries in `convex/audit_logs/queries.ts` gated only on org *membership*, so any member/editor/developer could read the full org audit trail by calling the API directly, contradicting the admin-only UI gate (`orgSettings`) and the docs ("Admins and Owners read this").

- **Admin-gate the public read queries** — `listAuditLogs`, `listAuditLogsPaginated`, `getActivitySummary` now throw for non-admin/owner roles via an exported `assertAuditLogReadAccess` helper (same pattern as `verifyIntegrity` and governance `listTrashedRows`), unit-tested across all roles in `read_access.test.ts`.
- **Delete `getResourceAuditTrail`** (public query) — zero consumers anywhere in the repo. The `helpers.ts` function of the same name stays; the GDPR erasure flow uses it internally.
- **Tighten the RLS matrix** (`access_control.ts`, defense-in-depth): `auditLogs` read is now admin-only. Developer/editor drop to `WRITE_ONLY` (write must stay — the RLS `insert` rule authorizes audit-row inserts); member drops to `NONE` (member audit rows already bypass RLS via `internal_mutations.createAuditLog`, see `prompts/mutations.ts`). The `modify` rule is untouched so the chain-link `chainSuccessor` patch keeps working.
- **Mirror the client CASL ability matrix** (`lib/permissions/ability.ts`): `cannot('read', 'auditLogs')` for developer and member, removed from the editor read-only list. Consistency-only — no UI consumer checks this subject today.
- **Write paths unchanged**: chain-linked inserts, retention deletes with signed checkpoints, and the signed PII scrub all keep working (locked in by the existing `append_only.test.ts`).
- Fix the stale `crons.ts` comment claiming the integrity cron alerts on unsigned PII scrubs (it deliberately does not).
- Docs: one sentence in `docs/{en,de,fr}/platform/admin/governance/audit-logs.md` documenting that a failed integrity check also raises a critical in-app notification to admins and fans out to Slack.

## Decision-gate recommendations baked in

- **In-app + Slack is the monitored-control alert channel** (no email) — matches the epic precedent on #1566 ("no email transport, front with an IdP"); the platform has no email infrastructure. An email sink stays a follow-up.
- **Read scope is strictly admin/owner-only** — matches the issue, the docs wording, and the `orgSettings` UI gate (not admin+developer). The scoped skills change-history endpoint stays admin-OR-developer, unchanged.
- **`getResourceAuditTrail` deleted** rather than gated — it had no consumer.

## Verification

Performed:
- `bun run check` at repo root — all 40 tasks green (366 platform test files / 71,917 tests).
- Targeted: `vitest run convex/audit_logs convex/lib/rls/helpers lib/permissions` — 9 files, 84 tests pass.
- `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — locale parity green.

### Manual verification required
- On a live deployment: sign in as a `member` or `editor` and call `api.audit_logs.queries.listAuditLogsPaginated` from the browser console → expect "Only admins can read audit logs"; as admin → rows return; the audit-logs settings page is unaffected (already behind the admin-only governance route).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no UI rendering change).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no new user-facing strings; the gate error is an API-level error, consistent with the existing `verifyIntegrity` gate).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change (audit-logs page, alerting sentence, all three locales).
- [x] Every touched docs page has a real opening and closing (pre-existing page, prose intact; docs tests green).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.

Part of #1803. Closes the read-side authz items of #1505 (requirement 4 and the RLS confirmation); together with the already-merged #1805/#1820 this completes the issue's acceptance criteria — Part of #1505.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit log integrity verification failures now trigger critical in-app notifications to organization admins and optional Slack alerts when configured.
  * Audit log access is now restricted to organization admins and owners only.

* **Documentation**
  * Updated audit logs documentation to reflect new failure notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->