### PR TITLE
feat(platform): per-node execution status on the workflow canvas

### DIFF
--- a/docs/de/platform/automations/workflows.md
+++ b/docs/de/platform/automations/workflows.md
@@ -21,6 +21,8 @@ Der **Triggers**-Tab am Workflow hängt die laufenden Pfade an: ein manueller Tr
 
 Das **Automatisierung testen**-Panel in der Editor-Toolbar feuert einen einmaligen Lauf direkt aus dem Editor. Fügst du die Eingabe-JSON ein, die der Lauf erhalten soll, klickst **Ausführen**, taucht der Lauf im Ausführungen-Tab mit seiner ID auf. Greif zum Test-Panel, wenn du an einem Workflow iterierst und das volle Ausführungsjournal sehen willst, ohne erst einen Trigger zu verdrahten.
 
+Während der Lauf läuft, spiegelt die Canvas ihn live: Jeder Schritt trägt ein Status-Badge — ein Spinner während der Ausführung, ein Häkchen bei Erfolg, ein Warnsymbol bei Fehlern, ein Pause-Symbol beim Warten auf Eingabe — und ein Banner über der Canvas zeigt, welcher Lauf gerade angezeigt wird. Klick auf ein Badge, um Dauer, Fehler und eine Vorschau der Ausgabe des Schritts zu prüfen. Der angezeigte Lauf hängt am URL-Parameter `execution` und übersteht damit ein Neuladen; schließt du das Banner, verschwinden die Badges.
+
 Der **Dry run**-Button im selben Panel simuliert einen Lauf ohne Seiteneffekte — der Workflow validiert gegen die Eingabe, läuft den Schritte-Graph ab und meldet Fehler und Warnungen, ohne irgendeinen Agent, eine API oder einen Mail-Server zu rufen. Greif zum Dry Run, wenn der Workflow noch nicht sicher ist, ihn von Anfang bis Ende laufen zu lassen.
 
 ## Pausieren und deaktivieren

--- a/docs/en/platform/automations/workflows.md
+++ b/docs/en/platform/automations/workflows.md
@@ -21,6 +21,8 @@ The **Triggers** tab on the workflow attaches the running paths: a manual trigge
 
 The **Test automation** panel in the editor toolbar fires a one-off run from the editor. Paste the input JSON the run should receive, click **Execute**, and the run shows up in the Executions tab with its ID. Reach for the test panel when you are iterating on a workflow and want to see the full execution journal without wiring a trigger first.
 
+While the run is live, the canvas mirrors it: every step carries a status badge — a spinner while running, a check on success, an alert on failure, a pause icon while waiting for input — and a banner above the canvas names the run being viewed. Click a badge to inspect the step's duration, error, and a preview of its output. The viewed run rides the `execution` URL parameter, so it survives a reload; dismiss the banner to clear the badges.
+
 The **Dry run** button on the same panel simulates a run without side effects — the workflow validates against the input, walks the step graph, and reports errors and warnings without calling out to any agent, API, or mail server. Reach for dry run when the workflow is not yet safe to run end to end.
 
 ## Pausing and disabling

--- a/docs/fr/platform/automations/workflows.md
+++ b/docs/fr/platform/automations/workflows.md
@@ -21,6 +21,8 @@ L'onglet **Triggers** sur le workflow attache les chemins de déclenchement : un
 
 Le panneau **Tester l'automatisation** dans la barre d'outils de l'éditeur déclenche une exécution ponctuelle directement depuis l'éditeur. Colle le JSON d'entrée que l'exécution doit recevoir, clique **Exécuter** et l'exécution apparaît dans l'onglet Exécutions avec son ID. Sers-toi du panneau de test quand tu itères sur un workflow et veux voir le journal d'exécution complet sans câbler de trigger d'abord.
 
+Pendant que l'exécution tourne, la canvas la reflète en direct : chaque étape porte un badge de statut — un spinner pendant l'exécution, une coche en cas de succès, une alerte en cas d'échec, une icône pause en attente de saisie — et une bannière au-dessus de la canvas indique l'exécution affichée. Clique sur un badge pour inspecter la durée de l'étape, son erreur et un aperçu de sa sortie. L'exécution affichée tient dans le paramètre d'URL `execution` et survit donc à un rechargement ; ferme la bannière pour masquer les badges.
+
 Le bouton **Dry run** dans le même panneau simule une exécution sans effets de bord — le workflow valide contre l'entrée, parcourt le graphe d'étapes et signale erreurs et avertissements sans appeler aucun agent, API ou serveur de mail. Sers-toi du dry run quand le workflow n'est pas encore sûr à exécuter de bout en bout.
 
 ## Mettre en pause et désactiver

--- a/services/platform/app/features/automations/components/automation-loop-container.tsx
+++ b/services/platform/app/features/automations/components/automation-loop-container.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { useT } from '@/lib/i18n/client';
 
 import { InvisibleHandle } from './invisible-handle';
+import { NodeExecutionStatusBadge } from './node-execution-status-badge';
 
 interface AutomationLoopContainerProps {
   data: {
@@ -115,6 +116,14 @@ export function AutomationLoopContainer({
           </div>
         </div>
       </button>
+
+      {/* Execution status badge — sibling of the card button (nesting would
+          be invalid HTML), overlaid on the top-right corner. The popover also
+          carries the loop's n/total progress while it is the current step. */}
+      <NodeExecutionStatusBadge
+        stepSlug={data.stepSlug}
+        className="absolute -top-2.5 -right-2.5 z-10"
+      />
 
       {/* Bottom Target Handle - incoming from lower-ranked nodes */}
       <InvisibleHandle

--- a/services/platform/app/features/automations/components/automation-step.test.tsx
+++ b/services/platform/app/features/automations/components/automation-step.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ExecutionNodeState } from '@/convex/workflows/executions/get_execution_step_statuses';
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render } from '@/test/utils/render';
+
+const h = vi.hoisted(() => {
+  const fixture: {
+    nodeStatus: Record<string, unknown> | null;
+    viewedExecution: Record<string, unknown> | null;
+    onNodeClick: ReturnType<typeof vi.fn>;
+  } = {
+    nodeStatus: null,
+    viewedExecution: null,
+    onNodeClick: vi.fn(),
+  };
+  return fixture;
+});
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params
+        ? `automations.${key} ${Object.values(params).join(' ')}`
+        : `automations.${key}`,
+  }),
+}));
+
+vi.mock('./invisible-handle', () => ({
+  InvisibleHandle: () => null,
+}));
+
+vi.mock('./automation-callbacks-context', () => ({
+  useAutomationCallbacks: () => ({
+    onNodeClick: h.onNodeClick,
+    onAddStep: vi.fn(),
+    onAddStepOnEdge: vi.fn(),
+    onDeleteEdge: vi.fn(),
+  }),
+}));
+
+vi.mock('./execution-status-context', () => ({
+  useNodeExecutionStatus: () => h.nodeStatus,
+  useViewedExecution: () => ({
+    executionId: h.viewedExecution ? 'exec-1' : null,
+    execution: h.viewedExecution,
+  }),
+}));
+
+vi.mock('@/app/components/ui/data-display/json-viewer', () => ({
+  JsonViewer: ({ data }: { data: unknown }) => (
+    <pre data-testid="json-viewer">{String(data)}</pre>
+  ),
+}));
+
+import { AutomationStep } from './automation-step';
+
+const baseData = {
+  label: 'Fetch data',
+  stepType: 'action' as const,
+  stepSlug: 'fetch-data',
+};
+
+function nodeStatus(overrides: Partial<ExecutionNodeState>) {
+  return {
+    status: 'success',
+    attempts: 1,
+    startedAt: 1000,
+    completedAt: 3500,
+    ...overrides,
+  };
+}
+
+const badgeName = /steps\.execution\.nodeBadgeLabel/;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  h.nodeStatus = null;
+  h.viewedExecution = null;
+});
+
+describe('AutomationStep execution status badge (#1487)', () => {
+  it('renders no badge when no execution is viewed', () => {
+    render(<AutomationStep data={baseData} />);
+
+    expect(screen.queryByRole('button', { name: badgeName })).toBeNull();
+  });
+
+  it('shows a running badge and highlights the card', () => {
+    h.nodeStatus = nodeStatus({ status: 'running', completedAt: undefined });
+
+    render(<AutomationStep data={baseData} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'automations.steps.execution.nodeBadgeLabel automations.steps.execution.status.running',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'automations.step.openStep Fetch data',
+      }),
+    ).toHaveClass('ring-blue-400');
+  });
+
+  it('opens a popover with the error for a failed node', async () => {
+    h.nodeStatus = nodeStatus({
+      status: 'failed',
+      error: 'Missing recipient address',
+      attempts: 3,
+    });
+    const user = userEvent.setup();
+
+    render(<AutomationStep data={baseData} />);
+
+    await user.click(screen.getByRole('button', { name: badgeName }));
+
+    expect(
+      await screen.findByText('Missing recipient address'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('automations.steps.execution.attempts 3'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'automations.step.openStep Fetch data',
+      }),
+    ).toHaveClass('ring-destructive');
+  });
+
+  it('opens a popover with the output preview for a successful node', async () => {
+    h.nodeStatus = nodeStatus({
+      status: 'success',
+      outputPreview: '{"rows":3}',
+      outputTruncated: true,
+    });
+    const user = userEvent.setup();
+
+    render(<AutomationStep data={baseData} />);
+
+    await user.click(screen.getByRole('button', { name: badgeName }));
+
+    expect(await screen.findByTestId('json-viewer')).toHaveTextContent(
+      '{"rows":3}',
+    );
+    expect(
+      screen.getByText('automations.steps.execution.outputTruncated'),
+    ).toBeInTheDocument();
+  });
+
+  it('still opens the step panel when the card is clicked', async () => {
+    h.nodeStatus = nodeStatus({ status: 'success' });
+    const user = userEvent.setup();
+
+    render(<AutomationStep data={baseData} />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'automations.step.openStep Fetch data',
+      }),
+    );
+
+    expect(h.onNodeClick).toHaveBeenCalledWith('fetch-data');
+  });
+
+  describe('accessibility', () => {
+    it('has no critical accessibility violations with a badge', async () => {
+      h.nodeStatus = nodeStatus({ status: 'failed', error: 'boom' });
+
+      const { container } = render(<AutomationStep data={baseData} />);
+
+      await checkAccessibility(container);
+    });
+  });
+});

--- a/services/platform/app/features/automations/components/automation-step.tsx
+++ b/services/platform/app/features/automations/components/automation-step.tsx
@@ -11,7 +11,9 @@ import { cn } from '@/lib/utils/cn';
 
 import { getStepIconComponent } from '../utils/step-icons';
 import { useAutomationCallbacks } from './automation-callbacks-context';
+import { useNodeExecutionStatus } from './execution-status-context';
 import { InvisibleHandle } from './invisible-handle';
+import { NodeExecutionStatusBadge } from './node-execution-status-badge';
 
 interface AutomationStepProps {
   data: {
@@ -34,6 +36,7 @@ interface AutomationStepProps {
 export function AutomationStep({ data }: AutomationStepProps) {
   const { t } = useT('automations');
   const { onNodeClick } = useAutomationCallbacks();
+  const nodeStatus = useNodeExecutionStatus(data.stepSlug);
 
   // Determine handle positions based on whether each edge (top/bottom) has bidirectional connections
   // Only offset if there are connections in both directions at that specific edge
@@ -91,6 +94,9 @@ export function AutomationStep({ data }: AutomationStepProps) {
         data.isTerminalNode
           ? 'border-dashed border-2 border-muted-foreground/50'
           : 'border-border',
+        nodeStatus?.status === 'running' && 'ring-2 ring-blue-400',
+        nodeStatus?.status === 'failed' && 'ring-2 ring-destructive',
+        nodeStatus?.status === 'waiting' && 'ring-2 ring-amber-400',
       )}
       onClick={() => onNodeClick(data.stepSlug)}
     >
@@ -172,6 +178,14 @@ export function AutomationStep({ data }: AutomationStepProps) {
       />
 
       {cardContent}
+
+      {/* Execution status badge — a SIBLING of the card button (nesting a
+          button inside the card's <button> would be invalid HTML), overlaid
+          on the top-right corner. Renders nothing when no run is viewed. */}
+      <NodeExecutionStatusBadge
+        stepSlug={data.stepSlug}
+        className="absolute -top-2.5 -right-2.5 z-10"
+      />
 
       {/* Bottom Target Handle - incoming from lower-ranked nodes */}
       <InvisibleHandle

--- a/services/platform/app/features/automations/components/automation-steps.tsx
+++ b/services/platform/app/features/automations/components/automation-steps.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
@@ -48,6 +49,10 @@ import { AutomationEdge } from './automation-edge';
 import { AutomationGroupNode } from './automation-group-node';
 import { AutomationLoopContainer } from './automation-loop-container';
 import { AutomationStep } from './automation-step';
+import {
+  AUTOMATION_EXECUTION_URL_DEFINITIONS,
+  useViewedExecution,
+} from './execution-status-context';
 import { CreateStepDialog } from './step-create-dialog';
 
 interface AutomationStepsProps {
@@ -73,6 +78,17 @@ export const AUTOMATION_PANEL_URL_DEFINITIONS = {
   panel: { default: null },
   step: { default: null },
 } as const;
+
+const RUN_STATUS_BADGE_VARIANTS: Record<
+  string,
+  'green' | 'destructive' | 'blue' | 'outline' | 'yellow'
+> = {
+  completed: 'green',
+  failed: 'destructive',
+  running: 'blue',
+  pending: 'outline',
+  waiting: 'yellow',
+};
 
 const MINIMAP_STYLES = `
   .react-flow__edges { z-index: auto; }
@@ -122,6 +138,12 @@ function AutomationStepsInner({
 
   const { setStates: setPanelStates } = useUrlState({
     definitions: AUTOMATION_PANEL_URL_DEFINITIONS,
+  });
+
+  const { executionId: viewedExecutionId, execution: viewedExecution } =
+    useViewedExecution();
+  const { setState: setExecutionUrlState } = useUrlState({
+    definitions: AUTOMATION_EXECUTION_URL_DEFINITIONS,
   });
 
   const [_parentStepForNewStep, setParentStepForNewStep] = useState<
@@ -262,6 +284,14 @@ function AutomationStepsInner({
     [steps],
   );
 
+  // Surface waiting-for-input as its own banner state; the run row in the
+  // executions table applies the same mapping.
+  const viewedRunStatus = viewedExecution
+    ? viewedExecution.status === 'running' && viewedExecution.waitingFor
+      ? 'waiting'
+      : viewedExecution.status
+    : null;
+
   const { initialNodes, initialEdges } = useAutomationLayout(steps);
 
   useEffect(() => {
@@ -387,22 +417,62 @@ function AutomationStepsInner({
               </div>
             )}
 
-            {showActivityBanner && hasActiveTrigger && (
+            {((showActivityBanner && hasActiveTrigger) ||
+              viewedExecutionId) && (
               <Panel position="top-center" className="mx-4 mt-4 w-full px-4">
-                <div className="mx-auto flex max-w-3xl items-center gap-2.5 rounded-lg bg-amber-50 px-4 py-3 shadow-sm ring-1 ring-amber-200">
-                  <AlertTriangle className="size-5 shrink-0 text-amber-600" />
-                  <Text className="text-sm text-amber-600">
-                    {t('steps.banners.hasActiveTriggers')}
-                  </Text>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="ml-auto size-6 shrink-0 p-1 text-amber-600 hover:bg-amber-100 hover:text-amber-700"
-                    onClick={() => setShowActivityBanner(false)}
-                  >
-                    <X className="size-4" />
-                  </Button>
-                </div>
+                <Stack gap={2} className="mx-auto max-w-3xl">
+                  {showActivityBanner && hasActiveTrigger && (
+                    <div className="flex items-center gap-2.5 rounded-lg bg-amber-50 px-4 py-3 shadow-sm ring-1 ring-amber-200">
+                      <AlertTriangle className="size-5 shrink-0 text-amber-600" />
+                      <Text className="text-sm text-amber-600">
+                        {t('steps.banners.hasActiveTriggers')}
+                      </Text>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="ml-auto size-6 shrink-0 p-1 text-amber-600 hover:bg-amber-100 hover:text-amber-700"
+                        onClick={() => setShowActivityBanner(false)}
+                      >
+                        <X className="size-4" />
+                      </Button>
+                    </div>
+                  )}
+                  {viewedExecutionId && (
+                    <div
+                      className="bg-background ring-border flex items-center gap-2.5 rounded-lg px-4 py-2 shadow-sm ring-1"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <Text className="text-sm">
+                        {t('steps.execution.viewingRun', {
+                          id: viewedExecutionId.slice(-6),
+                        })}
+                      </Text>
+                      {viewedRunStatus && (
+                        <Badge
+                          dot
+                          variant={
+                            RUN_STATUS_BADGE_VARIANTS[viewedRunStatus] ||
+                            'outline'
+                          }
+                          className="text-xs"
+                        >
+                          {t(`steps.execution.status.${viewedRunStatus}`)}
+                        </Badge>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        title={t('steps.execution.clear')}
+                        aria-label={t('steps.execution.clear')}
+                        className="ml-auto size-6 shrink-0 p-1"
+                        onClick={() => setExecutionUrlState('execution', null)}
+                      >
+                        <X className="size-4" />
+                      </Button>
+                    </div>
+                  )}
+                </Stack>
               </Panel>
             )}
 

--- a/services/platform/app/features/automations/components/automation-tester.test.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.test.tsx
@@ -18,9 +18,13 @@ const h = vi.hoisted(() => {
   const fixture: {
     startMock: ReturnType<typeof vi.fn>;
     executionStatus: { data: ExecStatusData | undefined };
+    setUrlState: ReturnType<typeof vi.fn>;
+    urlState: Record<string, string | null>;
   } = {
     startMock: vi.fn(() => Promise.resolve('exec-1')),
     executionStatus: { data: undefined },
+    setUrlState: vi.fn(),
+    urlState: { execution: null },
   };
   return fixture;
 });
@@ -37,6 +41,19 @@ vi.mock('@/lib/i18n/client', () => ({
 }));
 
 vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+// useUrlState wraps TanStack router hooks, which need a RouterProvider; the
+// tester only writes the `execution` param through it, so stub the surface.
+vi.mock('@/app/hooks/use-url-state', () => ({
+  useUrlState: () => ({
+    state: h.urlState,
+    setState: h.setUrlState,
+    setStates: vi.fn(),
+    clearState: vi.fn(),
+    clearAll: vi.fn(),
+    isPending: false,
+  }),
+}));
 
 vi.mock('@/app/hooks/use-persisted-state', () => ({
   usePersistedState: () => ['{}', vi.fn()],
@@ -70,6 +87,7 @@ import { AutomationTester } from './automation-tester';
 afterEach(() => {
   vi.clearAllMocks();
   h.executionStatus = { data: undefined };
+  h.urlState = { execution: null };
 });
 
 async function runExecute() {
@@ -124,6 +142,14 @@ describe('AutomationTester result feedback (#1484)', () => {
       expect(
         screen.getByText('automations.tester.result.completed'),
       ).toBeInTheDocument(),
+    );
+  });
+
+  it('mirrors the started run into the execution URL param (#1487)', async () => {
+    await runExecute();
+
+    await waitFor(() =>
+      expect(h.setUrlState).toHaveBeenCalledWith('execution', 'exec-1'),
     );
   });
 

--- a/services/platform/app/features/automations/components/automation-tester.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.tsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { JsonInput } from '@/app/components/ui/forms/json-input';
 import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
+import { useUrlState } from '@/app/hooks/use-url-state';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -30,6 +31,7 @@ import {
   type InputSchema,
 } from '../utils/input-schema-template';
 import { getStepTypeColor } from '../utils/step-icons';
+import { AUTOMATION_EXECUTION_URL_DEFINITIONS } from './execution-status-context';
 
 interface AutomationTesterProps {
   organizationId: string;
@@ -112,6 +114,11 @@ export function AutomationTester({
   const { data: executionStatus } = useExecutionStatus(
     activeExecutionId ?? undefined,
   );
+
+  // Mirror the started run into the `execution` URL param so the canvas
+  // (via ExecutionStatusProvider) shows live per-node badges for it (#1487).
+  const { state: executionUrlState, setState: setExecutionUrlState } =
+    useUrlState({ definitions: AUTOMATION_EXECUTION_URL_DEFINITIONS });
 
   const { mutateAsync: startWorkflow, isPending: isExecuting } =
     useStartWorkflowFromFile();
@@ -200,6 +207,7 @@ export function AutomationTester({
 
       setDryRunResult(null);
       setActiveExecutionId(executionId);
+      setExecutionUrlState('execution', executionId);
       onTestComplete?.();
     } catch (error) {
       console.error('Test execution failed:', error);
@@ -224,6 +232,11 @@ export function AutomationTester({
             setTestInput(value);
             setDryRunResult(null);
             setActiveExecutionId(null);
+            // Guard: writing URL state navigates — only clear when a run is
+            // actually being viewed, not on every keystroke.
+            if (executionUrlState.execution) {
+              setExecutionUrlState('execution', null);
+            }
           }}
           label={t('tester.inputLabel')}
           description={t('tester.inputDescription')}

--- a/services/platform/app/features/automations/components/execution-status-context.tsx
+++ b/services/platform/app/features/automations/components/execution-status-context.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { useUrlState } from '@/app/hooks/use-url-state';
+import type { ExecutionStepStatuses } from '@/convex/workflows/executions/get_execution_step_statuses';
+
+import { useExecutionStepStatuses } from '../hooks/queries';
+
+/**
+ * Shared "viewed execution" state for the automation detail page.
+ *
+ * The viewed execution id lives in the `execution` URL param (written by the
+ * test panel after starting a run, survives reloads and deep links). This
+ * provider subscribes once to the derived per-node status query and fans the
+ * result out to the canvas nodes via context — NOT via ReactFlow `node.data`,
+ * which would retrigger StoreUpdater on every journal write (see
+ * `AutomationCallbacksProvider` for the render-loop rationale).
+ *
+ * Kept separate from `AUTOMATION_PANEL_URL_DEFINITIONS` so closing a side
+ * panel (`clearAll` on the panel definitions) does not drop the viewed run.
+ */
+export const AUTOMATION_EXECUTION_URL_DEFINITIONS = {
+  execution: { default: null },
+} as const;
+
+interface ExecutionStatusContextValue {
+  executionId: string | null;
+  statuses: ExecutionStepStatuses | null;
+}
+
+const ExecutionStatusContext = createContext<ExecutionStatusContextValue>({
+  executionId: null,
+  statuses: null,
+});
+
+export function ExecutionStatusProvider({ children }: { children: ReactNode }) {
+  const { state } = useUrlState({
+    definitions: AUTOMATION_EXECUTION_URL_DEFINITIONS,
+  });
+  const executionId = state.execution;
+  const { data } = useExecutionStepStatuses(executionId ?? undefined);
+
+  const value = useMemo(
+    () => ({ executionId, statuses: data ?? null }),
+    [executionId, data],
+  );
+
+  return (
+    <ExecutionStatusContext.Provider value={value}>
+      {children}
+    </ExecutionStatusContext.Provider>
+  );
+}
+
+/**
+ * Per-node execution state for one canvas node, or `null` when no execution
+ * is being viewed (or the node has not run). Safe to call without a provider
+ * (returns `null`) so node components stay renderable in isolation.
+ */
+export function useNodeExecutionStatus(stepSlug: string) {
+  const { statuses } = useContext(ExecutionStatusContext);
+  return statuses?.nodes[stepSlug] ?? null;
+}
+
+/** Execution-level view state (id + run summary) for banners and panels. */
+export function useViewedExecution() {
+  const { executionId, statuses } = useContext(ExecutionStatusContext);
+  return { executionId, execution: statuses?.execution ?? null };
+}

--- a/services/platform/app/features/automations/components/node-execution-status-badge.tsx
+++ b/services/platform/app/features/automations/components/node-execution-status-badge.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useLocale } from '@tale/ui/i18n/locale-provider';
+import { Stack } from '@tale/ui/layout';
+import { Popover } from '@tale/ui/popover';
+import { Text } from '@tale/ui/text';
+import {
+  AlertCircle,
+  CheckCircle2,
+  CirclePause,
+  Loader2,
+  XCircle,
+} from 'lucide-react';
+
+import { JsonViewer } from '@/app/components/ui/data-display/json-viewer';
+import type { ExecutionNodeStatus } from '@/convex/workflows/executions/get_execution_step_statuses';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+import { formatDuration } from '@/lib/utils/format/number';
+
+import {
+  useNodeExecutionStatus,
+  useViewedExecution,
+} from './execution-status-context';
+
+const STATUS_ICONS: Record<
+  ExecutionNodeStatus,
+  { Icon: typeof Loader2; className: string }
+> = {
+  running: {
+    Icon: Loader2,
+    className:
+      'animate-spin motion-reduce:animate-none text-blue-600 dark:text-blue-400',
+  },
+  success: {
+    Icon: CheckCircle2,
+    className: 'text-emerald-600 dark:text-emerald-400',
+  },
+  failed: { Icon: AlertCircle, className: 'text-destructive' },
+  waiting: {
+    Icon: CirclePause,
+    className: 'text-amber-600 dark:text-amber-400',
+  },
+  canceled: { Icon: XCircle, className: 'text-muted-foreground' },
+};
+
+interface NodeExecutionStatusBadgeProps {
+  stepSlug: string;
+  className?: string;
+}
+
+/**
+ * Per-node execution status badge for the workflow canvas (#1487). Renders
+ * nothing unless an execution is being viewed AND this node appears in its
+ * journal. Clicking opens a popover with timing, attempts, error and a capped
+ * output preview. Positioned by the caller (absolute top-right of the card);
+ * deliberately a sibling of the card `<button>` — nesting would be invalid
+ * HTML and would swallow the card's open-step click.
+ */
+export function NodeExecutionStatusBadge({
+  stepSlug,
+  className,
+}: NodeExecutionStatusBadgeProps) {
+  const { t } = useT('automations');
+  const { locale } = useLocale();
+  const nodeStatus = useNodeExecutionStatus(stepSlug);
+  const { execution } = useViewedExecution();
+
+  if (!nodeStatus) return null;
+
+  const { Icon, className: iconClassName } = STATUS_ICONS[nodeStatus.status];
+  const statusLabel = t(`steps.execution.status.${nodeStatus.status}`);
+  const durationMs =
+    nodeStatus.completedAt !== undefined && nodeStatus.startedAt !== undefined
+      ? nodeStatus.completedAt - nodeStatus.startedAt
+      : undefined;
+  const isCurrentLoopStep =
+    execution?.loopProgress && execution.currentStepSlug === stepSlug
+      ? execution.loopProgress
+      : undefined;
+
+  return (
+    <Popover
+      align="end"
+      contentClassName="w-80 max-w-80 max-h-96 overflow-y-auto p-3"
+      trigger={
+        <button
+          type="button"
+          aria-label={t('steps.execution.nodeBadgeLabel', {
+            status: statusLabel,
+          })}
+          className={cn(
+            'bg-background ring-border flex size-6 cursor-pointer items-center justify-center rounded-full shadow-sm ring-1',
+            className,
+          )}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Icon className={cn('size-4', iconClassName)} aria-hidden="true" />
+        </button>
+      }
+    >
+      <Stack gap={2}>
+        <Text as="span" variant="label">
+          {statusLabel}
+        </Text>
+
+        {durationMs !== undefined && durationMs >= 0 && (
+          <Text className="text-muted-foreground text-xs">
+            {t('steps.execution.duration', {
+              duration: formatDuration(durationMs, locale),
+            })}
+          </Text>
+        )}
+
+        {nodeStatus.attempts > 1 && (
+          <Text className="text-muted-foreground text-xs">
+            {t('steps.execution.attempts', { count: nodeStatus.attempts })}
+          </Text>
+        )}
+
+        {isCurrentLoopStep && (
+          <Text className="text-muted-foreground text-xs">
+            {t('steps.execution.loopProgress', {
+              current: isCurrentLoopStep.current,
+              total: isCurrentLoopStep.total,
+            })}
+          </Text>
+        )}
+
+        {nodeStatus.error && (
+          <Stack gap={1}>
+            <Text variant="label-sm">{t('steps.execution.error')}</Text>
+            <Text
+              variant="error-sm"
+              className="break-words whitespace-pre-line"
+            >
+              {nodeStatus.error}
+            </Text>
+          </Stack>
+        )}
+
+        {nodeStatus.outputUnavailable && (
+          <Text className="text-muted-foreground text-xs">
+            {t('steps.execution.outputUnavailable')}
+          </Text>
+        )}
+
+        {nodeStatus.outputPreview !== undefined && (
+          <Stack gap={1}>
+            <Text variant="label-sm">{t('steps.execution.output')}</Text>
+            {nodeStatus.outputTruncated && (
+              <Text className="text-muted-foreground text-xs">
+                {t('steps.execution.outputTruncated')}
+              </Text>
+            )}
+            <JsonViewer
+              data={nodeStatus.outputPreview}
+              collapsed={1}
+              className="rounded-md border"
+            />
+          </Stack>
+        )}
+      </Stack>
+    </Popover>
+  );
+}

--- a/services/platform/app/features/automations/hooks/queries.ts
+++ b/services/platform/app/features/automations/hooks/queries.ts
@@ -26,6 +26,20 @@ export function useExecutionStatus(
   );
 }
 
+/**
+ * Reactive per-node statuses for one execution, derived server-side from the
+ * step journal (compact payload keyed by step slug). Drives the canvas node
+ * badges and the test panel's per-step feedback. Accepts a plain string
+ * because the id typically comes from the `execution` URL param; the backend
+ * normalizes and returns `null` for malformed ids.
+ */
+export function useExecutionStepStatuses(executionId: string | undefined) {
+  return useConvexQuery(
+    api.wf_executions.queries.getExecutionStepStatuses,
+    executionId ? { executionId } : 'skip',
+  );
+}
+
 interface ListExecutionsArgs {
   wfDefinitionId: string;
   status?: string[];

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -21,6 +21,7 @@ import { AutomationAIChatPanel } from '@/app/features/automations/components/aut
 import { AutomationNavigation } from '@/app/features/automations/components/automation-navigation';
 import { AutomationSidePanel } from '@/app/features/automations/components/automation-sidepanel';
 import { AUTOMATION_PANEL_URL_DEFINITIONS } from '@/app/features/automations/components/automation-steps';
+import { ExecutionStatusProvider } from '@/app/features/automations/components/execution-status-context';
 import { useReadWorkflow } from '@/app/features/automations/hooks/file-queries';
 import {
   WorkflowConfigProvider,
@@ -456,59 +457,61 @@ function AutomationDetailInner({
       }
       organizationId={organizationId}
     >
-      <div className="relative flex min-h-0 flex-1">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
-          {isExactAutomationPage ? (
-            <SuspenseBoundary
-              fallback={
-                // The ReactFlow canvas is a genuine code-split chunk, so a
-                // fallback is unavoidable while it downloads — but reuse the
-                // SAME step-card placeholder as the route-level loading state
-                // instead of a generic text skeleton. Otherwise the skeleton
-                // visibly "blinks": canvas placeholder → text lines → canvas.
-                <Skeletonize loading className="contents">
-                  <AutomationCanvasSkeleton />
-                </Skeletonize>
-              }
-            >
-              <AutomationSteps
-                hasActiveTrigger={hasActiveTrigger}
-                className="flex-1"
-                // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- file-based steps mapped to Doc shape; component only reads display fields
-                steps={steps as Doc<'wfStepDefs'>[]}
-                onOpenAIChat={handleOpenAIChat}
-              />
-            </SuspenseBoundary>
-          ) : (
-            <Outlet />
+      <ExecutionStatusProvider>
+        <div className="relative flex min-h-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
+            {isExactAutomationPage ? (
+              <SuspenseBoundary
+                fallback={
+                  // The ReactFlow canvas is a genuine code-split chunk, so a
+                  // fallback is unavoidable while it downloads — but reuse the
+                  // SAME step-card placeholder as the route-level loading state
+                  // instead of a generic text skeleton. Otherwise the skeleton
+                  // visibly "blinks": canvas placeholder → text lines → canvas.
+                  <Skeletonize loading className="contents">
+                    <AutomationCanvasSkeleton />
+                  </Skeletonize>
+                }
+              >
+                <AutomationSteps
+                  hasActiveTrigger={hasActiveTrigger}
+                  className="flex-1"
+                  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- file-based steps mapped to Doc shape; component only reads display fields
+                  steps={steps as Doc<'wfStepDefs'>[]}
+                  onOpenAIChat={handleOpenAIChat}
+                />
+              </SuspenseBoundary>
+            ) : (
+              <Outlet />
+            )}
+          </div>
+
+          {isAIChatOpen && !isUrlSidePanelOpen && (
+            <AutomationAIChatPanel
+              workflowSlug={workflowSlug}
+              workflowName={config.name}
+              organizationId={organizationId}
+              onClose={handleCloseAIChat}
+              panelWidth={panelWidth}
+              onPanelWidthChange={setPanelWidth}
+            />
+          )}
+
+          {isUrlSidePanelOpen && (
+            <AutomationSidePanel
+              step={selectedStep}
+              isOpen
+              onClose={clearPanelUrlState}
+              showTestPanel={panelState.panel === 'test'}
+              automationId={workflowSlug}
+              organizationId={organizationId}
+              stepOptions={stepOptions}
+              panelWidth={panelWidth}
+              onPanelWidthChange={setPanelWidth}
+            />
           )}
         </div>
-
-        {isAIChatOpen && !isUrlSidePanelOpen && (
-          <AutomationAIChatPanel
-            workflowSlug={workflowSlug}
-            workflowName={config.name}
-            organizationId={organizationId}
-            onClose={handleCloseAIChat}
-            panelWidth={panelWidth}
-            onPanelWidthChange={setPanelWidth}
-          />
-        )}
-
-        {isUrlSidePanelOpen && (
-          <AutomationSidePanel
-            step={selectedStep}
-            isOpen
-            onClose={clearPanelUrlState}
-            showTestPanel={panelState.panel === 'test'}
-            automationId={workflowSlug}
-            organizationId={organizationId}
-            stepOptions={stepOptions}
-            panelWidth={panelWidth}
-            onPanelWidthChange={setPanelWidth}
-          />
-        )}
-      </div>
+      </ExecutionStatusProvider>
     </PageLayout>
   );
 }

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1261,8 +1261,10 @@ import type * as workflows_executions_delete_storage_blob from "../workflows/exe
 import type * as workflows_executions_fail_execution from "../workflows/executions/fail_execution.js";
 import type * as workflows_executions_get_execution from "../workflows/executions/get_execution.js";
 import type * as workflows_executions_get_execution_step_journal from "../workflows/executions/get_execution_step_journal.js";
+import type * as workflows_executions_get_execution_step_statuses from "../workflows/executions/get_execution_step_statuses.js";
 import type * as workflows_executions_get_org_workflow_metrics from "../workflows/executions/get_org_workflow_metrics.js";
 import type * as workflows_executions_get_raw_execution from "../workflows/executions/get_raw_execution.js";
+import type * as workflows_executions_get_workflow_component from "../workflows/executions/get_workflow_component.js";
 import type * as workflows_executions_get_workflow_execution_stats from "../workflows/executions/get_workflow_execution_stats.js";
 import type * as workflows_executions_helpers from "../workflows/executions/helpers.js";
 import type * as workflows_executions_list_executions from "../workflows/executions/list_executions.js";
@@ -2589,8 +2591,10 @@ declare const fullApi: ApiFromModules<{
   "workflows/executions/fail_execution": typeof workflows_executions_fail_execution;
   "workflows/executions/get_execution": typeof workflows_executions_get_execution;
   "workflows/executions/get_execution_step_journal": typeof workflows_executions_get_execution_step_journal;
+  "workflows/executions/get_execution_step_statuses": typeof workflows_executions_get_execution_step_statuses;
   "workflows/executions/get_org_workflow_metrics": typeof workflows_executions_get_org_workflow_metrics;
   "workflows/executions/get_raw_execution": typeof workflows_executions_get_raw_execution;
+  "workflows/executions/get_workflow_component": typeof workflows_executions_get_workflow_component;
   "workflows/executions/get_workflow_execution_stats": typeof workflows_executions_get_workflow_execution_stats;
   "workflows/executions/helpers": typeof workflows_executions_helpers;
   "workflows/executions/list_executions": typeof workflows_executions_list_executions;

--- a/services/platform/convex/wf_executions/queries.ts
+++ b/services/platform/convex/wf_executions/queries.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 
 import { queryWithRLS } from '../lib/rls';
 import { getExecutionStepJournal as getExecutionStepJournalHelper } from '../workflows/executions/get_execution_step_journal';
+import { getExecutionStepStatuses as getExecutionStepStatusesHelper } from '../workflows/executions/get_execution_step_statuses';
 import { getOrgWorkflowMetrics as getOrgWorkflowMetricsHelper } from '../workflows/executions/get_org_workflow_metrics';
 import { getRawExecution as getRawExecutionHelper } from '../workflows/executions/get_raw_execution';
 import { listExecutionsCursor as listExecutionsCursorHelper } from '../workflows/executions/list_executions_cursor';
@@ -33,6 +34,20 @@ export const getExecutionStepJournal = queryWithRLS({
   },
   handler: async (ctx, args) => {
     return await getExecutionStepJournalHelper(ctx, args);
+  },
+});
+
+export const getExecutionStepStatuses = queryWithRLS({
+  args: {
+    // v.string() + normalizeId instead of v.id: the execution id arrives from
+    // a user-editable URL param, and a malformed value must resolve to `null`
+    // rather than throw an ArgumentValidationError at the subscription.
+    executionId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const executionId = ctx.db.normalizeId('wfExecutions', args.executionId);
+    if (!executionId) return null;
+    return await getExecutionStepStatusesHelper(ctx, { executionId });
   },
 });
 

--- a/services/platform/convex/workflows/executions/get_execution_step_journal.test.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_journal.test.ts
@@ -4,6 +4,19 @@ import type { Id } from '../../_generated/dataModel';
 import type { QueryCtx } from '../../_generated/server';
 import { getExecutionStepJournal } from './get_execution_step_journal';
 
+// Component references resist identity assertions (every property access on
+// the generated `components` proxy mints a new object), so stub the shard
+// lookup with per-shard sentinels and assert those reach `ctx.runQuery`.
+const shardMock = vi.hoisted(() => ({
+  getWorkflowComponentForExecution: vi.fn(
+    (execution: { shardIndex?: number }) => ({
+      journal: { load: `journal-load-shard-${execution.shardIndex ?? 0}` },
+    }),
+  ),
+}));
+
+vi.mock('./get_workflow_component', () => shardMock);
+
 function createMockCtx(
   execution: Record<string, unknown> | null = null,
   journalsByWorkflowId: Record<
@@ -147,6 +160,34 @@ describe('getExecutionStepJournal', () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it('loads the journal from the component of the execution shard', async () => {
+    const ctx = createMockCtx(
+      {
+        _id: 'exec_1',
+        metadata: null,
+        componentWorkflowId: 'wf_1',
+        shardIndex: 2,
+      },
+      {
+        wf_1: {
+          journalEntries: [{ stepNumber: 1, name: 'step' }],
+        },
+      },
+    );
+
+    const result = await getExecutionStepJournal(ctx as unknown as QueryCtx, {
+      executionId: 'exec_1' as Id<'wfExecutions'>,
+    });
+
+    expect(shardMock.getWorkflowComponentForExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ shardIndex: 2 }),
+    );
+    expect(ctx.runQuery).toHaveBeenCalledWith('journal-load-shard-2', {
+      workflowId: 'wf_1',
+    });
+    expect(result).toHaveLength(1);
   });
 
   it('deduplicates workflow IDs from metadata and componentWorkflowId', async () => {

--- a/services/platform/convex/workflows/executions/get_execution_step_journal.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_journal.ts
@@ -1,8 +1,6 @@
-import { components } from '../../_generated/api';
 import type { Id } from '../../_generated/dataModel';
 import type { QueryCtx } from '../../_generated/server';
-
-const workflow = components.workflow;
+import { getWorkflowComponentForExecution } from './get_workflow_component';
 
 export type GetExecutionStepJournalArgs = {
   executionId: Id<'wfExecutions'>;
@@ -14,6 +12,10 @@ export async function getExecutionStepJournal(
 ): Promise<Array<unknown>> {
   const execution = await ctx.db.get(args.executionId);
   if (!execution) return [];
+
+  // Journals live on the component shard the execution was started on —
+  // loading from a fixed shard made ~75% of journals appear empty.
+  const workflow = getWorkflowComponentForExecution(execution);
 
   const metadata: Record<string, unknown> = execution.metadata
     ? JSON.parse(execution.metadata)
@@ -36,7 +38,13 @@ export async function getExecutionStepJournal(
     idsOrdered.map(async (wid) => {
       try {
         return await ctx.runQuery(workflow.journal.load, { workflowId: wid });
-      } catch {
+      } catch (error) {
+        // Cleaned-up component workflows legitimately 404 here; this swallow
+        // also hid the shard-routing bug, so keep a trace of every miss.
+        console.warn(
+          `getExecutionStepJournal: failed to load journal for workflow ${wid}:`,
+          error,
+        );
         return null;
       }
     }),

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Doc, Id } from '../../_generated/dataModel';
+import type { QueryCtx } from '../../_generated/server';
+import {
+  deriveStepStatuses,
+  getExecutionStepStatuses,
+  OUTPUT_PREVIEW_MAX_CHARS,
+} from './get_execution_step_statuses';
+
+vi.mock('./get_workflow_component', () => ({
+  getWorkflowComponentForExecution: vi.fn(() => ({
+    journal: { load: 'journal-load' },
+  })),
+}));
+
+function execution(
+  overrides: Partial<Doc<'wfExecutions'>> = {},
+): Doc<'wfExecutions'> {
+  return {
+    _id: 'exec_1' as Id<'wfExecutions'>,
+    _creationTime: 0,
+    organizationId: 'org_1',
+    wfDefinitionId: null,
+    status: 'running',
+    startedAt: 1000,
+    updatedAt: 1000,
+    workflowSlug: 'nightly-sync',
+    ...overrides,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; only fields read by the helper are populated
+  } as Doc<'wfExecutions'>;
+}
+
+function executeStepEntry(
+  stepSlug: string,
+  step: Record<string, unknown>,
+  stepNumber = 1,
+) {
+  return {
+    stepNumber,
+    step: {
+      name: `${stepSlug} (action)`,
+      args: { stepSlug, stepType: 'action', stepName: stepSlug },
+      startedAt: 1000,
+      completedAt: 2000,
+      inProgress: false,
+      ...step,
+    },
+  };
+}
+
+describe('deriveStepStatuses', () => {
+  it('maps an in-progress executeStep entry to running', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('fetch', {
+          inProgress: true,
+          completedAt: undefined,
+        }),
+      ],
+      execution(),
+    );
+
+    expect(result.nodes.fetch).toMatchObject({
+      status: 'running',
+      attempts: 1,
+      startedAt: 1000,
+    });
+  });
+
+  it('maps a successful executeStep entry to success with its output preview', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('fetch', {
+          runResult: { kind: 'success', returnValue: { port: 'next' } },
+        }),
+      ],
+      execution({
+        variables: JSON.stringify({
+          steps: { fetch: { stepType: 'action', output: { rows: 3 } } },
+        }),
+      }),
+    );
+
+    expect(result.nodes.fetch).toMatchObject({
+      status: 'success',
+      attempts: 1,
+      completedAt: 2000,
+      outputPreview: JSON.stringify({ rows: 3 }),
+    });
+    expect(result.nodes.fetch.outputTruncated).toBeUndefined();
+  });
+
+  it('maps a failed runResult to failed with the error', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('send', {
+          runResult: { kind: 'failed', error: 'SMTP unreachable' },
+        }),
+      ],
+      execution({ status: 'failed' }),
+    );
+
+    expect(result.nodes.send).toMatchObject({
+      status: 'failed',
+      error: 'SMTP unreachable',
+    });
+  });
+
+  it('treats a success runResult routed through the error port as failed', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('lookup', {
+          runResult: {
+            kind: 'success',
+            returnValue: { port: 'error', error: 'missing variable' },
+          },
+        }),
+      ],
+      execution(),
+    );
+
+    expect(result.nodes.lookup).toMatchObject({
+      status: 'failed',
+      error: 'missing variable',
+    });
+  });
+
+  it('maps a canceled runResult to canceled', () => {
+    const result = deriveStepStatuses(
+      [executeStepEntry('fetch', { runResult: { kind: 'canceled' } })],
+      execution(),
+    );
+
+    expect(result.nodes.fetch.status).toBe('canceled');
+  });
+
+  it('maps recordBodyStepFailure entries (stepSlug + error, no stepType) to failed', () => {
+    const result = deriveStepStatuses(
+      [
+        {
+          stepNumber: 4,
+          step: {
+            name: 'recordBodyStepFailure',
+            args: {
+              executionId: 'exec_1',
+              stepSlug: 'body-step',
+              stepName: 'Body step',
+              error: 'iteration 3 blew up',
+            },
+            startedAt: 1500,
+            completedAt: 1600,
+            inProgress: false,
+            runResult: { kind: 'success', returnValue: null },
+          },
+        },
+      ],
+      execution(),
+    );
+
+    expect(result.nodes['body-step']).toMatchObject({
+      status: 'failed',
+      error: 'iteration 3 blew up',
+      stepName: 'Body step',
+    });
+  });
+
+  it('collapses repeated entries per slug to the latest, counting attempts', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry(
+          'loop-body',
+          { runResult: { kind: 'failed', error: 'first try' } },
+          1,
+        ),
+        executeStepEntry(
+          'loop-body',
+          { runResult: { kind: 'success', returnValue: { port: 'next' } } },
+          2,
+        ),
+      ],
+      execution(),
+    );
+
+    expect(result.nodes['loop-body']).toMatchObject({
+      status: 'success',
+      attempts: 2,
+    });
+    expect(result.nodes['loop-body'].error).toBeUndefined();
+  });
+
+  it('ignores framework entries without a stepSlug in args', () => {
+    const result = deriveStepStatuses(
+      [
+        {
+          stepNumber: 1,
+          step: {
+            name: 'updateExecutionStatus',
+            args: { executionId: 'exec_1', status: 'running' },
+            inProgress: false,
+            runResult: { kind: 'success', returnValue: null },
+          },
+        },
+        'not-an-object',
+      ],
+      execution(),
+    );
+
+    expect(result.nodes).toEqual({});
+  });
+
+  it('marks the current step as waiting while the execution waits for input', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('approval', {
+          runResult: { kind: 'success', returnValue: { port: 'next' } },
+        }),
+      ],
+      execution({
+        status: 'running',
+        waitingFor: 'human_input:approval',
+        currentStepSlug: 'approval',
+        currentStepName: 'Approval',
+      }),
+    );
+
+    expect(result.nodes.approval.status).toBe('waiting');
+    expect(result.execution.waitingFor).toBe('human_input:approval');
+  });
+
+  it('flags outputs as unavailable when variables were offloaded to storage', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('fetch', {
+          runResult: { kind: 'success', returnValue: { port: 'next' } },
+        }),
+      ],
+      execution({
+        variables: JSON.stringify({ _storageRef: 'storage_id_1' }),
+      }),
+    );
+
+    expect(result.nodes.fetch.outputUnavailable).toBe(true);
+    expect(result.nodes.fetch.outputPreview).toBeUndefined();
+  });
+
+  it('caps oversized output previews and flags truncation', () => {
+    const big = 'x'.repeat(OUTPUT_PREVIEW_MAX_CHARS + 100);
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('fetch', {
+          runResult: { kind: 'success', returnValue: { port: 'next' } },
+        }),
+      ],
+      execution({
+        variables: JSON.stringify({
+          steps: { fetch: { stepType: 'action', output: big } },
+        }),
+      }),
+    );
+
+    expect(result.nodes.fetch.outputTruncated).toBe(true);
+    expect(result.nodes.fetch.outputPreview).toHaveLength(
+      OUTPUT_PREVIEW_MAX_CHARS,
+    );
+  });
+
+  it('returns the execution summary fields', () => {
+    const result = deriveStepStatuses(
+      [],
+      execution({
+        status: 'failed',
+        error: 'boom',
+        currentStepSlug: 'send',
+        currentStepName: 'Send',
+        completedAt: 5000,
+        loopProgress: { current: 2, total: 5 },
+      }),
+    );
+
+    expect(result.execution).toEqual({
+      status: 'failed',
+      currentStepSlug: 'send',
+      currentStepName: 'Send',
+      waitingFor: undefined,
+      loopProgress: { current: 2, total: 5 },
+      error: 'boom',
+      startedAt: 1000,
+      completedAt: 5000,
+    });
+  });
+});
+
+describe('getExecutionStepStatuses', () => {
+  it('returns null when the execution does not exist', async () => {
+    const ctx = {
+      db: { get: vi.fn().mockResolvedValue(null) },
+      runQuery: vi.fn(),
+    };
+
+    const result = await getExecutionStepStatuses(ctx as unknown as QueryCtx, {
+      executionId: 'missing' as Id<'wfExecutions'>,
+    });
+
+    expect(result).toBeNull();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('derives node statuses from the loaded journal', async () => {
+    const exec = execution({
+      componentWorkflowId: 'wf_1',
+      variables: JSON.stringify({
+        steps: { fetch: { stepType: 'action', output: 'ok' } },
+      }),
+    });
+    const ctx = {
+      db: { get: vi.fn().mockResolvedValue(exec) },
+      runQuery: vi.fn().mockResolvedValue({
+        journalEntries: [
+          executeStepEntry('fetch', {
+            runResult: { kind: 'success', returnValue: { port: 'next' } },
+          }),
+        ],
+      }),
+    };
+
+    const result = await getExecutionStepStatuses(ctx as unknown as QueryCtx, {
+      executionId: 'exec_1' as Id<'wfExecutions'>,
+    });
+
+    expect(result?.nodes.fetch).toMatchObject({
+      status: 'success',
+      outputPreview: JSON.stringify('ok'),
+    });
+  });
+});

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
@@ -1,0 +1,269 @@
+/**
+ * Per-node execution statuses, derived server-side from the step journal and
+ * the execution row. One compact reactive payload keyed by step slug drives
+ * the canvas node badges (#1487), the test-panel per-step feedback (#1484)
+ * and the step-debug inspector (#1490).
+ */
+
+import { getNumber, getString, isRecord } from '../../../lib/utils/type-guards';
+import type { Doc, Id } from '../../_generated/dataModel';
+import type { QueryCtx } from '../../_generated/server';
+import { getExecutionStepJournal } from './get_execution_step_journal';
+
+/** Per-node output previews are capped server-side to keep the reactive payload small. */
+export const OUTPUT_PREVIEW_MAX_CHARS = 8 * 1024;
+
+export type ExecutionNodeStatus =
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'waiting'
+  | 'canceled';
+
+export interface ExecutionNodeState {
+  status: ExecutionNodeStatus;
+  stepName?: string;
+  stepType?: string;
+  /** Number of journal entries for this slug (loop iterations / retries). */
+  attempts: number;
+  startedAt?: number;
+  completedAt?: number;
+  error?: string;
+  /** JSON-stringified `steps.<slug>.output`, capped at OUTPUT_PREVIEW_MAX_CHARS. */
+  outputPreview?: string;
+  outputTruncated?: boolean;
+  /** Variables were offloaded to storage — outputs are not readable from a query. */
+  outputUnavailable?: boolean;
+}
+
+export interface ExecutionStepStatuses {
+  execution: {
+    status: Doc<'wfExecutions'>['status'];
+    currentStepSlug?: string;
+    currentStepName?: string;
+    waitingFor?: string;
+    loopProgress?: { current: number; total: number };
+    error?: string;
+    startedAt: number;
+    completedAt?: number;
+  };
+  nodes: Record<string, ExecutionNodeState>;
+}
+
+interface JournalStepFields {
+  stepSlug: string;
+  stepType?: string;
+  stepName?: string;
+  argsError?: string;
+  inProgress: boolean;
+  startedAt?: number;
+  completedAt?: number;
+  runResult?: Record<string, unknown>;
+}
+
+/**
+ * Extract the fields we care about from one untyped journal entry. Returns
+ * null for framework entries (status mutations, awaitEvent, output
+ * serialization, …) — only entries whose args carry a `stepSlug` describe a
+ * canvas node.
+ */
+function parseJournalEntry(entry: unknown): JournalStepFields | null {
+  if (!isRecord(entry)) return null;
+  const step = entry.step;
+  if (!isRecord(step)) return null;
+  const args = step.args;
+  if (!isRecord(args)) return null;
+  const stepSlug = getString(args, 'stepSlug');
+  if (!stepSlug) return null;
+
+  return {
+    stepSlug,
+    stepType: getString(args, 'stepType'),
+    stepName: getString(args, 'stepName') ?? getString(step, 'name'),
+    argsError: getString(args, 'error'),
+    inProgress: step.inProgress === true,
+    startedAt: getNumber(step, 'startedAt'),
+    completedAt: getNumber(step, 'completedAt'),
+    runResult: isRecord(step.runResult) ? step.runResult : undefined,
+  };
+}
+
+function deriveEntryStatus(
+  fields: JournalStepFields,
+): Pick<ExecutionNodeState, 'status' | 'error'> {
+  // `recordBodyStepFailure` entries (continueOnError loop bodies) carry the
+  // error in args and no stepType; the action itself succeeds, so the
+  // runResult is not authoritative for them.
+  if (!fields.stepType && fields.argsError !== undefined) {
+    return { status: 'failed', error: fields.argsError };
+  }
+  if (fields.inProgress) return { status: 'running' };
+
+  const runResult = fields.runResult;
+  const kind = runResult ? getString(runResult, 'kind') : undefined;
+  if (kind === 'failed') {
+    return {
+      status: 'failed',
+      error: runResult ? getString(runResult, 'error') : undefined,
+    };
+  }
+  if (kind === 'canceled') return { status: 'canceled' };
+  if (kind === 'success') {
+    // executeStep returns `{ port, error? }`; a step that routed through its
+    // error port failed even though the action resolved successfully.
+    const returnValue = runResult?.returnValue;
+    if (isRecord(returnValue) && getString(returnValue, 'port') === 'error') {
+      return {
+        status: 'failed',
+        error: getString(returnValue, 'error'),
+      };
+    }
+    return { status: 'success' };
+  }
+  // No runResult and not in progress: scheduled but not started yet.
+  return { status: 'running' };
+}
+
+interface StepOutputs {
+  outputs: Map<string, unknown>;
+  unavailable: boolean;
+}
+
+/** Read per-step outputs from the execution's inline variables JSON. */
+function readStepOutputs(execution: Doc<'wfExecutions'>): StepOutputs {
+  const empty: StepOutputs = { outputs: new Map(), unavailable: false };
+  if (!execution.variables) return empty;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(execution.variables);
+  } catch (error) {
+    console.warn(
+      `getExecutionStepStatuses: failed to parse variables for execution ${execution._id}:`,
+      error,
+    );
+    return empty;
+  }
+  if (!isRecord(parsed)) return empty;
+  if (parsed._storageRef !== undefined) {
+    // Variables were offloaded to Convex storage (≥400KB) — not readable here.
+    return { outputs: new Map(), unavailable: true };
+  }
+
+  const steps = parsed.steps;
+  if (!isRecord(steps)) return empty;
+
+  const outputs = new Map<string, unknown>();
+  for (const [slug, info] of Object.entries(steps)) {
+    if (isRecord(info) && 'output' in info) {
+      outputs.set(slug, info.output);
+    }
+  }
+  return { outputs, unavailable: false };
+}
+
+function buildOutputPreview(
+  output: unknown,
+): Pick<ExecutionNodeState, 'outputPreview' | 'outputTruncated'> {
+  const json = JSON.stringify(output);
+  if (typeof json !== 'string') return {};
+  if (json.length > OUTPUT_PREVIEW_MAX_CHARS) {
+    return {
+      outputPreview: json.slice(0, OUTPUT_PREVIEW_MAX_CHARS),
+      outputTruncated: true,
+    };
+  }
+  return { outputPreview: json };
+}
+
+/**
+ * Pure derivation: fold the (stepNumber-ordered) journal entries into one
+ * latest-wins state per step slug, then overlay execution-level facts
+ * (waiting-for-input, output previews).
+ */
+export function deriveStepStatuses(
+  journalEntries: Array<unknown>,
+  execution: Doc<'wfExecutions'>,
+): ExecutionStepStatuses {
+  const nodes: Record<string, ExecutionNodeState> = {};
+
+  for (const entry of journalEntries) {
+    const fields = parseJournalEntry(entry);
+    if (!fields) continue;
+
+    const previous = nodes[fields.stepSlug];
+    const { status, error } = deriveEntryStatus(fields);
+    // Entries arrive sorted by stepNumber, so the last entry per slug wins —
+    // for loops this surfaces the latest iteration's status. Only real
+    // executeStep entries count as attempts; a recordBodyStepFailure entry
+    // re-describes an executeStep failure that was already counted.
+    nodes[fields.stepSlug] = {
+      status,
+      stepName: fields.stepName ?? previous?.stepName,
+      stepType: fields.stepType ?? previous?.stepType,
+      attempts: (previous?.attempts ?? 0) + (fields.stepType ? 1 : 0),
+      startedAt: fields.startedAt ?? previous?.startedAt,
+      completedAt: fields.completedAt,
+      error,
+    };
+  }
+
+  // A running execution that waits on an external event (human input,
+  // approval, debug pause) shows the current node as 'waiting'.
+  if (
+    execution.status === 'running' &&
+    execution.waitingFor &&
+    execution.currentStepSlug
+  ) {
+    const current = nodes[execution.currentStepSlug];
+    nodes[execution.currentStepSlug] = current
+      ? { ...current, status: 'waiting' }
+      : {
+          status: 'waiting',
+          stepName: execution.currentStepName,
+          attempts: 0,
+        };
+  }
+
+  const { outputs, unavailable } = readStepOutputs(execution);
+  for (const [slug, node] of Object.entries(nodes)) {
+    if (unavailable) {
+      node.outputUnavailable = true;
+      continue;
+    }
+    if (outputs.has(slug)) {
+      Object.assign(node, buildOutputPreview(outputs.get(slug)));
+    }
+  }
+
+  return {
+    execution: {
+      status: execution.status,
+      currentStepSlug: execution.currentStepSlug,
+      currentStepName: execution.currentStepName,
+      waitingFor: execution.waitingFor,
+      loopProgress: execution.loopProgress,
+      error: execution.error,
+      startedAt: execution.startedAt,
+      completedAt: execution.completedAt,
+    },
+    nodes,
+  };
+}
+
+export type GetExecutionStepStatusesArgs = {
+  executionId: Id<'wfExecutions'>;
+};
+
+export async function getExecutionStepStatuses(
+  ctx: QueryCtx,
+  args: GetExecutionStepStatusesArgs,
+): Promise<ExecutionStepStatuses | null> {
+  const execution = await ctx.db.get(args.executionId);
+  if (!execution) return null;
+
+  const journalEntries = await getExecutionStepJournal(ctx, {
+    executionId: args.executionId,
+  });
+  return deriveStepStatuses(journalEntries, execution);
+}

--- a/services/platform/convex/workflows/executions/get_workflow_component.test.ts
+++ b/services/platform/convex/workflows/executions/get_workflow_component.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getShardIndex,
+  NUM_SHARDS,
+} from '../../workflow_engine/helpers/engine/shard';
+import {
+  getWorkflowComponentForExecution,
+  resolveExecutionShardIndex,
+  WORKFLOW_COMPONENTS,
+} from './get_workflow_component';
+
+describe('resolveExecutionShardIndex', () => {
+  it('prefers the persisted shardIndex when valid', () => {
+    expect(resolveExecutionShardIndex({ _id: 'exec_1', shardIndex: 2 })).toBe(
+      2,
+    );
+  });
+
+  it('derives the shard from the execution id when shardIndex is missing', () => {
+    const id = 'jd7f8gh2k3m4n5p6q7r8s9t0';
+    expect(resolveExecutionShardIndex({ _id: id })).toBe(getShardIndex(id));
+  });
+
+  it('falls back to shard 0 for out-of-range persisted values', () => {
+    expect(resolveExecutionShardIndex({ _id: 'exec_1', shardIndex: 7 })).toBe(
+      0,
+    );
+    expect(resolveExecutionShardIndex({ _id: 'exec_1', shardIndex: -1 })).toBe(
+      0,
+    );
+  });
+});
+
+describe('getWorkflowComponentForExecution', () => {
+  it('exposes one component instance per shard', () => {
+    expect(WORKFLOW_COMPONENTS).toHaveLength(NUM_SHARDS);
+  });
+
+  it('returns the component instance matching the execution shard', () => {
+    for (let shard = 0; shard < NUM_SHARDS; shard++) {
+      expect(
+        getWorkflowComponentForExecution({ _id: 'exec_1', shardIndex: shard }),
+      ).toBe(WORKFLOW_COMPONENTS[shard]);
+    }
+  });
+});

--- a/services/platform/convex/workflows/executions/get_workflow_component.ts
+++ b/services/platform/convex/workflows/executions/get_workflow_component.ts
@@ -1,0 +1,46 @@
+/**
+ * Shard-aware workflow component lookup.
+ *
+ * Executions are distributed across four `@convex-dev/workflow` component
+ * instances (`workflow`, `workflow_1..3`) by `getShardIndex(executionId)` at
+ * start time (see `wf_executions/internal_mutations.ts`). Any read of a
+ * component-side resource (journal, runStatus, …) must target the SAME shard
+ * the execution was started on, otherwise the lookup silently misses.
+ */
+
+import { components } from '../../_generated/api';
+import {
+  getShardIndex,
+  safeShardIndex,
+} from '../../workflow_engine/helpers/engine/shard';
+
+/** Shard-ordered component instances; index = shard index. */
+export const WORKFLOW_COMPONENTS = [
+  components.workflow,
+  components.workflow_1,
+  components.workflow_2,
+  components.workflow_3,
+] as const;
+
+interface ShardedExecution {
+  _id: string;
+  shardIndex?: number;
+}
+
+/**
+ * Resolve the shard an execution runs on. Prefers the persisted `shardIndex`;
+ * falls back to re-deriving it from the execution id — the same hash used at
+ * start time, so the fallback is deterministic for rows written before
+ * `shardIndex` existed.
+ */
+export function resolveExecutionShardIndex(
+  execution: ShardedExecution,
+): number {
+  return safeShardIndex(execution.shardIndex ?? getShardIndex(execution._id));
+}
+
+export function getWorkflowComponentForExecution(
+  execution: ShardedExecution,
+): (typeof WORKFLOW_COMPONENTS)[number] {
+  return WORKFLOW_COMPONENTS[resolveExecutionShardIndex(execution)];
+}

--- a/services/platform/convex/workflows/executions/helpers.ts
+++ b/services/platform/convex/workflows/executions/helpers.ts
@@ -18,3 +18,5 @@ export * from './update_execution_metadata';
 export * from './update_execution_variables';
 export * from './get_workflow_execution_stats';
 export * from './get_execution_step_journal';
+export * from './get_execution_step_statuses';
+export * from './get_workflow_component';

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -606,6 +606,27 @@
         "aiAssistant": "KI-Assistent",
         "testAutomation": "Automatisierung testen",
         "addStep": "Schritt hinzufügen"
+      },
+      "execution": {
+        "viewingRun": "Lauf {id} wird angezeigt",
+        "clear": "Laufergebnisse ausblenden",
+        "nodeBadgeLabel": "Ausführungsstatus: {status}",
+        "duration": "Dauer: {duration}",
+        "attempts": "{count, plural, one {# Versuch} other {# Versuche}}",
+        "loopProgress": "Durchlauf {current} von {total}",
+        "output": "Ausgabe",
+        "error": "Fehler",
+        "outputTruncated": "Ausgabevorschau gekürzt",
+        "outputUnavailable": "Ausgabe ist zu groß für die Vorschau",
+        "status": {
+          "pending": "Ausstehend",
+          "running": "Läuft",
+          "completed": "Abgeschlossen",
+          "failed": "Fehlgeschlagen",
+          "waiting": "Wartet auf Eingabe",
+          "success": "Erfolgreich",
+          "canceled": "Abgebrochen"
+        }
       }
     },
     "stepTypes": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -606,6 +606,27 @@
         "aiAssistant": "AI assistant",
         "testAutomation": "Test automation",
         "addStep": "Add step"
+      },
+      "execution": {
+        "viewingRun": "Viewing run {id}",
+        "clear": "Hide run results",
+        "nodeBadgeLabel": "Execution status: {status}",
+        "duration": "Duration: {duration}",
+        "attempts": "{count, plural, one {# attempt} other {# attempts}}",
+        "loopProgress": "Iteration {current} of {total}",
+        "output": "Output",
+        "error": "Error",
+        "outputTruncated": "Output preview truncated",
+        "outputUnavailable": "Output too large to preview",
+        "status": {
+          "pending": "Pending",
+          "running": "Running",
+          "completed": "Completed",
+          "failed": "Failed",
+          "waiting": "Waiting for input",
+          "success": "Succeeded",
+          "canceled": "Canceled"
+        }
       }
     },
     "stepTypes": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -607,6 +607,27 @@
         "aiAssistant": "Assistant IA",
         "testAutomation": "Tester l'automatisation",
         "addStep": "Ajouter une étape"
+      },
+      "execution": {
+        "viewingRun": "Affichage de l'exécution {id}",
+        "clear": "Masquer les résultats de l'exécution",
+        "nodeBadgeLabel": "Statut d'exécution : {status}",
+        "duration": "Durée : {duration}",
+        "attempts": "{count, plural, one {# tentative} other {# tentatives}}",
+        "loopProgress": "Itération {current} sur {total}",
+        "output": "Sortie",
+        "error": "Erreur",
+        "outputTruncated": "Aperçu de la sortie tronqué",
+        "outputUnavailable": "Sortie trop volumineuse pour l'aperçu",
+        "status": {
+          "pending": "En attente",
+          "running": "En cours",
+          "completed": "Terminée",
+          "failed": "Échouée",
+          "waiting": "En attente de saisie",
+          "success": "Réussie",
+          "canceled": "Annulée"
+        }
       }
     },
     "stepTypes": {


### PR DESCRIPTION
Closes #1487

## What / why

Workflow canvas nodes had no execution awareness — the only runtime feedback was the Executions table. This PR adds live per-node status to the canvas, driven by a single reactive Convex query, and fixes the journal bug that blocked it:

1. **Bug fix — journal shard routing.** `getExecutionStepJournal` loaded journals only from `components.workflow`, while executions are sharded across 4 component instances (`workflow`, `workflow_1..3`) by `getShardIndex(executionId)`. For shards 1–3 the load threw, was silently swallowed, and the journal rendered empty — ~75% of runs. Loads now resolve the component via the execution's persisted `shardIndex` (falling back to the same start-time id hash for rows that predate the field), and the catch logs every miss (`convex/workflows/executions/get_workflow_component.ts`).
2. **`getExecutionStepStatuses` (shared seam for #1484/#1490).** New `queryWithRLS` query deriving a compact per-node map from the journal + execution row, server-side: `running / success / failed / waiting / canceled`, attempts (loop iterations), timing, error (incl. `recordBodyStepFailure` entries and success results routed through the `error` port), and a JSON output preview from `steps.<slug>.output` capped at 8KB/node (`outputTruncated` / `outputUnavailable` for storage-offloaded variables). Takes `v.string()` + `normalizeId` instead of `v.id` because the id arrives from a user-editable URL param — malformed ids resolve to `null` instead of throwing at the subscription.
3. **URL-state + context threading.** The viewed run lives in a new `execution` URL param (separate definitions object, so closing a side panel doesn't drop it; survives reload / deep links). The test panel writes it after `Execute`; `ExecutionStatusProvider` subscribes once and fans the result out to node components via context — not `node.data`, which retriggers ReactFlow's StoreUpdater (same rationale as `AutomationCallbacksProvider`).
4. **Canvas UI.** Status badge on each step card (and loop container) with ring tint on running/failed/waiting; click opens a popover with status, duration, attempts, loop progress, error, and a `JsonViewer` output preview. A dismissable "Viewing run" banner (stacked with the active-triggers banner) names the run and clears the badges.
5. **i18n** (`automations.steps.execution.*` in en/de/fr) and docs (`docs/{en,de,fr}/platform/automations/workflows.md`).

Note: nested-loop body steps show the **latest iteration's** status (latest journal entry per slug wins), with an attempts counter in the popover.

## Decision-gate recommendations baked in

- **Explicit selection only** — badges follow the tester-started run (or an `?execution=` deep link); no auto-follow of trigger/schedule runs. Auto-follow stays a possible fast-follow.
- **`waiting` amber state included** — a running execution with `waitingFor` set marks the current node as waiting (human input / approval pauses), and the banner shows "Waiting for input".
- **8KB per-node output preview cap** — derivation + truncation happen server-side to keep the reactive payload small.
- Exported query name kept as **`getExecutionStepStatuses`** — #1484 and #1490 build on it.

## Verification

Performed:
- `bun run check` at repo root (format, lint, typecheck, all tests) — green.
- `bun run --filter @tale/platform test:ui` — 282 files / 2206 tests green (not part of the root `test` task).
- New unit tests: `get_workflow_component.test.ts` (shard resolution), `get_execution_step_journal.test.ts` (shard-routed load), `get_execution_step_statuses.test.ts` (14 derivation cases incl. body failures, error port, waiting, truncation, storage offload), `automation-step.test.tsx` (badge states, popover, card click, a11y), `automation-tester.test.tsx` (URL-param mirroring).
- `bun run --filter @tale/docs lint` + `test` (locale parity) — green.

Not performed (needs a running stack):
- Live end-to-end repro: run a workflow from the test panel and watch badges progress in real time; shard-bug regression sweep (≥8 executions, journal non-empty for every run); sanity-check of the 8KB cap on an LLM-heavy workflow.

## Manual verification required

- **Design sign-off** (issue is tagged needs-discussion): badge placement (top-right corner overlay), popover contents/width, ring tints, and the viewing-run banner placement need a design pass before polish.

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no loading states added).
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change.
- [x] Every touched docs page has a real opening and closing (existing page, paragraph added mid-page; opening/closing tests pass).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.