### PR TITLE
feat(platform): @-mention knowledge-base documents in chat

### DIFF
--- a/docs/de/platform/chat/attachments.md
+++ b/docs/de/platform/chat/attachments.md
@@ -23,6 +23,12 @@ Jeder Anhang wird in Tales Objektspeicher abgelegt und an den Chat gebunden, der
 
 Kleine Textdateien und strukturierte Dokumente unter dem Inline-Budget des Agents werden wörtlich eingefügt. Grössere werden in Chunks geteilt, eingebettet und indiziert; der Agent ruft die relevanten Chunks zur Antwortzeit ab und zitiert sie. Die Grenze hängt vom Modell ab — Long-Context-Modelle schlucken mehr im Ganzen. Wenn der Agent aus einem Anhang abruft, statt ihn ganz zu lesen, zeigen die Zitate auf Chunk-Bereiche in der Originaldatei.
 
+## Wissensdokumente mit @ referenzieren
+
+Tippst du `@` in den Composer, öffnet sich ein Picker über die indizierten Wissensdokumente der Organisation. Tipp weiter, um nach Titel zu filtern, wähl eines aus, und ein Chip erscheint im Composer — die Nachricht trägt jetzt einen angehefteten Verweis auf dieses Dokument. Beim Senden prüft Tale deinen Zugriff, begrenzt das Retrieval dieser Antwort auf genau die angehefteten Dokumente und fügt die relevanten Passagen ein, selbst wenn der Wissensmodus des Agents aus ist — eine explizite Erwähnung schlägt die Retrieval-Konfiguration des Agents. Bis zu fünf Dokumente lassen sich pro Nachricht anheften.
+
+Die Chips sind die Quelle der Wahrheit: Löschst du den `@Titel`-Text aus der Nachricht, bleibt das Dokument angeheftet — entfern stattdessen den Chip. Der Picker bietet nur Dokumente an, deren Indizierung abgeschlossen ist und auf die deine Teams Zugriff haben. Der Verweis gilt pro Nachricht; eine Nachfrage ohne Erwähnungen fällt auf den normalen Wissens-Scope des Agents zurück.
+
 ## Wo das hineinpasst
 
 Anhänge sind der leichtgewichtige, chat-gebundene Weg, eine Datei in eine Antwort zu bringen. Das schwergewichtige, org-gebundene Äquivalent ist [Dokumente](/de/platform/knowledge/documents) — dieselbe Indizierungs-Pipeline, aber an Agents statt an einen einzelnen Chat gebunden. Welche Seite du als Nächstes liest, hängt davon ab, was du vorhast — zählt die Datei einmal, häng sie hier an; wird sie wieder zählen, lad sie in Wissen hoch und lass einen Agent aus jedem Chat darauf verweisen.

--- a/docs/en/platform/chat/attachments.md
+++ b/docs/en/platform/chat/attachments.md
@@ -23,6 +23,12 @@ Each attachment is stored in Tale's object store and bound to the chat that rece
 
 Small text files and structured documents under the agent's inline budget are pasted verbatim. Larger ones are chunked, embedded, and indexed; the agent retrieves the relevant chunks at reply time and cites them. The boundary depends on the model — long-context models swallow more whole. When the agent retrieves from an attachment rather than reading it whole, the citations point to chunk ranges in the original file.
 
+## Referencing knowledge documents with @
+
+Typing `@` in the composer opens a picker over the org's indexed knowledge documents. Type to filter by title, pick one, and a chip appears in the composer — the message now carries a pinned reference to that document. On send, Tale checks your access, scopes that reply's retrieval to exactly the pinned documents, and injects the relevant passages even when the agent's knowledge mode is off — an explicit mention outranks the agent's retrieval configuration. Up to five documents can be pinned per message.
+
+The chips are the source of truth: deleting the `@Title` text from the message does not unpin the document — remove the chip instead. The picker only offers documents that have finished indexing and that your teams can access. The reference is per-message; a follow-up without mentions falls back to the agent's normal knowledge scope.
+
 ## Where this fits
 
 Attachments are the lightweight, chat-scoped way to bring a file into a reply. The heavyweight, org-scoped equivalent is [Documents](/platform/knowledge/documents) — same indexing pipeline, but bound to agents instead of a single chat. The page worth reading next depends on what you are trying to do — if the file matters once, attach it here; if it will matter again, upload it to Knowledge and let an agent reference it from every chat.

--- a/docs/fr/platform/chat/attachments.md
+++ b/docs/fr/platform/chat/attachments.md
@@ -23,6 +23,12 @@ Chaque pièce jointe est stockée dans le stockage objet de Tale et liée au cha
 
 Les petits fichiers texte et les documents structurés sous le budget en ligne de l'agent sont insérés tels quels. Les plus grands sont chunked, embedded et indexés ; l'agent récupère les chunks pertinents à la réponse et les cite. La limite dépend du modèle — les modèles à long contexte avalent davantage entier. Quand l'agent récupère depuis une pièce jointe plutôt que de la lire entière, les citations pointent vers des plages de chunks dans le fichier d'origine.
 
+## Référencer des documents Knowledge avec @
+
+Taper `@` dans le composer ouvre un sélecteur sur les documents Knowledge indexés de l'organisation. Tape pour filtrer par titre, choisis-en un, et une puce apparaît dans le composer — le message porte désormais une référence épinglée vers ce document. À l'envoi, Tale vérifie ton accès, restreint la récupération de cette réponse exactement aux documents épinglés et injecte les passages pertinents même quand le mode connaissance de l'agent est désactivé — une mention explicite l'emporte sur la configuration de récupération de l'agent. Jusqu'à cinq documents peuvent être épinglés par message.
+
+Les puces sont la source de vérité : supprimer le texte `@Titre` du message ne désépingle pas le document — retire plutôt la puce. Le sélecteur ne propose que des documents dont l'indexation est terminée et auxquels tes équipes ont accès. La référence vaut par message ; une question de suivi sans mention retombe sur le périmètre de connaissance normal de l'agent.
+
 ## Où ça s'inscrit
 
 Les pièces jointes sont le moyen léger, scopé au chat, d'amener un fichier dans une réponse. L'équivalent lourd, scopé à l'organisation, est [Documents](/fr/platform/knowledge/documents) — même pipeline d'indexation, mais lié à des agents au lieu d'un seul chat. La page à lire ensuite dépend de ce que tu essaies de faire — si le fichier compte une fois, attache-le ici ; s'il comptera encore, téléverse-le dans Knowledge et laisse un agent le référencer depuis chaque chat.

--- a/services/platform/app/features/chat/components/chat-input.tsx
+++ b/services/platform/app/features/chat/components/chat-input.tsx
@@ -32,6 +32,12 @@ import { formatFileSize, middleEllipsis } from '@/lib/utils/format/file';
 import { useChatLayout } from '../context/chat-layout-context';
 import type { VideoLinkJob } from '../hooks/use-chat-video-links';
 import type { FileAttachment } from '../hooks/use-convex-file-upload';
+import {
+  detectMentionTrigger,
+  MAX_KB_MENTIONS,
+  type KbMention,
+  type MentionTrigger,
+} from '../hooks/use-kb-mentions';
 import { captureScreenshot } from '../utils/capture-screenshot';
 import { normalizeCopiedText } from '../utils/normalize-copied-text';
 import { AgentSelector } from './agent-selector';
@@ -43,6 +49,8 @@ import {
   DictationButton,
   type DictationButtonHandle,
 } from './dictation-button';
+import { createDocumentsMentionSource } from './documents-mention-source';
+import { KbMentionPopover } from './kb-mention-popover';
 import { ImagePreviewDialog } from './message-bubble';
 import { ModelSelector } from './model-selector';
 import { QuotedReferenceChip } from './quoted-reference-chip';
@@ -68,7 +76,11 @@ interface ChatInputProps extends Omit<
   ComponentPropsWithoutRef<'div'>,
   'onChange'
 > {
-  onSendMessage: (message: string, attachments?: FileAttachment[]) => void;
+  onSendMessage: (
+    message: string,
+    attachments?: FileAttachment[],
+    kbReferences?: KbMention[],
+  ) => void;
   onStopGenerating?: () => void;
   isLoading?: boolean;
   disabled?: boolean;
@@ -156,6 +168,16 @@ interface ChatInputProps extends Omit<
    * caller; safe to omit.
    */
   onComposerActivate?: () => void;
+  /**
+   * `@`-mention knowledge-base references (from `useKbMentions`, owned by the
+   * caller so a failed send can restore the chips). The picker only renders
+   * when ALL four are provided — surfaces without the feature (shared chat
+   * view, automation assistant) simply omit them. Hidden in arena mode.
+   */
+  kbMentions?: KbMention[];
+  addKbMention?: (mention: KbMention) => boolean;
+  removeKbMention?: (documentId: Id<'documents'>) => void;
+  clearKbMentions?: () => KbMention[];
 }
 
 export function ChatInput({
@@ -193,6 +215,10 @@ export function ChatInput({
   sendBlocked = false,
   sendBlockedReason,
   onComposerActivate,
+  kbMentions,
+  addKbMention,
+  removeKbMention,
+  clearKbMentions,
   ...restProps
 }: ChatInputProps) {
   const { t: tChat } = useT('chat');
@@ -250,6 +276,120 @@ export function ChatInput({
 
   const { quotedText, setQuotedText } = useChatLayout();
 
+  // ---- `@` knowledge-base mention picker -------------------------------
+  // Enabled only when the caller wires the full mention contract (chips are
+  // the source of truth and live with the caller for send-failure rollback).
+  // Hidden in arena mode — referencedDocumentIds is not wired through
+  // arena_chat in v1.
+  const kbMentionsEnabled =
+    !isArenaMode &&
+    !!kbMentions &&
+    !!addKbMention &&
+    !!removeKbMention &&
+    !!clearKbMentions;
+  const [mentionTrigger, setMentionTrigger] = useState<MentionTrigger | null>(
+    null,
+  );
+  const [mentionHighlight, setMentionHighlight] = useState(0);
+  const mentionListboxId = `${textareaId}-kb-mentions`;
+  const mentionPickerOpen =
+    kbMentionsEnabled && mentionTrigger !== null && !inputDisabled;
+
+  // SearchSource contract: stable identity, called unconditionally every
+  // render (it is a hook); inactive renders pass 'skip' to Convex.
+  const mentionSource = useMemo(
+    () => createDocumentsMentionSource({ organizationId }),
+    [organizationId],
+  );
+  const mentionState = mentionSource(mentionTrigger?.query ?? '', {
+    active: mentionPickerOpen,
+    open: mentionPickerOpen,
+  });
+  const mentionResults = useMemo(
+    () => mentionState.results.slice(0, 8),
+    [mentionState.results],
+  );
+  const clampedMentionHighlight = Math.min(
+    mentionHighlight,
+    Math.max(mentionResults.length - 1, 0),
+  );
+
+  /**
+   * Re-evaluate the `@` trigger from the current caret. `onlyWhenOpen`
+   * restricts caret-move events (clicks, arrows) to UPDATING/CLOSING an open
+   * picker — only typing opens it, so clicking into previously inserted
+   * "@Title" prose doesn't pop the picker back up.
+   */
+  const updateMentionTrigger = useCallback(
+    (onlyWhenOpen: boolean) => {
+      if (!kbMentionsEnabled) return;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      const next = detectMentionTrigger(
+        textarea.value,
+        textarea.selectionStart ?? textarea.value.length,
+      );
+      setMentionTrigger((prev) => {
+        if (onlyWhenOpen && prev === null) return prev;
+        if (
+          prev &&
+          next &&
+          prev.query === next.query &&
+          prev.start === next.start &&
+          prev.end === next.end
+        ) {
+          return prev;
+        }
+        if (prev === null || next === null || prev.query !== next.query) {
+          setMentionHighlight(0);
+        }
+        return next;
+      });
+    },
+    [kbMentionsEnabled],
+  );
+
+  const handleSelectMention = useCallback(
+    (mention: KbMention) => {
+      const trigger = mentionTrigger;
+      if (!trigger || !kbMentionsEnabled) return;
+      const added = addKbMention?.(mention) ?? false;
+      if (!added) {
+        toast({
+          title: tComposer('kbMention.limitReached', {
+            max: MAX_KB_MENTIONS,
+          }),
+          variant: 'destructive',
+        });
+        setMentionTrigger(null);
+        return;
+      }
+      // Replace the typed `@query` with `@Title ` prose. `setRangeText` on
+      // the DOM node keeps the caret + undo stack intact (same rationale as
+      // the video-link chip strip path below).
+      const insertion = `@${mention.title} `;
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.setRangeText(insertion, trigger.start, trigger.end, 'end');
+        onChange?.(textarea.value);
+      } else {
+        onChange?.(
+          value.slice(0, trigger.start) + insertion + value.slice(trigger.end),
+        );
+      }
+      setMentionTrigger(null);
+      setMentionHighlight(0);
+    },
+    [
+      mentionTrigger,
+      kbMentionsEnabled,
+      addKbMention,
+      onChange,
+      value,
+      tComposer,
+    ],
+  );
+
   const handleSendMessage = () => {
     // When the user clearly intends to send (there's content) but the send is
     // blocked for a stated reason, surface it. The disabled send button shows
@@ -292,7 +432,15 @@ export function ChatInput({
     // the message is sent (#1462).
     dictationRef.current?.stop();
 
-    onSendMessage(messageToSend, attachmentsToSend);
+    // Hand the pinned KB references over with the message; the caller owns
+    // the snapshot for send-failure rollback (mirrors clearAttachments).
+    const kbRefsToSend =
+      kbMentionsEnabled && kbMentions && kbMentions.length > 0
+        ? clearKbMentions?.()
+        : undefined;
+    setMentionTrigger(null);
+
+    onSendMessage(messageToSend, attachmentsToSend, kbRefsToSend);
   };
 
   const screenshotSupported =
@@ -329,6 +477,10 @@ export function ChatInput({
 
   const handleInputChange = (newValue: string) => {
     onChange?.(newValue);
+    // Typing both opens and closes the `@` picker (caret-move events only
+    // update/close it — see updateMentionTrigger). Runs after onChange so the
+    // textarea's value + caret reflect this keystroke.
+    updateMentionTrigger(false);
   };
 
   const handleTranscript = useCallback(
@@ -340,7 +492,6 @@ export function ChatInput({
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== 'Enter' || e.shiftKey) return;
     // IME composition guard. macOS Pinyin / Japanese Kotoeri commits a
     // candidate via Enter; without these checks the textarea swallows
     // the commit and sends the half-composed romaji. `isComposing` is
@@ -348,14 +499,45 @@ export function ChatInput({
     // mirror (composition events arrive on the DOM but React's
     // synthetic event types don't expose `isComposing`), and
     // `keyCode === 229` is the legacy Safari path. All three are
-    // necessary to cover Chromium + WebKit + Firefox.
-    if (
-      e.nativeEvent.isComposing ||
-      isComposingRef.current ||
-      e.keyCode === 229
-    ) {
-      return;
+    // necessary to cover Chromium + WebKit + Firefox. The guard also
+    // covers the mention-picker keys below — an IME commit must never
+    // select a mention.
+    const isComposing =
+      e.nativeEvent.isComposing || isComposingRef.current || e.keyCode === 229;
+
+    // `@` mention picker navigation — intercepted while open so the caret
+    // stays put and Enter selects instead of sending.
+    if (mentionPickerOpen && !isComposing) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setMentionHighlight((i) =>
+          Math.min(i + 1, Math.max(mentionResults.length - 1, 0)),
+        );
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setMentionHighlight((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setMentionTrigger(null);
+        return;
+      }
+      if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+        const selected = mentionResults[clampedMentionHighlight]?.data;
+        if (selected) {
+          e.preventDefault();
+          handleSelectMention(selected);
+          return;
+        }
+        // No results to pick: Enter falls through to send below.
+      }
     }
+
+    if (e.key !== 'Enter' || e.shiftKey) return;
+    if (isComposing) return;
     e.preventDefault();
     handleSendMessage();
   };
@@ -562,8 +744,48 @@ export function ChatInput({
               ))}
             </HStack>
           )}
-          {(attachments.length > 0 || uploadingFiles.length > 0) && (
+          {(attachments.length > 0 ||
+            uploadingFiles.length > 0 ||
+            (kbMentionsEnabled && (kbMentions?.length ?? 0) > 0)) && (
             <HStack gap={1} wrap className="mb-2">
+              {kbMentionsEnabled &&
+                kbMentions?.map((mention) => (
+                  <div
+                    key={mention.documentId}
+                    className="bg-muted group relative flex max-w-[280px] items-center gap-3 rounded-lg px-3 py-2"
+                  >
+                    <DocumentIcon
+                      fileName={
+                        mention.extension
+                          ? `${mention.title}.${mention.extension}`
+                          : mention.title
+                      }
+                      mimeType={mention.fileType}
+                    />
+                    <VStack className="min-w-0 flex-1 gap-1">
+                      <Text as="div" variant="label" title={mention.title}>
+                        {middleEllipsis(mention.title, 28)}
+                      </Text>
+                      <Text
+                        as="span"
+                        variant="caption"
+                        className="text-muted-foreground/50"
+                      >
+                        {tComposer('kbMention.chipLabel')}
+                      </Text>
+                    </VStack>
+                    <button
+                      type="button"
+                      aria-label={tComposer('kbMention.removeMention', {
+                        title: mention.title,
+                      })}
+                      onClick={() => removeKbMention?.(mention.documentId)}
+                      className="bg-background absolute top-0.5 right-0.5 flex size-5 items-center justify-center rounded-full opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                    >
+                      <X className="text-muted-foreground size-3" />
+                    </button>
+                  </div>
+                ))}
               {imageAttachments.map((attachment) => (
                 <div
                   key={attachment.fileId}
@@ -833,6 +1055,18 @@ export function ChatInput({
           <QuotedReferenceChip />
 
           <div className="relative">
+            {mentionPickerOpen && mentionTrigger && (
+              <KbMentionPopover
+                results={mentionResults}
+                status={mentionState.status}
+                query={mentionTrigger.query}
+                highlightedIndex={clampedMentionHighlight}
+                onHighlight={setMentionHighlight}
+                onSelect={handleSelectMention}
+                listboxId={mentionListboxId}
+                optionId={(index) => `${mentionListboxId}-option-${index}`}
+              />
+            )}
             <label
               id={textareaLabelId}
               htmlFor={textareaId}
@@ -848,6 +1082,10 @@ export function ChatInput({
               onFocus={onComposerActivate}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
+              // Caret moves (clicks, arrow keys) only update/close an open
+              // mention picker — typing is what opens it (handleInputChange).
+              onSelect={() => updateMentionTrigger(true)}
+              onBlur={() => setMentionTrigger(null)}
               // Track IME composition so the paste handler and the chip
               // cancel-strip path don't mutate the textarea mid-commit.
               // `e.nativeEvent.isComposing` on the paste event is the
@@ -863,6 +1101,14 @@ export function ChatInput({
               disabled={inputDisabled}
               placeholder=""
               aria-labelledby={textareaLabelId}
+              aria-autocomplete={kbMentionsEnabled ? 'list' : undefined}
+              aria-expanded={kbMentionsEnabled ? mentionPickerOpen : undefined}
+              aria-controls={mentionPickerOpen ? mentionListboxId : undefined}
+              aria-activedescendant={
+                mentionPickerOpen && mentionResults.length > 0
+                  ? `${mentionListboxId}-option-${clampedMentionHighlight}`
+                  : undefined
+              }
             />
             {value.length === 0 && !inputDisabled && (
               <Text

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -51,6 +51,7 @@ import { useConvexFileUpload } from '../hooks/use-convex-file-upload';
 import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { useFileIndexingStatus } from '../hooks/use-file-indexing-status';
 import { useFileTranscriptionStatus } from '../hooks/use-file-transcription-status';
+import { useKbMentions, type KbMention } from '../hooks/use-kb-mentions';
 import { useMergedChatItems } from '../hooks/use-merged-chat-items';
 import { useMessageProcessing } from '../hooks/use-message-processing';
 import { useModelFallbackAutoSwitch } from '../hooks/use-model-fallback-auto-switch';
@@ -217,6 +218,16 @@ export function ChatInterface({
     markJobsSent: markVideoJobsSent,
     unmarkJobsSent: unmarkVideoJobsSent,
   } = useChatVideoLinks({ threadId, organizationId });
+
+  // `@`-mention knowledge-base references. Owned here (not inside ChatInput)
+  // so a failed send can restore the chips — mirrors the attachments hook.
+  const {
+    mentions: kbMentions,
+    addMention: addKbMention,
+    removeMention: removeKbMention,
+    clearMentions: clearKbMentions,
+    restoreMentions: restoreKbMentions,
+  } = useKbMentions();
 
   const { data: featureFlags } = useMyFeatureFlags(organizationId);
   const fileUploadDisabled = featureFlags?.fileUpload === false;
@@ -612,11 +623,14 @@ export function ChatInterface({
     // Mirrors the `setInputValue(draftSnapshot)` rollback we do here
     // for the typed text below.
     unmarkJobsSent: unmarkVideoJobsSent,
+    // Same rollback contract for `@`-mention KB reference chips.
+    restoreKbMentions,
   });
 
   const handleSendMessage = async (
     message: string,
     sentAttachments?: FileAttachment[],
+    kbReferences?: KbMention[],
   ) => {
     // Scroll-intent now set inside `useSendMessage` adjacent to each
     // setPendingMessage call — see `scrollIntentRef` prop above. Setting
@@ -677,11 +691,17 @@ export function ChatInterface({
     }
 
     try {
-      await sendMessage(message, finalAttachments, videoLinkSnapshot);
+      await sendMessage(
+        message,
+        finalAttachments,
+        videoLinkSnapshot,
+        kbReferences,
+      );
     } catch (err) {
       // Restore the draft so the user can retry or edit. The chip
       // unbind already happens inside `useSendMessage`'s catch via the
-      // `unmarkJobsSent` prop wired above.
+      // `unmarkJobsSent` prop wired above; KB mention chips are restored
+      // there too via `restoreKbMentions`.
       setInputValue(draftSnapshot);
       throw err;
     }
@@ -1219,6 +1239,10 @@ export function ChatInterface({
                   setSavePromptData({ messageId: '', content })
                 }
                 onOpenPromptLibrary={() => setPromptLibraryOpen(true)}
+                kbMentions={kbMentions}
+                addKbMention={addKbMention}
+                removeKbMention={removeKbMention}
+                clearKbMentions={clearKbMentions}
               />
             </div>
           </FileUpload.Root>

--- a/services/platform/app/features/chat/components/documents-mention-source.ts
+++ b/services/platform/app/features/chat/components/documents-mention-source.ts
@@ -1,0 +1,59 @@
+import { type SearchResult, type SearchSource } from '@tale/ui/search';
+import { useMemo } from 'react';
+
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+
+import type { KbMention } from '../hooks/use-kb-mentions';
+
+interface DocumentsMentionSourceConfig {
+  organizationId: string;
+}
+
+/**
+ * Build a {@link SearchSource} over RAG-indexed, user-accessible knowledge
+ * documents for the composer's `@`-mention picker. Backed by the
+ * `searchDocumentsForMention` query (title search through the shared
+ * `runEntitySearch` seam); skipped entirely while the picker is closed.
+ *
+ * Returned from a `useMemo` so its identity stays stable across renders
+ * (the SearchSource contract — it is called as a hook).
+ */
+export function createDocumentsMentionSource(
+  config: DocumentsMentionSourceConfig,
+): SearchSource<KbMention> {
+  const { organizationId } = config;
+  return (query, { active }) => {
+    const trimmed = query.trim();
+
+    const { data: rows } = useConvexQuery(
+      api.documents.queries.searchDocumentsForMention,
+      active ? { organizationId, query: trimmed } : 'skip',
+    );
+
+    const results = useMemo<SearchResult<KbMention>[]>(
+      () =>
+        (rows ?? []).map(
+          (row): SearchResult<KbMention> => ({
+            id: row.documentId,
+            title: row.title,
+            subtitle: row.folderPath || undefined,
+            data: {
+              documentId: row.documentId,
+              fileId: row.fileId,
+              title: row.title,
+              fileType: row.fileType,
+              fileSize: row.fileSize,
+              extension: row.extension,
+              folderPath: row.folderPath,
+            },
+          }),
+        ),
+      [rows],
+    );
+
+    const status = !active ? 'idle' : rows === undefined ? 'loading' : 'ready';
+
+    return { results, status };
+  };
+}

--- a/services/platform/app/features/chat/components/kb-mention-popover.test.tsx
+++ b/services/platform/app/features/chat/components/kb-mention-popover.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render, screen } from '@/test/utils/render';
+
+import type { KbMention } from '../hooks/use-kb-mentions';
+import { KbMentionPopover } from './kb-mention-popover';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'kbMention.title': 'Knowledge base',
+        'kbMention.loading': 'Searching documents…',
+        'kbMention.empty': 'No matching indexed documents',
+        'kbMention.emptyNoQuery': 'No indexed documents yet',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+function mention(n: number): KbMention {
+  return {
+    documentId: `doc_${n}` as Id<'documents'>,
+    fileId: `file_${n}` as Id<'_storage'>,
+    title: `Document ${n}`,
+    fileType: 'application/pdf',
+    fileSize: 100,
+    folderPath: n === 1 ? 'reports/q3' : undefined,
+  };
+}
+
+function resultOf(n: number) {
+  const data = mention(n);
+  return {
+    id: data.documentId,
+    title: data.title,
+    subtitle: data.folderPath,
+    data,
+  };
+}
+
+const baseProps = {
+  query: 'doc',
+  highlightedIndex: 0,
+  onHighlight: vi.fn(),
+  onSelect: vi.fn(),
+  listboxId: 'kb-listbox',
+  optionId: (index: number) => `kb-listbox-option-${index}`,
+};
+
+describe('KbMentionPopover', () => {
+  it('renders results as listbox options and selects on mousedown', () => {
+    const onSelect = vi.fn();
+    render(
+      <KbMentionPopover
+        {...baseProps}
+        onSelect={onSelect}
+        results={[resultOf(1), resultOf(2)]}
+        status="ready"
+      />,
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+
+    options[1].dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, cancelable: true }),
+    );
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'doc_2' }),
+    );
+  });
+
+  it('shows the empty state when there are no results', () => {
+    render(<KbMentionPopover {...baseProps} results={[]} status="ready" />);
+    expect(
+      screen.getByText('No matching indexed documents'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the loading state while searching', () => {
+    render(<KbMentionPopover {...baseProps} results={[]} status="loading" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  describe('accessibility', () => {
+    it('passes axe audit with results', async () => {
+      const { container } = render(
+        <KbMentionPopover
+          {...baseProps}
+          results={[resultOf(1), resultOf(2)]}
+          status="ready"
+        />,
+      );
+      await checkAccessibility(container);
+    });
+
+    it('passes axe audit in the empty state', async () => {
+      const { container } = render(
+        <KbMentionPopover {...baseProps} results={[]} status="ready" />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+});

--- a/services/platform/app/features/chat/components/kb-mention-popover.tsx
+++ b/services/platform/app/features/chat/components/kb-mention-popover.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import {
+  Highlight,
+  type SearchResult,
+  type SearchStatus,
+} from '@tale/ui/search';
+import { Text } from '@tale/ui/text';
+import { Loader } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+import { DocumentIcon } from '@/app/components/ui/data-display/document-icon';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+import type { KbMention } from '../hooks/use-kb-mentions';
+
+interface KbMentionPopoverProps {
+  results: SearchResult<KbMention>[];
+  status: SearchStatus;
+  /** The query typed after `@` — drives highlighting + empty-state copy. */
+  query: string;
+  highlightedIndex: number;
+  onHighlight: (index: number) => void;
+  onSelect: (mention: KbMention) => void;
+  /** id of the listbox element (wired to the textarea's aria-controls). */
+  listboxId: string;
+  /** Option element id for `aria-activedescendant`. */
+  optionId: (index: number) => string;
+}
+
+/**
+ * Lightweight listbox anchored above the composer textarea for the `@`
+ * knowledge-base mention picker. Purely presentational: the composer owns
+ * the trigger state and keyboard navigation (Up/Down/Enter/Escape in
+ * chat-input.tsx#handleKeyDown) and feeds `highlightedIndex` down — the
+ * textarea keeps focus the whole time (combobox pattern).
+ */
+export function KbMentionPopover({
+  results,
+  status,
+  query,
+  highlightedIndex,
+  onHighlight,
+  onSelect,
+  listboxId,
+  optionId,
+}: KbMentionPopoverProps) {
+  const { t } = useT('composer');
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Keep the highlighted option visible while navigating with the keyboard.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const active = list.querySelector('[aria-selected="true"]');
+    active?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const terms = query.trim() ? [query.trim()] : [];
+
+  return (
+    <div className="border-border bg-popover text-popover-foreground absolute right-0 bottom-full left-0 z-50 mb-2 overflow-hidden rounded-xl border shadow-lg">
+      <div className="text-muted-foreground border-border border-b px-3 py-1.5 text-xs font-medium">
+        {t('kbMention.title')}
+      </div>
+      {status === 'loading' ? (
+        <div
+          role="status"
+          aria-label={t('kbMention.loading')}
+          className="text-muted-foreground flex items-center gap-2 px-3 py-3"
+        >
+          <Loader className="size-3.5 animate-spin" />
+          <Text as="span" variant="caption">
+            {t('kbMention.loading')}
+          </Text>
+        </div>
+      ) : results.length === 0 ? (
+        <Text
+          as="div"
+          variant="caption"
+          className="text-muted-foreground px-3 py-3"
+        >
+          {query.trim() ? t('kbMention.empty') : t('kbMention.emptyNoQuery')}
+        </Text>
+      ) : (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label={t('kbMention.title')}
+          className="max-h-64 overflow-y-auto py-1"
+        >
+          {results.map((result, index) => {
+            const mention = result.data;
+            if (!mention) return null;
+            const isActive = index === highlightedIndex;
+            return (
+              <li
+                key={result.id}
+                id={optionId(index)}
+                role="option"
+                aria-selected={isActive}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2.5 px-3 py-2',
+                  isActive && 'bg-accent text-accent-foreground',
+                )}
+                // Mouse selection must not steal focus from the textarea
+                // (mousedown would blur it and close the picker before the
+                // click lands), so select on mousedown and prevent default.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(mention);
+                }}
+                onMouseEnter={() => onHighlight(index)}
+              >
+                <DocumentIcon
+                  fileName={
+                    mention.extension
+                      ? `${mention.title}.${mention.extension}`
+                      : mention.title
+                  }
+                  mimeType={mention.fileType}
+                  className="size-4 shrink-0"
+                />
+                <span className="min-w-0 flex-1">
+                  <Text as="span" variant="label" className="block truncate">
+                    <Highlight text={result.title} terms={terms} />
+                  </Text>
+                  {result.subtitle && (
+                    <Text
+                      as="span"
+                      variant="caption"
+                      className="text-muted-foreground block truncate"
+                    >
+                      {result.subtitle}
+                    </Text>
+                  )}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/services/platform/app/features/chat/hooks/use-kb-mentions.test.ts
+++ b/services/platform/app/features/chat/hooks/use-kb-mentions.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+
+import {
+  detectMentionTrigger,
+  MAX_KB_MENTIONS,
+  useKbMentions,
+  type KbMention,
+} from './use-kb-mentions';
+
+function mention(n: number): KbMention {
+  return {
+    documentId: `doc_${n}` as Id<'documents'>,
+    fileId: `file_${n}` as Id<'_storage'>,
+    title: `Document ${n}`,
+    fileType: 'application/pdf',
+    fileSize: 100 + n,
+  };
+}
+
+describe('detectMentionTrigger', () => {
+  it('triggers on a leading @', () => {
+    expect(detectMentionTrigger('@', 1)).toEqual({
+      query: '',
+      start: 0,
+      end: 1,
+    });
+  });
+
+  it('triggers on @ after whitespace and captures the query', () => {
+    expect(detectMentionTrigger('summarize @rep', 14)).toEqual({
+      query: 'rep',
+      start: 10,
+      end: 14,
+    });
+  });
+
+  it('uses the text BEFORE the caret only', () => {
+    // Caret right after '@re' even though more text follows.
+    expect(detectMentionTrigger('see @re and more', 7)).toEqual({
+      query: 're',
+      start: 4,
+      end: 7,
+    });
+  });
+
+  it('does not trigger mid-word (email addresses)', () => {
+    expect(detectMentionTrigger('mail me at ym@tale.dev', 22)).toBeNull();
+  });
+
+  it('does not trigger once whitespace follows the query', () => {
+    expect(detectMentionTrigger('@report done', 12)).toBeNull();
+  });
+
+  it('does not trigger without an @', () => {
+    expect(detectMentionTrigger('plain message', 13)).toBeNull();
+  });
+});
+
+describe('useKbMentions', () => {
+  it('adds mentions, dedupes by documentId, and enforces the cap', () => {
+    const { result } = renderHook(() => useKbMentions());
+
+    act(() => {
+      expect(result.current.addMention(mention(1))).toBe(true);
+      // Duplicate add is a no-op but reports success (already pinned).
+      expect(result.current.addMention(mention(1))).toBe(true);
+    });
+    expect(result.current.mentions).toHaveLength(1);
+
+    act(() => {
+      for (let i = 2; i <= MAX_KB_MENTIONS; i++) {
+        expect(result.current.addMention(mention(i))).toBe(true);
+      }
+      // One past the cap is rejected.
+      expect(result.current.addMention(mention(MAX_KB_MENTIONS + 1))).toBe(
+        false,
+      );
+    });
+    expect(result.current.mentions).toHaveLength(MAX_KB_MENTIONS);
+  });
+
+  it('removes a mention by documentId', () => {
+    const { result } = renderHook(() => useKbMentions());
+    act(() => {
+      result.current.addMention(mention(1));
+      result.current.addMention(mention(2));
+    });
+    act(() => {
+      result.current.removeMention('doc_1' as Id<'documents'>);
+    });
+    expect(result.current.mentions.map((m) => m.documentId)).toEqual(['doc_2']);
+  });
+
+  it('clearMentions returns the snapshot and restoreMentions brings it back', () => {
+    const { result } = renderHook(() => useKbMentions());
+    act(() => {
+      result.current.addMention(mention(1));
+      result.current.addMention(mention(2));
+    });
+
+    let snapshot: KbMention[] = [];
+    act(() => {
+      snapshot = result.current.clearMentions();
+    });
+    expect(snapshot).toHaveLength(2);
+    expect(result.current.mentions).toHaveLength(0);
+
+    act(() => {
+      result.current.restoreMentions(snapshot);
+    });
+    expect(result.current.mentions).toHaveLength(2);
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-kb-mentions.ts
+++ b/services/platform/app/features/chat/hooks/use-kb-mentions.ts
@@ -1,0 +1,119 @@
+import { useCallback, useRef, useState } from 'react';
+
+import type { Id } from '@/convex/_generated/dataModel';
+
+/** Mirrors `MAX_KB_REFERENCES` in convex/agents/chat_turn.ts. */
+export const MAX_KB_MENTIONS = 5;
+
+/**
+ * A knowledge-base document pinned to the next message via the composer's
+ * `@`-mention picker. The chips (this state) are the source of truth — the
+ * inserted `@Title` prose is presentational, so editing it out of the text
+ * does not drop the pin (remove the chip instead).
+ */
+export interface KbMention {
+  documentId: Id<'documents'>;
+  fileId: Id<'_storage'>;
+  title: string;
+  fileType: string;
+  fileSize: number;
+  extension?: string;
+  folderPath?: string;
+}
+
+export interface MentionTrigger {
+  /** Text typed after the `@` (may be empty right after typing `@`). */
+  query: string;
+  /** Index of the `@` character in the textarea value. */
+  start: number;
+  /** Caret position — end of the query. */
+  end: number;
+}
+
+/**
+ * Caret-based `@` trigger detection: the token between the last
+ * `@` (at a word boundary) and the caret, with no whitespace in between.
+ * Mid-word `@` (e.g. an email address) does not trigger.
+ */
+export function detectMentionTrigger(
+  value: string,
+  caret: number,
+): MentionTrigger | null {
+  const beforeCaret = value.slice(0, Math.max(caret, 0));
+  const match = /(^|\s)@(\S*)$/.exec(beforeCaret);
+  if (!match) return null;
+  const query = match[2];
+  return {
+    query,
+    start: beforeCaret.length - query.length - 1,
+    end: beforeCaret.length,
+  };
+}
+
+interface UseKbMentionsResult {
+  mentions: KbMention[];
+  /** Adds a mention (deduped by documentId). Returns false when the per-turn
+   *  cap is reached and nothing was added. */
+  addMention: (mention: KbMention) => boolean;
+  removeMention: (documentId: Id<'documents'>) => void;
+  /** Empties the list and returns the cleared mentions (send-time snapshot
+   *  for failure rollback — mirrors `clearAttachments`). */
+  clearMentions: () => KbMention[];
+  /** Restores a previously cleared snapshot (send-failure rollback). */
+  restoreMentions: (mentions: KbMention[]) => void;
+}
+
+/** Composer state for `@`-mentioned knowledge-base documents. */
+export function useKbMentions(): UseKbMentionsResult {
+  const [mentions, setMentions] = useState<KbMention[]>([]);
+  // Synchronous source of truth alongside the render state: updated at
+  // mutation time (not render time) so clearMentions can return the snapshot
+  // and back-to-back adds in one tick don't read a stale list. Same pattern
+  // as use-convex-file-upload's attachmentsRef.
+  const mentionsRef = useRef(mentions);
+  const commit = useCallback((next: KbMention[]) => {
+    mentionsRef.current = next;
+    setMentions(next);
+  }, []);
+
+  const addMention = useCallback(
+    (mention: KbMention): boolean => {
+      const current = mentionsRef.current;
+      if (current.some((m) => m.documentId === mention.documentId)) {
+        return true;
+      }
+      if (current.length >= MAX_KB_MENTIONS) return false;
+      commit([...current, mention]);
+      return true;
+    },
+    [commit],
+  );
+
+  const removeMention = useCallback(
+    (documentId: Id<'documents'>) => {
+      commit(mentionsRef.current.filter((m) => m.documentId !== documentId));
+    },
+    [commit],
+  );
+
+  const clearMentions = useCallback((): KbMention[] => {
+    const cleared = mentionsRef.current;
+    commit([]);
+    return cleared;
+  }, [commit]);
+
+  const restoreMentions = useCallback(
+    (restored: KbMention[]) => {
+      commit(restored);
+    },
+    [commit],
+  );
+
+  return {
+    mentions,
+    addMention,
+    removeMention,
+    clearMentions,
+    restoreMentions,
+  };
+}

--- a/services/platform/app/features/chat/hooks/use-message-processing.test.ts
+++ b/services/platform/app/features/chat/hooks/use-message-processing.test.ts
@@ -47,6 +47,7 @@ vi.mock('../context/chat-layout-context', () => ({
 import { useUIMessages } from '@convex-dev/agent/react';
 
 import { api } from '@/convex/_generated/api';
+import { appendKbReferenceBlock } from '@/convex/lib/agent_chat/kb_reference_block';
 
 import {
   useMessageProcessing,
@@ -1079,6 +1080,60 @@ describe('useMessageProcessing', () => {
       const input =
         '![photo.jpg](https://example.com/img.jpg)\n*(fileId: abc123)*';
       expect(extractFileAttachments(input)).toEqual([]);
+    });
+  });
+
+  // Locks the server marker format to the client regexes: the KB reference
+  // block built in convex/lib/agent_chat/kb_reference_block.ts must round-trip
+  // through extractFileAttachments (chips) and stripInternalFileReferences
+  // (bubble body) — a drift on either side silently breaks sent-bubble chips
+  // for `@`-mentioned documents.
+  describe('KB reference block round-trip (kb_reference_block.ts)', () => {
+    const refs = [
+      {
+        documentId: 'doc1',
+        fileId: 'kd7abc123',
+        fileName: 'Q3 Report.pdf',
+        fileType: 'application/pdf',
+        fileSize: 2048,
+      },
+      {
+        documentId: 'doc2',
+        fileId: 'kd7def456',
+        fileName: 'Handbook.docx',
+        fileType:
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        fileSize: 4096,
+      },
+    ];
+
+    it('extractFileAttachments recovers every referenced file as a chip', () => {
+      const message = appendKbReferenceBlock('Summarize @Q3 Report.pdf', refs);
+      expect(extractFileAttachments(message)).toEqual([
+        {
+          fileId: 'kd7abc123',
+          fileName: 'Q3 Report.pdf',
+          fileType: 'application/pdf',
+          fileSize: 2048,
+        },
+        {
+          fileId: 'kd7def456',
+          fileName: 'Handbook.docx',
+          fileType:
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          fileSize: 4096,
+        },
+      ]);
+    });
+
+    it('stripInternalFileReferences removes the whole block from the bubble body', () => {
+      const userText = 'Summarize @Q3 Report.pdf';
+      const message = appendKbReferenceBlock(userText, refs);
+      expect(stripInternalFileReferences(message)).toBe(userText);
+    });
+
+    it('appendKbReferenceBlock is a no-op for zero refs', () => {
+      expect(appendKbReferenceBlock('hello', [])).toBe('hello');
     });
   });
 

--- a/services/platform/app/features/chat/hooks/use-send-message.ts
+++ b/services/platform/app/features/chat/hooks/use-send-message.ts
@@ -27,6 +27,7 @@ import {
   useUpdateThread,
 } from './mutations';
 import type { VideoLinkJob } from './use-chat-video-links';
+import type { KbMention } from './use-kb-mentions';
 import type { ChatMessage } from './use-message-processing';
 import { clearSendPending, markSendPending } from './use-pending-send';
 import { resetGlobalFreeze } from './use-stream-buffer';
@@ -87,6 +88,20 @@ function extractProjectErrorCode(error: unknown): ProjectErrorCode | null {
     return code;
   }
   return null;
+}
+
+/**
+ * `@`-mention KB reference rejected by `chatWithAgentTurn` (document deleted,
+ * moved out of the user's teams, or no longer RAG-indexed between pick and
+ * send). One opaque code server-side; mapped to a localized toast here.
+ */
+function isKbRefInvalidError(error: unknown): boolean {
+  if (!(error instanceof ConvexError)) return false;
+  const data: unknown = error.data;
+  if (typeof data !== 'object' || data === null || !('code' in data)) {
+    return false;
+  }
+  return data.code === 'KB_REF_INVALID';
 }
 
 /** Derive a thread title from the first message, truncating long input. */
@@ -167,6 +182,14 @@ interface UseSendMessageParams {
    * failed send.
    */
   unmarkJobsSent?: (jobIds: Array<Id<'videoLinkJobs'>>) => void;
+  /**
+   * Restore the composer's `@`-mention KB reference chips on send-failure
+   * paths (precheck block, chatWithAgent throw). The chips were cleared
+   * synchronously in ChatInput's send handler; without this rollback a
+   * failed send silently drops every pinned document. Mirrors
+   * `unmarkJobsSent` for video-link chips.
+   */
+  restoreKbMentions?: (mentions: KbMention[]) => void;
 }
 
 /**
@@ -192,6 +215,7 @@ export function useSendMessage({
   projectId,
   scrollIntentRef,
   unmarkJobsSent,
+  restoreKbMentions,
 }: UseSendMessageParams) {
   const { t } = useT('chat');
   const navigate = useNavigate();
@@ -220,6 +244,7 @@ export function useSendMessage({
       message: string,
       attachments?: FileAttachment[],
       videoLinkSnapshot?: VideoLinkJob[],
+      kbReferences?: KbMention[],
     ) => {
       if (sendingRef.current) return;
 
@@ -275,6 +300,33 @@ export function useSendMessage({
           fileType: a.fileType,
           fileSize: a.fileSize,
         })) ?? [];
+
+      // `@`-mention KB references ride the optimistic bubble as DISPLAY
+      // attachments only (matching the chips the persisted swap extracts from
+      // the server's enriched marker block) — they are NOT part of the
+      // mutation `attachments` arg, which would re-register the blobs with
+      // the agent and duplicate the existing RAG index. The server receives
+      // `referencedDocumentIds` instead and resolves them authoritatively.
+      const kbDisplayAttachments =
+        kbReferences?.map((ref) => ({
+          fileId: ref.fileId,
+          fileName: ref.title,
+          fileType: ref.fileType,
+          fileSize: ref.fileSize,
+        })) ?? [];
+      const buildDisplayAttachments = () =>
+        kbDisplayAttachments.length > 0
+          ? [...mutationAttachments, ...kbDisplayAttachments]
+          : mutationAttachments;
+      const referencedDocumentIds =
+        kbReferences && kbReferences.length > 0
+          ? kbReferences.map((ref) => ref.documentId)
+          : undefined;
+      const rollbackKbMentions = () => {
+        if (restoreKbMentions && kbReferences && kbReferences.length > 0) {
+          restoreKbMentions(kbReferences);
+        }
+      };
 
       // Synchronously derive video-link attachments + pasted-token strip
       // list from the click-time snapshot owned by chat-interface.tsx
@@ -393,6 +445,8 @@ export function useSendMessage({
             if (unmarkJobsSent && snapshotJobIds.length > 0) {
               unmarkJobsSent(snapshotJobIds);
             }
+            // Same rollback for `@`-mention KB reference chips.
+            rollbackKbMentions();
             const title =
               precheck.code === 'pii.blocked'
                 ? t('toast.piiBlocked')
@@ -447,7 +501,7 @@ export function useSendMessage({
             content: optimisticContent,
             threadId: currentArena.arenaThreadIdA,
             arenaThreadIdB: currentArena.arenaThreadIdB,
-            attachments: mutationAttachments,
+            attachments: buildDisplayAttachments(),
             timestamp: pendingTimestamp,
             lastMessageKey,
           });
@@ -458,7 +512,7 @@ export function useSendMessage({
           setPendingMessage({
             content: optimisticContent,
             threadId: currentArena.arenaThreadIdA ?? 'pending',
-            attachments: mutationAttachments,
+            attachments: buildDisplayAttachments(),
             timestamp: pendingTimestamp,
             lastMessageKey,
           });
@@ -467,7 +521,7 @@ export function useSendMessage({
         setPendingMessage({
           content: optimisticContent,
           threadId: threadId ?? 'pending',
-          attachments: mutationAttachments,
+          attachments: buildDisplayAttachments(),
           timestamp: pendingTimestamp,
           lastMessageKey,
         });
@@ -525,7 +579,7 @@ export function useSendMessage({
                   content: messageToSend,
                   threadId: currentArena.arenaThreadIdA,
                   arenaThreadIdB: currentArena.arenaThreadIdB,
-                  attachments: mutationAttachments,
+                  attachments: buildDisplayAttachments(),
                   timestamp: pendingTimestamp,
                   lastMessageKey,
                 });
@@ -534,7 +588,7 @@ export function useSendMessage({
               setPendingMessage({
                 content: messageToSend,
                 threadId,
-                attachments: mutationAttachments,
+                attachments: buildDisplayAttachments(),
                 timestamp: pendingTimestamp,
                 lastMessageKey,
               });
@@ -624,7 +678,7 @@ export function useSendMessage({
               content: messageToSend,
               threadId: tIdA,
               arenaThreadIdB: tIdB,
-              attachments: mutationAttachments,
+              attachments: buildDisplayAttachments(),
               timestamp: pendingTimestamp,
               lastMessageKey,
             });
@@ -732,7 +786,7 @@ export function useSendMessage({
             setPendingMessage({
               content: messageToSend,
               threadId: 'pending',
-              attachments: mutationAttachments,
+              attachments: buildDisplayAttachments(),
               timestamp: pendingTimestamp,
               lastMessageKey,
             });
@@ -758,7 +812,7 @@ export function useSendMessage({
             setPendingMessage({
               content: messageToSend,
               threadId: newThreadId,
-              attachments: mutationAttachments,
+              attachments: buildDisplayAttachments(),
               timestamp: pendingTimestamp,
               lastMessageKey,
             });
@@ -859,6 +913,9 @@ export function useSendMessage({
             capabilityBindings:
               enabledCapabilities.length > 0 ? enabledCapabilities : undefined,
             attachments: mutationAttachments,
+            // `@`-mention KB pins. Server-resolved (access + RAG status), so
+            // only the document ids travel — never client-supplied fileIds.
+            referencedDocumentIds,
             userContext: userContextPayload,
             // projectId from URL query is a string; chatWithAgent expects
             // an Id<'projects'>. The branding is structural-only TS; server
@@ -901,6 +958,10 @@ export function useSendMessage({
         if (unmarkJobsSent && boundJobIdsLocal.length > 0) {
           unmarkJobsSent(boundJobIdsLocal);
         }
+        // Restore the `@`-mention KB reference chips (cleared synchronously
+        // in ChatInput's send handler) so the user can retry without
+        // re-picking every document.
+        rollbackKbMentions();
         clearChatState();
         resetGlobalFreeze();
 
@@ -938,6 +999,8 @@ export function useSendMessage({
           title = t('toast.modelAccessDenied');
         } else if (lower.includes('usage limit') || lower.includes('budget')) {
           title = t('toast.budgetExceeded');
+        } else if (isKbRefInvalidError(error)) {
+          description = t('toast.kbRefInvalid');
         } else if (projectCode) {
           // Surface the localized project-context message instead of the raw
           // ConvexError payload (which would otherwise show as the description).
@@ -982,6 +1045,7 @@ export function useSendMessage({
       projectId,
       scrollIntentRef,
       unmarkJobsSent,
+      restoreKbMentions,
     ],
   );
 

--- a/services/platform/convex/agents/chat_turn.ts
+++ b/services/platform/convex/agents/chat_turn.ts
@@ -26,12 +26,94 @@ import {
   DEFAULT_CHAT_AGENT_SLUG,
 } from '../../lib/shared/constants/agents';
 import { internal } from '../_generated/api';
-import { mutation } from '../_generated/server';
+import type { Id } from '../_generated/dataModel';
+import { mutation, type MutationCtx } from '../_generated/server';
+import { isActiveDocument } from '../documents/_helpers';
 import { userContextValidator } from '../lib/agent_response/validators';
+import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { hasTeamAccess } from '../lib/team_access';
 import { persistentStreaming } from '../streaming/helpers';
 import { cancelGeneration } from '../threads/cancel_generation';
 import { normalizeMessageKey } from './auto_route_helpers';
+
+/** Hard cap on `@`-mentioned knowledge-base documents per turn. Mirrored by
+ *  the composer (`MAX_KB_MENTIONS` in use-kb-mentions.ts). */
+const MAX_KB_REFERENCES = 5;
+
+/** Branded-Id variant of `KbReferencedFile` (kb_reference_block.ts) for the
+ *  scheduled-action payload. */
+interface ResolvedKbReference {
+  documentId: Id<'documents'>;
+  fileId: Id<'_storage'>;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}
+
+/**
+ * Resolve + authorize the composer's `@`-mentioned documents synchronously so
+ * an invalid reference fails the send with a client-visible ConvexError
+ * instead of a mid-generation surprise. Each reference must be: same org,
+ * active, team-accessible to the sender, blob-backed, and RAG-indexed —
+ * the same gate the picker query applies, re-checked server-side.
+ *
+ * Bounded work on the Track-B fast path: ≤ MAX_KB_REFERENCES point reads plus
+ * one team lookup.
+ */
+async function resolveReferencedFiles(
+  ctx: MutationCtx,
+  args: {
+    organizationId: string;
+    userId: string;
+    referencedDocumentIds: Id<'documents'>[];
+  },
+): Promise<ResolvedKbReference[]> {
+  if (args.referencedDocumentIds.length > MAX_KB_REFERENCES) {
+    throw new ConvexError({ code: 'KB_REF_INVALID' });
+  }
+  const userTeamIds = await getUserTeamIds(ctx, args.userId);
+  // Org-wide sentinel mirrors get_accessible_document_ids.ts.
+  const teamSet = new Set([`org_${args.organizationId}`, ...userTeamIds]);
+
+  const resolved: ResolvedKbReference[] = [];
+  const seen = new Set<string>();
+  for (const documentId of args.referencedDocumentIds) {
+    if (seen.has(documentId)) continue;
+    seen.add(documentId);
+
+    const doc = await ctx.db.get(documentId);
+    // One opaque code for every failure mode so the error doesn't reveal
+    // whether an inaccessible document exists.
+    if (
+      !doc ||
+      doc.organizationId !== args.organizationId ||
+      !isActiveDocument(doc) ||
+      !hasTeamAccess(doc, teamSet)
+    ) {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    const fileId = doc.fileId;
+    if (!fileId) {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    const fm = await ctx.db
+      .query('fileMetadata')
+      .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+      .first();
+    if (!fm || fm.ragStatus !== 'completed') {
+      throw new ConvexError({ code: 'KB_REF_INVALID' });
+    }
+    resolved.push({
+      documentId,
+      fileId,
+      fileName: doc.title?.trim() || fm.fileName,
+      fileType: doc.mimeType ?? fm.contentType,
+      fileSize: fm.size,
+    });
+  }
+  return resolved;
+}
 
 export const chatWithAgentTurn = mutation({
   args: {
@@ -55,6 +137,13 @@ export const chatWithAgentTurn = mutation({
     additionalContext: v.optional(v.record(v.string(), v.string())),
     userContext: v.optional(userContextValidator),
     projectId: v.optional(v.id('projects')),
+    /**
+     * Knowledge-base documents the user pinned to this turn via the
+     * composer's `@`-mention picker (cap 5). Validated synchronously
+     * (org/team access, active, RAG-indexed) — an invalid reference throws
+     * `KB_REF_INVALID` before anything is marked generating.
+     */
+    referencedDocumentIds: v.optional(v.array(v.id('documents'))),
     /**
      * Cache pre-warm. Fired on composer focus/typing: resolves the agent +
      * config exactly as a real turn would and primes the prompt cache with one
@@ -141,6 +230,18 @@ export const chatWithAgentTurn = mutation({
         });
       }
     }
+
+    // Resolve + authorize `@`-mentioned knowledge-base documents BEFORE any
+    // state is committed, so a stale/inaccessible reference throws
+    // synchronously (client toast) and never leaves the thread generating.
+    const referencedFiles =
+      args.referencedDocumentIds && args.referencedDocumentIds.length > 0
+        ? await resolveReferencedFiles(ctx, {
+            organizationId: args.organizationId,
+            userId: authUser.userId,
+            referencedDocumentIds: args.referencedDocumentIds,
+          })
+        : undefined;
 
     // markGenerating inline (mirrors threads/internal_mutations:markGenerating)
     // — commit the spinner state + allocate the stream synchronously so the
@@ -236,6 +337,7 @@ export const chatWithAgentTurn = mutation({
         userName: authUser.name ?? '',
         requestStartMs,
         arenaBranchThreadId: args.arenaBranchThreadId,
+        referencedFiles,
       },
     );
 

--- a/services/platform/convex/agents/chat_turn_generate.ts
+++ b/services/platform/convex/agents/chat_turn_generate.ts
@@ -91,6 +91,20 @@ export const runChatTurnGeneration = internalAction({
     // Arena root side only: create the A↔B branch link from here, AFTER
     // startChat has saved this thread's user message (see chat_turn.ts).
     arenaBranchThreadId: v.optional(v.string()),
+    /** `@`-mentioned knowledge-base documents, already resolved + authorized
+     *  by `chatWithAgentTurn`. Threaded to startChat → startAgentChat, where
+     *  they become the enriched marker block + the pinned RAG scope. */
+    referencedFiles: v.optional(
+      v.array(
+        v.object({
+          documentId: v.id('documents'),
+          fileId: v.id('_storage'),
+          fileName: v.string(),
+          fileType: v.string(),
+          fileSize: v.number(),
+        }),
+      ),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -326,6 +340,7 @@ export const runChatTurnGeneration = internalAction({
           message,
           maxSteps: args.maxSteps,
           attachments: args.attachments,
+          referencedFiles: args.referencedFiles,
           additionalContext: args.additionalContext,
           userContext: args.userContext,
           agentConfig,

--- a/services/platform/convex/agents/start_chat.ts
+++ b/services/platform/convex/agents/start_chat.ts
@@ -41,6 +41,19 @@ export const startChat = internalMutation({
         }),
       ),
     ),
+    /** `@`-mentioned knowledge-base documents, resolved + authorized by the
+     *  chatWithAgentTurn entry mutation. */
+    referencedFiles: v.optional(
+      v.array(
+        v.object({
+          documentId: v.id('documents'),
+          fileId: v.id('_storage'),
+          fileName: v.string(),
+          fileType: v.string(),
+          fileSize: v.number(),
+        }),
+      ),
+    ),
     additionalContext: v.optional(v.record(v.string(), v.string())),
     userContext: v.optional(userContextValidator),
     agentConfig: v.any(),
@@ -157,6 +170,7 @@ export const startChat = internalMutation({
       message: args.message,
       maxSteps: args.maxSteps,
       attachments: args.attachments,
+      referencedFiles: args.referencedFiles,
       additionalContext: args.additionalContext,
       userContext: args.userContext,
       agentConfig: mergedConfig,

--- a/services/platform/convex/documents/queries.ts
+++ b/services/platform/convex/documents/queries.ts
@@ -14,6 +14,7 @@ import { getOrganizationMember } from '../lib/rls/organization/get_organization_
 import { hasTeamAccess } from '../lib/team_access';
 import { isActiveDocument } from './_helpers';
 import { listDocumentsPaginated as listDocumentsPaginatedHelper } from './list_documents_paginated';
+import { searchDocumentsForMention as searchDocumentsForMentionHelper } from './search_documents_for_mention';
 import { transformDocumentsBatch } from './transform_to_document_item';
 
 export const approxCountDocuments = query({
@@ -97,6 +98,37 @@ export const getDocumentById = query({
 
     const [item] = await transformDocumentsBatch(ctx, [doc]);
     return item ?? null;
+  },
+});
+
+/**
+ * Title search for the chat composer's `@` knowledge-base mention picker.
+ * Returns slim rows for RAG-indexed, user-accessible documents only (the
+ * picker must not offer a document that the pinned-turn retrieval could not
+ * actually search). Same auth contract as `listDocumentsPaginated`.
+ */
+export const searchDocumentsForMention = query({
+  args: {
+    organizationId: v.string(),
+    query: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return [];
+
+    try {
+      await getOrganizationMember(ctx, args.organizationId, authUser);
+    } catch {
+      return [];
+    }
+
+    const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
+
+    return await searchDocumentsForMentionHelper(ctx, {
+      organizationId: args.organizationId,
+      term: args.query,
+      userTeamIds,
+    });
   },
 });
 

--- a/services/platform/convex/documents/search_documents_for_mention.test.ts
+++ b/services/platform/convex/documents/search_documents_for_mention.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { QueryCtx } from '../_generated/server';
+import { searchDocumentsForMention } from './search_documents_for_mention';
+
+interface FakeFileMeta {
+  fileName: string;
+  contentType: string;
+  size: number;
+  ragStatus?: 'queued' | 'running' | 'completed' | 'failed';
+}
+
+function createCtx(
+  docs: Array<Record<string, unknown>>,
+  fileMetaByStorageId: Record<string, FakeFileMeta>,
+) {
+  const paginate = vi.fn().mockResolvedValue({
+    page: docs,
+    isDone: true,
+    continueCursor: '',
+  });
+  const documentsBuilder = {
+    withIndex: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    paginate,
+  };
+  const ctx = {
+    db: {
+      query: vi.fn((table: string) => {
+        if (table === 'documents') return documentsBuilder;
+        // fileMetadata by_storageId point lookup: capture the eq() value the
+        // index callback binds and resolve the matching row.
+        return {
+          withIndex: (
+            _name: string,
+            cb: (q: {
+              eq: (field: string, value: unknown) => object;
+            }) => unknown,
+          ) => {
+            let storageId: unknown;
+            cb({
+              eq: (_field, value) => {
+                storageId = value;
+                return {};
+              },
+            });
+            return {
+              first: () =>
+                Promise.resolve(fileMetaByStorageId[String(storageId)] ?? null),
+            };
+          },
+        };
+      }),
+    },
+  };
+  return { ctx, paginate };
+}
+
+const baseDoc = {
+  organizationId: 'org_1',
+  _creationTime: 1000,
+};
+
+describe('searchDocumentsForMention', () => {
+  it('returns RAG-indexed docs matching the term by title', async () => {
+    const { ctx } = createCtx(
+      [
+        { ...baseDoc, _id: 'd_1', title: 'Q3 Report', fileId: 'f_1' },
+        { ...baseDoc, _id: 'd_2', title: 'Unrelated', fileId: 'f_2' },
+      ],
+      {
+        f_1: {
+          fileName: 'q3-report.pdf',
+          contentType: 'application/pdf',
+          size: 42,
+          ragStatus: 'completed',
+        },
+        f_2: {
+          fileName: 'other.pdf',
+          contentType: 'application/pdf',
+          size: 7,
+          ragStatus: 'completed',
+        },
+      },
+    );
+
+    const results = await searchDocumentsForMention(
+      ctx as unknown as QueryCtx,
+      {
+        organizationId: 'org_1',
+        term: 'q3',
+        userTeamIds: [],
+      },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      documentId: 'd_1',
+      fileId: 'f_1',
+      title: 'Q3 Report',
+      fileType: 'application/pdf',
+      fileSize: 42,
+    });
+  });
+
+  it('excludes documents without a fileId or without completed RAG status', async () => {
+    const { ctx } = createCtx(
+      [
+        { ...baseDoc, _id: 'd_blobless', title: 'Report A' },
+        { ...baseDoc, _id: 'd_queued', title: 'Report B', fileId: 'f_q' },
+        { ...baseDoc, _id: 'd_failed', title: 'Report C', fileId: 'f_f' },
+        { ...baseDoc, _id: 'd_nometa', title: 'Report D', fileId: 'f_none' },
+        { ...baseDoc, _id: 'd_ok', title: 'Report E', fileId: 'f_ok' },
+      ],
+      {
+        f_q: {
+          fileName: 'b.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'queued',
+        },
+        f_f: {
+          fileName: 'c.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'failed',
+        },
+        f_ok: {
+          fileName: 'e.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+      },
+    );
+
+    const results = await searchDocumentsForMention(
+      ctx as unknown as QueryCtx,
+      {
+        organizationId: 'org_1',
+        term: 'report',
+        userTeamIds: [],
+      },
+    );
+
+    expect(results.map((r) => r.documentId)).toEqual(['d_ok']);
+  });
+
+  it('excludes documents without team access and inactive documents', async () => {
+    const { ctx } = createCtx(
+      [
+        {
+          ...baseDoc,
+          _id: 'd_team_a',
+          title: 'Doc team A',
+          fileId: 'f_1',
+          teamId: 'team_a',
+        },
+        {
+          ...baseDoc,
+          _id: 'd_team_b',
+          title: 'Doc team B',
+          fileId: 'f_2',
+          teamId: 'team_b',
+        },
+        {
+          ...baseDoc,
+          _id: 'd_trashed',
+          title: 'Doc trashed',
+          fileId: 'f_3',
+          lifecycleStatus: 'trashed',
+        },
+        { ...baseDoc, _id: 'd_org', title: 'Doc org-wide', fileId: 'f_4' },
+      ],
+      {
+        f_1: {
+          fileName: 'a.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+        f_2: {
+          fileName: 'b.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+        f_3: {
+          fileName: 'c.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+        f_4: {
+          fileName: 'd.pdf',
+          contentType: 'application/pdf',
+          size: 1,
+          ragStatus: 'completed',
+        },
+      },
+    );
+
+    const results = await searchDocumentsForMention(
+      ctx as unknown as QueryCtx,
+      {
+        organizationId: 'org_1',
+        term: 'doc',
+        userTeamIds: ['team_a'],
+      },
+    );
+
+    expect(results.map((r) => r.documentId).sort()).toEqual([
+      'd_org',
+      'd_team_a',
+    ]);
+  });
+
+  it('returns newest docs on an empty query and falls back to the blob file name when the title is empty', async () => {
+    const { ctx } = createCtx(
+      [
+        {
+          ...baseDoc,
+          _id: 'd_untitled',
+          title: '  ',
+          fileId: 'f_1',
+          mimeType: 'text/plain',
+        },
+      ],
+      {
+        f_1: {
+          fileName: 'notes.txt',
+          contentType: 'text/markdown',
+          size: 9,
+          ragStatus: 'completed',
+        },
+      },
+    );
+
+    const results = await searchDocumentsForMention(
+      ctx as unknown as QueryCtx,
+      {
+        organizationId: 'org_1',
+        term: '',
+        userTeamIds: [],
+      },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      title: 'notes.txt',
+      // doc.mimeType wins over fileMetadata.contentType
+      fileType: 'text/plain',
+    });
+  });
+});

--- a/services/platform/convex/documents/search_documents_for_mention.ts
+++ b/services/platform/convex/documents/search_documents_for_mention.ts
@@ -1,0 +1,101 @@
+/**
+ * Backend search for the chat composer's `@` knowledge-base mention picker.
+ *
+ * Title search runs through the shared entity-search seam
+ * (`runEntitySearch` + `documentsSearchStrategy`), then each candidate is
+ * post-filtered to documents the user can actually pin to a turn:
+ *  - team-accessible (same rule as `listDocumentsPaginated`)
+ *  - backed by a `_storage` blob (`fileId` present)
+ *  - RAG-indexed (`fileMetadata.ragStatus === 'completed'`) — the pinned-turn
+ *    retrieval scopes the RAG query to these fileIds, so a non-indexed doc
+ *    would silently contribute nothing. Indexed-only keeps the picker honest.
+ *
+ * The scan is bounded: at most `MAX_SCAN_SLICES` paginate slices of
+ * `SCAN_SLICE_SIZE` rows, collecting up to `MENTION_RESULT_LIMIT` results.
+ */
+
+import type { PaginationResult } from 'convex/server';
+
+import type { Doc, Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import { documentsSearchStrategy, runEntitySearch } from '../lib/search';
+import { hasTeamAccess } from '../lib/team_access';
+
+export const MENTION_RESULT_LIMIT = 10;
+const MAX_SCAN_SLICES = 5;
+const SCAN_SLICE_SIZE = 50;
+
+export interface MentionDocumentResult {
+  documentId: Id<'documents'>;
+  fileId: Id<'_storage'>;
+  /** Display title — document title, falling back to the blob's file name. */
+  title: string;
+  fileType: string;
+  fileSize: number;
+  extension?: string;
+  folderPath?: string;
+}
+
+interface SearchDocumentsForMentionArgs {
+  organizationId: string;
+  /** Raw query the user typed after `@`. Empty shows the newest indexed docs. */
+  term: string;
+  userTeamIds: string[];
+}
+
+async function toMentionResult(
+  ctx: QueryCtx,
+  doc: Doc<'documents'>,
+): Promise<MentionDocumentResult | null> {
+  const fileId = doc.fileId;
+  if (!fileId) return null;
+  const fm = await ctx.db
+    .query('fileMetadata')
+    .withIndex('by_storageId', (q) => q.eq('storageId', fileId))
+    .first();
+  if (!fm || fm.ragStatus !== 'completed') return null;
+  return {
+    documentId: doc._id,
+    fileId,
+    title: doc.title?.trim() || fm.fileName,
+    fileType: doc.mimeType ?? fm.contentType,
+    fileSize: fm.size,
+    extension: doc.extension,
+    folderPath: doc.folderPath,
+  };
+}
+
+export async function searchDocumentsForMention(
+  ctx: QueryCtx,
+  args: SearchDocumentsForMentionArgs,
+): Promise<MentionDocumentResult[]> {
+  const teamSet = new Set(args.userTeamIds);
+  const results: MentionDocumentResult[] = [];
+
+  let cursor: string | null = null;
+  for (let slice = 0; slice < MAX_SCAN_SLICES; slice++) {
+    // Explicit annotation: `cursor` feeds the call whose result feeds
+    // `cursor`, which otherwise trips TS's circular-inference guard.
+    const page: PaginationResult<Doc<'documents'>> = await runEntitySearch(
+      ctx,
+      documentsSearchStrategy,
+      {
+        organizationId: args.organizationId,
+        term: args.term,
+        paginationOpts: { cursor, numItems: SCAN_SLICE_SIZE },
+        accessFilter: (doc) => !!doc.fileId && hasTeamAccess(doc, teamSet),
+      },
+    );
+
+    for (const doc of page.page) {
+      if (results.length >= MENTION_RESULT_LIMIT) break;
+      const result = await toMentionResult(ctx, doc);
+      if (result) results.push(result);
+    }
+
+    if (results.length >= MENTION_RESULT_LIMIT || page.isDone) break;
+    cursor = page.continueCursor;
+  }
+
+  return results;
+}

--- a/services/platform/convex/lib/agent_chat/internal_actions.ts
+++ b/services/platform/convex/lib/agent_chat/internal_actions.ts
@@ -270,6 +270,13 @@ const runGenerationArgs = {
   generationParams: v.optional(v.any()),
   maxContextTokens: v.optional(v.number()),
   threadTeamId: v.optional(v.string()),
+  /**
+   * Storage IDs of knowledge-base documents the user `@`-mentioned on this
+   * turn (already access-validated by chatWithAgentTurn). When present, the
+   * per-turn auto-RAG context is forced on and scoped to exactly these files
+   * — see generate_response.ts.
+   */
+  pinnedFileIds: v.optional(v.array(v.string())),
   // Server-stamped turn-start (chatWithAgent entry) for TTFT measurement.
   // Optional so jobs scheduled before this field existed still validate
   // during a rolling deploy (the consumer falls back to the action start).
@@ -756,6 +763,7 @@ export async function runGenerationCore(
             maxSteps,
             deadlineMs,
             generationParams,
+            pinnedFileIds: args.pinnedFileIds,
             requestStartMs: args.requestStartMs,
             // Suppress error cleanup (stream error, generation status clear,
             // failed message) when there are more fallback models to try.

--- a/services/platform/convex/lib/agent_chat/kb_reference_block.ts
+++ b/services/platform/convex/lib/agent_chat/kb_reference_block.ts
@@ -1,0 +1,44 @@
+/**
+ * Knowledge-base reference block appended to a user message when the composer
+ * pins documents via `@`-mention.
+ *
+ * The `*(fileId: … | fileName: … | fileType: … | fileSize: …)*` marker line
+ * MUST byte-match the enriched attachment marker emitted by
+ * `buildMessageWithAttachments` (start_agent_chat.ts): the client extracts it
+ * with `ENRICHED_ATTACHMENT_MARKER` / strips it with `INTERNAL_ENRICHED_BLOCK`
+ * (app/features/chat/hooks/use-message-processing.ts) to render file chips on
+ * the sent bubble, and the `rag_search` tool's prompt tells the model to
+ * prioritize fileIds found in the message. The round-trip is locked by a test
+ * in use-message-processing.test.ts.
+ *
+ * Kept dependency-free so app-side tests can import it without pulling the
+ * Convex runtime.
+ */
+
+export interface KbReferencedFile {
+  documentId: string;
+  fileId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}
+
+export function buildKbReferenceBlock(
+  refs: readonly KbReferencedFile[],
+): string {
+  return refs
+    .map(
+      (ref) =>
+        `📚 Referenced from the knowledge base: ${ref.fileName}\n*(fileId: ${ref.fileId} | fileName: ${ref.fileName} | fileType: ${ref.fileType} | fileSize: ${ref.fileSize})*`,
+    )
+    .join('\n\n');
+}
+
+export function appendKbReferenceBlock(
+  message: string,
+  refs: readonly KbReferencedFile[],
+): string {
+  if (refs.length === 0) return message;
+  const block = buildKbReferenceBlock(refs);
+  return message ? `${message}\n\n${block}` : block;
+}

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.test.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.test.ts
@@ -254,6 +254,85 @@ describe('startAgentChat — deferGeneration (Track B return path)', () => {
   });
 });
 
+describe('startAgentChat — `@`-mention KB references', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListMessages.mockResolvedValue({ page: [] });
+    mockSaveMessage.mockResolvedValue({ messageId: 'msg_1' });
+  });
+
+  const referencedFiles = [
+    {
+      documentId: 'doc_1',
+      fileId: 'file_kb_1',
+      fileName: 'Q3 Report.pdf',
+      fileType: 'application/pdf',
+      fileSize: 2048,
+    },
+  ];
+
+  it('appends the enriched KB reference block to the saved message and pins the fileIds', async () => {
+    const ctx = createMockCtx({ _id: 'meta_1', generationStatus: 'idle' });
+
+    const result = await startAgentChat({
+      ...createDefaultArgs(ctx),
+      deferGeneration: true,
+      referencedFiles,
+    } as never);
+
+    expect(mockSaveMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          role: 'user',
+          content:
+            'hello\n\n📚 Referenced from the knowledge base: Q3 Report.pdf\n*(fileId: file_kb_1 | fileName: Q3 Report.pdf | fileType: application/pdf | fileSize: 2048)*',
+        }),
+      }),
+    );
+    expect(result.generationArgs).toMatchObject({
+      promptMessage: expect.stringContaining('fileId: file_kb_1'),
+      // The un-augmented text used for multimodal prompts stays clean.
+      originalUserText: 'hello',
+      pinnedFileIds: ['file_kb_1'],
+    });
+    // KB refs are NOT attachments — no blob re-registration.
+    expect(result.generationArgs).toMatchObject({ attachments: undefined });
+  });
+
+  it('omits pinnedFileIds and the block when no references are passed', async () => {
+    const ctx = createMockCtx({ _id: 'meta_1', generationStatus: 'idle' });
+
+    const result = await startAgentChat({
+      ...createDefaultArgs(ctx),
+      deferGeneration: true,
+    } as never);
+
+    expect(result.generationArgs).toMatchObject({
+      promptMessage: 'hello',
+      pinnedFileIds: undefined,
+    });
+  });
+
+  it('drops KB references entirely on a prewarm turn', async () => {
+    const ctx = createMockCtx({ _id: 'meta_1', generationStatus: 'idle' });
+
+    const result = await startAgentChat({
+      ...createDefaultArgs(ctx),
+      deferGeneration: true,
+      prewarm: true,
+      referencedFiles,
+    } as never);
+
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+    expect(result.generationArgs).toMatchObject({
+      promptMessage: '.',
+      pinnedFileIds: undefined,
+    });
+  });
+});
+
 describe('startAgentChat — feature flag enforcement', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -33,6 +33,10 @@ import {
   computeDeduplicationState,
   type AgentListMessagesResult,
 } from '../message_deduplication';
+import {
+  appendKbReferenceBlock,
+  type KbReferencedFile,
+} from './kb_reference_block';
 import type {
   SerializableAgentConfig,
   AgentHooksConfig,
@@ -69,6 +73,15 @@ export interface StartAgentChatArgs {
   message: string;
   maxSteps?: number;
   attachments?: FileAttachment[];
+  /**
+   * `@`-mentioned knowledge-base documents, already resolved + authorized by
+   * the entry mutation (`chatWithAgentTurn`). Appended to the saved message as
+   * an enriched marker block (same format as attachment markers, so the
+   * client's chip extraction and the `rag_search` tool's fileId-priority
+   * behavior apply unchanged) and forwarded as `pinnedFileIds` to scope the
+   * per-turn auto-RAG query.
+   */
+  referencedFiles?: KbReferencedFile[];
   /** Additional context to pass to the agent (key-value pairs) */
   additionalContext?: Record<string, string>;
   /** User environment context (timezone, language, UI locale) for template variables */
@@ -283,11 +296,20 @@ export async function startAgentChat(
     computeDeduplicationState(existingMessages, message);
 
   const hasAttachments = attachments && attachments.length > 0;
+  const referencedFiles = prewarm ? [] : (args.referencedFiles ?? []);
 
-  // Build message content with attachment markdown
-  const messageContent = hasAttachments
+  // Build message content with attachment markdown, then append the
+  // knowledge-base reference block for `@`-mentioned documents. The block
+  // reuses the enriched attachment marker format, so the client renders the
+  // refs as file chips and strips the block from the bubble body with zero
+  // new display plumbing (see kb_reference_block.ts).
+  const messageWithAttachments = hasAttachments
     ? await buildMessageWithAttachments(ctx, trimmedMessage, attachments)
     : trimmedMessage;
+  const messageContent = appendKbReferenceBlock(
+    messageWithAttachments,
+    referencedFiles,
+  );
 
   // Save user message if not a duplicate
   let promptMessageId: string;
@@ -520,6 +542,12 @@ export async function startAgentChat(
     promptMessage: prewarm ? '.' : messageContent,
     originalUserText: prewarm ? '.' : trimmedMessage,
     attachments: prewarm ? undefined : actionAttachments,
+    // Pinned RAG scope for this turn — explicit user intent, so it applies
+    // even on a dedup hit (a resend of the same message keeps its pins).
+    pinnedFileIds:
+      referencedFiles.length > 0
+        ? referencedFiles.map((ref) => ref.fileId)
+        : undefined,
     streamId: streamId || undefined,
     promptMessageId: prewarm ? undefined : promptMessageId,
     maxSteps,

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -97,6 +97,14 @@ import { AgentTimeoutError, withTimeout } from './with_timeout';
 
 const OUTPUT_BLOCKED_SENTINEL = '[blocked by content policy]';
 
+/**
+ * Similarity threshold for the auto-RAG query when the turn carries
+ * `@`-mentioned (pinned) documents. Matches the `rag_search` tool default —
+ * the standard 0.51 returns nothing for indirect phrasings like
+ * "summarize @Doc", and the pinned scope already bounds the result set.
+ */
+const PINNED_KB_SIMILARITY_THRESHOLD = 0.3;
+
 function convexErrorToBlockedReason(err: unknown): BlockedReason | null {
   if (!(err instanceof ConvexError)) return null;
   const data: unknown = err.data;
@@ -480,6 +488,7 @@ export async function generateAgentResponse(
     generationParams,
     suppressErrorCleanup,
     prewarm,
+    pinnedFileIds,
   } = args;
 
   const debugLog = createDebugLog(
@@ -810,13 +819,19 @@ export async function generateAgentResponse(
     // Determine retrieval modes
     const knowledgeMode = configKnowledgeMode ?? 'off';
     const webSearchMode = configWebSearchMode ?? 'off';
+    // `@`-mentioned KB documents force knowledge-context injection regardless
+    // of the agent's knowledgeMode — an explicit user pin is stronger intent
+    // than the agent's default retrieval config.
+    const hasPinnedKbRefs =
+      !prewarm && pinnedFileIds !== undefined && pinnedFileIds.length > 0;
     // Prewarm skips volatile RAG/web retrieval: those land AFTER the cache
     // breakpoint, so omitting them keeps the cached prefix identical to the
     // real first turn while making the priming call cheap and fast. Thread
     // history is also volatile (post-breakpoint) but isn't gated here — prewarm
     // primes a fresh thread, so it's empty in practice either way.
     const needsKnowledgeContext =
-      !prewarm && (knowledgeMode === 'context' || knowledgeMode === 'both');
+      hasPinnedKbRefs ||
+      (!prewarm && (knowledgeMode === 'context' || knowledgeMode === 'both'));
     const needsWebContext =
       !prewarm && (webSearchMode === 'context' || webSearchMode === 'both');
 
@@ -833,24 +848,31 @@ export async function generateAgentResponse(
       // Degrade to "no knowledge context this turn" (logged) rather than abort
       // the whole response — same guardrail as the orgSlugFromId resolve below.
       let accessibleFileIds: string[] = [];
-      try {
-        accessibleFileIds = await ctx.runQuery(
-          internal.documents.internal_queries.getAgentScopedFileIds,
-          {
-            organizationId,
-            agentTeamId,
-            agentTeamIds,
-            includeTeamKnowledge,
-            includeOrgKnowledge,
-            knowledgeFileIds,
-            agentProjectIds,
-          },
-        );
-      } catch (err) {
-        console.warn(
-          '[generateAgentResponse] getAgentScopedFileIds failed; skipping knowledge context',
-          err instanceof Error ? err.message : err,
-        );
+      if (hasPinnedKbRefs && pinnedFileIds) {
+        // Explicit `@`-mentions REPLACE the agent scope for this turn (focused
+        // retrieval over the pinned documents only). Access was validated
+        // synchronously in chatWithAgentTurn, so no scope query is needed.
+        accessibleFileIds = pinnedFileIds;
+      } else {
+        try {
+          accessibleFileIds = await ctx.runQuery(
+            internal.documents.internal_queries.getAgentScopedFileIds,
+            {
+              organizationId,
+              agentTeamId,
+              agentTeamIds,
+              includeTeamKnowledge,
+              includeOrgKnowledge,
+              knowledgeFileIds,
+              agentProjectIds,
+            },
+          );
+        } catch (err) {
+          console.warn(
+            '[generateAgentResponse] getAgentScopedFileIds failed; skipping knowledge context',
+            err instanceof Error ? err.message : err,
+          );
+        }
       }
       if (accessibleFileIds.length === 0) {
         debugLog('No accessible RAG documents, skipping knowledge context');
@@ -873,13 +895,17 @@ export async function generateAgentResponse(
           knowledgeContextPromise = queryRagContext(
             promptMessage,
             undefined,
-            undefined,
+            // Pinned queries relax the similarity threshold (matching the
+            // rag_search tool default): "summarize @Doc" phrasing scores low
+            // against the doc body, and the default 0.51 returns nothing.
+            hasPinnedKbRefs ? PINNED_KB_SIMILARITY_THRESHOLD : undefined,
             undefined,
             undefined,
             { fileIds: accessibleFileIds, orgSlug },
           );
           debugLog('Knowledge context query started', {
             threadId,
+            pinned: hasPinnedKbRefs,
             elapsedMs: Date.now() - startTime,
           });
         }

--- a/services/platform/convex/lib/agent_response/types.ts
+++ b/services/platform/convex/lib/agent_response/types.ts
@@ -219,6 +219,15 @@ export interface GenerateResponseArgs {
   /** Governance-resolved max context tokens (overrides agent default) */
   maxContextTokens?: number;
   /**
+   * Storage IDs of knowledge-base documents the user explicitly
+   * `@`-mentioned on this turn (resolved + access-validated upstream by
+   * `chatWithAgentTurn`). When non-empty, knowledge-context injection is
+   * forced on (explicit user intent overrides the agent's `knowledgeMode`)
+   * and the RAG query is scoped to exactly these files instead of the
+   * agent's configured scope, with a relaxed similarity threshold.
+   */
+  pinnedFileIds?: string[];
+  /**
    * When true, the error path skips saving a failed message, marking the
    * stream as error, and clearing the generation status. Used by the
    * fallback retry loop so the caller can handle cleanup itself without

--- a/services/platform/convex/lib/search/index.ts
+++ b/services/platform/convex/lib/search/index.ts
@@ -10,3 +10,4 @@ export { isActiveRow, rowMatches, scoreAndSort } from './relevance';
 
 // Per-entity strategies.
 export { customersSearchStrategy } from './strategies/customers';
+export { documentsSearchStrategy } from './strategies/documents';

--- a/services/platform/convex/lib/search/strategies/documents.ts
+++ b/services/platform/convex/lib/search/strategies/documents.ts
@@ -1,0 +1,13 @@
+import type { SearchStrategy } from '../types';
+
+/** Documents are searched by title (substring). Trashed/expired rows are
+ *  excluded via `activeOnly`. Swap `engine` to `'searchIndex'` (+
+ *  `searchIndexName: 'search_documents'`, `searchIndexField: 'title'`) once
+ *  the bootstrap is fixed — see `TODO(search-index-disabled)`. */
+export const documentsSearchStrategy: SearchStrategy<'documents'> = {
+  table: 'documents',
+  orgIndex: 'by_organizationId',
+  textFields: ['title'],
+  activeOnly: true,
+  engine: 'scan',
+};

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -801,7 +801,8 @@
       "piiBlocked": "Nachricht durch PII-Richtlinie blockiert",
       "policyViolation": "Nachricht durch Inhaltsrichtlinie blockiert",
       "modelAccessDenied": "Modell nicht verfügbar",
-      "budgetExceeded": "Nutzungslimit erreicht"
+      "budgetExceeded": "Nutzungslimit erreicht",
+      "kbRefInvalid": "Ein referenziertes Dokument ist nicht mehr verfügbar. Entferne es und versuche es erneut."
     },
     "blockedNotice": {
       "body": "Diese Antwort wurde durch die Inhaltsrichtlinie deiner Organisation blockiert."
@@ -1559,7 +1560,16 @@
     "capabilityDisable": "{name} deaktivieren",
     "requiresIntegration": "Benötigt {name}",
     "takeScreenshot": "Screenshot aufnehmen",
-    "screenshotFailed": "Screenshot konnte nicht aufgenommen werden"
+    "screenshotFailed": "Screenshot konnte nicht aufgenommen werden",
+    "kbMention": {
+      "title": "Wissensdatenbank",
+      "loading": "Dokumente werden durchsucht …",
+      "empty": "Keine passenden indexierten Dokumente",
+      "emptyNoQuery": "Noch keine indexierten Dokumente",
+      "chipLabel": "Wissensdatenbank",
+      "removeMention": "Verweis auf {title} entfernen",
+      "limitReached": "Du kannst pro Nachricht bis zu {max} Dokumente referenzieren"
+    }
   },
   "connectivity": {
     "tabTitle": "Verbindung wird wiederhergestellt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -801,7 +801,8 @@
       "piiBlocked": "Message blocked by PII policy",
       "policyViolation": "Message blocked by content policy",
       "modelAccessDenied": "Model not available",
-      "budgetExceeded": "Usage limit reached"
+      "budgetExceeded": "Usage limit reached",
+      "kbRefInvalid": "A referenced document is no longer available. Remove it and try again."
     },
     "blockedNotice": {
       "body": "This response was blocked by your organization's content policy."
@@ -1559,7 +1560,16 @@
     "modeHeader": "Modes",
     "capabilityHeader": "Capabilities",
     "capabilityDisable": "Disable {name}",
-    "requiresIntegration": "Requires {name}"
+    "requiresIntegration": "Requires {name}",
+    "kbMention": {
+      "title": "Knowledge base",
+      "loading": "Searching documents…",
+      "empty": "No matching indexed documents",
+      "emptyNoQuery": "No indexed documents yet",
+      "chipLabel": "Knowledge base",
+      "removeMention": "Remove reference to {title}",
+      "limitReached": "You can reference up to {max} documents per message"
+    }
   },
   "connectivity": {
     "tabTitle": "Reconnecting",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -802,7 +802,8 @@
       "piiBlocked": "Message bloqué par la politique de protection des données personnelles",
       "policyViolation": "Message bloqué par la politique de contenu",
       "modelAccessDenied": "Modèle non disponible",
-      "budgetExceeded": "Limite d'utilisation atteinte"
+      "budgetExceeded": "Limite d'utilisation atteinte",
+      "kbRefInvalid": "Un document référencé n’est plus disponible. Supprime-le et réessaie."
     },
     "blockedNotice": {
       "body": "Cette réponse a été bloquée par la politique de contenu de ton organisation."
@@ -1560,7 +1561,16 @@
     "capabilityDisable": "Désactiver {name}",
     "requiresIntegration": "Nécessite {name}",
     "takeScreenshot": "Faire une capture d'écran",
-    "screenshotFailed": "Impossible de faire la capture d'écran"
+    "screenshotFailed": "Impossible de faire la capture d'écran",
+    "kbMention": {
+      "title": "Base de connaissances",
+      "loading": "Recherche de documents…",
+      "empty": "Aucun document indexé correspondant",
+      "emptyNoQuery": "Aucun document indexé pour le moment",
+      "chipLabel": "Base de connaissances",
+      "removeMention": "Supprimer la référence à {title}",
+      "limitReached": "Tu peux référencer jusqu’à {max} documents par message"
+    }
   },
   "connectivity": {
     "tabTitle": "Reconnexion",


### PR DESCRIPTION
Closes #1337

## What / why

There was no way to reference a specific knowledge-base document directly in chat — KB grounding was automatic-only (agent-scoped RAG) and the only manual path was attach-upload, which re-uploads and re-indexes a blob that is already in the knowledge base. This adds a Cursor-style `@`-mention picker to the composer that pins specific indexed documents to a single turn.

**Flow:** `@` in the composer → anchored picker over RAG-indexed, team-accessible documents (title search) → selection adds a chip + inserts `@Title` prose → on send the client passes `referencedDocumentIds` (cap 5) → `chatWithAgentTurn` re-validates each reference synchronously (same org, active, team access, blob-backed, `ragStatus === 'completed'`; one opaque `KB_REF_INVALID` error for all failure modes) → the resolved refs are appended to the saved user message as the existing enriched `*(fileId: …)*` marker block and the turn's auto-RAG query is scoped to exactly the pinned fileIds.

**Key pieces:**
- `convex/lib/search/strategies/documents.ts` — documents title-search strategy on the shared `runEntitySearch` seam (scan engine; flips to search-index with zero call-site changes when the bootstrap lands).
- `convex/documents/search_documents_for_mention.ts` + public query `searchDocumentsForMention` — bounded scan (≤5 slices × 50 rows), post-filtered to team-accessible + RAG-indexed docs, slim rows.
- `chatWithAgentTurn` → `runChatTurnGeneration` → `startChat` → `startAgentChat`: `referencedFiles` threading; `kb_reference_block.ts` emits the marker block (byte-compatible with `ENRICHED_ATTACHMENT_MARKER`, locked by a round-trip test against the client regexes), so sent-bubble chips and the `rag_search` tool's "prioritize fileIds found in the message" behavior work with zero new display plumbing.
- `generate_response.ts`: `pinnedFileIds` forces knowledge-context injection, replaces the agent scope for the turn, and relaxes the similarity threshold to 0.3.
- Composer: `useKbMentions` (chips state + caret-based `(^|\s)@(\S*)$` trigger detection), `KbMentionPopover` (listbox, full keyboard nav via `chat-input.tsx#handleKeyDown`, `aria-activedescendant` combobox pattern, IME-guarded), send-failure rollback mirroring the video-link chip pattern.

**No `services/rag` changes** — the existing `/api/v1/search` `file_ids` filter does the scoping.

## Decision-gate recommendations baked in (veto at review)

- **Pinned-turn retrieval scope: REPLACE the agent scope** with the pinned fileIds (focused retrieval), not union.
- **Explicit mention forces knowledge-context injection** even when the agent's `knowledgeMode` is `off`/`tool` (explicit user intent overrides admin agent config).
- **Similarity threshold relaxed to 0.3** for pinned queries (rag_search tool default; 0.51 returns nothing for "summarize @Doc" phrasing).
- **Chips are the source of truth** — deleting the `@Title` prose does not drop the pin; remove the chip instead.
- **Arena mode: `@` trigger hidden in v1** (`referencedDocumentIds` not wired through `arena_chat`).
- **Picker is indexed-only** (no greyed-out non-indexed rows in v1).

## Merge-order note (#662 / #1517)

This PR makes **no changes to `agent_tools/rag/rag_search_tool.ts`** or to the RAG service — the tool benefit comes for free from the marker block in the message text. #662/#1517 are changing that tool's parameter surface in parallel; per the plan's merge order, **#1337 rebases last** if anything overlaps (expected overlap: none).

## Deviations from the plan

- `KbMentionPopover` is purely presentational; the `SearchSource` hook is consumed in `chat-input.tsx` (which owns keyboard nav state) instead of inside the popover — keeps Up/Down/Enter/Escape interception and the highlighted index in one place.
- The mention helper reads `fileMetadata` directly (single pass also yields `fileName`/`contentType`/`size`) instead of `getDocumentRagProjectionBatch`; semantics identical (`ragStatus === 'completed'`).
- Error toast key is `chat.toast.kbRefInvalid` (the `chat.errors.*` namespace the plan implied doesn't exist).

## Verification

Performed:
- `bun run check` at repo root — green (format, lint incl. type-aware oxlint, typecheck, 366 server/pii test files).
- Platform `test:ui` full suite — 283 files / 2216 tests green (includes the new `use-kb-mentions`, `kb-mention-popover` a11y, and marker round-trip tests).
- New tests: `search_documents_for_mention.test.ts` (access/indexed-only filtering, title fallback), `use-kb-mentions.test.ts` (trigger detection incl. email/mid-word non-triggers, cap/dedupe/rollback), `start_agent_chat.test.ts` (marker block on saved message, `pinnedFileIds` in generation args, prewarm drops refs), KB-block round-trip lock in `use-message-processing.test.ts` against the client regexes.
- `bun run --filter @tale/docs lint && test` — green (locale/structure parity for the new docs section).

Manual verification required (needs the running local stack with a live RAG deployment — not performed here):
- Mention an indexed doc → chip renders pre/post send; the agent answer cites the pinned doc (citations flow through `knowledgeContextResult.citations`).
- Agent with `knowledgeMode: 'off'` still injects pinned context.
- Doc outside the agent's scope but user-accessible works; non-indexed docs absent from the picker.
- Arena mode shows no trigger; IME composition unaffected (existing `isComposingRef` guards).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no loading states added).
- [x] Updated `services/platform/messages/{en,de,fr}.json` (`composer.kbMention.*`, `chat.toast.kbRefInvalid`; de-CH carries no override).
- [x] Updated `/docs/{en,de,fr}/platform/chat/attachments.md` ("Referencing knowledge documents with @" section).
- [x] Touched docs page has a real opening and closing (pre-existing; section added mid-page).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] README updates — N/A.
