### PR TITLE
fix(platform): gate RAG queueing on a shared indexability allowlist

### DIFF
--- a/docs/de/platform/knowledge/documents.md
+++ b/docs/de/platform/knowledge/documents.md
@@ -29,13 +29,13 @@ Die Pipeline ist idempotent auf dem Hash der Quelldatei. Dieselbe Datei zweimal 
 Die Pipeline behandelt die Dateitypen, die das Gros des Organisations-Wissens abdecken:
 
 - **Text und Code.** Markdown (`.md`), Klartext (`.txt`), Quellcode (jede Sprache, die Tale hervorhebt — siehe die Highlighter-Liste).
-- **Dokumente.** PDF (`.pdf`), Word (`.docx`), Open Document (`.odt`), Rich Text (`.rtf`).
-- **Tabellenkalkulationen.** Excel (`.xlsx`), CSV (`.csv`), Open Document Sheet (`.ods`).
-- **Folien.** PowerPoint (`.pptx`), Open Document Presentation (`.odp`).
+- **Dokumente.** PDF (`.pdf`), Word (`.docx`).
+- **Tabellenkalkulationen.** Excel (`.xlsx`), CSV (`.csv`), TSV (`.tsv`).
+- **Folien.** PowerPoint (`.pptx`).
 - **Webseiten.** HTML (`.html`) und die gerenderte Ausgabe eines Seiten-Crawls.
-- **Bilder.** PNG, JPG, WEBP, mit OCR angewendet, um Text zu extrahieren.
+- **Bilder.** PNG, JPG, GIF, BMP, TIFF, WEBP, mit OCR angewendet, um Text zu extrahieren.
 
-Eine Datei in einem nicht unterstützten Format lädt hoch, scheitert aber bei der Indexierung; die Zeile zeigt den Format-nicht-unterstützt-Fehler. Die Liste der unterstützten Formate wächst, wie die Pipeline wächst.
+Eine Datei in einem Format außerhalb dieser Liste — eine ältere Office-Datei (`.doc`, `.xls`, `.ppt`), ein Archiv, eine beliebige Binärdatei — lädt weiterhin hoch und bleibt als gespeicherte Datei verfügbar, aber Tale überspringt die Indexierungs-Pipeline für sie: Die Zeile zeigt **Nicht indexiert** statt eines Indexierungsfehlers, und Agents können ihren Inhalt nicht abrufen. Die Liste der unterstützten Formate wächst, wie die Pipeline wächst.
 
 ## Der Per-Dokument-Lebenszyklus
 

--- a/docs/en/platform/knowledge/documents.md
+++ b/docs/en/platform/knowledge/documents.md
@@ -29,13 +29,13 @@ The pipeline is idempotent on the source file's hash. Uploading the same file tw
 The pipeline handles the file types that cover the bulk of org knowledge:
 
 - **Text and code.** Markdown (`.md`), plain text (`.txt`), source code (every language Tale highlights — see the highlighter list).
-- **Documents.** PDF (`.pdf`), Word (`.docx`), Open Document (`.odt`), Rich Text (`.rtf`).
-- **Spreadsheets.** Excel (`.xlsx`), CSV (`.csv`), Open Document Sheet (`.ods`).
-- **Slides.** PowerPoint (`.pptx`), Open Document Presentation (`.odp`).
+- **Documents.** PDF (`.pdf`), Word (`.docx`).
+- **Spreadsheets.** Excel (`.xlsx`), CSV (`.csv`), TSV (`.tsv`).
+- **Slides.** PowerPoint (`.pptx`).
 - **Web pages.** HTML (`.html`) and the rendered output of a page crawl.
-- **Images.** PNG, JPG, WEBP, with OCR applied to extract any text.
+- **Images.** PNG, JPG, GIF, BMP, TIFF, WEBP, with OCR applied to extract any text.
 
-A file in an unsupported format uploads but fails indexing; the row surfaces the unsupported-format error. The list of supported formats grows as the pipeline does.
+A file in a format outside this list — an older Office file (`.doc`, `.xls`, `.ppt`), an archive, an arbitrary binary — still uploads and stays available as a stored file, but Tale skips the indexing pipeline for it: the row shows **Not indexed** instead of an indexing error, and agents cannot retrieve its content. The list of supported formats grows as the pipeline does.
 
 ## The per-document lifecycle
 

--- a/docs/fr/platform/knowledge/documents.md
+++ b/docs/fr/platform/knowledge/documents.md
@@ -29,13 +29,13 @@ La pipeline est idempotente sur le hash du fichier source. Téléverser le même
 La pipeline gère les types de fichiers qui couvrent le gros de la connaissance d'org :
 
 - **Texte et code.** Markdown (`.md`), texte brut (`.txt`), code source (chaque langage que Tale colorise — voir la liste du highlighter).
-- **Documents.** PDF (`.pdf`), Word (`.docx`), Open Document (`.odt`), Rich Text (`.rtf`).
-- **Tableurs.** Excel (`.xlsx`), CSV (`.csv`), Open Document Sheet (`.ods`).
-- **Présentations.** PowerPoint (`.pptx`), Open Document Presentation (`.odp`).
+- **Documents.** PDF (`.pdf`), Word (`.docx`).
+- **Tableurs.** Excel (`.xlsx`), CSV (`.csv`), TSV (`.tsv`).
+- **Présentations.** PowerPoint (`.pptx`).
 - **Pages web.** HTML (`.html`) et la sortie rendue d'un crawl de page.
-- **Images.** PNG, JPG, WEBP, avec OCR appliqué pour extraire tout texte.
+- **Images.** PNG, JPG, GIF, BMP, TIFF, WEBP, avec OCR appliqué pour extraire tout texte.
 
-Un fichier dans un format non supporté se téléverse mais échoue à l'indexation ; la ligne fait remonter l'erreur format-non-supporté. La liste des formats supportés grandit en même temps que la pipeline.
+Un fichier dans un format hors de cette liste — un ancien fichier Office (`.doc`, `.xls`, `.ppt`), une archive, un binaire quelconque — se téléverse quand même et reste disponible comme fichier stocké, mais Tale saute la pipeline d'indexation pour lui : la ligne affiche **Non indexé** au lieu d'une erreur d'indexation, et les agents ne peuvent pas récupérer son contenu. La liste des formats supportés grandit en même temps que la pipeline.
 
 ## Le cycle de vie par document
 

--- a/services/platform/app/features/automations/components/automation-assistant/chat-input.tsx
+++ b/services/platform/app/features/automations/components/automation-assistant/chat-input.tsx
@@ -296,11 +296,15 @@ export function ChatInput({
                           );
                         }
                         if (ragStatus === 'failed') {
+                          // Surface the stored failure reason (ragError) so
+                          // the user can tell a transient outage from a
+                          // rejected file without digging into logs.
                           return (
                             <Text
                               as="span"
                               variant="caption"
                               className="text-destructive"
+                              title={info?.error}
                             >
                               {tChat('indexingFailed')}
                             </Text>

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -747,11 +747,15 @@ export function ChatInput({
                           );
                         }
                         if (ragStatus === 'failed') {
+                          // Surface the stored failure reason (ragError) so
+                          // the user can tell a transient outage from a
+                          // rejected file without digging into logs.
                           return (
                             <Text
                               as="span"
                               variant="caption"
                               className="text-destructive"
+                              title={info?.error}
                             >
                               {tChat('indexingFailed')}
                             </Text>

--- a/services/platform/convex/file_metadata/internal_actions.ts
+++ b/services/platform/convex/file_metadata/internal_actions.ts
@@ -65,15 +65,25 @@ export const uploadFileToRag = internalAction({
         },
       );
     } catch (error) {
+      // For upstream HTTP errors, keep the response detail (e.g. FastAPI's
+      // "Unsupported file type: .xls …" or a secret-scanner rejection) —
+      // `bodySnippet` is already truncated and secret-scrubbed by
+      // `sanitizeError`. Without it, a RAG 4xx stores an unactionable
+      // "returned HTTP 400." as the failure reason.
+      const ragError = isUpstreamHttpError(error)
+        ? [error.safeMessage, error.bodySnippet].filter(Boolean).join(' ')
+        : error instanceof Error
+          ? error.message
+          : String(error);
       console.error(
-        `[uploadFileToRag] Failed to upload file ${args.storageId}: ${error instanceof Error ? error.message : String(error)}`,
+        `[uploadFileToRag] Failed to upload file ${args.storageId}: ${ragError}`,
       );
       await ctx.runMutation(
         internal.file_metadata.internal_mutations.updateFileRagStatus,
         {
           storageId: args.storageId,
           ragStatus: 'failed',
-          ragError: error instanceof Error ? error.message : String(error),
+          ragError,
         },
       );
     }

--- a/services/platform/convex/file_metadata/internal_mutations.test.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.test.ts
@@ -147,6 +147,30 @@ describe('saveFileMetadata (internal)', () => {
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
+  it('does not queue RAG for formats the RAG service cannot index', async () => {
+    const { ctx } = createMockCtx(null);
+    const handler = await getSaveHandler();
+
+    await handler(ctx, {
+      ...baseArgs,
+      fileName: 'legacy.xls',
+      contentType: 'application/vnd.ms-excel',
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({
+        ragStatus: undefined,
+        ragQueuedAt: undefined,
+      }),
+    );
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
   it('queries by storageId index', async () => {
     const { ctx, builder } = createMockCtx(null);
     const handler = await getSaveHandler();

--- a/services/platform/convex/file_metadata/internal_mutations.ts
+++ b/services/platform/convex/file_metadata/internal_mutations.ts
@@ -1,5 +1,6 @@
 import { v } from 'convex/values';
 
+import { isRagIndexableFile } from '../../lib/shared/file-types';
 import { internal } from '../_generated/api';
 import { internalMutation } from '../_generated/server';
 import {
@@ -73,14 +74,21 @@ export const saveFileMetadata = internalMutation({
       args.contentType.startsWith('audio/') ||
       args.contentType.startsWith('video/');
 
+    // Only queue formats the RAG service can actually index — anything
+    // else (legacy Office .doc/.xls/.ppt, misc text extensions) gets a
+    // deterministic HTTP 400 from RAG and a permanent "Index failed".
+    // Mirrors the public saveFileMetadata in mutations.ts.
+    const shouldIndex =
+      !isAudio && isRagIndexableFile(args.fileName, args.contentType);
+
     const id = await ctx.db.insert('fileMetadata', {
       organizationId: args.organizationId,
       storageId: args.storageId,
       fileName: args.fileName,
       contentType: args.contentType,
       size: args.size,
-      ragStatus: isAudio ? undefined : 'queued',
-      ragQueuedAt: isAudio ? undefined : Date.now(),
+      ragStatus: shouldIndex ? 'queued' : undefined,
+      ragQueuedAt: shouldIndex ? Date.now() : undefined,
       transcriptionStatus: isAudio ? 'queued' : undefined,
       ...(args.documentId !== undefined && { documentId: args.documentId }),
       ...(args.source !== undefined && { source: args.source }),
@@ -99,7 +107,7 @@ export const saveFileMetadata = internalMutation({
       }),
     });
 
-    if (!isAudio) {
+    if (shouldIndex) {
       await ctx.scheduler.runAfter(
         0,
         internal.file_metadata.internal_actions.uploadFileToRag,

--- a/services/platform/convex/file_metadata/mutations.test.ts
+++ b/services/platform/convex/file_metadata/mutations.test.ts
@@ -34,7 +34,12 @@ vi.mock('../lib/rate_limiter/helpers', () => ({
 vi.mock('../_generated/api', () => ({
   internal: {
     governance: { retention_cleanup: { runRetentionCleanup: 'mock' } },
-    file_metadata: { internal_actions: { uploadFileToRag: 'mock' } },
+    file_metadata: {
+      internal_actions: {
+        uploadFileToRag: 'mock',
+        extractFileMetadata: 'extract_mock',
+      },
+    },
   },
 }));
 
@@ -220,6 +225,121 @@ describe('saveFileMetadata (public)', () => {
       ragQueuedAt: expect.any(Number),
     });
     expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
+  it('does not queue RAG for formats the RAG service cannot index', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await handler(ctx, {
+      ...baseArgs,
+      fileName: 'legacy.doc',
+      contentType: 'application/msword',
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({
+        ragStatus: undefined,
+        ragQueuedAt: undefined,
+      }),
+    );
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
+  it('does not queue RAG for extension-less files with unknown MIME', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await handler(ctx, {
+      ...baseArgs,
+      fileName: 'README',
+      contentType: 'application/octet-stream',
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({ ragStatus: undefined }),
+    );
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
+  it.each([
+    [
+      'report.docx',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    [
+      'sheet.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+  ])('queues RAG for indexable office format %s', async (fileName, mime) => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await handler(ctx, { ...baseArgs, fileName, contentType: mime });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({
+        ragStatus: 'queued',
+        ragQueuedAt: expect.any(Number),
+      }),
+    );
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
+  it('clears stale failed RAG state on non-indexable re-upload without re-queueing', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const existing = {
+      _id: 'fm_existing',
+      organizationId: 'org_1',
+      storageId: 'storage_1',
+      fileName: 'legacy.doc',
+      contentType: 'application/msword',
+      size: 512,
+      ragStatus: 'failed',
+      ragError: 'RAG /api/v1/documents/upload returned HTTP 400.',
+    };
+    const { ctx } = createMockCtx(existing);
+    const handler = await getHandler();
+
+    await handler(ctx, {
+      ...baseArgs,
+      fileName: 'legacy.doc',
+      contentType: 'application/msword',
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_existing', {
+      fileName: 'legacy.doc',
+      contentType: 'application/msword',
+      size: 1024,
+      uploadedBy: 'user_1',
+      ragStatus: undefined,
+      ragError: undefined,
+      ragProgress: undefined,
+      ragQueuedAt: undefined,
+    });
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalledWith(
       0,
       'mock',
       expect.objectContaining({ storageId: 'storage_1' }),

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -1,6 +1,9 @@
 import { v } from 'convex/values';
 
-import { extractExtension } from '../../lib/shared/file-types';
+import {
+  extractExtension,
+  isRagIndexableFile,
+} from '../../lib/shared/file-types';
 import { internal } from '../_generated/api';
 import { mutation } from '../_generated/server';
 import { checkUploadPolicy } from '../governance/upload_enforcement';
@@ -74,6 +77,14 @@ export const saveFileMetadata = mutation({
       args.contentType.startsWith('audio/') ||
       args.contentType.startsWith('video/');
 
+    // Only queue formats the RAG service can actually index. Force-queueing
+    // anything else (legacy Office .doc/.xls/.ppt, misc text extensions)
+    // earns a deterministic HTTP 400 from RAG and a permanent "Index
+    // failed" badge. Non-indexable files keep ragStatus undefined — the
+    // audio pattern — and stay usable inline in chat.
+    const shouldIndex =
+      !isAudio && isRagIndexableFile(args.fileName, args.contentType);
+
     const now = Date.now();
 
     const existing = await ctx.db
@@ -101,7 +112,7 @@ export const saveFileMetadata = mutation({
       // left at `queued` by a silently-dropped scheduled action would
       // stay stuck forever.
       const needsRagRetry =
-        !isAudio &&
+        shouldIndex &&
         (existing.ragStatus === undefined || existing.ragStatus === 'failed');
       const needsTranscribeRetry =
         isAudio &&
@@ -113,6 +124,20 @@ export const saveFileMetadata = mutation({
         patchData.ragError = undefined;
         patchData.ragProgress = undefined;
         patchData.ragQueuedAt = now;
+      }
+      // A non-indexable re-upload clears RAG state left over from the
+      // pre-allowlist era (rows deterministically failed by RAG's 400),
+      // so the composer stops showing a stale "Index failed" for formats
+      // that were never indexable.
+      if (
+        !isAudio &&
+        !shouldIndex &&
+        (existing.ragStatus === 'failed' || existing.ragStatus === 'queued')
+      ) {
+        patchData.ragStatus = undefined;
+        patchData.ragError = undefined;
+        patchData.ragProgress = undefined;
+        patchData.ragQueuedAt = undefined;
       }
       if (needsTranscribeRetry) {
         patchData.transcriptionStatus = 'queued';
@@ -156,10 +181,12 @@ export const saveFileMetadata = mutation({
       fileName: args.fileName,
       contentType: args.contentType,
       size: args.size,
-      // RAG runs on the primary upload for non-audio; audio's transcript
-      // is indexed to RAG separately after transcription succeeds.
-      ragStatus: isAudio ? undefined : 'queued',
-      ragQueuedAt: isAudio ? undefined : now,
+      // RAG runs on the primary upload for indexable non-audio files;
+      // audio's transcript is indexed to RAG separately after
+      // transcription succeeds, and non-indexable formats are never
+      // queued (RAG would reject them with HTTP 400).
+      ragStatus: shouldIndex ? 'queued' : undefined,
+      ragQueuedAt: shouldIndex ? now : undefined,
       transcriptionStatus: isAudio ? 'queued' : undefined,
       uploadedBy: userId,
       ...(args.documentId !== undefined && { documentId: args.documentId }),
@@ -167,7 +194,7 @@ export const saveFileMetadata = mutation({
       ...(args.threadId !== undefined && { threadId: args.threadId }),
     });
 
-    if (!isAudio) {
+    if (shouldIndex) {
       await ctx.scheduler.runAfter(
         0,
         internal.file_metadata.internal_actions.uploadFileToRag,

--- a/services/platform/lib/shared/file-types.test.ts
+++ b/services/platform/lib/shared/file-types.test.ts
@@ -4,6 +4,7 @@ import {
   detectMediaMime,
   extractExtension,
   isAllowedDocumentUpload,
+  isRagIndexableFile,
   mimeToExtension,
   resolveFileType,
 } from './file-types';
@@ -374,5 +375,55 @@ describe('mimeToExtension', () => {
   it('handles uppercase MIME types', () => {
     expect(mimeToExtension('IMAGE/JPEG')).toBe('jpg');
     expect(mimeToExtension('Application/PDF')).toBe('pdf');
+  });
+});
+
+describe('isRagIndexableFile', () => {
+  it.each([
+    ['report.pdf', 'application/pdf'],
+    [
+      'report.docx',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    [
+      'sheet.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    ['notes.md', 'text/markdown'],
+    ['data.csv', 'text/csv'],
+    ['photo.png', 'image/png'],
+  ])('accepts indexable file %s', (fileName, contentType) => {
+    expect(isRagIndexableFile(fileName, contentType)).toBe(true);
+  });
+
+  it.each([
+    ['legacy.doc', 'application/msword'],
+    ['legacy.xls', 'application/vnd.ms-excel'],
+    ['legacy.ppt', 'application/vnd.ms-powerpoint'],
+    ['.env', 'application/octet-stream'],
+    ['.gitignore', 'text/plain'],
+    ['archive.zip', 'application/zip'],
+  ])('rejects non-indexable file %s', (fileName, contentType) => {
+    expect(isRagIndexableFile(fileName, contentType)).toBe(false);
+  });
+
+  it('falls back to the MIME type when the filename has no extension', () => {
+    // Mirrors ensureExtension in the RAG upload helper, which appends
+    // the canonical extension for the MIME before RAG's gate sees it.
+    expect(isRagIndexableFile('README', 'text/plain')).toBe(true);
+    expect(isRagIndexableFile('export', 'application/pdf')).toBe(true);
+  });
+
+  it('rejects extension-less files with unknown MIME', () => {
+    expect(isRagIndexableFile('README', 'application/octet-stream')).toBe(
+      false,
+    );
+    expect(isRagIndexableFile('blob', '')).toBe(false);
+  });
+
+  it('does not fall back to MIME when the extension is non-indexable', () => {
+    // Extension wins over MIME — a .doc reported as text/plain is still
+    // a .doc to RAG's extension gate.
+    expect(isRagIndexableFile('legacy.doc', 'text/plain')).toBe(false);
   });
 });

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -688,3 +688,124 @@ export function mimeToExtension(mime: string): string | undefined {
   const base = mime.split(';')[0].trim().toLowerCase();
   return MIME_TO_EXTENSION[base];
 }
+
+// ---------------------------------------------------------------------------
+// RAG indexability
+// ---------------------------------------------------------------------------
+
+/**
+ * Extensions (lowercase, no dot) the RAG service can index.
+ *
+ * MUST stay in sync with `SUPPORTED_EXTENSIONS` in
+ * `services/rag/app/routers/documents.py` (which derives from
+ * `tale_knowledge.extraction.router.ALL_SUPPORTED_EXTENSIONS` minus the
+ * deliberately-unindexed `SENSITIVE_EXTENSIONS` like `.log`). Parity is
+ * enforced by `services/rag/tests/test_extension_sync.py` — update both
+ * sides in the same commit.
+ *
+ * The platform accepts more formats than RAG can index (legacy Office
+ * `.doc`/`.xls`/`.ppt`, audio/video, misc text extensions). Those stay
+ * usable inline in chat but must not be queued for indexing — RAG rejects
+ * them with HTTP 400, which used to surface as a permanent "Index failed".
+ */
+export const RAG_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+  // Documents
+  'pdf',
+  'docx',
+  'pptx',
+  'xlsx',
+  // Images
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'tiff',
+  'tif',
+  'webp',
+  // Text / markup
+  'txt',
+  'md',
+  'mdx',
+  'rst',
+  'tex',
+  'csv',
+  'tsv',
+  'html',
+  'htm',
+  'css',
+  'scss',
+  'sass',
+  'less',
+  // Data / config
+  'json',
+  'yaml',
+  'yml',
+  'toml',
+  'xml',
+  'ini',
+  'cfg',
+  'conf',
+  'properties',
+  // Code
+  'js',
+  'jsx',
+  'ts',
+  'tsx',
+  'mjs',
+  'cjs',
+  'py',
+  'pyi',
+  'c',
+  'h',
+  'cpp',
+  'hpp',
+  'cc',
+  'cxx',
+  'rs',
+  'go',
+  'swift',
+  'kt',
+  'java',
+  'rb',
+  'php',
+  'pl',
+  'lua',
+  'r',
+  'scala',
+  'groovy',
+  'dart',
+  'ex',
+  'exs',
+  // Shell / scripts
+  'sh',
+  'bash',
+  'zsh',
+  'ps1',
+  'bat',
+  'cmd',
+  // Query / schema
+  'sql',
+  'graphql',
+  'gql',
+  'proto',
+  // Build / project
+  'gradle',
+  'cmake',
+  'lock',
+]);
+
+/**
+ * Whether the RAG service can index this file. Keyed on the filename
+ * extension, falling back to the canonical extension for the MIME type
+ * when the filename has none (mirrors `ensureExtension` in the RAG
+ * upload helper, which applies the same fallback before the service's
+ * extension gate).
+ */
+export function isRagIndexableFile(
+  fileName: string,
+  contentType: string,
+): boolean {
+  const ext = extractExtension(fileName) ?? mimeToExtension(contentType);
+  return ext !== undefined && RAG_INDEXABLE_EXTENSIONS.has(ext);
+}

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -708,7 +708,7 @@ export function mimeToExtension(mime: string): string | undefined {
  * usable inline in chat but must not be queued for indexing — RAG rejects
  * them with HTTP 400, which used to surface as a permanent "Index failed".
  */
-export const RAG_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+const RAG_INDEXABLE_EXTENSIONS: ReadonlySet<string> = new Set([
   // Documents
   'pdf',
   'docx',

--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -18,6 +18,7 @@ from fastapi import (
 )
 from fastapi.background import BackgroundTasks
 from loguru import logger
+from tale_knowledge.extraction.router import ALL_SUPPORTED_EXTENSIONS
 from tale_shared.db import acquire_with_retry
 
 from ..auth import require_org_slug
@@ -44,91 +45,19 @@ _BASE_FILE = File(..., description="Base document file")
 _COMPARISON_FILE = File(..., description="Comparison document file")
 _MAX_CHANGES_FORM = Form(default=500, ge=1, le=2000, description="Maximum number of change items")
 
-SUPPORTED_EXTENSIONS = {
-    # Documents
-    ".pdf",
-    ".docx",
-    ".pptx",
-    ".xlsx",
-    # Images
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".bmp",
-    ".tiff",
-    ".webp",
-    # Text / markup
-    ".txt",
-    ".md",
-    ".mdx",
-    ".rst",
-    ".tex",
-    ".csv",
-    ".tsv",
-    ".html",
-    ".htm",
-    ".css",
-    ".scss",
-    ".sass",
-    ".less",
-    # Data / config
-    ".json",
-    ".yaml",
-    ".yml",
-    ".toml",
-    ".xml",
-    ".ini",
-    ".cfg",
-    ".conf",
-    ".properties",
-    # Code
-    ".js",
-    ".jsx",
-    ".ts",
-    ".tsx",
-    ".mjs",
-    ".cjs",
-    ".py",
-    ".pyi",
-    ".c",
-    ".h",
-    ".cpp",
-    ".hpp",
-    ".cc",
-    ".cxx",
-    ".rs",
-    ".go",
-    ".swift",
-    ".kt",
-    ".java",
-    ".rb",
-    ".php",
-    ".pl",
-    ".lua",
-    ".r",
-    ".scala",
-    ".groovy",
-    ".dart",
-    ".ex",
-    ".exs",
-    # Shell / scripts
-    ".sh",
-    ".bash",
-    ".zsh",
-    ".ps1",
-    ".bat",
-    ".cmd",
-    # Query / schema
-    ".sql",
-    ".graphql",
-    ".gql",
-    ".proto",
-    # Build / project
-    ".gradle",
-    ".cmake",
-    ".lock",
-}
+# Secret-bearing formats the extractors can technically read but the
+# knowledge base deliberately refuses to index — defense in depth on top of
+# the secret scanner. Enforced by tests/test_document_helpers.py and
+# tests/test_secret_scanner.py.
+SENSITIVE_EXTENSIONS = frozenset({".env", ".log"})
+
+# Derived from the extraction router's capability set so the upload gate and
+# the extractors can never drift (a previously duplicated literal here
+# rejected `.tif`, which the image extractor supports). The platform-side
+# mirror lives at services/platform/lib/shared/file-types.ts
+# (RAG_INDEXABLE_EXTENSIONS); parity is enforced by
+# tests/test_extension_sync.py.
+SUPPORTED_EXTENSIONS = frozenset(ALL_SUPPORTED_EXTENSIONS - SENSITIVE_EXTENSIONS)
 
 
 async def _insert_processing_row(
@@ -204,8 +133,13 @@ async def _mark_completed(
 
 
 def _sanitize_error(exc: Exception, max_length: int = 500) -> str:
-    """Return a truncated error message safe for DB storage."""
-    msg = str(exc)
+    """Return a truncated error message safe for DB storage.
+
+    Falls back to the exception class name when ``str(exc)`` is empty
+    (e.g. a bare ``ValueError()``), so a failure never reaches the UI as
+    an unactionable "Unknown error".
+    """
+    msg = str(exc) or type(exc).__name__
     if len(msg) > max_length:
         return msg[:max_length] + "..."
     return msg

--- a/services/rag/tests/test_background_ingest.py
+++ b/services/rag/tests/test_background_ingest.py
@@ -179,6 +179,12 @@ class TestSanitizeError:
         result = _sanitize_error(exc, max_length=500)
         assert result == "a" * 500
 
+    def test_empty_message_falls_back_to_type_name(self):
+        from app.routers.documents import _sanitize_error
+
+        exc = ValueError()
+        assert _sanitize_error(exc) == "ValueError"
+
 
 @_requires_multipart
 class TestBackgroundIngest:

--- a/services/rag/tests/test_extension_sync.py
+++ b/services/rag/tests/test_extension_sync.py
@@ -1,35 +1,36 @@
-"""Cross-check that Python SUPPORTED_EXTENSIONS stays in sync with TypeScript file-types."""
+"""Cross-check that the RAG upload allowlist stays in sync with TypeScript file-types.
 
-import ast
+Two directions are enforced:
+
+- Forward: every extension RAG accepts is uploadable from the platform
+  (Python ⊆ TypeScript chat/document accept surface).
+- Reverse: the platform's RAG_INDEXABLE_EXTENSIONS gate (which decides what
+  gets queued for indexing) equals RAG's SUPPORTED_EXTENSIONS exactly, so the
+  platform never force-queues a format RAG rejects with HTTP 400.
+"""
+
 import re
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
-PYTHON_SOURCE = REPO_ROOT / "services" / "rag" / "app" / "routers" / "documents.py"
 TS_TEXT_FILE_TYPES = REPO_ROOT / "services" / "platform" / "lib" / "utils" / "text-file-types.ts"
 TS_FILE_TYPES = REPO_ROOT / "services" / "platform" / "lib" / "shared" / "file-types.ts"
 
-IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".tif", ".webp"}
 
 
-def _parse_python_supported_extensions() -> set[str]:
-    source = PYTHON_SOURCE.read_text()
-    match = re.search(
-        r"SUPPORTED_EXTENSIONS\s*=\s*\{([^}]+)\}",
-        source,
-        re.DOTALL,
-    )
-    assert match, "Could not find SUPPORTED_EXTENSIONS in documents.py"
-    raw_block = match.group(1)
-    without_comments = re.sub(r"#[^\n]*", "", raw_block)
-    return set(ast.literal_eval(f"[{without_comments}]"))
+def _python_supported_extensions() -> set[str]:
+    from app.routers.documents import SUPPORTED_EXTENSIONS
+
+    return set(SUPPORTED_EXTENSIONS)
 
 
 def _parse_ts_set_literal(source: str, variable_name: str) -> set[str]:
-    pattern = rf"(?:const|export const)\s+{variable_name}\s*=\s*new\s+Set\(\[\s*(.*?)\]\)"
+    pattern = (
+        rf"(?:const|export const)\s+{variable_name}"
+        rf"(?:\s*:\s*[\w<>\[\], .]+)?\s*=\s*new\s+Set\(\[\s*(.*?)\]\)"
+    )
     match = re.search(pattern, source, re.DOTALL)
     if not match:
         return set()
@@ -62,6 +63,11 @@ def _parse_ts_document_upload_extensions() -> set[str]:
     return extensions
 
 
+def _parse_ts_rag_indexable_extensions() -> set[str]:
+    source = TS_FILE_TYPES.read_text()
+    return {f".{ext}" for ext in _parse_ts_set_literal(source, "RAG_INDEXABLE_EXTENSIONS")}
+
+
 def _build_typescript_extensions() -> set[str]:
     text_file_exts = _parse_ts_text_file_extensions()
     doc_upload_exts = _parse_ts_document_upload_extensions()
@@ -70,35 +76,54 @@ def _build_typescript_extensions() -> set[str]:
 
 class TestExtensionSync:
     def test_python_is_subset_of_typescript(self):
-        python_exts = _parse_python_supported_extensions()
+        python_exts = _python_supported_extensions()
         ts_exts = _build_typescript_extensions()
 
         non_image_python = python_exts - IMAGE_EXTENSIONS
         missing = non_image_python - ts_exts
 
         assert not missing, (
-            f"Python SUPPORTED_EXTENSIONS has {len(missing)} extension(s) "
-            f"not found in TypeScript: {sorted(missing)}"
+            f"Python SUPPORTED_EXTENSIONS has {len(missing)} extension(s) not found in TypeScript: {sorted(missing)}"
+        )
+
+    def test_rag_indexable_extensions_match_python(self):
+        """Reverse parity: the platform's indexability gate equals RAG's allowlist.
+
+        A platform-only extension would be force-queued and rejected by RAG
+        (HTTP 400 → permanent "Index failed"); a RAG-only extension would
+        never be queued and silently skip indexing.
+        """
+        ts_exts = _parse_ts_rag_indexable_extensions()
+        python_exts = _python_supported_extensions()
+
+        only_ts = ts_exts - python_exts
+        only_python = python_exts - ts_exts
+
+        assert ts_exts == python_exts, (
+            f"RAG_INDEXABLE_EXTENSIONS (file-types.ts) and SUPPORTED_EXTENSIONS "
+            f"(app/routers/documents.py) drifted. Only in TypeScript: "
+            f"{sorted(only_ts)}; only in Python: {sorted(only_python)}"
         )
 
     def test_image_extensions_covered_by_wildcard(self):
         source = TS_TEXT_FILE_TYPES.read_text()
-        assert "'image/*'" in source or '"image/*"' in source or (
-            "image/*" in TS_FILE_TYPES.read_text()
-        ), "TypeScript TEXT_FILE_ACCEPT should include image/* wildcard"
+        assert "'image/*'" in source or '"image/*"' in source or ("image/*" in TS_FILE_TYPES.read_text()), (
+            "TypeScript TEXT_FILE_ACCEPT should include image/* wildcard"
+        )
 
-        python_exts = _parse_python_supported_extensions()
+        python_exts = _python_supported_extensions()
         python_images = python_exts & IMAGE_EXTENSIONS
         assert python_images, "Python SUPPORTED_EXTENSIONS should contain image extensions"
 
     def test_parsers_return_nonempty(self):
-        python_exts = _parse_python_supported_extensions()
+        python_exts = _python_supported_extensions()
         ts_exts = _build_typescript_extensions()
+        rag_indexable_exts = _parse_ts_rag_indexable_extensions()
 
-        assert len(python_exts) > 0, "Failed to parse any Python extensions"
+        assert len(python_exts) > 0, "Failed to load any Python extensions"
         assert len(ts_exts) > 0, "Failed to parse any TypeScript extensions"
+        assert len(rag_indexable_exts) > 0, "Failed to parse RAG_INDEXABLE_EXTENSIONS"
 
     def test_source_files_exist(self):
-        assert PYTHON_SOURCE.exists(), f"Missing {PYTHON_SOURCE}"
         assert TS_TEXT_FILE_TYPES.exists(), f"Missing {TS_TEXT_FILE_TYPES}"
         assert TS_FILE_TYPES.exists(), f"Missing {TS_FILE_TYPES}"

--- a/services/rag/tests/test_secret_scanner.py
+++ b/services/rag/tests/test_secret_scanner.py
@@ -126,19 +126,19 @@ class TestScanFileForSecrets:
 
 
 class TestSupportedExtensions:
-    """Verify .env and .log are no longer in SUPPORTED_EXTENSIONS."""
+    """Verify .env and .log stay out of SUPPORTED_EXTENSIONS.
 
-    @staticmethod
-    def _read_documents_source() -> str:
-        from pathlib import Path
-
-        source_path = Path(__file__).resolve().parent.parent / "app" / "routers" / "documents.py"
-        return source_path.read_text()
+    Asserts against the imported set (not the source text) so the guarantee
+    holds now that SUPPORTED_EXTENSIONS is derived from the extraction
+    router's capability set minus SENSITIVE_EXTENSIONS.
+    """
 
     def test_env_not_in_supported_extensions(self):
-        source = self._read_documents_source()
-        assert '".env"' not in source, ".env should not be in SUPPORTED_EXTENSIONS"
+        from app.routers.documents import SUPPORTED_EXTENSIONS
+
+        assert ".env" not in SUPPORTED_EXTENSIONS, ".env should not be in SUPPORTED_EXTENSIONS"
 
     def test_log_not_in_supported_extensions(self):
-        source = self._read_documents_source()
-        assert '".log"' not in source, ".log should not be in SUPPORTED_EXTENSIONS"
+        from app.routers.documents import SUPPORTED_EXTENSIONS
+
+        assert ".log" not in SUPPORTED_EXTENSIONS, ".log should not be in SUPPORTED_EXTENSIONS"


### PR DESCRIPTION
## What / why

Closes #1522.

Genuine `.docx`/`.xlsx` are supported end-to-end by the RAG indexer. The deterministic bug behind the "Index failed" reports is an allowlist gap: the platform accepts formats the RAG service rejects (legacy Office `.doc`/`.xls`/`.ppt` plus misc text extensions), force-queues them for indexing, and RAG's HTTP 400 lands as a permanent **Index failed** badge — which users read as broken Word/Excel support. (The original `.docx`/`.xlsx` reports most likely date to the embedding-credentials bug already fixed in #1476.)

### Changes

- **Shared indexability allowlist.** `RAG_INDEXABLE_EXTENSIONS` + `isRagIndexableFile()` in `lib/shared/file-types.ts` mirror RAG's `SUPPORTED_EXTENSIONS`. Both `saveFileMetadata` variants (chat upload + connectors/documents) only queue RAG indexing when the format is indexable; non-indexable files keep `ragStatus` undefined (the existing audio pattern), show no badge in the composer, show **Not indexed** in the Document Hub, and stay fully usable inline in chat (`.xls` is parsed by the platform-side Excel parser, text files are inlined).
- **RAG-side drift closed.** `SUPPORTED_EXTENSIONS` in `app/routers/documents.py` is now derived from the extraction router's `ALL_SUPPORTED_EXTENSIONS` minus an explicit `SENSITIVE_EXTENSIONS` (`.env`, `.log`) exclusion — fixing the `.tif` drift (extractor-supported, route-rejected) while preserving the deliberate secret-bearing-format posture that `test_document_helpers.py` / `test_secret_scanner.py` enforce.
- **Two-way parity is test-enforced.** `test_extension_sync.py` now imports the live Python set (instead of regex-on-source) and adds a reverse-parity test asserting `RAG_INDEXABLE_EXTENSIONS` equals RAG's set exactly, so the lists can never drift again.
- **Error fidelity.** `uploadFileToRag` stores the upstream response detail (`UpstreamHttpError.bodySnippet`, already truncated + secret-scrubbed) in `ragError` instead of an unactionable "returned HTTP 400."; RAG's `_sanitize_error` falls back to the exception class name when `str(exc)` is empty so failures never surface as "Unknown error".
- **Error surfaced in chat.** The **Index failed** badge in both chat composers now carries the stored `ragError` as a tooltip (`title`), matching the Document Hub which already shows the reason.
- **Stale-state cleanup.** Re-uploading a non-indexable file clears `ragStatus: 'failed'`/`ragError` left by the pre-allowlist era, so stuck badges self-heal.
- **Docs.** Corrected the supported-formats list on `platform/knowledge/documents.md` (en/de/fr) to match the pipeline (removed never-supported `.odt`/`.rtf`/`.ods`/`.odp`) and documented the new not-indexed behavior for out-of-list formats.

### Decision-gate recommendations baked in

- **No badge for non-indexable attachments** (plan-recommended): the composer falls through to the plain file-size row, exactly like audio uploads; the Hub shows **Not indexed**.
- **Sensitive text formats (`.env`, `.log`) deliberately stay unindexed** — encoded as `SENSITIVE_EXTENSIONS` rather than silently re-enabled by the derivation.
- **Legacy Office formats stay inline-only** (no `.doc`/`.xls`/`.ppt` conversion added to RAG); adding real legacy-Office support remains a possible follow-up issue.

### Coordination

#1498's agent is migrating the `xlsx` dependency to the SheetJS CDN tarball in parallel; this PR deliberately does **not** touch the `xlsx` dependency or the platform-side Excel parse path beyond the queue gating.

### Verification

Performed:
- `bun run check` at the repo root — all 40 turbo tasks green (format, lint, typecheck, 71 921 platform tests incl. the new `isRagIndexableFile` / queue-gating cases).
- `cd services/rag && uv run pytest` — 320 passed (incl. new reverse-parity, `_sanitize_error` fallback, and the updated secret-posture tests asserting on the imported set).
- `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test` — green.

Manual verification required (needs a running stack / the reporter's deployment):
- Upload `.docx`/`.xlsx` in chat → "Indexed"; upload `.doc`/`.xls` → no badge, spreadsheet content still usable in chat; stop the rag container and upload a `.docx` → badge appears with the failure reason visible on hover.
- Reporter's environment: `SELECT filename, status, error FROM private_knowledge.documents WHERE status='failed' ORDER BY updated_at DESC LIMIT 5;` to confirm no residual `.docx`/`.xlsx` failure exists post-#1476 (if errors show embedding-auth, it is a deployment/provider-config issue, not code).

Known limitation (follow-up candidate): the Document Hub **Index** retry button on a non-indexable file will still 400 → failed; with the improved `ragError` the dialog now shows the real reason. `retryRagIndexing` could early-return using the same helper.

### Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no loading states touched).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no new keys; tooltip shows the raw stored error, existing `indexingFailed` label reused).
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change.
- [x] Every touched docs page has a real opening and closing (pre-existing page; openings/closings unchanged and passing the docs tests).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A.