### PR TITLE
perf(platform): cut cross-component round-trips in getOrganizationMember

### DIFF
--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -900,6 +900,60 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
               );
             }
           },
+          // teamMember mirror sync for client-direct Better Auth team endpoints
+          // (Tale's custom mutations + the Entra SSO sync update the mirror
+          // inline). Re-derive from source so it's idempotent; non-fatal — the
+          // reconcile cron self-heals any miss.
+          afterAddTeamMember: async (data) => {
+            const teamId = getString(data.teamMember, 'teamId');
+            const userId = getString(data.teamMember, 'userId');
+            if (!teamId || !userId) return;
+            try {
+              const runCtx = requireRunMutationCtx(ctx);
+              await runCtx.runMutation(
+                internal.members.mirror_sync.resyncTeamMemberMirror,
+                { teamId, userId },
+              );
+            } catch (err) {
+              console.error(
+                '[afterAddTeamMember] failed to sync team mirror',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          },
+          afterRemoveTeamMember: async (data) => {
+            const teamId = getString(data.teamMember, 'teamId');
+            const userId = getString(data.teamMember, 'userId');
+            if (!teamId || !userId) return;
+            try {
+              const runCtx = requireRunMutationCtx(ctx);
+              await runCtx.runMutation(
+                internal.members.mirror_sync.resyncTeamMemberMirror,
+                { teamId, userId },
+              );
+            } catch (err) {
+              console.error(
+                '[afterRemoveTeamMember] failed to sync team mirror',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          },
+          afterDeleteTeam: async (data) => {
+            const teamId = getString(data.team, 'id');
+            if (!teamId) return;
+            try {
+              const runCtx = requireRunMutationCtx(ctx);
+              await runCtx.runMutation(
+                internal.members.mirror_sync.cascadeDeleteTeamMembersMirror,
+                { teamId },
+              );
+            } catch (err) {
+              console.error(
+                '[afterDeleteTeam] failed to cascade-delete team mirror',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          },
         },
       }),
       apiKey({

--- a/services/platform/convex/lib/get_user_teams.ts
+++ b/services/platform/convex/lib/get_user_teams.ts
@@ -82,7 +82,35 @@ export async function getUserTeamIds(
     }
   }
 
-  // Fallback: query teamMember table with pagination
+  // Local mirror: a single indexed db read instead of a cross-component
+  // teamMember round-trip. This is the other half of the RLS request-context
+  // prime (parallel with getUserOrganizations); on the self-hosted backend the
+  // old cross-component read here pushed queryWithRLS queries (listConversations,
+  // listDocuments, …) over the 1s budget. Synced inline on every teamMember
+  // write path + an hourly reconcile (see members/mirror_sync.ts).
+  //
+  // Unlike memberships, a user commonly has ZERO teams, so an empty mirror is
+  // the normal team-less case — we treat the mirror as authoritative (empty ⇒
+  // no teams) rather than falling back, which would re-introduce the round-trip
+  // for the common case. A not-yet-backfilled team member therefore fails CLOSED
+  // (no team access) until the hourly reconcile lands — a safe, bounded
+  // direction. Better Auth is the error fallback only (mirror read threw).
+  try {
+    const teamIds: string[] = [];
+    for await (const row of ctx.db
+      .query('teamMemberMirror')
+      .withIndex('by_userId', (q) => q.eq('userId', userId))) {
+      teamIds.push(row.teamId);
+    }
+    return teamIds;
+  } catch (err) {
+    console.warn(
+      '[getUserTeamIds] team mirror read failed; falling back to Better Auth',
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  // Error fallback: query teamMember table with pagination
   const allTeamIds: string[] = [];
   let cursor: string | null = null;
   let isDone = false;

--- a/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.test.ts
@@ -35,10 +35,19 @@ vi.mock('../errors', () => {
 const { UnauthorizedError } = await import('../errors');
 const { getOrganizationMember } = await import('./get_organization_member');
 
-function createMockCtx() {
+// `mirrorRow` seeds the local memberMirror lookup (the hot path). Default null
+// → mirror miss → fall back to the authoritative Better Auth `runQuery` path the
+// existing tests drive.
+function createMockCtx(mirrorRow: unknown = null) {
   return {
     runQuery: vi.fn(),
-    db: {},
+    db: {
+      query: () => ({
+        withIndex: () => ({
+          first: async () => mirrorRow,
+        }),
+      }),
+    },
     auth: {},
   };
 }
@@ -64,6 +73,44 @@ describe('getOrganizationMember', () => {
     const result = await getOrganizationMember(ctx as never, 'org_1', authUser);
 
     expect(result).toEqual(member);
+  });
+
+  it('reads the local mirror without any cross-component query', async () => {
+    const ctx = createMockCtx({
+      memberId: 'om_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'admin',
+      createdAt: 1000,
+    });
+
+    const result = await getOrganizationMember(ctx as never, 'org_1', authUser);
+
+    // Reconstructed OrganizationMember._id is the Better Auth member id.
+    expect(result).toEqual({
+      _id: 'om_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'admin',
+      createdAt: 1000,
+    });
+    // The whole point: no Better Auth round-trip on the hot path.
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws UnauthorizedError for a disabled member found in the mirror', async () => {
+    const ctx = createMockCtx({
+      memberId: 'om_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      role: 'disabled',
+      createdAt: 1000,
+    });
+
+    await expect(
+      getOrganizationMember(ctx as never, 'org_1', authUser),
+    ).rejects.toThrow(UnauthorizedError);
+    expect(ctx.runQuery).not.toHaveBeenCalled();
   });
 
   it('throws UnauthorizedError when member role is disabled', async () => {

--- a/services/platform/convex/lib/rls/organization/get_organization_member.ts
+++ b/services/platform/convex/lib/rls/organization/get_organization_member.ts
@@ -11,6 +11,50 @@ import type { AuthenticatedUser, OrganizationMember } from '../types';
 /**
  * Get organization member for authenticated user from Better Auth's member table
  */
+/**
+ * Resolve a member from the local `memberMirror` by `(organizationId, userId)` —
+ * a single indexed db read, no cross-component round-trip.
+ *
+ * This is what keeps raw-query callers like `getMyPreferences` (via
+ * `assertSelfAndOrgMember`) off the 1s-budget cliff: they don't prime the RLS
+ * request cache, so without the mirror they pay a cold cross-component
+ * `member.findMany` here — the read that, amplified on a self-hosted backend,
+ * tripped the chat composer's error boundary (white screen). Disabled members
+ * ARE in the mirror (stored unchanged), so the disabled check below still fires.
+ * A miss (not-yet-backfilled / disabled-only edge / email-linking principal)
+ * falls through to the authoritative Better Auth lookup, preserving the original
+ * semantics. Returns undefined on miss or any read error so the caller falls
+ * back.
+ */
+async function findMemberInMirror(
+  ctx: QueryCtx | MutationCtx,
+  organizationId: string,
+  userId: string,
+): Promise<OrganizationMember | undefined> {
+  try {
+    const row = await ctx.db
+      .query('memberMirror')
+      .withIndex('by_org_user', (q) =>
+        q.eq('organizationId', organizationId).eq('userId', userId),
+      )
+      .first();
+    if (!row) return undefined;
+    return {
+      _id: row.memberId,
+      createdAt: row.createdAt,
+      organizationId: row.organizationId,
+      userId: row.userId,
+      role: row.role,
+    };
+  } catch (err) {
+    console.warn(
+      '[getOrganizationMember] member mirror read failed; falling back to Better Auth',
+      err instanceof Error ? err.message : err,
+    );
+    return undefined;
+  }
+}
+
 export async function getOrganizationMember(
   ctx: QueryCtx | MutationCtx,
   organizationId: string,
@@ -18,28 +62,38 @@ export async function getOrganizationMember(
 ): Promise<OrganizationMember> {
   const authUser = user || (await requireAuthenticatedUser(ctx));
 
-  // Query Better Auth's member table by userId
-  let result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-    model: 'member',
-    paginationOpts: {
-      cursor: null,
-      numItems: 1,
-    },
-    where: [
-      {
-        field: 'organizationId',
-        value: organizationId,
-        operator: 'eq',
-      },
-      {
-        field: 'userId',
-        value: authUser.userId,
-        operator: 'eq',
-      },
-    ],
-  });
+  // Hot path: read the membership from the local mirror (synced inline on every
+  // write path + an hourly reconcile). Falls back to Better Auth on a miss.
+  let member: OrganizationMember | undefined = await findMemberInMirror(
+    ctx,
+    organizationId,
+    authUser.userId,
+  );
 
-  let member = result?.page?.[0];
+  // Authoritative lookup: Better Auth's member table by (organizationId, userId).
+  let result = member
+    ? undefined
+    : await ctx.runQuery(components.betterAuth.adapter.findMany, {
+        model: 'member',
+        paginationOpts: {
+          cursor: null,
+          numItems: 1,
+        },
+        where: [
+          {
+            field: 'organizationId',
+            value: organizationId,
+            operator: 'eq',
+          },
+          {
+            field: 'userId',
+            value: authUser.userId,
+            operator: 'eq',
+          },
+        ],
+      });
+
+  member = member ?? result?.page?.[0];
 
   // Fallback to email lookup if no direct match.
   // This handles cases where the JWT userId doesn't match the stored userId, which can occur during:

--- a/services/platform/convex/members/mirror_reconciliation.ts
+++ b/services/platform/convex/members/mirror_reconciliation.ts
@@ -19,7 +19,7 @@ import { v } from 'convex/values';
 import { isRecord, getString, getNumber } from '../../lib/utils/type-utils';
 import { components, internal } from '../_generated/api';
 import { internalAction, internalMutation } from '../_generated/server';
-import { upsertMemberMirror } from './mirror_sync';
+import { upsertMemberMirror, upsertTeamMemberMirror } from './mirror_sync';
 
 const JOB = 'memberMirrorReconcile';
 const ORGS_PER_RUN = 25;
@@ -84,6 +84,76 @@ export const reconcileOneOrg = internalMutation({
         await ctx.db.delete(row._id);
         deleted += 1;
       }
+    }
+
+    // Reconcile the teamMember mirror for every team in this org (upsert/delete
+    // counts fold into the same totals). teamMember is keyed by team, so we walk
+    // the org's teams, then each team's members.
+    let teamCursor: string | null = null;
+    for (;;) {
+      const teamsRes: {
+        page: unknown[];
+        isDone?: boolean;
+        continueCursor?: string;
+      } = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+        model: 'team',
+        paginationOpts: { cursor: teamCursor, numItems: MEMBERS_PAGE },
+        where: [
+          {
+            field: 'organizationId',
+            value: args.organizationId,
+            operator: 'eq',
+          },
+        ],
+      });
+      if (!teamsRes || teamsRes.page.length === 0) break;
+      for (const rawTeam of teamsRes.page) {
+        if (!isRecord(rawTeam)) continue;
+        const teamId = getString(rawTeam, '_id');
+        if (!teamId) continue;
+
+        const liveTeamMemberIds = new Set<string>();
+        let tmCursor: string | null = null;
+        for (;;) {
+          const tmRes: {
+            page: unknown[];
+            isDone?: boolean;
+            continueCursor?: string;
+          } = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+            model: 'teamMember',
+            paginationOpts: { cursor: tmCursor, numItems: MEMBERS_PAGE },
+            where: [{ field: 'teamId', value: teamId, operator: 'eq' }],
+          });
+          if (!tmRes || tmRes.page.length === 0) break;
+          for (const raw of tmRes.page) {
+            if (!isRecord(raw)) continue;
+            const teamMemberId = getString(raw, '_id');
+            const tmUserId = getString(raw, 'userId');
+            if (!teamMemberId || !tmUserId) continue;
+            liveTeamMemberIds.add(teamMemberId);
+            await upsertTeamMemberMirror(ctx, {
+              teamMemberId,
+              userId: tmUserId,
+              teamId,
+              createdAt: getNumber(raw, 'createdAt') ?? Date.now(),
+            });
+            upserted += 1;
+          }
+          if (tmRes.isDone || tmRes.continueCursor === tmCursor) break;
+          tmCursor = tmRes.continueCursor ?? null;
+        }
+
+        for await (const row of ctx.db
+          .query('teamMemberMirror')
+          .withIndex('by_teamId', (q) => q.eq('teamId', teamId))) {
+          if (!liveTeamMemberIds.has(row.teamMemberId)) {
+            await ctx.db.delete(row._id);
+            deleted += 1;
+          }
+        }
+      }
+      if (teamsRes.isDone || teamsRes.continueCursor === teamCursor) break;
+      teamCursor = teamsRes.continueCursor ?? null;
     }
 
     return { upserted, deleted };

--- a/services/platform/convex/members/mirror_sync.ts
+++ b/services/platform/convex/members/mirror_sync.ts
@@ -180,3 +180,159 @@ export const cascadeDeleteOrgMembersMirror = internalMutation({
     return { deleted };
   },
 });
+
+// ---------------------------------------------------------------------------
+// teamMember mirror — same machinery for Better Auth's `teamMember` table,
+// feeding getUserTeamIds.
+// ---------------------------------------------------------------------------
+
+export interface MirrorTeamMemberInput {
+  teamMemberId: string;
+  userId: string;
+  teamId: string;
+  createdAt: number;
+}
+
+/** Upsert one teamMember mirror row, keyed on `teamMemberId`. Idempotent. */
+export async function upsertTeamMemberMirror(
+  ctx: MutationCtx,
+  input: MirrorTeamMemberInput,
+): Promise<void> {
+  const existing = await ctx.db
+    .query('teamMemberMirror')
+    .withIndex('by_teamMemberId', (q) =>
+      q.eq('teamMemberId', input.teamMemberId),
+    )
+    .first();
+  if (existing) {
+    if (existing.userId === input.userId && existing.teamId === input.teamId) {
+      return; // already in sync — no write
+    }
+    await ctx.db.patch(existing._id, {
+      userId: input.userId,
+      teamId: input.teamId,
+      updatedAt: Date.now(),
+    });
+    return;
+  }
+  await ctx.db.insert('teamMemberMirror', {
+    teamMemberId: input.teamMemberId,
+    userId: input.userId,
+    teamId: input.teamId,
+    createdAt: input.createdAt,
+    updatedAt: Date.now(),
+  });
+}
+
+/** Delete the teamMember mirror row for a Better Auth `teamMemberId`. */
+export async function deleteTeamMemberMirrorByTeamMemberId(
+  ctx: MutationCtx,
+  teamMemberId: string,
+): Promise<void> {
+  const existing = await ctx.db
+    .query('teamMemberMirror')
+    .withIndex('by_teamMemberId', (q) => q.eq('teamMemberId', teamMemberId))
+    .first();
+  if (existing) {
+    await ctx.db.delete(existing._id);
+  }
+}
+
+/** Delete every teamMember mirror row for a `(teamId, userId)` pair. */
+async function deleteTeamMemberMirrorByTeamUser(
+  ctx: MutationCtx,
+  teamId: string,
+  userId: string,
+): Promise<number> {
+  let deleted = 0;
+  for await (const row of ctx.db
+    .query('teamMemberMirror')
+    .withIndex('by_team_user', (q) =>
+      q.eq('teamId', teamId).eq('userId', userId),
+    )) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
+  return deleted;
+}
+
+/**
+ * Read the authoritative Better Auth teamMember row for `(teamId, userId)`,
+ * if any. Used by the resync mutation to re-derive the mirror from source.
+ */
+async function readBetterAuthTeamMember(
+  ctx: MutationCtx,
+  teamId: string,
+  userId: string,
+): Promise<MirrorTeamMemberInput | null> {
+  const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+    model: 'teamMember',
+    paginationOpts: { cursor: null, numItems: 1 },
+    where: [
+      { field: 'teamId', value: teamId, operator: 'eq' },
+      { field: 'userId', value: userId, operator: 'eq' },
+    ],
+  });
+  const raw = result?.page?.[0];
+  if (!isRecord(raw)) return null;
+  const teamMemberId = getString(raw, '_id');
+  if (!teamMemberId) return null;
+  return {
+    teamMemberId,
+    userId,
+    teamId,
+    createdAt: getNumber(raw, 'createdAt') ?? Date.now(),
+  };
+}
+
+/**
+ * Re-derive the teamMember mirror for one `(teamId, userId)` from Better Auth.
+ * Used by the team-member org hooks (client-direct endpoint calls). Source row
+ * exists → upsert; gone → delete the stale mirror row(s). Idempotent.
+ */
+export const resyncTeamMemberMirror = internalMutation({
+  args: { teamId: v.string(), userId: v.string() },
+  returns: v.object({ action: v.string() }),
+  handler: async (ctx, args) => {
+    const source = await readBetterAuthTeamMember(
+      ctx,
+      args.teamId,
+      args.userId,
+    );
+    if (source) {
+      await upsertTeamMemberMirror(ctx, source);
+      return { action: 'upserted' };
+    }
+    const deleted = await deleteTeamMemberMirrorByTeamUser(
+      ctx,
+      args.teamId,
+      args.userId,
+    );
+    return { action: deleted > 0 ? 'deleted' : 'noop' };
+  },
+});
+
+/** Delete every teamMember mirror row for a team (inline helper). */
+export async function deleteTeamMemberMirrorByTeamId(
+  ctx: MutationCtx,
+  teamId: string,
+): Promise<number> {
+  let deleted = 0;
+  for await (const row of ctx.db
+    .query('teamMemberMirror')
+    .withIndex('by_teamId', (q) => q.eq('teamId', teamId))) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
+  return deleted;
+}
+
+/** Cascade-delete every teamMember mirror row for a team (team deletion). */
+export const cascadeDeleteTeamMembersMirror = internalMutation({
+  args: { teamId: v.string() },
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx, args) => {
+    const deleted = await deleteTeamMemberMirrorByTeamId(ctx, args.teamId);
+    return { deleted };
+  },
+});

--- a/services/platform/convex/members/schema.ts
+++ b/services/platform/convex/members/schema.ts
@@ -12,14 +12,17 @@ import { v } from 'convex/values';
  * function-execution timeout (the dominant E2E flake). This mirror lets those
  * two hot-path readers serve from a local indexed table instead.
  *
- * AUTHORITY: the mirror is a PERFORMANCE CACHE, never the security boundary.
- * `getOrganizationMember` (the authoritative RLS gate, with its email-fallback
- * and trusted-role override) keeps reading Better Auth directly. The two
- * mirror-backed readers fall back to Better Auth on a miss, and the trusted
- * headers `trustedRole` override is still applied at read time. Every member
- * write path syncs the mirror inline (or via the auth after-middleware), and an
- * hourly reconciliation cron repairs any drift from a partial failure. See
- * `lib/rls/MEMBERSHIP_MIRROR_DESIGN.md`.
+ * AUTHORITY: the mirror backs the org-level RLS reads — `getUserOrganizations`,
+ * `isOrgMember`, AND `getOrganizationMember` (the gate behind
+ * `assertSelfAndOrgMember` / raw-query callers like `getMyPreferences`, whose
+ * cold cross-component read here was the dominant white-screen timeout). All
+ * three read the mirror and fall back to Better Auth on a miss; the trusted
+ * headers `trustedRole` override is still applied at read time and the
+ * email-fallback / account-linking branch still resolves against Better Auth.
+ * This makes the mirror authoritative for org membership under BOUNDED EVENTUAL
+ * CONSISTENCY: every member write path syncs inline (same transaction) or via
+ * the auth hooks / after-middleware, and an hourly reconciliation cron converges
+ * any drift from a partial failure. See `lib/rls/MEMBERSHIP_MIRROR_DESIGN.md`.
  */
 export const memberMirrorTable = defineTable({
   // Better Auth's member._id — the stable foreign key used for point
@@ -42,6 +45,36 @@ export const memberMirrorTable = defineTable({
   .index('by_org_user', ['organizationId', 'userId'])
   .index('by_organizationId', ['organizationId'])
   .index('by_memberId', ['memberId']);
+
+/**
+ * App-native mirror of Better Auth's `teamMember` table — the team-level
+ * counterpart of `memberMirror`. `getUserTeamIds` is the OTHER half of the RLS
+ * request-context prime (run in parallel with `getUserOrganizations`); it used
+ * to paginate Better Auth's `teamMember` by `userId` cross-component on every
+ * `queryWithRLS` request, so on the self-hosted backend it kept queries
+ * (listConversations, listDocuments, …) over the 1s budget even after the member
+ * mirror landed. Reading this local indexed table removes that round-trip too.
+ *
+ * Same bounded-eventual-consistency model + sync machinery as `memberMirror`.
+ * The JWT `trustedTeams` short-circuit in `get_user_teams.ts` still wins when
+ * present. Unlike memberships, a user commonly has ZERO teams, so the reader
+ * treats an empty mirror as authoritative (no teams) rather than falling back.
+ */
+export const teamMemberMirrorTable = defineTable({
+  // Better Auth's teamMember._id.
+  teamMemberId: v.string(),
+  // Better Auth's teamMember.userId — primary lookup key (getUserTeamIds).
+  userId: v.string(),
+  // Better Auth's teamMember.teamId.
+  teamId: v.string(),
+  // Better Auth's teamMember.createdAt.
+  createdAt: v.optional(v.number()),
+  updatedAt: v.optional(v.number()),
+})
+  .index('by_userId', ['userId'])
+  .index('by_team_user', ['teamId', 'userId'])
+  .index('by_teamId', ['teamId'])
+  .index('by_teamMemberId', ['teamMemberId']);
 
 /**
  * Resume cursor for the hourly member-mirror reconciliation cron. Singleton

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -62,6 +62,7 @@ import { mcpServersTable } from './mcp_servers/schema';
 import {
   memberMirrorTable,
   memberMirrorReconcileCursorTable,
+  teamMemberMirrorTable,
 } from './members/schema';
 import {
   migrationLedgerTable,
@@ -181,6 +182,10 @@ export default defineSchema({
   // never the authoritative gate. See `members/schema.ts`.
   memberMirror: memberMirrorTable,
   memberMirrorReconcileCursor: memberMirrorReconcileCursorTable,
+  // Local mirror of Better Auth's `teamMember` table — the team-level
+  // counterpart of memberMirror, so getUserTeamIds (the other half of the RLS
+  // prime) also reads locally instead of cross-component. See members/schema.ts.
+  teamMemberMirror: teamMemberMirrorTable,
   conversationMessages: conversationMessagesTable,
   conversations: conversationsTable,
   agentBindings: agentBindingsTable,

--- a/services/platform/convex/sso_providers/entra_id/team_sync.ts
+++ b/services/platform/convex/sso_providers/entra_id/team_sync.ts
@@ -1,5 +1,11 @@
+import { isRecord, getString } from '../../../lib/utils/type-utils';
 import { components } from '../../_generated/api';
 import type { MutationCtx } from '../../_generated/server';
+import {
+  upsertTeamMemberMirror,
+  deleteTeamMemberMirrorByTeamMemberId,
+  deleteTeamMemberMirrorByTeamId,
+} from '../../members/mirror_sync';
 import type { SsoProviderAdapter, SsoProviderConfig } from '../types';
 
 interface Team {
@@ -134,16 +140,28 @@ async function addTeamMember(
   teamId: string,
   userId: string,
 ): Promise<void> {
-  await ctx.runMutation(components.betterAuth.adapter.create, {
+  const createdAt = Date.now();
+  const created = await ctx.runMutation(components.betterAuth.adapter.create, {
     input: {
       model: 'teamMember',
       data: {
         teamId,
         userId,
-        createdAt: Date.now(),
+        createdAt,
       },
     },
   });
+  const teamMemberId = isRecord(created)
+    ? (getString(created, '_id') ?? getString(created, 'id'))
+    : undefined;
+  if (teamMemberId) {
+    await upsertTeamMemberMirror(ctx, {
+      teamMemberId,
+      userId,
+      teamId,
+      createdAt,
+    });
+  }
 }
 
 async function removeStaleTeamMemberships(
@@ -216,6 +234,7 @@ async function removeStaleTeamMemberships(
           where: [{ field: '_id', value: membership._id, operator: 'eq' }],
         },
       });
+      await deleteTeamMemberMirrorByTeamMemberId(ctx, membership._id);
       removedCount++;
 
       const remainingMembers = await ctx.runQuery(
@@ -236,6 +255,8 @@ async function removeStaleTeamMemberships(
             where: [{ field: '_id', value: membership.teamId, operator: 'eq' }],
           },
         });
+        // Team gone → drop any remaining mirror rows for it (defensive).
+        await deleteTeamMemberMirrorByTeamId(ctx, membership.teamId);
       }
     }
   }

--- a/services/platform/convex/team_members/mutations.test.ts
+++ b/services/platform/convex/team_members/mutations.test.ts
@@ -59,7 +59,19 @@ function createMockCtx() {
   return {
     runQuery: vi.fn(),
     runMutation: vi.fn(),
-    db: {},
+    // teamMemberMirror sync touches ctx.db (upsert probes first(); delete looks
+    // up first()). Stub the minimum surface; no existing rows.
+    db: {
+      query: vi.fn().mockReturnValue({
+        withIndex: vi.fn().mockReturnValue({
+          first: async () => null,
+          collect: async () => [],
+        }),
+      }),
+      insert: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    },
     auth: {},
   };
 }

--- a/services/platform/convex/team_members/mutations.ts
+++ b/services/platform/convex/team_members/mutations.ts
@@ -1,10 +1,15 @@
 import { v } from 'convex/values';
 
+import { isRecord, getString } from '../../lib/utils/type-utils';
 import { components } from '../_generated/api';
 import { mutation } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { isAdmin } from '../lib/rls/helpers/role_helpers';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import {
+  upsertTeamMemberMirror,
+  deleteTeamMemberMirrorByTeamMemberId,
+} from '../members/mirror_sync';
 
 export const addMember = mutation({
   args: {
@@ -70,16 +75,35 @@ export const addMember = mutation({
       throw new Error('User is already a member of this team');
     }
 
-    return await ctx.runMutation(components.betterAuth.adapter.create, {
-      input: {
-        model: 'teamMember' as const,
-        data: {
-          teamId: args.teamId,
-          userId: args.userId,
-          createdAt: Date.now(),
+    const createdAt = Date.now();
+    const created = await ctx.runMutation(
+      components.betterAuth.adapter.create,
+      {
+        input: {
+          model: 'teamMember' as const,
+          data: {
+            teamId: args.teamId,
+            userId: args.userId,
+            createdAt,
+          },
         },
       },
-    });
+    );
+
+    // Keep the RLS read mirror in step (same transaction as the write above).
+    const teamMemberId = isRecord(created)
+      ? (getString(created, '_id') ?? getString(created, 'id'))
+      : undefined;
+    if (teamMemberId) {
+      await upsertTeamMemberMirror(ctx, {
+        teamMemberId,
+        userId: args.userId,
+        teamId: args.teamId,
+        createdAt,
+      });
+    }
+
+    return created;
   },
 });
 
@@ -149,6 +173,9 @@ export const removeMember = mutation({
         where: [{ field: '_id', value: args.teamMemberId, operator: 'eq' }],
       },
     });
+
+    // Drop the RLS read mirror row in the same transaction.
+    await deleteTeamMemberMirrorByTeamMemberId(ctx, args.teamMemberId);
 
     return null;
   },


### PR DESCRIPTION
## Context

This branch was rebased onto `main` after the member-mirror work (`memberMirror` table, `getUserOrganizations`/`isOrgMember` read-through, inline sync, hourly reconcile) landed there separately. It now **builds on that mirror** and closes the two RLS hot paths the merged version doesn't cover — both still issued cross-component Better Auth reads that blow the backend's ~1s function budget on the self-hosted/CI backend.

## Problem (what main's mirror doesn't fix)

1. **`getOrganizationMember`** — the gate behind `assertSelfAndOrgMember`, used by raw-query handlers like `user_preferences/queries:getMyPreferences`. Main deliberately keeps it reading Better Auth directly. On a CPU-starved backend that cold `[organizationId, userId]` cross-component `findMany` exceeds 1s, `getMyPreferences` throws, trips the `<VoiceModeToggle>` error boundary, and the chat composer flashes in then **blanks to a white screen**.
2. **`getUserTeamIds`** — the *other* half of `computeRequestAuthContext` (run in parallel with `getUserOrganizations`). It still paginates Better Auth's `teamMember` cross-component on every `queryWithRLS` request, so `listConversationsPaginated` / `listDocumentsPaginated` keep timing out (stack: `getUserTeamIds → computeRequestAuthContext`) even with the member mirror in place.

## Changes

**1. `getOrganizationMember` reads `memberMirror`.** A single indexed `by_org_user` read, falling back to Better Auth on a miss. Disabled members are in the mirror (stored unchanged) so the disabled check still fires; a miss falls through to the authoritative lookup, preserving the email-fallback / account-linking branch exactly.

**2. `teamMemberMirror` — the team-level counterpart**, following main's member-mirror conventions:
- new `teamMemberMirror` table (`by_userId` / `by_team_user` / `by_teamId` / `by_teamMemberId`);
- sync helpers in `members/mirror_sync.ts` (`upsertTeamMemberMirror` / `deleteTeamMemberMirrorByTeamMemberId` / `deleteTeamMemberMirrorByTeamId` + `resyncTeamMemberMirror` / `cascadeDeleteTeamMembersMirror` internal mutations);
- inline sync on every `teamMember` write path (`team_members/mutations` add/remove, Entra SSO `team_sync` add / remove-stale / team-delete cascade);
- Better Auth team hooks (`afterAddTeamMember` / `afterRemoveTeamMember` / `afterDeleteTeam`) for client-direct endpoint calls;
- `reconcileOneOrg` now also reconciles each team's `teamMember`s (so the existing hourly `reconcileMemberMirrors` cron backfills + repairs teams too);
- `getUserTeamIds` reads the mirror after the JWT `trustedTeams` short-circuit.

## Consistency model

This widens the mirror's authority from "performance cache only" to backing the **org/team-level RLS reads** under **bounded eventual consistency**: inline sync keeps the happy path exact (same transaction as the Better Auth write), the org/team hooks + after-middleware cover client-direct endpoints, and the hourly reconcile converges any drift from a partial failure. Steady-state window ≈ 0; only a crash between the two writes (or a lagging hook) opens a brief, self-healing window.

Two deliberate choices:
- **`getOrganizationMember`** now reads the mirror (vs. main's "always Better Auth"). The email-fallback / account-linking path still resolves against Better Auth.
- **`getUserTeamIds`** treats an **empty mirror as authoritative** (no teams) rather than falling back — because a user commonly has zero teams, and falling back would re-introduce the round-trip for the common case. A not-yet-backfilled team member therefore fails **closed** (no team access) until reconcile — a safe, bounded direction.

## Tests / verification

- Unit: `get_organization_member` (added mirror-hit + disabled-in-mirror cases), `members/member_mirror`, `team_members` — all green. Lint clean (`oxlint`); convex push typechecks.
- E2E on the self-hosted local backend (the repro env): backfilled the mirrors, reloaded the dashboard — chat composer renders with **zero** membership/team RLS errors in the console. `getMyPreferences`, `getOrganizationMember`, `getUserOrganizations`, `getUserTeamIds`, `listConversationsPaginated`, `listDocumentsPaginated` no longer time out.

**Out of scope:** the remaining `*/file_actions:list*` ("config catalog prewarm") timeouts are a separate filesystem-config subsystem (surfaces as "No AI provider configured"), pre-existing and unrelated to membership.
