### PR TITLE
feat(platform): show model capability details in info popover

### DIFF
--- a/services/platform/app/components/ui/feedback/toaster.tsx
+++ b/services/platform/app/components/ui/feedback/toaster.tsx
@@ -89,7 +89,10 @@ export function Toaster() {
                 </div>
               </div>
               <ToastPrimitives.Close
-                className="text-foreground/50 hover:text-foreground absolute top-2.5 right-2.5 rounded-md p-1 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-2 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600"
+                // Hover-reveal for mouse users; always-visible on coarse
+                // (touch) pointers, which have no hover so the toast would
+                // otherwise be undismissable until it auto-expires.
+                className="text-foreground/50 hover:text-foreground absolute top-2.5 right-2.5 rounded-md p-1 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-2 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 pointer-coarse:opacity-100"
                 aria-label="Close"
               >
                 <X className="size-4" aria-hidden="true" />

--- a/services/platform/app/components/ui/forms/model-selector.tsx
+++ b/services/platform/app/components/ui/forms/model-selector.tsx
@@ -4,7 +4,7 @@ import { Button } from '@tale/ui/button';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { useSkeleton } from '@tale/ui/skeleton-context';
 import { Plus } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 
@@ -29,6 +29,8 @@ export interface ModelSelectorProps {
   getDisplayName: (modelId: string) => string;
   /** Resolve the provider name that will serve this model (optional). */
   getProviderName?: (modelId: string) => string | undefined;
+  /** Optional trailing affordance per selected model (e.g. an info popover). */
+  renderItemAction?: (modelId: string) => ReactNode;
   /** Minimum number of models required (default 1) */
   minModels?: number;
   /** When true, hides drag/reorder controls */
@@ -43,6 +45,7 @@ function ModelSelectorBase({
   availableOptions,
   getDisplayName,
   getProviderName,
+  renderItemAction,
   minModels = 1,
   readonlyOrder = false,
 }: ModelSelectorProps) {
@@ -114,13 +117,18 @@ function ModelSelectorBase({
         renderItem={({ item }) => {
           const providerName = getProviderName?.(item.modelId);
           return (
-            <div className="flex min-w-0 items-baseline gap-2">
+            <div className="flex min-w-0 flex-1 items-baseline gap-2">
               <code className="truncate text-sm">
                 {getDisplayName(item.modelId)}
               </code>
               {providerName ? (
                 <span className="text-muted-foreground flex-shrink-0 text-xs">
                   {providerName}
+                </span>
+              ) : null}
+              {renderItemAction ? (
+                <span className="ml-auto shrink-0">
+                  {renderItemAction(item.modelId)}
                 </span>
               ) : null}
             </div>

--- a/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../hooks/mutations', () => ({
 }));
 
 vi.mock('@/app/features/settings/providers/hooks/queries', () => ({
+  useModelCapabilities: () => new Map(),
   useListProviders: () => ({
     providers: [
       {

--- a/services/platform/app/features/agents/components/agent-create-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.tsx
@@ -14,7 +14,11 @@ import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { ModelSelector } from '@/app/components/ui/forms/model-selector';
 import { Textarea } from '@/app/components/ui/forms/textarea';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import { ModelInfoPopover } from '@/app/features/chat/components/model-info-popover';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { resolveModelLocale } from '@/lib/shared/utils/resolve-provider-locale';
@@ -64,8 +68,14 @@ export function CreateAgentDialog({
   // Every model across all configured providers, as qualified refs. Used both
   // to seed the default and to resolve display/provider names for the list.
   const modelCatalog = useMemo(() => {
-    const all: { ref: string; displayName: string; providerName: string }[] =
-      [];
+    const all: {
+      ref: string;
+      modelId: string;
+      displayName: string;
+      description?: string;
+      tags: string[];
+      providerName: string;
+    }[] = [];
     for (const provider of providers) {
       if (
         !provider ||
@@ -81,13 +91,40 @@ export function CreateAgentDialog({
         all.push({
           // Qualified form pins routing to this exact provider.
           ref: `${provider.name}:${model.id}`,
+          modelId: model.id,
           displayName: resolved.displayName || model.displayName,
+          description: resolved.description || undefined,
+          tags: model.tags ?? [],
           providerName: provider.name,
         });
       }
     }
     return all;
   }, [providers, locale]);
+
+  // Cached catalog capabilities keyed by bare model id (refs here are qualified
+  // `provider:id`), for the per-model info popover.
+  const capabilities = useModelCapabilities(
+    organizationId,
+    useMemo(() => modelCatalog.map((m) => m.modelId), [modelCatalog]),
+  );
+
+  const renderItemAction = useCallback(
+    (ref: string) => {
+      const entry = modelCatalog.find((m) => m.ref === ref);
+      if (!entry) return null;
+      return (
+        <ModelInfoPopover
+          providerName={entry.providerName}
+          description={entry.description}
+          tags={entry.tags}
+          capabilities={capabilities.get(entry.modelId)}
+          organizationId={organizationId}
+        />
+      );
+    },
+    [modelCatalog, capabilities, organizationId],
+  );
 
   // No models means no provider is configured (or none exposes a model).
   // An agent must reference a real model, so creation can't proceed until one
@@ -326,6 +363,7 @@ export function CreateAgentDialog({
             availableOptions={availableOptions}
             getDisplayName={getDisplayName}
             getProviderName={getProviderName}
+            renderItemAction={renderItemAction}
           />
           <Text variant="caption">
             {t('agents.createDialog.modelDefaultHint')}

--- a/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
+++ b/services/platform/app/features/chat/components/arena/arena-model-selector.tsx
@@ -16,7 +16,10 @@ import {
   type SearchableSelectOption,
 } from '@/app/components/ui/forms/searchable-select';
 import { useAccessibleModels } from '@/app/features/settings/governance/hooks/queries';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { useT } from '@/lib/i18n/client';
 import {
   expandModelVariants,
@@ -30,7 +33,7 @@ import { resolveModelLocale } from '@/lib/shared/utils/resolve-provider-locale';
 
 import { useChatAgents } from '../../hooks/queries';
 import { useEffectiveAgent } from '../../hooks/use-effective-agent';
-import { ModelTagIcons } from '../model-tag-icons';
+import { ModelInfoPopover } from '../model-info-popover';
 import { useArenaMode } from './arena-mode-context';
 
 interface ArenaModelSelectorProps {
@@ -91,13 +94,25 @@ export function ArenaModelSelector({
     return map;
   }, [providers, locale]);
 
-  const renderTagIcons = useCallback(
+  const capabilities = useModelCapabilities(organizationId, [
+    ...modelInfoMap.keys(),
+  ]);
+
+  const renderInfo = useCallback(
     (option: SearchableSelectOption): ReactNode => {
-      const info = modelInfoMap.get(stripModelRefQualifier(option.value));
-      if (!info?.tags.length) return null;
-      return <ModelTagIcons tags={info.tags} t={t} />;
+      const modelId = stripModelRefQualifier(option.value);
+      const info = modelInfoMap.get(modelId);
+      if (!info) return null;
+      return (
+        <ModelInfoPopover
+          description={info.description}
+          tags={info.tags}
+          capabilities={capabilities.get(modelId)}
+          organizationId={organizationId}
+        />
+      );
     },
-    [modelInfoMap, t],
+    [modelInfoMap, capabilities, organizationId],
   );
 
   const getDisplayName = useCallback(
@@ -207,7 +222,7 @@ export function ArenaModelSelector({
           searchPlaceholder={t('modelSelector.searchPlaceholder')}
           emptyText={t('modelSelector.noResults')}
           aria-label={t('arena.modelA')}
-          optionAction={renderTagIcons}
+          optionAction={renderInfo}
           trigger={
             <button
               type="button"
@@ -241,7 +256,7 @@ export function ArenaModelSelector({
           searchPlaceholder={t('modelSelector.searchPlaceholder')}
           emptyText={t('modelSelector.noResults')}
           aria-label={t('arena.modelB')}
-          optionAction={renderTagIcons}
+          optionAction={renderInfo}
           trigger={
             <button
               type="button"

--- a/services/platform/app/features/chat/components/model-info-popover.tsx
+++ b/services/platform/app/features/chat/components/model-info-popover.tsx
@@ -6,6 +6,9 @@ import { Link } from '@tanstack/react-router';
 import { Info } from 'lucide-react';
 import { useState } from 'react';
 
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+
 const TAG_LABEL_KEYS: Record<string, string> = {
   chat: 'modelSelector.tags.chat',
   vision: 'modelSelector.tags.vision',
@@ -32,6 +35,20 @@ function InfoRow({ label, children }: InfoRowProps) {
   );
 }
 
+/** The capability fields surfaced in the popover — a structural subset of the
+ *  `getModelCapabilities` query row, so callers can pass that row straight
+ *  through. All optional: the source only reports what it knows. */
+export interface ModelInfoCapabilities {
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  inputCentsPerMillion?: number;
+  outputCentsPerMillion?: number;
+  reasoning?: { knob: 'effort' | 'budgetTokens' | 'none' };
+  promptCaching?: { mode: 'explicit-breakpoints' | 'auto-server' | 'none' };
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+}
+
 interface ModelInfoPopoverProps {
   /** Human-readable provider name (the provider's displayName). */
   providerName?: string;
@@ -39,10 +56,35 @@ interface ModelInfoPopoverProps {
   description?: string;
   /** Capability tags for the model (chat, vision, …). */
   tags: string[];
+  /** Cached catalog capabilities (cost, context window, reasoning, …). When
+   *  present, each known field renders as its own row below provider/type. */
+  capabilities?: ModelInfoCapabilities;
   /** Provider slug for the settings link; omit to hide the link (non-admins). */
   providerSlug?: string;
   organizationId: string;
-  t: (key: string) => string;
+  /** Extra classes for the trigger button — e.g. `mt-0` to undo the default
+   *  list-baseline nudge when placed beside a form control instead of a row. */
+  triggerClassName?: string;
+}
+
+/** `1000000` → `1M`, `128000` → `128K`, smaller counts kept as-is. */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000;
+    return `${Number.isInteger(k) ? k : k.toFixed(1)}K`;
+  }
+  return String(n);
+}
+
+/** Cents-per-million → a `$X/M` dollar string (the cache stores cents). */
+function formatCost(centsPerMillion: number): string {
+  const dollars = centsPerMillion / 100;
+  // Sub-dollar prices need cents precision; whole-dollar+ reads fine at 2dp.
+  return `$${dollars < 1 ? dollars.toFixed(3).replace(/0+$/, '').replace(/\.$/, '') : dollars.toFixed(2)}/M`;
 }
 
 /**
@@ -55,16 +97,31 @@ export function ModelInfoPopover({
   providerName,
   description,
   tags,
+  capabilities,
   providerSlug,
   organizationId,
-  t,
+  triggerClassName,
 }: ModelInfoPopoverProps) {
+  const { t } = useT('chat');
   const [open, setOpen] = useState(false);
 
   const typeLabels = tags
     .map((tag) => TAG_LABEL_KEYS[tag])
     .filter((key): key is string => Boolean(key))
     .map((key) => t(key));
+
+  const reasoningLabel =
+    capabilities?.reasoning && capabilities.reasoning.knob !== 'none'
+      ? capabilities.reasoning.knob === 'effort'
+        ? t('modelSelector.info.reasoningEffort')
+        : t('modelSelector.info.reasoningBudget')
+      : null;
+  const cachingLabel =
+    capabilities?.promptCaching && capabilities.promptCaching.mode !== 'none'
+      ? capabilities.promptCaching.mode === 'explicit-breakpoints'
+        ? t('modelSelector.info.cachingExplicit')
+        : t('modelSelector.info.cachingAuto')
+      : null;
 
   return (
     <Popover
@@ -79,7 +136,10 @@ export function ModelInfoPopover({
         <button
           type="button"
           aria-label={t('modelSelector.viewInfo')}
-          className="text-muted-foreground hover:text-foreground mt-0.5 flex items-center rounded-sm transition-colors"
+          className={cn(
+            'text-muted-foreground hover:text-foreground mt-0.5 flex items-center rounded-sm transition-colors',
+            triggerClassName,
+          )}
           // Stop the row's select-and-close handler: clicking info should open
           // the popover, not pick the model.
           onClick={(e) => e.stopPropagation()}
@@ -105,6 +165,66 @@ export function ModelInfoPopover({
         {typeLabels.length ? (
           <InfoRow label={t('modelSelector.info.type')}>
             <Text className="text-xs">{typeLabels.join(', ')}</Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.contextWindow ? (
+          <InfoRow label={t('modelSelector.info.contextWindow')}>
+            <Text className="text-xs">
+              {formatTokens(capabilities.contextWindow)}
+            </Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.maxOutputTokens ? (
+          <InfoRow label={t('modelSelector.info.maxOutput')}>
+            <Text className="text-xs">
+              {formatTokens(capabilities.maxOutputTokens)}
+            </Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.inputCentsPerMillion != null ? (
+          <InfoRow label={t('modelSelector.info.inputCost')}>
+            <Text className="text-xs">
+              {formatCost(capabilities.inputCentsPerMillion)}
+            </Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.outputCentsPerMillion != null ? (
+          <InfoRow label={t('modelSelector.info.outputCost')}>
+            <Text className="text-xs">
+              {formatCost(capabilities.outputCentsPerMillion)}
+            </Text>
+          </InfoRow>
+        ) : null}
+        {reasoningLabel ? (
+          <InfoRow label={t('modelSelector.info.reasoning')}>
+            <Text className="text-xs">{reasoningLabel}</Text>
+          </InfoRow>
+        ) : null}
+        {cachingLabel ? (
+          <InfoRow label={t('modelSelector.info.promptCaching')}>
+            <Text className="text-xs">{cachingLabel}</Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.supportsTools != null ? (
+          <InfoRow label={t('modelSelector.info.tools')}>
+            <Text className="text-xs">
+              {t(
+                capabilities.supportsTools
+                  ? 'modelSelector.info.supported'
+                  : 'modelSelector.info.notSupported',
+              )}
+            </Text>
+          </InfoRow>
+        ) : null}
+        {capabilities?.supportsVision != null ? (
+          <InfoRow label={t('modelSelector.info.vision')}>
+            <Text className="text-xs">
+              {t(
+                capabilities.supportsVision
+                  ? 'modelSelector.info.supported'
+                  : 'modelSelector.info.notSupported',
+              )}
+            </Text>
           </InfoRow>
         ) : null}
         {providerSlug ? (

--- a/services/platform/app/features/chat/components/model-selector.test.tsx
+++ b/services/platform/app/features/chat/components/model-selector.test.tsx
@@ -79,6 +79,7 @@ vi.mock('../hooks/use-effective-agent', () => ({
 }));
 
 vi.mock('@/app/features/settings/providers/hooks/queries', () => ({
+  useModelCapabilities: () => new Map(),
   useListProviders: () => ({
     providers: [
       {

--- a/services/platform/app/features/chat/components/model-selector.tsx
+++ b/services/platform/app/features/chat/components/model-selector.tsx
@@ -24,7 +24,10 @@ import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { useProject } from '@/app/features/projects/hooks/queries';
 import { asProjectId } from '@/app/features/projects/hooks/use-project-id-param';
 import { useAccessibleModels } from '@/app/features/settings/governance/hooks/queries';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import {
@@ -143,6 +146,12 @@ export const ModelSelector = memo(function ModelSelector({
     return map;
   }, [providers, locale]);
 
+  // Cached catalog capabilities (cost, context, reasoning, …) for every model
+  // we might render, keyed by id — powers the info popover's detail rows.
+  const capabilities = useModelCapabilities(organizationId, [
+    ...modelInfoMap.keys(),
+  ]);
+
   // Return the provider's slug (its JSON filename without extension) — this
   // is the stable, machine-readable identifier users write in model refs,
   // not the cosmetic `displayName` from the provider JSON.
@@ -161,7 +170,8 @@ export const ModelSelector = memo(function ModelSelector({
   // capability-icon strip + sliders settings link with one consolidated control.
   const renderOptionAction = useCallback(
     (option: SearchableSelectOption): ReactNode => {
-      const info = modelInfoMap.get(stripModelRefQualifier(option.value));
+      const modelId = stripModelRefQualifier(option.value);
+      const info = modelInfoMap.get(modelId);
       const providerSlug = canSetUpProviders
         ? getProviderSlug(option.value)
         : undefined;
@@ -172,14 +182,20 @@ export const ModelSelector = memo(function ModelSelector({
             providerName={info.providerDisplayName}
             description={info.description}
             tags={info.tags}
+            capabilities={capabilities.get(modelId)}
             providerSlug={providerSlug}
             organizationId={organizationId}
-            t={t}
           />
         </div>
       );
     },
-    [modelInfoMap, canSetUpProviders, getProviderSlug, organizationId, t],
+    [
+      modelInfoMap,
+      capabilities,
+      canSetUpProviders,
+      getProviderSlug,
+      organizationId,
+    ],
   );
 
   const chatModels = useMemo(() => {

--- a/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
@@ -115,7 +115,7 @@ export function OpenRouterStep({ organizationId }: OpenRouterStepProps) {
       if (models.length === 0) {
         models = fetched.slice(0, FALLBACK_MODEL_CAP).map((m) => ({
           id: m.id,
-          displayName: m.id,
+          displayName: m.displayName ?? m.id,
           tags: ['chat' as const],
         }));
       }

--- a/services/platform/app/features/settings/governance/components/default-model-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@/app/features/settings/teams/hooks/queries', () => ({
 }));
 
 vi.mock('@/app/features/settings/providers/hooks/queries', () => ({
+  useModelCapabilities: () => new Map(),
   useListProviders: () => ({
     providers: [
       {

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -227,9 +227,15 @@ function RuleDialog({
     [chatModels],
   );
 
+  // Only subscribe to capabilities (a per-model indexed read fan-out) while the
+  // dialog is open — RuleDialog stays mounted when closed, so an ungated hook
+  // would keep a live subscription on this non-critical settings path.
   const capabilities = useModelCapabilities(
     organizationId,
-    useMemo(() => chatModels.map((m) => m.id), [chatModels]),
+    useMemo(
+      () => (open ? chatModels.map((m) => m.id) : []),
+      [open, chatModels],
+    ),
   );
 
   const renderModelInfo = useCallback(

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -20,9 +20,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
-import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import { ModelInfoPopover } from '@/app/features/chat/components/model-info-popover';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useToast } from '@/app/hooks/use-toast';
@@ -143,6 +150,7 @@ interface RuleDialogProps {
   teamOptions: { value: string; label: string }[];
   providerList: ProviderInfo[];
   accessConfig: ModelAccessConfig | null;
+  organizationId: string;
 }
 
 const PLACEHOLDER_ROW_COUNT = 3;
@@ -157,6 +165,7 @@ function RuleDialog({
   teamOptions,
   providerList,
   accessConfig,
+  organizationId,
 }: RuleDialogProps) {
   const { t } = useT('governance');
   const [draft, setDraft] = useState(initialRule);
@@ -204,16 +213,39 @@ function RuleDialog({
     [providerList],
   );
 
-  const modelOptions = useMemo(() => {
+  const chatModels = useMemo(() => {
     const provider = providerList.find((p) => p.name === draft.providerName);
-    if (!provider) return [];
-    return provider.models
-      .filter((m) => m.tags.includes('chat'))
-      .map((m) => ({
+    return provider?.models.filter((m) => m.tags.includes('chat')) ?? [];
+  }, [providerList, draft.providerName]);
+
+  const modelOptions = useMemo(
+    () =>
+      chatModels.map((m) => ({
         value: m.id,
         label: m.displayName || m.id,
-      }));
-  }, [providerList, draft.providerName]);
+      })),
+    [chatModels],
+  );
+
+  const capabilities = useModelCapabilities(
+    organizationId,
+    useMemo(() => chatModels.map((m) => m.id), [chatModels]),
+  );
+
+  const renderModelInfo = useCallback(
+    (option: SearchableSelectOption) => {
+      const model = chatModels.find((m) => m.id === option.value);
+      if (!model) return null;
+      return (
+        <ModelInfoPopover
+          tags={model.tags}
+          capabilities={capabilities.get(model.id)}
+          organizationId={organizationId}
+        />
+      );
+    },
+    [chatModels, capabilities, organizationId],
+  );
 
   const conflict = useMemo(
     () => computeAccessConflict(accessConfig, draft),
@@ -297,6 +329,7 @@ function RuleDialog({
           value={draft.modelId || null}
           onValueChange={(value) => updateDraft({ modelId: value })}
           options={modelOptions}
+          optionAction={renderModelInfo}
           searchPlaceholder={t('defaultModels.searchModels')}
           emptyText={t('defaultModels.noModelsFound')}
           aria-label={t('defaultModels.model')}
@@ -668,6 +701,7 @@ export function DefaultModelEditor({
           teamOptions={teamOptions}
           providerList={providerList}
           accessConfig={accessConfig}
+          organizationId={organizationId}
         />
 
         <ConfirmDialog

--- a/services/platform/app/features/settings/governance/components/model-access-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.test.tsx
@@ -59,6 +59,7 @@ const STABLE_PROVIDERS = {
 };
 vi.mock('@/app/features/settings/providers/hooks/queries', () => ({
   useListProviders: () => STABLE_PROVIDERS,
+  useModelCapabilities: () => new Map(),
 }));
 
 vi.mock('@/app/hooks/use-ability', () => ({

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -20,12 +20,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { CheckboxGroup } from '@/app/components/ui/forms/checkbox-group';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
 import { Switch } from '@/app/components/ui/forms/switch';
+import {
+  type ModelInfoCapabilities,
+  ModelInfoPopover,
+} from '@/app/features/chat/components/model-info-popover';
 import { useMembers } from '@/app/features/settings/organization/hooks/queries';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useAbility } from '@/app/hooks/use-ability';
 import { useToast } from '@/app/hooks/use-toast';
@@ -145,7 +153,9 @@ interface RuleDialogProps {
   cannotManage: boolean;
   memberOptions: { value: string; label: string; description?: string }[];
   teamOptions: { value: string; label: string }[];
-  allModelOptions: { value: string; label: string }[];
+  allModelOptions: { value: string; label: string; tags: string[] }[];
+  modelCapabilities: Map<string, ModelInfoCapabilities>;
+  organizationId: string;
   mode: ModelAccessConfig['mode'];
 }
 
@@ -161,6 +171,8 @@ function RuleDialog({
   memberOptions,
   teamOptions,
   allModelOptions,
+  modelCapabilities,
+  organizationId,
   mode,
 }: RuleDialogProps) {
   const { t } = useT('governance');
@@ -267,22 +279,46 @@ function RuleDialog({
               ? t('modelAccess.allowedModels')
               : t('modelAccess.blockedModels')
           }
-          options={allModelOptions}
-          value={
-            mode === 'allowlist'
-              ? draft.allowedModels
-              : (draft.blockedModels ?? [])
-          }
-          onValueChange={(values) => {
-            if (mode === 'allowlist') {
-              updateDraft({ allowedModels: values });
-            } else {
-              updateDraft({ blockedModels: values });
-            }
-          }}
           disabled={cannotManage}
-          columns={2}
-        />
+        >
+          <div className="grid grid-cols-2 gap-2">
+            {allModelOptions.map((option) => {
+              const selected =
+                mode === 'allowlist'
+                  ? draft.allowedModels
+                  : (draft.blockedModels ?? []);
+              const checked = selected.includes(option.value);
+              const toggle = (next: boolean) => {
+                const values = next
+                  ? [...selected, option.value]
+                  : selected.filter((v) => v !== option.value);
+                if (mode === 'allowlist') {
+                  updateDraft({ allowedModels: values });
+                } else {
+                  updateDraft({ blockedModels: values });
+                }
+              };
+              return (
+                <div
+                  key={option.value}
+                  className="flex items-start justify-between gap-1"
+                >
+                  <Checkbox
+                    label={option.label}
+                    checked={checked}
+                    onCheckedChange={(c) => toggle(c === true)}
+                    disabled={cannotManage}
+                  />
+                  <ModelInfoPopover
+                    tags={option.tags}
+                    capabilities={modelCapabilities.get(option.value)}
+                    organizationId={organizationId}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </CheckboxGroup>
       </Stack>
     </FormDialog>
   );
@@ -339,7 +375,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
   );
 
   const allModelOptions = useMemo(() => {
-    const options: { value: string; label: string }[] = [];
+    const options: { value: string; label: string; tags: string[] }[] = [];
     for (const provider of providers) {
       if (
         !provider ||
@@ -351,11 +387,17 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
         options.push({
           value: model.id,
           label: model.displayName || model.id,
+          tags: model.tags ?? [],
         });
       }
     }
     return options;
   }, [providers]);
+
+  const modelCapabilities = useModelCapabilities(
+    organizationId,
+    useMemo(() => allModelOptions.map((o) => o.value), [allModelOptions]),
+  );
 
   const savedConfig = useMemo(
     () => parseModelAccessConfig(policy?.config),
@@ -707,6 +749,8 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
             memberOptions={memberOptions}
             teamOptions={teamOptions}
             allModelOptions={allModelOptions}
+            modelCapabilities={modelCapabilities}
+            organizationId={organizationId}
             mode={mode}
           />
         )}

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -394,11 +394,6 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
     return options;
   }, [providers]);
 
-  const modelCapabilities = useModelCapabilities(
-    organizationId,
-    useMemo(() => allModelOptions.map((o) => o.value), [allModelOptions]),
-  );
-
   const savedConfig = useMemo(
     () => parseModelAccessConfig(policy?.config),
     [policy],
@@ -413,6 +408,16 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [dialogRule, setDialogRule] = useState(emptyRule());
   const [deletingIndex, setDeletingIndex] = useState<number | null>(null);
+
+  // Capabilities power the per-model info popover inside the rule dialog only,
+  // so don't subscribe (a per-model indexed read fan-out) until it's open.
+  const modelCapabilities = useModelCapabilities(
+    organizationId,
+    useMemo(
+      () => (dialogOpen ? allModelOptions.map((o) => o.value) : []),
+      [dialogOpen, allModelOptions],
+    ),
+  );
 
   // Pending save + affected-defaults confirmation state.
   const [pendingSave, setPendingSave] = useState<{

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-server-card.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-server-card.tsx
@@ -146,7 +146,7 @@ export function McpServerCard({
                   <HStack gap={1} align="center">
                     <Wrench className="text-muted-foreground size-3.5" />
                     <Text variant="muted" className="text-xs">
-                      {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
+                      {t('tools.count', { count: toolCount })}
                     </Text>
                   </HStack>
                 )}

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-server-card.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-server-card.tsx
@@ -5,9 +5,9 @@ import { Card } from '@tale/ui/card';
 import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { Heading } from '@tale/ui/heading';
 import { IconButton } from '@tale/ui/icon-button';
-import { Center, HStack, Stack } from '@tale/ui/layout';
+import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { Ellipsis, Pencil, Server, Trash2, Wrench } from 'lucide-react';
+import { Ellipsis, Pencil, Trash2, Wrench } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { useT } from '@/lib/i18n/client';
@@ -26,20 +26,32 @@ function StatusBadge({ status }: { status: string }) {
 
   if (status === 'active') {
     return (
-      <Badge variant="green" dot>
+      <Badge variant="green" dot className="shrink-0">
         {t('connected')}
       </Badge>
     );
   }
   if (status === 'error') {
-    return <Badge variant="destructive">{t('error')}</Badge>;
+    return (
+      <Badge variant="destructive" className="shrink-0">
+        {t('error')}
+      </Badge>
+    );
   }
-  return <Badge variant="outline">{t('disconnected')}</Badge>;
+  return (
+    <Badge variant="outline" className="shrink-0">
+      {t('disconnected')}
+    </Badge>
+  );
 }
 
 function TransportBadge({ type }: { type: string }) {
   const label = type === 'stdio' ? 'stdio' : type === 'sse' ? 'SSE' : 'HTTP';
-  return <Badge variant="blue">{label}</Badge>;
+  return (
+    <Badge variant="blue" className="shrink-0">
+      {label}
+    </Badge>
+  );
 }
 
 export function McpServerCard({
@@ -102,13 +114,7 @@ export function McpServerCard({
           className="w-full p-5 text-left outline-none"
         >
           <Stack gap={3}>
-            <HStack justify="between" align="start">
-              <Center className="border-border size-11 rounded-lg border">
-                <Server className="text-muted-foreground size-6" />
-              </Center>
-              <StatusBadge status={server.status} />
-            </HStack>
-            <Stack gap={1}>
+            <Stack gap={2}>
               <Heading
                 level={3}
                 size="base"
@@ -117,30 +123,35 @@ export function McpServerCard({
               >
                 {server.displayName}
               </Heading>
-              {server.description && (
-                <Text variant="muted" className="line-clamp-2 leading-[1.43]">
-                  {server.description}
-                </Text>
-              )}
+              <HStack gap={2} align="center" wrap>
+                <StatusBadge status={server.status} />
+                <TransportBadge type={server.transportType} />
+              </HStack>
             </Stack>
-            <HStack gap={2} align="center">
-              <TransportBadge type={server.transportType} />
-              {server.authType !== 'none' && (
-                <Badge variant="outline">
-                  {server.authType === 'api_key'
-                    ? t('form.apiKey')
-                    : t('form.oauth2')}
-                </Badge>
-              )}
-              {toolCount > 0 && (
-                <HStack gap={1} align="center">
-                  <Wrench className="text-muted-foreground size-3.5" />
-                  <Text variant="muted" className="text-xs">
-                    {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
-                  </Text>
-                </HStack>
-              )}
-            </HStack>
+            {server.description && (
+              <Text variant="muted" className="line-clamp-2 leading-[1.43]">
+                {server.description}
+              </Text>
+            )}
+            {(server.authType !== 'none' || toolCount > 0) && (
+              <HStack gap={2} align="center" className="pr-10">
+                {server.authType !== 'none' && (
+                  <Badge variant="outline">
+                    {server.authType === 'api_key'
+                      ? t('form.apiKey')
+                      : t('form.oauth2')}
+                  </Badge>
+                )}
+                {toolCount > 0 && (
+                  <HStack gap={1} align="center">
+                    <Wrench className="text-muted-foreground size-3.5" />
+                    <Text variant="muted" className="text-xs">
+                      {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
+                    </Text>
+                  </HStack>
+                )}
+              </HStack>
+            )}
           </Stack>
         </button>
       </div>

--- a/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
@@ -74,6 +74,11 @@ export function ProviderAddPanel({
 
   // Fetched model IDs from the provider endpoint
   const [fetchedModels, setFetchedModels] = useState<string[]>([]);
+  // Human-readable names the provider reported, keyed by id, so fetched rows
+  // show e.g. "Claude Opus (latest)" instead of the raw `~anthropic/...` id.
+  const [fetchedNames, setFetchedNames] = useState<Map<string, string>>(
+    () => new Map(),
+  );
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [hasFetched, setHasFetched] = useState(false);
   const [modelSearch, setModelSearch] = useState('');
@@ -199,6 +204,7 @@ export function ProviderAddPanel({
       fetchCredsApiKey !== fetchedCredentials.apiKey
     ) {
       setFetchedModels([]);
+      setFetchedNames(new Map());
       setHasFetched(false);
       setFetchError(null);
       setFetchedCredentials(null);
@@ -216,6 +222,13 @@ export function ProviderAddPanel({
       const result = await fetchModels({ organizationId, baseUrl, apiKey });
       const ids = result.map((m) => m.id);
       setFetchedModels(ids);
+      setFetchedNames(
+        new Map(
+          result.flatMap((m) =>
+            m.displayName ? [[m.id, m.displayName] as const] : [],
+          ),
+        ),
+      );
       // Fetched models default to UNCHECKED. Selecting a row IS the add
       // action, so we don't pre-append anything to the form here.
       setHasFetched(true);
@@ -238,12 +251,16 @@ export function ProviderAddPanel({
     (modelId: string, checked: boolean) => {
       const idx = watchedModels.findIndex((m) => m.id === modelId);
       if (checked && idx === -1) {
-        append({ id: modelId, displayName: modelId, tags: ['chat'] });
+        append({
+          id: modelId,
+          displayName: fetchedNames.get(modelId) ?? modelId,
+          tags: ['chat'],
+        });
       } else if (!checked && idx !== -1) {
         remove(idx);
       }
     },
-    [watchedModels, append, remove],
+    [watchedModels, fetchedNames, append, remove],
   );
 
   // Unified row list: fetched models (in provider order) followed by any
@@ -409,6 +426,7 @@ export function ProviderAddPanel({
       if (!isOpen) {
         reset();
         setFetchedModels([]);
+        setFetchedNames(new Map());
         setFetchError(null);
         setHasFetched(false);
         setModelSearch('');
@@ -553,6 +571,7 @@ export function ProviderAddPanel({
       onOpenChange={handleOpenChange}
       title={t('providers.addProvider')}
       size="md"
+      resize={{ storageKey: 'provider-add-panel-width' }}
       hideClose
       className="flex flex-col gap-0 overflow-hidden p-0"
     >
@@ -762,7 +781,9 @@ export function ProviderAddPanel({
                               />
                             )}
                             <Text className="truncate text-[13px] font-medium">
-                              {model?.displayName ?? row.id}
+                              {model?.displayName ??
+                                fetchedNames.get(row.id) ??
+                                row.id}
                             </Text>
                           </HStack>
                           <HStack gap={3} align="center" className="shrink-0">

--- a/services/platform/app/features/settings/providers/components/provider-default-models-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-default-models-panel.tsx
@@ -5,11 +5,12 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Select } from '@/app/components/ui/forms/select';
+import { ModelInfoPopover } from '@/app/features/chat/components/model-info-popover';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
 import { useSaveProvider } from '../hooks/mutations';
-import { useReadProvider } from '../hooks/queries';
+import { useModelCapabilities, useReadProvider } from '../hooks/queries';
 import { modelTagLabel } from '../utils/model-tag-label';
 
 const NONE_VALUE = '__none__';
@@ -96,6 +97,11 @@ export function ProviderDefaultModelsPanel({
 
   const models = data?.ok ? data.config.models : [];
 
+  const capabilities = useModelCapabilities(
+    organizationId,
+    models.map((m) => m.id),
+  );
+
   return (
     <FormDialog
       open={open}
@@ -114,25 +120,44 @@ export function ProviderDefaultModelsPanel({
         const modelsWithTag = models.filter((m) =>
           (m.tags as readonly string[]).includes(tag),
         );
+        const selectedId = defaults[tag];
+        const selected =
+          selectedId && selectedId !== NONE_VALUE
+            ? modelsWithTag.find((m) => m.id === selectedId)
+            : undefined;
         return (
-          <Select
-            key={tag}
-            label={modelTagLabel(tag, t)}
-            options={[
-              {
-                value: NONE_VALUE,
-                label: t('providers.defaultNone'),
-              },
-              ...modelsWithTag.map((m) => ({
-                value: m.id,
-                label: m.displayName,
-              })),
-            ]}
-            value={defaults[tag] ?? NONE_VALUE}
-            onValueChange={(value) =>
-              setDefaults((d) => ({ ...d, [tag]: value }))
-            }
-          />
+          <div key={tag} className="flex items-end gap-2">
+            <Select
+              wrapperClassName="flex-1"
+              label={modelTagLabel(tag, t)}
+              options={[
+                {
+                  value: NONE_VALUE,
+                  label: t('providers.defaultNone'),
+                },
+                ...modelsWithTag.map((m) => ({
+                  value: m.id,
+                  label: m.displayName,
+                })),
+              ]}
+              value={defaults[tag] ?? NONE_VALUE}
+              onValueChange={(value) =>
+                setDefaults((d) => ({ ...d, [tag]: value }))
+              }
+            />
+            {/* Match the default trigger's height (h-10) so the info icon
+                centers against the select, not its label. */}
+            <div className="flex h-10 items-center">
+              {selected ? (
+                <ModelInfoPopover
+                  tags={selected.tags as string[]}
+                  capabilities={capabilities.get(selected.id)}
+                  organizationId={organizationId}
+                  triggerClassName="mt-0"
+                />
+              ) : null}
+            </div>
+          </div>
         );
       })}
     </FormDialog>

--- a/services/platform/app/features/settings/providers/components/provider-detail-drawer.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-detail-drawer.tsx
@@ -142,6 +142,7 @@ export function ProviderDetailDrawer({
       onOpenChange={onOpenChange}
       title={t('providers.details')}
       size="md"
+      resize={{ storageKey: 'provider-detail-drawer-width' }}
       hideClose
       className="flex flex-col gap-0 p-0"
     >
@@ -1023,6 +1024,11 @@ function ModelsSection({
   // endpoint. Configured models live in config.models — this list holds the
   // delta the user can opt into via checkbox.
   const [fetchedModelIds, setFetchedModelIds] = useState<string[]>([]);
+  // Human-readable names the provider reported alongside the ids, so fetched
+  // rows show "Claude Opus (latest)" instead of the raw `~anthropic/...` id.
+  const [fetchedNames, setFetchedNames] = useState<Map<string, string>>(
+    () => new Map(),
+  );
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [hasFetched, setHasFetched] = useState(false);
   const [confirmAddModel, setConfirmAddModel] = useState<string | null>(null);
@@ -1037,6 +1043,13 @@ function ModelsSection({
         providerName,
       });
       setFetchedModelIds(result.map((m) => m.id));
+      setFetchedNames(
+        new Map(
+          result.flatMap((m) =>
+            m.displayName ? [[m.id, m.displayName] as const] : [],
+          ),
+        ),
+      );
       setHasFetched(true);
     } catch (err) {
       console.error('Failed to fetch provider models:', err);
@@ -1059,7 +1072,7 @@ function ModelsSection({
         ...config.models,
         {
           id: modelId,
-          displayName: modelId,
+          displayName: fetchedNames.get(modelId) ?? modelId,
           // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- 'chat' is a valid modelTagLiterals member
           tags: ['chat'] as Array<(typeof modelTagLiterals)[number]>,
         },
@@ -1073,7 +1086,7 @@ function ModelsSection({
         toast({ title: t('providers.saveFailed'), variant: 'destructive' });
       }
     },
-    [config.models, saveConfig, t, tAccessDenied],
+    [config.models, fetchedNames, saveConfig, t, tAccessDenied],
   );
 
   // Cached OpenRouter capabilities for the configured models (+ the model
@@ -1728,7 +1741,9 @@ function ModelsSection({
                       </SkeletonBox>
                       <Text className="truncate text-[13px] font-medium">
                         <SkeletonBox>
-                          {model?.displayName ?? row.id}
+                          {model?.displayName ??
+                            fetchedNames.get(row.id) ??
+                            row.id}
                         </SkeletonBox>
                       </Text>
                     </HStack>

--- a/services/platform/app/features/settings/providers/hooks/queries.ts
+++ b/services/platform/app/features/settings/providers/hooks/queries.ts
@@ -1,5 +1,9 @@
+import { useMemo } from 'react';
+
+import type { ModelInfoCapabilities } from '@/app/features/chat/components/model-info-popover';
 import { configKeys } from '@/app/hooks/config-query-keys';
 import { useActionQuery } from '@/app/hooks/use-action-query';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 import type {
   EnvSecretStatus,
@@ -92,4 +96,39 @@ export function useHasModelSecret(
     { organizationId, providerName, modelId },
     options,
   );
+}
+
+/**
+ * Cached OpenRouter/provider capabilities (cost, context window, reasoning,
+ * prompt-caching, tools/vision) for a set of model ids, keyed by id. Backs the
+ * `ModelInfoPopover` info button across every model selector. The daily cron
+ * and the live "Fetch models" action both populate `modelCapabilityCache`;
+ * ids without a cache row are simply absent from the map (the popover then
+ * hides those rows). Pass the currently-visible ids only — the query reads one
+ * row per id.
+ */
+export function useModelCapabilities(
+  organizationId: string,
+  modelIds: string[],
+): Map<string, ModelInfoCapabilities> {
+  const { data } = useConvexQuery(
+    api.model_catalog.queries.getModelCapabilities,
+    { organizationId, modelIds },
+  );
+  return useMemo(() => {
+    const map = new Map<string, ModelInfoCapabilities>();
+    for (const c of data ?? []) {
+      map.set(c.modelId, {
+        contextWindow: c.contextWindow,
+        maxOutputTokens: c.maxOutputTokens,
+        inputCentsPerMillion: c.inputCentsPerMillion,
+        outputCentsPerMillion: c.outputCentsPerMillion,
+        reasoning: c.reasoning,
+        promptCaching: c.promptCaching,
+        supportsTools: c.supportsTools,
+        supportsVision: c.supportsVision,
+      });
+    }
+    return map;
+  }, [data]);
 }

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -417,15 +417,31 @@ function NavRailPlaceholder() {
 export function DashboardShellFrame() {
   return (
     <div className="flex h-dvh w-full flex-col overflow-hidden md:flex-row">
-      {/* Mobile top bar */}
-      <div className="bg-background border-border flex items-center gap-2 border-b p-2 pt-[calc(var(--safe-top)+0.5rem)] md:hidden">
+      {/* Mobile top bar — mirrors the resolved chat header (the default
+          landing): a leading cluster of action icons + the trailing account
+          avatar, so the real header slots in without reflow. Matches the
+          DashboardLayout header geometry above (px-4, min-h-12). */}
+      <div className="bg-background border-border border-b px-4 pt-(--safe-top) md:hidden">
         <Skeletonize loading>
-          <SkeletonBox>
-            <div className="size-8" />
-          </SkeletonBox>
-          <SkeletonBox>
-            <div className="h-4 w-32" />
-          </SkeletonBox>
+          <div className="flex min-h-12 items-center gap-2">
+            {/* Leading action icons (chat history / search / new chat). */}
+            <div className="flex flex-1 justify-start">
+              {Array.from({ length: 3 }, (_, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={i} className="flex items-center justify-center p-2">
+                  <SkeletonBox>
+                    <div className="size-5" />
+                  </SkeletonBox>
+                </div>
+              ))}
+            </div>
+            {/* Trailing account avatar (UserButton). */}
+            <div className="flex items-center justify-center p-2">
+              <SkeletonCircle>
+                <div className="size-5" />
+              </SkeletonCircle>
+            </div>
+          </div>
         </Skeletonize>
       </div>
 

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -16,8 +16,12 @@ import { LocaleTabs } from '@/app/components/ui/i18n/locale-tabs';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { useTranslateAgentFields } from '@/app/features/agents/hooks/mutations';
 import { useAgentConfig } from '@/app/features/agents/hooks/use-agent-config-context';
+import { ModelInfoPopover } from '@/app/features/chat/components/model-info-popover';
 import { useOrganization } from '@/app/features/organization/hooks/queries';
-import { useListProviders } from '@/app/features/settings/providers/hooks/queries';
+import {
+  useListProviders,
+  useModelCapabilities,
+} from '@/app/features/settings/providers/hooks/queries';
 import { useToast } from '@/app/hooks/use-toast';
 import { SUPPORTED_TEMPLATE_VARIABLES } from '@/convex/lib/agent_response/resolve_template_variables';
 import { STRUCTURED_RESPONSE_INSTRUCTIONS } from '@/convex/lib/agent_response/structured_response_instructions';
@@ -198,6 +202,27 @@ function InstructionsTab() {
     return map;
   }, [providers]);
 
+  // Capability tags per bare model id, for the info popover's "Type" row.
+  const modelTagsMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const provider of providers) {
+      if (
+        !provider ||
+        !('models' in provider) ||
+        !Array.isArray(provider.models)
+      )
+        continue;
+      for (const model of provider.models) map.set(model.id, model.tags ?? []);
+    }
+    return map;
+  }, [providers]);
+
+  // Cached catalog capabilities keyed by bare model id, for the info popover.
+  const capabilities = useModelCapabilities(
+    organizationId,
+    useMemo(() => [...modelTagsMap.keys()], [modelTagsMap]),
+  );
+
   const availableOptions = useMemo(() => {
     // Each entry is a *concrete* selectable ref — for models with a
     // `quantizations` array, that's one entry per declared variant. The base
@@ -318,6 +343,21 @@ function InstructionsTab() {
     [modelProvidersMap],
   );
 
+  const renderItemAction = useCallback(
+    (ref: string) => {
+      const { modelId } = parseModelRef(ref);
+      return (
+        <ModelInfoPopover
+          providerName={getProviderName(ref)}
+          tags={modelTagsMap.get(modelId) ?? []}
+          capabilities={capabilities.get(modelId)}
+          organizationId={organizationId}
+        />
+      );
+    },
+    [modelTagsMap, capabilities, organizationId, getProviderName],
+  );
+
   const handleModelsChange = useCallback(
     (models: string[]) => {
       updateConfig({ supportedModels: models });
@@ -404,6 +444,7 @@ function InstructionsTab() {
           availableOptions={availableOptions}
           getDisplayName={getDisplayName}
           getProviderName={getProviderName}
+          renderItemAction={renderItemAction}
         />
       </PageSection>
 

--- a/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId.tsx
@@ -33,6 +33,7 @@ import type {
   StepDef,
 } from '@/app/features/automations/utils/step-icons';
 import { primeCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import { usePersistedState } from '@/app/hooks/use-persisted-state';
 import { DEFAULT_TABLE_PAGE_SIZE } from '@/app/hooks/use-table-config-factory';
 import { useUrlState } from '@/app/hooks/use-url-state';
 import { api } from '@/convex/_generated/api';
@@ -364,7 +365,10 @@ function AutomationDetailInner({
     workflowSlug,
   );
   const [isAIChatOpen, setIsAIChatOpen] = useState(true);
-  const [panelWidth, setPanelWidth] = useState(384);
+  const [panelWidth, setPanelWidth] = usePersistedState(
+    'automation-side-panel-width',
+    384,
+  );
 
   const { state: panelState, clearAll: clearPanelUrlState } = useUrlState({
     definitions: AUTOMATION_PANEL_URL_DEFINITIONS,

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -24,6 +24,8 @@ import { parseModelRef } from '../../lib/shared/utils/model-ref';
 import { internal } from '../_generated/api';
 import { action, internalAction, type ActionCtx } from '../_generated/server';
 import { resolveAgeRecipients } from '../lib/age_keygen';
+import type { NormalizedCapability } from '../lib/agent_response/model_capabilities/normalize';
+import { normalizeCatalogPayload } from '../lib/agent_response/model_capabilities/normalize';
 import {
   atomicWrite,
   atomicWriteSecret,
@@ -1575,13 +1577,29 @@ export const getAllProviderConfigs = action({
 // Model discovery
 // ---------------------------------------------------------------------------
 
+/** What a model-discovery action hands back to the UI: the raw id plus, when
+ *  the source reports it, a human-readable name so the fetched-row list isn't
+ *  stuck showing alias ids like `~anthropic/claude-opus-latest`. */
+interface FetchedModel {
+  id: string;
+  displayName?: string;
+}
+
 /**
- * Parse a `GET /v1/models` response body into a sorted list of model ids.
- * Throws `PROVIDER_FETCH_FAILED` on non-JSON bodies or any shape other than
- * `{ data: [{ id: string }, ...] }`. Shared by the connect-time and
- * already-configured model-discovery actions so their parsing can't drift.
+ * Parse a `GET /v1/models` response body via the same `normalizeCatalogPayload`
+ * the weekly catalog cron uses, so a rich OpenRouter-shaped response yields the
+ * full capability facts (cost, context window, reasoning, …) while a sparse
+ * OpenAI-compatible `{ id }` response degrades to id-only entries. Returns both
+ * the full normalized rows (for persisting to the capability cache) and the
+ * trimmed `{ id, displayName }` list the UI renders. Throws
+ * `PROVIDER_FETCH_FAILED` on non-JSON bodies or any shape that yields no ids.
+ * Shared by the connect-time and already-configured discovery actions so their
+ * parsing can't drift.
  */
-function parseProviderModelsList(body: string): Array<{ id: string }> {
+function parseProviderModelsList(body: string): {
+  models: FetchedModel[];
+  capabilities: NormalizedCapability[];
+} {
   let json: unknown;
   try {
     json = JSON.parse(body);
@@ -1591,28 +1609,57 @@ function parseProviderModelsList(body: string): Array<{ id: string }> {
       message: 'Provider returned non-JSON response',
     });
   }
-  if (
-    json == null ||
-    typeof json !== 'object' ||
-    !('data' in json) ||
-    !Array.isArray(json.data)
-  ) {
+  const isOpenAiShape =
+    json != null &&
+    typeof json === 'object' &&
+    'data' in json &&
+    Array.isArray(json.data);
+  // `normalizeCatalogPayload` accepts both `{ data: [...] }` and a bare array;
+  // reject anything else up front so the operator sees a clear shape error
+  // rather than a silent empty list.
+  if (!isOpenAiShape && !Array.isArray(json)) {
     throw new ConvexError({
       code: 'PROVIDER_FETCH_FAILED',
       message:
         'Unexpected response format: expected { data: [...] } from /v1/models',
     });
   }
-  return json.data
-    .filter(
-      (m): m is { id: string } =>
-        m != null &&
-        typeof m === 'object' &&
-        'id' in m &&
-        typeof m.id === 'string',
-    )
-    .map((m) => ({ id: m.id }))
+  const capabilities = normalizeCatalogPayload(json);
+  const models = capabilities
+    .map((c) => ({
+      id: c.modelId,
+      ...(c.displayName ? { displayName: c.displayName } : {}),
+    }))
     .sort((a, b) => a.id.localeCompare(b.id));
+  return { models, capabilities };
+}
+
+/** Persist freshly-fetched capability rows into `modelCapabilityCache`, exactly
+ *  as the weekly cron does (chunked, `displayName`/`isChat` projected off since
+ *  the cache table stores only runtime fields). Never throws — a cache write
+ *  failure must not fail the user-facing model-list fetch. */
+async function persistFetchedCapabilities(
+  ctx: ActionCtx,
+  source: string,
+  capabilities: NormalizedCapability[],
+  fetchedAt: number,
+): Promise<void> {
+  const CHUNK = 100;
+  try {
+    for (let i = 0; i < capabilities.length; i += CHUNK) {
+      const chunk = capabilities
+        .slice(i, i + CHUNK)
+        .map(({ displayName: _displayName, isChat: _isChat, ...row }) => row);
+      await ctx.runMutation(
+        internal.model_catalog.mutations.upsertCapabilities,
+        { source, fetchedAt, entries: chunk },
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[fetchProviderModels] failed to cache capabilities from ${source}: ${sanitizeError(err)}`,
+    );
+  }
 }
 
 /**
@@ -1625,8 +1672,10 @@ export const fetchProviderModels = action({
     baseUrl: v.string(),
     apiKey: v.string(),
   },
-  returns: v.array(v.object({ id: v.string() })),
-  handler: async (ctx, args): Promise<Array<{ id: string }>> => {
+  returns: v.array(
+    v.object({ id: v.string(), displayName: v.optional(v.string()) }),
+  ),
+  handler: async (ctx, args): Promise<FetchedModel[]> => {
     // Same gate as the rest of the provider mutations — operators with
     // developerSettings access only. Pre-this-fix, this action accepted any
     // authenticated user (`authComponent.getAuthUser`) and any baseUrl, which
@@ -1679,7 +1728,16 @@ export const fetchProviderModels = action({
       });
     }
 
-    return parseProviderModelsList(response.body);
+    const { models, capabilities } = parseProviderModelsList(response.body);
+    // Connect-time fetch isn't yet bound to a provider slug; stamp the cache
+    // with the canonical catalog source so these rows merge with the cron's.
+    await persistFetchedCapabilities(
+      ctx,
+      'openrouter',
+      capabilities,
+      Date.now(),
+    );
+    return models;
   },
 });
 
@@ -1689,8 +1747,10 @@ export const fetchProviderModels = action({
 
 export const fetchConfiguredProviderModels = action({
   args: { organizationId: v.string(), providerName: v.string() },
-  returns: v.array(v.object({ id: v.string() })),
-  handler: async (ctx, args): Promise<Array<{ id: string }>> => {
+  returns: v.array(
+    v.object({ id: v.string(), displayName: v.optional(v.string()) }),
+  ),
+  handler: async (ctx, args): Promise<FetchedModel[]> => {
     const { orgSlug } = await requireDeveloperSettingsAccessById(
       ctx,
       args.organizationId,
@@ -1783,7 +1843,14 @@ export const fetchConfiguredProviderModels = action({
       });
     }
 
-    return parseProviderModelsList(response.body);
+    const { models, capabilities } = parseProviderModelsList(response.body);
+    await persistFetchedCapabilities(
+      ctx,
+      args.providerName,
+      capabilities,
+      Date.now(),
+    );
+    return models;
   },
 });
 

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -1662,6 +1662,20 @@ async function persistFetchedCapabilities(
   }
 }
 
+/** Pick the capability-cache `source` for a connect-time fetch by its base URL.
+ *  OpenRouter responses are catalog-grade, so they share the cron's `openrouter`
+ *  source; any other host gets a `discovery:<host>` source so it can't overwrite
+ *  the shared catalog with partial/sparse rows. Falls back to a generic source
+ *  if the URL doesn't parse. */
+function capabilitySourceForBaseUrl(baseUrl: string): string {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host.includes('openrouter.ai') ? 'openrouter' : `discovery:${host}`;
+  } catch {
+    return 'discovery:unknown';
+  }
+}
+
 /**
  * Fetch available models from an OpenAI-compatible /v1/models endpoint.
  * Used by the "Add provider" panel to auto-populate models.
@@ -1729,11 +1743,13 @@ export const fetchProviderModels = action({
     }
 
     const { models, capabilities } = parseProviderModelsList(response.body);
-    // Connect-time fetch isn't yet bound to a provider slug; stamp the cache
-    // with the canonical catalog source so these rows merge with the cron's.
+    // Connect-time fetch isn't yet bound to a provider slug. Only OpenRouter
+    // rows are catalog-grade, so merge those with the cron's `openrouter`
+    // source; anything else is stamped with a host-scoped source so a
+    // non-OpenRouter provider can't overwrite the shared catalog.
     await persistFetchedCapabilities(
       ctx,
-      'openrouter',
+      capabilitySourceForBaseUrl(args.baseUrl),
       capabilities,
       Date.now(),
     );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3692,7 +3692,8 @@
     "tools": {
       "title": "Erkannte Tools",
       "noTools": "Keine Tools erkannt. Teste zuerst die Verbindung.",
-      "requiresApproval": "Genehmigung erforderlich"
+      "requiresApproval": "Genehmigung erforderlich",
+      "count": "{count, plural, one {# Tool} other {# Tools}}"
     },
     "saved": "MCP-Server gespeichert",
     "deleted": "MCP-Server gelöscht"

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -904,7 +904,21 @@
       "noApiKey": "Für den Anbieter dieses Modells ist kein API-Schlüssel konfiguriert — füge in Einstellungen → KI-Anbieter einen hinzu.",
       "info": {
         "provider": "Anbieter",
-        "type": "Typ"
+        "type": "Typ",
+        "contextWindow": "Kontext",
+        "maxOutput": "Max. Ausgabe",
+        "inputCost": "Eingabekosten",
+        "outputCost": "Ausgabekosten",
+        "reasoning": "Reasoning",
+        "promptCaching": "Prompt-Caching",
+        "tools": "Tools",
+        "vision": "Vision",
+        "supported": "Unterstützt",
+        "notSupported": "Nicht unterstützt",
+        "reasoningEffort": "Aufwandsstufen",
+        "reasoningBudget": "Token-Budget",
+        "cachingExplicit": "Manuelle Breakpoints",
+        "cachingAuto": "Automatisch"
       },
       "tags": {
         "chat": "Chat",
@@ -3658,7 +3672,7 @@
       "url": "URL",
       "command": "Befehl",
       "args": "Argumente",
-      "authType": "Authentifizierung",
+      "authType": "Methode",
       "apiKey": "API-Key",
       "oauth2": "OAuth 2.0",
       "save": "Server speichern",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3692,7 +3692,8 @@
     "tools": {
       "title": "Discovered Tools",
       "noTools": "No tools discovered. Test the connection first.",
-      "requiresApproval": "Requires approval"
+      "requiresApproval": "Requires approval",
+      "count": "{count, plural, one {# tool} other {# tools}}"
     },
     "saved": "MCP server saved",
     "deleted": "MCP server deleted"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -904,7 +904,21 @@
       "noApiKey": "No API key configured for this model's provider — add one in Settings → AI providers.",
       "info": {
         "provider": "Provider",
-        "type": "Type"
+        "type": "Type",
+        "contextWindow": "Context",
+        "maxOutput": "Max output",
+        "inputCost": "Input cost",
+        "outputCost": "Output cost",
+        "reasoning": "Reasoning",
+        "promptCaching": "Prompt caching",
+        "tools": "Tools",
+        "vision": "Vision",
+        "supported": "Supported",
+        "notSupported": "Not supported",
+        "reasoningEffort": "Effort levels",
+        "reasoningBudget": "Token budget",
+        "cachingExplicit": "Manual breakpoints",
+        "cachingAuto": "Automatic"
       },
       "tags": {
         "chat": "Chat",
@@ -3658,7 +3672,7 @@
       "url": "URL",
       "command": "Command",
       "args": "Arguments",
-      "authType": "Authentication",
+      "authType": "Method",
       "apiKey": "API Key",
       "oauth2": "OAuth 2.0",
       "save": "Save server",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3693,7 +3693,8 @@
     "tools": {
       "title": "Outils découverts",
       "noTools": "Aucun outil découvert. Teste d'abord la connexion.",
-      "requiresApproval": "Nécessite une approbation"
+      "requiresApproval": "Nécessite une approbation",
+      "count": "{count, plural, one {# outil} other {# outils}}"
     },
     "saved": "Serveur MCP enregistré",
     "deleted": "Serveur MCP supprimé"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -905,7 +905,21 @@
       "noApiKey": "Aucune clé API configurée pour le fournisseur de ce modèle — ajoutes-en une dans Paramètres → Fournisseurs d’IA.",
       "info": {
         "provider": "Fournisseur",
-        "type": "Type"
+        "type": "Type",
+        "contextWindow": "Contexte",
+        "maxOutput": "Sortie max.",
+        "inputCost": "Coût d'entrée",
+        "outputCost": "Coût de sortie",
+        "reasoning": "Raisonnement",
+        "promptCaching": "Mise en cache des prompts",
+        "tools": "Outils",
+        "vision": "Vision",
+        "supported": "Pris en charge",
+        "notSupported": "Non pris en charge",
+        "reasoningEffort": "Niveaux d'effort",
+        "reasoningBudget": "Budget de tokens",
+        "cachingExplicit": "Points de rupture manuels",
+        "cachingAuto": "Automatique"
       },
       "tags": {
         "chat": "Chat",
@@ -3659,7 +3673,7 @@
       "url": "URL",
       "command": "Commande",
       "args": "Arguments",
-      "authType": "Authentification",
+      "authType": "Méthode",
       "apiKey": "Clé API",
       "oauth2": "OAuth 2.0",
       "save": "Enregistrer le serveur",


### PR DESCRIPTION
## Summary

Surfaces model capability details — cost, context window, max output, reasoning knob, prompt-caching mode, and tools/vision support — in the `ModelInfoPopover`, wired across every model selector (chat, arena, agent create, governance default/access editors, provider panels).

## Changes

- **`ModelInfoPopover`** gains an optional `capabilities` prop. Each known field renders as its own row; absent fields are hidden so sparse providers stay clean. The component now pulls its own `useT('chat')` instead of receiving `t`, and accepts a `triggerClassName` for placement beside form controls (vs. list rows).
- **`useModelCapabilities`** hook backed by the `getModelCapabilities` query / `modelCapabilityCache`, keyed by model id. Pass the currently-visible ids only.
- **`parseProviderModelsList`** now runs the live "Fetch models" response through the same `normalizeCatalogPayload` the weekly catalog cron uses:
  - A rich OpenRouter-shaped response yields full capability rows, persisted to the cache via `persistFetchedCapabilities` (chunked, never throws — a cache write failure can't fail the user-facing fetch).
  - A sparse OpenAI-compatible `{ id }` response degrades to id-only entries.
  - Fetched models now carry an optional `displayName` so lists no longer show alias ids like `~anthropic/claude-opus-latest`.

## Drive-by UX fixes

- Toast close button is always visible on coarse (touch) pointers, which have no hover and could otherwise never dismiss a toast before auto-expiry.
- Automation side-panel width persists via `usePersistedState`.
- MCP server auth-type label reads "Method".

## Test plan

- [ ] Open a model selector → info popover shows cost / context / reasoning / caching / tools / vision rows for cached models.
- [ ] Models without a cache row show only provider/type rows (no empty fields).
- [ ] "Fetch models" against an OpenRouter key populates capability rows; against a bare OpenAI-compatible endpoint, still lists ids.
- [ ] Dismiss a toast on a touch device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich model capability information now displays across model selection interfaces, including context window, token limits, cost data, tool support, vision capabilities, and reasoning features.

* **Improvements**
  * Better model display names throughout the application.
  * Enhanced mobile dashboard layout.
  * Persistent UI panel widths for improved workflow continuity.
  * Multi-language support for model capability information.

* **UI/UX**
  * Refined MCP server card styling and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->