### PR TITLE
fix(platform): stream external-agent answer text incrementally

### DIFF
--- a/services/platform/convex/node_only/sandbox/agent_message_parts.test.ts
+++ b/services/platform/convex/node_only/sandbox/agent_message_parts.test.ts
@@ -436,3 +436,100 @@ describe('estimateContentBytes (S4 segmentation guard)', () => {
     expect(estimateContentBytes(content)).toBeLessThan(MAX_MESSAGE_BYTES);
   });
 });
+
+describe('buildAssistantContent — live in-progress text (incremental reveal)', () => {
+  // `liveText` is the open MAIN-agent block (delta-accumulated) the streaming
+  // flush passes so a long answer renders as it streams; the caller clears it
+  // the instant the block's `text` event lands in the timeline.
+
+  it('no-tools, streaming: returns the open block when finalText is empty', () => {
+    expect(
+      buildAssistantContent([], '', undefined, undefined, 'The history of'),
+    ).toBe('The history of');
+  });
+
+  it('no-tools, streaming: joins closed blocks with the open block', () => {
+    const events: AgentEvent[] = [{ type: 'text', text: 'First paragraph.' }];
+    expect(
+      buildAssistantContent(events, '', undefined, undefined, 'Second para so'),
+    ).toBe('First paragraph.\n\nSecond para so');
+  });
+
+  it('no-tools, terminal: finalText wins (liveText already cleared)', () => {
+    const events: AgentEvent[] = [{ type: 'text', text: 'the answer' }];
+    expect(
+      buildAssistantContent(events, 'the answer', undefined, undefined, ''),
+    ).toBe('the answer');
+  });
+
+  it('tools, streaming: the open block renders as a trailing text part', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      '',
+      undefined,
+      undefined,
+      'Now analyzing the',
+    ) as Array<Record<string, unknown>>;
+    expect(parts[parts.length - 1]).toEqual({
+      type: 'text',
+      text: 'Now analyzing the',
+    });
+  });
+
+  it('coalesce: a completed block (cleared liveText) is never duplicated', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+      { type: 'text', text: 'The final answer.' },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      'The final answer.',
+      undefined,
+      undefined,
+      '',
+    ) as Array<Record<string, unknown>>;
+    const textParts = parts.filter((p) => p.type === 'text');
+    expect(textParts).toEqual([{ type: 'text', text: 'The final answer.' }]);
+  });
+
+  it('Stop mid-write (no tools): keeps the partial answer', () => {
+    expect(
+      buildAssistantContent([], '', undefined, undefined, 'partial so far'),
+    ).toBe('partial so far');
+  });
+
+  it('Stop mid-write (with tools): the partial survives as a trailing part', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      '',
+      undefined,
+      undefined,
+      'partial after tool',
+    ) as Array<Record<string, unknown>>;
+    expect(
+      parts.some((p) => p.type === 'text' && p.text === 'partial after tool'),
+    ).toBe(true);
+  });
+
+  it('omitting liveText (default) preserves the prior behavior', () => {
+    expect(buildAssistantContent([], '')).toBe('');
+  });
+
+  it('sub-agent text is not folded into the main body', () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'sub narration', parentToolUseId: 'task1' },
+    ];
+    expect(buildAssistantContent(events, '', undefined, undefined, '')).toBe(
+      '',
+    );
+  });
+});

--- a/services/platform/convex/node_only/sandbox/agent_message_parts.ts
+++ b/services/platform/convex/node_only/sandbox/agent_message_parts.ts
@@ -162,12 +162,34 @@ export function buildAssistantContent(
   // seam so a sub-agent tool-result landing in a later segment still resolves
   // to its top-level Task ancestor (mirrors knownToolNames).
   knownToolParents?: ReadonlyMap<string, string>,
+  // Live in-progress MAIN-agent text: the currently-open text block accumulated
+  // from `text-delta` partials that haven't coalesced into a complete `text`
+  // event yet. Threaded by the streaming flush so a long answer reveals as it
+  // streams (and a mid-write Stop keeps it) instead of appearing only at block
+  // end. The caller clears it the instant the block's `text` event lands in
+  // `events`, so a completed block is never double-counted. Empty at terminal.
+  liveText: string = '',
 ): AgentAssistantContent {
   const hasToolTimeline = events.some(
     (e) => e.type === 'tool-use' || e.type === 'tool-result',
   );
   // No tools → the message is just its answer; keep it a plain string.
-  if (!hasToolTimeline) return finalText;
+  // `finalText` (set at the terminal `result`) is authoritative when present.
+  // While streaming it's empty, so fall back to the main-agent text so far —
+  // the closed `text` blocks plus the open `liveText` — so a plain answer
+  // renders incrementally and survives a mid-write Stop instead of staying
+  // blank until the turn ends.
+  if (!hasToolTimeline) {
+    if (finalText.trim() !== '') return finalText;
+    const streamed: string[] = [];
+    for (const e of events) {
+      if (e.type === 'text' && !e.parentToolUseId && e.text.trim() !== '') {
+        streamed.push(e.text);
+      }
+    }
+    if (liveText.trim() !== '') streamed.push(liveText);
+    return streamed.join('\n\n');
+  }
 
   const parts: Exclude<AgentAssistantContent, string> = [];
   // toolUseId → toolName, so a tool-result (which carries no toolName) pairs
@@ -296,6 +318,15 @@ export function buildAssistantContent(
         ...(e.isError ? { isError: true } : {}),
       });
     }
+  }
+
+  // Open (still-streaming) main-agent text block: not yet coalesced into a
+  // `text` event, so render it as a trailing text part. The caller clears it
+  // the instant its `text` event lands (which the loop above already emitted as
+  // a part), so a completed block is never duplicated. Empty at terminal.
+  if (liveText.trim() !== '') {
+    parts.push({ type: 'text', text: liveText });
+    lastText = liveText;
   }
 
   // Ensure the final answer is present exactly once (the stream usually already

--- a/services/platform/convex/node_only/sandbox/run_agent.ts
+++ b/services/platform/convex/node_only/sandbox/run_agent.ts
@@ -287,6 +287,12 @@ export async function runAgentInSessionImpl(
   // (S4 segmentation), so a resumed segment starts with an EMPTY timeline — only
   // the cursor + captured session id carry across the handoff.
   let progressText = '';
+  // The currently-OPEN main-agent text block, accumulated from `text-delta`
+  // partials and threaded into the streaming flush so a long answer reveals as
+  // it streams (and a mid-write Stop keeps it). Cleared when the block's `text`
+  // event lands (it is then in `timeline`). Main-level only — sub-agent text
+  // stays folded. Per-segment, like the rest of this progress state.
+  let liveText = '';
   const recentEvents: string[] = [];
   const timeline: AgentEvent[] = [];
   // Reconnect cursor: starts at the handoff seq on resume so the re-attach skips
@@ -741,6 +747,14 @@ export async function runAgentInSessionImpl(
       }
       if (e.type === 'text-delta' || e.type === 'text') {
         progressText += e.text;
+        // Track the open MAIN-agent block for incremental reveal. A `text`
+        // event is the coalesced complete block (pushed to `timeline` below),
+        // so clear the live buffer when it lands to avoid double-counting; a
+        // delta extends the open block. Sub-agent text (parentToolUseId set)
+        // stays folded and never enters the main message body.
+        if (!e.parentToolUseId) {
+          liveText = e.type === 'text' ? '' : liveText + e.text;
+        }
       } else if (e.type === 'run-started' && e.agentSessionId) {
         capturedSessionId = e.agentSessionId;
       } else if (e.type === 'result') {
@@ -905,6 +919,7 @@ export async function runAgentInSessionImpl(
       finalText ?? '',
       toolNames,
       toolUseParents,
+      liveText,
     );
     if (args.onTimeline) {
       try {
@@ -1201,6 +1216,10 @@ export async function runAgentInSessionImpl(
     finalText ?? '',
     toolNames,
     toolUseParents,
+    // Include the open block so a mid-write Stop (terminal 'cancelled') keeps
+    // the partial answer. On a clean end it is '' (the block's `text` event
+    // already cleared it), so terminal content is byte-identical to before.
+    liveText,
   );
 
   return {


### PR DESCRIPTION
## Problem

When chatting with an external agent (Claude Code), a long answer showed **no text the entire time the model was writing it** — only a "thinking" indicator — then the whole answer appeared at once. Users perceived this as "content only shows when I click Stop." Worse, **clicking Stop mid-write discarded the partial answer** (the message ended empty/failed).

## Root cause (verified locally)

External-agent assistant text only reached the chat at **text-block completion**:

1. Incremental `text-delta` partials were **excluded from the message timeline** (`run_agent.ts`) and routed only to the op-row `progressText`, which the chat render path never displays.
2. The no-tools path of `buildAssistantContent` returned only `finalText`, which is set at the terminal `result` event.

So while the model composed a long block (often 30–60s), the persisted message stayed empty and the chat showed nothing.

Instrumenting the persisted message vs the DOM confirmed it: persisted `textLen` was `0` for the whole write, then jumped `0 → full` in one step. (The previously-suspected "reveal stalls during the linger" did **not** occur — once a block is persisted it renders promptly.)

## Fix

Thread a live in-progress **main-agent** text buffer (`liveText`) through the streaming flush so the open block renders as it streams and survives a mid-write Stop. Terminal output is **byte-identical** to before (`liveText` is `''` once the block's `text` event lands).

- **`run_agent.ts`**: track `liveText` (main-level only — sub-agent text stays folded); accumulate from `text-delta`, clear when the complete `text` event lands. Pass it to the **flush** + **terminal** `buildAssistantContent`, but **not** the handoff (the continuation re-streams the open block, avoiding cross-segment duplication).
- **`agent_message_parts.ts`**: `buildAssistantContent` gains a trailing `liveText` param. No-tools path returns the streamed text while `finalText` is empty; tools path appends the open block as a trailing text part (coalesced — no duplication).
- **tests**: incremental reveal, coalesce/no-dup, Stop-keeps-partial (10 new cases; 26 total pass).

## Verification

- Unit: `agent_message_parts.test.ts` (26 pass); `tsc` clean; lint 0/0; format clean.
- **Live E2E** (long tool-less essay, real sandbox):
  - Persisted text now **climbs incrementally** (`1846 → 2188 → … → 12782`) during writing, vs the prior `0 → full` jump.
  - DOM **reveals as it streams** (visible + growing while generating).
  - Terminal answer is the full essay, **exactly once** (dedup intact) — unchanged from before.

## Side effect (improvement)

A **mid-write Stop now keeps the partial answer** (message ends `success`, non-empty) instead of discarding it.

## v1 limitation (noted)

Across the rare S4 handoff seam (>25-min turns / 1 MB segments), `liveText` is not carried across the seam — the continuation re-streams the open block. The handoff seal excludes it to avoid cross-segment duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now display text in real-time as it's being generated with smooth incremental updates
  * Partial responses are preserved when operations are interrupted mid-stream
  * Enhanced visibility into in-progress agent work through live streaming text display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->