### PR TITLE
fix(platform): recover stuck websocket auth on cold start + skeleton mask sizing

### DIFF
--- a/packages/ui/src/components/feedback/skeleton.tsx
+++ b/packages/ui/src/components/feedback/skeleton.tsx
@@ -58,18 +58,27 @@ function MaskedContent({
  * Renders the real value as-is. While loading (`useSkeleton()` is true, i.e.
  * inside a `<Skeletonize loading>`) a static opaque base covers it with a pulse
  * shimmer layered on top — the base never animates, so the content stays hidden
- * even at the trough of the pulse. The base is inset by a negative 2px so it
- * slightly overhangs the content on every side — anti-aliased glyph/border
- * edges can't peek out from under the mask — without over-extending enough to
- * overlap adjacent masks in tight layouts. It also intercepts pointer events so
- * masked controls aren't interactive. When *not* loading the wrapper is
- * `display: contents`, so it
- * adds no box and can't tangle layout — wrap any dynamic value (text, a number,
- * a control) unconditionally and leave it in place.
+ * even at the trough of the pulse. The content itself is `visibility: hidden`
+ * while masked (see {@link MaskedContent}), so the base only has to draw the
+ * placeholder *shape* and hugs the content box exactly. (It used to overhang by
+ * 2px to swallow anti-aliased glyph edges, but that predates the visibility
+ * mask — and the overhang made adjacent masks bleed into each other in tight
+ * `gap-1` stacks.) The base also intercepts pointer events so masked controls
+ * aren't interactive. When *not* loading the wrapper is `display: contents`, so
+ * it adds no box and can't tangle layout — wrap any dynamic value (text, a
+ * number, a control) unconditionally and leave it in place.
  *
  * Deliberately has no `className`/`style`: the skeleton's size comes from the
  * content it wraps, never from call-site styling. Reach for `fullWidth` (or a
  * new semantic prop here) instead of one-off classes.
+ *
+ * Sizing gotcha: with `fullWidth` the mask fills the *wrapper*, not the hidden
+ * placeholder — a narrower placeholder (`w-2/3`, `max-w-48`) inside a
+ * `fullWidth` box still paints a full-width mask. Put the width on an element
+ * AROUND the box (`<div className="w-2/3"><SkeletonBox fullWidth>…`) so the
+ * mask is exactly that wide. Percentage widths can't live on the placeholder
+ * in the non-`fullWidth` case either: the wrapper is shrink-to-fit, so a
+ * `%`-wide child collapses to zero.
  *
  * Decorative (`aria-hidden`): the enclosing `<Skeletonize>` announces "Loading"
  * once for the whole region, so individual boxes must not re-announce.
@@ -90,7 +99,7 @@ export function SkeletonBox({ children, fullWidth }: SkeletonWrapProps) {
     >
       <MaskedContent loading={loading}>{children}</MaskedContent>
       {loading && (
-        <span className="bg-muted absolute -inset-0.5 overflow-hidden rounded-[inherit]">
+        <span className="bg-muted absolute inset-0 overflow-hidden rounded-[inherit]">
           <span className={SKELETON_SHIMMER} />
         </span>
       )}
@@ -119,7 +128,7 @@ export function SkeletonCircle({ children, fullWidth }: SkeletonWrapProps) {
     >
       <MaskedContent loading={loading}>{children}</MaskedContent>
       {loading && (
-        <span className="bg-muted absolute -inset-0.5 overflow-hidden rounded-full">
+        <span className="bg-muted absolute inset-0 overflow-hidden rounded-full">
           <span className={SKELETON_SHIMMER} />
         </span>
       )}

--- a/packages/ui/src/components/search/search-command.tsx
+++ b/packages/ui/src/components/search/search-command.tsx
@@ -206,7 +206,7 @@ export function SearchCommand({
                   duration: reduceMotion ? 0 : 0.18,
                   ease: [0.22, 1, 0.36, 1],
                 }}
-                className="fixed inset-0 z-40 bg-black/50 backdrop-blur-md"
+                className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md"
               />
             </Dialog.Overlay>
             <Dialog.Content asChild aria-label={labels.title}>

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -633,11 +633,17 @@ export function DataTable<TData, TValue = unknown>({
         <TableBody>
           {tableBodyState === 'loading' || tableBodyState === 'skeleton' ? (
             // Skeleton rows — count-loading uses 3 placeholder rows,
-            // skeleton uses the actual approxRowCount
+            // skeleton uses the actual approxRowCount.
+            // Text-line widths vary per cell (deterministic, so SSR-stable)
+            // instead of painting a uniform grid of identical bars; the width
+            // lives on a wrapper around the box because a narrower placeholder
+            // INSIDE a fullWidth SkeletonBox is ignored by the mask.
             Array.from({ length: skeletonRowCount }).map((_, rowIndex) => (
               <TableRow key={`skeleton-${rowIndex}`}>
                 {enableExpanding && <TableCell className="w-[3rem]" />}
                 {columns.map((col, colIndex) => {
+                  const textWidth = (salt: number, min: number, span: number) =>
+                    `${min + ((rowIndex * 17 + colIndex * 29 + salt * 13) % span)}%`;
                   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ColumnDef.meta is typed as unknown by TanStack Table
                   const meta = col.meta as ColumnMeta | undefined;
                   const isActionCol = meta?.isAction === true;
@@ -671,9 +677,11 @@ export function DataTable<TData, TValue = unknown>({
                     cellContent = (
                       <HStack gap={2}>
                         <div className="min-w-0 flex-1">
-                          <SkeletonBox fullWidth>
-                            <div className="h-3.5 max-w-[120px]" />
-                          </SkeletonBox>
+                          <div className="max-w-[120px]">
+                            <SkeletonBox fullWidth>
+                              <div className="h-3.5" />
+                            </SkeletonBox>
+                          </div>
                         </div>
                         <SkeletonBox>
                           <div className="size-6 shrink-0 rounded-md" />
@@ -695,12 +703,22 @@ export function DataTable<TData, TValue = unknown>({
                           <div className="size-8 shrink-0 rounded-md" />
                         </SkeletonBox>
                         <Stack gap={1} className="min-w-0 flex-1">
-                          <SkeletonBox fullWidth>
-                            <div className="h-3.5 w-full max-w-48" />
-                          </SkeletonBox>
-                          <SkeletonBox fullWidth>
-                            <div className="h-3 w-2/3 max-w-24" />
-                          </SkeletonBox>
+                          <div
+                            className="max-w-48"
+                            style={{ width: textWidth(1, 62, 31) }}
+                          >
+                            <SkeletonBox fullWidth>
+                              <div className="h-3.5" />
+                            </SkeletonBox>
+                          </div>
+                          <div
+                            className="max-w-24"
+                            style={{ width: textWidth(2, 38, 25) }}
+                          >
+                            <SkeletonBox fullWidth>
+                              <div className="h-3" />
+                            </SkeletonBox>
+                          </div>
                         </Stack>
                       </HStack>
                     );
@@ -711,9 +729,14 @@ export function DataTable<TData, TValue = unknown>({
                           <div className="size-4 shrink-0 rounded" />
                         </SkeletonBox>
                         <div className="min-w-0 flex-1">
-                          <SkeletonBox fullWidth>
-                            <div className="h-3.5 w-full max-w-48" />
-                          </SkeletonBox>
+                          <div
+                            className="max-w-48"
+                            style={{ width: textWidth(3, 62, 31) }}
+                          >
+                            <SkeletonBox fullWidth>
+                              <div className="h-3.5" />
+                            </SkeletonBox>
+                          </div>
                         </div>
                       </HStack>
                     );
@@ -722,12 +745,22 @@ export function DataTable<TData, TValue = unknown>({
                     // skeleton row matches the real two-line cell height.
                     cellContent = (
                       <Stack gap={1} className="min-w-0">
-                        <SkeletonBox fullWidth>
-                          <div className="h-3.5 w-full max-w-48" />
-                        </SkeletonBox>
-                        <SkeletonBox fullWidth>
-                          <div className="h-3 w-2/3 max-w-24" />
-                        </SkeletonBox>
+                        <div
+                          className="max-w-48"
+                          style={{ width: textWidth(4, 62, 31) }}
+                        >
+                          <SkeletonBox fullWidth>
+                            <div className="h-3.5" />
+                          </SkeletonBox>
+                        </div>
+                        <div
+                          className="max-w-24"
+                          style={{ width: textWidth(5, 38, 25) }}
+                        >
+                          <SkeletonBox fullWidth>
+                            <div className="h-3" />
+                          </SkeletonBox>
+                        </div>
                       </Stack>
                     );
                   } else if (align === 'right') {
@@ -748,9 +781,11 @@ export function DataTable<TData, TValue = unknown>({
                     );
                   } else {
                     cellContent = (
-                      <SkeletonBox fullWidth>
-                        <div className="h-3.5 w-full max-w-[80%]" />
-                      </SkeletonBox>
+                      <div style={{ width: textWidth(6, 52, 38) }}>
+                        <SkeletonBox fullWidth>
+                          <div className="h-3.5" />
+                        </SkeletonBox>
+                      </div>
                     );
                   }
 

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -525,9 +525,11 @@ export function ChatHistorySidebar({
           {showSkeleton ? (
             // Mirror the loaded sidebar geometry (Projects header + folder rows,
             // Chats header + chat rows) so the reveal is a mask swap, not a
-            // layout change. `fullWidth` on the label boxes is required: the
-            // rows are flex with `items-center` (no horizontal stretch), so a
-            // non-fullWidth (inline-block) box would collapse the % width to 0.
+            // layout change. The varied label widths live on plain flex-item
+            // wrappers (a % width resolves against the row there), with a
+            // `fullWidth` box filling each wrapper — a % width on the hidden
+            // placeholder itself would either collapse to 0 (non-fullWidth)
+            // or be ignored by the mask (fullWidth).
             <Skeletonize loading>
               <Stack gap={1} className="pb-2">
                 <div className="flex h-7 items-center px-2">
@@ -550,12 +552,11 @@ export function ChatHistorySidebar({
                     <SkeletonBox>
                       <div className="size-3 rounded-sm" />
                     </SkeletonBox>
-                    <SkeletonBox fullWidth>
-                      <div
-                        className="h-3.5"
-                        style={{ width: `${58 - i * 14}%` }}
-                      />
-                    </SkeletonBox>
+                    <div style={{ width: `${58 - i * 14}%` }}>
+                      <SkeletonBox fullWidth>
+                        <div className="h-3.5" />
+                      </SkeletonBox>
+                    </div>
                   </div>
                 ))}
                 <div className="border-border mt-1.5 flex h-7 items-center border-t px-2 pt-2.5">
@@ -568,12 +569,11 @@ export function ChatHistorySidebar({
                     key={`chat-${i}`}
                     className="flex min-h-[1.5rem] items-center px-2 py-1.5"
                   >
-                    <SkeletonBox fullWidth>
-                      <div
-                        className="h-3.5"
-                        style={{ width: `${82 - (i % 4) * 14}%` }}
-                      />
-                    </SkeletonBox>
+                    <div style={{ width: `${82 - (i % 4) * 14}%` }}>
+                      <SkeletonBox fullWidth>
+                        <div className="h-3.5" />
+                      </SkeletonBox>
+                    </div>
                   </div>
                 ))}
               </Stack>

--- a/services/platform/app/features/chat/components/chat-messages-skeleton.tsx
+++ b/services/platform/app/features/chat/components/chat-messages-skeleton.tsx
@@ -1,28 +1,33 @@
 'use client';
 
-import { SkeletonBox } from '@tale/ui/skeleton';
+import { SkeletonBox, SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
-const PLACEHOLDER_MESSAGE_ROWS: Array<{
-  role: 'user' | 'assistant';
-  widths: string[];
-}> = [
-  { role: 'user', widths: ['w-40'] },
-  { role: 'assistant', widths: ['w-full', 'w-5/6', 'w-2/3'] },
-  { role: 'user', widths: ['w-56'] },
-  { role: 'assistant', widths: ['w-full', 'w-4/5'] },
+const PLACEHOLDER_MESSAGE_ROWS: Array<
+  | { role: 'user'; width: string }
+  | { role: 'assistant'; lines: number; lastLineWidth: string }
+> = [
+  { role: 'user', width: 'w-40' },
+  { role: 'assistant', lines: 3, lastLineWidth: '66%' },
+  { role: 'user', width: 'w-56' },
+  { role: 'assistant', lines: 2, lastLineWidth: '82%' },
 ];
 
 /**
  * Message-column skeleton that mirrors `ChatMessages`' loaded geometry
  * (`mx-auto … max-w-(--chat-max-width) … gap-3 pt-6` with right/left aligned
- * placeholder bubbles). Shared by the arena-exit window AND the cold-load
+ * placeholder rows). Shared by the arena-exit window AND the cold-load
  * Suspense fallback so revealing the real list is a mask swap with no layout
- * shift — previously the cold fallback was a generic top-left `SkeletonText`
- * whose geometry didn't match the centered message column.
+ * shift.
+ *
+ * Granularity matters here: user turns mask as one hugging bubble-shaped box,
+ * assistant turns mask as word-shaped prose lines (`SkeletonText`) instead of
+ * solid full-width bars. The widths live on wrappers around the boxes — a
+ * width on the hidden placeholder inside a `fullWidth` box would be ignored
+ * (the mask fills the wrapper; see the SkeletonBox docs).
  */
 export function ChatMessagesSkeleton() {
   const { t } = useT('chat');
@@ -31,17 +36,28 @@ export function ChatMessagesSkeleton() {
       <div className="mx-auto flex w-full max-w-(--chat-max-width) flex-col gap-3 pt-6">
         {PLACEHOLDER_MESSAGE_ROWS.map((row, rowIdx) => (
           <div
+            // eslint-disable-next-line react/no-array-index-key
             key={rowIdx}
             className={cn(
-              'flex flex-col gap-2',
+              'flex flex-col',
               row.role === 'user' ? 'items-end' : 'items-start',
             )}
           >
-            {row.widths.map((w, i) => (
-              <SkeletonBox key={i} fullWidth>
-                <div className={cn('h-4', w)} />
-              </SkeletonBox>
-            ))}
+            {row.role === 'user' ? (
+              <div className={cn('max-w-full', row.width)}>
+                <SkeletonBox fullWidth>
+                  <div className="h-9 rounded-xl" />
+                </SkeletonBox>
+              </div>
+            ) : (
+              <div className="w-full text-sm">
+                <SkeletonText
+                  lines={row.lines}
+                  lastLineWidth={row.lastLineWidth}
+                  seed={rowIdx}
+                />
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/services/platform/app/features/conversations/components/conversations-list.tsx
+++ b/services/platform/app/features/conversations/components/conversations-list.tsx
@@ -248,13 +248,15 @@ const ConversationRow = memo(function ConversationRow({
           </div>
 
           <Text variant="muted" truncate className="mb-1.5 tracking-tight">
-            <SkeletonBox fullWidth>
-              {conversation ? (
-                conversation.title
-              ) : (
-                <span className="inline-block w-3/4">&nbsp;</span>
-              )}
-            </SkeletonBox>
+            {conversation ? (
+              <SkeletonBox fullWidth>{conversation.title}</SkeletonBox>
+            ) : (
+              // Width sits on a wrapper around the box: a narrower placeholder
+              // INSIDE a fullWidth box would be ignored by the mask.
+              <span className="block w-3/4">
+                <SkeletonBox fullWidth>&nbsp;</SkeletonBox>
+              </span>
+            )}
           </Text>
 
           <Text variant="caption" truncate className="mb-2 tracking-tight">

--- a/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
+++ b/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
@@ -419,9 +419,16 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
                     <tr key={i} className="border-border border-t">
                       {Array.from({ length: 6 }).map((__, j) => (
                         <td key={j} className="px-3 py-2">
-                          <SkeletonBox fullWidth>
-                            <div className="h-3.5 w-full max-w-24" />
-                          </SkeletonBox>
+                          <div
+                            className="max-w-24"
+                            style={{
+                              width: `${58 + ((i * 17 + j * 29) % 35)}%`,
+                            }}
+                          >
+                            <SkeletonBox fullWidth>
+                              <div className="h-3.5" />
+                            </SkeletonBox>
+                          </div>
                         </td>
                       ))}
                     </tr>

--- a/services/platform/app/features/settings/integrations/components/integration-manage/integration-related-automations.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-manage/integration-related-automations.tsx
@@ -78,9 +78,11 @@ export function IntegrationRelatedAutomations({
                 <SkeletonBox fullWidth>
                   <div className="h-8 w-full rounded-md" />
                 </SkeletonBox>
-                <SkeletonBox fullWidth>
-                  <div className="h-8 w-3/4 rounded-md" />
-                </SkeletonBox>
+                <div className="w-3/4">
+                  <SkeletonBox fullWidth>
+                    <div className="h-8 rounded-md" />
+                  </SkeletonBox>
+                </div>
               </div>
             </Skeletonize>
           ) : count > 0 ? (

--- a/services/platform/app/features/tasks/components/tasks-workspace.tsx
+++ b/services/platform/app/features/tasks/components/tasks-workspace.tsx
@@ -76,9 +76,14 @@ function TasksSkeleton({ view }: { view: TaskView }) {
               <div className="size-4 rounded" />
             </SkeletonBox>
             <div className="min-w-0 flex-1">
-              <SkeletonBox fullWidth>
-                <div className="h-3.5 w-1/2 max-w-xs" />
-              </SkeletonBox>
+              <div
+                className="max-w-xs"
+                style={{ width: `${42 + ((i * 19) % 31)}%` }}
+              >
+                <SkeletonBox fullWidth>
+                  <div className="h-3.5" />
+                </SkeletonBox>
+              </div>
             </div>
             <SkeletonBox>
               <div className="h-5 w-16 rounded-full" />

--- a/services/platform/app/lib/auth/session-query.ts
+++ b/services/platform/app/lib/auth/session-query.ts
@@ -11,8 +11,24 @@ import { authClient } from '@/lib/auth-client';
  */
 export const sessionQueryOptions = {
   queryKey: ['auth', 'session'] as const,
-  queryFn: () => authClient.getSession(),
+  queryFn: async () => {
+    const session = await authClient.getSession();
+    // Better Auth resolves transport failures as `{ data: null, error }`
+    // instead of throwing. Returning that would cache "signed out" as fresh
+    // data for the whole staleTime and bounce a logged-in user to /log-in
+    // while the backend is still warming up. Throw so TanStack Query treats
+    // it as a failure: retryable, never cached as data. Genuine signed-out
+    // (`data: null`, no transport error) still resolves normally.
+    const status = session?.error?.status;
+    if (status !== undefined && (status === 0 || status >= 500)) {
+      throw new Error(`getSession failed with status ${status}`);
+    }
+    return session;
+  },
   staleTime: 5 * 60 * 1000, // 5 minutes
+  // The auth fetch layer already retries 5xx with backoff (see auth-client);
+  // one extra round here covers a backend that came up between the two.
+  retry: 1,
 };
 
 /**

--- a/services/platform/app/routes/_auth.tsx
+++ b/services/platform/app/routes/_auth.tsx
@@ -6,7 +6,11 @@ import { sessionQueryOptions } from '@/app/lib/auth/session-query';
 
 export const Route = createFileRoute('/_auth')({
   beforeLoad: async ({ context }) => {
-    const session = await context.queryClient.fetchQuery(sessionQueryOptions);
+    // fetchQuery rejects on transport failures (after retries) — treat that
+    // as signed-out and show the auth page rather than a route error.
+    const session = await context.queryClient
+      .fetchQuery(sessionQueryOptions)
+      .catch(() => null);
     if (session?.data?.user) {
       throw redirect({ to: '/dashboard' });
     }

--- a/services/platform/app/routes/dashboard.tsx
+++ b/services/platform/app/routes/dashboard.tsx
@@ -17,10 +17,18 @@ import { api } from '@/convex/_generated/api';
 import { authClient } from '@/lib/auth-client';
 import { getEnv } from '@/lib/env';
 
+// sessionStorage key arming the one-shot "stuck websocket auth" recovery
+// reload (see the effect in DashboardRedirect).
+const CONVEX_AUTH_RELOAD_GUARD = 'convex-auth-recovery-reloaded';
+
 export const Route = createFileRoute('/dashboard')({
   beforeLoad: async ({ context }) => {
-    // Use TanStack Query for caching and deduplication
-    const session = await context.queryClient.fetchQuery(sessionQueryOptions);
+    // Use TanStack Query for caching and deduplication. fetchQuery rejects on
+    // transport failures (after retries) — fall back to the signed-out path
+    // rather than surfacing a route error.
+    const session = await context.queryClient
+      .fetchQuery(sessionQueryOptions)
+      .catch(() => null);
     if (!session?.data?.user) {
       throw redirect({ to: '/log-in' });
     }
@@ -52,20 +60,84 @@ function DashboardRedirect() {
   const [hasValidSession, setHasValidSession] = useState(true);
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      // Convex auth may lag behind Better Auth after sign-up.
-      // Re-check Better Auth before doing a hard redirect.
+    if (isLoading) return undefined;
+    if (isAuthenticated) {
+      // Healthy (or recovered) — re-arm the one-shot recovery reload below.
+      sessionStorage.removeItem(CONVEX_AUTH_RELOAD_GUARD);
+      return undefined;
+    }
+
+    // Convex reports unauthenticated. That's either a genuinely signed-out
+    // user, Convex auth lagging behind Better Auth after sign-up, or a STUCK
+    // handshake: the auth provider latches the first session/token fetch
+    // result, so a transient cold-start failure (backend still warming,
+    // first-run JWKS bootstrap) strands the websocket unauthenticated and
+    // every auth-gated query disabled — endless skeletons until a manual
+    // reload. Re-check Better Auth directly before doing a hard redirect, and
+    // un-stick the provider when the session is actually alive.
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const MAX_RECHECKS = 8;
+
+    const scheduleRecheck = (attempt: number) => {
+      // Backend unreachable — keep the shell up instead of bouncing a
+      // possibly-valid session to /log-in on a blip, and re-check until the
+      // backend answers (the fetch layer's own retries cover ~8s; this
+      // extends coverage to ~40s of outage). Only a CLEAN signed-out answer
+      // ever triggers the redirect.
+      if (attempt + 1 < MAX_RECHECKS) {
+        timer = setTimeout(() => verify(attempt + 1), 4_000);
+      }
+    };
+
+    const verify = (attempt: number) => {
       void authClient
         .getSession()
         .then((session) => {
-          setHasValidSession(!!session?.data?.user);
+          if (cancelled) return;
+          const status = session?.error?.status;
+          if (status !== undefined && (status === 0 || status >= 500)) {
+            console.warn(
+              `[auth] Session re-check failed with ${status} (attempt ${attempt + 1})`,
+            );
+            scheduleRecheck(attempt);
+            return;
+          }
+          const valid = !!session?.data?.user;
+          setHasValidSession(valid);
           setSessionVerified(true);
+          if (!valid) return;
+          // Better Auth has a live session but the Convex websocket never
+          // authenticated. Poke the session signal so the provider refetches
+          // its session atom and rebuilds the token fetch → ws auth chain.
+          authClient.$store.notify('$sessionSignal');
+          // Last resort: if the kick doesn't authenticate within 8s, reload
+          // once (what this state otherwise forces the user to do manually).
+          // Guarded per tab so it can never loop; cleared on success above.
+          if (!sessionStorage.getItem(CONVEX_AUTH_RELOAD_GUARD)) {
+            timer = setTimeout(() => {
+              sessionStorage.setItem(CONVEX_AUTH_RELOAD_GUARD, '1');
+              console.warn(
+                '[auth] Convex websocket auth is stuck with a valid session — reloading once to recover.',
+              );
+              window.location.reload();
+            }, 8_000);
+          }
         })
-        .catch(() => {
-          setHasValidSession(false);
-          setSessionVerified(true);
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          // Thrown fetch = transport failure too (offline, refused) — same
+          // treatment as 5xx: hold the shell and re-check.
+          console.warn('[auth] Session re-check failed', err);
+          scheduleRecheck(attempt);
         });
-    }
+    };
+
+    verify(0);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [isLoading, isAuthenticated]);
 
   useEffect(() => {

--- a/services/platform/app/routes/dashboard.tsx
+++ b/services/platform/app/routes/dashboard.tsx
@@ -76,6 +76,10 @@ function DashboardRedirect() {
     // reload. Re-check Better Auth directly before doing a hard redirect, and
     // un-stick the provider when the session is actually alive.
     let cancelled = false;
+    // At most one timer is ever pending: a verify() run finishes before it
+    // schedules anything, and it arms exactly one of the two timers (the
+    // re-check backoff in scheduleRecheck or the one-shot reload below) — never
+    // both — overwriting this single handle. Cleanup clears whichever is set.
     let timer: ReturnType<typeof setTimeout> | undefined;
     const MAX_RECHECKS = 8;
 

--- a/services/platform/app/routes/dashboard/index.tsx
+++ b/services/platform/app/routes/dashboard/index.tsx
@@ -12,7 +12,11 @@ import { authClient } from '@/lib/auth-client';
 
 export const Route = createFileRoute('/dashboard/')({
   beforeLoad: async ({ context }) => {
-    const session = await context.queryClient.fetchQuery(sessionQueryOptions);
+    // fetchQuery rejects on transport failures (after retries) — fall back to
+    // the signed-out path rather than surfacing a route error.
+    const session = await context.queryClient
+      .fetchQuery(sessionQueryOptions)
+      .catch(() => null);
     if (!session?.data?.user) {
       throw redirect({ to: '/log-in' });
     }

--- a/services/platform/app/routes/docs.tsx
+++ b/services/platform/app/routes/docs.tsx
@@ -30,16 +30,22 @@ function SwaggerSkeleton() {
   return (
     <Skeletonize loading className="contents">
       <ContentArea variant="page" gap={4} className="p-8">
-        <SkeletonBox fullWidth>
-          <div className="h-10 w-full max-w-md" />
-        </SkeletonBox>
-        <SkeletonBox fullWidth>
-          <div className="h-8 w-3/4" />
-        </SkeletonBox>
-        <Stack gap={2}>
+        <div className="max-w-md">
           <SkeletonBox fullWidth>
-            <div className="h-6 w-1/2" />
+            <div className="h-10" />
           </SkeletonBox>
+        </div>
+        <div className="w-3/4">
+          <SkeletonBox fullWidth>
+            <div className="h-8" />
+          </SkeletonBox>
+        </div>
+        <Stack gap={2}>
+          <div className="w-1/2">
+            <SkeletonBox fullWidth>
+              <div className="h-6" />
+            </SkeletonBox>
+          </div>
           <SkeletonBox fullWidth>
             <div className="h-24 w-full" />
           </SkeletonBox>

--- a/services/platform/app/routes/index.tsx
+++ b/services/platform/app/routes/index.tsx
@@ -4,7 +4,11 @@ import { sessionQueryOptions } from '@/app/lib/auth/session-query';
 
 export const Route = createFileRoute('/')({
   beforeLoad: async ({ context }) => {
-    const session = await context.queryClient.fetchQuery(sessionQueryOptions);
+    // fetchQuery rejects on transport failures (after retries) — fall back to
+    // the signed-out path rather than surfacing a route error.
+    const session = await context.queryClient
+      .fetchQuery(sessionQueryOptions)
+      .catch(() => null);
     if (session?.data?.user) {
       throw redirect({ to: '/dashboard' });
     }

--- a/services/platform/lib/auth-client.ts
+++ b/services/platform/lib/auth-client.ts
@@ -43,6 +43,24 @@ export const authClient = createAuthClient({
   baseURL: basePath
     ? `${window.location.origin}${basePath}/api/auth`
     : undefined,
+  // Retry transient failures (5xx / unreachable backend) inside the fetch
+  // layer. On cold start the backend can briefly answer 502/503 while
+  // functions, env vars and the JWKS bootstrap settle — and two consumers
+  // latch the FIRST result forever: the auth provider's session atom never
+  // refetches on its own, and its Convex token fetch is only rebuilt when the
+  // session id changes. A single failed hop therefore used to strand the
+  // websocket unauthenticated (endless skeletons) until a manual reload.
+  // Retrying here keeps those one-shot fetches pending until the backend is
+  // actually up. 4xx (signed out, bad request) is never retried.
+  fetchOptions: {
+    retry: {
+      type: 'exponential',
+      attempts: 4,
+      baseDelay: 500,
+      maxDelay: 4000,
+      shouldRetry: (response) => response === null || response.status >= 500,
+    },
+  },
   plugins: [
     convexClient(),
     apiKeyClient(),

--- a/services/platform/scripts/dev.ts
+++ b/services/platform/scripts/dev.ts
@@ -361,6 +361,45 @@ async function assertPortFree(port: number): Promise<void> {
   );
 }
 
+/** Probe the Better Auth HTTP surface (served by the Convex site proxy on
+ *  :3211) until `/api/auth/ok` answers 200. This is a true end-to-end auth
+ *  readiness check: it proves the http router is pushed AND the better-auth
+ *  handler can execute with its env (BETTER_AUTH_SECRET etc.). On the FIRST
+ *  run in a clean repo the browser used to race this bootstrap — the page's
+ *  initial session/token fetches failed, the auth provider latched the
+ *  failure, and the app sat in skeletons until a manual reload. Probing
+ *  before Vite starts means the app is never reachable before auth is.
+ *  Warn-and-continue on timeout: a genuinely broken auth route fails loudly
+ *  in the browser anyway, and the client now retries transient failures. */
+async function waitForAuthRoutes(timeoutMs = 90_000): Promise<void> {
+  const convexBase =
+    process.env.CONVEX_URL ||
+    `http://${DEFAULT_CONVEX_HOST}:${DEFAULT_CONVEX_PORT}`;
+  const siteBase =
+    process.env.CONVEX_SITE_PROXY_URL || convexBase.replace(/:\d+$/, ':3211');
+  const url = `${siteBase.replace(/\/$/, '')}/api/auth/ok`;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = 'no response yet';
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(3_000) });
+      if (res.ok) {
+        console.log('[dev] ✅ Auth routes ready');
+        return;
+      }
+      lastError = `HTTP ${res.status}`;
+    } catch (err) {
+      // Expected while the backend is still warming — remember the failure
+      // for the timeout warning instead of spamming once per second.
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  console.warn(
+    `[dev] ⚠️  Auth routes did not answer at ${url} within ${timeoutMs / 1000}s (last: ${lastError}) — continuing; the first page load may need the in-app auth retry.`,
+  );
+}
+
 /** Poll until the dev server is actually accepting connections, then print one
  *  unmistakable READY banner. This matters because (a) the log line printed
  *  just before spawning Vite only *promises* the URL — the socket isn't bound
@@ -718,6 +757,9 @@ async function main() {
     console.log('[dev] 🔄 Running code generation...');
     await runCommand('npx', ['convex', 'codegen']);
     console.log('[dev] ✅ Code generation completed');
+
+    console.log('[dev] ⏳ Waiting for auth routes to serve...');
+    await waitForAuthRoutes();
 
     // Preserve any existing CONVEX_URL the user set (external mode); only
     // synthesize one for local mode where we own the spawned backend.

--- a/services/platform/scripts/dev.ts
+++ b/services/platform/scripts/dev.ts
@@ -375,8 +375,21 @@ async function waitForAuthRoutes(timeoutMs = 90_000): Promise<void> {
   const convexBase =
     process.env.CONVEX_URL ||
     `http://${DEFAULT_CONVEX_HOST}:${DEFAULT_CONVEX_PORT}`;
+  // Derive the Convex site-proxy origin (:3211) from CONVEX_URL. Parse with
+  // URL and set the port explicitly so a trailing slash or path on CONVEX_URL
+  // (e.g. `http://127.0.0.1:3210/`) can't defeat a `:\d+$` swap and leave the
+  // probe pointed at the backend port — which would block startup for the full
+  // timeout despite auth being healthy on :3211.
   const siteBase =
-    process.env.CONVEX_SITE_PROXY_URL || convexBase.replace(/:\d+$/, ':3211');
+    process.env.CONVEX_SITE_PROXY_URL ||
+    (() => {
+      const u = new URL(convexBase);
+      u.port = '3211';
+      u.pathname = '';
+      u.search = '';
+      u.hash = '';
+      return u.toString();
+    })();
   const url = `${siteBase.replace(/\/$/, '')}/api/auth/ok`;
   const deadline = Date.now() + timeoutMs;
   let lastError = 'no response yet';


### PR DESCRIPTION
## What

Two cold-load fixes that were sitting in my working tree:

### 1. Recover stuck websocket auth on cold start
On a cold backend the first session/token fetch can hit a transient 502/503 while functions, env, and the JWKS bootstrap settle. Two consumers latch that first result forever (the auth provider's session atom never refetches; its Convex token fetch only rebuilds on session-id change), so one failed hop stranded the websocket unauthenticated — every auth-gated query disabled, endless skeletons until a manual reload.

Four layers of recovery:
- **auth-client fetch layer** retries 5xx / unreachable with exponential backoff (4 attempts); 4xx never retried.
- **session queryFn** throws on transport failures (status `0` / `>=500`) so TanStack Query treats them as retryable failures instead of caching "signed out" as fresh; adds one query-level retry.
- **route `beforeLoad` guards** (`_auth`, `dashboard`, `dashboard/index`, `index`) catch the rejection and fall back to the signed-out path instead of surfacing a route error.
- **`DashboardRedirect`** re-checks Better Auth when unauthenticated, holds the shell during outages (~40s), kicks `$sessionSignal` to rebuild the ws-auth chain, and reloads once (tab-guarded) as a last resort.
- **`dev.ts`** probes `/api/auth/ok` before starting Vite so the first page load in a clean repo never races the auth bootstrap.

### 2. Size skeleton masks from a wrapper, not the hidden placeholder
A narrower placeholder inside a `fullWidth` `SkeletonBox` was ignored — the mask filled the wrapper, so every "varied width" skeleton painted a uniform full-width bar. Moved the width onto a wrapper element around the box across the data table, chat history sidebar, chat messages, conversations list, governance overview, related automations, tasks workspace, and the docs Swagger skeleton. Dropped the base mask's `-inset-0.5` overhang (content is already `visibility: hidden` while masked) so masks no longer bleed into each other in tight `gap-1` stacks. Bumped the search palette overlay to `z-50`.

## Pre-PR checklist
- [x] Ran `bun run check` (typecheck + lint scoped to `@tale/platform` + `@tale/ui` — both clean; full CI runs the rest).
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — this PR *removes* the magic widths and routes everything through `<Skeletonize>` + skeleton-aware leaves.
- [x] N/A — no `messages/` keys added or changed.
- [x] N/A — no user-visible text, config, env, or API surface changed (console warnings only).
- [x] N/A — no docs pages touched.
- [x] N/A — docs workspace untouched.
- [x] N/A — README untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authentication resilience with improved error recovery during transient backend failures
  * Added automatic retry logic for backend communication to prevent authentication timeouts
  * Fixed potential stuck authentication states with recovery mechanisms and page reload guards

* **Chores**
  * Refined loading placeholder visuals across data tables and chat components
  * Improved development environment setup with authentication readiness checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->