### PR TITLE
fix(platform): surface raw provider error & stop mislabeling param rejections in chat

### DIFF
--- a/services/platform/app/features/chat/components/chat-error-display.tsx
+++ b/services/platform/app/features/chat/components/chat-error-display.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { CollapsibleDetails } from '@tale/ui/collapsible-details';
+import { RotateCcw, TriangleAlert } from 'lucide-react';
+
+import { useT } from '@/lib/i18n/client';
+
+import { sanitizeChatError } from '../utils/sanitize-chat-error';
+
+interface ChatErrorDisplayProps {
+  /** Raw error string stored on the message (the verbatim provider error). */
+  error: string | undefined;
+  onRetry?: () => void;
+}
+
+/**
+ * Renders a failed/aborted chat turn's error: a friendly, classified hint plus
+ * the verbatim provider error tucked behind a collapsed "Technical details"
+ * disclosure. The raw error is always available (it's needed to debug provider
+ * misconfigurations — e.g. an Azure reasoning deployment rejecting `max_tokens`
+ * is otherwise mislabeled as a token-limit problem). Unknown ("generic") errors
+ * open the disclosure by default since the raw text is the only signal.
+ */
+export function ChatErrorDisplay({ error, onRetry }: ChatErrorDisplayProps) {
+  const { t: tChat } = useT('chat');
+  const sanitized = sanitizeChatError(error);
+
+  return (
+    <div className="mt-3 flex flex-col gap-2" role="alert" aria-live="polite">
+      <div className="text-destructive flex items-center gap-2">
+        <TriangleAlert className="size-4 shrink-0" />
+        <span className="text-sm font-medium">{tChat('errorGenerating')}</span>
+      </div>
+      <p className="text-muted-foreground text-[13px]">
+        {tChat(sanitized.i18nKey)}
+      </p>
+      {error && (
+        <CollapsibleDetails
+          variant="compact"
+          summary={tChat('errorDetailsSummary')}
+          open={sanitized.category === 'generic'}
+        >
+          <p className="text-muted-foreground mt-1 font-mono text-xs break-all whitespace-pre-wrap opacity-70">
+            {error}
+          </p>
+        </CollapsibleDetails>
+      )}
+      {onRetry && (
+        <Button
+          variant="secondary"
+          size="sm"
+          className="text-foreground w-fit gap-1.5 rounded-lg border-[#E5E7EB] bg-transparent px-3 py-1.5 text-[13px] font-medium"
+          onClick={onRetry}
+        >
+          <RotateCcw className="size-3.5" />
+          {tChat('retryGeneration')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -11,7 +11,6 @@ import {
   Pencil,
   Bookmark,
   BookmarkCheck,
-  TriangleAlert,
   RotateCcw,
   Square,
   Volume2,
@@ -55,9 +54,9 @@ import {
   type MessageSegment,
 } from '../utils/build-message-segments';
 import { normalizeCopiedText } from '../utils/normalize-copied-text';
-import { sanitizeChatError } from '../utils/sanitize-chat-error';
 import { hasThoughtSteps } from '../utils/thought-predicates';
 import { BlockedNotice } from './blocked-notice';
+import { ChatErrorDisplay } from './chat-error-display';
 import {
   FileAttachmentDisplay,
   FilePartDisplay,
@@ -842,87 +841,13 @@ function MessageBubbleComponent({
               </div>
             )}
             {message.isFailed && (
-              <div
-                className="mt-3 flex flex-col gap-2"
-                role="alert"
-                aria-live="polite"
-              >
-                <div className="text-destructive flex items-center gap-2">
-                  <TriangleAlert className="size-4 shrink-0" />
-                  <span className="text-sm font-medium">
-                    {tChat('errorGenerating')}
-                  </span>
-                </div>
-                {(() => {
-                  const sanitized = sanitizeChatError(message.error);
-                  return (
-                    <>
-                      <p className="text-muted-foreground text-[13px]">
-                        {tChat(sanitized.i18nKey)}
-                      </p>
-                      {sanitized.rawMessage && (
-                        <p className="text-muted-foreground text-xs break-all whitespace-pre-wrap opacity-70">
-                          {sanitized.rawMessage}
-                        </p>
-                      )}
-                    </>
-                  );
-                })()}
-                {onRetry && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="text-foreground w-fit gap-1.5 rounded-lg border-[#E5E7EB] bg-transparent px-3 py-1.5 text-[13px] font-medium"
-                    onClick={onRetry}
-                  >
-                    <RotateCcw className="size-3.5" />
-                    {tChat('retryGeneration')}
-                  </Button>
-                )}
-              </div>
+              <ChatErrorDisplay error={message.error} onRetry={onRetry} />
             )}
           </div>
         ) : (
           message.isAborted &&
           (message.error ? (
-            <div
-              className="mt-3 flex flex-col gap-2"
-              role="alert"
-              aria-live="polite"
-            >
-              <div className="text-destructive flex items-center gap-2">
-                <TriangleAlert className="size-4 shrink-0" />
-                <span className="text-sm font-medium">
-                  {tChat('errorGenerating')}
-                </span>
-              </div>
-              {(() => {
-                const sanitized = sanitizeChatError(message.error);
-                return (
-                  <>
-                    <p className="text-muted-foreground text-[13px]">
-                      {tChat(sanitized.i18nKey)}
-                    </p>
-                    {sanitized.rawMessage && (
-                      <p className="text-muted-foreground text-xs break-all whitespace-pre-wrap opacity-70">
-                        {sanitized.rawMessage}
-                      </p>
-                    )}
-                  </>
-                );
-              })()}
-              {onRetry && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="text-foreground w-fit gap-1.5 rounded-lg border-[#E5E7EB] bg-transparent px-3 py-1.5 text-[13px] font-medium"
-                  onClick={onRetry}
-                >
-                  <RotateCcw className="size-3.5" />
-                  {tChat('retryGeneration')}
-                </Button>
-              )}
-            </div>
+            <ChatErrorDisplay error={message.error} onRetry={onRetry} />
           ) : (
             <div className="text-muted-foreground flex items-center gap-1.5 text-sm italic">
               <Square className="size-3" />

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.test.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.test.ts
@@ -220,6 +220,51 @@ describe('sanitizeChatError', () => {
         i18nKey: 'errorHintTokenLimit',
       });
     });
+
+    it('still classifies a genuine output-limit error as tokenLimit', () => {
+      expect(
+        sanitizeChatError(
+          'max_tokens is too large: 200000. This model supports at most 128000 completion tokens.',
+        ),
+      ).toEqual({
+        category: 'tokenLimit',
+        i18nKey: 'errorHintTokenLimit',
+      });
+    });
+  });
+
+  describe('unsupported parameter errors', () => {
+    it('classifies an Azure reasoning-model max_tokens rejection as unsupportedParameter, not tokenLimit', () => {
+      // GPT-5 / o-series reasoning deployments reject `max_tokens` and require
+      // `max_completion_tokens`. The verbatim 400 body contains "max_tokens",
+      // which must NOT be mislabeled as an output-token-limit problem.
+      const raw =
+        "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.";
+      expect(sanitizeChatError(raw)).toEqual({
+        category: 'unsupportedParameter',
+        i18nKey: 'errorHintUnsupportedParameter',
+      });
+    });
+
+    it('matches "is not supported with this model" phrasing', () => {
+      expect(
+        sanitizeChatError(
+          "Unsupported value: 'temperature' is not supported with this model.",
+        ),
+      ).toEqual({
+        category: 'unsupportedParameter',
+        i18nKey: 'errorHintUnsupportedParameter',
+      });
+    });
+
+    it('matches an unrecognized request argument error', () => {
+      expect(
+        sanitizeChatError('Unrecognized request argument supplied: foo'),
+      ).toEqual({
+        category: 'unsupportedParameter',
+        i18nKey: 'errorHintUnsupportedParameter',
+      });
+    });
   });
 
   describe('context length errors', () => {

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.ts
@@ -3,6 +3,7 @@ type ErrorCategory =
   | 'creditExhausted'
   | 'authError'
   | 'modelNotFound'
+  | 'unsupportedParameter'
   | 'tokenLimit'
   | 'rateLimited'
   | 'contentFilter'
@@ -40,6 +41,17 @@ const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
     pattern: /model.*not found|model.*not available|invalid model|\b404\b/i,
     category: 'modelNotFound',
   },
+  // A provider/model rejecting a request PARAMETER (e.g. Azure reasoning
+  // deployments returning "Unsupported parameter: 'max_tokens' ... Use
+  // 'max_completion_tokens' instead") is an operator-config mismatch, not an
+  // end-user token-limit problem. This must precede `tokenLimit` below, whose
+  // broad `max_tokens` match would otherwise mislabel it as "output token
+  // limit exceeded".
+  {
+    pattern:
+      /unsupported parameter|is not supported with this model|unsupported_parameter|unknown parameter|unrecognized request argument/i,
+    category: 'unsupportedParameter',
+  },
   {
     pattern: /fewer max_tokens|token.*limit|max_tokens/i,
     category: 'tokenLimit',
@@ -72,6 +84,7 @@ const CATEGORY_I18N_KEY: Record<ErrorCategory, string> = {
   creditExhausted: 'errorHintCreditExhausted',
   authError: 'errorHintAuthError',
   modelNotFound: 'errorHintModelNotFound',
+  unsupportedParameter: 'errorHintUnsupportedParameter',
   tokenLimit: 'errorHintTokenLimit',
   rateLimited: 'errorHintRateLimited',
   contentFilter: 'errorHintContentFilter',

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -986,6 +986,7 @@
       }
     },
     "errorGenerating": "Etwas ist schiefgelaufen",
+    "errorDetailsSummary": "Technische Details",
     "retryGeneration": "Erneut versuchen",
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
@@ -1396,6 +1397,7 @@
     "errorHintRateLimited": "Zu viele Anfragen. Bitte warte einen Moment und versuche es erneut.",
     "errorHintTokenLimit": "Das Token-Limit des Modells wurde überschritten. Versuche eine kürzere Anfrage oder bitte deinen Administrator, die Modelleinstellungen anzupassen.",
     "errorHintToolFailure": "Der Agent hat beim Datenzugriff einen Fehler festgestellt. Versuche, deine Anfrage umzuformulieren oder weniger Daten anzufordern.",
+    "errorHintUnsupportedParameter": "Das Modell hat einen der Anfrageparameter abgelehnt. Das deutet meist auf eine falsch konfigurierte Anbieter- oder Modelleinstellung hin – prüfe die Modelleinstellungen oder öffne die Details unten.",
     "workspaceFiles": {
       "title": "Arbeitsbereichsdateien",
       "toggleLabel": "Arbeitsbereichsdateien",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -986,6 +986,7 @@
       }
     },
     "errorGenerating": "Something went wrong",
+    "errorDetailsSummary": "Technical details",
     "retryGeneration": "Try again",
     "showMore": "Show more",
     "showLess": "Show less",
@@ -1416,6 +1417,7 @@
     "errorHintRateLimited": "Too many requests. Please wait a moment and try again.",
     "errorHintTokenLimit": "The model's output token limit was exceeded. Try a shorter request or ask your administrator to adjust the model settings.",
     "errorHintToolFailure": "The agent encountered an error while accessing data. Try rephrasing your request or asking for a smaller set of data.",
+    "errorHintUnsupportedParameter": "The model rejected one of the request parameters. This usually means a provider or model configuration mismatch — check the model settings, or expand the details below.",
     "liveBrowser": {
       "title": "Live browser",
       "toggleLabel": "Live browser",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -987,6 +987,7 @@
       }
     },
     "errorGenerating": "Une erreur s'est produite",
+    "errorDetailsSummary": "Détails techniques",
     "retryGeneration": "Réessayer",
     "showMore": "Voir plus",
     "showLess": "Voir moins",
@@ -1397,6 +1398,7 @@
     "errorHintRateLimited": "Trop de requêtes. Merci de patienter un moment et réessayer.",
     "errorHintTokenLimit": "La limite de tokens en sortie du modèle a été dépassée. Essaie une requête plus courte ou demande à ton administrateur d'ajuster les paramètres du modèle.",
     "errorHintToolFailure": "L'agent a rencontré une erreur lors de l'accès aux données. Essaie de reformuler ta demande ou de demander un ensemble de données plus restreint.",
+    "errorHintUnsupportedParameter": "Le modèle a rejeté l'un des paramètres de la requête. Cela indique généralement une mauvaise configuration du fournisseur ou du modèle — vérifie les paramètres du modèle ou ouvre les détails ci-dessous.",
     "workspaceFiles": {
       "title": "Fichiers de l'espace de travail",
       "toggleLabel": "Fichiers de l'espace de travail",


### PR DESCRIPTION
## Problem

A chat against an Azure **GPT-5 reasoning** deployment (e.g. `gpt-5.4`) fails on every message — even a one-word "Hallo" — with *"The model's output token limit was exceeded. Try a shorter request…"*. That message is **wrong and un-actionable**, and the real error is nowhere to be seen in the UI.

## Root cause (display layer)

1. Azure reasoning models reject the `max_tokens` body field and require `max_completion_tokens` (HTTP 400: *"Unsupported parameter: 'max_tokens' … Use 'max_completion_tokens' instead"*). The chat path sends `max_tokens` via `@ai-sdk/openai-compatible`, so the request is rejected before any generation.
2. `sanitizeChatError`'s `tokenLimit` pattern `/…|max_tokens/i` greedily matched the **substring** `max_tokens` inside that param-rejection text → classified it as `tokenLimit`.
3. For any **classified** category the original error was **dropped from the UI** (raw was only rendered for `generic`). So users/operators saw a misleading hint and had to dig into the DB/logs to find the real error.

## What this changes (frontend only)

- **Stop mislabeling**: new `unsupportedParameter` category in `sanitize-chat-error.ts`, matched **before** `tokenLimit`, covering `unsupported parameter` / `is not supported with this model` / `unrecognized request argument`. The `tokenLimit` pattern is left intact (genuine `max_tokens exceeded` / `token limit` cases still classify correctly).
- **Always surface the original error**: new `ChatErrorDisplay` component renders the friendly hint plus the verbatim provider error behind a collapsed **"Technical details"** disclosure (`@tale/ui/collapsible-details`). Unknown/`generic` errors auto-expand (preserving today's at-a-glance behavior); classified ones stay collapsed. This is *more* conservative than today, where the generic raw was shown inline to everyone.
- **De-dup**: the two byte-identical failed/aborted error blocks in `message-bubble.tsx` collapse into the new component (−78 lines there).
- **i18n**: `errorHintUnsupportedParameter` + `errorDetailsSummary` added to `en` / `de` / `fr` (`de-CH` inherits via fallback).

## Out of scope (separate follow-up)

The actual wire fix — emitting `max_completion_tokens` for reasoning models in `resolve_model.ts` — is a separate change. This PR improves error classification and debuggability for **all** provider errors.

## Test plan

- `sanitize-chat-error.test.ts` — **51 passed** (incl. new cases: the exact Azure string → `unsupportedParameter` not `tokenLimit`; a genuine output-limit string still → `tokenLimit`).
- i18n locale parity (`lib/i18n/messages.test.ts`) — **23 passed**.
- UI tests touching `message-bubble` (`chat-messages`, `structured-message`) — **31 passed**.
- `tsc --noEmit` clean · `oxlint --type-aware` 0 errors · `oxfmt --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat errors now display with clearer messages, retry capability, and expandable technical details for troubleshooting.

* **Bug Fixes**
  * Improved error classification to better identify unsupported parameter issues from providers.

* **Documentation**
  * Added multi-language support for error messaging in English, German, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->