### PR TITLE
fix(cli): gate tale rollback to patch-only previous version

### DIFF
--- a/tools/cli/src/commands/rollback.ts
+++ b/tools/cli/src/commands/rollback.ts
@@ -9,12 +9,11 @@ import * as logger from '../utils/logger';
 
 export function createRollbackCommand(): Command {
   return new Command('rollback')
-    .description('Rollback to the previous version or a specific version')
-    .option(
-      '-v, --version <version>',
-      'Specific version to rollback to (e.g., v1.0.0)',
+    .description(
+      'Roll back to the previous version (patch-level rollbacks only — ' +
+        'minor/major recovery goes through backup restore)',
     )
-    .action(async (options) => {
+    .action(async () => {
       try {
         const projectDir = requireProject();
         await resolveProjectContext(projectDir);
@@ -25,7 +24,7 @@ export function createRollbackCommand(): Command {
           process.exit(1);
         }
         const env = loadEnv(projectDir);
-        await rollback({ env, version: options.version });
+        await rollback({ env });
       } catch (err) {
         logger.error(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/tools/cli/src/lib/actions/rollback.test.ts
+++ b/tools/cli/src/lib/actions/rollback.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { DeploymentEnv } from '../../utils/load-env';
+import { setProjectId } from '../project/project-context';
+import { rollback } from './rollback';
+
+// getProjectId() (used for container names) throws unless seeded. Seed the
+// real singleton with the same id the compose generator tests use — bun's
+// mock.module leaks across test files in one process, so mocking the shared
+// load-env module here would break sibling suites.
+setProjectId('tale');
+
+const getCurrentColorMock = mock();
+const getPreviousVersionMock = mock();
+const getContainerVersionMock = mock();
+const pullImageMock = mock();
+const dockerComposeMock = mock();
+const ensureVolumesMock = mock();
+const ensureNetworkMock = mock();
+const waitForHealthyMock = mock();
+const stopContainerMock = mock();
+const removeContainerMock = mock();
+const setCurrentColorMock = mock();
+const setPreviousVersionMock = mock();
+const loggerInfoMock = mock();
+const loggerErrorMock = mock();
+
+mock.module('../state/with-lock', () => ({
+  withLock: (_dir: string, _cmd: string, fn: () => Promise<unknown>) => fn(),
+}));
+mock.module('../state/get-current-color', () => ({
+  getCurrentColor: getCurrentColorMock,
+}));
+mock.module('../state/get-previous-version', () => ({
+  getPreviousVersion: getPreviousVersionMock,
+}));
+mock.module('../state/set-current-color', () => ({
+  setCurrentColor: setCurrentColorMock,
+}));
+mock.module('../state/set-previous-version', () => ({
+  setPreviousVersion: setPreviousVersionMock,
+}));
+mock.module('../docker/get-container-version', () => ({
+  getContainerVersion: getContainerVersionMock,
+}));
+mock.module('../docker/pull-image', () => ({ pullImage: pullImageMock }));
+mock.module('../docker/docker-compose', () => ({
+  dockerCompose: dockerComposeMock,
+}));
+mock.module('../docker/ensure-volumes', () => ({
+  ensureVolumes: ensureVolumesMock,
+}));
+mock.module('../docker/ensure-network', () => ({
+  ensureNetwork: ensureNetworkMock,
+}));
+mock.module('../docker/wait-for-healthy', () => ({
+  waitForHealthy: waitForHealthyMock,
+}));
+mock.module('../docker/stop-container', () => ({
+  stopContainer: stopContainerMock,
+}));
+mock.module('../docker/remove-container', () => ({
+  removeContainer: removeContainerMock,
+}));
+mock.module('../../utils/logger', () => ({
+  info: loggerInfoMock,
+  error: loggerErrorMock,
+  warn: mock(),
+  step: mock(),
+  success: mock(),
+  header: mock(),
+  blank: mock(),
+  debug: mock(),
+}));
+const env: DeploymentEnv = {
+  GHCR_REGISTRY: 'ghcr.io/tale-project/tale',
+  SITE_URL: 'https://tale.local',
+  HEALTH_CHECK_TIMEOUT: 1,
+  DRAIN_TIMEOUT: 0,
+  DEPLOY_DIR: '/tmp/tale-rollback-test',
+};
+
+function expectRunbookPrinted(): void {
+  const infoLines = loggerInfoMock.mock.calls.map((c) => String(c[0]));
+  expect(
+    infoLines.some((line) => line.includes('tale upgrade --version')),
+  ).toBe(true);
+  expect(infoLines.some((line) => line.includes('tale deploy --all'))).toBe(
+    true,
+  );
+}
+
+afterEach(() => {
+  getCurrentColorMock.mockReset();
+  getPreviousVersionMock.mockReset();
+  getContainerVersionMock.mockReset();
+  pullImageMock.mockReset();
+  dockerComposeMock.mockReset();
+  ensureVolumesMock.mockReset();
+  ensureNetworkMock.mockReset();
+  waitForHealthyMock.mockReset();
+  stopContainerMock.mockReset();
+  removeContainerMock.mockReset();
+  setCurrentColorMock.mockReset();
+  setPreviousVersionMock.mockReset();
+  loggerInfoMock.mockReset();
+  loggerErrorMock.mockReset();
+});
+
+describe('rollback gate', () => {
+  test('refuses a minor-version rollback and prints the restore runbook', async () => {
+    getCurrentColorMock.mockResolvedValue('blue');
+    getPreviousVersionMock.mockResolvedValue('0.9.6');
+    getContainerVersionMock.mockResolvedValue('0.10.1');
+
+    await expect(rollback({ env })).rejects.toThrow(
+      'Rollback refused: not a patch-level rollback',
+    );
+
+    expect(pullImageMock).not.toHaveBeenCalled();
+    expect(setCurrentColorMock).not.toHaveBeenCalled();
+    expectRunbookPrinted();
+  });
+
+  test('refuses when no previous version is recorded', async () => {
+    getCurrentColorMock.mockResolvedValue('blue');
+    getPreviousVersionMock.mockResolvedValue(null);
+
+    await expect(rollback({ env })).rejects.toThrow('No previous version');
+
+    expect(pullImageMock).not.toHaveBeenCalled();
+    expectRunbookPrinted();
+  });
+
+  test('refuses when the running platform version is unknown', async () => {
+    getCurrentColorMock.mockResolvedValue('blue');
+    getPreviousVersionMock.mockResolvedValue('0.9.2');
+    getContainerVersionMock.mockResolvedValue(null);
+
+    await expect(rollback({ env })).rejects.toThrow('Unknown running version');
+
+    expect(pullImageMock).not.toHaveBeenCalled();
+    expectRunbookPrinted();
+  });
+
+  test('refuses when the running version is not semver-parseable', async () => {
+    getCurrentColorMock.mockResolvedValue('blue');
+    getPreviousVersionMock.mockResolvedValue('0.9.2');
+    getContainerVersionMock.mockResolvedValue('latest');
+
+    await expect(rollback({ env })).rejects.toThrow(
+      'Rollback refused: cannot compare versions',
+    );
+
+    expect(pullImageMock).not.toHaveBeenCalled();
+    expectRunbookPrinted();
+  });
+
+  test('allows a patch-level rollback to the previous version', async () => {
+    getCurrentColorMock.mockResolvedValue('blue');
+    getPreviousVersionMock.mockResolvedValue('0.9.2');
+    getContainerVersionMock.mockResolvedValue('0.9.3');
+    pullImageMock.mockResolvedValue(true);
+    ensureVolumesMock.mockResolvedValue(true);
+    ensureNetworkMock.mockResolvedValue(true);
+    dockerComposeMock.mockResolvedValue({
+      success: true,
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+    });
+    waitForHealthyMock.mockResolvedValue(true);
+    stopContainerMock.mockResolvedValue(true);
+    removeContainerMock.mockResolvedValue(true);
+
+    await rollback({ env });
+
+    // platform, rag, crawler — the rotatable services
+    expect(pullImageMock).toHaveBeenCalledTimes(3);
+    expect(pullImageMock).toHaveBeenCalledWith(
+      'ghcr.io/tale-project/tale/tale-platform:0.9.2',
+    );
+    expect(setCurrentColorMock).toHaveBeenCalledWith(env.DEPLOY_DIR, 'green');
+    expect(setPreviousVersionMock).toHaveBeenCalledWith(
+      env.DEPLOY_DIR,
+      '0.9.3',
+    );
+  });
+});

--- a/tools/cli/src/lib/actions/rollback.ts
+++ b/tools/cli/src/lib/actions/rollback.ts
@@ -1,3 +1,4 @@
+import { sameMinor } from '../../utils/compare-versions';
 import { getProjectId, type DeploymentEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { REQUIRED_VOLUMES } from '../compose/generators/constants';
@@ -20,11 +21,31 @@ import { withLock } from '../state/with-lock';
 
 interface RollbackOptions {
   env: DeploymentEnv;
-  version?: string;
+}
+
+/**
+ * Printed whenever the rollback gate refuses. Minor and major upgrades can
+ * run forward-only data migrations, so re-deploying an older binary on top
+ * of migrated data corrupts the instance instead of recovering it — the
+ * real recovery path is restoring the pre-upgrade backup and re-deploying
+ * the version that matches it.
+ */
+function printSnapshotRestoreRunbook(): void {
+  logger.blank();
+  logger.info('Minor and major upgrades can run forward-only data migrations;');
+  logger.info(
+    'redeploying an older binary on top of migrated data corrupts the',
+  );
+  logger.info('instance instead of recovering it. To recover:');
+  logger.info('  1. Restore the data-volume backup taken before the upgrade');
+  logger.info('     (see docs/self-hosted/operate/backups-and-restore.md).');
+  logger.info('  2. Re-deploy the version that matches the restored data:');
+  logger.info('       tale upgrade --version <version>');
+  logger.info('       tale deploy --all');
 }
 
 export async function rollback(options: RollbackOptions): Promise<void> {
-  const { env, version: targetVersion } = options;
+  const { env } = options;
 
   await withLock(env.DEPLOY_DIR, 'rollback', async () => {
     logger.header('Rolling Back Deployment');
@@ -36,30 +57,54 @@ export async function rollback(options: RollbackOptions): Promise<void> {
       throw new Error('No active deployment');
     }
 
-    // Determine rollback version: use provided version or fall back to previous
-    let rollbackVersion: string;
-    if (targetVersion) {
-      rollbackVersion = targetVersion.replace(/^v/, '');
-      logger.info(`Using specified version: ${rollbackVersion}`);
-    } else {
-      const previousVersion = await getPreviousVersion(env.DEPLOY_DIR);
-      if (!previousVersion) {
-        logger.error('No previous version found to rollback to');
-        logger.info('Use --version <version> to specify a version explicitly');
-        throw new Error('No previous version');
-      }
-      rollbackVersion = previousVersion;
+    // Forward-only migration gate: the only legal rollback target is the
+    // recorded previous version, and only when it is a patch-level step
+    // from the running version (the "patch = always safe" contract in
+    // docs/self-hosted/operate/upgrades.md). There is no applied-migrations
+    // ledger to consult, so anything beyond a patch difference must be
+    // treated as potentially migrated — refuse and point at the
+    // snapshot-restore runbook instead of corrupting the instance.
+    const rollbackVersion = await getPreviousVersion(env.DEPLOY_DIR);
+    if (!rollbackVersion) {
+      logger.error('No previous version recorded — nothing to roll back to.');
+      printSnapshotRestoreRunbook();
+      throw new Error('No previous version');
+    }
+
+    const currentVersion = await getContainerVersion(
+      `${getProjectId()}-platform-${currentColor}`,
+    );
+    if (!currentVersion) {
+      logger.error(
+        'Cannot determine the running platform version — refusing to roll back blind.',
+      );
+      printSnapshotRestoreRunbook();
+      throw new Error('Unknown running version');
+    }
+
+    let isPatchRollback: boolean;
+    try {
+      isPatchRollback = sameMinor(currentVersion, rollbackVersion);
+    } catch (err) {
+      logger.error(err instanceof Error ? err.message : String(err));
+      printSnapshotRestoreRunbook();
+      throw new Error('Rollback refused: cannot compare versions', {
+        cause: err,
+      });
+    }
+    if (!isPatchRollback) {
+      logger.error(
+        `Refusing to roll back from ${currentVersion} to ${rollbackVersion}: ` +
+          'only patch-level rollbacks (same major.minor) are safe.',
+      );
+      printSnapshotRestoreRunbook();
+      throw new Error('Rollback refused: not a patch-level rollback');
     }
 
     const rollbackColor = getOppositeColor(currentColor);
 
-    // Get current version before rollback (for version history)
-    const currentVersion = await getContainerVersion(
-      `${getProjectId()}-platform-${currentColor}`,
-    );
-
     logger.info(`Current color: ${currentColor}`);
-    logger.info(`Current version: ${currentVersion ?? 'unknown'}`);
+    logger.info(`Current version: ${currentVersion}`);
     logger.info(
       `Rolling back to: ${rollbackColor} (version ${rollbackVersion})`,
     );
@@ -128,10 +173,8 @@ export async function rollback(options: RollbackOptions): Promise<void> {
     // Switch traffic and update version history
     logger.step(`Switching traffic to ${rollbackColor}...`);
     await setCurrentColor(env.DEPLOY_DIR, rollbackColor);
-    if (currentVersion) {
-      await setPreviousVersion(env.DEPLOY_DIR, currentVersion);
-      logger.info(`Version history updated: previous=${currentVersion}`);
-    }
+    await setPreviousVersion(env.DEPLOY_DIR, currentVersion);
+    logger.info(`Version history updated: previous=${currentVersion}`);
 
     // Drain current color
     logger.step(`Draining ${currentColor} services (${env.DRAIN_TIMEOUT}s)...`);

--- a/tools/cli/src/utils/compare-versions.test.ts
+++ b/tools/cli/src/utils/compare-versions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { compareVersions, extractVersion } from './compare-versions';
+import { compareVersions, extractVersion, sameMinor } from './compare-versions';
 
 describe('extractVersion', () => {
   test('extracts version from plain semver', () => {
@@ -109,6 +109,38 @@ describe('compareVersions', () => {
 
   test('throws on empty string', () => {
     expect(() => compareVersions('', '0.2.7')).toThrow(
+      /Cannot compare versions/,
+    );
+  });
+});
+
+describe('sameMinor', () => {
+  test('true for a patch-level difference', () => {
+    expect(sameMinor('0.9.3', '0.9.1')).toBe(true);
+  });
+
+  test('true for identical versions', () => {
+    expect(sameMinor('1.2.3', '1.2.3')).toBe(true);
+  });
+
+  test('true across v-prefixed and plain forms', () => {
+    expect(sameMinor('v0.9.3', '0.9.1')).toBe(true);
+  });
+
+  test('ignores prerelease suffixes', () => {
+    expect(sameMinor('1.2.3-rc1', '1.2.4')).toBe(true);
+  });
+
+  test('false for a minor-version difference', () => {
+    expect(sameMinor('0.10.0', '0.9.6')).toBe(false);
+  });
+
+  test('false for a major-version difference', () => {
+    expect(sameMinor('1.0.0', '0.9.9')).toBe(false);
+  });
+
+  test('throws when no semver can be extracted', () => {
+    expect(() => sameMinor('latest', '0.9.1')).toThrow(
       /Cannot compare versions/,
     );
   });

--- a/tools/cli/src/utils/compare-versions.ts
+++ b/tools/cli/src/utils/compare-versions.ts
@@ -62,3 +62,27 @@ export function compareVersions(a: string, b: string): number {
 
   return aVer.localeCompare(bVer);
 }
+
+/**
+ * True when two versions share the same `major.minor` — i.e. moving between
+ * them is a patch-level step. Prerelease suffixes are ignored.
+ *
+ * Accepts any format supported by {@link extractVersion}. Throws when no
+ * semver can be extracted from either argument (e.g. `latest`), because a
+ * caller gating a data-safety decision must not treat "unparseable" as
+ * "same minor".
+ */
+export function sameMinor(a: string, b: string): boolean {
+  const aVer = extractVersion(a);
+  const bVer = extractVersion(b);
+
+  if (!aVer || !bVer) {
+    throw new Error(
+      `Cannot compare versions: unable to extract semver from "${!aVer ? a : b}"`,
+    );
+  }
+
+  const [aMajor, aMinor] = aVer.split('-')[0].split('.');
+  const [bMajor, bMinor] = bVer.split('-')[0].split('.');
+  return aMajor === bMajor && aMinor === bMinor;
+}


### PR DESCRIPTION
PR 1 of 3 for the rollback/recovery rework (#1540). Part of #1540.

## What / why

`tale rollback` accepted any `--version` unvalidated and re-ran its own deploy path. On a minor/major downgrade that lands an old binary on forward-migrated data — the "looks like recovery, actually corrupts" trap from the issue. This PR keeps the command (operators script against it) but gates it:

- The only legal target is the recorded previous version (`.tale/deployment-previous-version`); the arbitrary `-v/--version` flag is removed.
- The rollback proceeds only when the running platform version (container label) and the target share `major.minor` — the documented "patch = always safe" contract. There is **no applied-migrations ledger in the CLI** (the gate the issue presumed doesn't exist), so patch-only semver is the gate.
- On refusal — including unknown/unparseable running version — the command prints the snapshot-restore runbook (restore the pre-upgrade backup, redeploy the matching version) instead of proceeding.
- `setPreviousVersion` stays: the gate depends on it.

New `sameMinor()` helper in `utils/compare-versions.ts` (throws on unparseable versions so a data-safety gate can't treat "unparseable" as "same minor").

## Decision-gate recommendations baked in

- **Patch-only-semver gate instead of building an applied-migrations ledger now** (plan-recommended; the ledger does not exist and nothing maintains one).
- Gated `tale rollback` is kept, not removed — full removal after a deprecation window is left open for a later release decision.

## Verification

- `cd tools/cli && bun test && bunx tsc --noEmit && bunx oxlint` — green (new `rollback.test.ts` covers: refuses minor downgrade, refuses missing/unknown/unparseable versions, prints the runbook, allows patch rollback; `sameMinor` unit tests).
- `bun run check` at repo root — green (40/40 turbo tasks).
- Not performed: live `tale deploy`/`tale rollback` cycle against a running stack (needs a deployed host); covered by the restore drill planned with PR 3.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons — N/A (CLI only).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no platform UI strings).
- [x] Updated `/docs/{en,de,fr}/` — the upgrades/backups pages are rewritten in PR 3 of this chain (the docs rewrite is that PR's subject); this PR's refusal output already points at the correct doc path.
- [x] Docs opening/closing rules — N/A here (no docs touched in this PR).
- [x] Ran docs lint/test — N/A here.
- [x] README updates — `tale rollback` sections of README{,.de,.fr}.md and tools/cli/README.md are updated in PR 3 of this chain.