### PR TITLE
feat(platform): external-agent interactive/autonomous mode + incremental answer streaming

### DIFF
--- a/services/platform/convex/agents/external_agent/continue_external_agent_turn.ts
+++ b/services/platform/convex/agents/external_agent/continue_external_agent_turn.ts
@@ -61,6 +61,11 @@ export const continueExternalAgentTurn = internalAction({
     permissionMode: v.optional(
       v.union(v.literal('plan'), v.literal('execute')),
     ),
+    /** Interaction posture, frozen at exec start — carried so the resumed
+     * segment keeps suppressing the human-in-loop seams for an autonomous run. */
+    interactionMode: v.optional(
+      v.union(v.literal('interactive'), v.literal('autonomous')),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -76,6 +81,9 @@ export const continueExternalAgentTurn = internalAction({
       continuationCount: args.continuationCount,
       ...(args.permissionMode !== undefined && {
         permissionMode: args.permissionMode,
+      }),
+      ...(args.interactionMode !== undefined && {
+        interactionMode: args.interactionMode,
       }),
       ...(args.agentSlug !== undefined && { agentSlug: args.agentSlug }),
       ...(args.userId !== undefined && { userId: args.userId }),
@@ -151,26 +159,33 @@ export const continueExternalAgentTurn = internalAction({
         ...(args.permissionMode !== undefined && {
           permissionMode: args.permissionMode,
         }),
+        ...(args.interactionMode !== undefined && {
+          interactionMode: args.interactionMode,
+        }),
         resumeFrom,
         onTimeline: async (content) => {
           await patchStreamingMessage(ctx, args.assistantMessageId, content);
         },
         // Handoff requested in a continuation segment → raise the card now too
-        // (idempotent on the mutation side).
-        onHumanControlRequest: async (reason: string) => {
-          await ctx.runMutation(
-            internal.approvals.internal_mutations.createHumanControlRequest,
-            {
-              organizationId: turn.organizationId,
-              threadId: turn.threadId,
-              messageId: turn.assistantMessageId,
-              agentSlug: turn.agentSlug ?? turn.agentKind,
-              modelRef: turn.modelRef,
-              reason,
-              ...(turn.userId !== undefined && { requestedBy: turn.userId }),
-            },
-          );
-        },
+        // (idempotent on the mutation side). Autonomous runs have no human to
+        // take over, so the callback is never wired (defense-in-depth — the
+        // tool is also gated off in the adapter).
+        ...(args.interactionMode !== 'autonomous' && {
+          onHumanControlRequest: async (reason: string) => {
+            await ctx.runMutation(
+              internal.approvals.internal_mutations.createHumanControlRequest,
+              {
+                organizationId: turn.organizationId,
+                threadId: turn.threadId,
+                messageId: turn.assistantMessageId,
+                agentSlug: turn.agentSlug ?? turn.agentKind,
+                modelRef: turn.modelRef,
+                reason,
+                ...(turn.userId !== undefined && { requestedBy: turn.userId }),
+              },
+            );
+          },
+        }),
       });
       await handleTurnOutcome(ctx, turn, result);
     } catch (err) {

--- a/services/platform/convex/agents/external_agent/run_external_agent.ts
+++ b/services/platform/convex/agents/external_agent/run_external_agent.ts
@@ -176,6 +176,13 @@ export const runExternalAgentTurn = internalAction({
     permissionMode: v.optional(
       v.union(v.literal('plan'), v.literal('execute')),
     ),
+    /** Interaction posture from the thread's interactive/autonomous toggle
+     * ('interactive' when absent). Autonomous = no human in the loop: the
+     * human-in-loop seams (steering, plan/human-control cards, prose questions)
+     * are suppressed. Carried for the whole turn. */
+    interactionMode: v.optional(
+      v.union(v.literal('interactive'), v.literal('autonomous')),
+    ),
     streamId: v.optional(v.string()),
     agentSlug: v.optional(v.string()),
     /** The agent's integration allowlist — the session's dispatch grant set
@@ -596,6 +603,9 @@ export const runExternalAgentTurn = internalAction({
         ...(args.permissionMode !== undefined && {
           permissionMode: args.permissionMode,
         }),
+        ...(args.interactionMode !== undefined && {
+          interactionMode: args.interactionMode,
+        }),
         ...(args.agentSlug !== undefined && { agentSlug: args.agentSlug }),
         ...(args.userId !== undefined && { userId: args.userId }),
         ...(args.streamId !== undefined && { streamId: args.streamId }),
@@ -635,6 +645,7 @@ export const runExternalAgentTurn = internalAction({
       const systemPromptAppend = buildSystemPromptAppend({
         systemInstructions: args.systemInstructions,
         permissionMode: args.permissionMode,
+        interactionMode: args.interactionMode,
         browserCdp: BROWSER_VIEW_ENABLED,
       });
 
@@ -673,26 +684,35 @@ export const runExternalAgentTurn = internalAction({
           // Raise the browser-handoff card the moment the agent calls
           // request_human_control — mid-stream, not at turn end (a lingering
           // session may not terminate for a while). Idempotent on the mutation
-          // side, so a later turn-end pass is a safe no-op.
-          onHumanControlRequest: async (reason: string) => {
-            if (assistantMessageId === null) return;
-            await ctx.runMutation(
-              internal.approvals.internal_mutations.createHumanControlRequest,
-              {
-                organizationId: args.organizationId,
-                threadId: args.threadId,
-                messageId: assistantMessageId,
-                agentSlug: args.agentSlug ?? args.agentKind,
-                modelRef: args.modelRef,
-                reason,
-                ...(args.userId !== undefined && { requestedBy: args.userId }),
-              },
-            );
-          },
+          // side, so a later turn-end pass is a safe no-op. Autonomous runs have
+          // no human to take over, so the callback is never wired (the tool is
+          // also gated off in the adapter — this is defense-in-depth).
+          ...(args.interactionMode !== 'autonomous' && {
+            onHumanControlRequest: async (reason: string) => {
+              if (assistantMessageId === null) return;
+              await ctx.runMutation(
+                internal.approvals.internal_mutations.createHumanControlRequest,
+                {
+                  organizationId: args.organizationId,
+                  threadId: args.threadId,
+                  messageId: assistantMessageId,
+                  agentSlug: args.agentSlug ?? args.agentKind,
+                  modelRef: args.modelRef,
+                  reason,
+                  ...(args.userId !== undefined && {
+                    requestedBy: args.userId,
+                  }),
+                },
+              );
+            },
+          }),
           ...(agentSessionId !== null && { agentSessionId }),
           ...(systemPromptAppend !== '' && { systemPromptAppend }),
           ...(args.permissionMode !== undefined && {
             permissionMode: args.permissionMode,
+          }),
+          ...(args.interactionMode !== undefined && {
+            interactionMode: args.interactionMode,
           }),
           // MANAGED only: route through the gateway with the minted VK and
           // expose the integration-dispatch bridge (authed by that key). BYO

--- a/services/platform/convex/agents/external_agent/system_prompt.test.ts
+++ b/services/platform/convex/agents/external_agent/system_prompt.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  ASK_IN_CHAT_ADDENDUM,
+  AUTONOMOUS_MODE_ADDENDUM,
+  AUTONOMOUS_PLAN_ADDENDUM,
   BROWSER_VIEW_RECOVERY_ADDENDUM,
   buildSystemPromptAppend,
   PLAN_MODE_ADDENDUM,
@@ -63,5 +66,54 @@ describe('buildSystemPromptAppend', () => {
     });
     expect(out).toContain(PLAN_MODE_ADDENDUM);
     expect(out).toContain(BROWSER_VIEW_RECOVERY_ADDENDUM);
+  });
+
+  // --- interaction mode ---
+
+  it('interactive turns (default) get the ask-in-chat addendum', () => {
+    const out = buildSystemPromptAppend({
+      systemInstructions: 'X',
+      permissionMode: 'execute',
+    });
+    expect(out).toContain(ASK_IN_CHAT_ADDENDUM);
+    expect(out).toContain(STEERING_RESPONSIVENESS_ADDENDUM);
+    expect(out).not.toContain(AUTONOMOUS_MODE_ADDENDUM);
+  });
+
+  it('an explicit interactive interactionMode matches the default', () => {
+    const out = buildSystemPromptAppend({
+      systemInstructions: 'X',
+      permissionMode: 'execute',
+      interactionMode: 'interactive',
+    });
+    expect(out).toContain(ASK_IN_CHAT_ADDENDUM);
+    expect(out).toContain(STEERING_RESPONSIVENESS_ADDENDUM);
+  });
+
+  it('autonomous execute turns swap in the autonomous addendum and never ask', () => {
+    const out = buildSystemPromptAppend({
+      systemInstructions: 'X',
+      permissionMode: 'execute',
+      interactionMode: 'autonomous',
+    });
+    expect(out).toContain(AUTONOMOUS_MODE_ADDENDUM);
+    expect(out).not.toContain(STEERING_RESPONSIVENESS_ADDENDUM);
+    expect(out).not.toContain(ASK_IN_CHAT_ADDENDUM);
+    expect(out).not.toContain(PLAN_MODE_ADDENDUM);
+  });
+
+  it('autonomous plan turns use the trimmed plan addendum (no chat-UI approval promise)', () => {
+    const out = buildSystemPromptAppend({
+      systemInstructions: 'X',
+      permissionMode: 'plan',
+      interactionMode: 'autonomous',
+    });
+    expect(out).toContain(AUTONOMOUS_PLAN_ADDENDUM);
+    expect(out).not.toContain(PLAN_MODE_ADDENDUM);
+    expect(out).not.toContain(AUTONOMOUS_MODE_ADDENDUM);
+    expect(out).not.toContain(ASK_IN_CHAT_ADDENDUM);
+    // The interactive plan addendum promises chat-UI approval; the autonomous
+    // one must not.
+    expect(out).not.toContain('chat UI');
   });
 });

--- a/services/platform/convex/agents/external_agent/system_prompt.ts
+++ b/services/platform/convex/agents/external_agent/system_prompt.ts
@@ -45,6 +45,35 @@ export const STEERING_RESPONSIVENESS_ADDENDUM =
   'Never block a foreground Bash on a long build or on a server you expect to ' +
   'stay up.';
 
+// Appended on INTERACTIVE turns. The structured AskUserQuestion tool is
+// disabled (it has no answer path in chat), so the agent must ask in prose; the
+// user replies as a normal chat message and the turn continues from there.
+export const ASK_IN_CHAT_ADDENDUM =
+  'ASKING THE USER: when you need a decision or information only the user can ' +
+  'provide, ask plainly in your reply and stop there — the user answers in ' +
+  'chat and you continue from their response. There is no structured-question ' +
+  'tool here. When a choice is low-stakes or reasonably inferable, just proceed ' +
+  'and state what you assumed rather than blocking on a question.';
+
+// Appended on AUTONOMOUS (no-human-in-the-loop) ACT turns — replaces the
+// steering addendum. Nobody is watching: the agent must not ask, request human
+// control, or wait for approval; it makes assumptions and runs to completion.
+export const AUTONOMOUS_MODE_ADDENDUM =
+  'AUTONOMOUS RUN: no human is available. Do NOT ask the user questions, do ' +
+  'NOT request human control, and do NOT wait for approval — there is no one ' +
+  'to respond. Make reasonable assumptions, proceed to completion on your own, ' +
+  'and at the end clearly summarize what you did and the assumptions you made. ' +
+  'If you genuinely cannot proceed, stop and explain why instead of waiting.';
+
+// Appended on AUTONOMOUS PLAN turns — the plan-mode addendum's "the user
+// reviews and approves in the chat UI" promise is false with no human, so this
+// trims it: read-only, present the plan, end the turn, no approval step.
+export const AUTONOMOUS_PLAN_ADDENDUM =
+  'AUTONOMOUS PLANNING RUN: this is a read-only turn — explore as needed, then ' +
+  'present the complete plan in your final message and end your turn. There is ' +
+  'no approval step and no human to review it; do not ask questions, do not ' +
+  'wait for confirmation, and do not start executing.';
+
 /**
  * Compose the `--append-system-prompt` payload for a turn:
  *   - the agent's own configured instructions (first, never clobbered),
@@ -55,14 +84,32 @@ export const STEERING_RESPONSIVENESS_ADDENDUM =
 export function buildSystemPromptAppend(opts: {
   systemInstructions?: string;
   permissionMode?: string;
+  /** Interaction posture. `autonomous` (no human in the loop) swaps the
+   * steering / plan addenda for autonomous guidance — the agent must not ask or
+   * wait for a human. `interactive` (default / absent) keeps the human-in-loop
+   * addenda plus the ask-in-chat nudge (the structured-question tool is
+   * disabled, so it asks in prose). */
+  interactionMode?: string;
   /** Live-browser-view session: append browser-recovery guidance so a wedged
    * managed Chromium doesn't make the agent loop on raw CDP errors. */
   browserCdp?: boolean;
 }): string {
   const isPlan = opts.permissionMode === 'plan';
+  const isAutonomous = opts.interactionMode === 'autonomous';
+  // Posture addendum: plan vs execute, crossed with interactive vs autonomous.
+  const postureAddendum = isAutonomous
+    ? isPlan
+      ? AUTONOMOUS_PLAN_ADDENDUM
+      : AUTONOMOUS_MODE_ADDENDUM
+    : isPlan
+      ? PLAN_MODE_ADDENDUM
+      : STEERING_RESPONSIVENESS_ADDENDUM;
   return [
     opts.systemInstructions,
-    isPlan ? PLAN_MODE_ADDENDUM : STEERING_RESPONSIVENESS_ADDENDUM,
+    postureAddendum,
+    // Interactive only: AskUserQuestion is disabled, so steer the agent to ask
+    // in prose instead of stalling or guessing. Autonomous must never ask.
+    isAutonomous ? undefined : ASK_IN_CHAT_ADDENDUM,
     opts.browserCdp ? BROWSER_VIEW_RECOVERY_ADDENDUM : undefined,
     UNTRUSTED_CONTENT_SYSTEM_PROMPT,
   ]

--- a/services/platform/convex/agents/external_agent/turn_lifecycle.ts
+++ b/services/platform/convex/agents/external_agent/turn_lifecycle.ts
@@ -65,6 +65,10 @@ export interface TurnContext {
    * start for the whole turn; continuations carry it so the terminal plan
    * detection below knows how the turn ran. */
   permissionMode?: 'plan' | 'execute';
+  /** Turn interaction posture (autonomous = no human in the loop). Fixed at
+   * exec start and carried across continuations; the terminal card suppression
+   * below reads it. Orthogonal to permissionMode. */
+  interactionMode?: 'interactive' | 'autonomous';
 }
 
 /** Patch the streaming assistant message's content in place (reactive read path
@@ -445,6 +449,9 @@ export async function handleTurnOutcome(
         ...(turn.permissionMode !== undefined && {
           permissionMode: turn.permissionMode,
         }),
+        ...(turn.interactionMode !== undefined && {
+          interactionMode: turn.interactionMode,
+        }),
       },
     );
     return;
@@ -513,8 +520,10 @@ export async function handleTurnOutcome(
   // Plan proposal → approval card (any terminal status except cancelled — a
   // plan captured before a max-turns/error end is still worth reviewing).
   // Best-effort: a card failure must never skip finalize (VK revoke, ledger).
+  // Autonomous turns have no human to approve: the plan still lands in the
+  // finalized message above (patchStreamingMessage), but no blocking card.
   const plan = resolvePlanText(result, turn.permissionMode);
-  if (plan !== null) {
+  if (plan !== null && turn.interactionMode !== 'autonomous') {
     try {
       await ctx.runMutation(
         internal.approvals.internal_mutations.createPlanApproval,
@@ -545,6 +554,7 @@ export async function handleTurnOutcome(
   // in the same Claude session (returnHumanControl → startQueuedTurn).
   if (
     plan === null &&
+    turn.interactionMode !== 'autonomous' &&
     result.humanControlReason !== undefined &&
     result.humanControlReason.trim() !== ''
   ) {

--- a/services/platform/convex/lib/agent_chat/start_agent_chat.ts
+++ b/services/platform/convex/lib/agent_chat/start_agent_chat.ts
@@ -661,6 +661,9 @@ export async function startAgentChat(
         // plan/act posture fresh.
         permissionMode:
           threadMeta?.externalAgentMode === 'plan' ? 'plan' : 'execute',
+        // Chat is always interactive — no autonomous entry point here. The turn
+        // arg defaults to interactive when omitted; a future automation caller
+        // (workflow/trigger) is what passes interactionMode: 'autonomous'.
         // The agent's integration allowlist becomes the session's dispatch grant
         // set (scope.integrationGrants), enforced by /api/integrations/execute.
         integrationBindings: enforcedConfig.integrationBindings ?? [],

--- a/services/platform/convex/node_only/sandbox/agent_message_parts.test.ts
+++ b/services/platform/convex/node_only/sandbox/agent_message_parts.test.ts
@@ -436,3 +436,100 @@ describe('estimateContentBytes (S4 segmentation guard)', () => {
     expect(estimateContentBytes(content)).toBeLessThan(MAX_MESSAGE_BYTES);
   });
 });
+
+describe('buildAssistantContent — live in-progress text (incremental reveal)', () => {
+  // `liveText` is the open MAIN-agent block (delta-accumulated) the streaming
+  // flush passes so a long answer renders as it streams; the caller clears it
+  // the instant the block's `text` event lands in the timeline.
+
+  it('no-tools, streaming: returns the open block when finalText is empty', () => {
+    expect(
+      buildAssistantContent([], '', undefined, undefined, 'The history of'),
+    ).toBe('The history of');
+  });
+
+  it('no-tools, streaming: joins closed blocks with the open block', () => {
+    const events: AgentEvent[] = [{ type: 'text', text: 'First paragraph.' }];
+    expect(
+      buildAssistantContent(events, '', undefined, undefined, 'Second para so'),
+    ).toBe('First paragraph.\n\nSecond para so');
+  });
+
+  it('no-tools, terminal: finalText wins (liveText already cleared)', () => {
+    const events: AgentEvent[] = [{ type: 'text', text: 'the answer' }];
+    expect(
+      buildAssistantContent(events, 'the answer', undefined, undefined, ''),
+    ).toBe('the answer');
+  });
+
+  it('tools, streaming: the open block renders as a trailing text part', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      '',
+      undefined,
+      undefined,
+      'Now analyzing the',
+    ) as Array<Record<string, unknown>>;
+    expect(parts[parts.length - 1]).toEqual({
+      type: 'text',
+      text: 'Now analyzing the',
+    });
+  });
+
+  it('coalesce: a completed block (cleared liveText) is never duplicated', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+      { type: 'text', text: 'The final answer.' },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      'The final answer.',
+      undefined,
+      undefined,
+      '',
+    ) as Array<Record<string, unknown>>;
+    const textParts = parts.filter((p) => p.type === 'text');
+    expect(textParts).toEqual([{ type: 'text', text: 'The final answer.' }]);
+  });
+
+  it('Stop mid-write (no tools): keeps the partial answer', () => {
+    expect(
+      buildAssistantContent([], '', undefined, undefined, 'partial so far'),
+    ).toBe('partial so far');
+  });
+
+  it('Stop mid-write (with tools): the partial survives as a trailing part', () => {
+    const events: AgentEvent[] = [
+      { type: 'tool-use', toolUseId: 't1', toolName: 'Bash', input: {} },
+      { type: 'tool-result', toolUseId: 't1', output: 'ok', isError: false },
+    ];
+    const parts = buildAssistantContent(
+      events,
+      '',
+      undefined,
+      undefined,
+      'partial after tool',
+    ) as Array<Record<string, unknown>>;
+    expect(
+      parts.some((p) => p.type === 'text' && p.text === 'partial after tool'),
+    ).toBe(true);
+  });
+
+  it('omitting liveText (default) preserves the prior behavior', () => {
+    expect(buildAssistantContent([], '')).toBe('');
+  });
+
+  it('sub-agent text is not folded into the main body', () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'sub narration', parentToolUseId: 'task1' },
+    ];
+    expect(buildAssistantContent(events, '', undefined, undefined, '')).toBe(
+      '',
+    );
+  });
+});

--- a/services/platform/convex/node_only/sandbox/agent_message_parts.ts
+++ b/services/platform/convex/node_only/sandbox/agent_message_parts.ts
@@ -162,12 +162,34 @@ export function buildAssistantContent(
   // seam so a sub-agent tool-result landing in a later segment still resolves
   // to its top-level Task ancestor (mirrors knownToolNames).
   knownToolParents?: ReadonlyMap<string, string>,
+  // Live in-progress MAIN-agent text: the currently-open text block accumulated
+  // from `text-delta` partials that haven't coalesced into a complete `text`
+  // event yet. Threaded by the streaming flush so a long answer reveals as it
+  // streams (and a mid-write Stop keeps it) instead of appearing only at block
+  // end. The caller clears it the instant the block's `text` event lands in
+  // `events`, so a completed block is never double-counted. Empty at terminal.
+  liveText: string = '',
 ): AgentAssistantContent {
   const hasToolTimeline = events.some(
     (e) => e.type === 'tool-use' || e.type === 'tool-result',
   );
   // No tools → the message is just its answer; keep it a plain string.
-  if (!hasToolTimeline) return finalText;
+  // `finalText` (set at the terminal `result`) is authoritative when present.
+  // While streaming it's empty, so fall back to the main-agent text so far —
+  // the closed `text` blocks plus the open `liveText` — so a plain answer
+  // renders incrementally and survives a mid-write Stop instead of staying
+  // blank until the turn ends.
+  if (!hasToolTimeline) {
+    if (finalText.trim() !== '') return finalText;
+    const streamed: string[] = [];
+    for (const e of events) {
+      if (e.type === 'text' && !e.parentToolUseId && e.text.trim() !== '') {
+        streamed.push(e.text);
+      }
+    }
+    if (liveText.trim() !== '') streamed.push(liveText);
+    return streamed.join('\n\n');
+  }
 
   const parts: Exclude<AgentAssistantContent, string> = [];
   // toolUseId → toolName, so a tool-result (which carries no toolName) pairs
@@ -296,6 +318,15 @@ export function buildAssistantContent(
         ...(e.isError ? { isError: true } : {}),
       });
     }
+  }
+
+  // Open (still-streaming) main-agent text block: not yet coalesced into a
+  // `text` event, so render it as a trailing text part. The caller clears it
+  // the instant its `text` event lands (which the loop above already emitted as
+  // a part), so a completed block is never duplicated. Empty at terminal.
+  if (liveText.trim() !== '') {
+    parts.push({ type: 'text', text: liveText });
+    lastText = liveText;
   }
 
   // Ensure the final answer is present exactly once (the stream usually already

--- a/services/platform/convex/node_only/sandbox/run_agent.ts
+++ b/services/platform/convex/node_only/sandbox/run_agent.ts
@@ -295,6 +295,12 @@ export async function runAgentInSessionImpl(
   // (S4 segmentation), so a resumed segment starts with an EMPTY timeline — only
   // the cursor + captured session id carry across the handoff.
   let progressText = '';
+  // The currently-OPEN main-agent text block, accumulated from `text-delta`
+  // partials and threaded into the streaming flush so a long answer reveals as
+  // it streams (and a mid-write Stop keeps it). Cleared when the block's `text`
+  // event lands (it is then in `timeline`). Main-level only — sub-agent text
+  // stays folded. Per-segment, like the rest of this progress state.
+  let liveText = '';
   const recentEvents: string[] = [];
   const timeline: AgentEvent[] = [];
   // Reconnect cursor: starts at the handoff seq on resume so the re-attach skips
@@ -755,6 +761,14 @@ export async function runAgentInSessionImpl(
       }
       if (e.type === 'text-delta' || e.type === 'text') {
         progressText += e.text;
+        // Track the open MAIN-agent block for incremental reveal. A `text`
+        // event is the coalesced complete block (pushed to `timeline` below),
+        // so clear the live buffer when it lands to avoid double-counting; a
+        // delta extends the open block. Sub-agent text (parentToolUseId set)
+        // stays folded and never enters the main message body.
+        if (!e.parentToolUseId) {
+          liveText = e.type === 'text' ? '' : liveText + e.text;
+        }
       } else if (e.type === 'run-started' && e.agentSessionId) {
         capturedSessionId = e.agentSessionId;
       } else if (e.type === 'result') {
@@ -919,6 +933,7 @@ export async function runAgentInSessionImpl(
       finalText ?? '',
       toolNames,
       toolUseParents,
+      liveText,
     );
     if (args.onTimeline) {
       try {
@@ -1215,6 +1230,10 @@ export async function runAgentInSessionImpl(
     finalText ?? '',
     toolNames,
     toolUseParents,
+    // Include the open block so a mid-write Stop (terminal 'cancelled') keeps
+    // the partial answer. On a clean end it is '' (the block's `text` event
+    // already cleared it), so terminal content is byte-identical to before.
+    liveText,
   );
 
   return {

--- a/services/platform/convex/node_only/sandbox/run_agent.ts
+++ b/services/platform/convex/node_only/sandbox/run_agent.ts
@@ -111,6 +111,11 @@ export interface RunAgentInSessionArgs {
    * capture below: in execute mode a captured plan is discarded if any other
    * tool call follows it (the agent kept working — see recordEvents). */
   permissionMode?: 'plan' | 'execute';
+  /** Turn interaction posture (interactive = human in the loop, default;
+   * autonomous = unsupervised). Threaded to the adapter spec AND used here to
+   * skip mid-turn steering / the human-control card for autonomous runs.
+   * Independent of permissionMode. */
+  interactionMode?: 'interactive' | 'autonomous';
   /** Extra system-prompt text appended to the agent CLI's own prompt. */
   systemPromptAppend?: string;
   /** Credential mode (default 'managed'). 'byo' skips the gateway entirely. */
@@ -257,6 +262,9 @@ export async function runAgentInSessionImpl(
         ...(args.browserCdp !== undefined && { browserCdp: args.browserCdp }),
         ...(args.permissionMode !== undefined && {
           permissionMode: args.permissionMode,
+        }),
+        ...(args.interactionMode !== undefined && {
+          interactionMode: args.interactionMode,
         }),
         ...(args.systemPromptAppend !== undefined && {
           systemPromptAppend: args.systemPromptAppend,
@@ -617,8 +625,14 @@ export async function runAgentInSessionImpl(
         setAgentIdle(true);
         await flushProgress(true);
       }
-      if (args.threadId === undefined) {
-        // No thread ⇒ no steering; just close once background work drains.
+      if (
+        args.threadId === undefined ||
+        args.interactionMode === 'autonomous'
+      ) {
+        // No thread, or autonomous (no human in the loop) ⇒ no mid-turn
+        // steering; just close once background work drains. An autonomous run
+        // still carries a threadId (for the transcript), so the mode check is
+        // what gates steering, not just the missing-thread case.
         if (agentResultSeen && pendingTasks.size === 0) await sendEof();
         return;
       }

--- a/services/platform/lib/agent-adapters/build-exec.test.ts
+++ b/services/platform/lib/agent-adapters/build-exec.test.ts
@@ -55,12 +55,13 @@ describe('ClaudeCodeAdapter.buildExec', () => {
     ]);
     // No integration bridge unless integrationsBaseUrl is set.
     expect(mcpConfig.mcpServers.integrations).toBeUndefined();
-    // Built-in WebSearch AND WebFetch are denied — both are model-coupled and
-    // ungoverned, so ALL web access routes through a connected integration via
-    // the dispatch bridge (search op + extract/fetch op), audited and wrapped.
+    // Built-in AskUserQuestion is always denied (no answer path in chat), plus
+    // WebSearch AND WebFetch on managed runs — both model-coupled and ungoverned,
+    // so ALL web access routes through a connected integration via the dispatch
+    // bridge (search op + extract/fetch op), audited and wrapped.
     expect(argv).toContain('--disallowedTools');
     expect(argv[argv.indexOf('--disallowedTools') + 1]).toBe(
-      'WebSearch,WebFetch',
+      'AskUserQuestion,WebSearch,WebFetch',
     );
     // prompt rides stdin as ONE stream-json user-message NDJSON line (a
     // malformed line kills the CLI's stream-json reader), never argv.
@@ -195,6 +196,40 @@ describe('ClaudeCodeAdapter.buildExec', () => {
       'bypassPermissions',
     );
   });
+
+  it('gates the human-control MCP server off for autonomous runs (no human to take over)', () => {
+    const interactive = new ClaudeCodeAdapter().buildExec({
+      ...base,
+      browserCdp: true,
+      interactionMode: 'interactive',
+    });
+    const interactiveMcp = JSON.parse(
+      interactive.argv[interactive.argv.indexOf('--mcp-config') + 1] ?? '{}',
+    );
+    expect(interactiveMcp.mcpServers.humanControl).toBeDefined();
+
+    const autonomous = new ClaudeCodeAdapter().buildExec({
+      ...base,
+      browserCdp: true,
+      interactionMode: 'autonomous',
+    });
+    const autonomousMcp = JSON.parse(
+      autonomous.argv[autonomous.argv.indexOf('--mcp-config') + 1] ?? '{}',
+    );
+    expect(autonomousMcp.mcpServers.humanControl).toBeUndefined();
+    // Playwright is still attached — an autonomous run can still drive the browser.
+    expect(autonomousMcp.mcpServers.playwright).toBeDefined();
+  });
+
+  it('denies AskUserQuestion in autonomous mode too (unchanged deny list)', () => {
+    const { argv } = new ClaudeCodeAdapter().buildExec({
+      ...base,
+      interactionMode: 'autonomous',
+    });
+    expect(argv[argv.indexOf('--disallowedTools') + 1]).toBe(
+      'AskUserQuestion,WebSearch,WebFetch',
+    );
+  });
 });
 
 describe('ClaudeCodeAdapter.buildExec — BYO mode', () => {
@@ -231,9 +266,12 @@ describe('ClaudeCodeAdapter.buildExec — BYO mode', () => {
     expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined();
   });
 
-  it('lifts the governance-motivated WebSearch/WebFetch denial (native tools enabled)', () => {
+  it('lifts the governance-motivated WebSearch/WebFetch denial but still denies AskUserQuestion (no chat answer path)', () => {
     const { argv } = new ClaudeCodeAdapter().buildExec(byoBase);
-    expect(argv).not.toContain('--disallowedTools');
+    // BYO opts out of governance (web tools enabled) but AskUserQuestion has no
+    // answer path in chat regardless of credential mode, so it stays denied.
+    expect(argv).toContain('--disallowedTools');
+    expect(argv[argv.indexOf('--disallowedTools') + 1]).toBe('AskUserQuestion');
   });
 
   it('omits the integration bridge even if integrationsBaseUrl is set (no session key to auth it)', () => {

--- a/services/platform/lib/agent-adapters/claude-code/adapter.ts
+++ b/services/platform/lib/agent-adapters/claude-code/adapter.ts
@@ -114,7 +114,8 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       // Human takeover only applies to the live headed browser (browserCdp) —
       // that's the one a human can drive via x11vnc. The self-launched headless
       // browser has no VNC surface, so the tool would be a dead end there.
-      if (spec.browserCdp === true) {
+      // Autonomous runs have no human to take over, so the tool is never offered.
+      if (spec.browserCdp === true && spec.interactionMode !== 'autonomous') {
         mcpServers.humanControl = HUMAN_CONTROL_MCP_SERVER;
       }
     }
@@ -139,6 +140,17 @@ export class ClaudeCodeAdapter implements AgentAdapter {
         '--strict-mcp-config',
       );
     }
+    // Collected deny list (a deny rule with a bare built-in name removes the
+    // tool from the model's context entirely — verified against the permissions
+    // docs).
+    const disallowedTools: string[] = [];
+    // AskUserQuestion (built-in): there is NO answer path in our chat surface —
+    // the agent is a conversational worker, so it asks in prose (interactive,
+    // the user replies in chat) or makes assumptions (autonomous). The built-in
+    // structured-question tool would dead-end, so deny it in BOTH modes and for
+    // BOTH managed and BYO — this is interaction-correctness, not governance, so
+    // it is NOT lifted for BYO.
+    disallowedTools.push('AskUserQuestion');
     // Deny the built-in WebSearch AND WebFetch. Both are model-coupled and
     // ungoverned: WebSearch is a provider-run search, and WebFetch pipes the
     // fetched page through a model to extract the answer — neither flows
@@ -152,7 +164,10 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     // user's own credential). The container + egress policy stay the isolation
     // boundary.
     if (!byo) {
-      argv.push('--disallowedTools', 'WebSearch,WebFetch');
+      disallowedTools.push('WebSearch', 'WebFetch');
+    }
+    if (disallowedTools.length > 0) {
+      argv.push('--disallowedTools', disallowedTools.join(','));
     }
 
     const env: Record<string, string> = {

--- a/services/platform/lib/agent-adapters/types.ts
+++ b/services/platform/lib/agent-adapters/types.ts
@@ -27,6 +27,11 @@ export interface AgentRunSpec {
    * = the existing full-access behavior. Adapters without the concept ignore
    * it. Fixed for the whole turn — continuations re-attach to the same exec. */
   permissionMode?: 'plan' | 'execute';
+  /** Turn interaction posture. `autonomous` = no human in the loop: adapters
+   * gate off the human-in-loop affordances (e.g. the request_human_control MCP
+   * server). `interactive` (default / absent) keeps them. Independent of
+   * permissionMode. Adapters without the concept ignore it. */
+  interactionMode?: 'interactive' | 'autonomous';
   /** Extra system-prompt text appended to the agent's defaults. */
   systemPromptAppend?: string;
   /**


### PR DESCRIPTION
Two related external-agent (Claude Code / OpenCode) chat-behaviour changes, both verified live against a real sandbox.

---

## 1. Interactive vs autonomous mode (`2dc32bcdd`)

Adds a per-turn **`interactionMode: 'interactive' | 'autonomous'`** posture for external agents, threaded to the adapter alongside `permissionMode`. **Chat is always interactive** — there's no autonomous entry point in the chat UI; the mode is a turn-level parameter a future automation/workflow caller passes to run an agent unsupervised. One agent supports both modes; the caller chooses per run.

**Autonomous ("yolo")** removes the human-in-the-loop seams — plan-approval and `request_human_control` cards are suppressed, mid-turn steering is skipped, the human-control MCP tool is gated off, and the system prompt tells the agent to make assumptions and proceed. Guardrails (duration/budget/never-kill) are unchanged. Interactive behaviour is byte-identical to today.

**`AskUserQuestion`** is disabled in **both** modes (it has no answer path in the chat surface): interactive steers the agent to ask in prose (answered via normal chat steering), autonomous to assume. The agent is a conversational worker, not a re-creation of Claude Code's structured client UI — so no SDK migration and no structured-question card.

- thread the mode: `start_agent_chat` (omitted → interactive default) → turn args → `TurnContext` → continuation → `AgentRunSpec` (mirrors `permissionMode`)
- `turn_lifecycle`: suppress plan + human-control cards for autonomous
- `run_agent` / adapter: skip steering, gate the human-control MCP off, always deny the built-in `AskUserQuestion`
- `system_prompt`: `AUTONOMOUS_MODE` / `AUTONOMOUS_PLAN` / `ASK_IN_CHAT` addenda

Live-verified: autonomous runs straight through (no cards, those tools absent, reports its assumptions); interactive keeps plan/act + steering + live-browser human-control.

## 2. Incremental answer-text streaming (`e11a24b75`)

External-agent assistant text only reached the chat at **text-block completion**: `text-delta` partials were excluded from the message timeline (`run_agent.ts`) and the no-tools path of `buildAssistantContent` returned only `finalText` (set at the terminal `result`). So a long answer showed nothing while the model wrote it (just a "thinking" indicator), then appeared all at once — and a mid-write Stop discarded the partial.

Fix: thread a live in-progress main-agent text buffer (`liveText`, accumulated from `text-delta`, cleared when the block's `text` event lands) into the streaming flush so the open block renders as it streams and survives a mid-write Stop. Terminal output is byte-identical (`liveText` is empty once the block closes). Sub-agent text stays folded; the handoff seal omits `liveText` so the continuation re-streams it (no cross-segment dup).

Live-verified: persisted text now climbs incrementally (`1846 → 12782 → …`) vs the prior `0 → full` jump; the DOM reveals as it streams; terminal answer unchanged, no duplication; a mid-write Stop now keeps the partial.

---

## Verification

- Unit: `agent_message_parts.test.ts`, `system_prompt.test.ts`, `lib/agent-adapters/build-exec.test.ts` (52 tests); `tsc` clean on changed files; lint + format clean.
- Live E2E via the chat UI against a real sandbox for both features (above).

Rebased onto latest `main` (#1883), which had moved `packages/agent_adapters` → `services/platform/lib/agent-adapters`; the adapter edits follow the new paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now support autonomous execution mode, allowing tasks to complete without requiring human approval at decision points; interactive mode remains available as the default.
  * Enhanced rendering of agent progress during streaming execution.
  * System prompts and available tools now adapt based on the execution mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->