### PR TITLE
fix(platform): knowledge-db local dev wiring + pdfjs extraction in Convex node runtime

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -709,6 +709,7 @@ import type * as lib_knowledge_extraction_helpers from "../lib/knowledge/extract
 import type * as lib_knowledge_extraction_image from "../lib/knowledge/extraction/image.js";
 import type * as lib_knowledge_extraction_ooxml from "../lib/knowledge/extraction/ooxml.js";
 import type * as lib_knowledge_extraction_pdf from "../lib/knowledge/extraction/pdf.js";
+import type * as lib_knowledge_extraction_pdfjs_dom_polyfill from "../lib/knowledge/extraction/pdfjs_dom_polyfill.js";
 import type * as lib_knowledge_extraction_pptx from "../lib/knowledge/extraction/pptx.js";
 import type * as lib_knowledge_extraction_router from "../lib/knowledge/extraction/router.js";
 import type * as lib_knowledge_extraction_text from "../lib/knowledge/extraction/text.js";
@@ -2203,6 +2204,7 @@ declare const fullApi: ApiFromModules<{
   "lib/knowledge/extraction/image": typeof lib_knowledge_extraction_image;
   "lib/knowledge/extraction/ooxml": typeof lib_knowledge_extraction_ooxml;
   "lib/knowledge/extraction/pdf": typeof lib_knowledge_extraction_pdf;
+  "lib/knowledge/extraction/pdfjs_dom_polyfill": typeof lib_knowledge_extraction_pdfjs_dom_polyfill;
   "lib/knowledge/extraction/pptx": typeof lib_knowledge_extraction_pptx;
   "lib/knowledge/extraction/router": typeof lib_knowledge_extraction_router;
   "lib/knowledge/extraction/text": typeof lib_knowledge_extraction_text;

--- a/services/platform/convex/lib/knowledge/extraction/pdf.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdf.ts
@@ -18,18 +18,38 @@
 
 import type { PDFPageProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 
+import { installPdfjsDomGlobals } from './pdfjs_dom_polyfill';
+
 type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 let pdfjsModulePromise: Promise<PdfjsModule> | undefined;
 /**
- * Lazily load pdfjs so its DOM-global setup (DOMMatrix/OffscreenCanvas, the
- * optional `@napi-rs/canvas` probe) runs only when an action actually parses a
- * PDF — never during Convex's module *analyze* pass, where those globals are
- * undefined and a top-level pdfjs import throws `DOMMatrix is not defined`.
- * pdfjs is bundled (tree-shaken) rather than externalized to keep the module
- * upload under the backend's size limit.
+ * Lazily load pdfjs so its DOM-global setup runs only when an action actually
+ * parses a PDF — never during Convex's module *analyze* pass, where those
+ * globals are undefined and a top-level pdfjs import throws `DOMMatrix is not
+ * defined`. pdfjs is bundled (tree-shaken) rather than externalized to keep the
+ * module upload under the backend's size limit.
+ *
+ * Before importing pdfjs we install pure-JS `DOMMatrix`/`ImageData`/`Path2D`
+ * globals: pdfjs's own polyfill does `require("@napi-rs/canvas")` (a native
+ * module Convex does NOT ship to the node-action runtime — see
+ * {@link installPdfjsDomGlobals}), so without this every PDF fails with
+ * `DOMMatrix is not defined`. pdfjs only sets its globals when absent, so ours
+ * win and the native require is skipped.
  */
 function loadPdfjs(): Promise<PdfjsModule> {
-  return (pdfjsModulePromise ??= import('pdfjs-dist/legacy/build/pdf.mjs'));
+  installPdfjsDomGlobals();
+  return (pdfjsModulePromise ??= (async () => {
+    // pdfjs's fake worker would dynamically `import('./pdf.worker.mjs')` at
+    // getDocument time — a sibling file that doesn't exist in the Convex action
+    // bundle, so it fails with "Setting up fake worker failed". Pre-load the
+    // worker module and expose it as `globalThis.pdfjsWorker`: pdfjs's
+    // PDFWorker._setupFakeWorkerGlobal then uses its `WorkerMessageHandler`
+    // in-process and skips the file import. The worker is bundled with the
+    // action because we import it statically here.
+    const worker = await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
+    (globalThis as Record<string, unknown>).pdfjsWorker = worker;
+    return import('pdfjs-dist/legacy/build/pdf.mjs');
+  })());
 }
 
 import type { VisionClient } from '../vision/client';

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_dom_polyfill.ts
@@ -1,0 +1,272 @@
+'use node';
+
+/**
+ * Pure-JS DOM-global polyfills for running pdfjs-dist in the Convex node
+ * action runtime.
+ *
+ * pdfjs 5.x's Node setup polyfills `DOMMatrix` / `ImageData` / `Path2D` by
+ * `require("@napi-rs/canvas")` — a NATIVE module. Convex extracts a bundled
+ * 'use node' action to a temp dir and does NOT ship externalized native
+ * packages there (a pure-JS external like `postgres` resolves, a `.node` addon
+ * does not), so that require fails and pdfjs throws `DOMMatrix is not defined`
+ * on every PDF. We never rasterize (text is read per page; embedded image bytes
+ * go to the Vision API), so a correct affine `DOMMatrix` plus inert
+ * `ImageData` / `Path2D` stubs are sufficient — and because they're plain JS
+ * they bundle into the action and are present at runtime.
+ *
+ * pdfjs only assigns its own polyfill when the global is absent
+ * (`if (!globalThis.DOMMatrix)`), so installing these first makes pdfjs defer
+ * to them and skips the native `require` entirely.
+ */
+
+interface Point2D {
+  x?: number;
+  y?: number;
+  z?: number;
+  w?: number;
+}
+
+/**
+ * Spec-faithful 2D affine matrix:
+ *   | a c e |
+ *   | b d f |
+ *   | 0 0 1 |
+ * Implements the surface pdfjs exercises during text extraction: construction
+ * from a 6- or 16-element array (or another matrix), multiply / translate /
+ * scale / rotate (and their `*Self` mutating variants), inverse / invertSelf,
+ * and transformPoint. 3D is collapsed to 2D (pdfjs passes 2D transforms here).
+ */
+class DOMMatrixPolyfill {
+  a = 1;
+  b = 0;
+  c = 0;
+  d = 1;
+  e = 0;
+  f = 0;
+
+  constructor(init?: number[] | DOMMatrixPolyfill | string) {
+    if (init == null) return;
+    if (typeof init === 'string') {
+      throw new Error('DOMMatrix(string) is not supported in this polyfill');
+    }
+    if (Array.isArray(init)) {
+      if (init.length === 6) {
+        [this.a, this.b, this.c, this.d, this.e, this.f] = init;
+      } else if (init.length === 16) {
+        // Column-major 4x4 → 2D components (m11,m12,m21,m22,m41,m42).
+        this.a = init[0];
+        this.b = init[1];
+        this.c = init[4];
+        this.d = init[5];
+        this.e = init[12];
+        this.f = init[13];
+      } else {
+        throw new Error(
+          `DOMMatrix init array length ${init.length} unsupported`,
+        );
+      }
+      return;
+    }
+    this.a = init.a;
+    this.b = init.b;
+    this.c = init.c;
+    this.d = init.d;
+    this.e = init.e;
+    this.f = init.f;
+  }
+
+  // 4x4 aliases pdfjs / callers may read; 2D matrix → fixed 3rd/4th rows.
+  get m11(): number {
+    return this.a;
+  }
+  get m12(): number {
+    return this.b;
+  }
+  get m21(): number {
+    return this.c;
+  }
+  get m22(): number {
+    return this.d;
+  }
+  get m41(): number {
+    return this.e;
+  }
+  get m42(): number {
+    return this.f;
+  }
+  get is2D(): boolean {
+    return true;
+  }
+  get isIdentity(): boolean {
+    return (
+      this.a === 1 &&
+      this.b === 0 &&
+      this.c === 0 &&
+      this.d === 1 &&
+      this.e === 0 &&
+      this.f === 0
+    );
+  }
+
+  private clone(): DOMMatrixPolyfill {
+    return new DOMMatrixPolyfill([
+      this.a,
+      this.b,
+      this.c,
+      this.d,
+      this.e,
+      this.f,
+    ]);
+  }
+
+  /** this · other (matrix product), returning a new matrix. */
+  multiply(other: DOMMatrixPolyfill): DOMMatrixPolyfill {
+    return this.clone().multiplySelf(other);
+  }
+
+  multiplySelf(o: DOMMatrixPolyfill): DOMMatrixPolyfill {
+    const a = this.a * o.a + this.c * o.b;
+    const b = this.b * o.a + this.d * o.b;
+    const c = this.a * o.c + this.c * o.d;
+    const d = this.b * o.c + this.d * o.d;
+    const e = this.a * o.e + this.c * o.f + this.e;
+    const f = this.b * o.e + this.d * o.f + this.f;
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.e = e;
+    this.f = f;
+    return this;
+  }
+
+  /** this = other · this (pre-multiply), returning this. */
+  preMultiplySelf(o: DOMMatrixPolyfill): DOMMatrixPolyfill {
+    const a = o.a * this.a + o.c * this.b;
+    const b = o.b * this.a + o.d * this.b;
+    const c = o.a * this.c + o.c * this.d;
+    const d = o.b * this.c + o.d * this.d;
+    const e = o.a * this.e + o.c * this.f + o.e;
+    const f = o.b * this.e + o.d * this.f + o.f;
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.e = e;
+    this.f = f;
+    return this;
+  }
+
+  translate(tx = 0, ty = 0): DOMMatrixPolyfill {
+    return this.clone().translateSelf(tx, ty);
+  }
+
+  translateSelf(tx = 0, ty = 0): DOMMatrixPolyfill {
+    this.e += this.a * tx + this.c * ty;
+    this.f += this.b * tx + this.d * ty;
+    return this;
+  }
+
+  scale(sx = 1, sy?: number): DOMMatrixPolyfill {
+    return this.clone().scaleSelf(sx, sy);
+  }
+
+  scaleSelf(sx = 1, sy?: number): DOMMatrixPolyfill {
+    const sceY = sy ?? sx;
+    this.a *= sx;
+    this.b *= sx;
+    this.c *= sceY;
+    this.d *= sceY;
+    return this;
+  }
+
+  rotate(deg = 0): DOMMatrixPolyfill {
+    return this.clone().rotateSelf(deg);
+  }
+
+  rotateSelf(deg = 0): DOMMatrixPolyfill {
+    const rad = (deg * Math.PI) / 180;
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+    return this.multiplySelf(
+      new DOMMatrixPolyfill([cos, sin, -sin, cos, 0, 0]),
+    );
+  }
+
+  inverse(): DOMMatrixPolyfill {
+    return this.clone().invertSelf();
+  }
+
+  invertSelf(): DOMMatrixPolyfill {
+    const det = this.a * this.d - this.b * this.c;
+    if (!det) {
+      this.a = this.b = this.c = this.d = this.e = this.f = NaN;
+      return this;
+    }
+    const { a, b, c, d, e, f } = this;
+    this.a = d / det;
+    this.b = -b / det;
+    this.c = -c / det;
+    this.d = a / det;
+    this.e = (c * f - d * e) / det;
+    this.f = (b * e - a * f) / det;
+    return this;
+  }
+
+  transformPoint(point: Point2D = {}): Point2D {
+    const x = point.x ?? 0;
+    const y = point.y ?? 0;
+    return {
+      x: this.a * x + this.c * y + this.e,
+      y: this.b * x + this.d * y + this.f,
+      z: point.z ?? 0,
+      w: point.w ?? 1,
+    };
+  }
+}
+
+/** Inert stand-ins — only constructed on the rasterization path we never take. */
+class ImageDataPolyfill {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+  constructor(widthOrData: number | Uint8ClampedArray, height?: number) {
+    if (typeof widthOrData === 'number') {
+      this.width = widthOrData;
+      this.height = height ?? 0;
+      this.data = new Uint8ClampedArray(this.width * this.height * 4);
+    } else {
+      this.data = widthOrData;
+      this.width = height ?? 0;
+      this.height = this.width ? widthOrData.length / 4 / this.width : 0;
+    }
+  }
+}
+
+class Path2DPolyfill {
+  // No-op: pdfjs only builds paths when rendering to a canvas.
+  addPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  bezierCurveTo(): void {}
+  quadraticCurveTo(): void {}
+  arc(): void {}
+  rect(): void {}
+  closePath(): void {}
+}
+
+let installed = false;
+
+/**
+ * Idempotently install the DOM globals pdfjs needs, BEFORE pdfjs is imported.
+ * Only fills gaps so a real browser/runtime global (or @napi-rs/canvas, if it
+ * ever does load) still wins.
+ */
+export function installPdfjsDomGlobals(): void {
+  if (installed) return;
+  installed = true;
+  const g = globalThis as Record<string, unknown>;
+  g.DOMMatrix ??= DOMMatrixPolyfill;
+  g.ImageData ??= ImageDataPolyfill;
+  g.Path2D ??= Path2DPolyfill;
+}

--- a/services/platform/convex/lib/types/pdfjs_worker.d.ts
+++ b/services/platform/convex/lib/types/pdfjs_worker.d.ts
@@ -1,0 +1,8 @@
+// pdfjs-dist ships no `.d.ts` for its worker entry, so importing it trips
+// TS7016 under noImplicitAny. We import it only for its side effect — exposing
+// `WorkerMessageHandler` so `extraction/pdf.ts` can set `globalThis.pdfjsWorker`
+// and run pdfjs's worker in-process inside the Convex node action (see
+// loadPdfjs). Declare the minimal shape we touch.
+declare module 'pdfjs-dist/legacy/build/pdf.worker.mjs' {
+  export const WorkerMessageHandler: unknown;
+}

--- a/services/platform/scripts/dev.ts
+++ b/services/platform/scripts/dev.ts
@@ -235,6 +235,36 @@ function ensureEncryptionSecret() {
     .digest('hex');
 }
 
+// knowledge-db (ParadeDB) connection for the RAG / knowledge-base Convex node
+// actions. Since #1883 the platform talks to the knowledge corpus DIRECTLY via
+// postgres.js (convex/lib/knowledge/db/knowledge_db.ts) instead of the old
+// Python `rag` service. A containerized Convex run resolves the compose
+// hostname `knowledge-db`, but the local `bun dev` backend runs on the host,
+// where that name does NOT resolve — the node action dies with
+// `getaddrinfo ENOTFOUND knowledge-db` and every RAG upload/search fails. Point
+// it at the port compose publishes to the host (the `knowledge-db` service maps
+// `5433:5432` in compose.yml) so RAG works with zero manual setup. Pushed into
+// Convex via ORCHESTRATOR_MANAGED_KEYS in sync-convex-env-from-dotenv.ts. An
+// explicit KNOWLEDGE_DATABASE_URL / RAG_DATABASE_URL (.env) always wins — we
+// only fill the gap. Run after loadEnvFiles() so DB_PASSWORD is populated.
+function ensureKnowledgeDatabaseUrl() {
+  if (process.env.KNOWLEDGE_DATABASE_URL || process.env.RAG_DATABASE_URL) {
+    return;
+  }
+  const password = process.env.DB_PASSWORD;
+  if (!password) {
+    console.warn(
+      '[dev] ⚠️  DB_PASSWORD not set; cannot derive KNOWLEDGE_DATABASE_URL —\n   knowledge base / RAG search will fail. Set DB_PASSWORD in .env.',
+    );
+    return;
+  }
+  // Host port published by the `knowledge-db` service in compose.yml (5433:5432).
+  const KNOWLEDGE_DB_HOST_PORT = 5433;
+  process.env.KNOWLEDGE_DATABASE_URL = `postgresql://tale:${encodeURIComponent(
+    password,
+  )}@localhost:${KNOWLEDGE_DB_HOST_PORT}/tale_knowledge`;
+}
+
 // WebDAV's dev route (vite-plugins/serve-webdav.ts) talks to Convex with the
 // deployment ADMIN_KEY to call internal functions; without it the plugin
 // disables /dav/* and every request returns 503. Prod derives the key with the
@@ -738,6 +768,7 @@ async function main() {
     ensureBetterAuthSecret();
     ensureWebdavHmacKey();
     ensureEncryptionSecret();
+    ensureKnowledgeDatabaseUrl();
     const deployment = process.env.CONVEX_DEPLOYMENT;
     const hasLocalDeployment = deployment?.startsWith('anonymous:');
     if (deployment && !hasLocalDeployment) {

--- a/services/platform/scripts/sync-convex-env-from-dotenv.ts
+++ b/services/platform/scripts/sync-convex-env-from-dotenv.ts
@@ -83,6 +83,13 @@ const ORCHESTRATOR_MANAGED_KEYS = [
   // not present in any .env file. Required by setProjectSecret + the guardrails
   // secret box (get_secret_key / secret_box) for at-rest secret encryption.
   'ENCRYPTION_SECRET_HEX',
+  // Derived by the dev orchestrator (ensureKnowledgeDatabaseUrl) to point the
+  // host `bun dev` Convex backend at the knowledge-db port compose publishes to
+  // localhost. Read from the DEPLOYMENT env by convex/lib/knowledge/db/
+  // knowledge_db.ts (postgres.js) for RAG upload/search; without it the node
+  // action falls back to the compose hostname `knowledge-db`, which does not
+  // resolve from the host (getaddrinfo ENOTFOUND). An explicit .env value wins.
+  'KNOWLEDGE_DATABASE_URL',
 ] as const;
 
 // Vars read by Convex functions from the DEPLOYMENT env that are documented


### PR DESCRIPTION
Two fixes that fall out of #1883 (RAG/crawler moved off the Python services into Convex).

## 1. Wire local `bun dev` Convex backend to the knowledge-db host port

Since #1883, the platform talks to knowledge-db directly via postgres.js (`convex/lib/knowledge/db/knowledge_db.ts`). The local `bun dev` Convex backend runs as a host process, not in the `tale-convex` container, so it can't resolve the docker-internal hostname `knowledge-db` — RAG upload and search died with `getaddrinfo ENOTFOUND knowledge-db`.

- Derive `KNOWLEDGE_DATABASE_URL` from `DB_PASSWORD`, pointing at the port compose publishes to the host (`knowledge-db` maps `5433:5432`), in a new `ensureKnowledgeDatabaseUrl()` helper that mirrors `ensureEncryptionSecret`.
- Carry it through the env sync's `ORCHESTRATOR_MANAGED_KEYS` so the stale-cleanup pass doesn't wipe it.
- An explicit `KNOWLEDGE_DATABASE_URL` / `RAG_DATABASE_URL` still wins.

Files: `scripts/dev.ts`, `scripts/sync-convex-env-from-dotenv.ts`

## 2. Make pdfjs PDF extraction work in the Convex node runtime

#1883 ported PDF text extraction from PyMuPDF to `pdfjs-dist` 5.x, which does not run in the Convex node-action runtime for two reasons:

1. pdfjs polyfills `DOMMatrix`/`ImageData`/`Path2D` by `require("@napi-rs/canvas")`, a **native** module Convex does not ship to the action runtime (a bundled action is extracted to `/tmp/.../modules` with no native `node_modules` — a pure-JS externalPackage like `postgres` resolves there, a `.node` addon does not). So every PDF threw `DOMMatrix is not defined`.
2. With that fixed, pdfjs's fake worker dynamically imports `./pdf.worker.mjs`, which is absent from the bundle → "Setting up fake worker failed".

The fix is runtime-agnostic and bundles into the action (no native dep, no externalPackages):

- `pdfjs_dom_polyfill.ts` installs a pure-JS `DOMMatrix` (correct 2D affine) plus inert `ImageData`/`Path2D` on `globalThis` **before** pdfjs loads. pdfjs only sets its own globals when absent, so ours win and the native require is skipped. We never rasterize (text per page; embedded image bytes go to the Vision API), so the stubs suffice.
- `loadPdfjs` pre-imports `pdf.worker.mjs` and exposes it as `globalThis.pdfjsWorker`; `PDFWorker._setupFakeWorkerGlobal` then uses its `WorkerMessageHandler` in-process and skips the missing-file import.

Files: `convex/lib/knowledge/extraction/pdf.ts`, new `pdfjs_dom_polyfill.ts`, `convex/lib/types/pdfjs_worker.d.ts`, `api.d.ts`

## Testing

- pdfjs fix verified e2e against the live deployment: `rag/documents:upload` of a real PDF indexes ("1 chunks", `success: true`) with no `DOMMatrix` or fake-worker error.
- knowledge-db URL fix unblocks RAG upload/search under local `bun dev`.
