### PR TITLE
fix(platform): stop document name overflowing adjacent columns

### DIFF
--- a/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
+++ b/services/platform/app/features/documents/hooks/use-documents-table-config.tsx
@@ -97,6 +97,13 @@ export function useDocumentsTableConfig({
       {
         accessorKey: 'name',
         header: tTables('headers.document'),
+        // The document name is the primary, longest column — opt it in as the
+        // table's flex column so it absorbs all the container slack while the
+        // fixed-width metadata columns keep their declared px. Without this the
+        // name shares width equally with every sibling under `table-fixed`,
+        // squeezing it so long filenames overflow their cell (and the inner
+        // `truncate` can't engage — see the `min-w-0` on the button below).
+        meta: { flex: true },
         cell: ({ row }) => {
           const fullPath = row.original.name ?? '';
           const fileName = fullPath.split('/').pop() || fullPath;
@@ -104,6 +111,7 @@ export function useDocumentsTableConfig({
           return (
             <HStack gap={3}>
               <DocumentIcon
+                className="shrink-0"
                 fileName={fileName}
                 mimeType={row.original.mimeType}
                 isFolder={row.original.type === 'folder'}
@@ -111,7 +119,10 @@ export function useDocumentsTableConfig({
               <button
                 type="button"
                 title={fullPath}
-                className="cursor-pointer text-left"
+                // `min-w-0` lets this flex item shrink below its content width so
+                // the inner `truncate` clips long names with an ellipsis instead
+                // of overflowing into the next column.
+                className="min-w-0 cursor-pointer text-left"
                 aria-label={
                   row.original.type === 'folder'
                     ? tDocuments('aria.openFolder', { name: fileName })


### PR DESCRIPTION
## What

Stops long document names from overflowing into adjacent columns in the documents table.

## Why

Under `table-fixed`, the `name` column shared width equally with every sibling, squeezing it so long filenames spilled out of their cell — the inner `truncate` couldn't engage because the flex item couldn't shrink below its content width.

## How

- Opt the `name` column in as the table's flex column via `meta: { flex: true }`, so it absorbs all container slack while the fixed-width metadata columns keep their declared px. This reuses the existing `meta.flex` mechanism already consumed by the data-table component and used by the skills table.
- Add `min-w-0` to the name button so the flex item can shrink below its content width, letting the inner `truncate` clip long names with an ellipsis.
- Add `shrink-0` to the leading `DocumentIcon` so it isn't compressed when the name is long.

## Testing

- Matches the established `meta: { flex: true }` pattern in `use-skills-table-config.tsx`; the inner `Text` already carries `truncate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout issues in the documents table where long filenames could overflow into adjacent columns. Improved text truncation behavior for better readability and visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->