### PR TITLE
fix(platform): derive dev builtin catalog from TALE_CONFIG_DIR

### DIFF
--- a/services/platform/scripts/dev.ts
+++ b/services/platform/scripts/dev.ts
@@ -150,14 +150,16 @@ function envNormalizeCommon() {
   // Immutable seed catalog for new-org scaffolding. Prod sets this in the
   // Docker image (services/convex/Dockerfile copies examples/default →
   // /app/builtin/default; services/platform/Dockerfile sets the env to
-  // /app/builtin). Dev has no build step, so default it to the repo `examples`
-  // dir — the SAME source the image bakes in. Without this, `seedDomain` falls
-  // back to seeding new orgs from the LIVE `default` org's mutable dir, so an
-  // agent deleted in `default` (or a custom TALE_CONFIG_DIR pointing away from
-  // the repo) wrongly propagates to every new org. Pointing at the repo
-  // baseline makes dev use the identical seed-from-catalog path as prod.
+  // /app/builtin). Dev has no build step, so default it to whatever
+  // TALE_CONFIG_DIR points at — the same tree dev already serves. Without this,
+  // `seedDomain` falls back to seeding new orgs from the LIVE `default` org's
+  // mutable dir, so an agent deleted in `default` wrongly propagates to every
+  // new org. Deriving from TALE_CONFIG_DIR (not a hardcoded `examples`) keeps
+  // hermetic setups intact: the E2E stack points TALE_CONFIG_DIR at its own
+  // fixtures, and the builtin catalog must follow it rather than leaking the
+  // real `examples` agents/providers into freshly scaffolded test orgs.
   if (!process.env.TALE_CONFIG_BUILTIN_DIR) {
-    process.env.TALE_CONFIG_BUILTIN_DIR = join(repoRoot, 'examples');
+    process.env.TALE_CONFIG_BUILTIN_DIR = process.env.TALE_CONFIG_DIR;
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up fix for #1891. That PR added a `TALE_CONFIG_BUILTIN_DIR` default to `scripts/dev.ts` (the immutable seed catalog for new-org scaffolding) but **hardcoded it to `examples`**. That broke the hermetic Playwright E2E stack.

### Root cause

The E2E webServer (`playwright.config.ts`) points `TALE_CONFIG_DIR` at `e2e/fixtures/config` and leaves `TALE_CONFIG_BUILTIN_DIR` unset. Before #1891, `seedDomain` fell back to `resolveDomainDir('default')` — i.e. `fixtures/config/default` — so freshly scaffolded test orgs got the hermetic seed (the **E2E Assistant** agent + the **mock** provider at `http://127.0.0.1:4141/v1`).

After #1891, `dev.ts` forced `TALE_CONFIG_BUILTIN_DIR=<repo>/examples`, so the E2E stack scaffolded new orgs from `examples/default` instead — handing them the **real OpenRouter provider** (`https://openrouter.ai/api/v1`, no key in CI) and none of the E2E seed. Chat/agent/onboarding specs then failed or hung on real-provider timeouts, which is why all four Playwright shards went red (1 hard failure, 3 fail-fast cancellations, 10–30 min runtimes).

Note: the E2E job is `continue-on-error` on PRs (burn-in), so this never gated the merge — but it should be green.

### Fix

Default `TALE_CONFIG_BUILTIN_DIR` to `TALE_CONFIG_DIR` rather than a hardcoded `examples`:

- **Normal dev:** `TALE_CONFIG_DIR` already defaults to `examples`, so the builtin catalog stays `examples` — #1891's intended behavior (new orgs seed from the repo baseline, not the mutable live `default` org) is preserved.
- **E2E:** the builtin catalog follows the fixtures dir, restoring the exact pre-#1891 hermetic seed source.

### Verification

- Confirmed `examples/default/providers/openrouter.json` (real) vs `e2e/fixtures/config/default/providers/e2e-mock.json` (mock) differ — proving the regression was real.
- Verified the derivation logic in isolation for both env scenarios (normal-dev → `examples`; E2E → fixtures).
- Could not run the full local E2E suite: a dev stack already occupies :3000 and I would not stop the user's running stack. The fix is logic-only on `dev.ts` env defaults.

## Pre-PR checklist

- [x] Ran format check on the touched file (`oxfmt --check` clean).
- [ ] `services/platform/messages/{en,de,fr}.json` — N/A (no UI strings).
- [ ] `/docs/{en,de,fr}/` — N/A (internal dev-script env default; not user-facing).
- [ ] READMEs — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to align builtin catalog settings with the active configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->