### PR TITLE
feat(platform): knowledge entries with approval-gated knowledge_write

### DIFF
--- a/docs/de/platform/knowledge/knowledge-entries.md
+++ b/docs/de/platform/knowledge/knowledge-entries.md
@@ -1,0 +1,36 @@
+---
+title: Wissenseinträge
+description: Wissenseinträge sind kleine, themen-basierte Fakten, die Nutzer zur Wissensdatenbank beitragen — mit Genehmigung aus dem Chat erfasst oder manuell hinzugefügt. Diese Seite behandelt, woher Einträge kommen, die Eine-Live-Version-pro-Thema-Regel und wie du sie verwaltest.
+---
+
+Wissenseinträge sind die Fakten-Oberfläche der Wissensdatenbank. Wo ein Dokument eine ganze Datei trägt, trägt ein Wissenseintrag einen kleinen, dauerhaften Fakt — „der Laden öffnet um 9", „die Rückgabefrist ist 3 Tage" — unter einem Themen-Namen. Einträge kommen aus zwei Quellen: Ein Agent kann während eines Chats einen vorschlagen, wenn du Informationen bestätigst oder korrigierst (du genehmigst ihn auf einer Karte, bevor irgendetwas gespeichert wird), und Redakteure können einen manuell im Tab **Wissenseinträge** hinzufügen. In beiden Fällen landet der Eintrag in derselben Indexierungs-Pipeline wie ein Dokument, sodass jeder Agent, der die Wissensdatenbank durchsucht, ihn abrufen und zitieren kann.
+
+Diese Seite behandelt die Verwaltungsseite: woher Einträge kommen, die Eine-Live-Version-pro-Thema-Regel, die verhindert, dass Korrekturen neben den Fakten weiterleben, die sie korrigiert haben, und wie du Einträge hinzufügst, bearbeitest und löschst.
+
+## Woher Einträge kommen
+
+**Aus dem Chat, mit deiner Genehmigung.** Agents mit aktiviertem `knowledge_write`-Tool können vorschlagen, einen Fakt zu speichern, den du im Gespräch genannt oder korrigiert hast. Der Vorschlag erscheint als Genehmigungs-Karte im Chat mit dem Thema, dem vollständigen Inhalt und — wenn das Thema bereits existiert — einem Hinweis, dass die Genehmigung den aktuellen Eintrag ersetzt. Nichts erreicht die Wissensdatenbank, bevor du auf **Genehmigen** klickst; **Ablehnen** verwirft den Vorschlag. Das Tool ist standardmässig aus — aktivier es pro Agent in den Tool-Einstellungen des Agents unter der Documents-Gruppe. Das ist Absicht: Ein Agent kann nie ins geteilte Wissen der Organisation schreiben, ohne dass ein Mensch den exakten Text abgesegnet hat.
+
+**Manuell.** Um einen Eintrag von Hand hinzuzufügen, öffne **Wissen > Wissenseinträge** und klick auf **Eintrag hinzufügen**. Gib ihm ein Thema (bis 120 Zeichen — kurz und stabil, wie eine Überschrift) und den Inhalt als Markdown (bis 8000 Zeichen), so formuliert, dass er ohne umgebendes Gespräch verständlich ist. Manuelle Einträge überspringen die Genehmigungs-Karte — du bist der Mensch in der Schleife.
+
+## Eine Live-Version pro Thema
+
+Themen sind der Dedup-Schlüssel. Wer auf ein Thema schreibt, das bereits einen Eintrag hat — ob aus dem Chat oder per Bearbeitung — ersetzt die Live-Version, statt eine zweite hinzuzufügen; die Wissensdatenbank liefert also nie zwei Versionen desselben Fakts. Der Themen-Abgleich ignoriert Gross-/Kleinschreibung und überflüssige Leerzeichen: „Öffnungszeiten" und „öffnungszeiten" sind dasselbe Thema.
+
+Ersetzte Versionen gehen nicht verloren. Jeder Eintrag behält seinen Versionsverlauf — klick auf eine Zeile, um den Eintrag zu öffnen, und klapp eine ersetzte Version auf, um zu sehen, was sie sagte und wann sie ersetzt wurde. Nur die Live-Version ist für den Abruf indexiert; ersetzte Versionen existieren nur für Audit und Nachschlagen.
+
+## Wie Einträge Agents erreichen
+
+Hinter jedem Eintrag sitzt ein kleines Markdown-Dokument im Dokumenten-Hub, im reservierten Ordner **Knowledge entries**. Dieses Hintergrund-Dokument fährt durch exakt dieselbe Indexierungs-Pipeline wie eine hochgeladene Datei — extrahieren, chunken, einbetten, speichern — weshalb die Eintragsliste pro Zeile das vertraute Indexierungsstatus-Badge zeigt. Ein frisch gespeicherter Eintrag zeigt kurz `Indexierung`; sobald er auf `Indexiert` umspringt, rufen Agents, deren Wissens-Umfang das Hintergrund-Dokument einschliesst, ihn ab und zitieren ihn wie jede andere Quelle.
+
+Weil das Hintergrund-Dokument ein reguläres Dokument ist, funktioniert die Agent-Bindung unverändert: Ein Agent mit Zugriff auf die ganze Bibliothek sieht jeden Eintrag, und ein Agent mit Zugriff auf spezifische Ordner sieht Einträge nur, wenn der Knowledge-entries-Ordner im Umfang liegt. Einträge gelten organisationsweit — eine Per-Team-Skopierung auf Einträgen selbst gibt es in dieser Version nicht.
+
+## Bearbeiten und Löschen
+
+Um einen Eintrag zu bearbeiten, öffne sein Zeilen-Menü und klick auf **Bearbeiten**. Speichern erzeugt eine neue Live-Version und verschiebt die vorherige in den Versionsverlauf; das Hintergrund-Dokument wird im Hintergrund neu indexiert, sodass Suchergebnisse den neuen Text aufnehmen, sobald das Status-Badge wieder `Indexiert` zeigt. Das Umbenennen des Themas nimmt den Versionsverlauf mit.
+
+Um einen Eintrag zu löschen, öffne sein Zeilen-Menü und klick auf **Löschen**. Das Löschen entfernt den ganzen Eintrag — Live-Version, Verlauf, das Hintergrund-Dokument und die indexierten Chunks — sodass Agents den Fakt nicht mehr finden können. Es gibt kein Rückgängig; war der Fakt richtig, füg ihn neu hinzu. Das Löschen des Hintergrund-Dokuments im Dokumente-Tab hat denselben Effekt: Der Eintrag wird ebenfalls entfernt, damit die zwei Ansichten nie auseinanderlaufen.
+
+## Wo das hingehört
+
+Wissenseinträge schliessen die Schleife zwischen Gesprächen und der Wissensdatenbank: Eine einmal im Chat gemachte Korrektur wird zu einem Fakt, den jeder Agent abruft — mit einem Menschen, der den exakten Wortlaut genehmigt, und einer Live-Version pro Thema, die garantiert, dass der alte Fakt verschwindet, wenn der neue landet. Für die datei-förmige Hälfte der Wissensdatenbank lies [Dokumente](/de/platform/knowledge/documents); dafür, wie ein Agent an Wissen bindet und zur Antwort-Zeit darüber abruft, lies [Agent-Wissen](/de/platform/agents/knowledge).

--- a/docs/de/platform/knowledge/overview.md
+++ b/docs/de/platform/knowledge/overview.md
@@ -25,6 +25,8 @@ Der Abruf selbst passiert zur Antwort-Zeit und wird von der RAG-getaggten Tool-F
 
 **[Dokumente](/de/platform/knowledge/documents)** — Redakteure lesen das, wenn sie Dateien hochladen, die Indexierungs-Pipeline beobachten und den Per-Dokument-Lebenszyklus verwalten.
 
+**[Wissenseinträge](/de/platform/knowledge/knowledge-entries)** — Redakteure lesen das, wenn sie die kleinen, themen-basierten Fakten verwalten, die Nutzer beitragen — mit Genehmigung aus dem Chat erfasst oder von Hand hinzugefügt — und die durch dieselbe Indexierungs-Pipeline fahren wie Dokumente.
+
 **[Strukturierte Daten](/de/platform/knowledge/structured-data)** — Redakteure lesen das, wenn sie typisierte Tabellen pflegen — Kunden, Produkte, Lieferanten, Websites — die Agents als Datensätze lesen.
 
 ## Wo das hingehört

--- a/docs/en/platform/knowledge/knowledge-entries.md
+++ b/docs/en/platform/knowledge/knowledge-entries.md
@@ -1,0 +1,36 @@
+---
+title: Knowledge entries
+description: Knowledge entries are small, topic-keyed facts that users contribute to the knowledge base — captured from chat with approval or added manually. This page covers where entries come from, the one-live-version-per-topic rule, and how to manage them.
+---
+
+Knowledge entries are the knowledge base's fact surface. Where a document carries a whole file, a knowledge entry carries one small, durable fact — "the store opens at 9", "the return window is 3 days" — keyed by a topic name. Entries come from two places: an agent can propose one during a chat when you confirm or correct information (you approve it on a card before anything is saved), and Editors can add one manually from the **Knowledge entries** tab. Either way, the entry lands in the same indexing pipeline as a document, so every agent that searches the knowledge base can retrieve and cite it.
+
+This page covers the management side: where entries come from, the one-live-version-per-topic rule that keeps corrections from coexisting with the facts they corrected, and how to add, edit, and delete entries.
+
+## Where entries come from
+
+**From chat, with your approval.** Agents with the `knowledge_write` tool enabled can propose saving a fact you stated or corrected during a conversation. The proposal shows up as an approval card in the chat with the topic, the full content, and — when the topic already exists — a notice that approving will replace the current entry. Nothing reaches the knowledge base until you click **Approve**; **Reject** discards the proposal. The tool is off by default — enable it per agent in the agent's tool settings under the Documents group. This is deliberate: an agent can never write into the org's shared knowledge without a human signing off on the exact text.
+
+**Manually.** To add an entry by hand, open **Knowledge > Knowledge entries** and click **Add entry**. Give it a topic (up to 120 characters — short and stable, like a heading) and the content as markdown (up to 8000 characters), written so it makes sense without any surrounding conversation. Manual entries skip the approval card — you are the human in the loop.
+
+## One live version per topic
+
+Topics are the dedup key. Writing to a topic that already has an entry — whether from chat or by editing — replaces the live version instead of adding a second one, so the knowledge base never serves two versions of the same fact. Topic matching ignores case and extra whitespace: "Store Hours" and "store hours" are the same topic.
+
+Replaced versions are not lost. Each entry keeps its version history — click a row to open the entry and expand any superseded version to see what it said and when it was replaced. Only the live version is indexed for retrieval; superseded versions exist for audit and reference only.
+
+## How entries reach agents
+
+Behind each entry sits a small markdown document in the documents hub, inside the reserved **Knowledge entries** folder. That backing document rides the exact same indexing pipeline as an uploaded file — extract, chunk, embed, store — which is why the entry list shows the familiar indexing status badge per row. A freshly saved entry shows `Indexing` briefly; once it flips to `Indexed`, agents whose knowledge scope includes the backing document retrieve and cite it like any other source.
+
+Because the backing document is a regular document, agent binding works unchanged: an agent scoped to the whole library sees every entry, and an agent scoped to specific folders sees entries only if the Knowledge entries folder is in scope. Entries are org-wide — there is no per-team scoping on entries themselves in this version.
+
+## Editing and deleting
+
+To edit an entry, open its row menu and click **Edit**. Saving creates a new live version and moves the previous one into the version history; the backing document is re-indexed in the background, so search results pick up the new text once the status badge returns to `Indexed`. Renaming the topic carries the version history along.
+
+To delete an entry, open its row menu and click **Delete**. Deletion removes the whole entry — live version, history, the backing document, and the indexed chunks — so agents can no longer find the fact. There is no undo; if the fact was right, add it again. Deleting the backing document from the Documents tab has the same effect: the entry is removed too, so the two views never disagree.
+
+## Where this fits
+
+Knowledge entries close the loop between conversations and the knowledge base: a correction made once in chat becomes a fact every agent retrieves, with a human approving the exact wording and one live version per topic guaranteeing the old fact disappears when the new one lands. For the file-shaped half of the knowledge base read [Documents](/platform/knowledge/documents); for how an agent binds to knowledge and retrieves over it at reply time, read [Agent knowledge](/platform/agents/knowledge).

--- a/docs/en/platform/knowledge/overview.md
+++ b/docs/en/platform/knowledge/overview.md
@@ -25,6 +25,8 @@ The retrieval itself happens at reply time and is driven by the RAG-tagged tool 
 
 **[Documents](/platform/knowledge/documents)** — Editors read this when they upload files, watch the indexing pipeline, and manage the per-document lifecycle.
 
+**[Knowledge entries](/platform/knowledge/knowledge-entries)** — Editors read this when they manage the small, topic-keyed facts users contribute — captured from chat with approval or added by hand — that ride the same indexing pipeline as documents.
+
 **[Structured data](/platform/knowledge/structured-data)** — Editors read this when they maintain typed tables — customers, products, vendors, websites — that agents read as records.
 
 ## Where this fits

--- a/docs/fr/platform/knowledge/knowledge-entries.md
+++ b/docs/fr/platform/knowledge/knowledge-entries.md
@@ -1,0 +1,36 @@
+---
+title: Entrées de connaissances
+description: Les entrées de connaissances sont de petits faits indexés par sujet que les utilisateurs apportent à la base de connaissances — capturés depuis le chat avec approbation ou ajoutés manuellement. Cette page couvre d'où viennent les entrées, la règle d'une version live par sujet, et comment les gérer.
+---
+
+Les entrées de connaissances sont la surface des faits de la base de connaissances. Là où un document porte un fichier entier, une entrée de connaissances porte un petit fait durable — « le magasin ouvre à 9 h », « le délai de retour est de 3 jours » — sous un nom de sujet. Les entrées viennent de deux sources : un agent peut en proposer une pendant un chat quand tu confirmes ou corriges une information (tu l'approuves sur une carte avant que quoi que ce soit soit enregistré), et les Éditeurs peuvent en ajouter une manuellement depuis l'onglet **Entrées de connaissances**. Dans les deux cas, l'entrée passe par la même pipeline d'indexation qu'un document, donc chaque agent qui cherche dans la base de connaissances peut la récupérer et la citer.
+
+Cette page couvre le côté gestion : d'où viennent les entrées, la règle d'une version live par sujet qui empêche les corrections de coexister avec les faits qu'elles ont corrigés, et comment ajouter, modifier et supprimer des entrées.
+
+## D'où viennent les entrées
+
+**Depuis le chat, avec ton approbation.** Les agents avec le tool `knowledge_write` activé peuvent proposer d'enregistrer un fait que tu as énoncé ou corrigé pendant une conversation. La proposition apparaît comme une carte d'approbation dans le chat avec le sujet, le contenu complet et — quand le sujet existe déjà — un avis indiquant que l'approbation remplacera l'entrée actuelle. Rien n'atteint la base de connaissances avant que tu cliques sur **Approuver** ; **Rejeter** écarte la proposition. Le tool est désactivé par défaut — active-le par agent dans les réglages de tools de l'agent sous le groupe Documents. C'est voulu : un agent ne peut jamais écrire dans la connaissance partagée de l'org sans qu'un humain valide le texte exact.
+
+**Manuellement.** Pour ajouter une entrée à la main, ouvre **Connaissance > Entrées de connaissances** et clique sur **Ajouter une entrée**. Donne-lui un sujet (jusqu'à 120 caractères — court et stable, comme un titre) et le contenu en markdown (jusqu'à 8000 caractères), rédigé pour être compréhensible sans la conversation autour. Les entrées manuelles sautent la carte d'approbation — tu es l'humain dans la boucle.
+
+## Une version live par sujet
+
+Les sujets sont la clé de déduplication. Écrire sur un sujet qui a déjà une entrée — depuis le chat ou en modifiant — remplace la version live au lieu d'en ajouter une seconde ; la base de connaissances ne sert donc jamais deux versions du même fait. La correspondance de sujets ignore la casse et les espaces superflus : « Horaires d'ouverture » et « horaires d'ouverture » sont le même sujet.
+
+Les versions remplacées ne sont pas perdues. Chaque entrée garde son historique des versions — clique sur une ligne pour ouvrir l'entrée et déplie une version remplacée pour voir ce qu'elle disait et quand elle a été remplacée. Seule la version live est indexée pour la récupération ; les versions remplacées n'existent que pour l'audit et la consultation.
+
+## Comment les entrées atteignent les agents
+
+Derrière chaque entrée se trouve un petit document markdown dans le hub de documents, dans le dossier réservé **Knowledge entries**. Ce document de fond passe par exactement la même pipeline d'indexation qu'un fichier téléversé — extraire, découper, embed, ranger — c'est pourquoi la liste des entrées montre le badge de statut d'indexation familier par ligne. Une entrée fraîchement enregistrée montre brièvement `Indexation` ; dès qu'elle bascule sur `Indexé`, les agents dont le périmètre de connaissances inclut le document de fond la récupèrent et la citent comme n'importe quelle autre source.
+
+Parce que le document de fond est un document ordinaire, la liaison aux agents fonctionne sans changement : un agent cadré sur toute la bibliothèque voit chaque entrée, et un agent cadré sur des dossiers spécifiques voit les entrées seulement si le dossier Knowledge entries est dans le périmètre. Les entrées valent pour toute l'org — il n'y a pas de cadrage par équipe sur les entrées elles-mêmes dans cette version.
+
+## Modifier et supprimer
+
+Pour modifier une entrée, ouvre son menu de ligne et clique sur **Modifier**. Enregistrer crée une nouvelle version live et déplace la précédente dans l'historique des versions ; le document de fond est réindexé en arrière-plan, donc les résultats de recherche prennent le nouveau texte dès que le badge de statut revient à `Indexé`. Renommer le sujet emporte l'historique des versions avec lui.
+
+Pour supprimer une entrée, ouvre son menu de ligne et clique sur **Supprimer**. La suppression retire l'entrée entière — version live, historique, le document de fond et les chunks indexés — donc les agents ne peuvent plus trouver le fait. Il n'y a pas d'annulation ; si le fait était juste, ajoute-le à nouveau. Supprimer le document de fond depuis l'onglet Documents a le même effet : l'entrée est retirée aussi, pour que les deux vues ne divergent jamais.
+
+## Où cela s'inscrit
+
+Les entrées de connaissances bouclent la boucle entre les conversations et la base de connaissances : une correction faite une fois dans le chat devient un fait que chaque agent récupère, avec un humain qui approuve la formulation exacte et une version live par sujet qui garantit que l'ancien fait disparaît quand le nouveau arrive. Pour la moitié fichiers de la base de connaissances, lis [Documents](/fr/platform/knowledge/documents) ; pour comment un agent se lie à la connaissance et récupère dessus à la réponse, lis [Connaissance d'agent](/fr/platform/agents/knowledge).

--- a/docs/fr/platform/knowledge/overview.md
+++ b/docs/fr/platform/knowledge/overview.md
@@ -25,6 +25,8 @@ La récupération elle-même arrive à la réponse et est pilotée par la famill
 
 **[Documents](/fr/platform/knowledge/documents)** — Les Éditeurs lisent ceci quand ils téléversent des fichiers, regardent la pipeline d'indexation, et gèrent le cycle de vie par document.
 
+**[Entrées de connaissances](/fr/platform/knowledge/knowledge-entries)** — Les Éditeurs lisent ceci quand ils gèrent les petits faits indexés par sujet que les utilisateurs apportent — capturés depuis le chat avec approbation ou ajoutés à la main — et qui passent par la même pipeline d'indexation que les documents.
+
 **[Données structurées](/fr/platform/knowledge/structured-data)** — Les Éditeurs lisent ceci quand ils maintiennent des tables typées — clients, produits, fournisseurs, sites web — que les agents lisent comme enregistrements.
 
 ## Où cela s'inscrit

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -153,6 +153,7 @@
           "pages": [
             "platform/knowledge/overview",
             "platform/knowledge/documents",
+            "platform/knowledge/knowledge-entries",
             "platform/knowledge/crawling",
             "platform/knowledge/structured-data"
           ]

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -521,6 +521,14 @@
       "description": "Wissen ist der Bereich, in dem die Dokumente und strukturierten Daten der Organisation liegen, damit Agents sie zitieren können. Redakteure kuratieren ihn; Agents rufen zur Antwort-Zeit darüber ab. Diese Übersicht nennt die zwei Hälften und verweist auf die Per-Bereich-Seiten."
     }
   },
+  "de:platform/knowledge/knowledge-entries": {
+    "slug": "platform/knowledge/knowledge-entries",
+    "locale": "de",
+    "frontmatter": {
+      "title": "Wissenseinträge",
+      "description": "Wissenseinträge sind kleine, themen-basierte Fakten, die Nutzer zur Wissensdatenbank beitragen — mit Genehmigung aus dem Chat erfasst oder manuell hinzugefügt. Diese Seite behandelt, woher Einträge kommen, die Eine-Live-Version-pro-Thema-Regel und wie du sie verwaltest."
+    }
+  },
   "de:platform/knowledge/structured-data": {
     "slug": "platform/knowledge/structured-data",
     "locale": "de",
@@ -1545,6 +1553,14 @@
       "description": "Connaissance est la zone où vivent les documents et données structurées de l'org pour que les agents puissent les citer. Les Éditeurs la curent ; les agents récupèrent dessus à la réponse. Cette vue d'ensemble nomme les deux moitiés et pointe vers les pages par zone."
     }
   },
+  "fr:platform/knowledge/knowledge-entries": {
+    "slug": "platform/knowledge/knowledge-entries",
+    "locale": "fr",
+    "frontmatter": {
+      "title": "Entrées de connaissances",
+      "description": "Les entrées de connaissances sont de petits faits indexés par sujet que les utilisateurs apportent à la base de connaissances — capturés depuis le chat avec approbation ou ajoutés manuellement. Cette page couvre d'où viennent les entrées, la règle d'une version live par sujet, et comment les gérer."
+    }
+  },
   "fr:platform/knowledge/structured-data": {
     "slug": "platform/knowledge/structured-data",
     "locale": "fr",
@@ -2567,6 +2583,14 @@
     "frontmatter": {
       "title": "Knowledge",
       "description": "Knowledge is the area where the org's documents and structured data live so agents can cite them. Editors curate it; agents retrieve over it at reply time. This overview names the two halves and points at the per-area pages."
+    }
+  },
+  "en:platform/knowledge/knowledge-entries": {
+    "slug": "platform/knowledge/knowledge-entries",
+    "locale": "en",
+    "frontmatter": {
+      "title": "Knowledge entries",
+      "description": "Knowledge entries are small, topic-keyed facts that users contribute to the knowledge base — captured from chat with approval or added manually. This page covers where entries come from, the one-live-version-per-topic rule, and how to manage them."
     }
   },
   "en:platform/knowledge/structured-data": {

--- a/services/platform/app/features/agents/components/tool-selector.tsx
+++ b/services/platform/app/features/agents/components/tool-selector.tsx
@@ -38,6 +38,7 @@ const TOOL_CATEGORIES: Record<string, ToolName[]> = {
     'document_retrieve',
     'document_find',
     'document_write',
+    'knowledge_write',
   ],
   Workflows: [
     'workflow_read',

--- a/services/platform/app/features/chat/components/approval-card-renderer.tsx
+++ b/services/platform/app/features/chat/components/approval-card-renderer.tsx
@@ -4,6 +4,7 @@ import type { ChatItem } from '../hooks/use-merged-chat-items';
 import { DocumentWriteApprovalCard } from './document-write-approval-card';
 import { HumanInputRequestCard } from './human-input-request-card';
 import { IntegrationApprovalCard } from './integration-approval-card';
+import { KnowledgeWriteApprovalCard } from './knowledge-write-approval-card';
 import { LocationRequestCard } from './location-request-card';
 import { WorkflowCreationApprovalCard } from './workflow-creation-approval-card';
 import { WorkflowRunApprovalCard } from './workflow-run-approval-card';
@@ -90,6 +91,16 @@ export function ApprovalCardRenderer({
       )}
       {item.type === 'document_write_approval' && (
         <DocumentWriteApprovalCard
+          approvalId={item.data._id}
+          organizationId={organizationId}
+          status={item.data.status}
+          metadata={item.data.metadata}
+          executedAt={item.data.executedAt}
+          executionError={item.data.executionError}
+        />
+      )}
+      {item.type === 'knowledge_write_approval' && (
+        <KnowledgeWriteApprovalCard
           approvalId={item.data._id}
           organizationId={organizationId}
           status={item.data.status}

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -357,6 +357,7 @@ export function ChatInterface({
     humanInputRequests,
     locationRequests,
     documentWriteApprovals,
+    knowledgeWriteApprovals,
   } = useThreadApprovals(organizationId, dataThreadId);
 
   // Resolved human-input requests — rendered inline in the history with the
@@ -380,6 +381,7 @@ export function ChatInterface({
     resolvedHumanInputRequests,
     locationRequests,
     documentWriteApprovals,
+    knowledgeWriteApprovals,
   });
 
   // Block input when any pending or executing approval exists

--- a/services/platform/app/features/chat/components/knowledge-write-approval-card.tsx
+++ b/services/platform/app/features/chat/components/knowledge-write-approval-card.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { ActionRow } from '@tale/ui/action-row';
+import { Badge } from '@tale/ui/badge';
+import { Button } from '@tale/ui/button';
+import { HStack, Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import {
+  BookOpen,
+  CheckCircle,
+  Loader2,
+  RefreshCw,
+  XCircle,
+} from 'lucide-react';
+import { memo, useState } from 'react';
+
+import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import {
+  useExecuteApprovedKnowledgeWrite,
+  useUpdateApprovalStatus,
+} from '@/app/features/chat/hooks/mutations';
+import { useAuth } from '@/app/hooks/use-convex-auth';
+import type { Id } from '@/convex/_generated/dataModel';
+import type { KnowledgeWriteMetadata } from '@/convex/approvals/types';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
+interface KnowledgeWriteApprovalCardProps {
+  approvalId: Id<'approvals'>;
+  organizationId: string;
+  status: 'pending' | 'executing' | 'completed' | 'rejected';
+  metadata: KnowledgeWriteMetadata;
+  executedAt?: number;
+  executionError?: string;
+  className?: string;
+}
+
+function KnowledgeWriteApprovalCardComponent({
+  approvalId,
+  status,
+  metadata,
+  executedAt,
+  executionError,
+  className,
+}: KnowledgeWriteApprovalCardProps) {
+  const { t } = useT('knowledgeWriteApproval');
+  const { t: tCommon } = useT('approvalCommon');
+  const { user } = useAuth();
+  const [isApproving, setIsApproving] = useState(false);
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: updateApprovalStatus } = useUpdateApprovalStatus();
+  const { mutateAsync: executeKnowledgeWrite } =
+    useExecuteApprovedKnowledgeWrite();
+
+  const isPending = status === 'pending';
+  const isProcessing = isApproving || isRejecting;
+  const isReplacement = !!metadata.replacesEntryId;
+
+  const handleApprove = async () => {
+    if (!user?.userId) {
+      setError(tCommon('errorNotAuthenticated'));
+      return;
+    }
+    setIsApproving(true);
+    setError(null);
+    try {
+      await updateApprovalStatus({
+        approvalId,
+        status: 'executing',
+      });
+      await executeKnowledgeWrite({ approvalId });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errorSaveFailed'));
+      console.error('Failed to approve knowledge write:', err);
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!user?.userId) {
+      setError(tCommon('errorNotAuthenticated'));
+      return;
+    }
+    setIsRejecting(true);
+    setError(null);
+    try {
+      await updateApprovalStatus({
+        approvalId,
+        status: 'rejected',
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : tCommon('errorRejectFailed'),
+      );
+      console.error('Failed to reject knowledge write:', err);
+    } finally {
+      setIsRejecting(false);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border p-4 bg-card max-w-md overflow-hidden',
+        className,
+      )}
+    >
+      {/* Header */}
+      <HStack gap={2} align="center" className="mb-2">
+        <BookOpen className="text-primary size-4 shrink-0" />
+        <Text as="div" variant="label">
+          {isReplacement ? t('cardTitleReplace') : t('cardTitle')}
+        </Text>
+      </HStack>
+
+      {/* Topic + content preview */}
+      <Stack gap={2} className="mb-3 pl-6">
+        <div className="min-w-0">
+          <Text as="div" variant="caption">
+            {t('topicLabel')}
+          </Text>
+          <Text as="div" variant="label" className="wrap-break-word">
+            {metadata.topic}
+          </Text>
+        </div>
+        <div className="min-w-0">
+          <Text as="div" variant="caption">
+            {t('contentLabel')}
+          </Text>
+          <Text
+            as="div"
+            className="bg-muted/50 mt-1 max-h-48 overflow-y-auto rounded-md p-2 text-sm wrap-break-word whitespace-pre-wrap"
+          >
+            {metadata.content}
+          </Text>
+        </div>
+        {metadata.incorrectInfo && (
+          <div className="min-w-0">
+            <Text as="div" variant="caption">
+              {t('incorrectInfoLabel')}
+            </Text>
+            <Text
+              as="div"
+              variant="caption"
+              className="text-muted-foreground wrap-break-word line-through"
+            >
+              {metadata.incorrectInfo}
+            </Text>
+          </div>
+        )}
+      </Stack>
+
+      {/* Replace notice */}
+      {isReplacement && (
+        <HStack gap={1} align="start" className="mb-3 pl-6 text-amber-600">
+          <RefreshCw className="mt-0.5 size-3 shrink-0" />
+          <Text as="span" variant="caption" className="min-w-0">
+            {t('replaceNotice', {
+              topic: metadata.replacesTopic ?? metadata.topic,
+            })}
+          </Text>
+        </HStack>
+      )}
+
+      {/* Execution success */}
+      {(status === 'executing' || status === 'completed') &&
+        executedAt &&
+        !executionError && (
+          <HStack gap={1} className="mb-3 text-xs text-green-600">
+            <CheckCircle className="size-3" />
+            {t('savedSuccessfully')}
+          </HStack>
+        )}
+
+      {/* Execution error */}
+      {executionError && (
+        <HStack
+          gap={1}
+          align="start"
+          className="text-destructive mb-3 text-xs wrap-break-word"
+        >
+          <XCircle className="size-3 shrink-0" />
+          <Text as="span" className="min-w-0">
+            {executionError}
+          </Text>
+        </HStack>
+      )}
+
+      {/* Temporary UI error */}
+      {error && (
+        <HStack
+          gap={1}
+          align="start"
+          className="text-destructive mb-3 text-xs wrap-break-word"
+        >
+          <XCircle className="size-3 shrink-0" />
+          <Text as="span" className="min-w-0">
+            {error}
+          </Text>
+        </HStack>
+      )}
+
+      {/* Action buttons */}
+      {isPending && (
+        <ActionRow gap={2}>
+          <Tooltip
+            content={
+              isReplacement ? t('approveTooltipReplace') : t('approveTooltip')
+            }
+          >
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={handleApprove}
+              disabled={isProcessing}
+              className="flex-1"
+            >
+              {isApproving && <Loader2 className="mr-1 size-4 animate-spin" />}
+              {t('approve')}
+            </Button>
+          </Tooltip>
+
+          <Tooltip content={t('rejectTooltip')}>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={handleReject}
+              disabled={isProcessing}
+              className="flex-1"
+            >
+              {isRejecting && <Loader2 className="mr-1 size-4 animate-spin" />}
+              {t('reject')}
+            </Button>
+          </Tooltip>
+        </ActionRow>
+      )}
+
+      {/* Resolved status */}
+      {!isPending && (
+        <HStack justify="between" align="center" className="mt-2">
+          <Text as="div" variant="caption">
+            {status === 'executing'
+              ? t('statusExecuting')
+              : status === 'completed' && executionError
+                ? t('statusCompletedFailed')
+                : status === 'completed'
+                  ? t('statusCompletedSuccess')
+                  : executionError
+                    ? t('statusCompletedFailed')
+                    : t('statusRejected')}
+          </Text>
+          <Badge
+            variant={
+              status === 'completed'
+                ? 'green'
+                : status === 'executing'
+                  ? 'blue'
+                  : 'destructive'
+            }
+            className="shrink-0 text-xs capitalize"
+          >
+            {status}
+          </Badge>
+        </HStack>
+      )}
+    </div>
+  );
+}
+
+export const KnowledgeWriteApprovalCard = memo(
+  KnowledgeWriteApprovalCardComponent,
+  (prevProps, nextProps) => {
+    return (
+      prevProps.approvalId === nextProps.approvalId &&
+      prevProps.status === nextProps.status &&
+      prevProps.className === nextProps.className &&
+      prevProps.executedAt === nextProps.executedAt &&
+      prevProps.executionError === nextProps.executionError &&
+      prevProps.organizationId === nextProps.organizationId &&
+      JSON.stringify(prevProps.metadata) === JSON.stringify(nextProps.metadata)
+    );
+  },
+);

--- a/services/platform/app/features/chat/hooks/mutations.ts
+++ b/services/platform/app/features/chat/hooks/mutations.ts
@@ -60,6 +60,10 @@ export function useExecuteApprovedDocumentWrite() {
   return useConvexAction(api.approvals.actions.executeApprovedDocumentWrite);
 }
 
+export function useExecuteApprovedKnowledgeWrite() {
+  return useConvexAction(api.approvals.actions.executeApprovedKnowledgeWrite);
+}
+
 export function useCreateThread() {
   return useConvexMutation(api.threads.mutations.createChatThread);
 }

--- a/services/platform/app/features/chat/hooks/queries.ts
+++ b/services/platform/app/features/chat/hooks/queries.ts
@@ -10,6 +10,7 @@ import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import type {
+  KnowledgeWriteMetadata,
   WorkflowCreationMetadata,
   WorkflowRunMetadata,
   WorkflowUpdateMetadata,
@@ -638,6 +639,16 @@ export function useDocumentWriteApprovals(
     approvals: documentWriteApprovals,
     isLoading,
   };
+}
+
+export interface KnowledgeWriteApproval {
+  _id: Id<'approvals'>;
+  status: 'pending' | 'executing' | 'completed' | 'rejected';
+  metadata: KnowledgeWriteMetadata;
+  executedAt?: number;
+  executionError?: string;
+  _creationTime: number;
+  messageId?: string;
 }
 
 export interface ToolUsage {

--- a/services/platform/app/features/chat/hooks/use-merged-chat-items.ts
+++ b/services/platform/app/features/chat/hooks/use-merged-chat-items.ts
@@ -6,6 +6,7 @@ import type {
   DocumentWriteApproval,
   HumanInputRequest,
   IntegrationApproval,
+  KnowledgeWriteApproval,
   LocationRequest,
   WorkflowCreationApproval,
   WorkflowRunApproval,
@@ -21,6 +22,7 @@ export type ChatItem =
   | { type: 'workflow_run_approval'; data: WorkflowRunApproval }
   | { type: 'human_input_request'; data: HumanInputRequest }
   | { type: 'document_write_approval'; data: DocumentWriteApproval }
+  | { type: 'knowledge_write_approval'; data: KnowledgeWriteApproval }
   | { type: 'location_request'; data: LocationRequest };
 
 type ApprovalChatItem = Exclude<ChatItem, { type: 'message' }>;
@@ -38,6 +40,9 @@ interface UseMergedChatItemsParams {
   resolvedHumanInputRequests?: HumanInputRequest[];
   locationRequests: LocationRequest[] | undefined;
   documentWriteApprovals: DocumentWriteApproval[] | undefined;
+  /** Optional — surfaces only on the main chat path (the `knowledge_write`
+   *  tool); arena/automation callers don't pass it. */
+  knowledgeWriteApprovals?: KnowledgeWriteApproval[];
 }
 
 export interface MergedChatItemsResult {
@@ -131,6 +136,7 @@ export function useMergedChatItems({
   resolvedHumanInputRequests,
   locationRequests,
   documentWriteApprovals,
+  knowledgeWriteApprovals,
 }: UseMergedChatItemsParams): MergedChatItemsResult {
   return useMemo((): MergedChatItemsResult => {
     // Build message items
@@ -238,6 +244,15 @@ export function useMergedChatItems({
         activeApprovals.push({ type: 'document_write_approval', data: a });
       }
     }
+    for (const a of knowledgeWriteApprovals ?? []) {
+      if (
+        a.messageId &&
+        loadedMessageIds.has(a.messageId) &&
+        isActiveStatus(a.status)
+      ) {
+        activeApprovals.push({ type: 'knowledge_write_approval', data: a });
+      }
+    }
 
     // Pick the latest active approval by creation time
     let activeApproval: ChatItem | null = null;
@@ -271,5 +286,6 @@ export function useMergedChatItems({
     resolvedHumanInputRequests,
     locationRequests,
     documentWriteApprovals,
+    knowledgeWriteApprovals,
   ]);
 }

--- a/services/platform/app/features/chat/hooks/use-thread-approvals.ts
+++ b/services/platform/app/features/chat/hooks/use-thread-approvals.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import type {
+  KnowledgeWriteMetadata,
   WorkflowCreationMetadata,
   WorkflowRunMetadata,
   WorkflowUpdateMetadata,
@@ -21,6 +22,7 @@ import {
   type HumanInputRequest,
   type IntegrationApproval,
   type IntegrationOperationMetadata,
+  type KnowledgeWriteApproval,
   type LocationRequest,
   type WorkflowCreationApproval,
   type WorkflowRunApproval,
@@ -35,6 +37,7 @@ export interface ThreadApprovals {
   humanInputRequests: HumanInputRequest[];
   locationRequests: LocationRequest[];
   documentWriteApprovals: DocumentWriteApproval[];
+  knowledgeWriteApprovals: KnowledgeWriteApproval[];
   isLoading: boolean;
 }
 
@@ -71,6 +74,7 @@ export function useThreadApprovals(
     const humanInputRequests: HumanInputRequest[] = [];
     const locationRequests: LocationRequest[] = [];
     const documentWriteApprovals: DocumentWriteApproval[] = [];
+    const knowledgeWriteApprovals: KnowledgeWriteApproval[] = [];
 
     if (approvals && threadId) {
       for (const a of approvals) {
@@ -165,6 +169,18 @@ export function useThreadApprovals(
               messageId: a.messageId,
             });
             break;
+          case 'knowledge_write':
+            knowledgeWriteApprovals.push({
+              _id: toId<'approvals'>(a._id),
+              status: a.status,
+              // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Metadata shape is guaranteed by resourceType filter above
+              metadata: a.metadata as unknown as KnowledgeWriteMetadata,
+              executedAt: a.executedAt,
+              executionError: a.executionError,
+              _creationTime: a._creationTime,
+              messageId: a.messageId,
+            });
+            break;
           default:
             break;
         }
@@ -179,6 +195,7 @@ export function useThreadApprovals(
       humanInputRequests,
       locationRequests,
       documentWriteApprovals,
+      knowledgeWriteApprovals,
     };
     // `isLoading` is intentionally excluded from the deps below: it's a cheap
     // passthrough, so re-partitioning when it toggles would be wasted work.

--- a/services/platform/app/features/chat/utils/format-tool-detail.ts
+++ b/services/platform/app/features/chat/utils/format-tool-detail.ts
@@ -72,6 +72,7 @@ export function formatToolDetail(
     customer_read: t('tools.customerRead'),
     product_read: t('tools.productRead'),
     rag_search: t('tools.ragSearch'),
+    knowledge_write: t('tools.knowledgeWrite'),
     web: t('tools.web'),
     pdf: t('tools.pdf'),
     image: t('tools.image'),

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entries-action-menu.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entries-action-menu.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
+import { useAbility } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+
+import { AddKnowledgeEntryDialog } from './knowledge-entry-add-dialog';
+
+interface KnowledgeEntriesActionMenuProps {
+  organizationId: string;
+}
+
+export function KnowledgeEntriesActionMenu({
+  organizationId,
+}: KnowledgeEntriesActionMenuProps) {
+  const { t } = useT('knowledgeEntries');
+  const ability = useAbility();
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  const handleAddClick = useCallback(() => {
+    setIsAddDialogOpen(true);
+  }, []);
+
+  if (ability.cannot('write', 'knowledgeWrite')) {
+    return null;
+  }
+
+  return (
+    <>
+      <DataTableActionMenu
+        label={t('addButton')}
+        icon={Plus}
+        onClick={handleAddClick}
+      />
+      <AddKnowledgeEntryDialog
+        isOpen={isAddDialogOpen}
+        onClose={() => setIsAddDialogOpen(false)}
+        organizationId={organizationId}
+      />
+    </>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entries-table.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entries-table.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import type { Row, RowSelectionState } from '@tanstack/react-table';
+import { BookOpen } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { DataTable } from '@/app/components/ui/data-table/data-table';
+import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
+import { useListPage } from '@/app/hooks/use-list-page';
+import { toId } from '@/convex/lib/type_cast_helpers';
+import { useT } from '@/lib/i18n/client';
+
+import { useDeleteKnowledgeEntry } from '../hooks/mutations';
+import {
+  useApproxKnowledgeEntryCount,
+  useListKnowledgeEntriesPaginated,
+  type KnowledgeEntryItem,
+} from '../hooks/queries';
+import { useKnowledgeEntriesTableConfig } from '../hooks/use-knowledge-entries-table-config';
+import { KnowledgeEntriesActionMenu } from './knowledge-entries-action-menu';
+import { ViewKnowledgeEntryDialog } from './knowledge-entry-view-dialog';
+
+export interface KnowledgeEntriesTableProps {
+  organizationId: string;
+}
+
+export function KnowledgeEntriesTable({
+  organizationId,
+}: KnowledgeEntriesTableProps) {
+  const { t: tEmpty } = useT('emptyStates');
+  const { t } = useT('knowledgeEntries');
+
+  const { data: count } = useApproxKnowledgeEntryCount(organizationId);
+  const { columns, searchPlaceholder, stickyLayout, pageSize } =
+    useKnowledgeEntriesTableConfig();
+  const paginatedResult = useListKnowledgeEntriesPaginated({
+    organizationId,
+    initialNumItems: pageSize,
+  });
+
+  const [viewingEntryId, setViewingEntryId] = useState<string | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { mutateAsync: deleteEntry } = useDeleteKnowledgeEntry();
+
+  const viewingEntry = useMemo(
+    () =>
+      viewingEntryId
+        ? (paginatedResult.results.find((e) => e._id === viewingEntryId) ??
+          null)
+        : null,
+    [viewingEntryId, paginatedResult.results],
+  );
+
+  const handleRowClick = useCallback((row: Row<KnowledgeEntryItem>) => {
+    setViewingEntryId(row.original._id);
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setRowSelection({});
+  }, []);
+
+  const handleDeleteItem = useCallback(
+    async (id: string) => {
+      // RowSelectionState keys are the row `_id`s by construction (getRowId).
+      await deleteEntry({ entryId: toId<'knowledgeEntries'>(id) });
+    },
+    [deleteEntry],
+  );
+
+  const list = useListPage<KnowledgeEntryItem>({
+    dataSource: {
+      type: 'paginated',
+      results: paginatedResult.results,
+      status: paginatedResult.status,
+      loadMore: paginatedResult.loadMore,
+      isLoading: paginatedResult.isLoading,
+    },
+    pageSize,
+    search: {
+      fields: ['topic', 'content'],
+      placeholder: searchPlaceholder,
+    },
+    approxRowCount: count,
+    entityLabel: t('title').toLowerCase(),
+  });
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        stickyLayout={stickyLayout}
+        enableRowSelection
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+        onRowClick={handleRowClick}
+        actionMenu={
+          <KnowledgeEntriesActionMenu organizationId={organizationId} />
+        }
+        emptyState={{
+          icon: BookOpen,
+          title: tEmpty('knowledgeEntries.title'),
+          description: tEmpty('knowledgeEntries.description'),
+        }}
+        footer={
+          <BulkDeleteBar
+            rowSelection={rowSelection}
+            onClearSelection={handleClearSelection}
+            onDeleteItem={handleDeleteItem}
+            onDeleteComplete={handleClearSelection}
+          />
+        }
+        {...list.tableProps}
+      />
+
+      {viewingEntry && (
+        <ViewKnowledgeEntryDialog
+          isOpen={!!viewingEntry}
+          onClose={() => setViewingEntryId(null)}
+          entry={viewingEntry}
+        />
+      )}
+    </>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Input } from '@/app/components/ui/forms/input';
+import { Textarea } from '@/app/components/ui/forms/textarea';
+import { toast } from '@/app/hooks/use-toast';
+import {
+  CONTENT_MAX_LENGTH,
+  TOPIC_MAX_LENGTH,
+} from '@/convex/knowledge_entries/constants';
+import { useT } from '@/lib/i18n/client';
+
+import { useCreateKnowledgeEntry } from '../hooks/mutations';
+
+type FormData = {
+  topic: string;
+  content: string;
+};
+
+interface AddKnowledgeEntryDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  organizationId: string;
+}
+
+export function AddKnowledgeEntryDialog({
+  isOpen,
+  onClose,
+  organizationId,
+}: AddKnowledgeEntryDialogProps) {
+  const { t } = useT('knowledgeEntries');
+  const { mutate: createEntry, isPending } = useCreateKnowledgeEntry();
+
+  const formSchema = useMemo(
+    () =>
+      z.object({
+        topic: z
+          .string()
+          .trim()
+          .min(1, t('validation.topicRequired'))
+          .max(TOPIC_MAX_LENGTH, t('validation.topicTooLong')),
+        content: z
+          .string()
+          .trim()
+          .min(1, t('validation.contentRequired'))
+          .max(CONTENT_MAX_LENGTH, t('validation.contentTooLong')),
+      }),
+    [t],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { topic: '', content: '' },
+  });
+
+  const onSubmit = (data: FormData) => {
+    createEntry(
+      {
+        organizationId,
+        topic: data.topic,
+        content: data.content,
+      },
+      {
+        onSuccess: () => {
+          toast({ title: t('toast.addSuccess'), variant: 'success' });
+          reset();
+          onClose();
+        },
+        onError: (error) => {
+          console.error('Failed to add knowledge entry:', error);
+          const isDuplicate =
+            error instanceof Error && error.message.includes('already exists');
+          toast({
+            title: isDuplicate
+              ? t('toast.addErrorDuplicate')
+              : t('toast.addError'),
+            variant: 'destructive',
+          });
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <FormDialog
+      open={isOpen}
+      onOpenChange={(open) => !open && handleClose()}
+      title={t('addEntry')}
+      submittingText={t('adding')}
+      isSubmitting={isPending}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Input
+        id="topic"
+        type="text"
+        label={t('topic')}
+        placeholder={t('topicPlaceholder')}
+        {...register('topic')}
+        disabled={isPending}
+        errorMessage={errors.topic?.message}
+      />
+
+      <Textarea
+        id="content"
+        label={t('content')}
+        placeholder={t('contentPlaceholder')}
+        rows={8}
+        {...register('content')}
+        disabled={isPending}
+        errorMessage={errors.content?.message}
+      />
+    </FormDialog>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-delete-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-delete-dialog.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { EntityDeleteDialog } from '@/app/components/ui/entity/entity-delete-dialog';
+import { useDeleteDialogTranslations } from '@/app/components/ui/entity/use-delete-dialog';
+import { useT } from '@/lib/i18n/client';
+
+import { useDeleteKnowledgeEntry } from '../hooks/mutations';
+import type { KnowledgeEntryItem } from '../hooks/queries';
+
+interface DeleteKnowledgeEntryDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  entry: KnowledgeEntryItem;
+}
+
+export function DeleteKnowledgeEntryDialog({
+  isOpen,
+  onClose,
+  entry,
+}: DeleteKnowledgeEntryDialogProps) {
+  const { t } = useT('knowledgeEntries');
+  const { t: tToast } = useT('toast');
+  const { mutateAsync: deleteEntry } = useDeleteKnowledgeEntry();
+
+  const translations = useDeleteDialogTranslations({
+    tEntity: t,
+    tToast,
+    keys: {
+      title: 'delete.title',
+      description: 'delete.confirmation',
+      errorMessage: 'toast.deleteError',
+    },
+  });
+
+  const handleDelete = useCallback(
+    async (e: KnowledgeEntryItem) => {
+      await deleteEntry({ entryId: e._id });
+    },
+    [deleteEntry],
+  );
+
+  const getEntityName = useCallback((e: KnowledgeEntryItem) => e.topic, []);
+
+  return (
+    <EntityDeleteDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      entity={entry}
+      getEntityName={getEntityName}
+      deleteMutation={handleDelete}
+      translations={translations}
+    />
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-edit-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-edit-dialog.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Input } from '@/app/components/ui/forms/input';
+import { Textarea } from '@/app/components/ui/forms/textarea';
+import { toast } from '@/app/hooks/use-toast';
+import {
+  CONTENT_MAX_LENGTH,
+  TOPIC_MAX_LENGTH,
+} from '@/convex/knowledge_entries/constants';
+import { useT } from '@/lib/i18n/client';
+
+import { useUpdateKnowledgeEntry } from '../hooks/mutations';
+import type { KnowledgeEntryItem } from '../hooks/queries';
+
+type FormData = {
+  topic: string;
+  content: string;
+};
+
+interface EditKnowledgeEntryDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  entry: KnowledgeEntryItem;
+}
+
+export function EditKnowledgeEntryDialog({
+  isOpen,
+  onClose,
+  entry,
+}: EditKnowledgeEntryDialogProps) {
+  const { t } = useT('knowledgeEntries');
+  const { mutate: updateEntry, isPending } = useUpdateKnowledgeEntry();
+
+  const formSchema = useMemo(
+    () =>
+      z.object({
+        topic: z
+          .string()
+          .trim()
+          .min(1, t('validation.topicRequired'))
+          .max(TOPIC_MAX_LENGTH, t('validation.topicTooLong')),
+        content: z
+          .string()
+          .trim()
+          .min(1, t('validation.contentRequired'))
+          .max(CONTENT_MAX_LENGTH, t('validation.contentTooLong')),
+      }),
+    [t],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { topic: entry.topic, content: entry.content },
+  });
+
+  const onSubmit = (data: FormData) => {
+    updateEntry(
+      {
+        entryId: entry._id,
+        topic: data.topic,
+        content: data.content,
+      },
+      {
+        onSuccess: () => {
+          toast({ title: t('toast.updateSuccess'), variant: 'success' });
+          onClose();
+        },
+        onError: (error) => {
+          console.error('Failed to update knowledge entry:', error);
+          const isDuplicate =
+            error instanceof Error && error.message.includes('already exists');
+          toast({
+            title: isDuplicate
+              ? t('toast.addErrorDuplicate')
+              : t('toast.updateError'),
+            variant: 'destructive',
+          });
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <FormDialog
+      open={isOpen}
+      onOpenChange={(open) => !open && handleClose()}
+      title={t('editEntry')}
+      submittingText={t('saving')}
+      isSubmitting={isPending}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Input
+        id="topic"
+        type="text"
+        label={t('topic')}
+        placeholder={t('topicPlaceholder')}
+        {...register('topic')}
+        disabled={isPending}
+        errorMessage={errors.topic?.message}
+      />
+
+      <Textarea
+        id="content"
+        label={t('content')}
+        placeholder={t('contentPlaceholder')}
+        rows={8}
+        {...register('content')}
+        disabled={isPending}
+        errorMessage={errors.content?.message}
+      />
+    </FormDialog>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-row-actions.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-row-actions.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Pencil, Trash2 } from 'lucide-react';
+import { useMemo } from 'react';
+
+import {
+  EntityRowActions,
+  useEntityRowDialogs,
+} from '@/app/components/ui/entity/entity-row-actions';
+import { useAbility } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+
+import type { KnowledgeEntryItem } from '../hooks/queries';
+import { DeleteKnowledgeEntryDialog } from './knowledge-entry-delete-dialog';
+import { EditKnowledgeEntryDialog } from './knowledge-entry-edit-dialog';
+
+interface KnowledgeEntryRowActionsProps {
+  entry: KnowledgeEntryItem;
+}
+
+export function KnowledgeEntryRowActions({
+  entry,
+}: KnowledgeEntryRowActionsProps) {
+  const { t: tCommon } = useT('common');
+  const ability = useAbility();
+  const canWrite = ability.can('write', 'knowledgeWrite');
+  const dialogs = useEntityRowDialogs(['edit', 'delete']);
+
+  const actions = useMemo(
+    () => [
+      {
+        key: 'edit',
+        label: tCommon('actions.edit'),
+        icon: Pencil,
+        onClick: dialogs.open.edit,
+      },
+      {
+        key: 'delete',
+        label: tCommon('actions.delete'),
+        icon: Trash2,
+        onClick: dialogs.open.delete,
+        destructive: true,
+      },
+    ],
+    [tCommon, dialogs.open],
+  );
+
+  if (!canWrite) return null;
+
+  return (
+    <>
+      <EntityRowActions actions={actions} />
+
+      {dialogs.isOpen.edit && (
+        <EditKnowledgeEntryDialog
+          isOpen={dialogs.isOpen.edit}
+          onClose={() => dialogs.setOpen.edit(false)}
+          entry={entry}
+        />
+      )}
+
+      {dialogs.isOpen.delete && (
+        <DeleteKnowledgeEntryDialog
+          isOpen={dialogs.isOpen.delete}
+          onClose={() => dialogs.setOpen.delete(false)}
+          entry={entry}
+        />
+      )}
+    </>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-view-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-view-dialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { Badge } from '@tale/ui/badge';
+import { BorderedSection } from '@tale/ui/bordered-section';
+import { CollapsibleDetails } from '@tale/ui/collapsible-details';
+import { Heading } from '@tale/ui/heading';
+import { HStack } from '@tale/ui/layout';
+import { type StatGridItem, StatGrid } from '@tale/ui/stat-grid';
+import { Text } from '@tale/ui/text';
+import { useMemo } from 'react';
+
+import { CopyableTimestamp } from '@/app/components/ui/data-display/copyable-timestamp';
+import { ViewDialog } from '@/app/components/ui/dialog/view-dialog';
+import { RagStatusBadge } from '@/app/features/documents/components/rag-status-badge';
+import { useFormatDate } from '@/app/hooks/use-format-date';
+import { useT } from '@/lib/i18n/client';
+
+import { useKnowledgeEntryVersions } from '../hooks/queries';
+import type { KnowledgeEntryItem } from '../hooks/queries';
+
+interface ViewKnowledgeEntryDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  entry: KnowledgeEntryItem;
+}
+
+export function ViewKnowledgeEntryDialog({
+  isOpen,
+  onClose,
+  entry,
+}: ViewKnowledgeEntryDialogProps) {
+  const { t } = useT('knowledgeEntries');
+  const { formatDate } = useFormatDate();
+  const { data: versionData } = useKnowledgeEntryVersions(entry._id);
+
+  const versions = versionData?.versions ?? [];
+
+  const items = useMemo<StatGridItem[]>(
+    () => [
+      {
+        label: t('topic'),
+        value: <Text>{entry.topic}</Text>,
+      },
+      {
+        label: t('headers.source'),
+        value: (
+          <Badge variant="outline">
+            {entry.source === 'chat' ? t('source.chat') : t('source.manual')}
+          </Badge>
+        ),
+      },
+      {
+        label: t('viewDialog.indexingStatus'),
+        value: (
+          <RagStatusBadge
+            status={entry.ragStatus}
+            indexedAt={entry.ragIndexedAt}
+            error={entry.ragError}
+            documentId={entry.documentId ? String(entry.documentId) : undefined}
+          />
+        ),
+      },
+      {
+        label: t('viewDialog.updated'),
+        value: <CopyableTimestamp date={entry.createdAt} preset="long" />,
+      },
+      {
+        label: t('content'),
+        value: (
+          <Text className="max-h-72 overflow-y-auto whitespace-pre-wrap">
+            {entry.content}
+          </Text>
+        ),
+        colSpan: 2,
+      },
+    ],
+    [entry, t],
+  );
+
+  return (
+    <ViewDialog
+      open={isOpen}
+      onOpenChange={onClose}
+      title={t('viewDialog.title')}
+      size="wide"
+    >
+      <StatGrid items={items} />
+
+      {versions.length > 0 && (
+        <div className="mt-6 space-y-3">
+          <HStack justify="between" align="center">
+            <Heading level={2} size="sm" weight="semibold">
+              {t('viewDialog.history')}
+            </Heading>
+            <Text variant="caption">
+              {t('viewDialog.versionCount', { count: versions.length })}
+            </Text>
+          </HStack>
+
+          {versions.map((version) => (
+            <BorderedSection key={version._id}>
+              <CollapsibleDetails
+                summary={
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <HStack gap={2} align="center">
+                      <Badge variant="outline">
+                        {t('viewDialog.superseded')}
+                      </Badge>
+                      <Text variant="caption">
+                        {version.supersededAt
+                          ? t('viewDialog.supersededOn', {
+                              date: formatDate(
+                                new Date(version.supersededAt),
+                                'long',
+                              ),
+                            })
+                          : formatDate(new Date(version.createdAt), 'long')}
+                      </Text>
+                    </HStack>
+                    <Text variant="caption" className="break-words">
+                      {version.topic}
+                    </Text>
+                  </div>
+                }
+              >
+                <Text className="mt-3 max-h-48 overflow-y-auto text-sm wrap-break-word whitespace-pre-wrap">
+                  {version.content}
+                </Text>
+              </CollapsibleDetails>
+            </BorderedSection>
+          ))}
+        </div>
+      )}
+    </ViewDialog>
+  );
+}

--- a/services/platform/app/features/knowledge-entries/hooks/mutations.ts
+++ b/services/platform/app/features/knowledge-entries/hooks/mutations.ts
@@ -1,0 +1,20 @@
+import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
+import { api } from '@/convex/_generated/api';
+
+export function useCreateKnowledgeEntry() {
+  return useConvexMutation(
+    api.knowledge_entries.mutations.createKnowledgeEntry,
+  );
+}
+
+export function useUpdateKnowledgeEntry() {
+  return useConvexMutation(
+    api.knowledge_entries.mutations.updateKnowledgeEntry,
+  );
+}
+
+export function useDeleteKnowledgeEntry() {
+  return useConvexMutation(
+    api.knowledge_entries.mutations.deleteKnowledgeEntry,
+  );
+}

--- a/services/platform/app/features/knowledge-entries/hooks/queries.ts
+++ b/services/platform/app/features/knowledge-entries/hooks/queries.ts
@@ -1,0 +1,39 @@
+import { useCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import type { KnowledgeEntryItem } from '@/convex/knowledge_entries/queries';
+
+export type { KnowledgeEntryItem };
+
+export function useApproxKnowledgeEntryCount(organizationId: string) {
+  return useConvexQuery(
+    api.knowledge_entries.queries.approxCountKnowledgeEntries,
+    { organizationId },
+  );
+}
+
+interface ListKnowledgeEntriesPaginatedArgs {
+  organizationId: string;
+  initialNumItems: number;
+}
+
+export function useListKnowledgeEntriesPaginated(
+  args: ListKnowledgeEntriesPaginatedArgs,
+) {
+  const { initialNumItems, ...queryArgs } = args;
+  return useCachedPaginatedQuery(
+    api.knowledge_entries.queries.listKnowledgeEntriesPaginated,
+    queryArgs,
+    { initialNumItems },
+  );
+}
+
+export function useKnowledgeEntryVersions(
+  entryId: Id<'knowledgeEntries'> | undefined,
+) {
+  return useConvexQuery(
+    api.knowledge_entries.queries.getKnowledgeEntryVersions,
+    entryId ? { entryId } : 'skip',
+  );
+}

--- a/services/platform/app/features/knowledge-entries/hooks/use-knowledge-entries-table-config.tsx
+++ b/services/platform/app/features/knowledge-entries/hooks/use-knowledge-entries-table-config.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Badge } from '@tale/ui/badge';
+import { HStack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import type { ColumnDef } from '@tanstack/react-table';
+import { BookOpen } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { CopyableTimestamp } from '@/app/components/ui/data-display/copyable-timestamp';
+import {
+  ACTIONS_COLUMN_SIZE,
+  createActionsColumn,
+  createSelectColumn,
+} from '@/app/components/ui/data-table/column-builders';
+import { RagStatusBadge } from '@/app/features/documents/components/rag-status-badge';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
+import { useT } from '@/lib/i18n/client';
+
+import { KnowledgeEntryRowActions } from '../components/knowledge-entry-row-actions';
+import type { KnowledgeEntryItem } from './queries';
+
+interface KnowledgeEntriesTableConfig {
+  columns: ColumnDef<KnowledgeEntryItem>[];
+  searchPlaceholder: string;
+  stickyLayout: boolean;
+  pageSize: number;
+}
+
+export function useKnowledgeEntriesTableConfig(): KnowledgeEntriesTableConfig {
+  const { t: tTables } = useT('tables');
+  const { t: tEntity } = useT('knowledgeEntries');
+
+  const columns = useMemo<ColumnDef<KnowledgeEntryItem>[]>(
+    () => [
+      createSelectColumn<KnowledgeEntryItem>(),
+      {
+        accessorKey: 'topic',
+        header: tEntity('headers.topic'),
+        size: 240,
+        cell: ({ row }) => (
+          <HStack gap={2}>
+            <div className="bg-muted flex size-5 shrink-0 items-center justify-center rounded">
+              <BookOpen className="text-muted-foreground size-3" />
+            </div>
+            <Text as="span" variant="label" truncate>
+              {row.original.topic}
+            </Text>
+          </HStack>
+        ),
+      },
+      {
+        accessorKey: 'content',
+        header: tEntity('headers.content'),
+        cell: ({ row }) => (
+          <Text
+            as="span"
+            variant="caption"
+            truncate
+            className="block max-w-[28rem]"
+          >
+            {row.original.content}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: 'source',
+        header: tEntity('headers.source'),
+        size: 96,
+        cell: ({ row }) => (
+          <Badge variant="outline">
+            {row.original.source === 'chat'
+              ? tEntity('source.chat')
+              : tEntity('source.manual')}
+          </Badge>
+        ),
+      },
+      {
+        id: 'ragStatus',
+        header: tTables('headers.status'),
+        size: 128,
+        meta: { headerLabel: tTables('headers.status') },
+        cell: ({ row }) => (
+          <RagStatusBadge
+            status={row.original.ragStatus}
+            indexedAt={row.original.ragIndexedAt}
+            error={row.original.ragError}
+            documentId={
+              row.original.documentId
+                ? String(row.original.documentId)
+                : undefined
+            }
+          />
+        ),
+      },
+      {
+        accessorKey: 'createdAt',
+        header: () => (
+          <span className="block w-full text-right">
+            {tEntity('headers.updated')}
+          </span>
+        ),
+        size: 128,
+        meta: { headerLabel: tEntity('headers.updated') },
+        cell: ({ row }) => (
+          <CopyableTimestamp
+            date={row.original.createdAt}
+            preset="long"
+            alignRight
+          />
+        ),
+      },
+      createActionsColumn(KnowledgeEntryRowActions, 'entry', {
+        size: ACTIONS_COLUMN_SIZE,
+        headerLabel: tTables('headers.actions'),
+      }),
+    ],
+    [tTables, tEntity],
+  );
+
+  return {
+    columns,
+    searchPlaceholder: tEntity('searchPlaceholder'),
+    stickyLayout: true,
+    pageSize: DEFAULT_TABLE_PAGE_SIZE,
+  };
+}

--- a/services/platform/app/features/knowledge/components/knowledge-navigation.tsx
+++ b/services/platform/app/features/knowledge/components/knowledge-navigation.tsx
@@ -12,6 +12,7 @@ interface KnowledgeNavigationProps {
 
 type KnowledgeLabelKey =
   | 'documents'
+  | 'knowledgeEntries'
   | 'websites'
   | 'products'
   | 'customers'
@@ -30,6 +31,11 @@ export function KnowledgeNavigation({
       labelKey: 'documents',
       label: t('documents'),
       href: `/dashboard/${organizationId}/documents`,
+    },
+    {
+      labelKey: 'knowledgeEntries',
+      label: t('knowledgeEntries'),
+      href: `/dashboard/${organizationId}/knowledge-entries`,
     },
     {
       labelKey: 'websites',

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -64,6 +64,7 @@ import { Route as DashboardIdAgentsAgentIdRouteImport } from './routes/dashboard
 import { Route as DashboardIdKnowledgeWebsitesRouteImport } from './routes/dashboard/$id/_knowledge/websites';
 import { Route as DashboardIdKnowledgeVendorsRouteImport } from './routes/dashboard/$id/_knowledge/vendors';
 import { Route as DashboardIdKnowledgeProductsRouteImport } from './routes/dashboard/$id/_knowledge/products';
+import { Route as DashboardIdKnowledgeKnowledgeEntriesRouteImport } from './routes/dashboard/$id/_knowledge/knowledge-entries';
 import { Route as DashboardIdKnowledgeDocumentsRouteImport } from './routes/dashboard/$id/_knowledge/documents';
 import { Route as DashboardIdKnowledgeCustomersRouteImport } from './routes/dashboard/$id/_knowledge/customers';
 import { Route as DashboardIdSettingsGovernanceRouteRouteImport } from './routes/dashboard/$id/settings/governance/route';
@@ -411,6 +412,12 @@ const DashboardIdKnowledgeProductsRoute =
     path: '/products',
     getParentRoute: () => DashboardIdKnowledgeRoute,
   } as any);
+const DashboardIdKnowledgeKnowledgeEntriesRoute =
+  DashboardIdKnowledgeKnowledgeEntriesRouteImport.update({
+    id: '/knowledge-entries',
+    path: '/knowledge-entries',
+    getParentRoute: () => DashboardIdKnowledgeRoute,
+  } as any);
 const DashboardIdKnowledgeDocumentsRoute =
   DashboardIdKnowledgeDocumentsRouteImport.update({
     id: '/documents',
@@ -710,6 +717,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/$id/settings/governance': typeof DashboardIdSettingsGovernanceRouteRouteWithChildren;
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute;
   '/dashboard/$id/documents': typeof DashboardIdKnowledgeDocumentsRoute;
+  '/dashboard/$id/knowledge-entries': typeof DashboardIdKnowledgeKnowledgeEntriesRoute;
   '/dashboard/$id/products': typeof DashboardIdKnowledgeProductsRoute;
   '/dashboard/$id/vendors': typeof DashboardIdKnowledgeVendorsRoute;
   '/dashboard/$id/websites': typeof DashboardIdKnowledgeWebsitesRoute;
@@ -802,6 +810,7 @@ export interface FileRoutesByTo {
   '/dashboard/$id/inbox': typeof DashboardIdInboxRoute;
   '/dashboard/$id/customers': typeof DashboardIdKnowledgeCustomersRoute;
   '/dashboard/$id/documents': typeof DashboardIdKnowledgeDocumentsRoute;
+  '/dashboard/$id/knowledge-entries': typeof DashboardIdKnowledgeKnowledgeEntriesRoute;
   '/dashboard/$id/products': typeof DashboardIdKnowledgeProductsRoute;
   '/dashboard/$id/vendors': typeof DashboardIdKnowledgeVendorsRoute;
   '/dashboard/$id/websites': typeof DashboardIdKnowledgeWebsitesRoute;
@@ -901,6 +910,7 @@ export interface FileRoutesById {
   '/dashboard/$id/settings/governance': typeof DashboardIdSettingsGovernanceRouteRouteWithChildren;
   '/dashboard/$id/_knowledge/customers': typeof DashboardIdKnowledgeCustomersRoute;
   '/dashboard/$id/_knowledge/documents': typeof DashboardIdKnowledgeDocumentsRoute;
+  '/dashboard/$id/_knowledge/knowledge-entries': typeof DashboardIdKnowledgeKnowledgeEntriesRoute;
   '/dashboard/$id/_knowledge/products': typeof DashboardIdKnowledgeProductsRoute;
   '/dashboard/$id/_knowledge/vendors': typeof DashboardIdKnowledgeVendorsRoute;
   '/dashboard/$id/_knowledge/websites': typeof DashboardIdKnowledgeWebsitesRoute;
@@ -1003,6 +1013,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/settings/governance'
     | '/dashboard/$id/customers'
     | '/dashboard/$id/documents'
+    | '/dashboard/$id/knowledge-entries'
     | '/dashboard/$id/products'
     | '/dashboard/$id/vendors'
     | '/dashboard/$id/websites'
@@ -1095,6 +1106,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/inbox'
     | '/dashboard/$id/customers'
     | '/dashboard/$id/documents'
+    | '/dashboard/$id/knowledge-entries'
     | '/dashboard/$id/products'
     | '/dashboard/$id/vendors'
     | '/dashboard/$id/websites'
@@ -1193,6 +1205,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id/settings/governance'
     | '/dashboard/$id/_knowledge/customers'
     | '/dashboard/$id/_knowledge/documents'
+    | '/dashboard/$id/_knowledge/knowledge-entries'
     | '/dashboard/$id/_knowledge/products'
     | '/dashboard/$id/_knowledge/vendors'
     | '/dashboard/$id/_knowledge/websites'
@@ -1664,6 +1677,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIdKnowledgeProductsRouteImport;
       parentRoute: typeof DashboardIdKnowledgeRoute;
     };
+    '/dashboard/$id/_knowledge/knowledge-entries': {
+      id: '/dashboard/$id/_knowledge/knowledge-entries';
+      path: '/knowledge-entries';
+      fullPath: '/dashboard/$id/knowledge-entries';
+      preLoaderRoute: typeof DashboardIdKnowledgeKnowledgeEntriesRouteImport;
+      parentRoute: typeof DashboardIdKnowledgeRoute;
+    };
     '/dashboard/$id/_knowledge/documents': {
       id: '/dashboard/$id/_knowledge/documents';
       path: '/documents';
@@ -1999,6 +2019,7 @@ const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 interface DashboardIdKnowledgeRouteChildren {
   DashboardIdKnowledgeCustomersRoute: typeof DashboardIdKnowledgeCustomersRoute;
   DashboardIdKnowledgeDocumentsRoute: typeof DashboardIdKnowledgeDocumentsRoute;
+  DashboardIdKnowledgeKnowledgeEntriesRoute: typeof DashboardIdKnowledgeKnowledgeEntriesRoute;
   DashboardIdKnowledgeProductsRoute: typeof DashboardIdKnowledgeProductsRoute;
   DashboardIdKnowledgeVendorsRoute: typeof DashboardIdKnowledgeVendorsRoute;
   DashboardIdKnowledgeWebsitesRoute: typeof DashboardIdKnowledgeWebsitesRoute;
@@ -2007,6 +2028,8 @@ interface DashboardIdKnowledgeRouteChildren {
 const DashboardIdKnowledgeRouteChildren: DashboardIdKnowledgeRouteChildren = {
   DashboardIdKnowledgeCustomersRoute: DashboardIdKnowledgeCustomersRoute,
   DashboardIdKnowledgeDocumentsRoute: DashboardIdKnowledgeDocumentsRoute,
+  DashboardIdKnowledgeKnowledgeEntriesRoute:
+    DashboardIdKnowledgeKnowledgeEntriesRoute,
   DashboardIdKnowledgeProductsRoute: DashboardIdKnowledgeProductsRoute,
   DashboardIdKnowledgeVendorsRoute: DashboardIdKnowledgeVendorsRoute,
   DashboardIdKnowledgeWebsitesRoute: DashboardIdKnowledgeWebsitesRoute,

--- a/services/platform/app/routes/dashboard/$id/_knowledge/knowledge-entries.tsx
+++ b/services/platform/app/routes/dashboard/$id/_knowledge/knowledge-entries.tsx
@@ -1,0 +1,39 @@
+import { convexQuery } from '@convex-dev/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+
+import { KnowledgeEntriesTable } from '@/app/features/knowledge-entries/components/knowledge-entries-table';
+import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
+import { api } from '@/convex/_generated/api';
+import { seo } from '@/lib/utils/seo';
+
+export const Route = createFileRoute(
+  '/dashboard/$id/_knowledge/knowledge-entries',
+)({
+  head: () => ({
+    meta: seo('knowledgeEntries'),
+  }),
+  loader: ({ context, params }) => {
+    void context.queryClient.prefetchQuery(
+      convexQuery(api.knowledge_entries.queries.approxCountKnowledgeEntries, {
+        organizationId: params.id,
+      }),
+    );
+    // Prime the paginated list cache so the first page paints without a
+    // skeleton flash on first nav. Args mirror
+    // useListKnowledgeEntriesPaginated's base args.
+    void primeCachedPaginatedQuery(
+      context.convexQueryClient.convexClient,
+      api.knowledge_entries.queries.listKnowledgeEntriesPaginated,
+      { organizationId: params.id },
+      { initialNumItems: DEFAULT_TABLE_PAGE_SIZE },
+    );
+  },
+  component: KnowledgeEntriesPage,
+});
+
+function KnowledgeEntriesPage() {
+  const { id: organizationId } = Route.useParams();
+
+  return <KnowledgeEntriesTable organizationId={organizationId} />;
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -92,6 +92,7 @@ import type * as agent_tools_rag_format_search_results from "../agent_tools/rag/
 import type * as agent_tools_rag_helpers_fetch_document_chunks from "../agent_tools/rag/helpers/fetch_document_chunks.js";
 import type * as agent_tools_rag_helpers_list_indexed_documents from "../agent_tools/rag/helpers/list_indexed_documents.js";
 import type * as agent_tools_rag_helpers_verify_thread_scoped_access from "../agent_tools/rag/helpers/verify_thread_scoped_access.js";
+import type * as agent_tools_rag_knowledge_write_tool from "../agent_tools/rag/knowledge_write_tool.js";
 import type * as agent_tools_rag_parse_search_results from "../agent_tools/rag/parse_search_results.js";
 import type * as agent_tools_rag_query_rag_context from "../agent_tools/rag/query_rag_context.js";
 import type * as agent_tools_rag_rag_search_tool from "../agent_tools/rag/rag_search_tool.js";
@@ -453,6 +454,12 @@ import type * as integrations_update_integration_internal from "../integrations/
 import type * as integrations_update_sync_stats from "../integrations/update_sync_stats.js";
 import type * as integrations_utils_get_integration_type from "../integrations/utils/get_integration_type.js";
 import type * as integrations_validators from "../integrations/validators.js";
+import type * as knowledge_entries_constants from "../knowledge_entries/constants.js";
+import type * as knowledge_entries_internal_actions from "../knowledge_entries/internal_actions.js";
+import type * as knowledge_entries_internal_mutations from "../knowledge_entries/internal_mutations.js";
+import type * as knowledge_entries_internal_queries from "../knowledge_entries/internal_queries.js";
+import type * as knowledge_entries_mutations from "../knowledge_entries/mutations.js";
+import type * as knowledge_entries_queries from "../knowledge_entries/queries.js";
 import type * as lib_action_cache_index from "../lib/action_cache/index.js";
 import type * as lib_age_keygen from "../lib/age_keygen.js";
 import type * as lib_agent_chat_index from "../lib/agent_chat/index.js";
@@ -1420,6 +1427,7 @@ declare const fullApi: ApiFromModules<{
   "agent_tools/rag/helpers/fetch_document_chunks": typeof agent_tools_rag_helpers_fetch_document_chunks;
   "agent_tools/rag/helpers/list_indexed_documents": typeof agent_tools_rag_helpers_list_indexed_documents;
   "agent_tools/rag/helpers/verify_thread_scoped_access": typeof agent_tools_rag_helpers_verify_thread_scoped_access;
+  "agent_tools/rag/knowledge_write_tool": typeof agent_tools_rag_knowledge_write_tool;
   "agent_tools/rag/parse_search_results": typeof agent_tools_rag_parse_search_results;
   "agent_tools/rag/query_rag_context": typeof agent_tools_rag_query_rag_context;
   "agent_tools/rag/rag_search_tool": typeof agent_tools_rag_rag_search_tool;
@@ -1781,6 +1789,12 @@ declare const fullApi: ApiFromModules<{
   "integrations/update_sync_stats": typeof integrations_update_sync_stats;
   "integrations/utils/get_integration_type": typeof integrations_utils_get_integration_type;
   "integrations/validators": typeof integrations_validators;
+  "knowledge_entries/constants": typeof knowledge_entries_constants;
+  "knowledge_entries/internal_actions": typeof knowledge_entries_internal_actions;
+  "knowledge_entries/internal_mutations": typeof knowledge_entries_internal_mutations;
+  "knowledge_entries/internal_queries": typeof knowledge_entries_internal_queries;
+  "knowledge_entries/mutations": typeof knowledge_entries_mutations;
+  "knowledge_entries/queries": typeof knowledge_entries_queries;
   "lib/action_cache/index": typeof lib_action_cache_index;
   "lib/age_keygen": typeof lib_age_keygen;
   "lib/agent_chat/index": typeof lib_agent_chat_index;

--- a/services/platform/convex/agent_tools/rag/knowledge_write_tool.test.ts
+++ b/services/platform/convex/agent_tools/rag/knowledge_write_tool.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@convex-dev/agent', () => ({
+  createTool: vi.fn((def) => ({
+    _handler: def.execute,
+    _description: def.description,
+  })),
+}));
+
+vi.mock('../../_generated/api', () => ({
+  internal: {
+    knowledge_entries: {
+      internal_mutations: {
+        createKnowledgeWriteApproval: 'mock-create-knowledge-approval',
+      },
+    },
+  },
+  components: {},
+}));
+
+vi.mock('../../threads/get_parent_thread_id', () => ({
+  getApprovalThreadId: vi.fn().mockResolvedValue('thread-123'),
+}));
+
+import { knowledgeWriteArgs, knowledgeWriteTool } from './knowledge_write_tool';
+
+function createMockCtx(overrides?: Record<string, unknown>) {
+  return {
+    organizationId: 'org-1',
+    threadId: 'thread-1',
+    messageId: 'msg-1',
+    runQuery: vi.fn(),
+    runMutation: vi.fn(),
+    ...overrides,
+  };
+}
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- accessing internal handler for testing
+const handler = (knowledgeWriteTool.tool as unknown as { _handler: Function })
+  ._handler as (
+  ctx: ReturnType<typeof createMockCtx>,
+  args: { topic: string; content: string; incorrectInfo?: string },
+) => Promise<{
+  success: boolean;
+  message: string;
+  error?: string;
+  approvalId?: string;
+  requiresApproval?: boolean;
+  approvalCreated?: boolean;
+  approvalMessage?: string;
+  replacesTopic?: string;
+}>;
+
+describe('knowledgeWriteArgs schema validation', () => {
+  it('accepts topic and content', () => {
+    const result = knowledgeWriteArgs.parse({
+      topic: 'Store hours',
+      content: 'Open Monday to Friday, 9-5.',
+    });
+    expect(result.topic).toBe('Store hours');
+    expect(result.incorrectInfo).toBeUndefined();
+  });
+
+  it('accepts optional incorrectInfo', () => {
+    const result = knowledgeWriteArgs.parse({
+      topic: 'Return policy',
+      content: 'Returns accepted within 3 days.',
+      incorrectInfo: 'Returns accepted within 7 days.',
+    });
+    expect(result.incorrectInfo).toContain('7 days');
+  });
+
+  it('rejects missing topic', () => {
+    expect(() => knowledgeWriteArgs.parse({ content: 'x' })).toThrow();
+  });
+
+  it('rejects empty topic', () => {
+    expect(() =>
+      knowledgeWriteArgs.parse({ topic: '', content: 'x' }),
+    ).toThrow();
+  });
+
+  it('rejects topic over 120 characters', () => {
+    expect(() =>
+      knowledgeWriteArgs.parse({ topic: 'x'.repeat(121), content: 'x' }),
+    ).toThrow();
+  });
+
+  it('rejects missing content', () => {
+    expect(() => knowledgeWriteArgs.parse({ topic: 'Topic' })).toThrow();
+  });
+
+  it('rejects content over 8000 characters', () => {
+    expect(() =>
+      knowledgeWriteArgs.parse({ topic: 'Topic', content: 'x'.repeat(8001) }),
+    ).toThrow();
+  });
+});
+
+describe('knowledge_write tool handler', () => {
+  it('returns error when organizationId is missing', async () => {
+    const ctx = createMockCtx({ organizationId: undefined });
+    const result = await handler(ctx, {
+      topic: 'Store hours',
+      content: 'Open 9-5',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('organizationId');
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('creates an approval for a new topic', async () => {
+    const ctx = createMockCtx({
+      runMutation: vi
+        .fn()
+        .mockResolvedValue({ approvalId: 'approval-1', replacesTopic: null }),
+    });
+    const result = await handler(ctx, {
+      topic: 'Store hours',
+      content: 'Open 9-5',
+    });
+    expect(result.success).toBe(true);
+    expect(result.requiresApproval).toBe(true);
+    expect(result.approvalId).toBe('approval-1');
+    expect(result.replacesTopic).toBeUndefined();
+    expect(result.message).toContain('Store hours');
+    expect(result.message).not.toContain('REPLACE');
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'mock-create-knowledge-approval',
+      expect.objectContaining({
+        organizationId: 'org-1',
+        topic: 'Store hours',
+        content: 'Open 9-5',
+        threadId: 'thread-123',
+        messageId: 'msg-1',
+      }),
+    );
+  });
+
+  it('flags a replacement when the topic already exists', async () => {
+    const ctx = createMockCtx({
+      runMutation: vi.fn().mockResolvedValue({
+        approvalId: 'approval-2',
+        replacesTopic: 'Return policy',
+      }),
+    });
+    const result = await handler(ctx, {
+      topic: 'return policy',
+      content: 'Returns within 3 days.',
+      incorrectInfo: 'Returns within 7 days.',
+    });
+    expect(result.success).toBe(true);
+    expect(result.replacesTopic).toBe('Return policy');
+    expect(result.approvalMessage).toContain('REPLACE');
+    expect(result.message).toContain('Return policy');
+  });
+
+  it('surfaces mutation failures (e.g. rate limit) as a tool error', async () => {
+    const ctx = createMockCtx({
+      runMutation: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('Rate limit exceeded for knowledge:write'),
+        ),
+    });
+    const result = await handler(ctx, {
+      topic: 'Store hours',
+      content: 'Open 9-5',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Rate limit exceeded');
+  });
+});

--- a/services/platform/convex/agent_tools/rag/knowledge_write_tool.ts
+++ b/services/platform/convex/agent_tools/rag/knowledge_write_tool.ts
@@ -1,0 +1,133 @@
+/**
+ * Convex Tool: Knowledge Write
+ *
+ * Capture a user-confirmed fact as a knowledge entry in the knowledge base.
+ * Requires user approval — an approval card will be shown in chat. Writes are
+ * topic-keyed: writing to an existing topic replaces (supersedes) the
+ * previous version, so the knowledge base never serves two versions of the
+ * same fact. Successor to the removed `rag_write` tool.
+ */
+
+import type { ToolCtx } from '@convex-dev/agent';
+import { createTool } from '@convex-dev/agent';
+import { z } from 'zod/v4';
+
+import { internal } from '../../_generated/api';
+import {
+  CONTENT_MAX_LENGTH,
+  TOPIC_MAX_LENGTH,
+} from '../../knowledge_entries/constants';
+import { getApprovalThreadId } from '../../threads/get_parent_thread_id';
+import type { ToolDefinition } from '../types';
+
+export const knowledgeWriteArgs = z.object({
+  topic: z
+    .string()
+    .min(1)
+    .max(TOPIC_MAX_LENGTH)
+    .describe(
+      `Short, stable topic name for this fact (max ${TOPIC_MAX_LENGTH} characters), e.g. "Store opening hours" or "Return policy". Writing to an existing topic replaces its content — reuse the exact topic name when correcting or updating a previously saved fact.`,
+    ),
+  content: z
+    .string()
+    .min(1)
+    .max(CONTENT_MAX_LENGTH)
+    .describe(
+      `The knowledge to save, as self-contained markdown (max ${CONTENT_MAX_LENGTH} characters). Write it so it makes sense without the surrounding conversation.`,
+    ),
+  incorrectInfo: z
+    .string()
+    .optional()
+    .describe(
+      'Optional: the outdated or incorrect information this entry corrects, quoted briefly so the reviewer can compare.',
+    ),
+});
+
+export const knowledgeWriteTool = {
+  name: 'knowledge_write' as const,
+  tool: createTool({
+    description: `Save a user-confirmed fact to the organization's knowledge base as a knowledge entry. Requires user approval — an approval card will be created. When telling the user the card is ready, do not reference its position (no "above" / "below") — just say the approval card has been created.
+
+USE THIS TOOL TO:
+• Save a fact the user explicitly confirmed or corrected during the conversation (e.g. "our store hours are 9–5", "the return policy is 3 days, not 7")
+• Update a previously saved knowledge entry when the user provides newer information — reuse the SAME topic name so the old version is replaced
+
+WHEN TO USE THIS TOOL:
+• The user states a durable, org-relevant fact and asks to remember/save it
+• The user corrects information that came from the knowledge base
+• Only for facts that should be retrievable by ALL agents searching the knowledge base — for personal user preferences use propose_memory instead
+
+DO NOT USE THIS TOOL FOR:
+• Personal preferences about the current user — use propose_memory
+• Saving generated files — use document_write
+• Searching the knowledge base — use rag_search
+• Speculative or unconfirmed information — only save what the user confirmed
+
+PARAMETERS:
+• topic: REQUIRED — short, stable topic name (max ${TOPIC_MAX_LENGTH} chars). Writing to an existing topic supersedes its previous content.
+• content: REQUIRED — self-contained markdown (max ${CONTENT_MAX_LENGTH} chars).
+• incorrectInfo: Optional — the outdated information this entry corrects.`,
+    inputSchema: knowledgeWriteArgs,
+    execute: async (
+      ctx: ToolCtx,
+      args,
+    ): Promise<{
+      success: boolean;
+      requiresApproval?: boolean;
+      approvalId?: string;
+      approvalCreated?: boolean;
+      approvalMessage?: string;
+      replacesTopic?: string;
+      message: string;
+      error?: string;
+    }> => {
+      const { organizationId, threadId: currentThreadId, messageId } = ctx;
+
+      if (!organizationId) {
+        return {
+          success: false,
+          message:
+            'organizationId is required in the tool context to write a knowledge entry.',
+        };
+      }
+
+      const threadId = await getApprovalThreadId(ctx, currentThreadId);
+
+      try {
+        const { approvalId, replacesTopic } = await ctx.runMutation(
+          internal.knowledge_entries.internal_mutations
+            .createKnowledgeWriteApproval,
+          {
+            organizationId,
+            topic: args.topic,
+            content: args.content,
+            incorrectInfo: args.incorrectInfo,
+            threadId,
+            messageId,
+          },
+        );
+
+        const replaceNote = replacesTopic
+          ? ` This will REPLACE the existing knowledge entry "${replacesTopic}".`
+          : '';
+
+        return {
+          success: true,
+          requiresApproval: true,
+          approvalId: String(approvalId),
+          approvalCreated: true,
+          replacesTopic: replacesTopic ?? undefined,
+          approvalMessage: `APPROVAL CREATED SUCCESSFULLY: An approval card (ID: ${approvalId}) has been created for saving the knowledge entry "${args.topic}".${replaceNote} The user must approve before the entry is saved. Do NOT include suggested follow-ups or next steps — the user needs to act on the approval card first.`,
+          message: `The knowledge entry "${args.topic}" is ready to be saved to the knowledge base.${replaceNote} An approval card has been created. The entry will be saved once the user approves.`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          message: `Failed to create knowledge write approval: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+        };
+      }
+    },
+  }),
+} as const satisfies ToolDefinition;

--- a/services/platform/convex/agent_tools/tool_names.ts
+++ b/services/platform/convex/agent_tools/tool_names.ts
@@ -19,6 +19,7 @@ export const TOOL_NAMES = [
   'customer_read',
   'product_read',
   'rag_search',
+  'knowledge_write',
   'web',
   'pdf',
   'image',

--- a/services/platform/convex/agent_tools/tool_registry.ts
+++ b/services/platform/convex/agent_tools/tool_registry.ts
@@ -29,6 +29,7 @@ import { integrationTool } from './integrations/integration_tool';
 import { requestUserLocationTool } from './location/request_user_location_tool';
 import { proposeMemoryTool } from './memory/propose_memory_tool';
 import { productReadTool } from './products/product_read_tool';
+import { knowledgeWriteTool } from './rag/knowledge_write_tool';
 import { ragSearchTool } from './rag/rag_search_tool';
 import { runCodeTool } from './run_code_tool';
 import { secretReadTool } from './secrets/secret_read_tool';
@@ -63,6 +64,7 @@ export const TOOL_REGISTRY = [
   customerReadTool,
   productReadTool,
   ragSearchTool,
+  knowledgeWriteTool,
   webTool,
   workflowReadTool,
   workflowSyntaxTool,

--- a/services/platform/convex/approvals/actions.ts
+++ b/services/platform/convex/approvals/actions.ts
@@ -132,6 +132,29 @@ export const executeApprovedDocumentWrite = action({
   },
 });
 
+export const executeApprovedKnowledgeWrite = action({
+  args: {
+    approvalId: v.id('approvals'),
+  },
+  returns: jsonValueValidator,
+  handler: async (ctx, args): Promise<JsonValue> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      throw new Error('Unauthenticated');
+    }
+
+    await verifyApprovalAccess(ctx, args.approvalId, authUser);
+
+    return await ctx.runAction(
+      internal.knowledge_entries.internal_actions.executeApprovedKnowledgeWrite,
+      {
+        approvalId: args.approvalId,
+        approvedBy: authUser.userId,
+      },
+    );
+  },
+});
+
 export const executeApprovedWorkflowUpdate = action({
   args: {
     approvalId: v.id('approvals'),

--- a/services/platform/convex/approvals/helpers.ts
+++ b/services/platform/convex/approvals/helpers.ts
@@ -398,6 +398,7 @@ export async function linkApprovalsToMessage(
     'workflow_update',
     'human_input_request',
     'document_write',
+    'knowledge_write',
     'location_request',
     'mcp_tool_call',
   ] as const;

--- a/services/platform/convex/approvals/schema.ts
+++ b/services/platform/convex/approvals/schema.ts
@@ -23,6 +23,7 @@ export const approvalsTable = defineTable({
     v.literal('workflow_update'),
     v.literal('human_input_request'),
     v.literal('document_write'),
+    v.literal('knowledge_write'),
     v.literal('location_request'),
     v.literal('mcp_tool_call'),
     // GDPR Art 17 erasure request awaiting dual-admin approval. Used when

--- a/services/platform/convex/approvals/types.ts
+++ b/services/platform/convex/approvals/types.ts
@@ -155,6 +155,23 @@ export function normalizeDocumentWriteMetadata(
   };
 }
 
+export interface KnowledgeWriteMetadata {
+  topic: string;
+  topicKey: string;
+  content: string;
+  /** What the agent believes is outdated/incorrect (free-form, optional). */
+  incorrectInfo?: string;
+  /** Active entry this write will supersede (topic-keyed upsert). */
+  replacesEntryId?: string;
+  replacesTopic?: string;
+  requestedAt: number;
+  executedAt?: number;
+  /** Set after execution. */
+  entryId?: string;
+  documentId?: string;
+  executionError?: string;
+}
+
 export interface CreateApprovalArgs {
   organizationId: string;
   resourceType: ApprovalResourceType;

--- a/services/platform/convex/approvals/validators.ts
+++ b/services/platform/convex/approvals/validators.ts
@@ -29,6 +29,7 @@ export const approvalResourceTypeValidator = v.union(
   v.literal('workflow_update'),
   v.literal('human_input_request'),
   v.literal('document_write'),
+  v.literal('knowledge_write'),
   v.literal('location_request'),
   v.literal('mcp_tool_call'),
   // GDPR Art 17 erasure request awaiting dual-admin approval. Used when

--- a/services/platform/convex/documents/mutations.ts
+++ b/services/platform/convex/documents/mutations.ts
@@ -12,6 +12,7 @@ import { internal } from '../_generated/api';
 import { mutation } from '../_generated/server';
 import { assertNotHeld } from '../governance/legal_hold_guard';
 import { checkUploadPolicy } from '../governance/upload_enforcement';
+import { markEntryChainDeleted } from '../knowledge_entries/helpers';
 import { getUserTeamIds } from '../lib/get_user_teams';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
@@ -85,6 +86,20 @@ export const deleteDocument = mutation({
       undefined,
       document.createdBy ?? undefined,
     );
+
+    // Knowledge entries are backed by hub documents — deleting the backing
+    // document from the Documents tab must not orphan the entry, so mark
+    // every linked entry chain deleted too.
+    const linkedTopicKeys = new Set<string>();
+    for await (const entry of ctx.db
+      .query('knowledgeEntries')
+      .withIndex('by_documentId', (q) => q.eq('documentId', args.documentId))) {
+      if (entry.deletedAt !== undefined) continue;
+      linkedTopicKeys.add(entry.topicKey);
+    }
+    for (const topicKey of linkedTopicKeys) {
+      await markEntryChainDeleted(ctx, document.organizationId, topicKey);
+    }
 
     await ctx.scheduler.runAfter(
       0,

--- a/services/platform/convex/knowledge_entries/constants.ts
+++ b/services/platform/convex/knowledge_entries/constants.ts
@@ -1,0 +1,21 @@
+/** Maximum length of a knowledge entry topic (characters). */
+export const TOPIC_MAX_LENGTH = 120;
+
+/** Maximum length of a knowledge entry's markdown content (characters). */
+export const CONTENT_MAX_LENGTH = 8000;
+
+/** Reserved documents-hub folder that holds the markdown backing documents. */
+export const KNOWLEDGE_ENTRIES_FOLDER = 'Knowledge entries';
+
+/** `documents.sourceProvider` value for knowledge-entry backing documents. */
+export const KNOWLEDGE_SOURCE_PROVIDER = 'knowledge';
+
+/**
+ * Normalize a topic into the dedup key used for topic-keyed upsert:
+ * trim, collapse internal whitespace, lowercase. V1 duplicate detection —
+ * embedding-similarity dedup across differently-worded topics is an
+ * explicit follow-up.
+ */
+export function normalizeTopicKey(topic: string): string {
+  return topic.trim().replace(/\s+/g, ' ').toLowerCase();
+}

--- a/services/platform/convex/knowledge_entries/helpers.test.ts
+++ b/services/platform/convex/knowledge_entries/helpers.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { normalizeTopicKey } from './constants';
+import {
+  findActiveEntryByTopicKey,
+  markEntryChainDeleted,
+  upsertEntryRow,
+  validateTopicAndContent,
+} from './helpers';
+
+interface FakeEntryRow {
+  _id: string;
+  organizationId: string;
+  topic: string;
+  topicKey: string;
+  content: string;
+  status: 'active' | 'superseded';
+  documentId?: string;
+  source: 'chat' | 'manual';
+  createdBy: string;
+  createdAt: number;
+  supersededBy?: string;
+  supersededAt?: number;
+  deletedAt?: number;
+}
+
+function createMockCtx(rows: FakeEntryRow[]) {
+  let nextId = rows.length + 1;
+  const inserted: Array<Record<string, unknown>> = [];
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+
+  function matchingRows(constraints: Record<string, unknown>) {
+    return rows.filter((row) =>
+      Object.entries(constraints).every(
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test helper reads dynamic fields off the fake row
+        ([field, value]) =>
+          (row as unknown as Record<string, unknown>)[field] === value,
+      ),
+    );
+  }
+
+  const ctx = {
+    db: {
+      query: vi.fn((table: string) => {
+        expect(table).toBe('knowledgeEntries');
+        return {
+          withIndex: (_name: string, cb: (q: unknown) => unknown) => {
+            const constraints: Record<string, unknown> = {};
+            const builder = {
+              eq: (field: string, value: unknown) => {
+                constraints[field] = value;
+                return builder;
+              },
+            };
+            cb(builder);
+            const matched = matchingRows(constraints);
+            return {
+              first: async () => matched[0] ?? null,
+              async *[Symbol.asyncIterator]() {
+                for (const row of matched) yield row;
+              },
+            };
+          },
+        };
+      }),
+      insert: vi.fn(async (_table: string, doc: Record<string, unknown>) => {
+        const id = `entry-${nextId++}`;
+        inserted.push({ _id: id, ...doc });
+        return id;
+      }),
+      patch: vi.fn(async (id: string, patch: Record<string, unknown>) => {
+        patches.push({ id, patch });
+        const row = rows.find((r) => r._id === id);
+        if (row) Object.assign(row, patch);
+      }),
+    },
+  };
+
+  return { ctx, inserted, patches };
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any -- the fake ctx is structurally compatible with the MutationCtx surface the helpers use
+const asCtx = (ctx: unknown) => ctx as any;
+
+function makeRow(overrides: Partial<FakeEntryRow> = {}): FakeEntryRow {
+  return {
+    _id: 'entry-1',
+    organizationId: 'org-1',
+    topic: 'Store hours',
+    topicKey: 'store hours',
+    content: 'Open 9-5',
+    status: 'active',
+    source: 'chat',
+    createdBy: 'user-1',
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+describe('normalizeTopicKey', () => {
+  it('lowercases', () => {
+    expect(normalizeTopicKey('Store Hours')).toBe('store hours');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeTopicKey('  Return policy  ')).toBe('return policy');
+  });
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeTopicKey('Store \t  Hours\n today')).toBe(
+      'store hours today',
+    );
+  });
+
+  it('maps equivalent spellings to the same key', () => {
+    expect(normalizeTopicKey('STORE   hours ')).toBe(
+      normalizeTopicKey('store Hours'),
+    );
+  });
+});
+
+describe('validateTopicAndContent', () => {
+  it('trims and returns normalized topicKey', () => {
+    const result = validateTopicAndContent('  Store Hours ', ' Open 9-5 ');
+    expect(result.topic).toBe('Store Hours');
+    expect(result.topicKey).toBe('store hours');
+    expect(result.content).toBe('Open 9-5');
+  });
+
+  it('rejects empty topic', () => {
+    expect(() => validateTopicAndContent('   ', 'content')).toThrow(
+      'Topic is required',
+    );
+  });
+
+  it('rejects topic over the cap', () => {
+    expect(() => validateTopicAndContent('x'.repeat(121), 'content')).toThrow(
+      '120',
+    );
+  });
+
+  it('rejects empty content', () => {
+    expect(() => validateTopicAndContent('topic', '   ')).toThrow(
+      'Content is required',
+    );
+  });
+
+  it('rejects content over the cap', () => {
+    expect(() => validateTopicAndContent('topic', 'x'.repeat(8001))).toThrow(
+      '8000',
+    );
+  });
+});
+
+describe('findActiveEntryByTopicKey', () => {
+  it('returns the active row', async () => {
+    const { ctx } = createMockCtx([makeRow()]);
+    const found = await findActiveEntryByTopicKey(
+      asCtx(ctx),
+      'org-1',
+      'store hours',
+    );
+    expect(found?._id).toBe('entry-1');
+  });
+
+  it('ignores soft-deleted rows', async () => {
+    const { ctx } = createMockCtx([makeRow({ deletedAt: 5000 })]);
+    const found = await findActiveEntryByTopicKey(
+      asCtx(ctx),
+      'org-1',
+      'store hours',
+    );
+    expect(found).toBeNull();
+  });
+
+  it('returns null for an unknown topic', async () => {
+    const { ctx } = createMockCtx([makeRow()]);
+    const found = await findActiveEntryByTopicKey(
+      asCtx(ctx),
+      'org-1',
+      'return policy',
+    );
+    expect(found).toBeNull();
+  });
+});
+
+describe('upsertEntryRow', () => {
+  it('inserts a fresh active row when no active entry exists', async () => {
+    const { ctx, inserted, patches } = createMockCtx([]);
+    const result = await upsertEntryRow(asCtx(ctx), {
+      organizationId: 'org-1',
+      topic: 'Store hours',
+      topicKey: 'store hours',
+      content: 'Open 9-5',
+      source: 'chat',
+      createdBy: 'user-1',
+    });
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].status).toBe('active');
+    expect(inserted[0].documentId).toBeUndefined();
+    expect(result.replacedEntryId).toBeNull();
+    expect(result.documentId).toBeNull();
+    expect(patches).toHaveLength(0);
+  });
+
+  it('supersedes the existing active row and carries its documentId', async () => {
+    const existing = makeRow({ documentId: 'doc-1' });
+    const { ctx, inserted, patches } = createMockCtx([existing]);
+
+    const result = await upsertEntryRow(asCtx(ctx), {
+      organizationId: 'org-1',
+      topic: 'Store hours',
+      topicKey: 'store hours',
+      content: 'Open 10-6 now',
+      source: 'manual',
+      createdBy: 'user-2',
+    });
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].status).toBe('active');
+    expect(inserted[0].documentId).toBe('doc-1');
+    expect(inserted[0].content).toBe('Open 10-6 now');
+
+    expect(result.replacedEntryId).toBe('entry-1');
+    expect(result.documentId).toBe('doc-1');
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].id).toBe('entry-1');
+    expect(patches[0].patch.status).toBe('superseded');
+    expect(patches[0].patch.supersededBy).toBe(result.entryId);
+    expect(typeof patches[0].patch.supersededAt).toBe('number');
+  });
+
+  it('treats a soft-deleted active row as absent (no resurrection)', async () => {
+    const { ctx, inserted, patches } = createMockCtx([
+      makeRow({ deletedAt: 5000, documentId: 'doc-1' }),
+    ]);
+
+    const result = await upsertEntryRow(asCtx(ctx), {
+      organizationId: 'org-1',
+      topic: 'Store hours',
+      topicKey: 'store hours',
+      content: 'Open again',
+      source: 'chat',
+      createdBy: 'user-1',
+    });
+
+    expect(inserted[0].documentId).toBeUndefined();
+    expect(result.replacedEntryId).toBeNull();
+    expect(patches).toHaveLength(0);
+  });
+});
+
+describe('markEntryChainDeleted', () => {
+  it('soft-deletes every live row of the chain', async () => {
+    const rows = [
+      makeRow({ _id: 'entry-1', status: 'superseded' }),
+      makeRow({ _id: 'entry-2' }),
+    ];
+    const { ctx } = createMockCtx(rows);
+
+    const count = await markEntryChainDeleted(
+      asCtx(ctx),
+      'org-1',
+      'store hours',
+    );
+    expect(count).toBe(2);
+    expect(rows[0].deletedAt).toBeDefined();
+    expect(rows[1].deletedAt).toBeDefined();
+  });
+
+  it('skips rows that are already deleted', async () => {
+    const rows = [
+      makeRow({ _id: 'entry-1', deletedAt: 100 }),
+      makeRow({ _id: 'entry-2' }),
+    ];
+    const { ctx, patches } = createMockCtx(rows);
+
+    const count = await markEntryChainDeleted(
+      asCtx(ctx),
+      'org-1',
+      'store hours',
+    );
+    expect(count).toBe(1);
+    expect(patches).toHaveLength(1);
+    expect(patches[0].id).toBe('entry-2');
+    expect(rows[0].deletedAt).toBe(100);
+  });
+});

--- a/services/platform/convex/knowledge_entries/helpers.ts
+++ b/services/platform/convex/knowledge_entries/helpers.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure helpers for knowledge entries. Kept free of heavy imports (rate
+ * limiter, approvals) so light consumers — e.g. `documents/mutations.ts`'s
+ * delete hook — can import them without dragging those modules into their
+ * bundle (or their tests' mock surface).
+ */
+
+import type { Doc, Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import {
+  CONTENT_MAX_LENGTH,
+  TOPIC_MAX_LENGTH,
+  normalizeTopicKey,
+} from './constants';
+
+export interface UpsertEntryResult {
+  entryId: Id<'knowledgeEntries'>;
+  documentId: Id<'documents'> | null;
+  replacedEntryId: Id<'knowledgeEntries'> | null;
+}
+
+export async function findActiveEntryByTopicKey(
+  ctx: MutationCtx,
+  organizationId: string,
+  topicKey: string,
+): Promise<Doc<'knowledgeEntries'> | null> {
+  const existing = await ctx.db
+    .query('knowledgeEntries')
+    .withIndex('by_org_topicKey_status', (q) =>
+      q
+        .eq('organizationId', organizationId)
+        .eq('topicKey', topicKey)
+        .eq('status', 'active'),
+    )
+    .first();
+  if (!existing || existing.deletedAt !== undefined) return null;
+  return existing;
+}
+
+export function validateTopicAndContent(
+  topic: string,
+  content: string,
+): { topic: string; topicKey: string; content: string } {
+  const trimmedTopic = topic.trim();
+  const trimmedContent = content.trim();
+  if (!trimmedTopic) throw new Error('Topic is required');
+  if (trimmedTopic.length > TOPIC_MAX_LENGTH) {
+    throw new Error(`Topic exceeds ${TOPIC_MAX_LENGTH} characters`);
+  }
+  if (!trimmedContent) throw new Error('Content is required');
+  if (trimmedContent.length > CONTENT_MAX_LENGTH) {
+    throw new Error(`Content exceeds ${CONTENT_MAX_LENGTH} characters`);
+  }
+  return {
+    topic: trimmedTopic,
+    topicKey: normalizeTopicKey(trimmedTopic),
+    content: trimmedContent,
+  };
+}
+
+/**
+ * Topic-keyed upsert (Option A delete+replace): inserts the new ACTIVE
+ * version row; when an active row already exists for (org, topicKey) it is
+ * marked `superseded` and its `documentId` is carried onto the new row so
+ * the backing document (and its RAG entry) gets replaced, never duplicated.
+ * Superseded rows stay as an inert version chain for audit/undo.
+ */
+export async function upsertEntryRow(
+  ctx: MutationCtx,
+  args: {
+    organizationId: string;
+    topic: string;
+    topicKey: string;
+    content: string;
+    source: 'chat' | 'manual';
+    createdBy: string;
+    sourceThreadId?: string;
+    sourceMessageId?: string;
+  },
+): Promise<UpsertEntryResult> {
+  const existing = await findActiveEntryByTopicKey(
+    ctx,
+    args.organizationId,
+    args.topicKey,
+  );
+  const now = Date.now();
+
+  const entryId = await ctx.db.insert('knowledgeEntries', {
+    organizationId: args.organizationId,
+    topic: args.topic,
+    topicKey: args.topicKey,
+    content: args.content,
+    status: 'active',
+    documentId: existing?.documentId,
+    source: args.source,
+    sourceThreadId: args.sourceThreadId,
+    sourceMessageId: args.sourceMessageId,
+    createdBy: args.createdBy,
+    createdAt: now,
+  });
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      status: 'superseded',
+      supersededBy: entryId,
+      supersededAt: now,
+    });
+  }
+
+  return {
+    entryId,
+    documentId: existing?.documentId ?? null,
+    replacedEntryId: existing?._id ?? null,
+  };
+}
+
+/**
+ * Soft-delete every version row of the entry's topic chain. Used by the
+ * public delete mutation and by `deleteDocument` when the backing document
+ * is removed from the Documents tab (so a tab delete can't orphan entries).
+ */
+export async function markEntryChainDeleted(
+  ctx: MutationCtx,
+  organizationId: string,
+  topicKey: string,
+): Promise<number> {
+  const now = Date.now();
+  let count = 0;
+  for await (const row of ctx.db
+    .query('knowledgeEntries')
+    .withIndex('by_org_topicKey_status', (q) =>
+      q.eq('organizationId', organizationId).eq('topicKey', topicKey),
+    )) {
+    if (row.deletedAt !== undefined) continue;
+    await ctx.db.patch(row._id, { deletedAt: now });
+    count++;
+  }
+  return count;
+}

--- a/services/platform/convex/knowledge_entries/internal_actions.ts
+++ b/services/platform/convex/knowledge_entries/internal_actions.ts
@@ -1,0 +1,188 @@
+'use node';
+
+import { createHash } from 'node:crypto';
+
+import { v, type Infer } from 'convex/values';
+
+import { jsonValueValidator } from '../../lib/shared/schemas/utils/json-value';
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { internalAction, type ActionCtx } from '../_generated/server';
+import type { KnowledgeWriteMetadata } from '../approvals/types';
+
+type JsonValue = Infer<typeof jsonValueValidator>;
+
+interface MaterializeResult {
+  documentId: Id<'documents'> | null;
+}
+
+/**
+ * Store the entry's markdown content as a `_storage` blob and create/replace
+ * its backing document (which schedules the RAG upload/re-index). The entry
+ * row is the source of truth for the UI; this materialization only feeds the
+ * retrieval pipeline, so a failure here leaves the entry visible with its
+ * indexing status reported as failed/not indexed.
+ */
+async function materializeEntry(
+  ctx: ActionCtx,
+  entryId: Id<'knowledgeEntries'>,
+): Promise<MaterializeResult> {
+  const entry = await ctx.runQuery(
+    internal.knowledge_entries.internal_queries.getEntryById,
+    { entryId },
+  );
+  if (!entry || entry.deletedAt !== undefined || entry.status !== 'active') {
+    return { documentId: null };
+  }
+
+  const stored = await ctx.runAction(
+    internal.documents.internal_actions.storeRawContent,
+    {
+      organizationId: entry.organizationId,
+      fileName: `${entry.topic}.md`,
+      content: entry.content,
+      contentType: 'text/markdown',
+      extension: 'md',
+    },
+  );
+
+  const contentHash = createHash('sha256').update(entry.content).digest('hex');
+
+  const documentId = await ctx.runMutation(
+    internal.knowledge_entries.internal_mutations.attachEntryDocument,
+    {
+      entryId,
+      fileId: stored.fileStorageId,
+      contentHash,
+    },
+  );
+
+  return { documentId };
+}
+
+export const materializeKnowledgeEntry = internalAction({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    try {
+      await materializeEntry(ctx, args.entryId);
+    } catch (error) {
+      console.error(
+        `[materializeKnowledgeEntry] Failed to materialize entry ${args.entryId}:`,
+        error,
+      );
+      throw error;
+    }
+    return null;
+  },
+});
+
+export const executeApprovedKnowledgeWrite = internalAction({
+  args: {
+    approvalId: v.id('approvals'),
+    approvedBy: v.string(),
+  },
+  returns: jsonValueValidator,
+  handler: async (ctx, args): Promise<JsonValue> => {
+    const approval = await ctx.runQuery(
+      internal.approvals.internal_queries.getApprovalById,
+      { approvalId: args.approvalId },
+    );
+
+    if (!approval) {
+      throw new Error('Approval not found');
+    }
+    if (approval.status !== 'executing') {
+      throw new Error(
+        `Cannot execute knowledge write: approval status is "${approval.status}", expected "executing"`,
+      );
+    }
+    if (approval.resourceType !== 'knowledge_write') {
+      throw new Error(
+        `Invalid approval type: expected "knowledge_write", got "${approval.resourceType}"`,
+      );
+    }
+    if (approval.executedAt) {
+      throw new Error(
+        'This knowledge write approval has already been executed',
+      );
+    }
+
+    const claimed = await ctx.runMutation(
+      internal.knowledge_entries.internal_mutations
+        .claimKnowledgeWriteForExecution,
+      { approvalId: args.approvalId },
+    );
+    if (!claimed) {
+      throw new Error(
+        'This knowledge write approval has already been executed',
+      );
+    }
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- approval.metadata is v.any() but always matches KnowledgeWriteMetadata for knowledge_write approvals
+    const metadata = (approval.metadata ?? {}) as KnowledgeWriteMetadata;
+    if (!metadata.topic || !metadata.content) {
+      throw new Error('Invalid approval metadata: missing topic or content');
+    }
+
+    try {
+      const applied = await ctx.runMutation(
+        internal.knowledge_entries.internal_mutations.applyKnowledgeWrite,
+        {
+          organizationId: approval.organizationId,
+          topic: metadata.topic,
+          content: metadata.content,
+          source: 'chat',
+          createdBy: args.approvedBy,
+          sourceThreadId: approval.threadId,
+          sourceMessageId: approval.messageId,
+        },
+      );
+
+      const { documentId } = await materializeEntry(ctx, applied.entryId);
+
+      await ctx.runMutation(
+        internal.knowledge_entries.internal_mutations
+          .updateKnowledgeWriteApprovalWithResult,
+        {
+          approvalId: args.approvalId,
+          entryId: applied.entryId,
+          documentId,
+          executionError: null,
+        },
+      );
+
+      return {
+        success: true,
+        entryId: String(applied.entryId),
+        documentId: documentId ? String(documentId) : null,
+        replacedEntryId: applied.replacedEntryId
+          ? String(applied.replacedEntryId)
+          : null,
+        topic: metadata.topic,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[executeApprovedKnowledgeWrite] Failed for approval ${args.approvalId}: ${message}`,
+      );
+      await ctx.runMutation(
+        internal.knowledge_entries.internal_mutations
+          .updateKnowledgeWriteApprovalWithResult,
+        {
+          approvalId: args.approvalId,
+          entryId: null,
+          documentId: null,
+          executionError: message,
+        },
+      );
+      return {
+        success: false,
+        error: message,
+        topic: metadata.topic,
+      };
+    }
+  },
+});

--- a/services/platform/convex/knowledge_entries/internal_mutations.ts
+++ b/services/platform/convex/knowledge_entries/internal_mutations.ts
@@ -1,0 +1,275 @@
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { internalMutation, type MutationCtx } from '../_generated/server';
+import { createApproval } from '../approvals/helpers';
+import type { KnowledgeWriteMetadata } from '../approvals/types';
+import { createDocument } from '../documents/create_document';
+import { getOrCreateFolderPath } from '../folders/get_or_create_path';
+import { checkOrganizationRateLimit } from '../lib/rate_limiter/helpers';
+import {
+  KNOWLEDGE_ENTRIES_FOLDER,
+  KNOWLEDGE_SOURCE_PROVIDER,
+} from './constants';
+import {
+  findActiveEntryByTopicKey,
+  upsertEntryRow,
+  validateTopicAndContent,
+  type UpsertEntryResult,
+} from './helpers';
+
+export const createKnowledgeWriteApproval = internalMutation({
+  args: {
+    organizationId: v.string(),
+    topic: v.string(),
+    content: v.string(),
+    incorrectInfo: v.optional(v.string()),
+    threadId: v.optional(v.string()),
+    messageId: v.optional(v.string()),
+  },
+  returns: v.object({
+    approvalId: v.id('approvals'),
+    replacesTopic: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    await checkOrganizationRateLimit(
+      ctx,
+      'knowledge:write',
+      args.organizationId,
+    );
+
+    const { topic, topicKey, content } = validateTopicAndContent(
+      args.topic,
+      args.content,
+    );
+
+    const existing = await findActiveEntryByTopicKey(
+      ctx,
+      args.organizationId,
+      topicKey,
+    );
+
+    const metadata: KnowledgeWriteMetadata = {
+      topic,
+      topicKey,
+      content,
+      incorrectInfo: args.incorrectInfo,
+      replacesEntryId: existing ? String(existing._id) : undefined,
+      replacesTopic: existing?.topic,
+      requestedAt: Date.now(),
+    };
+
+    const approvalId = await createApproval(ctx, {
+      organizationId: args.organizationId,
+      resourceType: 'knowledge_write',
+      resourceId: `knowledge_write:${topicKey}:${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      priority: 'medium',
+      description: existing
+        ? `Update knowledge entry: ${topic}`
+        : `Add knowledge entry: ${topic}`,
+      threadId: args.threadId,
+      messageId: args.messageId,
+      metadata,
+    });
+
+    return {
+      approvalId,
+      replacesTopic: existing?.topic ?? null,
+    };
+  },
+});
+
+export const claimKnowledgeWriteForExecution = internalMutation({
+  args: {
+    approvalId: v.id('approvals'),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args): Promise<boolean> => {
+    const approval = await ctx.db.get(args.approvalId);
+    if (!approval) throw new Error('Approval not found');
+    if (approval.executedAt) return false;
+    await ctx.db.patch(args.approvalId, { executedAt: Date.now() });
+    return true;
+  },
+});
+
+export const applyKnowledgeWrite = internalMutation({
+  args: {
+    organizationId: v.string(),
+    topic: v.string(),
+    content: v.string(),
+    source: v.union(v.literal('chat'), v.literal('manual')),
+    createdBy: v.string(),
+    sourceThreadId: v.optional(v.string()),
+    sourceMessageId: v.optional(v.string()),
+  },
+  returns: v.object({
+    entryId: v.id('knowledgeEntries'),
+    documentId: v.union(v.id('documents'), v.null()),
+    replacedEntryId: v.union(v.id('knowledgeEntries'), v.null()),
+  }),
+  handler: async (ctx, args): Promise<UpsertEntryResult> => {
+    const { topic, topicKey, content } = validateTopicAndContent(
+      args.topic,
+      args.content,
+    );
+    return await upsertEntryRow(ctx, {
+      organizationId: args.organizationId,
+      topic,
+      topicKey,
+      content,
+      source: args.source,
+      createdBy: args.createdBy,
+      sourceThreadId: args.sourceThreadId,
+      sourceMessageId: args.sourceMessageId,
+    });
+  },
+});
+
+export const updateKnowledgeWriteApprovalWithResult = internalMutation({
+  args: {
+    approvalId: v.id('approvals'),
+    entryId: v.union(v.id('knowledgeEntries'), v.null()),
+    documentId: v.union(v.id('documents'), v.null()),
+    executionError: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const approval = await ctx.db.get(args.approvalId);
+    if (!approval) throw new Error('Approval not found');
+    if (approval.resourceType !== 'knowledge_write') {
+      throw new Error('Approval is not a knowledge_write approval');
+    }
+
+    const now = Date.now();
+    const metadata = approval.metadata || {};
+
+    await ctx.db.patch(args.approvalId, {
+      status: args.executionError ? 'rejected' : 'completed',
+      executedAt: now,
+      executionError: args.executionError ?? undefined,
+      metadata: {
+        ...metadata,
+        executedAt: now,
+        ...(args.entryId ? { entryId: String(args.entryId) } : {}),
+        ...(args.documentId ? { documentId: String(args.documentId) } : {}),
+        ...(args.executionError ? { executionError: args.executionError } : {}),
+      },
+    });
+    return null;
+  },
+});
+
+/**
+ * Create or replace the markdown backing document for an entry after its
+ * content blob has been stored. Called from `materializeKnowledgeEntry`.
+ *
+ * - Existing backing document → patch title/file and schedule
+ *   `reindexDocumentInRag` (upload-then-delete; tolerant of a never-indexed
+ *   old blob).
+ * - No backing document → create one in the reserved "Knowledge entries"
+ *   folder (`sourceProvider: 'knowledge'`) and schedule `uploadDocumentToRag`.
+ */
+export const attachEntryDocument = internalMutation({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+    fileId: v.id('_storage'),
+    contentHash: v.string(),
+  },
+  returns: v.union(v.id('documents'), v.null()),
+  handler: async (ctx, args): Promise<Id<'documents'> | null> => {
+    const entry = await ctx.db.get(args.entryId);
+    // Entry deleted or superseded while the blob was being stored — a newer
+    // version (or nothing) owns the backing document now.
+    if (!entry || entry.deletedAt !== undefined || entry.status !== 'active') {
+      return null;
+    }
+
+    const title = `${entry.topic}.md`;
+    const existingDoc = entry.documentId
+      ? await ctx.db.get(entry.documentId)
+      : null;
+
+    if (existingDoc) {
+      const oldFileId = existingDoc.fileId;
+      await ctx.db.patch(existingDoc._id, {
+        title,
+        fileId: args.fileId,
+        mimeType: 'text/markdown',
+        extension: 'md',
+        contentHash: args.contentHash,
+        ...(oldFileId
+          ? { historyFiles: [...(existingDoc.historyFiles ?? []), oldFileId] }
+          : {}),
+      });
+      await linkFileMetadataToDocument(ctx, args.fileId, existingDoc._id);
+
+      if (oldFileId) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.documents.internal_actions.reindexDocumentInRag,
+          {
+            documentId: existingDoc._id,
+            oldFileId,
+            oldOrganizationId: existingDoc.organizationId,
+          },
+        );
+      } else {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.documents.internal_actions.uploadDocumentToRag,
+          { documentId: existingDoc._id },
+        );
+      }
+      return existingDoc._id;
+    }
+
+    const folderId = await getOrCreateFolderPath(
+      ctx,
+      entry.organizationId,
+      [KNOWLEDGE_ENTRIES_FOLDER],
+      entry.createdBy,
+    );
+
+    const { documentId } = await createDocument(ctx, {
+      organizationId: entry.organizationId,
+      title,
+      fileId: args.fileId,
+      mimeType: 'text/markdown',
+      extension: 'md',
+      contentHash: args.contentHash,
+      sourceProvider: KNOWLEDGE_SOURCE_PROVIDER,
+      createdBy: entry.createdBy,
+      folderId,
+    });
+
+    await linkFileMetadataToDocument(ctx, args.fileId, documentId);
+    await ctx.db.patch(args.entryId, { documentId });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.documents.internal_actions.uploadDocumentToRag,
+      { documentId },
+    );
+    return documentId;
+  },
+});
+
+async function linkFileMetadataToDocument(
+  ctx: MutationCtx,
+  storageId: Id<'_storage'>,
+  documentId: Id<'documents'>,
+): Promise<void> {
+  const metadata = await ctx.db
+    .query('fileMetadata')
+    .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
+    .first();
+  if (!metadata) {
+    console.warn(
+      `[attachEntryDocument] No fileMetadata for storageId ${storageId}; skipping document link`,
+    );
+    return;
+  }
+  await ctx.db.patch(metadata._id, { documentId });
+}

--- a/services/platform/convex/knowledge_entries/internal_queries.ts
+++ b/services/platform/convex/knowledge_entries/internal_queries.ts
@@ -1,0 +1,13 @@
+import { v } from 'convex/values';
+
+import type { Doc } from '../_generated/dataModel';
+import { internalQuery } from '../_generated/server';
+
+export const getEntryById = internalQuery({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+  },
+  handler: async (ctx, args): Promise<Doc<'knowledgeEntries'> | null> => {
+    return await ctx.db.get(args.entryId);
+  },
+});

--- a/services/platform/convex/knowledge_entries/mutations.ts
+++ b/services/platform/convex/knowledge_entries/mutations.ts
@@ -1,0 +1,200 @@
+/**
+ * Knowledge entries mutations (manual management UI)
+ *
+ * Org-scoped (V1). Every mutation requires org membership and consumes the
+ * org-keyed `knowledge:mutate` rate limit. Content lives on the entry row;
+ * the markdown backing document + RAG indexing are materialized
+ * asynchronously by `materializeKnowledgeEntry`.
+ */
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import { mutation } from '../_generated/server';
+import { checkOrganizationRateLimit } from '../lib/rate_limiter/helpers';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import {
+  findActiveEntryByTopicKey,
+  markEntryChainDeleted,
+  upsertEntryRow,
+  validateTopicAndContent,
+} from './helpers';
+
+export const createKnowledgeEntry = mutation({
+  args: {
+    organizationId: v.string(),
+    topic: v.string(),
+    content: v.string(),
+  },
+  returns: v.id('knowledgeEntries'),
+  handler: async (ctx, args): Promise<Id<'knowledgeEntries'>> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+    await getOrganizationMember(ctx, args.organizationId, authUser);
+    await checkOrganizationRateLimit(
+      ctx,
+      'knowledge:mutate',
+      args.organizationId,
+    );
+
+    const { topic, topicKey, content } = validateTopicAndContent(
+      args.topic,
+      args.content,
+    );
+
+    const existing = await findActiveEntryByTopicKey(
+      ctx,
+      args.organizationId,
+      topicKey,
+    );
+    if (existing) {
+      throw new Error(
+        `A knowledge entry for the topic "${existing.topic}" already exists. Edit that entry instead.`,
+      );
+    }
+
+    const { entryId } = await upsertEntryRow(ctx, {
+      organizationId: args.organizationId,
+      topic,
+      topicKey,
+      content,
+      source: 'manual',
+      createdBy: authUser.userId,
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.knowledge_entries.internal_actions.materializeKnowledgeEntry,
+      { entryId },
+    );
+
+    return entryId;
+  },
+});
+
+export const updateKnowledgeEntry = mutation({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+    topic: v.string(),
+    content: v.string(),
+  },
+  returns: v.id('knowledgeEntries'),
+  handler: async (ctx, args): Promise<Id<'knowledgeEntries'>> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry || entry.deletedAt !== undefined) {
+      throw new Error('Knowledge entry not found');
+    }
+    if (entry.status !== 'active') {
+      throw new Error('Only the active version of an entry can be edited');
+    }
+
+    await getOrganizationMember(ctx, entry.organizationId, authUser);
+    await checkOrganizationRateLimit(
+      ctx,
+      'knowledge:mutate',
+      entry.organizationId,
+    );
+
+    const { topic, topicKey, content } = validateTopicAndContent(
+      args.topic,
+      args.content,
+    );
+
+    // Topic rename must not collide with another live topic.
+    if (topicKey !== entry.topicKey) {
+      const collision = await findActiveEntryByTopicKey(
+        ctx,
+        entry.organizationId,
+        topicKey,
+      );
+      if (collision) {
+        throw new Error(
+          `A knowledge entry for the topic "${collision.topic}" already exists.`,
+        );
+      }
+    }
+
+    const now = Date.now();
+    const newEntryId = await ctx.db.insert('knowledgeEntries', {
+      organizationId: entry.organizationId,
+      topic,
+      topicKey,
+      content,
+      status: 'active',
+      documentId: entry.documentId,
+      source: 'manual',
+      createdBy: authUser.userId,
+      createdAt: now,
+    });
+    await ctx.db.patch(entry._id, {
+      status: 'superseded',
+      supersededBy: newEntryId,
+      supersededAt: now,
+    });
+
+    // On rename, re-key the whole superseded chain so version history
+    // follows the entry to its new topic key.
+    if (topicKey !== entry.topicKey) {
+      for await (const row of ctx.db
+        .query('knowledgeEntries')
+        .withIndex('by_org_topicKey_status', (q) =>
+          q
+            .eq('organizationId', entry.organizationId)
+            .eq('topicKey', entry.topicKey),
+        )) {
+        if (row._id === newEntryId) continue;
+        await ctx.db.patch(row._id, { topicKey });
+      }
+    }
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.knowledge_entries.internal_actions.materializeKnowledgeEntry,
+      { entryId: newEntryId },
+    );
+
+    return newEntryId;
+  },
+});
+
+export const deleteKnowledgeEntry = mutation({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Unauthenticated');
+
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry || entry.deletedAt !== undefined) {
+      throw new Error('Knowledge entry not found');
+    }
+
+    await getOrganizationMember(ctx, entry.organizationId, authUser);
+    await checkOrganizationRateLimit(
+      ctx,
+      'knowledge:mutate',
+      entry.organizationId,
+    );
+
+    await markEntryChainDeleted(ctx, entry.organizationId, entry.topicKey);
+
+    // Remove the backing document (Convex row + RAG chunks + blob cleanup
+    // ride the existing document deletion pipeline).
+    if (entry.documentId) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.documents.internal_actions.deleteDocumentFromRag,
+        { documentId: entry.documentId },
+      );
+    }
+
+    return null;
+  },
+});

--- a/services/platform/convex/knowledge_entries/queries.ts
+++ b/services/platform/convex/knowledge_entries/queries.ts
@@ -1,0 +1,156 @@
+/**
+ * Knowledge entries queries
+ *
+ * Org-scoped (V1): every org member can list entries; team scoping is an
+ * explicit follow-up. Auth mirrors `documents/queries.ts`
+ * (getAuthUserIdentity + getOrganizationMember, failure → empty result).
+ */
+
+import { paginationOptsValidator } from 'convex/server';
+import { v } from 'convex/values';
+
+import type { Doc } from '../_generated/dataModel';
+import { query } from '../_generated/server';
+import {
+  getDocumentRagProjectionBatch,
+  type DocumentRagProjection,
+} from '../documents/get_document_rag_projection';
+import { countItemsInOrg } from '../lib/helpers/count_items_in_org';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+
+export interface KnowledgeEntryItem extends Doc<'knowledgeEntries'> {
+  ragStatus?: DocumentRagProjection['status'] | 'not_indexed';
+  ragIndexedAt?: number;
+  ragError?: string;
+}
+
+async function projectEntries(
+  ctx: Parameters<typeof getDocumentRagProjectionBatch>[0],
+  entries: Doc<'knowledgeEntries'>[],
+): Promise<KnowledgeEntryItem[]> {
+  const docIds = new Map<string, Doc<'documents'>>();
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.documentId) return;
+      const doc = await ctx.db.get(entry.documentId);
+      if (doc) docIds.set(String(entry._id), doc);
+    }),
+  );
+
+  const ragByDocId = await getDocumentRagProjectionBatch(ctx, [
+    ...docIds.values(),
+  ]);
+
+  return entries.map((entry) => {
+    const doc = docIds.get(String(entry._id));
+    const rag = doc ? ragByDocId.get(String(doc._id)) : undefined;
+    return {
+      ...entry,
+      ragStatus: rag?.status ?? 'not_indexed',
+      ragIndexedAt: rag?.indexedAt,
+      ragError: rag?.error,
+    };
+  });
+}
+
+export const approxCountKnowledgeEntries = query({
+  args: {
+    organizationId: v.string(),
+  },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return 0;
+    try {
+      await getOrganizationMember(ctx, args.organizationId, authUser);
+    } catch {
+      return 0;
+    }
+    return await countItemsInOrg(
+      ctx.db,
+      'knowledgeEntries',
+      args.organizationId,
+    );
+  },
+});
+
+export const listKnowledgeEntriesPaginated = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    organizationId: v.string(),
+    status: v.optional(v.union(v.literal('active'), v.literal('superseded'))),
+  },
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      return { page: [], isDone: true, continueCursor: '' };
+    }
+    try {
+      await getOrganizationMember(ctx, args.organizationId, authUser);
+    } catch {
+      return { page: [], isDone: true, continueCursor: '' };
+    }
+
+    const status = args.status ?? 'active';
+    const result = await ctx.db
+      .query('knowledgeEntries')
+      .withIndex('by_organizationId_and_status', (q) =>
+        q.eq('organizationId', args.organizationId).eq('status', status),
+      )
+      .order('desc')
+      .paginate(args.paginationOpts);
+
+    const live = result.page.filter((e) => e.deletedAt === undefined);
+    return {
+      ...result,
+      page: await projectEntries(ctx, live),
+    };
+  },
+});
+
+/**
+ * One entry plus its full version chain (active head first, then superseded
+ * versions newest-first). Returns null on not-found or any access failure.
+ */
+export const getKnowledgeEntryVersions = query({
+  args: {
+    entryId: v.id('knowledgeEntries'),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    entry: KnowledgeEntryItem;
+    versions: Doc<'knowledgeEntries'>[];
+  } | null> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return null;
+
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry || entry.deletedAt !== undefined) return null;
+
+    try {
+      await getOrganizationMember(ctx, entry.organizationId, authUser);
+    } catch {
+      return null;
+    }
+
+    const versions: Doc<'knowledgeEntries'>[] = [];
+    for await (const row of ctx.db
+      .query('knowledgeEntries')
+      .withIndex('by_org_topicKey_status', (q) =>
+        q
+          .eq('organizationId', entry.organizationId)
+          .eq('topicKey', entry.topicKey)
+          .eq('status', 'superseded'),
+      )) {
+      if (row.deletedAt !== undefined) continue;
+      versions.push(row);
+    }
+    versions.sort((a, b) => b.createdAt - a.createdAt);
+
+    const [projected] = await projectEntries(ctx, [entry]);
+    return { entry: projected, versions };
+  },
+});

--- a/services/platform/convex/knowledge_entries/schema.ts
+++ b/services/platform/convex/knowledge_entries/schema.ts
@@ -1,0 +1,44 @@
+import { defineTable } from 'convex/server';
+import { v } from 'convex/values';
+
+/**
+ * User-contributed knowledge entries — small markdown facts captured from
+ * chat (via the approval-gated `knowledge_write` tool) or authored manually
+ * in the Knowledge entries tab.
+ *
+ * Each entry is keyed by a normalized `topicKey` (trimmed, lowercased,
+ * whitespace-collapsed `topic`). At most ONE row per (org, topicKey) is
+ * `active`; writing to an existing topic supersedes the previous version
+ * (Option A delete+replace toward RAG, version chain kept in Convex for
+ * audit/undo). The active row is backed by a `documents` row
+ * (`sourceProvider: 'knowledge'`, title `{topic}.md`) so indexing, agent
+ * scoping, citations, and deletion ride the existing document pipeline.
+ *
+ * `status` machine:
+ *  - 'active'     : the live version — its content is what RAG serves.
+ *  - 'superseded' : replaced by a newer version (`supersededBy` points at it).
+ *
+ * `deletedAt` soft-deletes the whole chain (set on every row of a topic when
+ * the entry is deleted, or when its backing document is deleted from the
+ * Documents tab).
+ */
+export const knowledgeEntriesTable = defineTable({
+  organizationId: v.string(),
+  topic: v.string(),
+  topicKey: v.string(),
+  content: v.string(),
+  status: v.union(v.literal('active'), v.literal('superseded')),
+  documentId: v.optional(v.id('documents')),
+  source: v.union(v.literal('chat'), v.literal('manual')),
+  sourceThreadId: v.optional(v.string()),
+  sourceMessageId: v.optional(v.string()),
+  createdBy: v.string(),
+  createdAt: v.number(),
+  supersededBy: v.optional(v.id('knowledgeEntries')),
+  supersededAt: v.optional(v.number()),
+  deletedAt: v.optional(v.number()),
+})
+  .index('by_org_topicKey_status', ['organizationId', 'topicKey', 'status'])
+  .index('by_organizationId_and_status', ['organizationId', 'status'])
+  .index('by_documentId', ['documentId'])
+  .index('by_organizationId', ['organizationId']);

--- a/services/platform/convex/lib/helpers/count_items_in_org.ts
+++ b/services/platform/convex/lib/helpers/count_items_in_org.ts
@@ -1,6 +1,12 @@
 import type { DatabaseReader } from '../../_generated/server';
 
-type OrgTable = 'customers' | 'documents' | 'products' | 'vendors' | 'websites';
+type OrgTable =
+  | 'customers'
+  | 'documents'
+  | 'knowledgeEntries'
+  | 'products'
+  | 'vendors'
+  | 'websites';
 
 export const DEFAULT_COUNT_CAP = 20;
 

--- a/services/platform/convex/lib/rate_limiter/index.ts
+++ b/services/platform/convex/lib/rate_limiter/index.ts
@@ -173,6 +173,29 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
   },
 
   // ============================================
+  // TIER 3.55: Knowledge entries (Token Bucket)
+  // Bounds storage + RAG-pipeline churn from knowledge-entry writes.
+  // ============================================
+  // Agent-initiated knowledge_write approvals, keyed by org. Same shape as
+  // prompt:create: 20-burst headroom, refilling at 10/min. Each approved
+  // write stores a blob and triggers a RAG (re)index, so the bound matters.
+  'knowledge:write': {
+    kind: 'token bucket',
+    rate: 10,
+    period: MINUTE,
+    capacity: 20,
+    shards: 4,
+  },
+  // Manual create/update/delete from the Knowledge entries tab, keyed by org.
+  'knowledge:mutate': {
+    kind: 'token bucket',
+    rate: 10,
+    period: MINUTE,
+    capacity: 20,
+    shards: 4,
+  },
+
+  // ============================================
   // TIER 3.6: Projects (Token Bucket)
   // Bounds storage churn from scripted project creation/duplication and
   // caps blast radius of cascade deletes (which touch every doc + thread).

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -55,6 +55,7 @@ import {
   slackThreadsTable,
 } from './integrations/slack/schema';
 import { slackInstallationsTable } from './integrations/slack_installations_schema';
+import { knowledgeEntriesTable } from './knowledge_entries/schema';
 import { llmResponseCacheTable } from './lib/response_cache/schema';
 import {
   loginAttemptsTable,
@@ -160,6 +161,7 @@ export default defineSchema({
   documents: documentsTable,
   fileMetadata: fileMetadataTable,
   folders: foldersTable,
+  knowledgeEntries: knowledgeEntriesTable,
   integrationCredentials: integrationCredentialsTable,
   /** @deprecated Retained for backward compatibility with existing data. Use integrationCredentials + file-based config. */
   integrations: integrationsTable,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -837,6 +837,7 @@
       "customerRead": "Kundendaten",
       "productRead": "Produktkatalog",
       "ragSearch": "Wissensdatenbank",
+      "knowledgeWrite": "Wissenseintrag",
       "web": "Webinhalt",
       "pdf": "PDF",
       "image": "Bilder",
@@ -2090,6 +2091,10 @@
     "websites": {
       "title": "Noch keine Websites",
       "description": "Füge Websites hinzu, um deine KI zu verbessern"
+    },
+    "knowledgeEntries": {
+      "title": "Noch keine Wissenseinträge",
+      "description": "Speichere Fakten aus dem Chat oder füge Einträge hinzu, um deine KI zu verbessern"
     },
     "automations": {
       "title": "Noch keine Automatisierungen",
@@ -3397,10 +3402,80 @@
   "knowledge": {
     "title": "Wissen",
     "documents": "Dokumente",
+    "knowledgeEntries": "Wissenseinträge",
     "websites": "Websites",
     "products": "Produkte",
     "customers": "Kunden",
     "vendors": "Lieferanten"
+  },
+  "knowledgeEntries": {
+    "title": "Wissenseinträge",
+    "searchPlaceholder": "Wissenseinträge durchsuchen",
+    "addButton": "Eintrag hinzufügen",
+    "addEntry": "Wissenseintrag hinzufügen",
+    "editEntry": "Wissenseintrag bearbeiten",
+    "adding": "Wird hinzugefügt...",
+    "saving": "Wird gespeichert...",
+    "topic": "Thema",
+    "topicPlaceholder": "z. B. Öffnungszeiten",
+    "content": "Inhalt",
+    "contentPlaceholder": "Formuliere das Wissen so, dass es für sich allein verständlich ist, z. B. \"Unser Geschäft ist Montag bis Freitag von 9 bis 17 Uhr geöffnet.\"",
+    "headers": {
+      "topic": "Thema",
+      "content": "Inhalt",
+      "source": "Quelle",
+      "updated": "Aktualisiert"
+    },
+    "source": {
+      "chat": "Chat",
+      "manual": "Manuell"
+    },
+    "validation": {
+      "topicRequired": "Thema ist erforderlich",
+      "topicTooLong": "Das Thema darf höchstens 120 Zeichen lang sein",
+      "contentRequired": "Inhalt ist erforderlich",
+      "contentTooLong": "Der Inhalt darf höchstens 8000 Zeichen lang sein"
+    },
+    "toast": {
+      "addSuccess": "Wissenseintrag hinzugefügt",
+      "addError": "Wissenseintrag konnte nicht hinzugefügt werden",
+      "addErrorDuplicate": "Für dieses Thema existiert bereits ein Eintrag",
+      "updateSuccess": "Wissenseintrag aktualisiert",
+      "updateError": "Wissenseintrag konnte nicht aktualisiert werden",
+      "deleteError": "Wissenseintrag konnte nicht gelöscht werden"
+    },
+    "delete": {
+      "title": "Wissenseintrag löschen",
+      "confirmation": "Möchtest du diesen Wissenseintrag wirklich löschen? Er wird auch aus der Wissensdatenbank entfernt und ist für Agenten nicht mehr auffindbar. Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "viewDialog": {
+      "title": "Details zum Wissenseintrag",
+      "indexingStatus": "Indexierungsstatus",
+      "updated": "Aktualisiert",
+      "history": "Versionsverlauf",
+      "versionCount": "{count, plural, one {# frühere Version} other {# frühere Versionen}}",
+      "superseded": "Ersetzt",
+      "supersededOn": "Ersetzt am {date}"
+    }
+  },
+  "knowledgeWriteApproval": {
+    "cardTitle": "In Wissensdatenbank speichern",
+    "cardTitleReplace": "Wissensdatenbank aktualisieren",
+    "topicLabel": "Thema",
+    "contentLabel": "Inhalt",
+    "incorrectInfoLabel": "Ersetzt veraltete Information",
+    "replaceNotice": "Mit der Genehmigung wird der bestehende Eintrag \"{topic}\" ersetzt.",
+    "savedSuccessfully": "In der Wissensdatenbank gespeichert",
+    "approve": "Genehmigen",
+    "reject": "Ablehnen",
+    "approveTooltip": "Diesen Wissenseintrag genehmigen und speichern",
+    "approveTooltipReplace": "Genehmigen und den bestehenden Wissenseintrag ersetzen",
+    "rejectTooltip": "Diesen Wissenseintrag ablehnen",
+    "statusExecuting": "Wissenseintrag wird gespeichert...",
+    "statusCompletedFailed": "Dieser Wissenseintrag wurde genehmigt, konnte aber nicht gespeichert werden.",
+    "statusCompletedSuccess": "Dieser Wissenseintrag wurde in der Wissensdatenbank gespeichert.",
+    "statusRejected": "Dieser Wissenseintrag wurde abgelehnt.",
+    "errorSaveFailed": "Wissenseintrag konnte nicht gespeichert werden"
   },
   "locationRequest": {
     "title": "Standortanfrage",
@@ -3517,6 +3592,10 @@
     "websites": {
       "title": "Websites",
       "description": "Websites für die Wissensextraktion verwalten."
+    },
+    "knowledgeEntries": {
+      "title": "Wissenseinträge",
+      "description": "Von Nutzern beigetragene Wissenseinträge verwalten."
     },
     "settings": {
       "title": "Einstellungen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -837,6 +837,7 @@
       "customerRead": "Customer data",
       "productRead": "Product catalog",
       "ragSearch": "Knowledge base",
+      "knowledgeWrite": "Knowledge entry",
       "web": "Web content",
       "pdf": "PDF",
       "image": "Images",
@@ -2090,6 +2091,10 @@
     "websites": {
       "title": "No websites yet",
       "description": "Add websites to make your AI smarter"
+    },
+    "knowledgeEntries": {
+      "title": "No knowledge entries yet",
+      "description": "Save facts from chat or add entries to make your AI smarter"
     },
     "automations": {
       "title": "No automations yet",
@@ -3397,10 +3402,80 @@
   "knowledge": {
     "title": "Knowledge",
     "documents": "Documents",
+    "knowledgeEntries": "Knowledge entries",
     "websites": "Websites",
     "products": "Products",
     "customers": "Customers",
     "vendors": "Vendors"
+  },
+  "knowledgeEntries": {
+    "title": "Knowledge entries",
+    "searchPlaceholder": "Search knowledge entries",
+    "addButton": "Add entry",
+    "addEntry": "Add knowledge entry",
+    "editEntry": "Edit knowledge entry",
+    "adding": "Adding...",
+    "saving": "Saving...",
+    "topic": "Topic",
+    "topicPlaceholder": "e.g. Store opening hours",
+    "content": "Content",
+    "contentPlaceholder": "Write the knowledge so it makes sense on its own, e.g. \"Our store is open Monday to Friday from 9 am to 5 pm.\"",
+    "headers": {
+      "topic": "Topic",
+      "content": "Content",
+      "source": "Source",
+      "updated": "Updated"
+    },
+    "source": {
+      "chat": "Chat",
+      "manual": "Manual"
+    },
+    "validation": {
+      "topicRequired": "Topic is required",
+      "topicTooLong": "Topic must be 120 characters or fewer",
+      "contentRequired": "Content is required",
+      "contentTooLong": "Content must be 8000 characters or fewer"
+    },
+    "toast": {
+      "addSuccess": "Knowledge entry added",
+      "addError": "Failed to add knowledge entry",
+      "addErrorDuplicate": "An entry for this topic already exists",
+      "updateSuccess": "Knowledge entry updated",
+      "updateError": "Failed to update knowledge entry",
+      "deleteError": "Failed to delete knowledge entry"
+    },
+    "delete": {
+      "title": "Delete knowledge entry",
+      "confirmation": "Are you sure you want to delete this knowledge entry? It will also be removed from the knowledge base, so agents can no longer find it. This action cannot be undone."
+    },
+    "viewDialog": {
+      "title": "Knowledge entry details",
+      "indexingStatus": "Indexing status",
+      "updated": "Updated",
+      "history": "Version history",
+      "versionCount": "{count, plural, one {# previous version} other {# previous versions}}",
+      "superseded": "Superseded",
+      "supersededOn": "Replaced on {date}"
+    }
+  },
+  "knowledgeWriteApproval": {
+    "cardTitle": "Save to knowledge base",
+    "cardTitleReplace": "Update knowledge base",
+    "topicLabel": "Topic",
+    "contentLabel": "Content",
+    "incorrectInfoLabel": "Replaces outdated information",
+    "replaceNotice": "Approving will replace the existing entry \"{topic}\".",
+    "savedSuccessfully": "Saved to the knowledge base",
+    "approve": "Approve",
+    "reject": "Reject",
+    "approveTooltip": "Approve and save this knowledge entry",
+    "approveTooltipReplace": "Approve and replace the existing knowledge entry",
+    "rejectTooltip": "Reject this knowledge entry",
+    "statusExecuting": "Saving knowledge entry...",
+    "statusCompletedFailed": "This knowledge entry was approved but failed to save.",
+    "statusCompletedSuccess": "This knowledge entry was saved to the knowledge base.",
+    "statusRejected": "This knowledge entry was rejected.",
+    "errorSaveFailed": "Failed to save knowledge entry"
   },
   "locationRequest": {
     "title": "Location request",
@@ -3517,6 +3592,10 @@
     "websites": {
       "title": "Websites",
       "description": "Manage websites for knowledge extraction."
+    },
+    "knowledgeEntries": {
+      "title": "Knowledge entries",
+      "description": "Manage user-contributed knowledge entries."
     },
     "settings": {
       "title": "Settings",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -838,6 +838,7 @@
       "customerRead": "Données client",
       "productRead": "Catalogue produits",
       "ragSearch": "Base de connaissances",
+      "knowledgeWrite": "Entrée de connaissances",
       "web": "Contenu web",
       "pdf": "PDF",
       "image": "Images",
@@ -2091,6 +2092,10 @@
     "websites": {
       "title": "Aucun site web pour l'instant",
       "description": "Ajoute des sites web pour rendre ton IA plus performante"
+    },
+    "knowledgeEntries": {
+      "title": "Aucune entrée de connaissances pour l'instant",
+      "description": "Enregistre des faits depuis le chat ou ajoute des entrées pour rendre ton IA plus performante"
     },
     "automations": {
       "title": "Aucune automatisation pour l'instant",
@@ -3398,10 +3403,80 @@
   "knowledge": {
     "title": "Base de connaissances",
     "documents": "Documents",
+    "knowledgeEntries": "Entrées de connaissances",
     "websites": "Sites web",
     "products": "Produits",
     "customers": "Clients",
     "vendors": "Fournisseurs"
+  },
+  "knowledgeEntries": {
+    "title": "Entrées de connaissances",
+    "searchPlaceholder": "Rechercher des entrées de connaissances",
+    "addButton": "Ajouter une entrée",
+    "addEntry": "Ajouter une entrée de connaissances",
+    "editEntry": "Modifier l'entrée de connaissances",
+    "adding": "Ajout en cours...",
+    "saving": "Enregistrement...",
+    "topic": "Sujet",
+    "topicPlaceholder": "p. ex. Horaires d'ouverture",
+    "content": "Contenu",
+    "contentPlaceholder": "Rédige la connaissance pour qu'elle soit compréhensible seule, p. ex. \"Notre magasin est ouvert du lundi au vendredi de 9 h à 17 h.\"",
+    "headers": {
+      "topic": "Sujet",
+      "content": "Contenu",
+      "source": "Source",
+      "updated": "Mis à jour"
+    },
+    "source": {
+      "chat": "Chat",
+      "manual": "Manuel"
+    },
+    "validation": {
+      "topicRequired": "Le sujet est requis",
+      "topicTooLong": "Le sujet doit contenir au maximum 120 caractères",
+      "contentRequired": "Le contenu est requis",
+      "contentTooLong": "Le contenu doit contenir au maximum 8000 caractères"
+    },
+    "toast": {
+      "addSuccess": "Entrée de connaissances ajoutée",
+      "addError": "Échec de l'ajout de l'entrée de connaissances",
+      "addErrorDuplicate": "Une entrée existe déjà pour ce sujet",
+      "updateSuccess": "Entrée de connaissances mise à jour",
+      "updateError": "Échec de la mise à jour de l'entrée de connaissances",
+      "deleteError": "Échec de la suppression de l'entrée de connaissances"
+    },
+    "delete": {
+      "title": "Supprimer l'entrée de connaissances",
+      "confirmation": "Es-tu sûr de vouloir supprimer cette entrée de connaissances ? Elle sera aussi retirée de la base de connaissances et les agents ne pourront plus la trouver. Cette action est irréversible."
+    },
+    "viewDialog": {
+      "title": "Détails de l'entrée de connaissances",
+      "indexingStatus": "Statut d'indexation",
+      "updated": "Mis à jour",
+      "history": "Historique des versions",
+      "versionCount": "{count, plural, one {# version précédente} other {# versions précédentes}}",
+      "superseded": "Remplacée",
+      "supersededOn": "Remplacée le {date}"
+    }
+  },
+  "knowledgeWriteApproval": {
+    "cardTitle": "Enregistrer dans la base de connaissances",
+    "cardTitleReplace": "Mettre à jour la base de connaissances",
+    "topicLabel": "Sujet",
+    "contentLabel": "Contenu",
+    "incorrectInfoLabel": "Remplace une information obsolète",
+    "replaceNotice": "L'approbation remplacera l'entrée existante \"{topic}\".",
+    "savedSuccessfully": "Enregistré dans la base de connaissances",
+    "approve": "Approuver",
+    "reject": "Rejeter",
+    "approveTooltip": "Approuver et enregistrer cette entrée de connaissances",
+    "approveTooltipReplace": "Approuver et remplacer l'entrée de connaissances existante",
+    "rejectTooltip": "Rejeter cette entrée de connaissances",
+    "statusExecuting": "Enregistrement de l'entrée de connaissances...",
+    "statusCompletedFailed": "Cette entrée de connaissances a été approuvée mais n'a pas pu être enregistrée.",
+    "statusCompletedSuccess": "Cette entrée de connaissances a été enregistrée dans la base de connaissances.",
+    "statusRejected": "Cette entrée de connaissances a été rejetée.",
+    "errorSaveFailed": "Échec de l'enregistrement de l'entrée de connaissances"
   },
   "locationRequest": {
     "title": "Demande de localisation",
@@ -3518,6 +3593,10 @@
     "websites": {
       "title": "Sites web",
       "description": "Gère les sites web pour l'extraction de connaissances."
+    },
+    "knowledgeEntries": {
+      "title": "Entrées de connaissances",
+      "description": "Gère les entrées de connaissances ajoutées par les utilisateurs."
     },
     "settings": {
       "title": "Paramètres",


### PR DESCRIPTION
> [!IMPORTANT]
> **Open product decision — veto here if you disagree.** The #69 thread still has the zero-dev alternative on the table (just curate facts as files via the existing Documents page, no new feature). This PR implements the **build** option per the plan's recommendation. If the team prefers the Documents-page alternative, close this PR — nothing else depends on it.

## What

Re-enables conversational knowledge capture (successor to the removed `rag_write` tool, commit `0d441c6`) with the conflict-resolution strategy and management UI the removal was blocked on:

- **`knowledgeEntries` table** — small markdown facts keyed by a normalized `topicKey`. At most one `active` row per (org, topic); writing to an existing topic supersedes the previous version (kept as an inert version chain for audit/undo). Soft-delete via `deletedAt`.
- **`knowledge_write` agent tool** (opt-in per agent, Documents group in the tool selector) — creates a `knowledge_write` approval instead of writing directly. The chat approval card shows topic, full content, the outdated info it corrects, and a replace notice when the topic already exists. Nothing reaches the knowledge base without explicit human approval.
- **Markdown hub documents ride the existing RAG pipeline** — each entry's active version is backed by a `documents` row (`sourceProvider: 'knowledge'`, title `{topic}.md`, reserved "Knowledge entries" folder) so indexing, agent scoping (`rag_search` file-id resolution), citations, re-index and deletion all reuse the existing document pipeline (`storeRawContent`, `uploadDocumentToRag`, `reindexDocumentInRag`, `deleteDocumentFromRag`) unchanged. No RAG-service changes.
- **"Knowledge entries" tab** beside Documents — paginated table (RAG status badge per row, source chat/manual, client-side search), view dialog with superseded version history, add/edit/delete dialogs, bulk delete. Loader primes the paginated cache like the Websites tab.
- **Consistency hooks** — `deleteDocument` (Documents tab) marks linked entry chains deleted so the two views never disagree; entry delete schedules `deleteDocumentFromRag` for the backing document.
- **Rate limits** — org-keyed `knowledge:write` (agent path) and `knowledge:mutate` (manual UI) token buckets (10/min, burst 20).
- **i18n** en/de/fr + docs page `platform/knowledge/knowledge-entries` in all three locales (nav + overview updated).

## Why

Knowledge indexed in RAG without a backing hub document is unreachable (`rag_search` filters by document-resolved file ids), and the old `rag_write` had no conflict story — corrections coexisted with the facts they corrected. Topic-keyed delete+replace guarantees RAG holds exactly one live version per fact, and the approval gate gives the human-review benefit without building an admin queue.

## Decision-gate recommendations baked in

- **Build vs Documents-page alternative**: built (recommended; open decision stated at top).
- **Conflict resolution**: Option A topic-keyed delete+replace toward RAG, hardened with approval-gated chat writes + superseded version chain kept in Convex (Option-B-lite, no RAG-side version filtering).
- **Tool naming**: new convention-consistent `knowledge_write` (matches `document_write`/`task_write`), not a `rag_write` revival.
- **Scope**: org-wide V1; no team scoping on entries (`teamId` is a follow-up).
- **Approver**: the chatting user (parity with `document_write`); admin-only governance gate is a possible follow-up.
- **Backing documents**: visible in the Documents tab inside the reserved "Knowledge entries" folder (zero extra code, citations stay clickable).
- **Rollout**: tool is opt-in per agent via agent settings.
- **Retention**: superseded rows kept indefinitely in V1; lazy cleanup is an explicit follow-up. Embedding-similarity dedup across differently-worded topics is also a follow-up (V1 dedup = normalized topic key).

## Verification

Performed:
- `bun run check` at repo root — all 40 tasks green (format, lint, typecheck, 367 platform test files / 71,928 tests).
- New unit tests: `convex/knowledge_entries/helpers.test.ts` (topicKey normalization, validate caps, upsert/supersede transitions, soft-delete chain) and `convex/agent_tools/rag/knowledge_write_tool.test.ts` (schema + handler paths incl. replace notice and rate-limit error surface).
- Targeted UI suites (`test:ui` for chat/knowledge/knowledge-entries/agents features, governance skeleton conventions): all pass.
- Docs: `bun run --filter @tale/docs lint`, `test` (139 tests incl. nav parity, locale parity, opening/closing), and full `build` (prerender) — all pass.
- Regenerated `routeTree.gen.ts` (router generator) and `convex/_generated/api.d.ts` entries.

Manual verification required (needs the live local stack + RAG service; not runnable in this environment):
- Enable `knowledge_write` on an agent → chat a fact → approve the card → entry appears in the Knowledge entries tab + backing doc in the "Knowledge entries" folder → ragStatus completes → `rag_search` returns it.
- Correction flow: write to the same topic → card shows the replace notice → approve → old version listed as superseded, search returns only the new fact.
- Edit + delete from the UI → re-index/removal confirmed via the status badge and search.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons.
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change.
- [x] Every touched docs page has a real opening and a real closing.
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [ ] Updated `README.md`, `README.de.md`, `README.fr.md` — N/A (feature-level change, READMEs don't enumerate knowledge surfaces).

Part of #69