### PR TITLE
fix(k8s): add per-process ulimit parity with docker backend

### DIFF
--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
@@ -140,6 +140,13 @@ describe('buildSandboxPod', () => {
     expect(c.command?.[2]).toContain('/entrypoint.sh "$0" "$1" "$2" "$3"');
     expect(c.command?.[2]).toContain('2>/workspace/.tale/stderr.log');
     expect(c.command?.[2]).toContain('echo $? > /workspace/.tale/exit-code');
+    // Per-process ulimit parity with the docker backend (issue #1851).
+    expect(c.command?.[2]).toContain('ulimit -u 128 -f 204800 -t 600 -c 0');
+    expect(c.command?.[2]).toContain('ulimit -n 1024');
+    // ulimit lines appear BEFORE the entrypoint invocation.
+    expect(c.command?.[2].indexOf('ulimit -u')).toBeLessThan(
+      c.command?.[2].indexOf('/entrypoint.sh'),
+    );
     // No sentinel handshake — staging is an initContainer now.
     expect(c.command?.[2]).not.toContain('.staged');
     expect(c.command?.[2]).not.toContain('exec /entrypoint.sh');

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
@@ -96,6 +96,12 @@ export function podNameFor(executionId: string): string {
 // clean phase parsing). $0..$3 come from the Pod `args` trailer below.
 const RUNNER_WRAPPER = [
   `mkdir -p ${TALE_DIR}`,
+  // Per-process ulimit parity with the docker backend (docker-args.ts:117-135).
+  // Busybox sh supports ulimit, making this a zero-dependency mechanism that
+  // works under both runc and gVisor. Each call sets limits on the shell and
+  // everything it forks, mirroring Docker's per-container resource bounds.
+  `ulimit -u 128 -f 204800 -t 600 -c 0`,
+  `ulimit -n 1024`,
   `/entrypoint.sh "$0" "$1" "$2" "$3" 2>${STDERR_PATH}`,
   `echo $? > ${EXIT_CODE_PATH}`,
 ].join('\n');


### PR DESCRIPTION
## Summary

Fixes #1851 — the K8s runner pod now applies the same per-process ulimits as the Docker backend, making resource enforcement behavior consistent across backends.

## Docker reference (docker-args.ts:117-135)

| Docker flag | ulimit equivalent | Purpose |
|---|---|---|
| `--pids-limit=128` | `ulimit -u 128` | Max processes per user |
| `--ulimit fsize=104857600` | `ulimit -f 204800` | Max file size (100 MB in 512-byte blocks) |
| `--ulimit cpu=600` | `ulimit -t 600` | CPU time in seconds (soft only) |
| `--ulimit core=0` | `ulimit -c 0` | No core dumps |
| `--ulimit nofile=1024:4096` | `ulimit -n 1024` | Open file descriptors (soft only) |

## Approach

Added `ulimit` calls to `RUNNER_WRAPPER` before the entrypoint invocation. This is the most practical option from the issue's list:

- **Zero dependencies** — busybox sh supports `ulimit`, so no image changes or external tooling needed
- **Works under both runc and gVisor** — doesn't depend on a specific RuntimeClass
- **Directly mirrors Docker** — same limits, same semantics

The pod-level `securityContext` already prevents ulimit elevation, so the soft limits applied here are authoritative.

## Tests

All 19 existing `k8s-pod-spec.test.ts` tests pass. Added ulimit-specific assertions verifying:
- All five ulimit lines are present
- They appear `before` the entrypoint invocation in the wrapper script

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management in the sandbox runner with proper per-process limits (process count, file size, CPU time, and open files)

* **Tests**
  * Enhanced test coverage for resource limit validation in the runner environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->