### PR TITLE
feat(rag): folder-scoped search filter

### DIFF
--- a/docs/de/platform/agents/tools.md
+++ b/docs/de/platform/agents/tools.md
@@ -15,7 +15,7 @@ Der User fragt „wie ist das Wetter in Zürich heute". Der Agent hat das Web-To
 
 - **Web** — holt und liest URLs, die das Modell für nützlich hält.
 - **Dateien** — liest Anhänge und Dateien im aktiven Projekt.
-- **RAG** — sucht in Wissensquellen, die an den Agent gebunden sind, und gibt Chunks mit Zitaten zurück.
+- **RAG** — sucht in Wissensquellen, die an den Agent gebunden sind, und gibt Chunks mit Zitaten zurück. Nennst du in deiner Anfrage einen Ordner („such nur in Contracts/2024"), beschränkt der Agent die Suche auf diesen Ordner und seine Unterordner.
 - **Run code** — führt Python, Node oder Shell-Skripte in einer Sandbox aus. Gegated durch die [Run-Code-Richtlinie](/de/platform/admin/governance/run-code-policy) der Org.
 - **Sub-Agents** — delegiert an einen anderen Agent, den die Org als sub-agent-aufrufbar markiert hat. Loop-Verhinderung lebt in [Delegation](/de/platform/agents/delegation).
 - **Workflows** — ruft einen Tale-Workflow als Tool auf. Die Outputs des Workflows kommen als Tool-Ergebnis zurück.

--- a/docs/en/platform/agents/tools.md
+++ b/docs/en/platform/agents/tools.md
@@ -15,7 +15,7 @@ The user asks "what is the weather in Zurich today". The agent has the web tool 
 
 - **Web** — fetches and reads URLs the model decides are useful.
 - **Files** — reads attachments and files in the active Project.
-- **RAG** — searches knowledge sources bound to the agent and returns chunks with citations.
+- **RAG** — searches knowledge sources bound to the agent and returns chunks with citations. Name a folder in your request ("search only in Contracts/2024") and the agent scopes retrieval to that folder and its subfolders.
 - **Run code** — runs Python, Node, or shell scripts in a sandbox. Gated by the org's [run-code policy](/platform/admin/governance/run-code-policy).
 - **Sub-agents** — delegates to another agent the org has marked sub-agent-callable. Loop prevention rules live on [Delegation](/platform/agents/delegation).
 - **Workflows** — invokes a Tale workflow as a tool. The workflow's outputs come back as the tool result.

--- a/docs/fr/platform/agents/tools.md
+++ b/docs/fr/platform/agents/tools.md
@@ -15,7 +15,7 @@ L'utilisateur demande « quel temps fait-il à Zurich aujourd'hui ». L'agent a 
 
 - **Web** — récupère et lit les URL que le modèle juge utiles.
 - **Fichiers** — lit les pièces jointes et fichiers du Projet actif.
-- **RAG** — cherche dans les sources de connaissances liées à l'agent et retourne des chunks avec citations.
+- **RAG** — cherche dans les sources de connaissances liées à l'agent et retourne des chunks avec citations. Nomme un dossier dans ta demande (« cherche seulement dans Contracts/2024 ») et l'agent limite la recherche à ce dossier et à ses sous-dossiers.
 - **Run code** — exécute Python, Node ou des scripts shell dans une sandbox. Gouverné par la [politique run-code](/fr/platform/admin/governance/run-code-policy) de l'organisation.
 - **Sous-agents** — délègue à un autre agent que l'organisation a marqué appelable comme sous-agent. La prévention des boucles vit sur [Délégation](/fr/platform/agents/delegation).
 - **Workflows** — invoque un workflow Tale comme un outil. Les sorties du workflow reviennent comme résultat d'outil.

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -740,6 +740,7 @@ import type * as migrations_backfill_filemetadata_rag_status from "../migrations
 import type * as migrations_backfill_folder_path from "../migrations/backfill_folder_path.js";
 import type * as migrations_backfill_folders from "../migrations/backfill_folders.js";
 import type * as migrations_backfill_ledger_granularity from "../migrations/backfill_ledger_granularity.js";
+import type * as migrations_backfill_rag_folder_path from "../migrations/backfill_rag_folder_path.js";
 import type * as migrations_backfill_skill_scaffolding from "../migrations/backfill_skill_scaffolding.js";
 import type * as migrations_backfill_thread_metadata from "../migrations/backfill_thread_metadata.js";
 import type * as migrations_backfill_wf_installations from "../migrations/backfill_wf_installations.js";
@@ -2068,6 +2069,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/backfill_folder_path": typeof migrations_backfill_folder_path;
   "migrations/backfill_folders": typeof migrations_backfill_folders;
   "migrations/backfill_ledger_granularity": typeof migrations_backfill_ledger_granularity;
+  "migrations/backfill_rag_folder_path": typeof migrations_backfill_rag_folder_path;
   "migrations/backfill_skill_scaffolding": typeof migrations_backfill_skill_scaffolding;
   "migrations/backfill_thread_metadata": typeof migrations_backfill_thread_metadata;
   "migrations/backfill_wf_installations": typeof migrations_backfill_wf_installations;

--- a/services/platform/convex/agent_tools/rag/rag_search_tool.ts
+++ b/services/platform/convex/agent_tools/rag/rag_search_tool.ts
@@ -27,6 +27,10 @@ import {
 } from '../../lib/errors/upstream_http_error';
 import { orgSlugFromIdOrNull } from '../../lib/helpers/org_slug';
 import { ragFetch } from '../../lib/helpers/rag_config';
+import {
+  MAX_FOLDER_PATH_LENGTH,
+  normalizeFolderPath,
+} from '../../lib/helpers/rag_folder_path';
 import { toId } from '../../lib/type_cast_helpers';
 import { wrapUntrusted } from '../../lib/untrusted_content';
 import { getThreadAncestorChain } from '../../threads/get_thread_ancestor_chain';
@@ -141,6 +145,13 @@ const ragToolArgs = z.discriminatedUnion('operation', [
       .describe(
         'Specific file IDs to search within. When provided, only these files are searched (skips automatic file resolution). IMPORTANT: If the user message contains file IDs (from uploaded attachments), pass them here first to prioritize those files. Retry without fileIds for a broader search if no relevant results are found.',
       ),
+    folderPath: z
+      .string()
+      .max(MAX_FOLDER_PATH_LENGTH)
+      .optional()
+      .describe(
+        'Restrict search to one Document Hub folder and ALL of its subfolders (e.g. "contracts/2024" also matches "contracts/2024/q1"). Use "/" separators, no leading slash. Exact, hierarchical matching — unlike document_find\'s fuzzy, non-recursive folderPath filter. Retry without folderPath for a broader search if no relevant results are found.',
+      ),
     topK: z
       .number()
       .int()
@@ -204,6 +215,9 @@ WHEN TO USE 'search':
 
 SEARCH STRATEGY — file ID priority:
 When the user's message contains file IDs (e.g. from uploaded attachments), ALWAYS pass those IDs in the 'fileIds' parameter first to search within those specific files. If that returns no relevant results, retry WITHOUT fileIds to perform a broader knowledge base search. This ensures uploaded/referenced files are prioritized while still falling back to the full knowledge base when needed.
+
+SEARCH SCOPING — folder filter:
+When the user asks to search within a specific folder ("search the contracts folder", "only look in Reports/2024"), pass 'folderPath'. It matches that Document Hub folder and all of its subfolders. If the folder-scoped search returns nothing relevant, retry without folderPath.
 
 WHEN TO USE 'retrieve':
 • Reading content of a specific uploaded file (paginated, 10 chunks per call by default)
@@ -476,17 +490,21 @@ RESPONSE (list_indexed):
         };
       }
 
+      const folderPath = normalizeFolderPath(args.folderPath);
+
       const payload = {
         query: args.query,
         file_ids: fileIds,
         top_k: args.topK ?? DEFAULT_TOP_K,
         similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
         include_metadata: true,
+        ...(folderPath ? { folder_path: folderPath } : {}),
       };
 
       debugLog('tool:rag_search requesting search', {
         fileCount: fileIds.length,
         fileIds,
+        folderPath,
       });
 
       try {

--- a/services/platform/convex/documents/internal_actions.ts
+++ b/services/platform/convex/documents/internal_actions.ts
@@ -665,6 +665,7 @@ export const uploadDocumentToRag = internalAction({
           fileId: document.fileId,
           fileName: document.title,
           contentType: document.mimeType,
+          folderPath: document.folderPath,
         },
         { organizationId: document.organizationId },
       );
@@ -799,6 +800,7 @@ export const reindexDocumentInRag = internalAction({
           fileId: document.fileId,
           fileName: document.title,
           contentType: document.mimeType,
+          folderPath: document.folderPath,
         },
         { organizationId: document.organizationId },
       );
@@ -864,6 +866,74 @@ export const reindexDocumentInRag = internalAction({
       } else {
         console.warn(
           `[reindexDocumentInRag] No org context for old RAG delete; oldFileId ${args.oldFileId} may leak chunks (documentId=${args.documentId})`,
+        );
+      }
+    }
+
+    return null;
+  },
+});
+
+const FOLDER_PATH_SYNC_BATCH_SIZE = 200;
+
+/**
+ * Best-effort sync of denormalized folder paths to the RAG service via
+ * `PATCH /api/v1/documents/folder-paths` (no re-extraction/re-embedding).
+ * Scheduled on folder moves/renames so the folder-scoped search filter
+ * stays fresh.
+ *
+ * folder_path on the RAG side is a narrowing filter only — `file_ids`
+ * stays the authorization boundary — so a failed sync degrades folder
+ * filter precision but never leaks anything. Warn-and-skip on failure.
+ */
+export const syncRagFolderPaths = internalAction({
+  args: {
+    organizationId: v.string(),
+    updates: v.array(
+      v.object({
+        fileId: v.id('_storage'),
+        /** New folder path; omitted clears it (document moved to the root). */
+        folderPath: v.optional(v.string()),
+      }),
+    ),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    if (args.updates.length === 0) return null;
+
+    const orgSlug = await orgSlugFromIdOrNull(ctx, args.organizationId);
+    if (orgSlug === null) {
+      console.warn(
+        `[syncRagFolderPaths] org ${args.organizationId} unresolvable; skipping folder-path sync for ${args.updates.length} file(s)`,
+      );
+      return null;
+    }
+
+    for (let i = 0; i < args.updates.length; i += FOLDER_PATH_SYNC_BATCH_SIZE) {
+      const batch = args.updates.slice(i, i + FOLDER_PATH_SYNC_BATCH_SIZE);
+      try {
+        const response = await ragFetch('/api/v1/documents/folder-paths', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            updates: batch.map((u) => ({
+              file_id: u.fileId,
+              folder_path: u.folderPath ?? null,
+            })),
+          }),
+          timeoutMs: 30_000,
+          orgSlug,
+        });
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => '');
+          console.warn(
+            `[syncRagFolderPaths] RAG folder-path sync failed (${response.status}) for ${batch.length} file(s): ${errorText.slice(0, 200)}`,
+          );
+        }
+      } catch (error) {
+        console.warn(
+          '[syncRagFolderPaths] Error syncing folder paths to RAG:',
+          error,
         );
       }
     }

--- a/services/platform/convex/documents/update_document_internal.test.ts
+++ b/services/platform/convex/documents/update_document_internal.test.ts
@@ -10,13 +10,18 @@ type Doc = Record<string, unknown> & { _id: string; fileId?: string };
  * schedules `reindexDocumentInRag` when that blob is completed AND the file or
  * title changed.
  */
-function createMockCtx(document: Doc, fm: Record<string, unknown> | null) {
+function createMockCtx(
+  document: Doc,
+  fm: Record<string, unknown> | null,
+  folders: Record<string, Record<string, unknown>> = {},
+) {
   const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
   const scheduled: Array<{ args: Record<string, unknown> }> = [];
 
   const ctx = {
     db: {
-      get: async (id: unknown) => (id === document._id ? document : null),
+      get: async (id: unknown) =>
+        id === document._id ? document : (folders[String(id)] ?? null),
       query: () => {
         let storageId: unknown;
         const q = {
@@ -138,5 +143,79 @@ describe('updateDocumentInternal reindex gate', () => {
     });
 
     expect(scheduled).toHaveLength(0);
+  });
+});
+
+describe('updateDocumentInternal folder-move RAG sync', () => {
+  const contractsFolder = {
+    f1: { _id: 'f1', name: 'Contracts', organizationId: 'org1' },
+  };
+
+  it('schedules syncRagFolderPaths on a folder move of an indexed doc', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'completed' },
+      contractsFolder,
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      folderId: 'f1' as never,
+    });
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].args).toEqual({
+      organizationId: 'org1',
+      updates: [{ fileId: 's1', folderPath: 'Contracts' }],
+    });
+  });
+
+  it('does NOT sync folder paths when the doc is not indexed', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'queued' },
+      contractsFolder,
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      folderId: 'f1' as never,
+    });
+
+    expect(scheduled).toHaveLength(0);
+  });
+
+  it('does NOT sync when folderId is unchanged', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc, folderId: 'f1' },
+      { ragStatus: 'completed' },
+      contractsFolder,
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      folderId: 'f1' as never,
+    });
+
+    expect(scheduled).toHaveLength(0);
+  });
+
+  it('skips the folder sync when a reindex is scheduled (re-upload carries the path)', async () => {
+    const { ctx, scheduled } = createMockCtx(
+      { ...baseDoc },
+      { ragStatus: 'completed' },
+      contractsFolder,
+    );
+
+    await updateDocumentInternal(ctx, {
+      documentId: 'd1' as never,
+      contentHash: 'newhash',
+      fileId: 's2' as never,
+      folderId: 'f1' as never,
+    });
+
+    // Only the reindex is scheduled — not a duplicate folder-path sync.
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].args).toMatchObject({ documentId: 'd1' });
   });
 });

--- a/services/platform/convex/documents/update_document_internal.ts
+++ b/services/platform/convex/documents/update_document_internal.ts
@@ -127,4 +127,22 @@ export async function updateDocumentInternal(
       },
     );
   }
+
+  // Folder move on an indexed doc: RAG keeps a denormalized folder_path
+  // for folder-scoped search, and a move alone never re-uploads — sync
+  // it explicitly. Skipped when a re-index is scheduled (the re-upload
+  // carries the new folder path itself).
+  const folderMoved =
+    updateData.folderId !== undefined &&
+    updateData.folderId !== document.folderId;
+  if (folderMoved && wasIndexed && currentFileId && !needsReindex) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.documents.internal_actions.syncRagFolderPaths,
+      {
+        organizationId: document.organizationId,
+        updates: [{ fileId: currentFileId, folderPath: updateData.folderPath }],
+      },
+    );
+  }
 }

--- a/services/platform/convex/lib/helpers/rag_folder_path.test.ts
+++ b/services/platform/convex/lib/helpers/rag_folder_path.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_FOLDER_PATH_LENGTH, normalizeFolderPath } from './rag_folder_path';
+
+describe('normalizeFolderPath', () => {
+  it('returns a plain path unchanged', () => {
+    expect(normalizeFolderPath('contracts/2024')).toBe('contracts/2024');
+  });
+
+  it('strips surrounding whitespace and slashes', () => {
+    expect(normalizeFolderPath(' /contracts/2024/ ')).toBe('contracts/2024');
+    expect(normalizeFolderPath('/ / a')).toBe('a');
+  });
+
+  it('preserves inner slashes', () => {
+    expect(normalizeFolderPath('a/b/c')).toBe('a/b/c');
+  });
+
+  it('returns undefined for empty and separator-only values', () => {
+    expect(normalizeFolderPath('')).toBeUndefined();
+    expect(normalizeFolderPath('   ')).toBeUndefined();
+    expect(normalizeFolderPath('///')).toBeUndefined();
+  });
+
+  it('returns undefined for null and undefined', () => {
+    expect(normalizeFolderPath(null)).toBeUndefined();
+    expect(normalizeFolderPath(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for over-long paths', () => {
+    expect(
+      normalizeFolderPath('x'.repeat(MAX_FOLDER_PATH_LENGTH + 1)),
+    ).toBeUndefined();
+  });
+});

--- a/services/platform/convex/lib/helpers/rag_folder_path.ts
+++ b/services/platform/convex/lib/helpers/rag_folder_path.ts
@@ -1,0 +1,30 @@
+/**
+ * Folder-path normalization for the RAG folder-scoped search filter.
+ *
+ * The platform's canonical folder path format is `parent/child` —
+ * segments joined by `/` with no leading or trailing slash (see
+ * `folders/queries.ts buildFolderPath`). The Python twin of this helper
+ * lives at `services/rag/app/utils/folder_path.py` — keep both in sync.
+ */
+
+/** Mirrors MAX_FOLDER_PATH_LENGTH in services/rag/app/utils/folder_path.py. */
+const MAX_FOLDER_PATH_LENGTH = 1024;
+
+/**
+ * Normalize a folder path to the canonical `parent/child` form: strip
+ * surrounding whitespace and slashes. Returns `undefined` for empty,
+ * all-separator, or over-long values so callers can treat the result
+ * as "no folder filter".
+ */
+function normalizeFolderPath(
+  value: string | undefined | null,
+): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.replace(/^[\s/]+/, '').replace(/[\s/]+$/, '');
+  if (normalized.length === 0 || normalized.length > MAX_FOLDER_PATH_LENGTH) {
+    return undefined;
+  }
+  return normalized;
+}
+
+export { MAX_FOLDER_PATH_LENGTH, normalizeFolderPath };

--- a/services/platform/convex/migrations/backfill_rag_folder_path.ts
+++ b/services/platform/convex/migrations/backfill_rag_folder_path.ts
@@ -1,0 +1,103 @@
+/**
+ * Migration: Sync Document Hub folder paths to the RAG service.
+ *
+ * RAG stores a denormalized `documents.folder_path` used by the
+ * folder-scoped search filter. Documents indexed before that column
+ * existed carry NULL folder_path on the RAG side and would never match
+ * folder-filtered searches. This sweep pushes the platform's canonical
+ * `documents.folderPath` for every active file-backed document through
+ * the batch `PATCH /api/v1/documents/folder-paths` endpoint — no
+ * re-extraction or re-embedding. Files that were never indexed simply
+ * update zero RAG rows.
+ *
+ * Idempotent: re-running re-sends the same values.
+ *
+ * Usage:
+ *   bunx convex run migrations/backfill_rag_folder_path:backfillRagFolderPath
+ */
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { internalAction, internalQuery } from '../_generated/server';
+
+const BATCH_SIZE = 200;
+
+type FolderDocPage = {
+  continueCursor: string;
+  isDone: boolean;
+  docs: Array<{
+    organizationId: string;
+    fileId: Id<'_storage'>;
+    folderPath: string;
+  }>;
+};
+
+export const listFolderDocsPage = internalQuery({
+  args: { cursor: v.union(v.string(), v.null()) },
+  handler: async (ctx, args): Promise<FolderDocPage> => {
+    const result = await ctx.db
+      .query('documents')
+      .paginate({ cursor: args.cursor, numItems: BATCH_SIZE });
+
+    return {
+      continueCursor: result.continueCursor,
+      isDone: result.isDone,
+      docs: result.page.flatMap((doc) => {
+        if ((doc.lifecycleStatus ?? 'active') !== 'active') return [];
+        if (!doc.fileId || !doc.folderPath) return [];
+        return [
+          {
+            organizationId: doc.organizationId,
+            fileId: doc.fileId,
+            folderPath: doc.folderPath,
+          },
+        ];
+      }),
+    };
+  },
+});
+
+export const backfillRagFolderPath = internalAction({
+  args: {},
+  returns: v.object({ synced: v.number() }),
+  handler: async (ctx): Promise<{ synced: number }> => {
+    let cursor: string | null = null;
+    let isDone = false;
+    let synced = 0;
+
+    while (!isDone) {
+      const page: FolderDocPage = await ctx.runQuery(
+        internal.migrations.backfill_rag_folder_path.listFolderDocsPage,
+        { cursor },
+      );
+
+      const byOrg = new Map<
+        string,
+        Array<{ fileId: Id<'_storage'>; folderPath: string }>
+      >();
+      for (const doc of page.docs) {
+        const updates = byOrg.get(doc.organizationId) ?? [];
+        updates.push({ fileId: doc.fileId, folderPath: doc.folderPath });
+        byOrg.set(doc.organizationId, updates);
+      }
+
+      for (const [organizationId, updates] of byOrg) {
+        await ctx.runAction(
+          internal.documents.internal_actions.syncRagFolderPaths,
+          { organizationId, updates },
+        );
+        synced += updates.length;
+      }
+
+      cursor = page.continueCursor;
+      isDone = page.isDone;
+    }
+
+    console.log(
+      `[backfillRagFolderPath] Synced folder paths for ${synced} document(s)`,
+    );
+    return { synced };
+  },
+});

--- a/services/platform/convex/webdav/tree_mutations.ts
+++ b/services/platform/convex/webdav/tree_mutations.ts
@@ -401,6 +401,20 @@ export const moveResource = internalMutation({
         patch.driveId = undefined;
       }
       await ctx.db.patch(args.src.id, patch);
+      // Keep RAG's denormalized folder_path fresh so the folder-scoped
+      // search filter follows the move. Best-effort (the action
+      // warn-and-skips on failure); RAG updates zero rows for files
+      // that were never indexed.
+      if (existing.fileId) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.documents.internal_actions.syncRagFolderPaths,
+          {
+            organizationId: args.organizationId,
+            updates: [{ fileId: existing.fileId, folderPath: newFolderPath }],
+          },
+        );
+      }
     } else {
       await ctx.db.patch(args.src.id, {
         name: destName,
@@ -413,12 +427,30 @@ export const moveResource = internalMutation({
       // subtree, mirroring the per-document branch above — otherwise the
       // external-sync reconcile (which matches on folderPath / folderPathPrefix)
       // mis-matches the relocated subtree and re-creates duplicates.
+      const ragFolderPathUpdates: Array<{
+        fileId: Id<'_storage'>;
+        folderPath?: string;
+      }> = [];
       await fixupMovedFolderDescendants(
         ctx,
         args.organizationId,
         args.src.id,
         0,
+        newReadBudget(),
+        ragFolderPathUpdates,
       );
+      // One batch for the whole subtree; the action chunks the PATCH
+      // calls to the RAG endpoint's batch limit.
+      if (ragFolderPathUpdates.length > 0) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.documents.internal_actions.syncRagFolderPaths,
+          {
+            organizationId: args.organizationId,
+            updates: ragFolderPathUpdates,
+          },
+        );
+      }
     }
 
     // Drop lock rows at the old path (and below for folder moves).
@@ -798,7 +830,11 @@ async function fixupMovedFolderDescendants(
   organizationId: string,
   folderId: Id<'folders'>,
   depth: number,
-  budget: ReadBudget = newReadBudget(),
+  budget: ReadBudget,
+  ragFolderPathUpdates: Array<{
+    fileId: Id<'_storage'>;
+    folderPath?: string;
+  }>,
 ): Promise<void> {
   if (depth > MAX_FOLDER_DEPTH) {
     throw new ConvexError({ code: 'CONFLICT' });
@@ -820,6 +856,9 @@ async function fixupMovedFolderDescendants(
       patch.driveId = undefined;
     }
     await ctx.db.patch(d._id, patch);
+    if (d.fileId) {
+      ragFolderPathUpdates.push({ fileId: d.fileId, folderPath });
+    }
   }
   const childFolders = await ctx.db
     .query('folders')
@@ -835,6 +874,7 @@ async function fixupMovedFolderDescendants(
       cf._id,
       depth + 1,
       budget,
+      ragFolderPathUpdates,
     );
   }
 }

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/types.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/types.ts
@@ -8,6 +8,12 @@ export type RagActionParams =
       fileName?: string;
       contentType?: string;
       sync?: boolean;
+      /**
+       * Document Hub folder path (`parent/child`, no leading slash).
+       * Stored on the RAG side for folder-scoped search. When omitted,
+       * `uploadDocument` resolves it from the linked Hub document.
+       */
+      folderPath?: string;
     }
   | {
       operation: 'delete_document';

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.test.ts
@@ -212,4 +212,83 @@ describe('uploadDocument', () => {
     const callArgs = uploadFileMock.mock.calls[0][0];
     expect(callArgs.file).toBeInstanceOf(Blob);
   });
+
+  describe('folder path resolution', () => {
+    it('resolves folder_path from the linked Hub document', async () => {
+      // runQuery order: getByStorageId → getDocumentByIdRaw → org row.
+      const ctx = {
+        storage: {
+          getUrl: vi.fn().mockResolvedValue('https://storage.example.com/file'),
+        },
+        runQuery: vi
+          .fn()
+          .mockResolvedValueOnce({ ...DEFAULT_METADATA, documentId: 'doc-1' })
+          .mockResolvedValueOnce({ folderPath: 'contracts/2024' })
+          .mockResolvedValueOnce(DEFAULT_ORG_ROW),
+      };
+      mockFetchOk();
+
+      await uploadDocument(ctx as never, FILE_ID);
+
+      expect(uploadFileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ folder_path: 'contracts/2024' }),
+        }),
+      );
+    });
+
+    it('explicit folderPath option wins and skips the document lookup', async () => {
+      const ctx = {
+        storage: {
+          getUrl: vi.fn().mockResolvedValue('https://storage.example.com/file'),
+        },
+        runQuery: vi
+          .fn()
+          .mockResolvedValueOnce({ ...DEFAULT_METADATA, documentId: 'doc-1' })
+          .mockResolvedValueOnce(DEFAULT_ORG_ROW),
+      };
+      mockFetchOk();
+
+      await uploadDocument(ctx as never, FILE_ID, {
+        folderPath: '/reports/',
+      });
+
+      // Only two runQuery calls: getByStorageId + org row (no doc lookup).
+      expect(ctx.runQuery).toHaveBeenCalledTimes(2);
+      expect(uploadFileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ folder_path: 'reports' }),
+        }),
+      );
+    });
+
+    it('omits folder_path when the file has no linked document', async () => {
+      const ctx = createCtx();
+      mockFetchOk();
+
+      await uploadDocument(ctx as never, FILE_ID);
+
+      const callArgs = uploadFileMock.mock.calls[0][0];
+      expect(callArgs.metadata).toBeUndefined();
+    });
+
+    it('omits folder_path when the linked document has none', async () => {
+      const ctx = {
+        storage: {
+          getUrl: vi.fn().mockResolvedValue('https://storage.example.com/file'),
+        },
+        runQuery: vi
+          .fn()
+          .mockResolvedValueOnce({ ...DEFAULT_METADATA, documentId: 'doc-1' })
+          .mockResolvedValueOnce({ folderPath: undefined })
+          .mockResolvedValueOnce(DEFAULT_ORG_ROW),
+      };
+      mockFetchOk();
+
+      await uploadDocument(ctx as never, FILE_ID);
+
+      const callArgs = uploadFileMock.mock.calls[0][0];
+      expect(callArgs.metadata).toBeUndefined();
+    });
+  });
 });

--- a/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/helpers/upload_document.ts
@@ -5,6 +5,7 @@ import {
 import { internal } from '../../../../_generated/api';
 import type { ActionCtx } from '../../../../_generated/server';
 import { orgSlugFromId } from '../../../../lib/helpers/org_slug';
+import { normalizeFolderPath } from '../../../../lib/helpers/rag_folder_path';
 import { toId } from '../../../../lib/type_cast_helpers';
 import type { RagUploadResult } from './types';
 import { uploadFile } from './upload_file_direct';
@@ -30,6 +31,13 @@ export async function uploadDocument(
     fileName?: string;
     contentType?: string;
     metadata?: Record<string, unknown>;
+    /**
+     * Document Hub folder path for folder-scoped RAG search. When
+     * omitted, resolved from the Hub document linked via
+     * `fileMetadata.documentId` (covers every upload path that funnels
+     * through this helper).
+     */
+    folderPath?: string;
   },
 ): Promise<RagUploadResult> {
   const storageId = toId<'_storage'>(fileId);
@@ -68,6 +76,19 @@ export async function uploadDocument(
     contentType,
   );
 
+  // Resolve the Document Hub folder path so RAG can serve folder-scoped
+  // searches. Explicit option wins; otherwise fall back to the linked Hub
+  // document's denormalized folderPath. Chat uploads (no documentId)
+  // simply carry no folder.
+  let folderPath = normalizeFolderPath(options?.folderPath);
+  if (!folderPath && metadata.documentId) {
+    const document = await ctx.runQuery(
+      internal.documents.internal_queries.getDocumentByIdRaw,
+      { documentId: metadata.documentId },
+    );
+    folderPath = normalizeFolderPath(document?.folderPath);
+  }
+
   const orgSlug = await orgSlugFromId(ctx, metadata.organizationId);
 
   return uploadFile({
@@ -75,7 +96,9 @@ export async function uploadDocument(
     filename: fileName,
     contentType,
     fileId,
-    metadata: options?.metadata,
+    metadata: folderPath
+      ? { ...options?.metadata, folder_path: folderPath }
+      : options?.metadata,
     sync: options?.sync ?? false,
     orgSlug,
   });

--- a/services/platform/convex/workflow_engine/action_defs/rag/rag_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/rag/rag_action.ts
@@ -58,6 +58,7 @@ export const ragAction: ActionDefinition<RagActionParams> = {
       fileName: v.optional(v.string()),
       contentType: v.optional(v.string()),
       sync: v.optional(v.boolean()),
+      folderPath: v.optional(v.string()),
     }),
     v.object({
       operation: v.literal('delete_document'),
@@ -94,6 +95,7 @@ export const ragAction: ActionDefinition<RagActionParams> = {
           sync: migratedParams.sync,
           fileName: migratedParams.fileName,
           contentType: migratedParams.contentType,
+          folderPath: migratedParams.folderPath,
         });
         return { ...result, executionTimeMs: Date.now() - startTime };
       }

--- a/services/rag/app/models.py
+++ b/services/rag/app/models.py
@@ -1,9 +1,23 @@
 """Pydantic models for Tale RAG API."""
 
 import datetime as dt
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, BeforeValidator, Field
+
+from .utils.folder_path import MAX_FOLDER_PATH_LENGTH, normalize_folder_path
+
+
+def _normalize_folder_path_value(value: object) -> object:
+    """Pre-validator: normalize string folder paths, pass everything else
+    through so pydantic's own type/constraint validation reports it."""
+    if isinstance(value, str):
+        return normalize_folder_path(value)
+    return value
+
+
+NormalizedFolderPath = Annotated[str | None, BeforeValidator(_normalize_folder_path_value)]
+
 
 # ============================================================================
 # Health & Status Models
@@ -171,6 +185,44 @@ class DocumentStatusResponse(BaseModel):
 
 
 # ============================================================================
+# Folder Path Models
+# ============================================================================
+
+
+class FolderPathUpdate(BaseModel):
+    """A single folder-path assignment for an indexed document."""
+
+    file_id: str = Field(..., min_length=1, description="File ID whose folder_path to update")
+    folder_path: NormalizedFolderPath = Field(
+        default=None,
+        max_length=MAX_FOLDER_PATH_LENGTH,
+        description="New folder path, or null to clear it (document moved to the root)",
+    )
+
+
+class FolderPathUpdateRequest(BaseModel):
+    """Batch folder-path update for already-indexed documents.
+
+    Lets the platform keep the denormalized `documents.folder_path` fresh
+    on folder moves/renames without re-extraction or re-embedding.
+    """
+
+    updates: list[FolderPathUpdate] = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description="Folder-path assignments (max 200 per call)",
+    )
+
+
+class FolderPathUpdateResponse(BaseModel):
+    """Response after a batch folder-path update."""
+
+    success: bool = Field(..., description="Whether the operation succeeded")
+    updated_count: int = Field(..., description="Number of document rows updated")
+
+
+# ============================================================================
 # Query Models
 # ============================================================================
 
@@ -191,6 +243,16 @@ class QueryRequest(BaseModel):
         min_length=1,
         max_length=500,
         description="File IDs to restrict search to.",
+    )
+    folder_path: NormalizedFolderPath = Field(
+        default=None,
+        max_length=MAX_FOLDER_PATH_LENGTH,
+        description=(
+            "Optional folder path prefix filter (e.g. 'contracts/2024'). "
+            "Hierarchical: matches documents in the folder and all of its "
+            "subfolders, never sibling folders sharing the prefix. Narrows "
+            "within the file_ids scope; it is not an authorization boundary."
+        ),
     )
 
 

--- a/services/rag/app/routers/documents.py
+++ b/services/rag/app/routers/documents.py
@@ -31,11 +31,14 @@ from ..models import (
     DocumentStatusInfo,
     DocumentStatusRequest,
     DocumentStatusResponse,
+    FolderPathUpdateRequest,
+    FolderPathUpdateResponse,
 )
 from ..secret_scanner import scan_file_for_secrets
 from ..services.database import SCHEMA, get_pool
 from ..services.rag_service import rag_service
 from ..utils import cleanup_memory
+from ..utils.folder_path import MAX_FOLDER_PATH_LENGTH, normalize_folder_path
 
 router = APIRouter(prefix="/api/v1", tags=["Documents"])
 
@@ -135,22 +138,31 @@ async def _insert_processing_row(
     org_slug: str,
     file_id: str,
     filename: str,
+    folder_path: str | None = None,
 ) -> None:
-    """Insert a processing status row at ingestion start (scoped to org)."""
+    """Insert a processing status row at ingestion start (scoped to org).
+
+    `folder_path` is written here (insert AND conflict-update) because this
+    upsert runs unconditionally per upload — the later `_do_store` /
+    `_do_clone` upserts never touch the column, and `_do_store` skips its
+    UPDATE entirely when content is unchanged.
+    """
     pool = await get_pool()
     async with acquire_with_retry(pool) as conn:
         await conn.execute(
             f"""
-            INSERT INTO {SCHEMA}.documents (org_slug, file_id, filename, status)
-            VALUES ($1, $2, $3, 'processing')
+            INSERT INTO {SCHEMA}.documents (org_slug, file_id, filename, status, folder_path)
+            VALUES ($1, $2, $3, 'processing', $4)
             ON CONFLICT (org_slug, file_id)
             DO UPDATE SET status = 'processing', error = NULL, chunks_count = 0,
                          progress_phase = NULL, progress_detail = NULL,
+                         folder_path = EXCLUDED.folder_path,
                          updated_at = NOW()
             """,
             org_slug,
             file_id,
             filename,
+            folder_path,
         )
 
 
@@ -382,10 +394,18 @@ async def upload_document(
         parsed_metadata = _parse_metadata(metadata)
         source_created_at = _ms_timestamp_to_datetime(parsed_metadata.get("source_created_at"))
         source_modified_at = _ms_timestamp_to_datetime(parsed_metadata.get("source_modified_at"))
+        folder_path = normalize_folder_path(parsed_metadata.get("folder_path"))
+        if folder_path and len(folder_path) > MAX_FOLDER_PATH_LENGTH:
+            logger.warning(
+                "Ignoring over-long folder_path metadata ({} chars) | filename={}",
+                len(folder_path),
+                file.filename,
+            )
+            folder_path = None
 
         doc_id = file_id or f"file-{uuid4().hex}"
 
-        await _insert_processing_row(org_slug, doc_id, file.filename)
+        await _insert_processing_row(org_slug, doc_id, file.filename, folder_path)
 
         if sync:
             try:
@@ -442,6 +462,56 @@ async def upload_document(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to upload file. Please try again.",
         ) from e
+
+
+@router.patch("/documents/folder-paths", response_model=FolderPathUpdateResponse)
+async def update_folder_paths(
+    request: FolderPathUpdateRequest,
+    org_slug: str = Depends(require_org_slug),
+):
+    """Batch-update the denormalized folder_path on indexed documents.
+
+    Keeps the folder-scoped search filter fresh when the platform moves or
+    renames folders — no re-extraction or re-embedding. Scoped to the
+    caller's org; foreign-org file_ids update zero rows. folder_path is a
+    narrowing filter only, so a missed update degrades filter precision but
+    never authorization.
+    """
+    # Last occurrence wins for duplicate file_ids so the UPDATE ... FROM
+    # join below stays deterministic.
+    deduped: dict[str, str | None] = {u.file_id: u.folder_path for u in request.updates}
+    file_ids = list(deduped.keys())
+    folder_paths = list(deduped.values())
+
+    try:
+        pool = await get_pool()
+        async with acquire_with_retry(pool) as conn:
+            tag = await conn.execute(
+                f"""
+                UPDATE {SCHEMA}.documents d
+                SET folder_path = u.folder_path, updated_at = NOW()
+                FROM unnest($2::text[], $3::text[]) AS u(file_id, folder_path)
+                WHERE d.org_slug = $1 AND d.file_id = u.file_id
+                """,
+                org_slug,
+                file_ids,
+                folder_paths,
+            )
+    except Exception as e:
+        logger.error("Failed to update folder paths: {}", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update folder paths. Please try again.",
+        ) from e
+
+    # asyncpg returns a command tag like "UPDATE 3".
+    try:
+        updated_count = int(tag.rsplit(" ", 1)[-1])
+    except (ValueError, AttributeError):
+        logger.warning("Unexpected command tag from folder-path update: {!r}", tag)
+        updated_count = 0
+
+    return FolderPathUpdateResponse(success=True, updated_count=updated_count)
 
 
 @router.delete("/documents/{file_id}", response_model=DocumentDeleteResponse)

--- a/services/rag/app/routers/search.py
+++ b/services/rag/app/routers/search.py
@@ -34,6 +34,7 @@ async def search(
             top_k=request.top_k,
             similarity_threshold=request.similarity_threshold,
             file_ids=request.file_ids,
+            folder_path=request.folder_path,
         )
 
         processing_time = (time.time() - start_time) * 1000

--- a/services/rag/app/services/rag_service.py
+++ b/services/rag/app/services/rag_service.py
@@ -444,8 +444,13 @@ class RagService:
         top_k: int | None = None,
         similarity_threshold: float | None = None,
         file_ids: list[str] | None = None,
+        folder_path: str | None = None,
     ) -> tuple[list[dict[str, Any]], Any]:
         """Search the knowledge base scoped to `org_slug`.
+
+        `folder_path` optionally narrows results to one Document Hub folder
+        and its subfolders (hierarchical prefix). It is a pure narrowing
+        filter inside the file_ids scope, never an authorization boundary.
 
         Returns a `(results, embedding_usage)` tuple — the underlying
         `RagSearchService.search` returns the tuple directly so there's
@@ -460,6 +465,7 @@ class RagService:
             org_slug,
             query,
             file_ids=file_ids,
+            folder_path=folder_path,
             top_k=effective_top_k,
             similarity_threshold=threshold,
         )
@@ -475,6 +481,7 @@ class RagService:
                     org_slug,
                     query,
                     file_ids=file_ids,
+                    folder_path=folder_path,
                     top_k=effective_top_k,
                     similarity_threshold=threshold,
                 )

--- a/services/rag/app/services/search_service.py
+++ b/services/rag/app/services/search_service.py
@@ -2,8 +2,8 @@
 
 BM25 full-text (pg_search) + pgvector similarity with RRF fusion.
 Per-tenant scoping by `org_slug` (always applied), optional further
-restriction by `file_ids`. Optional semantic caching and cross-encoder
-re-ranking.
+restriction by `file_ids` and a hierarchical `folder_path` prefix.
+Optional semantic caching and cross-encoder re-ranking.
 """
 
 from __future__ import annotations
@@ -56,6 +56,7 @@ class RagSearchService:
         query: str,
         *,
         file_ids: list[str] | None = None,
+        folder_path: str | None = None,
         top_k: int = 10,
         similarity_threshold: float = 0.0,
     ) -> tuple[list[dict[str, Any]], EmbeddingUsage]:
@@ -68,6 +69,10 @@ class RagSearchService:
             file_ids: Optional file IDs to further restrict search to. The
                 org filter is independent — file_ids only narrows within
                 the org.
+            folder_path: Optional hierarchical folder prefix filter
+                (normalized, no surrounding slashes). Pure narrowing within
+                the already-authorized file_ids scope — never an
+                authorization boundary.
             top_k: Maximum number of results to return.
             similarity_threshold: Minimum cosine similarity for vector results.
                 Results below this threshold are discarded before RRF merge.
@@ -83,15 +88,21 @@ class RagSearchService:
             t0 = time.time()
             query_result, fts_results = await asyncio.gather(
                 _timed("embed", self._embedding.embed_query_with_usage(query)),
-                _timed("fts", self._fts_search(query, org_slug, file_ids, top_k * 3)),
+                _timed(
+                    "fts",
+                    self._fts_search(query, org_slug, file_ids, top_k * 3, folder_path=folder_path),
+                ),
             )
             query_embedding = query_result.embedding
             usage = query_result.usage
             logger.debug("PERF embed+FTS total: {:.1f}ms", (time.time() - t0) * 1000)
 
             # Semantic cache: check for a cached result before vector search.
-            # Cache is org-scoped — see SemanticCache.lookup.
-            if self._semantic_cache and query_embedding:
+            # Cache is org-scoped — see SemanticCache.lookup. Bypassed (both
+            # lookup and store) for folder-filtered queries: the cache key is
+            # (org_slug, embedding) only, so a folder-scoped query would hit
+            # unfiltered cached results and vice versa.
+            if self._semantic_cache and query_embedding and not folder_path:
                 cache_t0 = time.time()
                 cached = await self._semantic_cache.lookup(
                     org_slug,
@@ -110,7 +121,9 @@ class RagSearchService:
                         logger.warning("Invalid cached response format, performing fresh search")
 
             vec_t0 = time.time()
-            vector_results = await self._vector_search(query_embedding, org_slug, file_ids, top_k * 3)
+            vector_results = await self._vector_search(
+                query_embedding, org_slug, file_ids, top_k * 3, folder_path=folder_path
+            )
             vec_ms = (time.time() - vec_t0) * 1000
             logger.debug("PERF vector search: {:.1f}ms", vec_ms)
 
@@ -177,7 +190,8 @@ class RagSearchService:
             ]
 
             # Semantic cache: store results for future lookups (org-scoped).
-            if self._semantic_cache and query_embedding and results:
+            # Folder-filtered results are never stored — see the lookup bypass.
+            if self._semantic_cache and query_embedding and results and not folder_path:
                 result_file_ids = [r["file_id"] for r in results if r.get("file_id")]
                 await self._semantic_cache.store(
                     org_slug,
@@ -210,7 +224,9 @@ class RagSearchService:
 
                 if query_embedding is None:
                     query_embedding = await self._embedding.embed_query(query)
-                vector_results = await self._vector_search(query_embedding, org_slug, file_ids, top_k)
+                vector_results = await self._vector_search(
+                    query_embedding, org_slug, file_ids, top_k, folder_path=folder_path
+                )
                 results = [
                     {
                         "content": item.get("core_content") or item.get("chunk_content") or "",
@@ -230,27 +246,47 @@ class RagSearchService:
         org_slug: str,
         file_ids: list[str] | None,
         param_offset: int,
+        folder_path: str | None = None,
     ) -> tuple[str, list[Any]]:
-        """Build WHERE clause for per-tenant + optional file scoping.
+        """Build WHERE clause for per-tenant + optional per-document scoping.
 
-        `org_slug` is ALWAYS added as `AND c.org_slug = $N`. When `file_ids`
-        is non-empty, a secondary clause restricts the documents subquery
-        AND is itself org-scoped (defense in depth — even if the outer
-        chunks filter were ever bypassed by a code mistake, the inner
-        documents lookup also has org filter).
+        `org_slug` is ALWAYS added as `AND c.org_slug = $N`. Document-level
+        filters (`file_ids`, `folder_path`) are collected into a condition
+        list applied through a single documents subquery that is itself
+        org-scoped (defense in depth — even if the outer chunks filter were
+        ever bypassed by a code mistake, the inner documents lookup also has
+        the org filter). #1517's generic metadata filters extend the same
+        condition list.
+
+        `folder_path` is a boundary-safe hierarchical prefix: it matches the
+        folder itself and any descendant ('data-room' matches
+        'data-room/contracts' but NOT the sibling 'data-room-x'). The
+        `left()` comparison avoids LIKE-pattern escaping for user-supplied
+        paths; it is not index-sargable, which is acceptable because the
+        subquery is already org- and file_ids-bounded.
         """
         org_param = param_offset + 1
         clause = f" AND c.org_slug = ${org_param}"
         params: list[Any] = [org_slug]
 
+        doc_conditions: list[str] = []
         if file_ids:
-            file_param = param_offset + 2
+            params.append(file_ids)
+            doc_conditions.append(f"file_id = ANY(${param_offset + len(params)})")
+        if folder_path:
+            params.append(folder_path)
+            folder_param = f"${param_offset + len(params)}"
+            doc_conditions.append(
+                f"(folder_path = {folder_param} "
+                f"OR left(folder_path, char_length({folder_param}) + 1) = {folder_param} || '/')"
+            )
+
+        if doc_conditions:
             clause += (
                 f" AND c.document_id IN ("
                 f"SELECT id FROM {SCHEMA}.documents "
-                f"WHERE org_slug = ${org_param} AND file_id = ANY(${file_param}))"
+                f"WHERE org_slug = ${org_param} AND {' AND '.join(doc_conditions)})"
             )
-            params.append(file_ids)
 
         return clause, params
 
@@ -270,8 +306,9 @@ class RagSearchService:
         org_slug: str,
         file_ids: list[str] | None,
         limit: int,
+        folder_path: str | None = None,
     ) -> list[dict[str, Any]]:
-        tenant_clause, tenant_params = self._build_scope_clause(org_slug, file_ids, 1)
+        tenant_clause, tenant_params = self._build_scope_clause(org_slug, file_ids, 1, folder_path=folder_path)
 
         sql = f"""
             SELECT c.id, c.chunk_content, c.core_content, c.chunk_index, c.document_id,
@@ -304,9 +341,10 @@ class RagSearchService:
         org_slug: str,
         file_ids: list[str] | None,
         limit: int,
+        folder_path: str | None = None,
     ) -> list[dict[str, Any]]:
         vec_str = json.dumps(embedding)
-        tenant_clause, tenant_params = self._build_scope_clause(org_slug, file_ids, 1)
+        tenant_clause, tenant_params = self._build_scope_clause(org_slug, file_ids, 1, folder_path=folder_path)
 
         sql = f"""
             SELECT c.id, c.chunk_content, c.core_content, c.chunk_index, c.document_id,

--- a/services/rag/app/utils/folder_path.py
+++ b/services/rag/app/utils/folder_path.py
@@ -1,0 +1,28 @@
+"""Folder path normalization for the folder-scoped search filter.
+
+The platform's canonical folder path format is ``parent/child`` — segments
+joined by ``/`` with no leading or trailing slash (see
+``services/platform/convex/folders/queries.ts::buildFolderPath``). The
+TypeScript twin of this helper lives at
+``services/platform/convex/lib/helpers/rag_folder_path.ts`` — keep both in
+sync.
+"""
+
+from __future__ import annotations
+
+MAX_FOLDER_PATH_LENGTH = 1024
+
+_STRIP_CHARS = " \t\r\n/"
+
+
+def normalize_folder_path(value: object) -> str | None:
+    """Normalize a folder path to the canonical ``parent/child`` form.
+
+    Strips surrounding whitespace and slashes. Returns ``None`` for
+    non-string, empty, or all-separator values so callers can treat the
+    result as "no folder".
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip(_STRIP_CHARS)
+    return normalized or None

--- a/services/rag/migrations/20260611000001_add_documents_folder_path.sql
+++ b/services/rag/migrations/20260611000001_add_documents_folder_path.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+-- Folder-scoped search filter (#662): denormalized Document Hub folder
+-- path, written at ingestion from the upload `metadata` form field and
+-- kept fresh via PATCH /api/v1/documents/folder-paths. Used by /search
+-- as a boundary-safe hierarchical prefix filter inside the org-scoped
+-- documents subquery.
+
+ALTER TABLE private_knowledge.documents
+  ADD COLUMN IF NOT EXISTS folder_path TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_pk_docs_org_folder
+  ON private_knowledge.documents (org_slug, folder_path)
+  WHERE folder_path IS NOT NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS private_knowledge.idx_pk_docs_org_folder;
+
+ALTER TABLE private_knowledge.documents
+  DROP COLUMN IF EXISTS folder_path;

--- a/services/rag/tests/test_folder_path.py
+++ b/services/rag/tests/test_folder_path.py
@@ -1,0 +1,214 @@
+"""Tests for the folder-scoped search filter (#662).
+
+Covers:
+- normalize_folder_path: trimming, slash stripping, non-string input
+- QueryRequest.folder_path: normalization + max-length validation
+- FolderPathUpdate / FolderPathUpdateRequest validation
+- _insert_processing_row: folder_path written on insert and conflict-update
+- PATCH /documents/folder-paths handler: org scoping, dedupe, count parsing
+
+Note: tests importing app.routers.documents require python-multipart and
+are skipped if the dependency is unavailable (mirrors test_background_ingest).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import FolderPathUpdate, FolderPathUpdateRequest, QueryRequest
+from app.utils.folder_path import MAX_FOLDER_PATH_LENGTH, normalize_folder_path
+
+TEST_ORG = "test-org"
+
+
+def _can_import_router():
+    try:
+        from app.routers.documents import _insert_processing_row  # noqa: F401
+
+        return True
+    except (RuntimeError, ImportError):
+        return False
+
+
+_requires_multipart = pytest.mark.skipif(
+    not _can_import_router(),
+    reason="python-multipart required for router import",
+)
+
+
+def _async_ctx(mock_conn):
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+class TestNormalizeFolderPath:
+    def test_plain_path_unchanged(self):
+        assert normalize_folder_path("contracts/2024") == "contracts/2024"
+
+    def test_strips_surrounding_slashes_and_whitespace(self):
+        assert normalize_folder_path(" /contracts/2024/ ") == "contracts/2024"
+        assert normalize_folder_path("/ / a") == "a"
+
+    def test_empty_and_separator_only_become_none(self):
+        assert normalize_folder_path("") is None
+        assert normalize_folder_path("   ") is None
+        assert normalize_folder_path("///") is None
+
+    def test_non_string_becomes_none(self):
+        assert normalize_folder_path(None) is None
+        assert normalize_folder_path(42) is None
+        assert normalize_folder_path(["a"]) is None
+
+    def test_inner_slashes_preserved(self):
+        assert normalize_folder_path("a/b/c") == "a/b/c"
+
+
+class TestQueryRequestFolderPath:
+    def test_defaults_to_none(self):
+        req = QueryRequest(query="q", file_ids=["f1"])
+        assert req.folder_path is None
+
+    def test_normalizes_on_validation(self):
+        req = QueryRequest(query="q", file_ids=["f1"], folder_path="/data-room/")
+        assert req.folder_path == "data-room"
+
+    def test_blank_folder_path_becomes_none(self):
+        req = QueryRequest(query="q", file_ids=["f1"], folder_path="  / ")
+        assert req.folder_path is None
+
+    def test_over_long_folder_path_rejected(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(query="q", file_ids=["f1"], folder_path="x" * (MAX_FOLDER_PATH_LENGTH + 1))
+
+    def test_non_string_folder_path_rejected(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(query="q", file_ids=["f1"], folder_path=123)
+
+
+class TestFolderPathUpdateModels:
+    def test_update_normalizes_folder_path(self):
+        update = FolderPathUpdate(file_id="f1", folder_path="/a/b/")
+        assert update.folder_path == "a/b"
+
+    def test_update_accepts_null_folder_path(self):
+        update = FolderPathUpdate(file_id="f1", folder_path=None)
+        assert update.folder_path is None
+
+    def test_request_rejects_empty_updates(self):
+        with pytest.raises(ValidationError):
+            FolderPathUpdateRequest(updates=[])
+
+    def test_request_rejects_over_batch_limit(self):
+        updates = [{"file_id": f"f{i}", "folder_path": "a"} for i in range(201)]
+        with pytest.raises(ValidationError):
+            FolderPathUpdateRequest(updates=updates)
+
+
+@_requires_multipart
+class TestInsertProcessingRow:
+    @pytest.mark.asyncio
+    async def test_writes_folder_path(self):
+        from app.routers.documents import _insert_processing_row
+
+        conn = AsyncMock()
+        with (
+            patch("app.routers.documents.get_pool", new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.documents.acquire_with_retry", return_value=_async_ctx(conn)),
+        ):
+            await _insert_processing_row(TEST_ORG, "file-1", "a.pdf", "contracts/2024")
+
+        sql = conn.execute.call_args[0][0]
+        assert "folder_path" in sql
+        # Conflict-update keeps folder_path fresh on re-uploads.
+        assert "folder_path = EXCLUDED.folder_path" in sql
+        assert conn.execute.call_args[0][4] == "contracts/2024"
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_null_folder_path(self):
+        from app.routers.documents import _insert_processing_row
+
+        conn = AsyncMock()
+        with (
+            patch("app.routers.documents.get_pool", new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.documents.acquire_with_retry", return_value=_async_ctx(conn)),
+        ):
+            await _insert_processing_row(TEST_ORG, "file-1", "a.pdf")
+
+        assert conn.execute.call_args[0][4] is None
+
+
+@_requires_multipart
+class TestUpdateFolderPathsEndpoint:
+    @pytest.mark.asyncio
+    async def test_updates_scoped_to_org(self):
+        from app.routers.documents import update_folder_paths
+
+        conn = AsyncMock()
+        conn.execute = AsyncMock(return_value="UPDATE 2")
+        request = FolderPathUpdateRequest(
+            updates=[
+                {"file_id": "f1", "folder_path": "a/b"},
+                {"file_id": "f2", "folder_path": None},
+            ]
+        )
+
+        with (
+            patch("app.routers.documents.get_pool", new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.documents.acquire_with_retry", return_value=_async_ctx(conn)),
+        ):
+            response = await update_folder_paths(request, org_slug=TEST_ORG)
+
+        assert response.success is True
+        assert response.updated_count == 2
+        sql = conn.execute.call_args[0][0]
+        assert "org_slug = $1" in sql
+        assert conn.execute.call_args[0][1] == TEST_ORG
+        assert conn.execute.call_args[0][2] == ["f1", "f2"]
+        assert conn.execute.call_args[0][3] == ["a/b", None]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_file_ids_last_wins(self):
+        from app.routers.documents import update_folder_paths
+
+        conn = AsyncMock()
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+        request = FolderPathUpdateRequest(
+            updates=[
+                {"file_id": "f1", "folder_path": "old"},
+                {"file_id": "f1", "folder_path": "new"},
+            ]
+        )
+
+        with (
+            patch("app.routers.documents.get_pool", new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.documents.acquire_with_retry", return_value=_async_ctx(conn)),
+        ):
+            response = await update_folder_paths(request, org_slug=TEST_ORG)
+
+        assert response.updated_count == 1
+        assert conn.execute.call_args[0][2] == ["f1"]
+        assert conn.execute.call_args[0][3] == ["new"]
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_500(self):
+        from fastapi import HTTPException
+
+        from app.routers.documents import update_folder_paths
+
+        conn = AsyncMock()
+        conn.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        request = FolderPathUpdateRequest(updates=[{"file_id": "f1", "folder_path": "a"}])
+
+        with (
+            patch("app.routers.documents.get_pool", new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.documents.acquire_with_retry", return_value=_async_ctx(conn)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_folder_paths(request, org_slug=TEST_ORG)
+
+        assert exc_info.value.status_code == 500

--- a/services/rag/tests/test_org_isolation.py
+++ b/services/rag/tests/test_org_isolation.py
@@ -82,6 +82,17 @@ class TestSearchScopeClause:
         assert "file_id = ANY" in clause
         assert params == [ORG_A, ["d1", "d2"]]
 
+    def test_folder_path_filter_is_org_scoped(self):
+        from app.services.search_service import RagSearchService
+
+        svc = RagSearchService(MagicMock(), MagicMock())
+        clause, params = svc._build_scope_clause(ORG_A, None, 1, folder_path="shared-folder")
+        # The folder filter rides the same org-scoped documents subquery —
+        # an identical folder name in another org can never match.
+        assert clause.count("org_slug") == 2
+        assert "folder_path" in clause
+        assert params == [ORG_A, "shared-folder"]
+
 
 class TestDeleteDocumentScopedByOrg:
     """`delete_document` only deletes within `org_slug`."""

--- a/services/rag/tests/test_rag_service.py
+++ b/services/rag/tests/test_rag_service.py
@@ -223,6 +223,7 @@ class TestSearch:
             TEST_ORG,
             "test query",
             file_ids=["doc-1"],
+            folder_path=None,
             top_k=10,
             similarity_threshold=0.0,
         )
@@ -241,6 +242,7 @@ class TestSearch:
             TEST_ORG,
             "query",
             file_ids=None,
+            folder_path=None,
             top_k=10,
             similarity_threshold=0.7,
         )
@@ -258,6 +260,7 @@ class TestSearch:
             TEST_ORG,
             "query",
             file_ids=None,
+            folder_path=None,
             top_k=20,
             similarity_threshold=0.0,
         )
@@ -308,6 +311,7 @@ class TestSearch:
             TEST_ORG,
             "q",
             file_ids=["doc-1", "doc-2"],
+            folder_path=None,
             top_k=10,
             similarity_threshold=0.0,
         )

--- a/services/rag/tests/test_search_service.py
+++ b/services/rag/tests/test_search_service.py
@@ -250,6 +250,110 @@ class TestScopeFiltering:
         assert vec_args[0][2] == ["doc-1", "doc-2"]
 
 
+class TestFolderPathScope:
+    """Folder-path prefix filtering in the scope clause and search()."""
+
+    def _service(self):
+        from app.services.search_service import RagSearchService
+
+        return RagSearchService(MagicMock(), MagicMock())
+
+    def test_scope_clause_with_folder_path_only(self):
+        service = self._service()
+
+        clause, params = service._build_scope_clause(TEST_ORG, None, 1, folder_path="data-room")
+
+        # Folder filter alone still requires the org-scoped documents subquery.
+        assert "org_slug" in clause
+        assert "SELECT id FROM" in clause
+        assert "file_id" not in clause
+        # Boundary-safe prefix: exact match OR prefix followed by '/'.
+        assert "folder_path = $3" in clause
+        assert "left(folder_path, char_length($3) + 1) = $3 || '/'" in clause
+        assert params == [TEST_ORG, "data-room"]
+
+    def test_scope_clause_with_folder_path_and_file_ids(self):
+        service = self._service()
+
+        clause, params = service._build_scope_clause(TEST_ORG, ["doc-a"], 1, folder_path="data-room")
+
+        assert "ANY($3)" in clause
+        assert "folder_path = $4" in clause
+        assert params == [TEST_ORG, ["doc-a"], "data-room"]
+
+    def test_scope_clause_folder_path_respects_param_offset(self):
+        service = self._service()
+
+        clause, params = service._build_scope_clause(TEST_ORG, ["doc-a"], 3, folder_path="x")
+
+        # org at $4, file_ids at $5, folder_path at $6.
+        assert "$4" in clause
+        assert "ANY($5)" in clause
+        assert "folder_path = $6" in clause
+        assert params == [TEST_ORG, ["doc-a"], "x"]
+
+    def test_scope_clause_without_folder_path_unchanged(self):
+        service = self._service()
+
+        clause, params = service._build_scope_clause(TEST_ORG, None, 1)
+
+        assert "folder_path" not in clause
+        assert params == [TEST_ORG]
+
+    async def test_search_passes_folder_path_to_fts_and_vector(self):
+        service, *_ = _build_service()
+        service._fts_search = AsyncMock(return_value=[])
+        service._vector_search = AsyncMock(return_value=[])
+
+        await service.search(TEST_ORG, "query", file_ids=["doc-1"], folder_path="contracts/2024")
+
+        assert service._fts_search.call_args.kwargs["folder_path"] == "contracts/2024"
+        assert service._vector_search.call_args.kwargs["folder_path"] == "contracts/2024"
+
+    async def test_semantic_cache_bypassed_when_folder_path_set(self):
+        service, *_ = _build_service()
+        service._fts_search = AsyncMock(return_value=[_make_row(1, "hit", "doc-1", 5.0)])
+        service._vector_search = AsyncMock(return_value=[])
+        cache = AsyncMock()
+        cache.lookup = AsyncMock(return_value=None)
+        cache.store = AsyncMock()
+        service._semantic_cache = cache
+
+        results, _usage = await service.search(TEST_ORG, "query", folder_path="contracts")
+
+        assert len(results) == 1
+        cache.lookup.assert_not_awaited()
+        cache.store.assert_not_awaited()
+
+    async def test_semantic_cache_used_without_folder_path(self):
+        service, *_ = _build_service()
+        service._fts_search = AsyncMock(return_value=[_make_row(1, "hit", "doc-1", 5.0)])
+        service._vector_search = AsyncMock(return_value=[])
+        cache = AsyncMock()
+        cache.lookup = AsyncMock(return_value=None)
+        cache.store = AsyncMock()
+        service._semantic_cache = cache
+
+        results, _usage = await service.search(TEST_ORG, "query")
+
+        assert len(results) == 1
+        cache.lookup.assert_awaited_once()
+        cache.store.assert_awaited_once()
+
+    async def test_bm25_fallback_keeps_folder_path(self):
+        vector_rows = [_make_row(1, "vec result", "doc-1", 0.9)]
+        service, *_ = _build_service()
+
+        with patch.object(service, "_fts_search", side_effect=asyncpg.InternalServerError("bm25 index not found")):
+            with patch.object(service, "_vector_search", new_callable=AsyncMock) as mock_vec:
+                mock_vec.return_value = vector_rows
+                with patch.object(service._embedding, "embed_query", return_value=[0.1]):
+                    results, _usage = await service.search(TEST_ORG, "query", folder_path="contracts")
+
+        assert len(results) == 1
+        assert mock_vec.call_args.kwargs["folder_path"] == "contracts"
+
+
 class TestGracefulFallback:
     """Error handling: BM25 not ready, missing tables/columns."""
 


### PR DESCRIPTION
Closes #662

## What / why

Adds an optional **folder filter** to RAG search so retrieval can be scoped to one Document Hub folder and all of its subfolders — "search only in Contracts/2024". The issue's original sketch (`team_id` scoping, `(team_id, folder_path)` index) is stale: search is scoped by `org_slug` + a required `file_ids` list today, and **`file_ids` stays the sole authorization boundary** — `folder_path` is a pure narrowing filter, so staleness can only affect filter precision, never access.

### RAG service (`services/rag`)

- Migration `20260611000001_add_documents_folder_path.sql`: `documents.folder_path TEXT` + partial `(org_slug, folder_path)` index.
- `_build_scope_clause` now collects document-level filters into a generic condition list applied through the single org-scoped documents subquery (both FTS and vector channels). This is the seam #1517's metadata filters extend — `folder_path` is the first generic filter.
- Boundary-safe hierarchical prefix: `(folder_path = $p OR left(folder_path, char_length($p) + 1) = $p || '/')` — `data-room` matches `data-room/contracts` but never the sibling `data-room-x`, with no LIKE-escaping surface.
- `POST /api/v1/search` gains a flat optional `folder_path` (normalized + length-capped via pydantic). Semantic cache is bypassed (lookup **and** store) for folder-filtered queries — the cache key has no scope dimension.
- Ingestion: `folder_path` parsed from the existing upload `metadata` form field, written by `_insert_processing_row` (insert + conflict-update; the `_do_store`/`_do_clone` upserts never touch the column, so dedup/skip paths can't clobber it).
- New batch `PATCH /api/v1/documents/folder-paths` (org-scoped, max 200, single `UPDATE … FROM unnest(...)`) so folder moves stay fresh without re-extraction/re-embedding.

### Platform (`services/platform`)

- `uploadDocument` (the chokepoint every RAG upload funnels through) resolves `folderPath` from the linked Hub document via `fileMetadata.documentId` and merges `folder_path` into the upload metadata; `uploadDocumentToRag` / `reindexDocumentInRag` pass `document.folderPath` explicitly (belt-and-suspenders vs. linkage races). Chat uploads carry no folder.
- New `syncRagFolderPaths` internal action (warn-and-skip on failure) + freshness hooks: `updateDocumentInternal` on folder change of an indexed doc (skipped when a re-index is scheduled), WebDAV `moveResource` document branch, and the folder-subtree fixup (one batch per move).
- `rag_search` agent tool gains an optional `folderPath` arg (hierarchical/recursive, `/` separators, no leading slash — description contrasts with `document_find`'s fuzzy non-recursive filter).
- Backfill: `migrations/backfill_rag_folder_path.ts` (`bunx convex run migrations/backfill_rag_folder_path:backfillRagFolderPath`) sweeps already-indexed Hub documents through the PATCH endpoint — run once after deploy so pre-existing documents match folder filters.
- Shared normalization helper `lib/helpers/rag_folder_path.ts`, kept in sync with `app/utils/folder_path.py`.

## Decision-gate recommendations baked in (veto at review)

- **Wire shape**: flat `folder_path` on `QueryRequest` now; #1517 layers its `filters` object on the same `_build_scope_clause` seam.
- **Freshness sync in this PR**: PATCH endpoint + platform folder-move hooks ship here (not deferred).
- **Backfill**: Convex backfill action included (running it is an operational step post-deploy).
- **Tool surface**: `folderPath` on the `rag_search` tool only; `query_rag_context` auto-injection deferred to #1517 (no current caller needs it).
- **`/generate`**: does NOT accept `folder_path` (issue covers `/search` only).
- **Semantic cache**: bypassed for folder-filtered queries — cheapest correct option. The pre-existing `file_ids` cache-scope gap is unchanged and worth a follow-up issue.

## Verification

Performed:
- `cd services/rag && uv run pytest` — 346 passed (new: scope-clause folder tests incl. param offsets + boundary expression, cache-bypass both ways, BM25-fallback threading, org-isolation folder test, normalization/model validation, `_insert_processing_row`, PATCH handler incl. dedupe + 500 path).
- `uv run ruff check app` + `ruff format --check app` — clean.
- Platform vitest: `rag_folder_path`, `upload_document` (Hub-doc resolution, explicit override, no-doc/no-path omission), `update_document_internal` (folder-move sync schedule/skip matrix) — all green.
- `bun run check` at repo root — 40/40 tasks green (format, lint, typecheck, all tests incl. docs locale parity).
- `convex/_generated/api.d.ts` updated for the new migrations module (codegen needs a live deployment; entry added in the generated-file format).

Manual verification required (needs a running stack):
- Apply the dbmate migration; upload a Hub doc inside a folder; `POST /api/v1/search` with/without `folder_path`, verifying the boundary case (`data-room` must not match `data-room-x`).
- Move the doc to another folder (UI + WebDAV) and re-search.
- Agent chat: "search only in folder X" → tool call carries `folderPath`.
- Run the backfill action once on existing deployments.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons — N/A (no UI change).
- [x] Updated `services/platform/messages/{en,de,fr}.json` — N/A (no UI strings; agent tool descriptions are not i18n'd).
- [x] Updated `/docs/{en,de,fr}/` — RAG bullet in `platform/agents/tools.md` mentions folder-scoped retrieval in all three locales.
- [x] Touched docs pages keep their real opening/closing (bullet-only edit; docs tests pass).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated READMEs — N/A.

Note for #1517: branch `feat/rag-folder-scoped-search` is the base for the metadata pre-filter work — `_build_scope_clause`'s condition list and the upload-metadata path are the shared seams.