### PR TITLE
feat(platform): step-by-step debug mode for automations

### DIFF
--- a/docs/de/platform/automations/workflows.md
+++ b/docs/de/platform/automations/workflows.md
@@ -23,6 +23,8 @@ Das **Automatisierung testen**-Panel in der Editor-Toolbar feuert einen einmalig
 
 Während der Lauf läuft, spiegelt die Canvas ihn live: Jeder Schritt trägt ein Status-Badge — ein Spinner während der Ausführung, ein Häkchen bei Erfolg, ein Warnsymbol bei Fehlern, ein Pause-Symbol beim Warten auf Eingabe — und ein Banner über der Canvas zeigt, welcher Lauf gerade angezeigt wird. Klick auf ein Badge, um Dauer, Fehler und eine Vorschau der Ausgabe des Schritts zu prüfen. Der angezeigte Lauf hängt am URL-Parameter `execution` und übersteht damit ein Neuladen; schließt du das Banner, verschwinden die Badges.
 
+Der **Debuggen**-Button im selben Panel startet den Lauf im Schritt-für-Schritt-Modus. Die Engine hält vor jedem Schritt an: Der pausierte Schritt trägt ein Debug-Badge auf der Canvas, und das Panel zeigt, welcher Schritt als Nächstes dran ist, samt den Variablen des Laufs und der Ausgabe jedes abgeschlossenen Schritts — so prüfst du, was ein Schritt gleich erhält, bevor er läuft. **Schritt** führt den pausierten Schritt aus und hält vor dem nächsten wieder an, **Fortsetzen** lässt den Rest des Workflows ohne weitere Pausen durchlaufen, **Stoppen** bricht den Lauf ab. Debug-Läufe erscheinen im Ausführungen-Tab mit dem Badge _Pausiert (Debug)_, solange sie pausiert sind, und mit `debug` als Auslöser.
+
 Der **Dry run**-Button im selben Panel simuliert einen Lauf ohne Seiteneffekte — der Workflow validiert gegen die Eingabe, läuft den Schritte-Graph ab und meldet Fehler und Warnungen, ohne irgendeinen Agent, eine API oder einen Mail-Server zu rufen. Greif zum Dry Run, wenn der Workflow noch nicht sicher ist, ihn von Anfang bis Ende laufen zu lassen.
 
 ## Pausieren und deaktivieren

--- a/docs/en/platform/automations/workflows.md
+++ b/docs/en/platform/automations/workflows.md
@@ -23,6 +23,8 @@ The **Test automation** panel in the editor toolbar fires a one-off run from the
 
 While the run is live, the canvas mirrors it: every step carries a status badge — a spinner while running, a check on success, an alert on failure, a pause icon while waiting for input — and a banner above the canvas names the run being viewed. Click a badge to inspect the step's duration, error, and a preview of its output. The viewed run rides the `execution` URL parameter, so it survives a reload; dismiss the banner to clear the badges.
 
+The **Debug** button on the same panel starts the run in step-by-step mode. The engine pauses before every step: the paused step carries a debug badge on the canvas, and the panel shows which step is next together with the run's variables and each completed step's output, so you can check what a step is about to receive before it runs. **Step** executes the paused step and pauses again before the next one, **Continue** runs the rest of the workflow without further pauses, **Stop** cancels the run. Debug runs appear in the Executions tab with a _Paused (debug)_ badge while paused and `debug` as their trigger source.
+
 The **Dry run** button on the same panel simulates a run without side effects — the workflow validates against the input, walks the step graph, and reports errors and warnings without calling out to any agent, API, or mail server. Reach for dry run when the workflow is not yet safe to run end to end.
 
 ## Pausing and disabling

--- a/docs/fr/platform/automations/workflows.md
+++ b/docs/fr/platform/automations/workflows.md
@@ -23,6 +23,8 @@ Le panneau **Tester l'automatisation** dans la barre d'outils de l'éditeur déc
 
 Pendant que l'exécution tourne, la canvas la reflète en direct : chaque étape porte un badge de statut — un spinner pendant l'exécution, une coche en cas de succès, une alerte en cas d'échec, une icône pause en attente de saisie — et une bannière au-dessus de la canvas indique l'exécution affichée. Clique sur un badge pour inspecter la durée de l'étape, son erreur et un aperçu de sa sortie. L'exécution affichée tient dans le paramètre d'URL `execution` et survit donc à un rechargement ; ferme la bannière pour masquer les badges.
 
+Le bouton **Déboguer** dans le même panneau lance l'exécution en mode pas à pas. Le moteur s'arrête avant chaque étape : l'étape en pause porte un badge de débogage sur la canvas, et le panneau montre quelle étape vient ensuite, avec les variables de l'exécution et la sortie de chaque étape terminée — tu vérifies donc ce qu'une étape va recevoir avant de la laisser tourner. **Pas à pas** exécute l'étape en pause et s'arrête de nouveau avant la suivante, **Continuer** déroule le reste du workflow sans autre pause, **Arrêter** annule l'exécution. Les exécutions de débogage apparaissent dans l'onglet Exécutions avec un badge _En pause (débogage)_ tant qu'elles sont en pause et `debug` comme source de déclenchement.
+
 Le bouton **Dry run** dans le même panneau simule une exécution sans effets de bord — le workflow valide contre l'entrée, parcourt le graphe d'étapes et signale erreurs et avertissements sans appeler aucun agent, API ou serveur de mail. Sers-toi du dry run quand le workflow n'est pas encore sûr à exécuter de bout en bout.
 
 ## Mettre en pause et désactiver

--- a/services/platform/app/features/automations/components/automation-debug-controls.test.tsx
+++ b/services/platform/app/features/automations/components/automation-debug-controls.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { toId } from '@/convex/lib/type_cast_helpers';
+import { checkAccessibility } from '@/test/utils/a11y';
+import { render } from '@/test/utils/render';
+
+const h = vi.hoisted(() => {
+  const fixture: {
+    resumeMock: ReturnType<typeof vi.fn>;
+    cancelMock: ReturnType<typeof vi.fn>;
+    variablesQuery: {
+      data: unknown;
+      isPending: boolean;
+      isError: boolean;
+    };
+  } = {
+    resumeMock: vi.fn(),
+    cancelMock: vi.fn(),
+    variablesQuery: {
+      data: { steps: {}, variables: {}, input: {} },
+      isPending: false,
+      isError: false,
+    },
+  };
+  return fixture;
+});
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params
+        ? `automations.${key} ${Object.values(params).join(' ')}`
+        : `automations.${key}`,
+  }),
+}));
+
+vi.mock('../hooks/execution-mutations', () => ({
+  useResumeDebugStep: () => ({ mutate: h.resumeMock, isPending: false }),
+  useCancelExecution: () => ({ mutate: h.cancelMock, isPending: false }),
+}));
+
+vi.mock('@/app/hooks/use-action-query', () => ({
+  useActionQuery: () => h.variablesQuery,
+}));
+
+vi.mock('@/app/components/ui/data-display/json-viewer', () => ({
+  JsonViewer: ({ data }: { data: unknown }) => (
+    <pre data-testid="json-viewer">{JSON.stringify(data)}</pre>
+  ),
+}));
+
+import { AutomationDebugControls } from './automation-debug-controls';
+
+const executionId = toId<'wfExecutions'>('exec-1');
+
+function renderControls() {
+  return render(
+    <AutomationDebugControls
+      executionId={executionId}
+      waitingFor="debug:1:send-email"
+      currentStepName="Send email"
+    />,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  h.variablesQuery = {
+    data: { steps: {}, variables: {}, input: {} },
+    isPending: false,
+    isError: false,
+  };
+});
+
+describe('AutomationDebugControls (#1490)', () => {
+  describe('accessibility', () => {
+    it('has no critical accessibility violations', async () => {
+      const { container } = renderControls();
+      await checkAccessibility(container);
+    });
+  });
+
+  it('shows the paused step and the variables inspector', () => {
+    renderControls();
+
+    expect(
+      screen.getByText('automations.tester.debug.pausedAt Send email'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('json-viewer')).toBeInTheDocument();
+  });
+
+  it('sends a step event when Step is clicked', async () => {
+    const user = userEvent.setup();
+    renderControls();
+
+    await user.click(
+      screen.getByRole('button', { name: 'automations.tester.debug.step' }),
+    );
+
+    expect(h.resumeMock).toHaveBeenCalledWith({ executionId, action: 'step' });
+  });
+
+  it('sends a continue event when Continue is clicked', async () => {
+    const user = userEvent.setup();
+    renderControls();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'automations.tester.debug.continue',
+      }),
+    );
+
+    expect(h.resumeMock).toHaveBeenCalledWith({
+      executionId,
+      action: 'continue',
+    });
+  });
+
+  it('cancels the execution when Stop is clicked', async () => {
+    const user = userEvent.setup();
+    renderControls();
+
+    await user.click(
+      screen.getByRole('button', { name: 'automations.tester.debug.stop' }),
+    );
+
+    expect(h.cancelMock).toHaveBeenCalledWith({ executionId });
+  });
+
+  it('shows a loading state while variables are being fetched', () => {
+    h.variablesQuery = { data: undefined, isPending: true, isError: false };
+    renderControls();
+
+    expect(
+      screen.getByText('automations.tester.debug.variablesLoading'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('json-viewer')).not.toBeInTheDocument();
+  });
+
+  it('shows an error state when the variables fetch fails', () => {
+    h.variablesQuery = { data: undefined, isPending: false, isError: true };
+    renderControls();
+
+    expect(
+      screen.getByText('automations.tester.debug.variablesError'),
+    ).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/automations/components/automation-debug-controls.tsx
+++ b/services/platform/app/features/automations/components/automation-debug-controls.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { BorderedSection } from '@tale/ui/bordered-section';
+import { Button } from '@tale/ui/button';
+import { HStack, Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { Bug, FastForward, Loader2, Square, StepForward } from 'lucide-react';
+
+import { JsonViewer } from '@/app/components/ui/data-display/json-viewer';
+import { useActionQuery } from '@/app/hooks/use-action-query';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import {
+  useCancelExecution,
+  useResumeDebugStep,
+} from '../hooks/execution-mutations';
+
+interface AutomationDebugControlsProps {
+  executionId: Id<'wfExecutions'>;
+  /**
+   * The execution's current `waitingFor` value (`debug:<n>:<slug>`). Part of
+   * the variables query key so every new pause refetches the inspector data.
+   */
+  waitingFor: string;
+  currentStepName?: string;
+}
+
+/**
+ * Step / Continue / Stop controls plus the per-step I/O inspector, rendered
+ * by the test panel while a debug run is paused before a node (#1490).
+ */
+export function AutomationDebugControls({
+  executionId,
+  waitingFor,
+  currentStepName,
+}: AutomationDebugControlsProps) {
+  const { t } = useT('automations');
+  const { mutate: resumeDebugStep, isPending: isResuming } =
+    useResumeDebugStep();
+  const { mutate: cancelExecution, isPending: isStopping } =
+    useCancelExecution();
+
+  const {
+    data: variables,
+    isPending: isLoadingVariables,
+    isError: variablesFailed,
+  } = useActionQuery(
+    ['automation-execution-variables', executionId, waitingFor],
+    api.wf_executions.actions.getExecutionVariables,
+    { executionId },
+  );
+
+  const isBusy = isResuming || isStopping;
+
+  return (
+    <BorderedSection
+      className="border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/20"
+      role="status"
+      aria-live="polite"
+    >
+      <Stack gap={2}>
+        <HStack gap={2}>
+          <Bug
+            className="size-4 text-amber-600 dark:text-amber-400"
+            aria-hidden="true"
+          />
+          <Text as="span" variant="label">
+            {t('tester.debug.title')}
+          </Text>
+        </HStack>
+
+        {currentStepName && (
+          <Text className="text-xs text-amber-700 dark:text-amber-300">
+            {t('tester.debug.pausedAt', { step: currentStepName })}
+          </Text>
+        )}
+
+        <HStack gap={2} wrap>
+          <Button
+            size="sm"
+            onClick={() => resumeDebugStep({ executionId, action: 'step' })}
+            disabled={isBusy}
+          >
+            <StepForward className="mr-1 size-4" />
+            {t('tester.debug.step')}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => resumeDebugStep({ executionId, action: 'continue' })}
+            disabled={isBusy}
+          >
+            <FastForward className="mr-1 size-4" />
+            {t('tester.debug.continue')}
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => cancelExecution({ executionId })}
+            disabled={isBusy}
+          >
+            <Square className="mr-1 size-4" />
+            {t('tester.debug.stop')}
+          </Button>
+        </HStack>
+
+        <Stack gap={1}>
+          <Text variant="label-sm">{t('tester.debug.variables')}</Text>
+          {isLoadingVariables ? (
+            <HStack gap={2}>
+              <Loader2
+                className="size-4 animate-spin text-amber-600 motion-reduce:animate-none dark:text-amber-400"
+                aria-hidden="true"
+              />
+              <Text className="text-muted-foreground text-xs">
+                {t('tester.debug.variablesLoading')}
+              </Text>
+            </HStack>
+          ) : variablesFailed ? (
+            <Text variant="error-sm">{t('tester.debug.variablesError')}</Text>
+          ) : (
+            <JsonViewer
+              data={variables}
+              collapsed={1}
+              className="rounded-md border"
+            />
+          )}
+        </Stack>
+      </Stack>
+    </BorderedSection>
+  );
+}

--- a/services/platform/app/features/automations/components/automation-step.tsx
+++ b/services/platform/app/features/automations/components/automation-step.tsx
@@ -97,6 +97,7 @@ export function AutomationStep({ data }: AutomationStepProps) {
         nodeStatus?.status === 'running' && 'ring-2 ring-blue-400',
         nodeStatus?.status === 'failed' && 'ring-2 ring-destructive',
         nodeStatus?.status === 'waiting' && 'ring-2 ring-amber-400',
+        nodeStatus?.status === 'paused' && 'ring-2 ring-amber-400',
       )}
       onClick={() => onNodeClick(data.stepSlug)}
     >

--- a/services/platform/app/features/automations/components/automation-steps.tsx
+++ b/services/platform/app/features/automations/components/automation-steps.tsx
@@ -40,6 +40,7 @@ import React, {
 import { toast } from '@/app/hooks/use-toast';
 import { useUrlState } from '@/app/hooks/use-url-state';
 import { Doc } from '@/convex/_generated/dataModel';
+import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/debug_gate';
 import { useT } from '@/lib/i18n/client';
 
 import { useAutomationLayout } from '../hooks/use-automation-layout';
@@ -88,6 +89,7 @@ const RUN_STATUS_BADGE_VARIANTS: Record<
   running: 'blue',
   pending: 'outline',
   waiting: 'yellow',
+  paused: 'yellow',
 };
 
 const MINIMAP_STYLES = `
@@ -284,11 +286,13 @@ function AutomationStepsInner({
     [steps],
   );
 
-  // Surface waiting-for-input as its own banner state; the run row in the
-  // executions table applies the same mapping.
+  // Surface waiting-for-input and debug pauses as their own banner states;
+  // the run row in the executions table applies the same mapping.
   const viewedRunStatus = viewedExecution
     ? viewedExecution.status === 'running' && viewedExecution.waitingFor
-      ? 'waiting'
+      ? parseDebugWaitingFor(viewedExecution.waitingFor)
+        ? 'paused'
+        : 'waiting'
       : viewedExecution.status
     : null;
 

--- a/services/platform/app/features/automations/components/automation-tester.test.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.test.tsx
@@ -11,6 +11,7 @@ type ExecStatusData = {
   status: string;
   currentStepName?: string;
   error?: string;
+  waitingFor?: string;
 };
 
 // Mutable so each test sets the execution status the subscription returns.
@@ -80,6 +81,14 @@ vi.mock('../hooks/file-mutations', () => ({
 
 vi.mock('../hooks/queries', () => ({
   useExecutionStatus: () => h.executionStatus,
+}));
+
+// The debug controls pull in action-query/mutation hooks that need a Convex
+// provider; the tester test only asserts whether/with what they render.
+vi.mock('./automation-debug-controls', () => ({
+  AutomationDebugControls: (props: { currentStepName?: string }) => (
+    <div data-testid="debug-controls">{props.currentStepName}</div>
+  ),
 }));
 
 import { AutomationTester } from './automation-tester';
@@ -168,5 +177,77 @@ describe('AutomationTester result feedback (#1484)', () => {
     expect(
       screen.getByText('automations.tester.result.runningStep Fetch Data'),
     ).toBeInTheDocument();
+  });
+});
+
+describe('AutomationTester debug mode (#1490)', () => {
+  async function runDebug() {
+    const user = userEvent.setup();
+    render(
+      <AutomationTester organizationId="org-1" workflowSlug="my-workflow" />,
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'automations.tester.debug.button' }),
+    );
+  }
+
+  it('starts the run with debugMode and a distinct trigger source', async () => {
+    await runDebug();
+
+    expect(h.startMock).toHaveBeenCalledTimes(1);
+    expect(h.startMock.mock.calls[0][0]).toMatchObject({
+      organizationId: 'org-1',
+      workflowSlug: 'my-workflow',
+      debugMode: true,
+      triggeredBy: 'debug',
+    });
+  });
+
+  it('does not pass debugMode on a plain Execute run', async () => {
+    await runExecute();
+
+    expect(h.startMock).toHaveBeenCalledTimes(1);
+    expect(h.startMock.mock.calls[0][0]).toMatchObject({
+      triggeredBy: 'test',
+    });
+    expect(h.startMock.mock.calls[0][0]).not.toHaveProperty('debugMode');
+  });
+
+  it('renders the debug controls while the run is paused before a step', async () => {
+    h.executionStatus = {
+      data: {
+        status: 'running',
+        currentStepName: 'Send email',
+        waitingFor: 'debug:1:send-email',
+      },
+    };
+
+    await runDebug();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('debug-controls')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('debug-controls')).toHaveTextContent(
+      'Send email',
+    );
+  });
+
+  it('does not render the debug controls for a human-input pause', async () => {
+    h.executionStatus = {
+      data: {
+        status: 'running',
+        currentStepName: 'Approval',
+        waitingFor: 'approval-id-123',
+      },
+    };
+
+    await runExecute();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('automations.tester.result.running'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('debug-controls')).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/automations/components/automation-tester.tsx
+++ b/services/platform/app/features/automations/components/automation-tester.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   AlertCircle,
   ArrowRight,
+  Bug,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -19,6 +20,7 @@ import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { toast } from '@/app/hooks/use-toast';
 import { useUrlState } from '@/app/hooks/use-url-state';
 import type { Id } from '@/convex/_generated/dataModel';
+import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/debug_gate';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -31,6 +33,7 @@ import {
   type InputSchema,
 } from '../utils/input-schema-template';
 import { getStepTypeColor } from '../utils/step-icons';
+import { AutomationDebugControls } from './automation-debug-controls';
 import { AUTOMATION_EXECUTION_URL_DEFINITIONS } from './execution-status-context';
 
 interface AutomationTesterProps {
@@ -120,8 +123,23 @@ export function AutomationTester({
   const { state: executionUrlState, setState: setExecutionUrlState } =
     useUrlState({ definitions: AUTOMATION_EXECUTION_URL_DEFINITIONS });
 
-  const { mutateAsync: startWorkflow, isPending: isExecuting } =
-    useStartWorkflowFromFile();
+  const {
+    mutateAsync: startWorkflow,
+    isPending: isExecuting,
+    variables: startVariables,
+  } = useStartWorkflowFromFile();
+
+  // Which start button is in flight (the mutation's variables are only set
+  // while it is pending) — keeps the spinner on the button that was clicked.
+  const isDebugStarting = isExecuting && startVariables?.debugMode === true;
+  const isExecuteStarting = isExecuting && !isDebugStarting;
+
+  // Debug-mode pause: the engine sets waitingFor='debug:<n>:<slug>' while it
+  // waits for a Step/Continue event (status stays 'running').
+  const debugPause =
+    executionStatus?.status === 'running'
+      ? parseDebugWaitingFor(executionStatus.waitingFor)
+      : null;
 
   const parsedInput = (() => {
     try {
@@ -164,7 +182,7 @@ export function AutomationTester({
     setIsDryRunning(false);
   };
 
-  const handleExecute = async () => {
+  const handleExecute = async (debugMode: boolean) => {
     setActiveExecutionId(null);
     let input = {};
     try {
@@ -183,12 +201,15 @@ export function AutomationTester({
         organizationId,
         workflowSlug,
         input,
-        triggeredBy: 'test',
+        // Debug runs carry their own trigger source so the Executions tab can
+        // filter them apart from plain test runs.
+        triggeredBy: debugMode ? 'debug' : 'test',
         triggerData: {
           triggerType: 'manual',
-          reason: 'test',
+          reason: debugMode ? 'debug' : 'test',
           timestamp: Date.now(),
         },
+        ...(debugMode ? { debugMode: true } : {}),
       });
 
       if (!executionId) {
@@ -378,6 +399,14 @@ export function AutomationTester({
           </BorderedSection>
         )}
 
+        {activeExecutionId && debugPause && executionStatus?.waitingFor && (
+          <AutomationDebugControls
+            executionId={activeExecutionId}
+            waitingFor={executionStatus.waitingFor}
+            currentStepName={executionStatus.currentStepName}
+          />
+        )}
+
         <BorderedSection className="border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/20">
           <Text className="text-xs text-blue-900 dark:text-blue-100">
             {t('tester.tip')}
@@ -415,11 +444,29 @@ export function AutomationTester({
             )}
           </Button>
           <Button
-            onClick={handleExecute}
+            variant="secondary"
+            onClick={() => handleExecute(true)}
             disabled={isExecuting || isDryRunning || !canRun}
             className="flex-1"
           >
-            {isExecuting ? (
+            {isDebugStarting ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                {t('tester.executing')}
+              </>
+            ) : (
+              <>
+                <Bug className="mr-2 size-4" />
+                {t('tester.debug.button')}
+              </>
+            )}
+          </Button>
+          <Button
+            onClick={() => handleExecute(false)}
+            disabled={isExecuting || isDryRunning || !canRun}
+            className="flex-1"
+          >
+            {isExecuteStarting ? (
               <>
                 <Loader2 className="mr-2 size-4 animate-spin" />
                 {t('tester.executing')}

--- a/services/platform/app/features/automations/components/node-execution-status-badge.tsx
+++ b/services/platform/app/features/automations/components/node-execution-status-badge.tsx
@@ -6,6 +6,7 @@ import { Popover } from '@tale/ui/popover';
 import { Text } from '@tale/ui/text';
 import {
   AlertCircle,
+  Bug,
   CheckCircle2,
   CirclePause,
   Loader2,
@@ -39,6 +40,10 @@ const STATUS_ICONS: Record<
   failed: { Icon: AlertCircle, className: 'text-destructive' },
   waiting: {
     Icon: CirclePause,
+    className: 'text-amber-600 dark:text-amber-400',
+  },
+  paused: {
+    Icon: Bug,
     className: 'text-amber-600 dark:text-amber-400',
   },
   canceled: { Icon: XCircle, className: 'text-muted-foreground' },

--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -15,6 +15,7 @@ import { JsonViewer } from '@/app/components/ui/data-display/json-viewer';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
 import { useListPage } from '@/app/hooks/use-list-page';
 import type { Doc } from '@/convex/_generated/dataModel';
+import { parseDebugWaitingFor } from '@/convex/workflow_engine/helpers/engine/debug_gate';
 import { useT } from '@/lib/i18n/client';
 import { formatDuration } from '@/lib/utils/format/number';
 
@@ -45,6 +46,7 @@ const STATUS_BADGE_VARIANTS: Record<
   running: 'blue',
   pending: 'outline',
   waiting_for_input: 'yellow',
+  paused_debug: 'yellow',
 };
 
 type Execution = Doc<'wfExecutions'>;
@@ -169,7 +171,11 @@ export function ExecutionsTable({
   const getStatusBadge = useCallback(
     (statusVal: string, waitingFor?: string) => {
       const displayStatus =
-        statusVal === 'running' && waitingFor ? 'waiting_for_input' : statusVal;
+        statusVal === 'running' && waitingFor
+          ? parseDebugWaitingFor(waitingFor)
+            ? 'paused_debug'
+            : 'waiting_for_input'
+          : statusVal;
       return (
         <Badge
           dot
@@ -178,7 +184,9 @@ export function ExecutionsTable({
         >
           {displayStatus === 'waiting_for_input'
             ? tCommon('status.waitingForInput')
-            : statusVal}
+            : displayStatus === 'paused_debug'
+              ? tCommon('status.pausedDebug')
+              : statusVal}
         </Badge>
       );
     },
@@ -401,6 +409,7 @@ export function ExecutionsTable({
           { value: 'webhook', label: tCommon('triggerSource.webhook') },
           { value: 'api', label: tCommon('triggerSource.api') },
           { value: 'system', label: tCommon('triggerSource.system') },
+          { value: 'debug', label: tCommon('triggerSource.debug') },
         ],
         selectedValues: triggeredBy ? [triggeredBy] : [],
         onChange: handleTriggeredByChange,

--- a/services/platform/app/features/automations/hooks/execution-mutations.ts
+++ b/services/platform/app/features/automations/hooks/execution-mutations.ts
@@ -1,0 +1,15 @@
+import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
+import { api } from '@/convex/_generated/api';
+
+/**
+ * Resume a debug-paused execution: 'step' runs the paused node and pauses
+ * again before the next one, 'continue' runs to the end (#1490).
+ */
+export function useResumeDebugStep() {
+  return useConvexMutation(api.wf_executions.mutations.resumeDebugStep);
+}
+
+/** Cancel a running execution (also serves as debug "Stop"). */
+export function useCancelExecution() {
+  return useConvexMutation(api.wf_executions.mutations.cancelExecution);
+}

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1157,6 +1157,7 @@ import type * as workflow_engine_helpers_data_source_types from "../workflow_eng
 import type * as workflow_engine_helpers_engine_build_steps_config_map from "../workflow_engine/helpers/engine/build_steps_config_map.js";
 import type * as workflow_engine_helpers_engine_build_workflow_user_profile from "../workflow_engine/helpers/engine/build_workflow_user_profile.js";
 import type * as workflow_engine_helpers_engine_cleanup_component_workflow from "../workflow_engine/helpers/engine/cleanup_component_workflow.js";
+import type * as workflow_engine_helpers_engine_debug_gate from "../workflow_engine/helpers/engine/debug_gate.js";
 import type * as workflow_engine_helpers_engine_dynamic_workflow_handler from "../workflow_engine/helpers/engine/dynamic_workflow_handler.js";
 import type * as workflow_engine_helpers_engine_execute_step_handler from "../workflow_engine/helpers/engine/execute_step_handler.js";
 import type * as workflow_engine_helpers_engine_index from "../workflow_engine/helpers/engine/index.js";
@@ -1256,6 +1257,7 @@ import type * as workflow_engine_types_index from "../workflow_engine/types/inde
 import type * as workflow_engine_types_nodes from "../workflow_engine/types/nodes.js";
 import type * as workflow_engine_types_workflow from "../workflow_engine/types/workflow.js";
 import type * as workflow_engine_types_workflow_types from "../workflow_engine/types/workflow_types.js";
+import type * as workflows_executions_build_variables_inspection from "../workflows/executions/build_variables_inspection.js";
 import type * as workflows_executions_cleanup_execution_storage from "../workflows/executions/cleanup_execution_storage.js";
 import type * as workflows_executions_complete_execution from "../workflows/executions/complete_execution.js";
 import type * as workflows_executions_delete_storage_blob from "../workflows/executions/delete_storage_blob.js";
@@ -1273,6 +1275,7 @@ import type * as workflows_executions_list_executions_cursor from "../workflows/
 import type * as workflows_executions_list_executions_paginated_native from "../workflows/executions/list_executions_paginated_native.js";
 import type * as workflows_executions_patch_execution from "../workflows/executions/patch_execution.js";
 import type * as workflows_executions_persist_execution_output from "../workflows/executions/persist_execution_output.js";
+import type * as workflows_executions_resume_debug_step from "../workflows/executions/resume_debug_step.js";
 import type * as workflows_executions_resume_execution from "../workflows/executions/resume_execution.js";
 import type * as workflows_executions_set_component_workflow from "../workflows/executions/set_component_workflow.js";
 import type * as workflows_executions_types from "../workflows/executions/types.js";
@@ -2488,6 +2491,7 @@ declare const fullApi: ApiFromModules<{
   "workflow_engine/helpers/engine/build_steps_config_map": typeof workflow_engine_helpers_engine_build_steps_config_map;
   "workflow_engine/helpers/engine/build_workflow_user_profile": typeof workflow_engine_helpers_engine_build_workflow_user_profile;
   "workflow_engine/helpers/engine/cleanup_component_workflow": typeof workflow_engine_helpers_engine_cleanup_component_workflow;
+  "workflow_engine/helpers/engine/debug_gate": typeof workflow_engine_helpers_engine_debug_gate;
   "workflow_engine/helpers/engine/dynamic_workflow_handler": typeof workflow_engine_helpers_engine_dynamic_workflow_handler;
   "workflow_engine/helpers/engine/execute_step_handler": typeof workflow_engine_helpers_engine_execute_step_handler;
   "workflow_engine/helpers/engine/index": typeof workflow_engine_helpers_engine_index;
@@ -2587,6 +2591,7 @@ declare const fullApi: ApiFromModules<{
   "workflow_engine/types/nodes": typeof workflow_engine_types_nodes;
   "workflow_engine/types/workflow": typeof workflow_engine_types_workflow;
   "workflow_engine/types/workflow_types": typeof workflow_engine_types_workflow_types;
+  "workflows/executions/build_variables_inspection": typeof workflows_executions_build_variables_inspection;
   "workflows/executions/cleanup_execution_storage": typeof workflows_executions_cleanup_execution_storage;
   "workflows/executions/complete_execution": typeof workflows_executions_complete_execution;
   "workflows/executions/delete_storage_blob": typeof workflows_executions_delete_storage_blob;
@@ -2604,6 +2609,7 @@ declare const fullApi: ApiFromModules<{
   "workflows/executions/list_executions_paginated_native": typeof workflows_executions_list_executions_paginated_native;
   "workflows/executions/patch_execution": typeof workflows_executions_patch_execution;
   "workflows/executions/persist_execution_output": typeof workflows_executions_persist_execution_output;
+  "workflows/executions/resume_debug_step": typeof workflows_executions_resume_debug_step;
   "workflows/executions/resume_execution": typeof workflows_executions_resume_execution;
   "workflows/executions/set_component_workflow": typeof workflows_executions_set_component_workflow;
   "workflows/executions/types": typeof workflows_executions_types;

--- a/services/platform/convex/wf_executions/actions.ts
+++ b/services/platform/convex/wf_executions/actions.ts
@@ -8,6 +8,9 @@ import type { Id } from '../_generated/dataModel';
 import { action } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { resolveOrgSlug } from '../organizations/resolve_org_slug';
+import { deserializeVariablesInAction } from '../workflow_engine/helpers/serialization/deserialize_variables';
+import type { ExecutionVariablesInspection } from '../workflows/executions/build_variables_inspection';
+import { buildVariablesInspection } from '../workflows/executions/build_variables_inspection';
 
 export const startWorkflowFromFile = action({
   args: {
@@ -16,6 +19,7 @@ export const startWorkflowFromFile = action({
     input: v.optional(jsonValueValidator),
     triggeredBy: v.string(),
     triggerData: v.optional(jsonValueValidator),
+    debugMode: v.optional(v.boolean()),
   },
   returns: v.union(v.id('wfExecutions'), v.null()),
   handler: async (ctx, args): Promise<Id<'wfExecutions'> | null> => {
@@ -49,7 +53,57 @@ export const startWorkflowFromFile = action({
         triggeredBy: args.triggeredBy,
         triggerData: args.triggerData,
         userId: authUser.userId,
+        debugMode: args.debugMode,
       },
     );
+  },
+});
+
+/**
+ * Per-step I/O inspection for the step-debug panel (#1490). An action (not a
+ * query) because variables ≥400KB are offloaded to Convex storage, which only
+ * actions can read; outputs are capped server-side before returning.
+ */
+export const getExecutionVariables = action({
+  args: {
+    executionId: v.id('wfExecutions'),
+  },
+  returns: v.object({
+    input: v.optional(jsonValueValidator),
+    variables: jsonValueValidator,
+    steps: jsonValueValidator,
+    lastOutput: v.optional(jsonValueValidator),
+    lastOutputTruncated: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, args): Promise<ExecutionVariablesInspection> => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) {
+      throw new Error('Unauthenticated');
+    }
+
+    const execution = await ctx.runQuery(
+      internal.wf_executions.internal_queries.getRawExecution,
+      { executionId: args.executionId },
+    );
+    if (!execution) {
+      throw new Error('Execution not found');
+    }
+
+    // Throws when the caller is not a member of the execution's organization.
+    await ctx.runQuery(
+      internal.approvals.internal_queries.verifyOrganizationMembership,
+      {
+        organizationId: execution.organizationId,
+        userId: authUser.userId,
+        email: authUser.email,
+        name: authUser.name,
+      },
+    );
+
+    const variables = await deserializeVariablesInAction(
+      ctx,
+      execution.variables,
+    );
+    return buildVariablesInspection(variables, execution.input);
   },
 });

--- a/services/platform/convex/wf_executions/internal_mutations.ts
+++ b/services/platform/convex/wf_executions/internal_mutations.ts
@@ -144,6 +144,7 @@ export const startWorkflowFromFileConfig = internalMutation({
     triggeredBy: v.string(),
     triggerData: v.optional(jsonValueValidator),
     userId: v.optional(v.string()),
+    debugMode: v.optional(v.boolean()),
   },
   returns: v.id('wfExecutions'),
   handler: async (ctx, args) => {
@@ -219,6 +220,7 @@ export const startWorkflowFromFileConfig = internalMutation({
           input: toConvexJsonValue(args.input || {}),
           triggeredBy: args.triggeredBy,
           triggerData: toConvexJsonValue(args.triggerData || {}),
+          debugMode: args.debugMode,
         },
         {
           // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- our onComplete handler is compatible at runtime

--- a/services/platform/convex/wf_executions/mutations.ts
+++ b/services/platform/convex/wf_executions/mutations.ts
@@ -9,8 +9,20 @@ import { toId } from '../lib/type_cast_helpers';
 import { workflowManagers } from '../workflow_engine/engine';
 import { safeShardIndex } from '../workflow_engine/helpers/engine/shard';
 import { STORAGE_RETENTION_MS } from '../workflows/executions/cleanup_execution_storage';
+import { resumeDebugStep as resumeDebugStepHandler } from '../workflows/executions/resume_debug_step';
 
 const CLEANUP_DELAY_MS = 10_000;
+
+export const resumeDebugStep = mutationWithRLS({
+  args: {
+    executionId: v.id('wfExecutions'),
+    action: v.union(v.literal('step'), v.literal('continue')),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    return await resumeDebugStepHandler(ctx, args);
+  },
+});
 
 export const cancelExecution = mutationWithRLS({
   args: {

--- a/services/platform/convex/workflow_engine/engine.ts
+++ b/services/platform/convex/workflow_engine/engine.ts
@@ -36,6 +36,7 @@ const dynamicWorkflowDef = {
     resumeFromStepSlug: v.optional(v.string()),
     resumeVariables: v.optional(jsonValueValidator),
     threadId: v.optional(v.string()),
+    debugMode: v.optional(v.boolean()),
   },
   handler: async (
     step: WorkflowCtx,

--- a/services/platform/convex/workflow_engine/helpers/engine/debug_gate.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/debug_gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDebugWaitingFor,
+  debugEventName,
+  parseDebugWaitingFor,
+} from './debug_gate';
+
+describe('debugEventName / buildDebugWaitingFor', () => {
+  it('builds the per-pause event name', () => {
+    expect(debugEventName(1)).toBe('debug:1');
+    expect(debugEventName(42)).toBe('debug:42');
+  });
+
+  it('builds the waitingFor marker with the step slug', () => {
+    expect(buildDebugWaitingFor(3, 'send-email')).toBe('debug:3:send-email');
+  });
+});
+
+describe('parseDebugWaitingFor', () => {
+  it('round-trips a built waitingFor marker', () => {
+    expect(parseDebugWaitingFor(buildDebugWaitingFor(7, 'fetch-data'))).toEqual(
+      {
+        pauseIndex: 7,
+        stepSlug: 'fetch-data',
+      },
+    );
+  });
+
+  it('keeps colons inside the step slug intact', () => {
+    expect(parseDebugWaitingFor('debug:2:loop:body:step')).toEqual({
+      pauseIndex: 2,
+      stepSlug: 'loop:body:step',
+    });
+  });
+
+  it('returns null for empty or missing values', () => {
+    expect(parseDebugWaitingFor(undefined)).toBeNull();
+    expect(parseDebugWaitingFor('')).toBeNull();
+  });
+
+  it('returns null for non-debug waitingFor values (approval ids)', () => {
+    expect(parseDebugWaitingFor('jd7f8gh2k3m4n5p6q7r8s9t0')).toBeNull();
+  });
+
+  it('returns null for malformed debug markers', () => {
+    expect(parseDebugWaitingFor('debug:')).toBeNull();
+    expect(parseDebugWaitingFor('debug:1')).toBeNull();
+    expect(parseDebugWaitingFor('debug:abc:slug')).toBeNull();
+    expect(parseDebugWaitingFor('debug:0:slug')).toBeNull();
+    expect(parseDebugWaitingFor('debug:1:')).toBeNull();
+  });
+});

--- a/services/platform/convex/workflow_engine/helpers/engine/debug_gate.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/debug_gate.ts
@@ -1,0 +1,55 @@
+/**
+ * Debug-mode pause gate shared between the workflow engine (awaitEvent side),
+ * the resume mutation (sendEvent side) and the UI (waitingFor detection).
+ *
+ * A debug pause is encoded on the execution row as
+ * `waitingFor = 'debug:<pauseIndex>:<stepSlug>'` while `status` stays
+ * 'running' — the same convention human-input approvals use, so the
+ * stuck-execution watchdog, status filters and metrics need no changes. The
+ * matching workflow event is named `debug:<pauseIndex>`; indexing each pause
+ * prevents a double-clicked "Step" from queueing a second event that would
+ * silently skip the next pause.
+ */
+
+import { v } from 'convex/values';
+
+export const DEBUG_WAITING_PREFIX = 'debug:';
+
+export type DebugResumeAction = 'step' | 'continue';
+
+export const debugResumeEventValidator = v.object({
+  action: v.union(v.literal('step'), v.literal('continue')),
+});
+
+export function debugEventName(pauseIndex: number): string {
+  return `${DEBUG_WAITING_PREFIX}${pauseIndex}`;
+}
+
+export function buildDebugWaitingFor(
+  pauseIndex: number,
+  stepSlug: string,
+): string {
+  return `${DEBUG_WAITING_PREFIX}${pauseIndex}:${stepSlug}`;
+}
+
+export interface DebugPause {
+  pauseIndex: number;
+  stepSlug: string;
+}
+
+/**
+ * Parse a `waitingFor` value into its debug-pause parts, or `null` when the
+ * execution is not paused in debug mode (no value, approval id, malformed).
+ */
+export function parseDebugWaitingFor(
+  waitingFor: string | undefined,
+): DebugPause | null {
+  if (!waitingFor || !waitingFor.startsWith(DEBUG_WAITING_PREFIX)) return null;
+  const rest = waitingFor.slice(DEBUG_WAITING_PREFIX.length);
+  const separator = rest.indexOf(':');
+  if (separator <= 0) return null;
+  const pauseIndex = Number(rest.slice(0, separator));
+  const stepSlug = rest.slice(separator + 1);
+  if (!Number.isInteger(pauseIndex) || pauseIndex < 1 || !stepSlug) return null;
+  return { pauseIndex, stepSlug };
+}

--- a/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import type { WorkflowCtx } from '@convex-dev/workflow';
+import { describe, it, expect, vi } from 'vitest';
+
+import { toId } from '../../../lib/type_cast_helpers';
+import type { DynamicWorkflowArgs } from './dynamic_workflow_handler';
+import { handleDynamicWorkflow } from './dynamic_workflow_handler';
 
 // buildRetryBehaviorFromPolicy is not exported, so we test it via re-export
 // or inline the logic. Since it's a private function, we test the extracted logic.
@@ -65,5 +70,153 @@ describe('buildRetryBehaviorFromPolicy', () => {
     });
 
     expect(result?.base).toBe(2);
+  });
+});
+
+// --- Debug-mode pause gate (#1490) ---
+
+interface MockStepCtx {
+  runAction: ReturnType<typeof vi.fn>;
+  runMutation: ReturnType<typeof vi.fn>;
+  awaitEvent: ReturnType<typeof vi.fn>;
+}
+
+function createMockStepCtx(
+  resumeActions: Array<'step' | 'continue'>,
+): MockStepCtx {
+  let pauseCount = 0;
+  return {
+    // executeStep entries carry a stepSlug; the trailing
+    // serializeExecutionOutput call does not and returns null.
+    runAction: vi.fn((_ref: unknown, args: Record<string, unknown>) =>
+      Promise.resolve(args && 'stepSlug' in args ? { port: 'success' } : null),
+    ),
+    runMutation: vi.fn(() => Promise.resolve(null)),
+    awaitEvent: vi.fn(() => {
+      const action = resumeActions[pauseCount] ?? 'step';
+      pauseCount += 1;
+      return Promise.resolve({ action });
+    }),
+  };
+}
+
+function createWorkflowArgs(
+  overrides?: Partial<DynamicWorkflowArgs>,
+): DynamicWorkflowArgs {
+  return {
+    organizationId: 'org-1',
+    executionId: toId<'wfExecutions'>('exec-1'),
+    workflowDefinition: {
+      name: 'Test workflow',
+      status: 'draft',
+      config: {},
+    },
+    steps: [
+      {
+        stepSlug: 'step-1',
+        stepType: 'start',
+        name: 'Start',
+        organizationId: 'org-1',
+        nextSteps: { success: 'step-2' },
+        config: {},
+      },
+      {
+        stepSlug: 'step-2',
+        stepType: 'action',
+        name: 'Do thing',
+        organizationId: 'org-1',
+        nextSteps: {},
+        config: {},
+      },
+    ],
+    triggeredBy: 'test',
+    ...overrides,
+  };
+}
+
+function executedStepSlugs(ctx: MockStepCtx): string[] {
+  return ctx.runAction.mock.calls
+    .map((call: unknown[]) => {
+      const args = call[1];
+      return args && typeof args === 'object' && 'stepSlug' in args
+        ? String((args as Record<string, unknown>).stepSlug)
+        : null;
+    })
+    .filter((slug): slug is string => slug !== null);
+}
+
+function asWorkflowCtx(ctx: MockStepCtx): WorkflowCtx {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only: minimal WorkflowCtx surface
+  return ctx as unknown as WorkflowCtx;
+}
+
+describe('handleDynamicWorkflow debug gate', () => {
+  it('does not pause when debugMode is off', async () => {
+    const ctx = createMockStepCtx([]);
+
+    await handleDynamicWorkflow(asWorkflowCtx(ctx), createWorkflowArgs());
+
+    expect(ctx.awaitEvent).not.toHaveBeenCalled();
+    expect(executedStepSlugs(ctx)).toEqual(['step-1', 'step-2']);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('pauses before every step while stepping', async () => {
+    const ctx = createMockStepCtx(['step', 'step']);
+
+    await handleDynamicWorkflow(
+      asWorkflowCtx(ctx),
+      createWorkflowArgs({ debugMode: true }),
+    );
+
+    expect(ctx.awaitEvent).toHaveBeenCalledTimes(2);
+    expect(ctx.awaitEvent.mock.calls[0][0]).toMatchObject({ name: 'debug:1' });
+    expect(ctx.awaitEvent.mock.calls[1][0]).toMatchObject({ name: 'debug:2' });
+    expect(executedStepSlugs(ctx)).toEqual(['step-1', 'step-2']);
+  });
+
+  it('pauses BEFORE the step executes and journals the pause on the execution row', async () => {
+    const ctx = createMockStepCtx(['step', 'step']);
+
+    await handleDynamicWorkflow(
+      asWorkflowCtx(ctx),
+      createWorkflowArgs({ debugMode: true }),
+    );
+
+    // The pause-marker mutation and the awaitEvent both happen before the
+    // first executeStep runAction.
+    const firstAwaitOrder = ctx.awaitEvent.mock.invocationCallOrder[0];
+    const firstActionOrder = ctx.runAction.mock.invocationCallOrder[0];
+    expect(firstAwaitOrder).toBeLessThan(firstActionOrder);
+
+    // First mutation sets the debug waitingFor marker for step-1…
+    expect(ctx.runMutation.mock.calls[0][1]).toMatchObject({
+      status: 'running',
+      currentStepSlug: 'step-1',
+      currentStepName: 'Start',
+      waitingFor: 'debug:1:step-1',
+    });
+    // …and the next one clears it after the resume event.
+    expect(ctx.runMutation.mock.calls[1][1]).toMatchObject({
+      status: 'running',
+      waitingFor: '',
+    });
+    // Second pause targets step-2 with the next pause index.
+    expect(ctx.runMutation.mock.calls[2][1]).toMatchObject({
+      currentStepSlug: 'step-2',
+      waitingFor: 'debug:2:step-2',
+    });
+  });
+
+  it('stops pausing after a continue event', async () => {
+    const ctx = createMockStepCtx(['continue']);
+
+    await handleDynamicWorkflow(
+      asWorkflowCtx(ctx),
+      createWorkflowArgs({ debugMode: true }),
+    );
+
+    expect(ctx.awaitEvent).toHaveBeenCalledTimes(1);
+    expect(executedStepSlugs(ctx)).toEqual(['step-1', 'step-2']);
   });
 });

--- a/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/dynamic_workflow_handler.ts
@@ -14,6 +14,11 @@ import { jsonValueValidator } from '../../../lib/validators/json';
 type ConvexJsonValue = Infer<typeof jsonValueValidator>;
 
 import { createDebugLog } from '../../../lib/debug_log';
+import {
+  buildDebugWaitingFor,
+  debugEventName,
+  debugResumeEventValidator,
+} from './debug_gate';
 
 const debugLog = createDebugLog('DEBUG_WORKFLOW', '[Workflow]');
 
@@ -28,6 +33,14 @@ export type DynamicWorkflowArgs = {
   resumeFromStepSlug?: string;
   resumeVariables?: ConvexJsonValue;
   threadId?: string;
+  /**
+   * Step-by-step debug mode: the engine pauses before every node until the
+   * user sends a `debug:<pauseIndex>` event ('step' pauses again before the
+   * next node, 'continue' runs to the end). Journaled with the workflow args,
+   * so replays of in-flight executions are deterministic — runs started
+   * without the flag never hit the gate.
+   */
+  debugMode?: boolean;
 };
 
 function buildRetryBehaviorFromPolicy(policy?: {
@@ -107,10 +120,57 @@ export async function handleDynamicWorkflow(
   // outward and recover at the first loop that opted in.
   const activeLoopStack: string[] = [];
 
+  // Debug gate state: `pauseIndex` increments deterministically per pause so
+  // each awaitEvent gets a unique, journal-stable event name.
+  let runToEnd = !args.debugMode;
+  let pauseIndex = 0;
+
   while (currentStepSlug) {
     const stepDef = stepMap.get(currentStepSlug);
     if (!stepDef) {
       throw new Error(`Step not found: ${currentStepSlug}`);
+    }
+
+    if (!runToEnd) {
+      pauseIndex += 1;
+      debugLog('dynamicWorkflow Debug pause before step', {
+        executionId,
+        stepSlug: stepDef.stepSlug,
+        pauseIndex,
+      });
+
+      // Surface the pause on the execution row (status stays 'running', same
+      // convention as human-input approvals — watchdog/filter safe).
+      await step.runMutation(
+        internal.wf_executions.internal_mutations.updateExecutionStatus,
+        {
+          executionId,
+          status: 'running',
+          currentStepSlug: stepDef.stepSlug,
+          currentStepName: stepDef.name,
+          waitingFor: buildDebugWaitingFor(pauseIndex, stepDef.stepSlug),
+        },
+      );
+
+      const resume = await step.awaitEvent({
+        name: debugEventName(pauseIndex),
+        validator: debugResumeEventValidator,
+      });
+
+      if (resume.action === 'continue') {
+        runToEnd = true;
+      }
+
+      // Clear waitingFor (empty string signals "clear" since Convex strips
+      // undefined values from serialized args).
+      await step.runMutation(
+        internal.wf_executions.internal_mutations.updateExecutionStatus,
+        {
+          executionId,
+          status: 'running',
+          waitingFor: '',
+        },
+      );
     }
 
     // Determine retry policy: step-level override > workflow-level default

--- a/services/platform/convex/workflow_engine/helpers/engine/start_workflow_from_file.ts
+++ b/services/platform/convex/workflow_engine/helpers/engine/start_workflow_from_file.ts
@@ -29,6 +29,7 @@ export const startWorkflowFromFile = internalAction({
     triggeredBy: v.string(),
     triggerData: v.optional(jsonValueValidator),
     userId: v.optional(v.string()),
+    debugMode: v.optional(v.boolean()),
   },
   returns: v.union(v.id('wfExecutions'), v.null()),
   handler: async (ctx, args): Promise<Id<'wfExecutions'> | null> => {
@@ -90,6 +91,7 @@ export const startWorkflowFromFile = internalAction({
         triggeredBy: args.triggeredBy,
         triggerData: args.triggerData,
         userId: args.userId,
+        debugMode: args.debugMode,
       },
     );
 

--- a/services/platform/convex/workflows/executions/build_variables_inspection.test.ts
+++ b/services/platform/convex/workflows/executions/build_variables_inspection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildVariablesInspection,
+  INSPECTION_OUTPUT_MAX_CHARS,
+} from './build_variables_inspection';
+
+describe('buildVariablesInspection', () => {
+  it('shapes steps, variables, lastOutput and input', () => {
+    const result = buildVariablesInspection(
+      {
+        steps: {
+          fetch: { stepType: 'action', name: 'Fetch', output: { rows: 3 } },
+        },
+        variables: { customerId: 'c-1' },
+        lastOutput: { rows: 3 },
+        organizationId: 'org-1',
+      },
+      { source: 'test' },
+    );
+
+    expect(result).toEqual({
+      input: { source: 'test' },
+      variables: { customerId: 'c-1' },
+      steps: {
+        fetch: { stepType: 'action', name: 'Fetch', output: { rows: 3 } },
+      },
+      lastOutput: { rows: 3 },
+    });
+  });
+
+  it('handles empty variables', () => {
+    const result = buildVariablesInspection({}, undefined);
+
+    expect(result.steps).toEqual({});
+    expect(result.variables).toEqual({});
+    expect(result.lastOutput).toBeUndefined();
+    expect(result.lastOutputTruncated).toBeUndefined();
+  });
+
+  it('truncates oversized step outputs and flags them', () => {
+    const big = 'x'.repeat(INSPECTION_OUTPUT_MAX_CHARS + 100);
+    const result = buildVariablesInspection(
+      {
+        steps: {
+          llm: { stepType: 'llm', name: 'Generate', output: big },
+          small: { stepType: 'action', name: 'Small', output: 'ok' },
+        },
+      },
+      undefined,
+    );
+
+    expect(result.steps.llm.outputTruncated).toBe(true);
+    expect(typeof result.steps.llm.output).toBe('string');
+    expect(String(result.steps.llm.output)).toHaveLength(
+      INSPECTION_OUTPUT_MAX_CHARS,
+    );
+    expect(result.steps.small).toEqual({
+      stepType: 'action',
+      name: 'Small',
+      output: 'ok',
+    });
+  });
+
+  it('truncates an oversized lastOutput', () => {
+    const big = { text: 'y'.repeat(INSPECTION_OUTPUT_MAX_CHARS + 100) };
+    const result = buildVariablesInspection({ lastOutput: big }, undefined);
+
+    expect(result.lastOutputTruncated).toBe(true);
+    expect(typeof result.lastOutput).toBe('string');
+  });
+
+  it('ignores non-record step entries', () => {
+    const result = buildVariablesInspection(
+      { steps: { broken: 'not-a-record', ok: { output: 1 } } },
+      undefined,
+    );
+
+    expect(Object.keys(result.steps)).toEqual(['ok']);
+  });
+});

--- a/services/platform/convex/workflows/executions/build_variables_inspection.ts
+++ b/services/platform/convex/workflows/executions/build_variables_inspection.ts
@@ -1,0 +1,67 @@
+/**
+ * Shape the deserialized execution variables into the payload the step-debug
+ * inspector consumes (#1490). Pure so it can be unit-tested; the action wraps
+ * it after resolving storage-backed variables.
+ *
+ * Step outputs and `lastOutput` are capped per entry: an oversized value is
+ * replaced by a truncated JSON-string preview plus a flag, so the action
+ * result stays well below Convex's response size limits even for LLM-heavy
+ * workflows.
+ */
+
+import { getString, isRecord } from '../../../lib/utils/type-guards';
+
+export const INSPECTION_OUTPUT_MAX_CHARS = 32 * 1024;
+
+export interface InspectedStep {
+  stepType?: string;
+  name?: string;
+  output: unknown;
+  outputTruncated?: boolean;
+}
+
+export interface ExecutionVariablesInspection {
+  input: unknown;
+  /** User-set variables (the `set_variables` namespace). */
+  variables: Record<string, unknown>;
+  /** Per-step outputs keyed by step slug, each capped at INSPECTION_OUTPUT_MAX_CHARS. */
+  steps: Record<string, InspectedStep>;
+  lastOutput: unknown;
+  lastOutputTruncated?: boolean;
+}
+
+function capValue(value: unknown): { value: unknown; truncated: boolean } {
+  const json = JSON.stringify(value);
+  if (typeof json !== 'string' || json.length <= INSPECTION_OUTPUT_MAX_CHARS) {
+    return { value, truncated: false };
+  }
+  return { value: json.slice(0, INSPECTION_OUTPUT_MAX_CHARS), truncated: true };
+}
+
+export function buildVariablesInspection(
+  variables: Record<string, unknown>,
+  input: unknown,
+): ExecutionVariablesInspection {
+  const steps: Record<string, InspectedStep> = {};
+  const rawSteps = isRecord(variables.steps) ? variables.steps : {};
+  for (const [slug, info] of Object.entries(rawSteps)) {
+    if (!isRecord(info)) continue;
+    const { value, truncated } = capValue(info.output);
+    steps[slug] = {
+      stepType: getString(info, 'stepType'),
+      name: getString(info, 'name'),
+      output: value,
+      ...(truncated ? { outputTruncated: true } : {}),
+    };
+  }
+
+  const lastOutput = capValue(variables.lastOutput);
+
+  return {
+    input,
+    variables: isRecord(variables.variables) ? variables.variables : {},
+    steps,
+    lastOutput: lastOutput.value,
+    ...(lastOutput.truncated ? { lastOutputTruncated: true } : {}),
+  };
+}

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
@@ -228,6 +228,32 @@ describe('deriveStepStatuses', () => {
     expect(result.execution.waitingFor).toBe('human_input:approval');
   });
 
+  it('marks the current step as paused while the execution is debug-paused', () => {
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('fetch', {
+          runResult: { kind: 'success', returnValue: { port: 'next' } },
+        }),
+      ],
+      execution({
+        status: 'running',
+        waitingFor: 'debug:2:send-email',
+        currentStepSlug: 'send-email',
+        currentStepName: 'Send email',
+      }),
+    );
+
+    // The paused node has not executed yet, so it has no journal entry —
+    // the overlay synthesizes it from the execution row.
+    expect(result.nodes['send-email']).toMatchObject({
+      status: 'paused',
+      stepName: 'Send email',
+      attempts: 0,
+    });
+    expect(result.nodes.fetch.status).toBe('success');
+    expect(result.execution.waitingFor).toBe('debug:2:send-email');
+  });
+
   it('flags outputs as unavailable when variables were offloaded to storage', () => {
     const result = deriveStepStatuses(
       [

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
@@ -8,6 +8,7 @@
 import { getNumber, getString, isRecord } from '../../../lib/utils/type-guards';
 import type { Doc, Id } from '../../_generated/dataModel';
 import type { QueryCtx } from '../../_generated/server';
+import { parseDebugWaitingFor } from '../../workflow_engine/helpers/engine/debug_gate';
 import { getExecutionStepJournal } from './get_execution_step_journal';
 
 /** Per-node output previews are capped server-side to keep the reactive payload small. */
@@ -18,6 +19,7 @@ export type ExecutionNodeStatus =
   | 'success'
   | 'failed'
   | 'waiting'
+  | 'paused'
   | 'canceled';
 
 export interface ExecutionNodeState {
@@ -208,18 +210,22 @@ export function deriveStepStatuses(
     };
   }
 
-  // A running execution that waits on an external event (human input,
-  // approval, debug pause) shows the current node as 'waiting'.
+  // A running execution that waits on an external event shows the current
+  // node as 'waiting' (human input / approval) or 'paused' (debug-mode step
+  // gate — the node has not executed yet, it is paused right before running).
   if (
     execution.status === 'running' &&
     execution.waitingFor &&
     execution.currentStepSlug
   ) {
+    const overlayStatus = parseDebugWaitingFor(execution.waitingFor)
+      ? 'paused'
+      : 'waiting';
     const current = nodes[execution.currentStepSlug];
     nodes[execution.currentStepSlug] = current
-      ? { ...current, status: 'waiting' }
+      ? { ...current, status: overlayStatus }
       : {
-          status: 'waiting',
+          status: overlayStatus,
           stepName: execution.currentStepName,
           attempts: 0,
         };

--- a/services/platform/convex/workflows/executions/resume_debug_step.test.ts
+++ b/services/platform/convex/workflows/executions/resume_debug_step.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { toId } from '../../lib/type_cast_helpers';
+
+const h = vi.hoisted(() => ({
+  managers: Array.from({ length: 4 }, () => ({ sendEvent: vi.fn() })),
+}));
+
+vi.mock('../../workflow_engine/engine', () => ({
+  workflowManagers: h.managers,
+}));
+
+import type { MutationCtx } from '../../_generated/server';
+import { resumeDebugStep } from './resume_debug_step';
+
+function createMockCtx(execution: Record<string, unknown> | null) {
+  const ctx = { db: { get: vi.fn().mockResolvedValue(execution) } };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only: minimal MutationCtx surface
+  return ctx as unknown as MutationCtx;
+}
+
+const executionId = toId<'wfExecutions'>('exec-1');
+
+function pausedExecution(overrides?: Record<string, unknown>) {
+  return {
+    _id: executionId,
+    status: 'running',
+    waitingFor: 'debug:3:send-email',
+    componentWorkflowId: 'component-wf-1',
+    shardIndex: 2,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  for (const manager of h.managers) manager.sendEvent.mockClear();
+});
+
+describe('resumeDebugStep', () => {
+  it('throws when the execution does not exist', async () => {
+    await expect(
+      resumeDebugStep(createMockCtx(null), { executionId, action: 'step' }),
+    ).rejects.toThrow('Execution not found');
+  });
+
+  it('throws when the execution is not running', async () => {
+    await expect(
+      resumeDebugStep(createMockCtx(pausedExecution({ status: 'completed' })), {
+        executionId,
+        action: 'step',
+      }),
+    ).rejects.toThrow('Cannot resume a debug step');
+  });
+
+  it('throws when the execution is not paused in debug mode', async () => {
+    await expect(
+      resumeDebugStep(
+        createMockCtx(pausedExecution({ waitingFor: 'approval-id-123' })),
+        { executionId, action: 'continue' },
+      ),
+    ).rejects.toThrow('not paused in debug mode');
+
+    await expect(
+      resumeDebugStep(
+        createMockCtx(pausedExecution({ waitingFor: undefined })),
+        { executionId, action: 'step' },
+      ),
+    ).rejects.toThrow('not paused in debug mode');
+  });
+
+  it('throws when the component workflow id is missing', async () => {
+    await expect(
+      resumeDebugStep(
+        createMockCtx(pausedExecution({ componentWorkflowId: undefined })),
+        { executionId, action: 'step' },
+      ),
+    ).rejects.toThrow('component workflow ID');
+  });
+
+  it('sends the per-pause debug event on the execution shard manager', async () => {
+    const ctx = createMockCtx(pausedExecution());
+
+    await expect(
+      resumeDebugStep(ctx, { executionId, action: 'step' }),
+    ).resolves.toBeNull();
+
+    expect(h.managers[2].sendEvent).toHaveBeenCalledTimes(1);
+    expect(h.managers[2].sendEvent).toHaveBeenCalledWith(ctx, {
+      workflowId: 'component-wf-1',
+      name: 'debug:3',
+      value: { action: 'step' },
+    });
+    expect(h.managers[0].sendEvent).not.toHaveBeenCalled();
+  });
+
+  it('falls back to shard 0 for invalid shard indices', async () => {
+    const ctx = createMockCtx(pausedExecution({ shardIndex: undefined }));
+
+    await resumeDebugStep(ctx, { executionId, action: 'continue' });
+
+    expect(h.managers[0].sendEvent).toHaveBeenCalledWith(ctx, {
+      workflowId: 'component-wf-1',
+      name: 'debug:3',
+      value: { action: 'continue' },
+    });
+  });
+});

--- a/services/platform/convex/workflows/executions/resume_debug_step.ts
+++ b/services/platform/convex/workflows/executions/resume_debug_step.ts
@@ -1,0 +1,60 @@
+/**
+ * Resume a debug-paused execution: send the `debug:<pauseIndex>` event the
+ * engine's pause gate is awaiting (see workflow_engine/helpers/engine/
+ * debug_gate.ts). 'step' runs the paused node and pauses again before the
+ * next one; 'continue' runs to the end without further pauses.
+ */
+
+import type { WorkflowId } from '@convex-dev/workflow';
+
+import type { Id } from '../../_generated/dataModel';
+import type { MutationCtx } from '../../_generated/server';
+import { workflowManagers } from '../../workflow_engine/engine';
+import type { DebugResumeAction } from '../../workflow_engine/helpers/engine/debug_gate';
+import {
+  debugEventName,
+  parseDebugWaitingFor,
+} from '../../workflow_engine/helpers/engine/debug_gate';
+import { safeShardIndex } from '../../workflow_engine/helpers/engine/shard';
+
+export interface ResumeDebugStepArgs {
+  executionId: Id<'wfExecutions'>;
+  action: DebugResumeAction;
+}
+
+export async function resumeDebugStep(
+  ctx: MutationCtx,
+  args: ResumeDebugStepArgs,
+): Promise<null> {
+  const execution = await ctx.db.get(args.executionId);
+  if (!execution) {
+    throw new Error('Execution not found');
+  }
+
+  if (execution.status !== 'running') {
+    throw new Error(
+      `Cannot resume a debug step on execution with status "${execution.status}"`,
+    );
+  }
+
+  const pause = parseDebugWaitingFor(execution.waitingFor);
+  if (!pause) {
+    throw new Error('Execution is not paused in debug mode');
+  }
+
+  if (!execution.componentWorkflowId) {
+    throw new Error('Execution is missing its component workflow ID');
+  }
+
+  const manager = workflowManagers[safeShardIndex(execution.shardIndex)];
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- componentWorkflowId stored as string, WorkflowId is a branded type
+  const workflowId = execution.componentWorkflowId as unknown as WorkflowId;
+
+  await manager.sendEvent(ctx, {
+    workflowId,
+    name: debugEventName(pause.pauseIndex),
+    value: { action: args.action },
+  });
+
+  return null;
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -624,6 +624,7 @@
           "completed": "Abgeschlossen",
           "failed": "Fehlgeschlagen",
           "waiting": "Wartet auf Eingabe",
+          "paused": "Pausiert (Debug)",
           "success": "Erfolgreich",
           "canceled": "Abgebrochen"
         }
@@ -748,6 +749,17 @@
         "running": "Läuft …",
         "failedAtStep": "Fehlgeschlagen bei Schritt: {step}",
         "runningStep": "Aktueller Schritt: {step}"
+      },
+      "debug": {
+        "button": "Debuggen",
+        "title": "Debug-Sitzung",
+        "pausedAt": "Pausiert vor Schritt: {step}",
+        "step": "Schritt",
+        "continue": "Fortsetzen",
+        "stop": "Stoppen",
+        "variables": "Laufvariablen",
+        "variablesLoading": "Variablen werden geladen …",
+        "variablesError": "Die Laufvariablen konnten nicht geladen werden."
       }
     }
   },
@@ -1461,6 +1473,7 @@
       "completed": "Abgeschlossen",
       "failed": "Fehlgeschlagen",
       "waitingForInput": "Wartet auf Eingabe",
+      "pausedDebug": "Pausiert (Debug)",
       "draft": "Entwurf",
       "enabled": "Aktiviert",
       "disabled": "Deaktiviert",
@@ -1472,7 +1485,8 @@
       "event": "Ereignis",
       "webhook": "Webhook",
       "api": "API",
-      "system": "System"
+      "system": "System",
+      "debug": "Debug"
     },
     "validation": {
       "required": "{field} ist erforderlich",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -624,6 +624,7 @@
           "completed": "Completed",
           "failed": "Failed",
           "waiting": "Waiting for input",
+          "paused": "Paused (debug)",
           "success": "Succeeded",
           "canceled": "Canceled"
         }
@@ -748,6 +749,17 @@
         "running": "Running…",
         "failedAtStep": "Failed at step: {step}",
         "runningStep": "Current step: {step}"
+      },
+      "debug": {
+        "button": "Debug",
+        "title": "Debug session",
+        "pausedAt": "Paused before step: {step}",
+        "step": "Step",
+        "continue": "Continue",
+        "stop": "Stop",
+        "variables": "Run variables",
+        "variablesLoading": "Loading variables…",
+        "variablesError": "Couldn't load the run variables."
       }
     }
   },
@@ -1461,6 +1473,7 @@
       "completed": "Completed",
       "failed": "Failed",
       "waitingForInput": "Waiting for input",
+      "pausedDebug": "Paused (debug)",
       "draft": "Draft",
       "enabled": "Enabled",
       "disabled": "Disabled",
@@ -1472,7 +1485,8 @@
       "event": "Event",
       "webhook": "Webhook",
       "api": "API",
-      "system": "System"
+      "system": "System",
+      "debug": "Debug"
     },
     "validation": {
       "required": "{field} is required",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -625,6 +625,7 @@
           "completed": "Terminée",
           "failed": "Échouée",
           "waiting": "En attente de saisie",
+          "paused": "En pause (débogage)",
           "success": "Réussie",
           "canceled": "Annulée"
         }
@@ -749,6 +750,17 @@
         "running": "En cours…",
         "failedAtStep": "Échec à l'étape : {step}",
         "runningStep": "Étape en cours : {step}"
+      },
+      "debug": {
+        "button": "Déboguer",
+        "title": "Session de débogage",
+        "pausedAt": "En pause avant l'étape : {step}",
+        "step": "Pas à pas",
+        "continue": "Continuer",
+        "stop": "Arrêter",
+        "variables": "Variables de l'exécution",
+        "variablesLoading": "Chargement des variables…",
+        "variablesError": "Impossible de charger les variables de l'exécution."
       }
     }
   },
@@ -1462,6 +1474,7 @@
       "completed": "Terminé",
       "failed": "Échoué",
       "waitingForInput": "En attente de saisie",
+      "pausedDebug": "En pause (débogage)",
       "draft": "Brouillon",
       "enabled": "Activé",
       "disabled": "Désactivé",
@@ -1473,7 +1486,8 @@
       "event": "Événement",
       "webhook": "Webhook",
       "api": "API",
-      "system": "Système"
+      "system": "Système",
+      "debug": "Débogage"
     },
     "validation": {
       "required": "{field} est requis",


### PR DESCRIPTION
## What / why

Implements step-by-step debugging for automation runs (#1490), layered on the per-node execution status work from #1487. This PR was stacked on `feat/workflow-node-execution-status`, but that branch merged as #1868 while this was in flight, so the branch was rebased onto `main` and targets `main` directly.

**Engine (backend)**
- `debugMode` flag threaded through `startWorkflowFromFile` (public action) → `startWorkflowFromFileConfig` → the dynamic workflow args. Only the test panel sets it; scheduler/REST/webhook/event callers are untouched.
- Pause gate in `handleDynamicWorkflow`: before every node, the engine writes `waitingFor='debug:<pauseIndex>:<stepSlug>'` (status stays `running`) and blocks on `step.awaitEvent({ name: 'debug:<pauseIndex>' })` — the exact pause primitive the human-input approval path already uses, so the stuck-execution watchdog, status filters and metrics need no changes. Per-pause event names prevent a double-clicked "Step" from queueing an event that would skip the next pause. The gate is strictly arg-driven and journaled, so replays of in-flight executions during deploy are deterministic.
- New `resumeDebugStep` mutation (`mutationWithRLS`): guards status/`waitingFor`, then `sendEvent`s `{ action: 'step' | 'continue' }` on the execution's shard manager. Stop reuses `cancelExecution`.
- New `getExecutionVariables` action (auth: identity + org-membership check against the execution's org): deserializes run variables including storage-offloaded payloads (≥400KB) that a query cannot read, and caps each step output / `lastOutput` at 32KB with truncation flags.

**UI**
- Test panel: a **Debug** button starts the run with `debugMode: true` and `triggeredBy: 'debug'`; while paused, a debug card shows the paused step plus **Step / Continue / Stop** and a JSON inspector (input, user variables, per-step outputs) fetched via `getExecutionVariables` on every pause.
- Canvas: a distinct `paused` node state layered on #1487's `ExecutionStatusProvider` context (amber ring + debug badge on the paused node, `Paused (debug)` chip in the viewing-run banner). No duplicated plumbing — the same `getExecutionStepStatuses` query drives it.
- Executions table: `Paused (debug)` badge instead of `Waiting for input` for debug pauses, and a `Debug` option in the trigger-source filter.
- i18n (en/de/fr) + docs (`docs/{en,de,fr}/platform/automations/workflows.md`).

## Pre-PR checklist

- [x] Ran `bun run check` (format, lint, typecheck, all tests).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — N/A (no loading-state changes; debug card states are live-data states, not skeletons).
- [x] Updated `services/platform/messages/{en,de,fr}.json`.
- [x] Updated `/docs/{en,de,fr}/` for every user-visible change (`platform/automations/workflows.md`).
- [x] Every touched docs page has a real opening and closing (existing page; paragraph added mid-page, opening/closing untouched and tests pass).
- [x] Ran `bun run --filter @tale/docs lint` and `bun run --filter @tale/docs test`.
- [x] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A (no setup/env/feature-list changes).

## Decision-gate recommendations baked in (veto at review if wrong)

- **Pause representation**: `status='running'` + `waitingFor='debug:<n>:<slug>'` overlay (recommended) — no first-class `paused` execution status, no schema/metrics/watchdog ripple.
- **v1 scope**: pause before **every** node (recommended) — no canvas breakpoints; the event gate extends trivially to a breakpoint-slug list later.
- **Abandoned debug sessions**: keep the stuck-recovery defaults (6h + 24h `waitingFor` extension); no debug-specific auto-cancel in v1.
- **`triggeredBy`**: distinct `'debug'` value (per issue scope) so debug runs are filterable in the Executions tab. Note: the plan's step 7 parenthetical said keep `'test'`; the issue-level decision gate left it open and the scoping instruction picked `'debug'` — baked in as `'debug'`.
- **Sequencing with #1487**: #1487 landed the shared execution-status context/query; this PR only layers on it.

## Verification

Performed:
- `bun run check` at repo root — green (format, lint, typecheck, 370 test files / 71943 tests).
- Targeted: `dynamic_workflow_handler` (pause-before-execute ordering, per-step pauses, continue stops pausing, non-debug path unchanged), `debug_gate` (marker round-trip/malformed), `resume_debug_step` (guards + shard routing), `get_execution_step_statuses` (paused overlay), `build_variables_inspection` (truncation), UI: `automation-tester` (Debug passes `debugMode`/`triggeredBy`, controls render only for debug pauses) and `automation-debug-controls` (Step/Continue/Stop wiring, loading/error states, a11y).
- `bun run --filter @tale/docs lint` + `test` — green.

Not performed (manual verification required):
- End-to-end on the local dev stack (no running Convex deployment in this environment): run a seeded automation in Debug from the test panel and confirm pause-before-start-node, node highlight follows Step, Continue runs to completion, Stop cancels, inspector shows `steps.<slug>.output`, Executions tab shows `Paused (debug)` while paused. `bunx convex codegen` could not run for the same reason — the three new module entries in `convex/_generated/api.d.ts` were added by hand in the generated style; please re-run codegen against a dev deployment to confirm a no-op diff.

## Notes

- Loop bodies pause on every iteration; Continue covers long loops. Breakpoints are the natural follow-up.
- Debug pauses inherit the watchdog grace (6h + 24h when `waitingFor` is set) — an abandoned session occupies a workpool slot until then.

Closes #1490
