### PR TITLE
feat(platform): passkey admin revoke, 2FA-wall options, sign-in audit

### DIFF
--- a/docs/de/platform/admin/two-factor-authentication.md
+++ b/docs/de/platform/admin/two-factor-authentication.md
@@ -1,15 +1,15 @@
 ---
 title: Zwei-Faktor-Authentifizierung
-description: TOTP-Registrierung, Backup-Codes, die organisationsweite Erzwingungsrichtlinie und wie ein Admin ein Mitglied zurücksetzt, das seinen Authenticator verloren hat. Lies das, wenn du 2FA für die Org verdrahtest oder einen Account wiederherstellst.
+description: TOTP-Registrierung, Passkeys, Backup-Codes, die organisationsweite Erzwingungsrichtlinie und wie ein Admin ein Mitglied zurücksetzt, das seinen Authenticator verloren hat. Lies das, wenn du 2FA für die Org verdrahtest oder einen Account wiederherstellst.
 ---
 
-Zwei-Faktor-Authentifizierung legt einen zweiten Identitätsbeweis über das Passwort — einen sechsstelligen Code aus einer Authenticator-App. Tale bringt TOTP (zeitbasierte Einmal-Passwörter) mit, kompatibel zu Google Authenticator, 1Password, Authy und jeder anderen App, die dem Standard folgt. Die Seite deckt die Pro-Benutzer-Registrierung ab, die Backup-Codes, die einen Account wiederherstellen, wenn das Telefon weg ist, die organisationsweite Erzwingungsrichtlinie und das Admin-Reset für ein ausgesperrtes Mitglied.
+Zwei-Faktor-Authentifizierung legt einen zweiten Identitätsbeweis über das Passwort — einen sechsstelligen Code aus einer Authenticator-App oder einen WebAuthn-Passkey. Tale bringt TOTP (zeitbasierte Einmal-Passwörter) mit, kompatibel zu Google Authenticator, 1Password, Authy und jeder anderen App, die dem Standard folgt, plus Passkeys als phishing-resistente Alternative. Die Seite deckt die Pro-Benutzer-Registrierung ab, Passkeys, die Backup-Codes, die einen Account wiederherstellen, wenn das Telefon weg ist, die organisationsweite Erzwingungsrichtlinie und das Admin-Reset für ein ausgesperrtes Mitglied.
 
 Zwei-Faktor ist standardmäßig optional. Admins können sie für die ganze Organisation verpflichtend machen, mit einem Karenzfenster, damit Mitglieder Zeit zum Einrichten haben.
 
 ## Pro-Benutzer-Registrierung
 
-Um 2FA für deinen eigenen Account einzuschalten, öffne **Account > Sicherheit**. Klick auf **Zwei-Faktor aktivieren**, bestätige dein Passwort und scanne den QR-Code mit einer Authenticator-App. Tippe den sechsstelligen Code ein, den die App zeigt, um zu prüfen, dass das Geheimnis aufgenommen wurde, und sichere dann die Backup-Codes, die der nächste Bildschirm zeigt. Die Codes erscheinen einmal — lade oder kopiere sie, bevor du auf **Fertig** klickst.
+Um 2FA für deinen eigenen Account einzuschalten, öffne **Konto > Sicherheit**. Klick auf **Zwei-Faktor aktivieren**, bestätige dein Passwort und scanne den QR-Code mit einer Authenticator-App. Tippe den sechsstelligen Code ein, den die App zeigt, um zu prüfen, dass das Geheimnis aufgenommen wurde, und sichere dann die Backup-Codes, die der nächste Bildschirm zeigt. Die Codes erscheinen einmal — lade oder kopiere sie, bevor du auf **Fertig** klickst.
 
 Derselbe Bildschirm trägt **Deaktivieren** und **Backup-Codes neu erzeugen**. Deaktivieren entfernt den zweiten Faktor; Neu-Erzeugen entwertet jeden vorherigen Backup-Code. Beide Aktionen verlangen das Account-Passwort zur Bestätigung.
 
@@ -18,6 +18,16 @@ Derselbe Bildschirm trägt **Deaktivieren** und **Backup-Codes neu erzeugen**. D
 Backup-Codes sind einmal verwendbare Strings, die die Plattform prägt, wenn 2FA aktiviert oder neu erzeugt wird. Jeder davon ersetzt den Authenticator-Code bei einem einzelnen Sign-in — nützlich, wenn das Telefon verloren ist, der Authenticator deinstalliert wurde oder du irgendwo ohne das Gerät feststeckst. Die Plattform beobachtet die verbleibende Anzahl und zeigt ein Niedrig-Banner, wenn nur noch wenige Codes übrig sind; das Banner verlinkt direkt auf den Neu-Erzeugen-Flow.
 
 Behandle Backup-Codes wie Passwörter. Lege sie in einen Passwort-Manager oder drucke sie und schliesse sie weg. Wer dein Passwort und einen Backup-Code hat, kann sich als du anmelden.
+
+## Passkeys
+
+Ein Passkey ist ein WebAuthn-Credential — Face ID, Touch ID, Windows Hello oder ein Hardware-Security-Key —, das bei jeder Anmeldung eine Challenge signiert, statt einen getippten Code zu liefern. Das Credential ist an die Origin der Site gebunden; eine täuschend ähnliche Phishing-Domain bekommt nichts, was sie wiederverwenden könnte. Ein Passkey ist dadurch phishing-resistent auf eine Art, die TOTP nicht erreicht, und er erfüllt eine erzwungene Zwei-Faktor-Richtlinie genau wie TOTP.
+
+Zum Registrieren öffne **Konto > Sicherheit** und klick auf **Passkey hinzufügen**. Gib dem Credential einen Namen, den du später wiedererkennst, und wähle den **Authenticator-Typ**: **Beliebig (empfohlen)** lässt den Browser alles anbieten, was verfügbar ist, **Dieses Gerät (Face ID, Touch ID, Windows Hello)** beschränkt die Zeremonie auf den eingebauten Authenticator, und **Security-Key oder Smartphone** auf einen externen. Den Rest erledigt der Browser mit der Registrierungszeremonie. Dieselbe Liste trägt **Entfernen** zum Widerrufen deiner eigenen Credentials.
+
+Ein registrierter Passkey funktioniert an drei Türen. Auf dem Login-Bildschirm meldet dich **Mit einem Passkey anmelden** ohne Passwort an — das Credential ist selbst ein starker Nachweis. Auf dem Bestätigungs-Bildschirm nach einem Passwort-Login ersetzt **Stattdessen einen Passkey verwenden** den sechsstelligen Code. Und auf dem Registrierungs-Bildschirm, zu dem eine erzwungene Richtlinie nicht registrierte Mitglieder leitet, sitzt **Stattdessen einen Passkey registrieren** neben der TOTP-Einrichtung — ein Mitglied, das nur einen Passkey registriert und nie TOTP, besteht die Richtlinie.
+
+Verliert ein Mitglied ein Gerät mit einem Passkey darauf, widerruft ein Admin das Credential: Öffne **Einstellungen > Organisation**, klick beim Mitglied auf **Mitglied bearbeiten** und entferne das Credential im Abschnitt **Passkeys** des Dialogs. Tale löscht das Credential und beendet jede aktive Sitzung des Mitglieds, sodass ein verlorener oder gestohlener Authenticator keine Sitzung am Leben hält. Registrierung, Selbst-Entfernen, Admin-Widerruf und jede Passkey-Anmeldung landen im Audit-Log (`passkey_added`, `passkey_removed`, `passkey_revoked_by_admin`, `passkey_sign_in`).
 
 ## Die Erzwingen-für-Org-Richtlinie
 
@@ -33,7 +43,7 @@ Ein Mitglied innerhalb des Karenzfensters sieht ein Countdown-Banner in der App,
 
 ## Admin-Reset für ein ausgesperrtes Mitglied
 
-Wenn ein Mitglied sein Telefon und seine Backup-Codes verliert, entfernt ein Admin den zweiten Faktor auf seinem Account. Öffne **Einstellungen > Mitglieder**, finde das Mitglied und klick auf **Zwei-Faktor zurücksetzen** in seiner Zeile. Tale deaktiviert 2FA für den Account und beendet jede aktive Sitzung, sodass sich das Mitglied beim nächsten Sign-in neu registriert.
+Wenn ein Mitglied sein Telefon und seine Backup-Codes verliert, entfernt ein Admin den zweiten Faktor auf seinem Account. Öffne **Einstellungen > Organisation**, klick beim Mitglied auf **Mitglied bearbeiten** und dann auf **Zwei-Faktor zurücksetzen** im Dialog. Tale deaktiviert 2FA für den Account und beendet jede aktive Sitzung, sodass sich das Mitglied beim nächsten Sign-in neu registriert.
 
 Das Zurücksetzen wird im Audit-Log unter `2fa_reset_by_admin` festgehalten. Greif dazu als Wiederherstellungs-Aktion — das Mitglied sollte sich sofort neu registrieren, wenn es wieder drin ist.
 

--- a/docs/en/platform/admin/two-factor-authentication.md
+++ b/docs/en/platform/admin/two-factor-authentication.md
@@ -1,9 +1,9 @@
 ---
 title: Two-factor authentication
-description: TOTP enrolment, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account.
+description: TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account.
 ---
 
-Two-factor authentication adds a second proof of identity on top of the password — a six-digit code from an authenticator app. Tale ships TOTP (time-based one-time passwords) compatible with Google Authenticator, 1Password, Authy, and any other app that follows the standard. The page covers per-user enrolment, the backup codes that recover an account when the phone is gone, the org-wide enforce policy, and the admin reset for a locked-out member.
+Two-factor authentication adds a second proof of identity on top of the password — a six-digit code from an authenticator app, or a WebAuthn passkey. Tale ships TOTP (time-based one-time passwords) compatible with Google Authenticator, 1Password, Authy, and any other app that follows the standard, plus passkeys for a phishing-resistant alternative. The page covers per-user enrolment, passkeys, the backup codes that recover an account when the phone is gone, the org-wide enforce policy, and the admin reset for a locked-out member.
 
 Two-factor is optional by default. Admins can require it for the whole organisation with a grace window so members have time to enrol.
 
@@ -19,6 +19,16 @@ Backup codes are single-use strings the platform mints when 2FA is enabled or re
 
 Treat backup codes like passwords. Store them in a password manager or print them and lock them away. Anyone who has both your password and a backup code can sign in as you.
 
+## Passkeys
+
+A passkey is a WebAuthn credential — Face ID, Touch ID, Windows Hello, or a hardware security key — that signs a per-login challenge instead of producing a typed code. The credential is bound to the site's origin, so a look-alike phishing domain gets nothing to replay; that makes a passkey phishing-resistant in a way TOTP is not, and it satisfies an enforced two-factor policy exactly like TOTP does.
+
+To register one, open **Account > Security** and click **Add a passkey**. Give the credential a name you will recognise later, then pick the **Authenticator type**: **Any (recommended)** lets the browser offer everything available, **This device (Face ID, Touch ID, Windows Hello)** narrows the ceremony to the built-in authenticator, and **Security key or phone** narrows it to a roaming one. The browser runs the registration ceremony from there. The same list carries **Remove** for revoking your own credentials.
+
+A registered passkey works at three doors. On the login screen, **Sign in with a passkey** signs you in without typing the password — the credential is itself strong proof. On the verification screen after a password login, **Use a passkey instead** replaces the six-digit code. And on the enrolment screen an enforced policy routes unenrolled members to, **Register a passkey instead** sits next to the TOTP setup — a member who registers only a passkey, never TOTP, passes the policy.
+
+When a member loses a device with a passkey on it, an Admin revokes the credential: open **Settings > Organization**, click **Edit member** on the member, and remove the credential from the **Passkeys** section of the dialog. Tale deletes the credential and ends every active session of that member, so a lost or stolen authenticator can't keep a session alive. Registration, self-removal, admin revocation, and every passkey sign-in land in the audit log (`passkey_added`, `passkey_removed`, `passkey_revoked_by_admin`, `passkey_sign_in`).
+
 ## The enforce-for-org policy
 
 Admins can require two-factor for every password-authenticated member of the organisation. Open **Settings > Governance > Authentication** and toggle **Require two-factor authentication**. The policy carries a grace period (in days) that gives each member time to enrol from their first sign-in under the policy; set it to zero for immediate enforcement.
@@ -33,7 +43,7 @@ A member inside the grace window sees a count-down banner in the app pointing th
 
 ## Admin reset for a locked-out member
 
-When a member loses their phone and their backup codes, an Admin clears the second factor on their account. Open **Settings > People**, find the member, and click **Reset two-factor** on their row. Tale disables 2FA for the account and ends every active session, so the member re-enrols on their next sign-in.
+When a member loses their phone and their backup codes, an Admin clears the second factor on their account. Open **Settings > Organization**, click **Edit member** on the member, and click **Reset two-factor** in the dialog. Tale disables 2FA for the account and ends every active session, so the member re-enrols on their next sign-in.
 
 The reset is recorded in the audit log under `2fa_reset_by_admin`. Reach for it as a recovery action — the member should re-enrol immediately once they are back in.
 

--- a/docs/fr/platform/admin/two-factor-authentication.md
+++ b/docs/fr/platform/admin/two-factor-authentication.md
@@ -1,9 +1,9 @@
 ---
 title: Authentification à deux facteurs
-description: Inscription TOTP, codes de secours, la politique d'application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l'org ou que tu récupères un compte.
+description: Inscription TOTP, passkeys, codes de secours, la politique d'application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l'org ou que tu récupères un compte.
 ---
 
-L'authentification à deux facteurs ajoute une seconde preuve d'identité par-dessus le mot de passe — un code à six chiffres d'une appli authenticator. Tale embarque TOTP (mots de passe à usage unique basés sur le temps) compatible avec Google Authenticator, 1Password, Authy et toute autre appli qui suit le standard. La page couvre l'inscription par utilisateur, les codes de secours qui récupèrent un compte quand le téléphone n'est plus là, la politique d'application org-large et la réinitialisation admin pour un membre verrouillé.
+L'authentification à deux facteurs ajoute une seconde preuve d'identité par-dessus le mot de passe — un code à six chiffres d'une appli authenticator, ou un passkey WebAuthn. Tale embarque TOTP (mots de passe à usage unique basés sur le temps) compatible avec Google Authenticator, 1Password, Authy et toute autre appli qui suit le standard, plus les passkeys comme alternative résistante au phishing. La page couvre l'inscription par utilisateur, les passkeys, les codes de secours qui récupèrent un compte quand le téléphone n'est plus là, la politique d'application org-large et la réinitialisation admin pour un membre verrouillé.
 
 La 2FA est optionnelle par défaut. Les Administrateurs peuvent l'exiger pour toute l'organisation avec une fenêtre de grâce pour que les membres aient le temps de s'inscrire.
 
@@ -19,6 +19,16 @@ Les codes de secours sont des chaînes à usage unique que la plateforme frappe 
 
 Traite les codes de secours comme des mots de passe. Range-les dans un gestionnaire de mots de passe ou imprime-les et mets-les sous clé. Quiconque a ton mot de passe et un code de secours peut se connecter à ta place.
 
+## Passkeys
+
+Un passkey est un identifiant WebAuthn — Face ID, Touch ID, Windows Hello ou une clé de sécurité matérielle — qui signe un défi à chaque connexion au lieu de produire un code à taper. L'identifiant est lié à l'origine du site : un domaine de phishing qui lui ressemble n'obtient rien à rejouer. Un passkey résiste donc au phishing d'une façon que TOTP n'atteint pas, et il satisfait une politique de deux facteurs appliquée exactement comme TOTP.
+
+Pour en enregistrer un, ouvre **Compte > Sécurité** et clique sur **Ajouter un passkey**. Donne à l'identifiant un nom que tu reconnaîtras plus tard, puis choisis le **Type d'authentificateur** : **Indifférent (recommandé)** laisse le navigateur proposer tout ce qui est disponible, **Cet appareil (Face ID, Touch ID, Windows Hello)** restreint la cérémonie à l'authentificateur intégré, et **Clé de sécurité ou téléphone** à un authentificateur itinérant. Le navigateur déroule la cérémonie d'enregistrement à partir de là. La même liste porte **Supprimer** pour révoquer tes propres passkeys.
+
+Un passkey enregistré fonctionne à trois portes. Sur l'écran de connexion, **Se connecter avec un passkey** te connecte sans taper le mot de passe — l'identifiant est lui-même une preuve forte. Sur l'écran de vérification après une connexion par mot de passe, **Utiliser un passkey à la place** remplace le code à six chiffres. Et sur l'écran d'inscription vers lequel une politique appliquée route les membres non inscrits, **Enregistrer un passkey à la place** se trouve à côté de la configuration TOTP — un membre qui n'enregistre qu'un passkey, jamais TOTP, passe la politique.
+
+Quand un membre perd un appareil qui porte un passkey, un Administrateur révoque l'identifiant : ouvre **Paramètres > Organisation**, clique sur **Modifier le membre** et supprime l'identifiant dans la section **Passkeys** du dialogue. Tale supprime l'identifiant et met fin à chaque session active du membre, donc un authentificateur perdu ou volé ne garde aucune session en vie. L'enregistrement, la suppression par soi-même, la révocation admin et chaque connexion par passkey atterrissent dans le journal d'audit (`passkey_added`, `passkey_removed`, `passkey_revoked_by_admin`, `passkey_sign_in`).
+
 ## La politique d'application pour l'org
 
 Les Administrateurs peuvent exiger le second facteur pour chaque membre authentifié par mot de passe de l'organisation. Ouvre **Paramètres > Gouvernance > Authentification** et bascule **Exiger l'authentification à deux facteurs**. La politique porte une période de grâce (en jours) qui donne à chaque membre du temps pour s'inscrire à partir de sa première connexion sous la politique ; mets-la à zéro pour une application immédiate.
@@ -33,7 +43,7 @@ Un membre dans la fenêtre de grâce voit une bannière de compte à rebours dan
 
 ## Réinitialisation admin pour un membre verrouillé
 
-Quand un membre perd son téléphone et ses codes de secours, un Administrateur efface le second facteur sur son compte. Ouvre **Paramètres > Membres**, trouve le membre et clique sur **Réinitialiser la deux-facteurs** sur sa ligne. Tale désactive la 2FA pour le compte et met fin à chaque session active, donc le membre se réinscrit à sa prochaine connexion.
+Quand un membre perd son téléphone et ses codes de secours, un Administrateur efface le second facteur sur son compte. Ouvre **Paramètres > Organisation**, clique sur **Modifier le membre** puis sur **Réinitialiser le double facteur** dans le dialogue. Tale désactive la 2FA pour le compte et met fin à chaque session active, donc le membre se réinscrit à sa prochaine connexion.
 
 La réinitialisation est enregistrée dans le journal d'audit sous `2fa_reset_by_admin`. Va vers ça comme action de récupération — le membre doit se réinscrire immédiatement une fois revenu.
 

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -269,7 +269,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Zwei-Faktor-Authentifizierung",
-      "description": "TOTP-Registrierung, Backup-Codes, die organisationsweite Erzwingungsrichtlinie und wie ein Admin ein Mitglied zurücksetzt, das seinen Authenticator verloren hat. Lies das, wenn du 2FA für die Org verdrahtest oder einen Account wiederherstellst."
+      "description": "TOTP-Registrierung, Passkeys, Backup-Codes, die organisationsweite Erzwingungsrichtlinie und wie ein Admin ein Mitglied zurücksetzt, das seinen Authenticator verloren hat. Lies das, wenn du 2FA für die Org verdrahtest oder einen Account wiederherstellst."
     }
   },
   "de:platform/admin/integrations": {
@@ -1293,7 +1293,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Authentification à deux facteurs",
-      "description": "Inscription TOTP, codes de secours, la politique d'application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l'org ou que tu récupères un compte."
+      "description": "Inscription TOTP, passkeys, codes de secours, la politique d'application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l'org ou que tu récupères un compte."
     }
   },
   "fr:platform/admin/integrations": {
@@ -2317,7 +2317,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Two-factor authentication",
-      "description": "TOTP enrolment, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account."
+      "description": "TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account."
     }
   },
   "en:platform/admin/integrations": {

--- a/services/platform/app/features/settings/account/components/passkey-register-dialog.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-register-dialog.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Input } from '@/app/components/ui/forms/input';
+import { Select } from '@/app/components/ui/forms/select';
+import { authClient } from '@/lib/auth-client';
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * 'any' lets the browser offer every available authenticator (platform
+ * preferred); the explicit values narrow the WebAuthn ceremony to the
+ * built-in authenticator ('platform') or a roaming one like a security
+ * key or phone ('cross-platform').
+ */
+type AttachmentChoice = 'any' | 'platform' | 'cross-platform';
+
+interface PasskeyRegisterDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Fired after the WebAuthn ceremony succeeded and the credential is stored. */
+  onRegistered: () => void;
+}
+
+/**
+ * Name-and-register dialog for a new WebAuthn passkey (#1508). Shared by
+ * the account-settings `PasskeySection` and the `/2fa-enroll` wall so both
+ * run the exact same ceremony: prompt for a recognizable name, optionally
+ * narrow the authenticator attachment, then drive
+ * `navigator.credentials.create` via `authClient.passkey.addPasskey`.
+ */
+export function PasskeyRegisterDialog({
+  open,
+  onOpenChange,
+  onRegistered,
+}: PasskeyRegisterDialogProps) {
+  const { t } = useT('twoFactor');
+
+  const [name, setName] = useState('');
+  const [attachment, setAttachment] = useState<AttachmentChoice>('any');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setName('');
+    setAttachment('any');
+    setError(null);
+  }
+
+  async function register(passkeyName: string) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Drives the WebAuthn registration ceremony (navigator.credentials.create).
+      const result = await authClient.passkey.addPasskey({
+        name: passkeyName,
+        // 'any' = omit the field so the browser offers both kinds.
+        ...(attachment !== 'any' && { authenticatorAttachment: attachment }),
+      });
+      if (result?.error) {
+        setError(result.error.message ?? t('passkeys.errors.registerFailed'));
+        return;
+      }
+      onOpenChange(false);
+      reset();
+      onRegistered();
+    } catch {
+      // Thrown when the user dismisses the browser prompt or no authenticator
+      // is available — surface a non-alarming message.
+      setError(t('passkeys.errors.registerFailed'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <FormDialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) {
+          onOpenChange(false);
+          reset();
+        }
+      }}
+      title={t('passkeys.addButton')}
+      description={t('passkeys.namePromptDescription')}
+      submitText={t('passkeys.addButton')}
+      isSubmitting={submitting}
+      isDirty={name.length > 0}
+      isValid={name.trim().length > 0}
+      onSubmit={(e) => {
+        e?.preventDefault?.();
+        if (!submitting && name.trim()) void register(name.trim());
+      }}
+    >
+      <Input
+        id="passkey-name"
+        label={t('passkeys.nameLabel')}
+        placeholder={t('passkeys.namePlaceholder')}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={submitting}
+        errorMessage={error ?? undefined}
+      />
+      <Select
+        value={attachment}
+        onValueChange={(value) => {
+          if (
+            value === 'any' ||
+            value === 'platform' ||
+            value === 'cross-platform'
+          ) {
+            setAttachment(value);
+          }
+        }}
+        disabled={submitting}
+        label={t('passkeys.attachment.label')}
+        options={[
+          { value: 'any', label: t('passkeys.attachment.any') },
+          { value: 'platform', label: t('passkeys.attachment.platform') },
+          {
+            value: 'cross-platform',
+            label: t('passkeys.attachment.crossPlatform'),
+          },
+        ]}
+      />
+    </FormDialog>
+  );
+}

--- a/services/platform/app/features/settings/account/components/passkey-section.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.tsx
@@ -7,13 +7,13 @@ import { Text } from '@tale/ui/text';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
-import { Input } from '@/app/components/ui/forms/input';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
+
+import { PasskeyRegisterDialog } from './passkey-register-dialog';
 
 // Minimal shape of a better-auth passkey row (the client returns more fields;
 // we only render these). `name` is optional — older keys may lack it.
@@ -28,7 +28,8 @@ const PASSKEYS_QUERY_KEY = ['passkeys', 'list'] as const;
 /**
  * WebAuthn / passkey management (#1508). Lists the current user's registered
  * passkeys, lets them register a new one (the browser drives the ceremony via
- * `authClient.passkey.addPasskey`), and revoke existing ones.
+ * `authClient.passkey.addPasskey` inside `PasskeyRegisterDialog`), and revoke
+ * existing ones.
  *
  * Sits beside `TwoFactorSection`; a passkey counts as a phishing-resistant
  * second factor and satisfies an enforced org 2FA policy alongside TOTP.
@@ -41,10 +42,7 @@ export function PasskeySection() {
   // SSO-only users don't manage local credentials here (the IdP owns auth).
   const { data: status } = useConvexQuery(api.two_factor.queries.getStatus, {});
 
-  const [nameDialogOpen, setNameDialogOpen] = useState(false);
-  const [name, setName] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
 
   const { data: passkeys, isLoading } = useQuery({
     queryKey: PASSKEYS_QUERY_KEY,
@@ -62,31 +60,6 @@ export function PasskeySection() {
 
   function invalidate() {
     void queryClient.invalidateQueries({ queryKey: PASSKEYS_QUERY_KEY });
-  }
-
-  async function register(passkeyName: string) {
-    setSubmitting(true);
-    setError(null);
-    try {
-      // Drives the WebAuthn registration ceremony (navigator.credentials.create).
-      const result = await authClient.passkey.addPasskey({
-        name: passkeyName,
-      });
-      if (result?.error) {
-        setError(result.error.message ?? t('passkeys.errors.registerFailed'));
-        return;
-      }
-      setNameDialogOpen(false);
-      setName('');
-      toast({ title: t('passkeys.registered'), variant: 'success' });
-      invalidate();
-    } catch {
-      // Thrown when the user dismisses the browser prompt or no authenticator
-      // is available — surface a non-alarming message.
-      setError(t('passkeys.errors.registerFailed'));
-    } finally {
-      setSubmitting(false);
-    }
   }
 
   async function revoke(id: string) {
@@ -146,42 +119,23 @@ export function PasskeySection() {
         )}
 
         <div>
-          <Button variant="secondary" onClick={() => setNameDialogOpen(true)}>
+          <Button
+            variant="secondary"
+            onClick={() => setRegisterDialogOpen(true)}
+          >
             {t('passkeys.addButton')}
           </Button>
         </div>
       </Stack>
 
-      <FormDialog
-        open={nameDialogOpen}
-        onOpenChange={(o) => {
-          if (!o) {
-            setNameDialogOpen(false);
-            setName('');
-            setError(null);
-          }
+      <PasskeyRegisterDialog
+        open={registerDialogOpen}
+        onOpenChange={setRegisterDialogOpen}
+        onRegistered={() => {
+          toast({ title: t('passkeys.registered'), variant: 'success' });
+          invalidate();
         }}
-        title={t('passkeys.addButton')}
-        description={t('passkeys.namePromptDescription')}
-        submitText={t('passkeys.addButton')}
-        isSubmitting={submitting}
-        isDirty={name.length > 0}
-        isValid={name.trim().length > 0}
-        onSubmit={(e) => {
-          e?.preventDefault?.();
-          if (!submitting && name.trim()) void register(name.trim());
-        }}
-      >
-        <Input
-          id="passkey-name"
-          label={t('passkeys.nameLabel')}
-          placeholder={t('passkeys.namePlaceholder')}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          disabled={submitting}
-          errorMessage={error ?? undefined}
-        />
-      </FormDialog>
+      />
     </PageSection>
   );
 }

--- a/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@tale/ui/button';
+import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -27,10 +28,12 @@ import { createOptionalPasswordSchema } from '@/lib/shared/schemas/password';
 
 import {
   useResetMemberTwoFactor,
+  useRevokeMemberPasskey,
   useSetMemberPassword,
   useUpdateMemberDisplayName,
   useUpdateMemberRole,
 } from '../hooks/mutations';
+import { useMemberPasskeys } from '../hooks/queries';
 import { isMemberRole } from '../utils/role-guards';
 
 type EditMemberFormData = {
@@ -48,6 +51,7 @@ type MemberLite = {
   role?: string;
   email?: string;
   twoFactorEnabled?: boolean;
+  passkeyCount?: number;
 };
 
 interface EditMemberDialogProps {
@@ -324,6 +328,10 @@ export function EditMemberDialog({
           }}
         />
       )}
+
+      {!isEditingSelf && member && (member.passkeyCount ?? 0) > 0 && (
+        <PasskeyAdminControl memberId={member._id} />
+      )}
     </FormDialog>
   );
 }
@@ -363,6 +371,93 @@ function TwoFactorResetControl({
         variant="destructive"
         isLoading={resetting}
         onConfirm={onReset}
+      />
+    </FormSection>
+  );
+}
+
+/**
+ * Admin list/revoke of a member's WebAuthn passkeys (#1508). Mirrors
+ * `TwoFactorResetControl`: per-credential Remove behind a destructive
+ * confirm. Revoking also ends every session of the member, so the copy
+ * says so. Only rendered when the member actually has passkeys (gated on
+ * `passkeyCount` from the members list — no per-row query for the rest).
+ */
+function PasskeyAdminControl({ memberId }: { memberId: string }) {
+  const { t } = useT('twoFactor');
+  const { data: passkeys } = useMemberPasskeys(memberId);
+  const { mutateAsync: revokePasskey } = useRevokeMemberPasskey();
+  const [confirmTarget, setConfirmTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  if (!passkeys || passkeys.length === 0) return null;
+
+  async function handleRevoke() {
+    if (!confirmTarget) return;
+    setRevoking(true);
+    try {
+      await revokePasskey({ memberId, passkeyId: confirmTarget.id });
+      toast({ title: t('passkeys.revoked'), variant: 'success' });
+      setConfirmTarget(null);
+    } catch {
+      toast({
+        title: t('passkeys.errors.revokeFailed'),
+        variant: 'destructive',
+      });
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  return (
+    <FormSection className="border-t pt-4">
+      <Text className="text-sm font-medium">{t('admin.passkeys.title')}</Text>
+      <Stack gap={2}>
+        {passkeys.map((pk) => {
+          const name = pk.name?.trim() || t('passkeys.unnamed');
+          return (
+            <HStack
+              key={pk.id}
+              justify="between"
+              align="center"
+              className="rounded-md border px-3 py-2"
+            >
+              <Stack gap={0} className="min-w-0">
+                <Text className="truncate text-sm font-medium">{name}</Text>
+                <Text variant="muted" className="text-xs">
+                  {pk.deviceType === 'multiDevice'
+                    ? t('admin.passkeys.deviceTypes.multiDevice')
+                    : t('admin.passkeys.deviceTypes.singleDevice')}
+                </Text>
+              </Stack>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmTarget({ id: pk.id, name })}
+              >
+                {t('passkeys.revokeButton')}
+              </Button>
+            </HStack>
+          );
+        })}
+      </Stack>
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setConfirmTarget(null);
+        }}
+        title={t('admin.passkeys.confirmTitle')}
+        description={t('admin.passkeys.confirmDescription', {
+          name: confirmTarget?.name ?? '',
+        })}
+        confirmText={t('passkeys.revokeButton')}
+        variant="destructive"
+        isLoading={revoking}
+        onConfirm={handleRevoke}
       />
     </FormSection>
   );

--- a/services/platform/app/features/settings/organization/components/member-row-actions.tsx
+++ b/services/platform/app/features/settings/organization/components/member-row-actions.tsx
@@ -22,6 +22,7 @@ type MemberItem = {
   role?: string;
   displayName?: string;
   twoFactorEnabled?: boolean;
+  passkeyCount?: number;
 };
 
 interface MemberRowActionsProps {

--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -28,6 +28,8 @@ type Member = {
   email?: string;
   role?: string;
   displayName?: string;
+  twoFactorEnabled?: boolean;
+  passkeyCount?: number;
 };
 
 interface MemberContext {

--- a/services/platform/app/features/settings/organization/hooks/mutations.ts
+++ b/services/platform/app/features/settings/organization/hooks/mutations.ts
@@ -28,3 +28,7 @@ export function useTransferOwnership() {
 export function useResetMemberTwoFactor() {
   return useConvexMutation(api.two_factor.mutations.resetForUser);
 }
+
+export function useRevokeMemberPasskey() {
+  return useConvexMutation(api.two_factor.mutations.revokePasskeyForMember);
+}

--- a/services/platform/app/features/settings/organization/hooks/queries.ts
+++ b/services/platform/app/features/settings/organization/hooks/queries.ts
@@ -6,6 +6,10 @@ export type Member = ConvexItemOf<
   typeof api.members.queries.listByOrganization
 >;
 
+export type MemberPasskey = ConvexItemOf<
+  typeof api.two_factor.queries.listPasskeysForMember
+>;
+
 export function useMembers(organizationId: string) {
   const { data, isLoading } = useConvexQuery(
     api.members.queries.listByOrganization,
@@ -16,4 +20,15 @@ export function useMembers(organizationId: string) {
     members: data,
     isLoading,
   };
+}
+
+/**
+ * Admin view of a member's registered passkeys (#1508). Pass `undefined`
+ * to skip — the member edit dialog only fetches while it is open.
+ */
+export function useMemberPasskeys(memberId: string | undefined) {
+  return useConvexQuery(
+    api.two_factor.queries.listPasskeysForMember,
+    memberId ? { memberId } : 'skip',
+  );
 }

--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 
 import { Input } from '@/app/components/ui/forms/input';
 import { LogoLink } from '@/app/components/ui/logo/logo-link';
+import { PasskeyRegisterDialog } from '@/app/features/settings/account/components/passkey-register-dialog';
 import { useReactQueryClient } from '@/app/hooks/use-react-query-client';
 import { toast } from '@/app/hooks/use-toast';
 import { authClient } from '@/lib/auth-client';
@@ -80,6 +81,7 @@ function TwoFactorEnrollPage() {
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [passkeyDialogOpen, setPasskeyDialogOpen] = useState(false);
 
   async function beginEnrollment(e: React.FormEvent) {
     e.preventDefault();
@@ -156,26 +158,41 @@ function TwoFactorEnrollPage() {
           </Stack>
 
           {step.kind === 'password' && (
-            <form onSubmit={beginEnrollment}>
-              <Stack gap={4}>
-                <Input
-                  id="password"
-                  type="password"
-                  autoComplete="current-password"
-                  label={t('confirmPassword.label')}
-                  value={password}
-                  onChange={(e) => {
-                    setPassword(e.target.value);
-                    setError(null);
-                  }}
-                  errorMessage={error ?? undefined}
-                  disabled={submitting}
-                />
-                <Button type="submit" disabled={!password || submitting}>
-                  {t('enrollment.enableButton')}
-                </Button>
-              </Stack>
-            </form>
+            <Stack gap={4}>
+              <form onSubmit={beginEnrollment}>
+                <Stack gap={4}>
+                  <Input
+                    id="password"
+                    type="password"
+                    autoComplete="current-password"
+                    label={t('confirmPassword.label')}
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      setError(null);
+                    }}
+                    errorMessage={error ?? undefined}
+                    disabled={submitting}
+                  />
+                  <Button type="submit" disabled={!password || submitting}>
+                    {t('enrollment.enableButton')}
+                  </Button>
+                </Stack>
+              </form>
+              {/* A passkey is a phishing-resistant second factor and satisfies
+                  the enforced policy exactly like TOTP (#1508). The session is
+                  intentionally kept alive on this wall, so the registration
+                  ceremony can run; on success the enforcement decision flips
+                  to 'ok' via `hasPasskey` and we can leave immediately. */}
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setPasskeyDialogOpen(true)}
+                disabled={submitting}
+              >
+                {t('enroll.usePasskeyButton')}
+              </Button>
+            </Stack>
           )}
 
           {step.kind === 'verify' && (
@@ -254,6 +271,19 @@ function TwoFactorEnrollPage() {
           )}
         </Stack>
       </main>
+
+      <PasskeyRegisterDialog
+        open={passkeyDialogOpen}
+        onOpenChange={setPasskeyDialogOpen}
+        onRegistered={() => {
+          toast({
+            title: t('passkeys.registered'),
+            variant: 'success',
+            position: 'top-center',
+          });
+          void finish();
+        }}
+      />
     </VStack>
   );
 }

--- a/services/platform/app/routes/_auth/2fa.tsx
+++ b/services/platform/app/routes/_auth/2fa.tsx
@@ -107,6 +107,33 @@ function TwoFactorVerifyPage() {
     }
   }
 
+  // Passkey escape hatch at the 2FA wall (#1508): a WebAuthn sign-in is
+  // itself phishing-resistant strong auth, so completing the ceremony
+  // issues a full session that supersedes the pending password+TOTP
+  // half-state (the stale `two_factor` cookie is simply never consumed).
+  // Same handler shape as `handlePasskeyLogin` on the log-in page.
+  async function handlePasskeySignIn() {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await authClient.signIn.passkey();
+      if (res?.error) {
+        setError(t('verify.passkeyFailed'));
+        return;
+      }
+      await queryClient
+        .invalidateQueries({ queryKey: ['auth', 'session'] })
+        .catch(() => undefined);
+      void navigate({ to: redirectTo || '/dashboard' });
+    } catch {
+      // Thrown when the user dismisses the prompt or has no matching passkey.
+      setError(t('verify.passkeyFailed'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <AuthFormLayout title={t('verify.title')}>
       <Stack gap={6}>
@@ -161,6 +188,14 @@ function TwoFactorVerifyPage() {
               {useBackup
                 ? t('verify.useAuthenticatorToggle')
                 : t('verify.useBackupCodeToggle')}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handlePasskeySignIn}
+              disabled={submitting}
+            >
+              {t('verify.usePasskeyButton')}
             </Button>
           </Stack>
         </Form>

--- a/services/platform/convex/members/queries.test.ts
+++ b/services/platform/convex/members/queries.test.ts
@@ -479,6 +479,7 @@ describe('listByOrganizationHandler', () => {
         displayName: 'Alice',
         email: 'alice@example.com',
         twoFactorEnabled: false,
+        passkeyCount: 0,
       },
     ]);
   });
@@ -533,6 +534,7 @@ describe('listByOrganizationHandler', () => {
         displayName: undefined,
         email: undefined,
         twoFactorEnabled: false,
+        passkeyCount: 0,
       },
       {
         _id: 'm_2',
@@ -543,8 +545,66 @@ describe('listByOrganizationHandler', () => {
         displayName: 'Bob',
         email: 'bob@example.com',
         twoFactorEnabled: false,
+        passkeyCount: 0,
       },
     ]);
+  });
+
+  it('aggregates passkey counts per member from one batched lookup (#1508)', async () => {
+    mockedGetAuthUser.mockResolvedValue({ userId: 'user_1' });
+    mockedGetOrgMember.mockResolvedValue({
+      _id: 'om_1',
+      createdAt: 1000,
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'admin',
+    });
+    const ctx = createMockCtx();
+
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'm_1',
+          organizationId: 'org_1',
+          userId: 'u_1',
+          role: 'member',
+          createdAt: 1000,
+        },
+        {
+          _id: 'm_2',
+          organizationId: 'org_1',
+          userId: 'u_2',
+          role: 'admin',
+          createdAt: 2000,
+        },
+      ],
+    });
+
+    // Batched user lookup.
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        { _id: 'u_1', name: 'Alice', email: 'alice@example.com' },
+        { _id: 'u_2', name: 'Bob', email: 'bob@example.com' },
+      ],
+    });
+
+    // Batched passkey lookup: u_1 has two credentials, u_2 has none.
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        { _id: 'pk_1', userId: 'u_1' },
+        { _id: 'pk_2', userId: 'u_1' },
+      ],
+      isDone: true,
+    });
+
+    const result = await listByOrganizationHandler(ctx as unknown as QueryCtx, {
+      organizationId: 'org_1',
+    });
+
+    // Exactly three adapter queries — members, users, passkeys. The passkey
+    // count must never become a per-member N+1.
+    expect(ctx.runQuery).toHaveBeenCalledTimes(3);
+    expect(result.map((m) => m.passkeyCount)).toEqual([2, 0]);
   });
 });
 

--- a/services/platform/convex/members/queries.ts
+++ b/services/platform/convex/members/queries.ts
@@ -168,6 +168,41 @@ export async function listByOrganizationHandler(
     }
   }
 
+  // Passkey counts ride the same batched-`in` pattern (NOT per-member N+1).
+  // The count gates the admin list/revoke control in the member edit
+  // dialog (#1508), so the per-member passkey query only fires for members
+  // that actually have credentials.
+  const passkeyCountByUserId = new Map<string, number>();
+  if (userIds.length > 0) {
+    try {
+      let cursor: string | null = null;
+      let isDone = false;
+      while (!isDone) {
+        const passkeysResult: BetterAuthFindManyResult<{
+          _id: string;
+          userId: string;
+        }> = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+          model: 'passkey',
+          paginationOpts: { cursor, numItems: 200 },
+          where: [{ field: 'userId', value: userIds, operator: 'in' }],
+        });
+        for (const row of passkeysResult?.page ?? []) {
+          passkeyCountByUserId.set(
+            row.userId,
+            (passkeyCountByUserId.get(row.userId) ?? 0) + 1,
+          );
+        }
+        // Stop on `isDone` or a missing cursor — a null cursor would
+        // restart from the first page and loop forever.
+        isDone =
+          passkeysResult?.isDone !== false || !passkeysResult.continueCursor;
+        cursor = passkeysResult?.continueCursor ?? null;
+      }
+    } catch (error) {
+      console.warn('[Members] Failed to batch-fetch passkey counts', error);
+    }
+  }
+
   return result.page.map((member) => {
     const user = usersById.get(member.userId);
     const role: MemberRole = isValidRole(member.role) ? member.role : 'member';
@@ -181,6 +216,7 @@ export async function listByOrganizationHandler(
       displayName: user?.name,
       email: user?.email,
       twoFactorEnabled: user?.twoFactorEnabled === true,
+      passkeyCount: passkeyCountByUserId.get(member.userId) ?? 0,
     };
   });
 }
@@ -197,6 +233,7 @@ export const listByOrganization = query({
       displayName: v.optional(v.string()),
       email: v.optional(v.string()),
       twoFactorEnabled: v.boolean(),
+      passkeyCount: v.number(),
     }),
   ),
   handler: listByOrganizationHandler,

--- a/services/platform/convex/two_factor/auth_hooks.ts
+++ b/services/platform/convex/two_factor/auth_hooks.ts
@@ -30,6 +30,7 @@ const SIGN_IN_EMAIL_PATH = '/sign-in/email';
 // enroll/revoke events belong in the same security audit trail as TOTP.
 const PASSKEY_VERIFY_REGISTRATION_PATH = '/passkey/verify-registration';
 const PASSKEY_DELETE_PATH = '/passkey/delete-passkey';
+const PASSKEY_VERIFY_AUTH_PATH = '/passkey/verify-authentication';
 
 const VERIFY_PATHS = new Set<string>([
   VERIFY_TOTP_PATH,
@@ -202,7 +203,47 @@ export async function twoFactorAfterHook(
     );
   }
 
+  if (mw.path === PASSKEY_VERIFY_AUTH_PATH) {
+    return passkeySignInAfterHook(ctx, mw, clientIp, userAgent);
+  }
+
   return undefined;
+}
+
+/**
+ * Audit successful passkey sign-ins (#1508), keeping the WebAuthn path on
+ * par with the password path's `login_success`. The endpoint resolves the
+ * user from the credential, so on success the freshly-issued session is
+ * exposed as `mw.context.newSession`. Failures are challenge-based and
+ * unattributable to a user (no userId before verification succeeds), so
+ * only success is recorded.
+ */
+async function passkeySignInAfterHook(
+  ctx: GenericCtx<DataModel>,
+  mw: AuthMiddlewareCtx,
+  clientIp: string | undefined,
+  userAgent: string | undefined,
+): Promise<void> {
+  if (mw.context.returned instanceof APIError) return;
+
+  const newSession = mw.context.newSession;
+  if (!isRecord(newSession)) return;
+  const user = isRecord(newSession.user) ? newSession.user : null;
+  if (!user || typeof user.id !== 'string') return;
+  const email = typeof user.email === 'string' ? user.email : undefined;
+
+  const runCtx = requireRunMutationCtx(ctx);
+  await runCtx.runMutation(
+    internal.two_factor.internal_mutations.logEnrollmentEvent,
+    {
+      userId: user.id,
+      actorId: user.id,
+      actorEmail: email,
+      action: 'passkey_sign_in',
+      ip: clientIp,
+      userAgent,
+    },
+  );
 }
 
 /**

--- a/services/platform/convex/two_factor/helpers.ts
+++ b/services/platform/convex/two_factor/helpers.ts
@@ -40,6 +40,62 @@ export async function userHasPasskey(
   return (res?.page?.length ?? 0) > 0;
 }
 
+export interface MemberRecord {
+  memberId: string;
+  organizationId: string;
+  userId: string;
+  role: string | undefined;
+}
+
+/**
+ * Resolve a better-auth `member` row by its id. Shared by the admin-facing
+ * 2FA reset / passkey revoke mutations and the admin passkey list query —
+ * typed for both ctx kinds so queries can reuse it.
+ */
+export async function findMember(
+  ctx: QueryCtx | MutationCtx,
+  memberId: string,
+): Promise<MemberRecord | null> {
+  const res = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'member',
+    paginationOpts: { cursor: null, numItems: 1 },
+    where: [{ field: '_id', value: memberId, operator: 'eq' }],
+  });
+  const raw = res?.page?.[0];
+  if (!isRecord(raw)) return null;
+  const organizationId = getString(raw, 'organizationId');
+  const userId = getString(raw, 'userId');
+  if (!organizationId || !userId) return null;
+  return {
+    memberId,
+    organizationId,
+    userId,
+    role: getString(raw, 'role')?.toLowerCase(),
+  };
+}
+
+/**
+ * The caller's own membership in `organizationId`, for the
+ * lookup-then-check authorization pattern (see `resetForUser`).
+ */
+export async function findCallerMembership(
+  ctx: QueryCtx | MutationCtx,
+  organizationId: string,
+  callerUserId: string,
+): Promise<{ role: string | undefined } | null> {
+  const res = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'member',
+    paginationOpts: { cursor: null, numItems: 1 },
+    where: [
+      { field: 'organizationId', value: organizationId, operator: 'eq' },
+      { field: 'userId', value: callerUserId, operator: 'eq' },
+    ],
+  });
+  const raw = res?.page?.[0];
+  if (!isRecord(raw)) return null;
+  return { role: getString(raw, 'role')?.toLowerCase() };
+}
+
 export interface TwoFactorEnforcementResult {
   decision: TwoFactorGraceDecision;
   /**

--- a/services/platform/convex/two_factor/internal_mutations.ts
+++ b/services/platform/convex/two_factor/internal_mutations.ts
@@ -281,6 +281,11 @@ export const logEnrollmentEvent = internalMutation({
       // WebAuthn passkey lifecycle (#1508) — same security audit trail.
       v.literal('passkey_added'),
       v.literal('passkey_removed'),
+      v.literal('passkey_revoked_by_admin'),
+      // Successful passkey sign-in — failures are challenge-based and
+      // unattributable to a user, so only success is recorded (mirrors
+      // `login_success` on the password path).
+      v.literal('passkey_sign_in'),
     ),
     ip: v.optional(v.string()),
     userAgent: v.optional(v.string()),

--- a/services/platform/convex/two_factor/mutations.test.ts
+++ b/services/platform/convex/two_factor/mutations.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+        deleteMany: 'betterAuth:adapter:deleteMany',
+        updateMany: 'betterAuth:adapter:updateMany',
+      },
+    },
+  },
+  internal: {
+    two_factor: {
+      internal_mutations: {
+        logEnrollmentEvent: 'two_factor:internal_mutations:logEnrollmentEvent',
+      },
+    },
+  },
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    mutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+const { revokePasskeyForMember } = await import('./mutations');
+
+const handler = (
+  revokePasskeyForMember as unknown as {
+    handler: (
+      ctx: unknown,
+      args: { memberId: string; passkeyId: string },
+    ) => Promise<null>;
+  }
+).handler;
+
+interface CtxOptions {
+  /** Target member row (first `member` lookup). Null = not found. */
+  member?: Record<string, unknown> | null;
+  /** Caller's membership in the target org (second `member` lookup). */
+  callerMembership?: Record<string, unknown> | null;
+  /** Passkey row returned by the `passkey` lookup. Null = not found. */
+  passkey?: Record<string, unknown> | null;
+}
+
+function createCtx(opts: CtxOptions) {
+  let memberLookups = 0;
+  const runQuery = vi.fn(
+    async (_token: unknown, args: { model: string }): Promise<unknown> => {
+      if (args.model === 'member') {
+        memberLookups += 1;
+        const row = memberLookups === 1 ? opts.member : opts.callerMembership;
+        return { page: row ? [row] : [] };
+      }
+      if (args.model === 'passkey') {
+        return { page: opts.passkey ? [opts.passkey] : [] };
+      }
+      // `session` re-check inside invalidateAllSessions — report empty so
+      // the deletion loop terminates after one pass.
+      return { page: [] };
+    },
+  );
+  const runMutation = vi.fn(async () => null);
+  return { runQuery, runMutation };
+}
+
+const CALLER = { userId: 'user_admin', email: 'admin@example.com' };
+
+const TARGET_MEMBER = {
+  _id: 'm_target',
+  organizationId: 'org_1',
+  userId: 'user_target',
+  role: 'member',
+};
+
+const PASSKEY_ROW = {
+  _id: 'pk_1',
+  userId: 'user_target',
+  name: 'MacBook Touch ID',
+  deviceType: 'multiDevice',
+  backedUp: true,
+};
+
+describe('revokePasskeyForMember handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when unauthenticated', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(null);
+    const ctx = createCtx({});
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Unauthenticated');
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('throws when the target member does not exist', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({ member: null });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Member not found');
+  });
+
+  it('throws when the caller is not a member of the target org', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({ member: TARGET_MEMBER, callerMembership: null });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Only admins can revoke passkeys for members');
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('throws when the caller is a non-admin member', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: TARGET_MEMBER,
+      callerMembership: { role: 'member' },
+    });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Only admins can revoke passkeys for members');
+  });
+
+  it('rejects an admin (non-owner) targeting an owner', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: { ...TARGET_MEMBER, role: 'owner' },
+      callerMembership: { role: 'admin' },
+      passkey: PASSKEY_ROW,
+    });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Cannot revoke passkeys for this member');
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('IDOR guard: rejects a passkey that belongs to a different user', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: TARGET_MEMBER,
+      callerMembership: { role: 'admin' },
+      // Foreign credential — same org admin, but the passkey row belongs to
+      // a user outside the target membership.
+      passkey: { ...PASSKEY_ROW, userId: 'user_other_org' },
+    });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).rejects.toThrow('Passkey not found');
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('deletes the passkey, kills sessions, and audits on the happy path', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: TARGET_MEMBER,
+      callerMembership: { role: 'admin' },
+      passkey: PASSKEY_ROW,
+    });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).resolves.toBeNull();
+
+    // Passkey row deleted by id.
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'betterAuth:adapter:deleteMany',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          model: 'passkey',
+          where: [{ field: '_id', value: 'pk_1', operator: 'eq' }],
+        }),
+      }),
+    );
+
+    // All sessions of the target user invalidated (resetForUser parity).
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'betterAuth:adapter:deleteMany',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          model: 'session',
+          where: [{ field: 'userId', value: 'user_target', operator: 'eq' }],
+        }),
+      }),
+    );
+
+    // Audit entry keyed on both admin and target.
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'two_factor:internal_mutations:logEnrollmentEvent',
+      expect.objectContaining({
+        userId: 'user_target',
+        actorId: 'user_admin',
+        action: 'passkey_revoked_by_admin',
+        metadata: { memberId: 'm_target', passkeyId: 'pk_1' },
+      }),
+    );
+  });
+
+  it('allows an owner to revoke another owner’s passkey', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: { ...TARGET_MEMBER, role: 'owner' },
+      callerMembership: { role: 'owner' },
+      passkey: PASSKEY_ROW,
+    });
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', passkeyId: 'pk_1' }),
+    ).resolves.toBeNull();
+  });
+});

--- a/services/platform/convex/two_factor/mutations.ts
+++ b/services/platform/convex/two_factor/mutations.ts
@@ -11,53 +11,7 @@ import { components, internal } from '../_generated/api';
 import { mutation, type MutationCtx } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
-
-interface MemberRecord {
-  memberId: string;
-  organizationId: string;
-  userId: string;
-  role: string | undefined;
-}
-
-async function findMember(
-  ctx: MutationCtx,
-  memberId: string,
-): Promise<MemberRecord | null> {
-  const res = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-    model: 'member',
-    paginationOpts: { cursor: null, numItems: 1 },
-    where: [{ field: '_id', value: memberId, operator: 'eq' }],
-  });
-  const raw = res?.page?.[0];
-  if (!isRecord(raw)) return null;
-  const organizationId = getString(raw, 'organizationId');
-  const userId = getString(raw, 'userId');
-  if (!organizationId || !userId) return null;
-  return {
-    memberId,
-    organizationId,
-    userId,
-    role: getString(raw, 'role')?.toLowerCase(),
-  };
-}
-
-async function findCallerMembership(
-  ctx: MutationCtx,
-  organizationId: string,
-  callerUserId: string,
-): Promise<{ role: string | undefined } | null> {
-  const res = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-    model: 'member',
-    paginationOpts: { cursor: null, numItems: 1 },
-    where: [
-      { field: 'organizationId', value: organizationId, operator: 'eq' },
-      { field: 'userId', value: callerUserId, operator: 'eq' },
-    ],
-  });
-  const raw = res?.page?.[0];
-  if (!isRecord(raw)) return null;
-  return { role: getString(raw, 'role')?.toLowerCase() };
-}
+import { findCallerMembership, findMember } from './helpers';
 
 /**
  * Delete every session for a user. Forces them to re-authenticate — used
@@ -177,6 +131,91 @@ export const resetForUser = mutation({
         actorEmail: authUser.email,
         action: '2fa_reset_by_admin',
         metadata: { memberId: args.memberId },
+      },
+    );
+
+    return null;
+  },
+});
+
+/**
+ * Admin-triggered passkey revocation (#1508). Deletes a single passkey
+ * credential from the target member's user, kills all of their sessions
+ * (consistent with `resetForUser` — a revoked credential must not keep a
+ * live session alive), and emits an audit-log entry keyed on both the
+ * admin and the target.
+ *
+ * Authorization mirrors `resetForUser`: caller must be `owner` or `admin`
+ * in the SAME org as the target member, and owner targets are only
+ * touchable by a *different* owner. The passkey row itself is verified to
+ * belong to the target user before deletion (IDOR guard — without it, an
+ * admin of org A could delete credentials of users in org B by pairing a
+ * legitimate memberId with a foreign passkeyId).
+ */
+export const revokePasskeyForMember = mutation({
+  args: {
+    memberId: v.string(),
+    passkeyId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const member = await findMember(ctx, args.memberId);
+    if (!member) throw new Error('Member not found');
+
+    const callerMembership = await findCallerMembership(
+      ctx,
+      member.organizationId,
+      authUser.userId,
+    );
+    if (!callerMembership || !isAdmin(callerMembership.role)) {
+      throw new Error('Only admins can revoke passkeys for members');
+    }
+
+    if (
+      member.role === 'owner' &&
+      (callerMembership.role !== 'owner' || authUser.userId === member.userId)
+    ) {
+      throw new Error('Cannot revoke passkeys for this member');
+    }
+
+    // IDOR guard: the passkey must belong to the target member's user.
+    const passkeyRes = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: 'passkey',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [{ field: '_id', value: args.passkeyId, operator: 'eq' }],
+      },
+    );
+    const passkeyRow = passkeyRes?.page?.[0];
+    if (
+      !isRecord(passkeyRow) ||
+      getString(passkeyRow, 'userId') !== member.userId
+    ) {
+      throw new Error('Passkey not found');
+    }
+
+    await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+      input: {
+        model: 'passkey',
+        where: [{ field: '_id', value: args.passkeyId, operator: 'eq' }],
+      },
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    await invalidateAllSessions(ctx, member.userId);
+
+    await ctx.runMutation(
+      internal.two_factor.internal_mutations.logEnrollmentEvent,
+      {
+        userId: member.userId,
+        actorId: authUser.userId,
+        actorEmail: authUser.email,
+        action: 'passkey_revoked_by_admin',
+        metadata: { memberId: args.memberId, passkeyId: args.passkeyId },
       },
     );
 

--- a/services/platform/convex/two_factor/queries.test.ts
+++ b/services/platform/convex/two_factor/queries.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+      },
+    },
+  },
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    query: (config: Record<string, unknown>) => config,
+  };
+});
+
+const { listPasskeysForMember } = await import('./queries');
+
+const handler = (
+  listPasskeysForMember as unknown as {
+    handler: (ctx: unknown, args: { memberId: string }) => Promise<unknown>;
+  }
+).handler;
+
+interface CtxOptions {
+  member?: Record<string, unknown> | null;
+  callerMembership?: Record<string, unknown> | null;
+  passkeys?: Record<string, unknown>[];
+}
+
+function createCtx(opts: CtxOptions) {
+  let memberLookups = 0;
+  const runQuery = vi.fn(
+    async (_token: unknown, args: { model: string }): Promise<unknown> => {
+      if (args.model === 'member') {
+        memberLookups += 1;
+        const row = memberLookups === 1 ? opts.member : opts.callerMembership;
+        return { page: row ? [row] : [] };
+      }
+      if (args.model === 'passkey') {
+        return { page: opts.passkeys ?? [] };
+      }
+      return { page: [] };
+    },
+  );
+  return { runQuery };
+}
+
+const CALLER = { userId: 'user_admin', email: 'admin@example.com' };
+
+const TARGET_MEMBER = {
+  _id: 'm_target',
+  organizationId: 'org_1',
+  userId: 'user_target',
+  role: 'member',
+};
+
+describe('listPasskeysForMember handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when unauthenticated', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(null);
+    const ctx = createCtx({});
+
+    await expect(handler(ctx, { memberId: 'm_target' })).rejects.toThrow(
+      'Unauthenticated',
+    );
+  });
+
+  it('throws when the target member does not exist', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({ member: null });
+
+    await expect(handler(ctx, { memberId: 'm_target' })).rejects.toThrow(
+      'Member not found',
+    );
+  });
+
+  it('throws when the caller is not an admin in the target org', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: TARGET_MEMBER,
+      callerMembership: { role: 'member' },
+    });
+
+    await expect(handler(ctx, { memberId: 'm_target' })).rejects.toThrow(
+      'Only admins can list passkeys for members',
+    );
+  });
+
+  it('throws when the caller has no membership in the target org', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({ member: TARGET_MEMBER, callerMembership: null });
+
+    await expect(handler(ctx, { memberId: 'm_target' })).rejects.toThrow(
+      'Only admins can list passkeys for members',
+    );
+  });
+
+  it('returns display fields only for an admin caller', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(CALLER);
+    const ctx = createCtx({
+      member: TARGET_MEMBER,
+      callerMembership: { role: 'admin' },
+      passkeys: [
+        {
+          _id: 'pk_1',
+          userId: 'user_target',
+          name: 'MacBook Touch ID',
+          deviceType: 'multiDevice',
+          backedUp: true,
+          createdAt: 1700000000000,
+          // Credential material must never reach the client.
+          publicKey: 'secret-public-key',
+          counter: 7,
+          credentialID: 'cred-1',
+        },
+        {
+          _id: 'pk_2',
+          userId: 'user_target',
+          deviceType: 'singleDevice',
+          backedUp: false,
+        },
+      ],
+    });
+
+    await expect(handler(ctx, { memberId: 'm_target' })).resolves.toEqual([
+      {
+        id: 'pk_1',
+        name: 'MacBook Touch ID',
+        deviceType: 'multiDevice',
+        backedUp: true,
+        createdAt: 1700000000000,
+      },
+      {
+        id: 'pk_2',
+        name: null,
+        deviceType: 'singleDevice',
+        backedUp: false,
+        createdAt: null,
+      },
+    ]);
+  });
+});

--- a/services/platform/convex/two_factor/queries.ts
+++ b/services/platform/convex/two_factor/queries.ts
@@ -7,11 +7,17 @@
 import { symmetricDecrypt } from 'better-auth/crypto';
 import { v, type Infer } from 'convex/values';
 
-import { isRecord } from '../../lib/utils/type-guards';
+import { isRecord, getString } from '../../lib/utils/type-guards';
 import { components } from '../_generated/api';
 import { query, type QueryCtx } from '../_generated/server';
 import { getAuthUserIdentity, type AuthenticatedUser } from '../lib/rls';
-import { evaluateTwoFactorEnforcement, userHasPasskey } from './helpers';
+import { isAdmin } from '../lib/rls/helpers/role_helpers';
+import {
+  evaluateTwoFactorEnforcement,
+  findCallerMembership,
+  findMember,
+  userHasPasskey,
+} from './helpers';
 
 /**
  * Count the remaining backup codes for a user by reading the encrypted
@@ -166,4 +172,71 @@ export const getStatus = query({
   returns: twoFactorStatusValidator,
   handler: async (ctx) =>
     computeTwoFactorStatus(ctx, await getAuthUserIdentity(ctx)),
+});
+
+/**
+ * Admin view of a member's registered passkeys (#1508). Drives the
+ * list/revoke control in the member edit dialog so an admin can clean up
+ * credentials when a device is lost or a member leaves with a synced
+ * passkey still live.
+ *
+ * Authorization mirrors `revokePasskeyForMember`: lookup-then-check —
+ * caller must be `owner` or `admin` in the SAME org as the target member.
+ * Only display fields are returned; the credential public key and counter
+ * never leave the server.
+ */
+export const listPasskeysForMember = query({
+  args: { memberId: v.string() },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.union(v.string(), v.null()),
+      deviceType: v.string(),
+      backedUp: v.boolean(),
+      createdAt: v.union(v.number(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const member = await findMember(ctx, args.memberId);
+    if (!member) throw new Error('Member not found');
+
+    const callerMembership = await findCallerMembership(
+      ctx,
+      member.organizationId,
+      authUser.userId,
+    );
+    if (!callerMembership || !isAdmin(callerMembership.role)) {
+      throw new Error('Only admins can list passkeys for members');
+    }
+
+    const res = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+      model: 'passkey',
+      paginationOpts: { cursor: null, numItems: 50 },
+      where: [{ field: 'userId', value: member.userId, operator: 'eq' }],
+    });
+
+    const passkeys: {
+      id: string;
+      name: string | null;
+      deviceType: string;
+      backedUp: boolean;
+      createdAt: number | null;
+    }[] = [];
+    for (const row of res?.page ?? []) {
+      if (!isRecord(row)) continue;
+      const id = getString(row, '_id') ?? getString(row, 'id');
+      if (!id) continue;
+      passkeys.push({
+        id,
+        name: getString(row, 'name') ?? null,
+        deviceType: getString(row, 'deviceType') ?? 'unknown',
+        backedUp: row.backedUp === true,
+        createdAt: typeof row.createdAt === 'number' ? row.createdAt : null,
+      });
+    }
+    return passkeys;
+  },
 });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5449,6 +5449,8 @@
           "2fa_reset_by_admin": "Zwei-Faktor-Authentifizierung von Admin zurückgesetzt",
           "passkey_added": "Passkey registriert",
           "passkey_removed": "Passkey entfernt",
+          "passkey_revoked_by_admin": "Passkey von Admin entfernt",
+          "passkey_sign_in": "Passkey-Anmeldung",
           "project.created": "Projekt erstellt",
           "project.updated": "Projekt aktualisiert",
           "project.sharing.changed": "Projektfreigabe geändert",
@@ -5956,6 +5958,12 @@
       "namePromptDescription": "Gib diesem Passkey einen Namen, damit du ihn später wiedererkennst (z. B. \"MacBook Touch ID\").",
       "nameLabel": "Passkey-Name",
       "namePlaceholder": "MacBook Touch ID",
+      "attachment": {
+        "label": "Authenticator-Typ",
+        "any": "Beliebig (empfohlen)",
+        "platform": "Dieses Gerät (Face ID, Touch ID, Windows Hello)",
+        "crossPlatform": "Security-Key oder Smartphone"
+      },
       "errors": {
         "registerFailed": "Passkey konnte nicht registriert werden. Bitte versuche es erneut.",
         "revokeFailed": "Passkey konnte nicht entfernt werden. Bitte versuche es erneut."
@@ -5990,7 +5998,9 @@
       "submitButton": "Prüfen",
       "invalid": "Ungültiger oder abgelaufener Code. Bitte erneut versuchen.",
       "tooManyAttempts": "Zu viele Fehlversuche. Bitte später erneut versuchen.",
-      "backupCodeSuccess": "Backup-Code verwendet. Erwäge, die Backup-Codes in den Einstellungen neu zu erzeugen."
+      "backupCodeSuccess": "Backup-Code verwendet. Erwäge, die Backup-Codes in den Einstellungen neu zu erzeugen.",
+      "usePasskeyButton": "Stattdessen einen Passkey verwenden",
+      "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen oder abgebrochen. Versuche es erneut oder verwende einen Code."
     },
     "lowBackupCodes": {
       "body": "Erzeuge einen neuen Satz, damit du dein Konto wiederherstellen kannst, falls du deine Authenticator-App verlierst.",
@@ -6000,7 +6010,8 @@
     },
     "enroll": {
       "title": "Zwei-Faktor erforderlich",
-      "description": "Deine Organisation verlangt Zwei-Faktor-Authentifizierung, um fortzufahren."
+      "description": "Deine Organisation verlangt Zwei-Faktor-Authentifizierung, um fortzufahren.",
+      "usePasskeyButton": "Stattdessen einen Passkey registrieren"
     },
     "grace": {
       "body": "Deine Organisation wird von allen Mitgliedern einen zweiten Faktor verlangen. Richte ihn jetzt ein, um Unterbrechungen zu vermeiden.",
@@ -6011,7 +6022,16 @@
     "admin": {
       "resetButton": "Zwei-Faktor zurücksetzen",
       "confirmTitle": "Zwei-Faktor-Authentifizierung zurücksetzen?",
-      "confirmDescription": "Dies deaktiviert Zwei-Faktor für {name} und beendet alle aktiven Sitzungen. Beim nächsten Anmelden ist eine neue Einrichtung erforderlich."
+      "confirmDescription": "Dies deaktiviert Zwei-Faktor für {name} und beendet alle aktiven Sitzungen. Beim nächsten Anmelden ist eine neue Einrichtung erforderlich.",
+      "passkeys": {
+        "title": "Passkeys",
+        "confirmTitle": "Diesen Passkey entfernen?",
+        "confirmDescription": "Dies entfernt den Passkey \"{name}\" und beendet alle aktiven Sitzungen des Mitglieds. Danach ist eine neue Anmeldung nötig.",
+        "deviceTypes": {
+          "singleDevice": "Gerätegebundener Schlüssel",
+          "multiDevice": "Synchronisierter Passkey"
+        }
+      }
     },
     "errors": {
       "enableFailed": "Einrichtung der Zwei-Faktor-Authentifizierung fehlgeschlagen. Bitte erneut versuchen.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5710,6 +5710,8 @@
           "2fa_reset_by_admin": "Two-factor authentication reset by admin",
           "passkey_added": "Passkey registered",
           "passkey_removed": "Passkey removed",
+          "passkey_revoked_by_admin": "Passkey removed by admin",
+          "passkey_sign_in": "Passkey sign-in",
           "project.created": "Project created",
           "project.updated": "Project updated",
           "project.sharing.changed": "Project sharing changed",
@@ -6217,6 +6219,12 @@
       "namePromptDescription": "Give this passkey a name so you can recognize it later (e.g. \"MacBook Touch ID\").",
       "nameLabel": "Passkey name",
       "namePlaceholder": "MacBook Touch ID",
+      "attachment": {
+        "label": "Authenticator type",
+        "any": "Any (recommended)",
+        "platform": "This device (Face ID, Touch ID, Windows Hello)",
+        "crossPlatform": "Security key or phone"
+      },
       "errors": {
         "registerFailed": "Could not register the passkey. Please try again.",
         "revokeFailed": "Could not remove the passkey. Please try again."
@@ -6251,7 +6259,9 @@
       "submitButton": "Verify",
       "invalid": "Invalid or expired code. Please try again.",
       "tooManyAttempts": "Too many failed attempts. Try again later.",
-      "backupCodeSuccess": "Backup code used. Consider regenerating your backup codes in Settings."
+      "backupCodeSuccess": "Backup code used. Consider regenerating your backup codes in Settings.",
+      "usePasskeyButton": "Use a passkey instead",
+      "passkeyFailed": "Passkey sign-in failed or was cancelled. Try again or use a code."
     },
     "lowBackupCodes": {
       "body": "Generate a new batch so you can still recover your account if you lose your authenticator.",
@@ -6261,7 +6271,8 @@
     },
     "enroll": {
       "title": "Two-factor required",
-      "description": "Your organization requires two-factor authentication to continue."
+      "description": "Your organization requires two-factor authentication to continue.",
+      "usePasskeyButton": "Register a passkey instead"
     },
     "grace": {
       "body": "Your organization will require all members to use a second factor. Enrol now to avoid interruption.",
@@ -6272,7 +6283,16 @@
     "admin": {
       "resetButton": "Reset two-factor",
       "confirmTitle": "Reset two-factor authentication?",
-      "confirmDescription": "This disables two-factor for {name} and ends all their active sessions. They will have to enrol again on their next sign-in."
+      "confirmDescription": "This disables two-factor for {name} and ends all their active sessions. They will have to enrol again on their next sign-in.",
+      "passkeys": {
+        "title": "Passkeys",
+        "confirmTitle": "Remove this passkey?",
+        "confirmDescription": "This removes the passkey \"{name}\" and ends all of the member's active sessions. They will have to sign in again.",
+        "deviceTypes": {
+          "singleDevice": "Single-device key",
+          "multiDevice": "Synced passkey"
+        }
+      }
     },
     "errors": {
       "enableFailed": "Failed to start two-factor setup. Please try again.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5450,6 +5450,8 @@
           "2fa_reset_by_admin": "Authentification à deux facteurs réinitialisée par l'administrateur",
           "passkey_added": "Passkey enregistré",
           "passkey_removed": "Passkey supprimé",
+          "passkey_revoked_by_admin": "Passkey supprimé par l'administrateur",
+          "passkey_sign_in": "Connexion par passkey",
           "project.created": "Projet créé",
           "project.updated": "Projet mis à jour",
           "project.sharing.changed": "Partage du projet modifié",
@@ -5957,6 +5959,12 @@
       "namePromptDescription": "Donne un nom à ce passkey pour le reconnaître plus tard (p. ex. \"Touch ID du MacBook\").",
       "nameLabel": "Nom du passkey",
       "namePlaceholder": "Touch ID du MacBook",
+      "attachment": {
+        "label": "Type d'authentificateur",
+        "any": "Indifférent (recommandé)",
+        "platform": "Cet appareil (Face ID, Touch ID, Windows Hello)",
+        "crossPlatform": "Clé de sécurité ou téléphone"
+      },
       "errors": {
         "registerFailed": "Impossible d'enregistrer le passkey. Réessaie.",
         "revokeFailed": "Impossible de supprimer le passkey. Réessaie."
@@ -5991,7 +5999,9 @@
       "submitButton": "Vérifier",
       "invalid": "Code invalide ou expiré. Merci de réessayer.",
       "tooManyAttempts": "Trop de tentatives échouées. Merci de réessayer plus tard.",
-      "backupCodeSuccess": "Code de secours utilisé. Pense à régénérer tes codes de secours dans les Paramètres."
+      "backupCodeSuccess": "Code de secours utilisé. Pense à régénérer tes codes de secours dans les Paramètres.",
+      "usePasskeyButton": "Utiliser un passkey à la place",
+      "passkeyFailed": "Connexion par passkey échouée ou annulée. Réessaie ou utilise un code."
     },
     "lowBackupCodes": {
       "body": "Génère un nouveau lot afin de pouvoir récupérer ton compte en cas de perte de ton application d'authentification.",
@@ -6001,7 +6011,8 @@
     },
     "enroll": {
       "title": "Double facteur requis",
-      "description": "Ton organisation exige l'authentification à double facteur pour continuer."
+      "description": "Ton organisation exige l'authentification à double facteur pour continuer.",
+      "usePasskeyButton": "Enregistrer un passkey à la place"
     },
     "grace": {
       "body": "Ton organisation exigera bientôt que tous les membres utilisent un second facteur. Active-le maintenant pour éviter toute interruption.",
@@ -6012,7 +6023,16 @@
     "admin": {
       "resetButton": "Réinitialiser le double facteur",
       "confirmTitle": "Réinitialiser l'authentification à double facteur ?",
-      "confirmDescription": "Cela désactive le double facteur pour {name} et met fin à toutes ses sessions actives. {name} devra se réinscrire lors de sa prochaine connexion."
+      "confirmDescription": "Cela désactive le double facteur pour {name} et met fin à toutes ses sessions actives. {name} devra se réinscrire lors de sa prochaine connexion.",
+      "passkeys": {
+        "title": "Passkeys",
+        "confirmTitle": "Supprimer ce passkey ?",
+        "confirmDescription": "Cela supprime le passkey \"{name}\" et met fin à toutes les sessions actives du membre. Une nouvelle connexion sera nécessaire.",
+        "deviceTypes": {
+          "singleDevice": "Clé liée à un appareil",
+          "multiDevice": "Passkey synchronisé"
+        }
+      }
     },
     "errors": {
       "enableFailed": "Échec du démarrage de la configuration du double facteur. Merci de réessayer.",

--- a/tests/AUTH_TESTING.md
+++ b/tests/AUTH_TESTING.md
@@ -53,6 +53,21 @@ Naming: `auth_{test_id}.png` (e.g. `auth_F1.png`).
 | T2  | Login with 2FA  | Sign out, sign in                                        | Prompted for a TOTP code after password           |
 | T3  | Wrong TOTP code | Enter an invalid 6-digit code                            | Rejected; repeated failures contribute to lockout |
 
+## Passkey tests (WebAuthn, #1508)
+
+> These rows need an authenticator: real hardware (Touch ID, Windows Hello, a security key, or a phone) or the Chrome DevTools **WebAuthn** panel / Playwright CDP virtual authenticator. Virtual passes are fine for regression runs, but at least one full pass (P1–P8) must be recorded on a **real** authenticator before the feature is considered device-QA'd — that pass is the SOC 2 manual-procedure evidence for epic #1803.
+
+| ID  | Test                          | Steps                                                                                                                                    | Expected                                                                                                                                        |
+| --- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | Register passkey (platform)   | Settings → Account → Passkeys → **Add a passkey**; name it, pick **This device (Face ID, Touch ID, Windows Hello)**, complete the prompt | Passkey appears in the list under its name; `passkey_added` row in Settings → Logs → Audit                                                      |
+| P2  | Register passkey (roaming)    | **Add a passkey**; pick **Security key or phone**, complete with a security key or phone                                                 | Second passkey listed; `passkey_added` audit row                                                                                                |
+| P3  | Passkey login                 | Sign out → **Sign in with a passkey** on the login page                                                                                  | Signed in without typing the password; `passkey_sign_in` audit row                                                                              |
+| P4  | Passkey at the 2FA wall       | On a TOTP-enrolled account, sign in with email + password → on the verification screen click **Use a passkey instead**                   | WebAuthn prompt replaces the code entry; lands on the dashboard without a TOTP code                                                             |
+| P5  | Enrolment wall offers passkey | Enforce 2FA with zero grace for a member with no TOTP and no passkey; sign in as them → **Register a passkey instead** on /2fa-enroll    | Registration ceremony runs with the session intact; continues straight to the dashboard                                                         |
+| P6  | Passkey-only satisfies policy | With a passkey registered and TOTP never enrolled, sign in with email + password under the enforced policy                               | No enrolment wall; lands on the dashboard                                                                                                       |
+| P7  | Self-revoke                   | Settings → Account → Passkeys → **Remove**                                                                                               | Passkey gone from the list; `passkey_removed` audit row                                                                                         |
+| P8  | Admin revoke ends sessions    | As an admin: Settings → Organization → **Edit member** → Passkeys section → **Remove** → confirm                                         | Credential deleted; every session of the member ends (their open tab bounces to login); `passkey_revoked_by_admin` audit row keyed on the admin |
+
 ## API / integration tests
 
 | ID  | Test                    | Steps                                                  | Expected                                               |
@@ -87,7 +102,7 @@ Naming: `auth_{test_id}.png` (e.g. `auth_F1.png`).
 
 ```
 Module: Authentication
-Functional: ___/10   Boundary: ___/6   2FA: ___/3   API: ___/3   A11y: ___/4   Perf: ___/2
+Functional: ___/10   Boundary: ___/6   2FA: ___/3   Passkeys: ___/8   API: ___/3   A11y: ___/4   Perf: ___/2
 Issues found: ___ (crit __ / high __ / med __ / low __)
 Status: PASS / FAIL
 ```


### PR DESCRIPTION
Part of #1508 · Part of #1803

## What / why

PR #1822 shipped the core of WebAuthn passkeys as a second factor (plugin, schema, self-service enroll/revoke, login button, policy enforcement via `hasPasskey`, add/remove audit events). This PR implements the verified residual scope so the feature is complete end-to-end:

- **Admin list/revoke of a member's passkeys.** New `two_factor.queries.listPasskeysForMember` + `two_factor.mutations.revokePasskeyForMember` (lookup-then-check authz copied from `resetForUser`, owner-target rule, and an IDOR guard asserting the passkey row belongs to the target member's user before deletion). Revoking deletes the credential, invalidates **all** of the member's sessions, and emits a `passkey_revoked_by_admin` audit event keyed on both admin and target. Surfaced as a `PasskeyAdminControl` section in the member edit dialog, gated on a new `passkeyCount` field in `members.listByOrganization` (one batched `in` query — no per-member N+1; covered by a call-count test).
- **Passkey at the `/2fa` verification wall.** "Use a passkey instead" runs `authClient.signIn.passkey()`; a successful WebAuthn sign-in issues a full session that supersedes the pending 2FA half-state.
- **Passkey at the `/2fa-enroll` wall.** "Register a passkey instead" next to the TOTP setup — the session is intentionally alive on the wall, and a registered passkey flips the enforcement decision to `ok`, so the flow continues straight to the dashboard.
- **Authenticator-attachment picker.** The registration flow is extracted into a shared `PasskeyRegisterDialog` (used by both `PasskeySection` and the enroll wall) with an explicit choice: Any (default, field omitted) / This device → `platform` / Security key or phone → `cross-platform`.
- **Passkey sign-ins are now audited.** New `/passkey/verify-authentication` branch in `twoFactorAfterHook` logs success-only `passkey_sign_in` (failures are challenge-based and unattributable — mirrors `login_success` on the password path).
- **Docs + manual QA procedure.** Passkey sections added to `docs/{en,de,fr}/platform/admin/two-factor-authentication.md` (also corrected the stale "Settings > People" / mismatched FR reset-button label in the admin-reset section to match the shipped UI post-#1836). `tests/AUTH_TESTING.md` gains a Passkey table (P1–P8) covering platform + roaming registration, login, both walls, self-revoke, admin revoke, and passkey-only policy satisfaction — this is the documented manual procedure the epic's DoD requires.

Note: the Renovate/dependency exception for `@better-auth/passkey` / `@simplewebauthn/*` already merged in PR #1822 — no dependency changes here.

## Decision-gate recommendations baked in (veto at review)

- Admin passkey revoke **always invalidates the target's sessions** (consistent with `resetForUser`), not only when it was their last second factor.
- `resetForUser` stays **TOTP-only**; passkeys are revoked via the new per-credential control (kept separate).
- Passkey sign-in audit is **success-only** (`passkey_sign_in`) — failures carry no attributable userId before verification succeeds.
- `passkeyCount` is surfaced **dialog-only** (no member-table column churn).
- WebAuthn **conditional UI** (passkey autofill on the login email field) is deferred to a follow-up.

## Verification

- `bun run check` at the repo root: 40/40 tasks green (format, lint, typecheck, 367 test files / 71,914 tests).
- `bun run --filter @tale/docs lint` + `test` (incl. locale parity, opening/closing, terminology): green; frontmatter manifest regenerated.
- New unit tests: `convex/two_factor/mutations.test.ts` (revoke authz, owner rule, IDOR guard, session invalidation + audit on happy path), `convex/two_factor/queries.test.ts` (list authz + display-fields-only mapping), plus a batched passkey-count test in `convex/members/queries.test.ts`.
- Platform UI test projects for the touched settings/org and account features: green.

## Manual verification required

WebAuthn ceremonies cannot run in CI. The documented procedure is the new **Passkey tests (P1–P8)** table in `tests/AUTH_TESTING.md`:

1. P1/P2 — register a platform passkey (Touch ID / Windows Hello) and a roaming one (security key or phone) with the attachment picker.
2. P3 — sign in from the login page with the passkey (`passkey_sign_in` audit row appears).
3. P4 — on a TOTP-enrolled account, replace the code at the `/2fa` wall with "Use a passkey instead"; verify the stale `two_factor` cookie state is superseded by the new session.
4. P5/P6 — with an enforced zero-grace policy: the `/2fa-enroll` wall offers "Register a passkey instead" and a passkey-only user passes enforcement without ever enrolling TOTP.
5. P7/P8 — self-revoke from Account > Security; admin revoke from Settings > Organization > Edit member (member's open session must die; `passkey_revoked_by_admin` audit row keyed on the admin).

A first pass can use the Chrome DevTools / Playwright CDP virtual authenticator, but the run that closes #1508 must be on a **real** authenticator (this is the device QA deferred in #1822 and the SOC 2 evidence for epic #1803) — needs hardware, so it cannot be performed in this environment.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no new loading states; admin list mirrors the existing `PasskeySection` render-when-loaded behaviour).
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change.
- [x] Every touched docs page has a real opening and a real closing (structure tests green).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.