### PR TITLE
fix(deps): migrate xlsx to the SheetJS-maintained CDN tarball

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -10,39 +10,9 @@
 # .github/workflows/security.yml and .github/workflows/build.yml.
 # =============================================================================
 
-# =============================================================================
-# Vulnerability accept-risk entries (#1498)
-# =============================================================================
-# These are HIGH-severity advisories on dependencies with NO fixed release in
-# our channel. They do not affect the current gate (which blocks on CRITICAL),
-# but are recorded here with a compensating-control statement so that when the
-# Trivy gate ratchets to HIGH (tracked in #1498), the ratchet does not trip on
-# accepted, unfixable risk. Review each statement before relying on it; remove
-# the entry the moment a fixed release becomes available.
-vulnerabilities:
-  # xlsx (SheetJS community edition) is frozen at 0.18.5 on npm; these CVEs are
-  # only fixed in the maintained CDN build (https://cdn.sheetjs.com/), tracked
-  # as a separate migration. See the note in
-  # services/platform/convex/node_only/documents/internal_actions.ts.
-  - id: CVE-2023-30533 # Prototype Pollution (GHSA-4r6h-8v6p-xvw6)
-    statement: |
-      xlsx is used server-side only, from a Convex node action, to parse/
-      generate spreadsheets an authenticated org member explicitly uploaded or
-      requested — never anonymous or public input. Prototype pollution here
-      requires a crafted workbook reaching XLSX.read; the parse path is gated
-      behind auth + the org upload policy, and the action runs in an isolated
-      V8 with no privileged surface to escalate into. Accepted until the
-      CDN-build migration lands.
-  - id: CVE-2024-22363 # ReDoS (GHSA-5pgg-2g8v-p4x9)
-    statement: |
-      Same scope as CVE-2023-30533: server-side, authenticated upload path
-      only. A ReDoS at worst stalls the single document-processing action (its
-      own time budget bounds it); it cannot affect other requests. Accepted
-      until the CDN-build migration lands.
-  - id: CVE-2024-22364 # ReDoS (SheetJS community edition)
-    statement: |
-      Same scope and rationale as CVE-2024-22363. Accepted until the CDN-build
-      migration lands.
+# Vulnerability accept-risk entries go under a `vulnerabilities:` key with a
+# dated `statement:` documenting the compensating control. Remove each entry
+# the moment a fixed release becomes available.
 
 misconfigurations:
   # AVD-DS-0002: "Image user should not be 'root'"

--- a/bun.lock
+++ b/bun.lock
@@ -266,7 +266,7 @@
         "vite": "8.0.8",
         "vite-plugin-pwa": "1.3.0",
         "workbox-window": "7.4.1",
-        "xlsx": "0.18.5",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "yaml": "2.8.3",
         "zod": "4.3.6",
       },
@@ -2118,8 +2118,6 @@
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
-    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
-
     "age-encryption": ["age-encryption@0.3.0", "", { "dependencies": { "@noble/ciphers": "^2.1.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/post-quantum": "^0.5.3", "@scure/base": "^2.0.0" } }, "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
@@ -2258,8 +2256,6 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
-
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
@@ -2303,8 +2299,6 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
-
-    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
 
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
@@ -2375,8 +2369,6 @@
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
-
-    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
@@ -2709,8 +2701,6 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
-
-    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
 
@@ -3878,8 +3868,6 @@
 
     "sql-escaper": ["sql-escaper@1.3.3", "", {}, "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw=="],
 
-    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
-
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -4196,10 +4184,6 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
-
-    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
-
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
@@ -4244,7 +4228,7 @@
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
-    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
+    "xlsx": ["xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz", { "bin": { "xlsx": "./bin/xlsx.njs" } }, "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA=="],
 
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 
@@ -4371,8 +4355,6 @@
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@rollup/plugin-node-resolve/@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
-
-    "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@sentry/bundler-plugin-core/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -4636,8 +4618,6 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "to-buffer/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -4655,8 +4635,6 @@
     "typed-array-byte-offset/call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "typed-array-length/call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
-
-    "unplugin/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 

--- a/services/platform/app/features/documents/hooks/use-document-preview.ts
+++ b/services/platform/app/features/documents/hooks/use-document-preview.ts
@@ -27,10 +27,8 @@ export function useXlsxPreview(url: string) {
       if (!res.ok)
         throw new Error(`Failed to fetch spreadsheet (${res.status})`);
       const ab = await res.arrayBuffer();
-      // xlsx@0.18.5 npm build is frozen (SheetJS community edition); known
-      // CVEs are unfixed in this channel. Output is passed through
-      // DOMPurify, and migration to the maintained CDN build is tracked
-      // separately.
+      // xlsx resolves to the SheetJS-maintained CDN tarball pinned in
+      // package.json; output is passed through DOMPurify before rendering.
       const { read, utils } = await import('xlsx');
       const wb = read(ab);
       const ws = wb.Sheets[wb.SheetNames[0]];

--- a/services/platform/convex.json
+++ b/services/platform/convex.json
@@ -12,7 +12,6 @@
       "imapflow",
       "mailparser",
       "nodemailer",
-      "xlsx",
       "@modelcontextprotocol/sdk"
     ]
   },

--- a/services/platform/convex/node_only/documents/internal_actions.ts
+++ b/services/platform/convex/node_only/documents/internal_actions.ts
@@ -6,10 +6,10 @@
  */
 
 import { v } from 'convex/values';
-// xlsx@0.18.5 on npm is frozen (SheetJS community edition). Known CVEs
-// (CVE-2023-30533, CVE-2024-22363, CVE-2024-22364) are not fixed in this
-// channel; migration to the maintained CDN build (https://cdn.sheetjs.com/)
-// is tracked separately. Alerts for this dep are dismissed until then.
+// xlsx resolves to the SheetJS-maintained CDN tarball pinned in
+// services/platform/package.json (the npm release line is frozen at 0.18.5).
+// Renovate/OSV cannot track URL deps — bump the pin manually when
+// https://cdn.sheetjs.com/ announces a new release.
 import * as XLSX from 'xlsx';
 
 import { internalAction } from '../../_generated/server';

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -140,7 +140,7 @@
     "vite": "8.0.8",
     "vite-plugin-pwa": "1.3.0",
     "workbox-window": "7.4.1",
-    "xlsx": "0.18.5",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yaml": "2.8.3",
     "zod": "4.3.6"
   },


### PR DESCRIPTION
## What / why

Part of #1803 (security epic) · Part of #1498 (CVE gate ratchet). Stacked on #1854.

Removes the last prod-tree HIGH advisories: npm's `xlsx` is frozen at 0.18.5 with two open HIGHs (GHSA-4r6h-8v6p-xvw6 prototype pollution, GHSA-5pgg-2g8v-p4x9 ReDoS). SheetJS ships fixed releases off-registry, so the dependency now pins the maintained CDN tarball:

- `services/platform/package.json`: `xlsx: 0.18.5` → `https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz`. `bun.lock` records the tarball integrity hash (the supply-chain control for the off-registry source). Import specifier and all call-site APIs are unchanged (`read`, `write`, `sheet_to_json`, `sheet_to_html`, `aoa_to_sheet`, `book_new`, `book_append_sheet`).
- `services/platform/convex.json`: `xlsx` removed from `node.externalPackages` — Convex installs externals from the npm registry by version, which cannot resolve a URL dep; esbuild now bundles the CDN build into the node action (~960 KB, verified to bundle and load).
- `.trivyignore.yaml`: the three xlsx accept-risk entries are deleted — the advisories are fixed, not suppressed.
- Renovate/OSV cannot track URL deps; the pin is bumped manually when cdn.sheetjs.com announces a release (noted at both import sites).

## Decision-gate recommendations baked in

- **xlsx remediation**: SheetJS CDN tarball pin (recommended) over switching libraries (exceljs) or keeping 0.18.5 with suppressions + compensating controls.

## Coordination with #1522

The DOCX/XLSX "Index failed" fix (#1522) touches the same attachment parse path (`process_attachments.ts` → `parseExcel`). This migration may independently improve XLSX indexing (0.20.x contains parse fixes absent from 0.18.5) — whichever lands second should re-validate the chat-attachment XLSX path, and the #1522 repro file should be re-run against this build.

## Verification

Performed:
- Round-trip of every call-site API on the CDN build (generate → parse, incl. `sheet_to_html` for document preview).
- Full `bun audit --audit-level=high` → 0 advisories.
- Platform production build (`vite build`) emits the `vendor-xlsx` chunk from the CDN build.
- esbuild bundle of `convex/node_only/documents/internal_actions.ts` with xlsx inlined builds (~960 KB) and loads, exporting `generateExcel`/`parseExcel`.
- Targeted tests: `file-parsing`, `use-file-import`, `process_attachments` (39 tests) pass; platform typecheck green.
- `bun run check` green at the head of this PR chain.

Manual verification required:
- Deploy to a dev Convex deployment to confirm the node-action bundle within deploy limits and cold-start is acceptable (xlsx no longer external).
- Platform Docker image build: `bun install --production` (Dockerfile line 134) must reach `cdn.sheetjs.com` from the builder — confirm egress.
- Live-stack spreadsheet pass: chat-attach `.xlsx` (attachment indexing), customer/vendor/product import dialogs, agent Excel generation; re-run the #1522 repro file.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons — N/A.
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A.
- [x] Updated `/docs/{en,de,fr}/` — N/A (no user-visible behaviour change; parser version swap).
- [x] Docs opening/closing bar — N/A.
- [x] Ran `bun run --filter @tale/docs lint` and `test` — N/A.
- [x] Updated READMEs — N/A.
