### PR TITLE
refactor(platform): use shared Table component instead of raw <table>

### DIFF
--- a/services/platform/app/components/ui/data-display/copyable-timestamp.stories.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-timestamp.stories.tsx
@@ -1,4 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 
 import { CopyableTimestamp } from './copyable-timestamp';
 
@@ -118,28 +126,28 @@ export const AlignRight: Story = {
 
 export const InTableRow: Story = {
   render: () => (
-    <table className="border-collapse text-sm">
-      <thead>
-        <tr>
-          <th className="border p-2 text-left">Name</th>
-          <th className="border p-2 text-right">Modified</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead className="text-right">Modified</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {[
           { name: 'Design brief.pdf', date: NOW },
           { name: 'Q1 report.docx', date: YESTERDAY },
           { name: 'Onboarding guide.pdf', date: LAST_WEEK },
         ].map(({ name, date }) => (
-          <tr key={name}>
-            <td className="border p-2">{name}</td>
-            <td className="border p-2">
+          <TableRow key={name}>
+            <TableCell>{name}</TableCell>
+            <TableCell className="text-right">
               <CopyableTimestamp date={date} preset="short" alignRight />
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   ),
   parameters: {
     docs: {

--- a/services/platform/app/components/ui/data-display/table-date-cell.stories.tsx
+++ b/services/platform/app/components/ui/data-display/table-date-cell.stories.tsx
@@ -1,4 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 
 import { TableDateCell, TableTimestampCell } from './table-date-cell';
 
@@ -193,35 +201,35 @@ export const ISOStringInput: Story = {
 
 export const InTableContext: Story = {
   render: () => (
-    <table className="w-full border-collapse">
-      <thead>
-        <tr className="border-b">
-          <th className="p-2 text-left text-sm font-medium">Name</th>
-          <th className="p-2 text-left text-sm font-medium">Created</th>
-          <th className="p-2 text-right text-sm font-medium">Updated</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr className="border-b">
-          <td className="p-2 text-sm">Document 1</td>
-          <td className="p-2">
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead className="text-right">Updated</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Document 1</TableCell>
+          <TableCell>
             <TableDateCell date={sampleDate} preset="short" />
-          </td>
-          <td className="p-2">
+          </TableCell>
+          <TableCell>
             <TableDateCell date={recentDate} preset="relative" alignRight />
-          </td>
-        </tr>
-        <tr className="border-b">
-          <td className="p-2 text-sm">Document 2</td>
-          <td className="p-2">
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Document 2</TableCell>
+          <TableCell>
             <TableDateCell date={new Date('2024-01-10')} preset="short" />
-          </td>
-          <td className="p-2">
+          </TableCell>
+          <TableCell>
             <TableDateCell date={null} alignRight />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
   ),
   parameters: {
     docs: {

--- a/services/platform/app/components/ui/entity/entity-row-actions.stories.tsx
+++ b/services/platform/app/components/ui/entity/entity-row-actions.stories.tsx
@@ -1,5 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
+import {
   Eye,
   Pencil,
   Trash2,
@@ -262,22 +270,22 @@ export const AlignStart: Story = {
 
 export const InTableContext: Story = {
   render: () => (
-    <table className="w-full border-collapse">
-      <thead>
-        <tr className="border-b">
-          <th className="p-2 text-left text-sm font-medium">Name</th>
-          <th className="p-2 text-left text-sm font-medium">Status</th>
-          <th className="w-10"></th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="w-10" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {['Document 1', 'Document 2', 'Document 3'].map((name, i) => (
-          <tr key={name} className="hover:bg-muted/50 border-b">
-            <td className="p-2 text-sm">{name}</td>
-            <td className="text-muted-foreground p-2 text-sm">
+          <TableRow key={name}>
+            <TableCell>{name}</TableCell>
+            <TableCell className="text-muted-foreground">
               {i === 0 ? 'Active' : i === 1 ? 'Draft' : 'Archived'}
-            </td>
-            <td className="p-2">
+            </TableCell>
+            <TableCell>
               <EntityRowActions
                 actions={[
                   { key: 'view', label: 'View', icon: Eye, onClick: () => {} },
@@ -298,11 +306,11 @@ export const InTableContext: Story = {
                   },
                 ]}
               />
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   ),
   parameters: {
     docs: {

--- a/services/platform/app/features/chat/components/paginated-markdown-table.tsx
+++ b/services/platform/app/features/chat/components/paginated-markdown-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TableBody, TableCell } from '@tale/ui/table';
+import { Table, TableBody, TableCell } from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import {
@@ -143,17 +143,12 @@ export function PaginatedMarkdownTable({
 
   return (
     <div className="border-border my-4 max-w-(--chat-max-width) overflow-hidden rounded-lg border">
-      <div className="overflow-x-auto">
-        <table
-          className={cn(
-            'caption-bottom text-sm',
-            headerColumnCount > 6 ? 'min-w-full' : 'w-full table-fixed',
-          )}
-        >
-          {thead}
-          {paginatedTbody}
-        </table>
-      </div>
+      <Table
+        className={cn(headerColumnCount > 6 ? undefined : 'w-full table-fixed')}
+      >
+        {thead}
+        {paginatedTbody}
+      </Table>
 
       {showPagination && (
         <div className="border-border bg-background flex items-center gap-5 border-t p-2">

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -5,6 +5,15 @@ import { HStack, Stack } from '@tale/ui/layout';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
 import { Pencil, Plus, Trash2, Wallet } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -501,172 +510,139 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
           </Text>
 
           <div className="border-border overflow-hidden rounded-lg border">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <caption className="sr-only">{t('budgets.title')}</caption>
-                <thead className="bg-muted/50">
-                  <tr className="border-border border-b">
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-left font-medium"
-                    >
-                      {t('budgets.scope')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-left font-medium"
-                    >
-                      {t('budgets.target')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-left font-medium"
-                    >
-                      {t('budgets.period')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-right font-medium"
-                    >
-                      {t('budgets.tokenLimit')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-right font-medium"
-                    >
-                      {t('budgets.maxCost')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-right font-medium"
-                    >
-                      {t('budgets.maxRequests')}
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-muted-foreground px-3 py-2 text-right font-medium"
-                    >
-                      {t('budgets.actions')}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {loading ? (
-                    Array.from({ length: PLACEHOLDER_ROW_COUNT }).map(
-                      (_, i) => (
-                        <tr
-                          key={`placeholder-${i}`}
-                          className="border-border border-b last:border-b-0"
-                        >
-                          <td className="px-3 py-2">
-                            <SkeletonBox>
-                              <div className="h-3.5 w-16" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox>
-                              <div className="h-3.5 w-24" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox>
-                              <div className="h-3.5 w-16" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox fullWidth>
-                              <div className="ml-auto h-3.5 w-14" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox fullWidth>
-                              <div className="ml-auto h-3.5 w-14" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox fullWidth>
-                              <div className="ml-auto h-3.5 w-12" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <HStack gap={1} justify="end">
-                              <SkeletonBox>
-                                <div className="size-8 rounded-md" />
-                              </SkeletonBox>
-                              <SkeletonBox>
-                                <div className="size-8 rounded-md" />
-                              </SkeletonBox>
-                            </HStack>
-                          </td>
-                        </tr>
-                      ),
-                    )
-                  ) : rules.length > 0 ? (
-                    rules.map((rule, index) => (
-                      <tr
-                        key={index}
-                        className="border-border border-b last:border-b-0"
-                      >
-                        <td className="px-3 py-2 capitalize">{rule.scope}</td>
-                        <td className="px-3 py-2">{resolveTarget(rule)}</td>
-                        <td className="px-3 py-2 capitalize">{rule.period}</td>
-                        <td className="px-3 py-2 text-right">
-                          {rule.maxTokens != null
-                            ? rule.maxTokens.toLocaleString()
-                            : '—'}
-                        </td>
-                        <td className="px-3 py-2 text-right">
-                          {rule.maxCostCents != null
-                            ? formatCost(rule.maxCostCents)
-                            : '—'}
-                        </td>
-                        <td className="px-3 py-2 text-right">
-                          {rule.maxRequests != null
-                            ? rule.maxRequests.toLocaleString()
-                            : '—'}
-                        </td>
-                        <td className="px-3 py-2 text-right">
-                          <HStack gap={1} justify="end">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => onEditRule(index)}
-                              disabled={cannotManage}
-                              aria-label={t('budgets.editRuleAriaLabel', {
-                                index: index + 1,
-                              })}
-                            >
-                              <Pencil className="size-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => onRemoveRule(index)}
-                              disabled={cannotManage}
-                              aria-label={t('budgets.removeRuleAriaLabel', {
-                                index: index + 1,
-                              })}
-                            >
-                              <Trash2 className="size-4" />
-                            </Button>
-                          </HStack>
-                        </td>
-                      </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td colSpan={COLUMN_COUNT} className="p-0">
-                        <RulesTableEmptyState
-                          icon={Wallet}
-                          title={t('budgets.noRulesTitle')}
-                          description={t('budgets.noRulesDescription')}
-                        />
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
+            <Table>
+              <TableCaption className="sr-only">
+                {t('budgets.title')}
+              </TableCaption>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('budgets.scope')}</TableHead>
+                  <TableHead>{t('budgets.target')}</TableHead>
+                  <TableHead>{t('budgets.period')}</TableHead>
+                  <TableHead className="text-right">
+                    {t('budgets.tokenLimit')}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t('budgets.maxCost')}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t('budgets.maxRequests')}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t('budgets.actions')}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  Array.from({ length: PLACEHOLDER_ROW_COUNT }).map((_, i) => (
+                    <TableRow key={`placeholder-${i}`}>
+                      <TableCell>
+                        <SkeletonBox>
+                          <div className="h-3.5 w-16" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <SkeletonBox>
+                          <div className="h-3.5 w-24" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <SkeletonBox>
+                          <div className="h-3.5 w-16" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <SkeletonBox fullWidth>
+                          <div className="ml-auto h-3.5 w-14" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <SkeletonBox fullWidth>
+                          <div className="ml-auto h-3.5 w-14" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <SkeletonBox fullWidth>
+                          <div className="ml-auto h-3.5 w-12" />
+                        </SkeletonBox>
+                      </TableCell>
+                      <TableCell>
+                        <HStack gap={1} justify="end">
+                          <SkeletonBox>
+                            <div className="size-8 rounded-md" />
+                          </SkeletonBox>
+                          <SkeletonBox>
+                            <div className="size-8 rounded-md" />
+                          </SkeletonBox>
+                        </HStack>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : rules.length > 0 ? (
+                  rules.map((rule, index) => (
+                    <TableRow key={index}>
+                      <TableCell className="capitalize">{rule.scope}</TableCell>
+                      <TableCell>{resolveTarget(rule)}</TableCell>
+                      <TableCell className="capitalize">
+                        {rule.period}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {rule.maxTokens != null
+                          ? rule.maxTokens.toLocaleString()
+                          : '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {rule.maxCostCents != null
+                          ? formatCost(rule.maxCostCents)
+                          : '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {rule.maxRequests != null
+                          ? rule.maxRequests.toLocaleString()
+                          : '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <HStack gap={1} justify="end">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => onEditRule(index)}
+                            disabled={cannotManage}
+                            aria-label={t('budgets.editRuleAriaLabel', {
+                              index: index + 1,
+                            })}
+                          >
+                            <Pencil className="size-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => onRemoveRule(index)}
+                            disabled={cannotManage}
+                            aria-label={t('budgets.removeRuleAriaLabel', {
+                              index: index + 1,
+                            })}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        </HStack>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={COLUMN_COUNT} className="p-0">
+                      <RulesTableEmptyState
+                        icon={Wallet}
+                        title={t('budgets.noRulesTitle')}
+                        description={t('budgets.noRulesDescription')}
+                      />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
           </div>
         </Stack>
 

--- a/services/platform/app/features/settings/governance/components/chat-filter-config.tsx
+++ b/services/platform/app/features/settings/governance/components/chat-filter-config.tsx
@@ -4,6 +4,14 @@ import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { PageSection } from '@tale/ui/page-section';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Download, Pencil, Plus, Trash2, Upload } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
@@ -655,33 +663,23 @@ function CategoryList({
           {t('contentSafety.categoriesEmpty')}
         </div>
       ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-muted-foreground text-left text-xs">
-              <th className="py-1 font-medium">
-                {t('contentSafety.columnLabel')}
-              </th>
-              <th className="py-1 font-medium">
-                {t('contentSafety.columnMode')}
-              </th>
-              <th className="py-1 font-medium">
-                {t('contentSafety.columnEnabled')}
-              </th>
-              <th className="py-1 font-medium">
-                {t('contentSafety.columnWords')}
-              </th>
-              <th className="py-1 font-medium">
-                {t('contentSafety.columnPatterns')}
-              </th>
-              <th className="py-1 font-medium"></th>
-            </tr>
-          </thead>
-          <tbody>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('contentSafety.columnLabel')}</TableHead>
+              <TableHead>{t('contentSafety.columnMode')}</TableHead>
+              <TableHead>{t('contentSafety.columnEnabled')}</TableHead>
+              <TableHead>{t('contentSafety.columnWords')}</TableHead>
+              <TableHead>{t('contentSafety.columnPatterns')}</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {categories.map((category, index) => (
-              <tr key={category.id} className="border-border border-t">
-                <td className="py-2">{category.label}</td>
-                <td className="py-2 capitalize">{category.mode}</td>
-                <td className="py-2">
+              <TableRow key={category.id}>
+                <TableCell>{category.label}</TableCell>
+                <TableCell className="capitalize">{category.mode}</TableCell>
+                <TableCell>
                   <Switch
                     checked={category.enabled}
                     disabled={disabled}
@@ -690,10 +688,10 @@ function CategoryList({
                     })}
                     onCheckedChange={(next) => onToggleEnabled(index, next)}
                   />
-                </td>
-                <td className="py-2">{category.words.length}</td>
-                <td className="py-2">{category.patterns.length}</td>
-                <td className="py-2">
+                </TableCell>
+                <TableCell>{category.words.length}</TableCell>
+                <TableCell>{category.patterns.length}</TableCell>
+                <TableCell>
                   <div className="flex justify-end gap-1">
                     <Button
                       variant="ghost"
@@ -718,11 +716,11 @@ function CategoryList({
                       onClick={() => onDelete(index)}
                     />
                   </div>
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       )}
       <div>
         <Button

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -6,6 +6,15 @@ import { HStack, Stack } from '@tale/ui/layout';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { AlertCircle, Database, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -544,134 +553,105 @@ export function DefaultModelEditor({
         }
       >
         <div className="border-border overflow-hidden rounded-lg border">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <caption className="sr-only">{t('defaultModels.title')}</caption>
-              <thead className="bg-muted/50">
-                <tr className="border-border border-b">
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('defaultModels.scope')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('defaultModels.target')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('defaultModels.provider')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('defaultModels.model')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-right font-medium"
-                  >
-                    {t('defaultModels.actions')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {loading ? (
-                  displayRows.map((_, index) => (
-                    <tr
-                      key={`skeleton-${index}`}
-                      className="border-border border-b last:border-b-0"
-                    >
-                      <td className="px-3 py-2">
+          <Table>
+            <TableCaption className="sr-only">
+              {t('defaultModels.title')}
+            </TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('defaultModels.scope')}</TableHead>
+                <TableHead>{t('defaultModels.target')}</TableHead>
+                <TableHead>{t('defaultModels.provider')}</TableHead>
+                <TableHead>{t('defaultModels.model')}</TableHead>
+                <TableHead className="text-right">
+                  {t('defaultModels.actions')}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                displayRows.map((_, index) => (
+                  <TableRow key={`skeleton-${index}`}>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-16" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-24" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-20" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-28" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <HStack gap={1} justify="end">
                         <SkeletonBox>
-                          <div className="h-3.5 w-16" />
+                          <div className="size-8 rounded-md" />
                         </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
                         <SkeletonBox>
-                          <div className="h-3.5 w-24" />
+                          <div className="size-8 rounded-md" />
                         </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox>
-                          <div className="h-3.5 w-20" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox>
-                          <div className="h-3.5 w-28" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        <HStack gap={1} justify="end">
-                          <SkeletonBox>
-                            <div className="size-8 rounded-md" />
-                          </SkeletonBox>
-                          <SkeletonBox>
-                            <div className="size-8 rounded-md" />
-                          </SkeletonBox>
-                        </HStack>
-                      </td>
-                    </tr>
-                  ))
-                ) : rules.length > 0 ? (
-                  rules.map((rule, index) => (
-                    <tr
-                      key={index}
-                      className="border-border border-b last:border-b-0"
-                    >
-                      <td className="px-3 py-2 capitalize">{rule.scope}</td>
-                      <td className="px-3 py-2">{resolveTarget(rule)}</td>
-                      <td className="px-3 py-2">{resolveProviderName(rule)}</td>
-                      <td className="px-3 py-2">{resolveModelName(rule)}</td>
-                      <td className="px-3 py-2 text-right">
-                        <HStack gap={1} justify="end">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => openEditDialog(index)}
-                            disabled={cannotManage}
-                            aria-label={t('defaultModels.editRule', {
-                              index: index + 1,
-                            })}
-                          >
-                            <Pencil className="size-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => setDeletingIndex(index)}
-                            disabled={cannotManage}
-                            aria-label={t('defaultModels.removeRule', {
-                              index: index + 1,
-                            })}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </HStack>
-                      </td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr>
-                    <td colSpan={5} className="p-0">
-                      <RulesTableEmptyState
-                        icon={Database}
-                        title={t('defaultModels.noRulesTitle')}
-                        description={t('defaultModels.noRulesDescription')}
-                      />
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                      </HStack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : rules.length > 0 ? (
+                rules.map((rule, index) => (
+                  <TableRow key={index}>
+                    <TableCell className="capitalize">{rule.scope}</TableCell>
+                    <TableCell>{resolveTarget(rule)}</TableCell>
+                    <TableCell>{resolveProviderName(rule)}</TableCell>
+                    <TableCell>{resolveModelName(rule)}</TableCell>
+                    <TableCell className="text-right">
+                      <HStack gap={1} justify="end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEditDialog(index)}
+                          disabled={cannotManage}
+                          aria-label={t('defaultModels.editRule', {
+                            index: index + 1,
+                          })}
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeletingIndex(index)}
+                          disabled={cannotManage}
+                          aria-label={t('defaultModels.removeRule', {
+                            index: index + 1,
+                          })}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </HStack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={5} className="p-0">
+                    <RulesTableEmptyState
+                      icon={Database}
+                      title={t('defaultModels.noRulesTitle')}
+                      description={t('defaultModels.noRulesDescription')}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
 
         <RuleDialog

--- a/services/platform/app/features/settings/governance/components/feature-flags-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/feature-flags-editor.tsx
@@ -5,6 +5,15 @@ import { HStack, Stack } from '@tale/ui/layout';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
 import { Pencil, Plus, SlidersHorizontal, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -472,167 +481,133 @@ export function FeatureFlagsEditor({
         }
       >
         <div className="border-border overflow-hidden rounded-lg border">
-          <div className="overflow-x-auto">
-            <table
-              className="w-full text-sm"
-              aria-label={t('featureFlags.title')}
-            >
-              <caption className="sr-only">{t('featureFlags.title')}</caption>
-              <thead className="bg-muted/50">
-                <tr className="border-border border-b">
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('featureFlags.scope')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-left font-medium"
-                  >
-                    {t('featureFlags.target')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-center font-medium"
-                  >
-                    {t('featureFlags.webSearch')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-center font-medium"
-                  >
-                    {t('featureFlags.codeExecution')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-center font-medium"
-                  >
-                    {t('featureFlags.fileUpload')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-right font-medium"
-                  >
-                    {t('featureFlags.maxContextTokens')}
-                  </th>
-                  <th
-                    scope="col"
-                    className="text-muted-foreground px-3 py-2 text-right font-medium"
-                  >
-                    {t('featureFlags.actions')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {loading ? (
-                  Array.from({ length: PLACEHOLDER_ROW_COUNT }).map((_, i) => (
-                    <tr
-                      key={`placeholder-${i}`}
-                      className="border-border border-b last:border-b-0"
-                    >
-                      <td className="px-3 py-2">
+          <Table aria-label={t('featureFlags.title')}>
+            <TableCaption className="sr-only">
+              {t('featureFlags.title')}
+            </TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('featureFlags.scope')}</TableHead>
+                <TableHead>{t('featureFlags.target')}</TableHead>
+                <TableHead className="text-center">
+                  {t('featureFlags.webSearch')}
+                </TableHead>
+                <TableHead className="text-center">
+                  {t('featureFlags.codeExecution')}
+                </TableHead>
+                <TableHead className="text-center">
+                  {t('featureFlags.fileUpload')}
+                </TableHead>
+                <TableHead className="text-right">
+                  {t('featureFlags.maxContextTokens')}
+                </TableHead>
+                <TableHead className="text-right">
+                  {t('featureFlags.actions')}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                Array.from({ length: PLACEHOLDER_ROW_COUNT }).map((_, i) => (
+                  <TableRow key={`placeholder-${i}`}>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-16" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox>
+                        <div className="h-3.5 w-24" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox fullWidth>
+                        <div className="mx-auto size-4 rounded-sm" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox fullWidth>
+                        <div className="mx-auto size-4 rounded-sm" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox fullWidth>
+                        <div className="mx-auto size-4 rounded-sm" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <SkeletonBox fullWidth>
+                        <div className="ml-auto h-3.5 w-14" />
+                      </SkeletonBox>
+                    </TableCell>
+                    <TableCell>
+                      <HStack gap={1} justify="end">
                         <SkeletonBox>
-                          <div className="h-3.5 w-16" />
+                          <div className="size-8 rounded-md" />
                         </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
                         <SkeletonBox>
-                          <div className="h-3.5 w-24" />
+                          <div className="size-8 rounded-md" />
                         </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox fullWidth>
-                          <div className="mx-auto size-4 rounded-sm" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox fullWidth>
-                          <div className="mx-auto size-4 rounded-sm" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox fullWidth>
-                          <div className="mx-auto size-4 rounded-sm" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <SkeletonBox fullWidth>
-                          <div className="ml-auto h-3.5 w-14" />
-                        </SkeletonBox>
-                      </td>
-                      <td className="px-3 py-2">
-                        <HStack gap={1} justify="end">
-                          <SkeletonBox>
-                            <div className="size-8 rounded-md" />
-                          </SkeletonBox>
-                          <SkeletonBox>
-                            <div className="size-8 rounded-md" />
-                          </SkeletonBox>
-                        </HStack>
-                      </td>
-                    </tr>
-                  ))
-                ) : rules.length > 0 ? (
-                  rules.map((rule, index) => (
-                    <tr
-                      key={index}
-                      className="border-border border-b last:border-b-0"
-                    >
-                      <td className="px-3 py-2 capitalize">{rule.scope}</td>
-                      <td className="px-3 py-2">{resolveTarget(rule)}</td>
-                      <td className="px-3 py-2 text-center">
-                        {rule.webSearch === false ? '✘' : '✔'}
-                      </td>
-                      <td className="px-3 py-2 text-center">
-                        {rule.codeExecution === false ? '✘' : '✔'}
-                      </td>
-                      <td className="px-3 py-2 text-center">
-                        {rule.fileUpload === false ? '✘' : '✔'}
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        {rule.maxContextTokens != null
-                          ? formatNumber(rule.maxContextTokens)
-                          : '—'}
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        <HStack gap={1} justify="end">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => onEditRule(index)}
-                            disabled={cannotManage}
-                            aria-label={`${t('featureFlags.editRule')} ${index + 1}`}
-                          >
-                            <Pencil className="size-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => onRemoveRule(index)}
-                            disabled={cannotManage}
-                            aria-label={`${t('featureFlags.deleteRule')} ${index + 1}`}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </HStack>
-                      </td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr>
-                    <td colSpan={COLUMN_COUNT} className="p-0">
-                      <RulesTableEmptyState
-                        icon={SlidersHorizontal}
-                        title={t('featureFlags.noRulesTitle')}
-                        description={t('featureFlags.noRulesDescription')}
-                      />
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                      </HStack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : rules.length > 0 ? (
+                rules.map((rule, index) => (
+                  <TableRow key={index}>
+                    <TableCell className="capitalize">{rule.scope}</TableCell>
+                    <TableCell>{resolveTarget(rule)}</TableCell>
+                    <TableCell className="text-center">
+                      {rule.webSearch === false ? '✘' : '✔'}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {rule.codeExecution === false ? '✘' : '✔'}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {rule.fileUpload === false ? '✘' : '✔'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {rule.maxContextTokens != null
+                        ? formatNumber(rule.maxContextTokens)
+                        : '—'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <HStack gap={1} justify="end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEditRule(index)}
+                          disabled={cannotManage}
+                          aria-label={`${t('featureFlags.editRule')} ${index + 1}`}
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onRemoveRule(index)}
+                          disabled={cannotManage}
+                          aria-label={`${t('featureFlags.deleteRule')} ${index + 1}`}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </HStack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={COLUMN_COUNT} className="p-0">
+                    <RulesTableEmptyState
+                      icon={SlidersHorizontal}
+                      title={t('featureFlags.noRulesTitle')}
+                      description={t('featureFlags.noRulesDescription')}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
 
         <RuleDialog

--- a/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
+++ b/services/platform/app/features/settings/governance/components/guardrails-overview.tsx
@@ -5,6 +5,14 @@ import { Button } from '@tale/ui/button';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox, SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize, useSkeleton } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Copy, Info, ShieldAlert } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -388,37 +396,37 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
         <Skeletonize
           loading={isLoading}
           label={t('guardrailsOverview.recentEvents.title')}
-          className="border-border overflow-x-auto rounded-lg border"
+          className="border-border overflow-hidden rounded-lg border"
         >
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-border bg-muted/40 text-muted-foreground border-b text-left text-xs">
-                <th className="px-3 py-2 font-medium">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>
                   {t('guardrailsOverview.recentEvents.columnTime')}
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </TableHead>
+                <TableHead>
                   {t('guardrailsOverview.recentEvents.columnFilter')}
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </TableHead>
+                <TableHead>
                   {t('guardrailsOverview.recentEvents.columnDirection')}
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </TableHead>
+                <TableHead>
                   {t('guardrailsOverview.recentEvents.columnKind')}
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </TableHead>
+                <TableHead>
                   {t('guardrailsOverview.recentEvents.columnCategories')}
-                </th>
-                <th className="px-3 py-2 text-right font-medium">
+                </TableHead>
+                <TableHead className="text-right">
                   {t('guardrailsOverview.recentEvents.columnMatches')}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {isLoading
                 ? Array.from({ length: 3 }).map((_, i) => (
-                    <tr key={i} className="border-border border-t">
+                    <TableRow key={i}>
                       {Array.from({ length: 6 }).map((__, j) => (
-                        <td key={j} className="px-3 py-2">
+                        <TableCell key={j}>
                           <div
                             className="max-w-24"
                             style={{
@@ -429,16 +437,16 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
                               <div className="h-3.5" />
                             </SkeletonBox>
                           </div>
-                        </td>
+                        </TableCell>
                       ))}
-                    </tr>
+                    </TableRow>
                   ))
                 : (events ?? []).map((event) => {
                     const typedEvent = event as RecentEvent;
                     return (
-                      <tr
+                      <TableRow
                         key={typedEvent._id}
-                        className="border-border hover:bg-muted/30 cursor-pointer border-t transition-colors"
+                        className="hover:bg-muted/30 cursor-pointer transition-colors"
                         tabIndex={0}
                         aria-label={t(
                           'guardrailsOverview.recentEvents.viewEventAria',
@@ -452,8 +460,8 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
                           }
                         }}
                       >
-                        <td
-                          className="px-3 py-2 whitespace-nowrap"
+                        <TableCell
+                          className="whitespace-nowrap"
                           title={formatDate(
                             new Date(typedEvent.createdAt),
                             'medium',
@@ -463,17 +471,17 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
                             new Date(typedEvent.createdAt),
                             'relative',
                           )}
-                        </td>
-                        <td className="px-3 py-2">
+                        </TableCell>
+                        <TableCell>
                           {filterNameLabel(typedEvent.filterName, t)}
-                        </td>
-                        <td className="px-3 py-2 capitalize">
+                        </TableCell>
+                        <TableCell className="capitalize">
                           {typedEvent.direction}
-                        </td>
-                        <td className="px-3 py-2">
+                        </TableCell>
+                        <TableCell>
                           <KindBadge kind={typedEvent.kind} />
-                        </td>
-                        <td className="px-3 py-2">
+                        </TableCell>
+                        <TableCell>
                           {typedEvent.categoryIds.length === 0 ? (
                             <span className="text-muted-foreground">—</span>
                           ) : (
@@ -485,15 +493,15 @@ function RecentEvents({ organizationId, chatFilterLabels }: RecentEventsProps) {
                               ).join(', ')}
                             </span>
                           )}
-                        </td>
-                        <td className="px-3 py-2 text-right tabular-nums">
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
                           {typedEvent.matchCount ?? 0}
-                        </td>
-                      </tr>
+                        </TableCell>
+                      </TableRow>
                     );
                   })}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </Skeletonize>
       )}
 

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -5,6 +5,15 @@ import { HStack, Stack } from '@tale/ui/layout';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
 import { Pencil, Plus, ShieldCheck, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -581,129 +590,104 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
             </HStack>
 
             <div className="border-border overflow-hidden rounded-lg border">
-              <div className="overflow-x-auto">
-                <table
-                  className="w-full text-sm"
-                  aria-label={t('modelAccess.title')}
-                >
-                  <caption className="sr-only">
-                    {t('modelAccess.title')}
-                  </caption>
-                  <thead className="bg-muted/50">
-                    <tr className="border-border border-b">
-                      <th
-                        scope="col"
-                        className="text-muted-foreground px-3 py-2 text-left font-medium"
-                      >
-                        {t('modelAccess.scope')}
-                      </th>
-                      <th
-                        scope="col"
-                        className="text-muted-foreground px-3 py-2 text-left font-medium"
-                      >
-                        {t('modelAccess.target')}
-                      </th>
-                      <th
-                        scope="col"
-                        className="text-muted-foreground px-3 py-2 text-left font-medium"
-                      >
-                        {mode === 'allowlist'
-                          ? t('modelAccess.allowedModels')
-                          : t('modelAccess.blockedModels')}
-                      </th>
-                      <th
-                        scope="col"
-                        className="text-muted-foreground px-3 py-2 text-right font-medium"
-                      >
-                        {t('modelAccess.actions')}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {loading ? (
-                      displayRows.map((_, index) => (
-                        <tr
-                          key={`skeleton-${index}`}
-                          className="border-border border-b last:border-b-0"
-                        >
-                          <td className="px-3 py-2">
+              <Table aria-label={t('modelAccess.title')}>
+                <TableCaption className="sr-only">
+                  {t('modelAccess.title')}
+                </TableCaption>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t('modelAccess.scope')}</TableHead>
+                    <TableHead>{t('modelAccess.target')}</TableHead>
+                    <TableHead>
+                      {mode === 'allowlist'
+                        ? t('modelAccess.allowedModels')
+                        : t('modelAccess.blockedModels')}
+                    </TableHead>
+                    <TableHead className="text-right">
+                      {t('modelAccess.actions')}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {loading ? (
+                    displayRows.map((_, index) => (
+                      <TableRow key={`skeleton-${index}`}>
+                        <TableCell>
+                          <SkeletonBox>
+                            <div className="h-3.5 w-16" />
+                          </SkeletonBox>
+                        </TableCell>
+                        <TableCell>
+                          <SkeletonBox>
+                            <div className="h-3.5 w-24" />
+                          </SkeletonBox>
+                        </TableCell>
+                        <TableCell>
+                          <SkeletonBox>
+                            <div className="h-3.5 w-32" />
+                          </SkeletonBox>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <HStack gap={1} justify="end">
                             <SkeletonBox>
-                              <div className="h-3.5 w-16" />
+                              <div className="size-8 rounded-md" />
                             </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
                             <SkeletonBox>
-                              <div className="h-3.5 w-24" />
+                              <div className="size-8 rounded-md" />
                             </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2">
-                            <SkeletonBox>
-                              <div className="h-3.5 w-32" />
-                            </SkeletonBox>
-                          </td>
-                          <td className="px-3 py-2 text-right">
-                            <HStack gap={1} justify="end">
-                              <SkeletonBox>
-                                <div className="size-8 rounded-md" />
-                              </SkeletonBox>
-                              <SkeletonBox>
-                                <div className="size-8 rounded-md" />
-                              </SkeletonBox>
-                            </HStack>
-                          </td>
-                        </tr>
-                      ))
-                    ) : rules.length > 0 ? (
-                      rules.map((rule, index) => (
-                        <tr
-                          key={index}
-                          className="border-border border-b last:border-b-0"
-                        >
-                          <td className="px-3 py-2 capitalize">{rule.scope}</td>
-                          <td className="px-3 py-2">{resolveTarget(rule)}</td>
-                          <td className="px-3 py-2">
-                            {mode === 'allowlist'
-                              ? resolveModelNames(rule.allowedModels)
-                              : resolveModelNames(rule.blockedModels ?? [])}
-                          </td>
-                          <td className="px-3 py-2 text-right">
-                            <HStack gap={1} justify="end">
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => openEditDialog(index)}
-                                disabled={cannotManage}
-                                aria-label={t('modelAccess.editRule')}
-                              >
-                                <Pencil className="size-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => setDeletingIndex(index)}
-                                disabled={cannotManage}
-                                aria-label={t('modelAccess.deleteRule')}
-                              >
-                                <Trash2 className="size-4" />
-                              </Button>
-                            </HStack>
-                          </td>
-                        </tr>
-                      ))
-                    ) : (
-                      <tr>
-                        <td colSpan={4} className="p-0">
-                          <RulesTableEmptyState
-                            icon={ShieldCheck}
-                            title={t('modelAccess.noRulesTitle')}
-                            description={t('modelAccess.noRulesDescription')}
-                          />
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
+                          </HStack>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : rules.length > 0 ? (
+                    rules.map((rule, index) => (
+                      <TableRow key={index}>
+                        <TableCell className="capitalize">
+                          {rule.scope}
+                        </TableCell>
+                        <TableCell>{resolveTarget(rule)}</TableCell>
+                        <TableCell>
+                          {mode === 'allowlist'
+                            ? resolveModelNames(rule.allowedModels)
+                            : resolveModelNames(rule.blockedModels ?? [])}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <HStack gap={1} justify="end">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => openEditDialog(index)}
+                              disabled={cannotManage}
+                              aria-label={t('modelAccess.editRule')}
+                            >
+                              <Pencil className="size-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => setDeletingIndex(index)}
+                              disabled={cannotManage}
+                              aria-label={t('modelAccess.deleteRule')}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </HStack>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow className="hover:bg-transparent">
+                      <TableCell colSpan={4} className="p-0">
+                        <RulesTableEmptyState
+                          icon={ShieldCheck}
+                          title={t('modelAccess.noRulesTitle')}
+                          description={t('modelAccess.noRulesDescription')}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
             </div>
           </Stack>
         )}

--- a/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
@@ -7,6 +7,7 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import {
   Table,
   TableBody,
+  TableCaption,
   TableCell,
   TableHead,
   TableHeader,
@@ -1641,6 +1642,9 @@ function MappingList({ mappings, disabled, onAdd, onEdit }: MappingListProps) {
         </div>
       ) : (
         <Table>
+          <TableCaption className="sr-only">
+            {t('moderationProvider.categoryMappings')}
+          </TableCaption>
           <TableHeader>
             <TableRow>
               <TableHead>

--- a/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
+++ b/services/platform/app/features/settings/governance/components/moderation-provider-config.tsx
@@ -4,6 +4,14 @@ import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { PageSection } from '@tale/ui/page-section';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -1632,46 +1640,44 @@ function MappingList({ mappings, disabled, onAdd, onEdit }: MappingListProps) {
           {t('moderationProvider.mappingsEmpty')}
         </div>
       ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-muted-foreground text-left text-xs">
-              <th className="py-1 font-medium">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>
                 {t('moderationProvider.mappingColumnProviderCategory')}
-              </th>
-              <th className="py-1 font-medium">
+              </TableHead>
+              <TableHead>
                 {t('moderationProvider.mappingColumnInternalLabel')}
-              </th>
-              <th className="py-1 font-medium">
-                {t('moderationProvider.mappingColumnMode')}
-              </th>
-              <th className="py-1 font-medium">
+              </TableHead>
+              <TableHead>{t('moderationProvider.mappingColumnMode')}</TableHead>
+              <TableHead>
                 {t('moderationProvider.mappingColumnThreshold')}
-              </th>
-              <th className="py-1 font-medium">
+              </TableHead>
+              <TableHead>
                 {t('moderationProvider.mappingColumnEnabled')}
-              </th>
-              <th className="py-1 font-medium"></th>
-            </tr>
-          </thead>
-          <tbody>
+              </TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {mappings.map((mapping, index) => (
-              <tr key={index} className="border-border border-t">
-                <td className="py-2 font-mono text-xs">
+              <TableRow key={index}>
+                <TableCell className="font-mono text-xs">
                   {mapping.providerCategory}
-                </td>
-                <td className="py-2">{mapping.internalLabel}</td>
-                <td className="py-2 capitalize">{mapping.mode}</td>
-                <td className="py-2">
+                </TableCell>
+                <TableCell>{mapping.internalLabel}</TableCell>
+                <TableCell className="capitalize">{mapping.mode}</TableCell>
+                <TableCell>
                   {mapping.scoreThreshold ?? (
                     <span className="text-muted-foreground">—</span>
                   )}
-                </td>
-                <td className="py-2">
+                </TableCell>
+                <TableCell>
                   {mapping.enabled
                     ? t('moderationProvider.yes')
                     : t('moderationProvider.no')}
-                </td>
-                <td className="py-2 text-right">
+                </TableCell>
+                <TableCell className="text-right">
                   <Button
                     variant="ghost"
                     size="sm"
@@ -1681,11 +1687,11 @@ function MappingList({ mappings, disabled, onAdd, onEdit }: MappingListProps) {
                   >
                     {tCommon('actions.edit')}
                   </Button>
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       )}
       <div>
         <Button

--- a/services/platform/app/features/settings/governance/components/trash-page.tsx
+++ b/services/platform/app/features/settings/governance/components/trash-page.tsx
@@ -4,6 +4,14 @@ import { Button } from '@tale/ui/button';
 import { PageSection } from '@tale/ui/page-section';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { Skeletonize } from '@tale/ui/skeleton-context';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
 import { Undo2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -228,136 +236,132 @@ export function TrashPage({ organizationId }: Props) {
             </div>
           ) : (
             <div className="border-border overflow-hidden rounded-md border">
-              {/* Horizontal scroller so the six-column table can scroll on
-                  narrow viewports instead of squashing or clipping. */}
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[44rem] text-sm">
-                  <thead className="bg-muted/40 border-border border-b">
-                    <tr>
-                      <th className="px-3 py-2 text-left font-medium">
-                        {t('trash.column.type', 'Type')}
-                      </th>
-                      <th className="px-3 py-2 text-left font-medium">
-                        {t('trash.column.name', 'Name')}
-                      </th>
-                      <th className="px-3 py-2 text-left font-medium">
-                        {t('trash.column.owner', 'Owner')}
-                      </th>
-                      <th className="px-3 py-2 text-left font-medium">
-                        {t('trash.column.status', 'Status')}
-                      </th>
-                      <th className="px-3 py-2 text-left font-medium">
-                        {t('trash.column.statusChangedAt', 'Trashed')}
-                      </th>
-                      <th className="px-3 py-2 text-right font-medium">
-                        {t('trash.column.actions', 'Actions')}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-border divide-y">
-                    {loading
-                      ? Array.from({ length: PLACEHOLDER_ROW_COUNT }).map(
-                          (_, i) => (
-                            <tr key={`placeholder-${i}`}>
-                              <td className="px-3 py-2">
-                                <SkeletonBox>
-                                  <div className="h-3.5 w-16" />
-                                </SkeletonBox>
-                              </td>
-                              <td className="px-3 py-2">
-                                <SkeletonBox>
-                                  <div className="h-3.5 w-32" />
-                                </SkeletonBox>
-                              </td>
-                              <td className="px-3 py-2">
-                                <SkeletonBox>
-                                  <div className="h-3.5 w-24" />
-                                </SkeletonBox>
-                              </td>
-                              <td className="px-3 py-2">
-                                <SkeletonBox>
-                                  <div className="h-5 w-16 rounded" />
-                                </SkeletonBox>
-                              </td>
-                              <td className="px-3 py-2">
-                                <SkeletonBox>
-                                  <div className="h-3.5 w-20" />
-                                </SkeletonBox>
-                              </td>
-                              <td className="px-3 py-2">
-                                <SkeletonBox fullWidth>
-                                  <div className="ml-auto h-8 w-20 rounded-md" />
-                                </SkeletonBox>
-                              </td>
-                            </tr>
-                          ),
-                        )
-                      : rows.map((row) => (
-                          <tr
-                            key={`${row.resourceType}:${row.id}`}
-                            className="hover:bg-muted/20"
+              <Table className="min-w-[44rem]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="whitespace-nowrap">
+                      {t('trash.column.type', 'Type')}
+                    </TableHead>
+                    <TableHead className="whitespace-nowrap">
+                      {t('trash.column.name', 'Name')}
+                    </TableHead>
+                    <TableHead className="whitespace-nowrap">
+                      {t('trash.column.owner', 'Owner')}
+                    </TableHead>
+                    <TableHead className="whitespace-nowrap">
+                      {t('trash.column.status', 'Status')}
+                    </TableHead>
+                    <TableHead className="whitespace-nowrap">
+                      {t('trash.column.statusChangedAt', 'Trashed')}
+                    </TableHead>
+                    <TableHead className="text-right whitespace-nowrap">
+                      {t('trash.column.actions', 'Actions')}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {loading
+                    ? Array.from({ length: PLACEHOLDER_ROW_COUNT }).map(
+                        (_, i) => (
+                          <TableRow key={`placeholder-${i}`}>
+                            <TableCell>
+                              <SkeletonBox>
+                                <div className="h-3.5 w-16" />
+                              </SkeletonBox>
+                            </TableCell>
+                            <TableCell>
+                              <SkeletonBox>
+                                <div className="h-3.5 w-32" />
+                              </SkeletonBox>
+                            </TableCell>
+                            <TableCell>
+                              <SkeletonBox>
+                                <div className="h-3.5 w-24" />
+                              </SkeletonBox>
+                            </TableCell>
+                            <TableCell>
+                              <SkeletonBox>
+                                <div className="h-5 w-16 rounded" />
+                              </SkeletonBox>
+                            </TableCell>
+                            <TableCell>
+                              <SkeletonBox>
+                                <div className="h-3.5 w-20" />
+                              </SkeletonBox>
+                            </TableCell>
+                            <TableCell>
+                              <SkeletonBox fullWidth>
+                                <div className="ml-auto h-8 w-20 rounded-md" />
+                              </SkeletonBox>
+                            </TableCell>
+                          </TableRow>
+                        ),
+                      )
+                    : rows.map((row) => (
+                        <TableRow
+                          key={`${row.resourceType}:${row.id}`}
+                          className="hover:bg-muted/20"
+                        >
+                          <TableCell className="text-muted-foreground text-xs">
+                            {t(
+                              `trash.tab.${row.resourceType}`,
+                              row.resourceType,
+                            )}
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {row.displayName ?? row.id}
+                          </TableCell>
+                          <TableCell
+                            className={
+                              row.ownerName
+                                ? 'text-muted-foreground text-xs'
+                                : 'text-muted-foreground font-mono text-xs'
+                            }
                           >
-                            <td className="text-muted-foreground px-3 py-2 text-xs">
-                              {t(
-                                `trash.tab.${row.resourceType}`,
-                                row.resourceType,
-                              )}
-                            </td>
-                            <td className="px-3 py-2 font-mono text-xs">
-                              {row.displayName ?? row.id}
-                            </td>
-                            <td
+                            {row.ownerName ?? row.ownerId ?? '—'}
+                          </TableCell>
+                          <TableCell>
+                            <span
                               className={
-                                row.ownerName
-                                  ? 'text-muted-foreground px-3 py-2 text-xs'
-                                  : 'text-muted-foreground px-3 py-2 font-mono text-xs'
+                                row.status === 'expired'
+                                  ? 'rounded bg-orange-500/15 px-2 py-0.5 text-xs text-orange-600'
+                                  : 'rounded bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-700'
                               }
                             >
-                              {row.ownerName ?? row.ownerId ?? '—'}
-                            </td>
-                            <td className="px-3 py-2">
-                              <span
-                                className={
-                                  row.status === 'expired'
-                                    ? 'rounded bg-orange-500/15 px-2 py-0.5 text-xs text-orange-600'
-                                    : 'rounded bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-700'
-                                }
-                              >
-                                {t(`trash.status.${row.status}`, row.status)}
+                              {t(`trash.status.${row.status}`, row.status)}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground text-xs">
+                            {formatRelative(
+                              row.statusChangedAt ?? row.createdAt,
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              icon={Undo2}
+                              onClick={() =>
+                                onRequestRestore({
+                                  resourceType: row.resourceType,
+                                  rowId: row.id,
+                                  displayName: row.displayName ?? row.id,
+                                  status: row.status,
+                                })
+                              }
+                            >
+                              {/* Icon-only on mobile; the label stays in the
+                                a11y tree via `sr-only` so the button keeps
+                                its accessible name. */}
+                              <span className="max-sm:sr-only">
+                                {t('trash.restore.label', 'Restore')}
                               </span>
-                            </td>
-                            <td className="text-muted-foreground px-3 py-2 text-xs">
-                              {formatRelative(
-                                row.statusChangedAt ?? row.createdAt,
-                              )}
-                            </td>
-                            <td className="px-3 py-2 text-right">
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                icon={Undo2}
-                                onClick={() =>
-                                  onRequestRestore({
-                                    resourceType: row.resourceType,
-                                    rowId: row.id,
-                                    displayName: row.displayName ?? row.id,
-                                    status: row.status,
-                                  })
-                                }
-                              >
-                                {/* Icon-only on mobile; the label stays in the
-                                  a11y tree via `sr-only` so the button keeps
-                                  its accessible name. */}
-                                <span className="max-sm:sr-only">
-                                  {t('trash.restore.label', 'Restore')}
-                                </span>
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                  </tbody>
-                </table>
-              </div>
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                </TableBody>
+              </Table>
               {/* The load-more row reserves its height in both states (masked
               while the first page loads), so revealing it never pushes the
               page. It only shows the real button once more pages exist. */}


### PR DESCRIPTION
## Problem

The **Budget rules** table's header names wrapped over two rows. Root cause: the governance settings tables were hand-rolled raw `<table>` elements that bypassed **both** `DataTable` and the shared `<Table>` primitive (`@tale/ui/table`). Their raw `<th>` cells had no nowrap, so multi-word headers (e.g. "Token limit" / "Max requests") wrapped in the narrow settings container.

## Fix

Route every raw `<table>` through the shared `<Table>` / `TableHeader` / `TableHead` / `TableBody` / `TableRow` / `TableCell` primitives. That component already provides nowrap headers, the muted header fill, consistent borders, and its own horizontal scroll wrapper — so each table keeps its existing cells, skeletons, and empty states with far less markup, and the header-wrapping bug is fixed at the right layer (no per-`<th>` patching).

No change to the `<Table>` component itself was needed: it already nowraps headers, supplies its own `overflow-x-auto` scroll wrapper, and (via `cn`/tailwind-merge) lets callers override layout where required. It simply wasn't being used by these tables.

### Converted (raw `<table>` → `<Table>`)
- Governance: `budget-editor`, `default-model-editor`, `model-access-editor`, `feature-flags-editor`, `guardrails-overview` (recent events), `trash-page`, `chat-filter-config`, `moderation-provider-config`
- Chat: `paginated-markdown-table` (outer table only; keeps its conditional `table-fixed`/`min-w-full` layout)
- Storybook demos: `entity-row-actions`, `copyable-timestamp`, `table-date-cell`

### Intentionally left as raw `<table>`
- `email-preview.stories.tsx` — that `<table>` is a literal **HTML email-template string** being previewed, not a JSX element.
- `data-table.tsx` — only code comments mention `<table>`; it already renders the `<Table>` primitive.

## Verification

- `bunx tsc --noEmit` — clean (exit 0)
- `bunx oxlint --type-aware` — 0 warnings, 0 errors across all touched files