### PR TITLE
feat(platform): refine settings layouts and onboarding wizard UX

### DIFF
--- a/packages/ui/src/components/data-display/table.tsx
+++ b/packages/ui/src/components/data-display/table.tsx
@@ -62,7 +62,16 @@ const TableBody = forwardRef<
 >(({ className, ...props }, ref) => (
   <tbody
     ref={ref}
-    className={cn('[&_tr:hover]:bg-muted', className)}
+    // Row hover is an interactivity affordance, so it must not target
+    // non-interactive rows (empty/filtered-empty states, expanded-content
+    // rows). Those opt out with `data-no-hover`; excluding them here (rather
+    // than overriding per-row) avoids a specificity fight this descendant
+    // selector would otherwise win.
+    //
+    // Use a 50%-muted tint (not solid `bg-muted`) so the hover reads as a
+    // subtle highlight distinct from the header, whose cells are painted with
+    // solid `bg-muted` — at full strength the two were indistinguishable.
+    className={cn('[&_tr:not([data-no-hover]):hover]:bg-muted/50', className)}
     {...props}
   />
 ));

--- a/packages/ui/src/components/overlays/popover.tsx
+++ b/packages/ui/src/components/overlays/popover.tsx
@@ -19,7 +19,7 @@ interface PopoverProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
 
 export function Popover({
   trigger,

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -840,7 +840,7 @@ export function DataTable<TData, TValue = unknown>({
             // it stays centered even when the table overflows horizontally
             // (common on narrow viewports where many columns push the table
             // wider than the scroll viewport).
-            <TableRow className="hover:bg-transparent">
+            <TableRow data-no-hover>
               <TableCell colSpan={colSpan} className="p-0">
                 <div className="sticky left-0 w-screen max-w-full p-4">
                   <DataTableEmptyState
@@ -854,7 +854,7 @@ export function DataTable<TData, TValue = unknown>({
             </TableRow>
           ) : tableBodyState === 'filtered-empty' ? (
             // Filtered empty state — filters applied but no matching rows
-            <TableRow className="hover:bg-transparent">
+            <TableRow data-no-hover>
               <TableCell colSpan={colSpan} className="p-0">
                 <div className="sticky left-0 w-screen max-w-full p-4">
                   <DataTableEmptyState
@@ -934,7 +934,7 @@ export function DataTable<TData, TValue = unknown>({
                     })}
                   </TableRow>
                   {enableExpanding && isExpanded && renderExpandedRow && (
-                    <TableRow className="border-0 hover:bg-transparent">
+                    <TableRow className="border-0" data-no-hover>
                       <TableCell colSpan={columns.length + 1} className="p-0">
                         <div className="animate-in fade-in-0 slide-in-from-top-1 grid duration-150">
                           <div className="bg-muted/20 px-4 pb-2">

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -125,7 +125,7 @@ export interface SearchableSelectProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
 
 function defaultFilterFn(option: SearchableSelectOption, query: string) {
   const lower = query.toLowerCase();

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -20,7 +20,7 @@ const selectContentVariants = cva(
   // could extend past the edge and clip its first option (e.g. "End workflow")
   // behind the scroll buttons. The `,24rem` fallback keeps the cap for the
   // `item-aligned` position, where Radix does not expose the available-height var.
-  'relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height,24rem))] min-w-[8rem] overflow-hidden rounded-md border bg-muted text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+  'relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height,24rem))] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground dark:bg-muted shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
   {
     variants: {
       position: {

--- a/services/platform/app/components/ui/forms/switch.tsx
+++ b/services/platform/app/components/ui/forms/switch.tsx
@@ -70,7 +70,13 @@ const SwitchBase = forwardRef<
         id={id}
         data-slot="switch"
         className={cn(
-          'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-border focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-border/80 inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+          // Light mode: the unchecked track (`bg-border`, 90% L) is barely
+          // perceptible on the near-white page (~1.2:1) — and `disabled` halves
+          // it again into invisibility. Give the unchecked track a visible
+          // `border-border-strong` outline so the control's shape always reads,
+          // even when disabled. Dark mode already has enough edge contrast (see
+          // globals.css), so it keeps the transparent border there.
+          'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-border data-[state=unchecked]:border-border-strong data-[state=checked]:border-transparent dark:border-transparent focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-border/80 inline-flex shrink-0 items-center rounded-full border shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-60',
           SWITCH_TRACK_DIMENSIONS,
           className,
         )}

--- a/services/platform/app/components/ui/navigation/navigation-menu.tsx
+++ b/services/platform/app/components/ui/navigation/navigation-menu.tsx
@@ -76,7 +76,7 @@ const NavigationMenuViewport = forwardRef<
   <div className={cn('absolute left-0 top-full z-50 flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-muted text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out md:w-(--radix-navigation-menu-viewport-width)',
+        'origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-popover text-popover-foreground dark:bg-muted shadow data-[state=open]:animate-in data-[state=closed]:animate-out md:w-(--radix-navigation-menu-viewport-width)',
         className,
       )}
       ref={ref}

--- a/services/platform/app/components/ui/wizard/use-wizard.ts
+++ b/services/platform/app/components/ui/wizard/use-wizard.ts
@@ -19,6 +19,17 @@ export type WizardStatus = 'idle' | 'submitting';
  */
 export type WizardBeforeNext = () => boolean | Promise<boolean>;
 
+/**
+ * Per-step override for the footer's primary (Next) control. Lets a step adapt
+ * the label/emphasis to the current input — e.g. an optional key step showing
+ * "Skip for now" (secondary) while empty and "Connect" (primary) once filled,
+ * so a single button always reflects what will happen.
+ */
+export interface WizardPrimaryOverride {
+  label?: string;
+  variant?: 'primary' | 'secondary';
+}
+
 export interface WizardContextValue {
   steps: WizardStepMeta[];
   activeIndex: number;
@@ -39,6 +50,13 @@ export interface WizardContextValue {
     handler: WizardBeforeNext | undefined,
   ) => void;
   isStepValid: (id: string) => boolean;
+  /** A step registers/clears its primary-action override (label + emphasis). */
+  setStepPrimary: (
+    id: string,
+    override: WizardPrimaryOverride | undefined,
+  ) => void;
+  /** The active step's primary-action override, if any. */
+  activePrimary: WizardPrimaryOverride | undefined;
 }
 
 export const WizardContext = createContext<WizardContextValue | null>(null);

--- a/services/platform/app/components/ui/wizard/wizard-footer.tsx
+++ b/services/platform/app/components/ui/wizard/wizard-footer.tsx
@@ -14,6 +14,13 @@ export interface WizardFooterProps {
   /** Required only when any step is optional (renders the Skip action). */
   skipLabel?: string;
   className?: string;
+  /**
+   * Full-width, vertically-stacked layout: the primary Next/Finish button spans
+   * the container width (matching form inputs), with Skip and Back as full-width
+   * secondary buttons below. Use for narrow / onboarding flows. Default is the
+   * horizontal Back-left / Next-right bar.
+   */
+  stacked?: boolean;
 }
 
 /**
@@ -27,6 +34,7 @@ export function WizardFooter({
   finishLabel,
   skipLabel,
   className,
+  stacked,
 }: WizardFooterProps) {
   const {
     activeStep,
@@ -37,11 +45,49 @@ export function WizardFooter({
     goNext,
     skip,
     isStepValid,
+    activePrimary,
   } = useWizard();
 
   const submitting = status === 'submitting';
   const nextDisabled = !activeStep || !isStepValid(activeStep.id) || submitting;
   const showSkip = Boolean(activeStep?.optional && skipLabel);
+
+  // The active step may override the primary label/emphasis (e.g. "Skip for
+  // now" vs "Connect"); otherwise fall back to the standard Next/Finish label.
+  const primaryLabel =
+    activePrimary?.label ?? (isLast ? finishLabel : nextLabel);
+  const primaryVariant =
+    activePrimary?.variant === 'secondary' ? 'secondary' : undefined;
+
+  if (stacked) {
+    // Full-width primary action (matching the inputs). Back lives at the
+    // top-left of the flow (rendered in the wizard header), so the footer only
+    // carries the primary plus an optional, centered Skip beneath it.
+    return (
+      <div className={cn('flex flex-col gap-4', className)}>
+        <Button
+          className="w-full"
+          variant={primaryVariant}
+          onClick={goNext}
+          disabled={nextDisabled}
+          isLoading={submitting}
+        >
+          {primaryLabel}
+        </Button>
+        {showSkip && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={skip}
+            disabled={submitting}
+            className="mx-auto"
+          >
+            {skipLabel}
+          </Button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className={cn('flex items-center justify-between gap-2', className)}>
@@ -58,8 +104,13 @@ export function WizardFooter({
             {skipLabel}
           </Button>
         )}
-        <Button onClick={goNext} disabled={nextDisabled} isLoading={submitting}>
-          {isLast ? finishLabel : nextLabel}
+        <Button
+          variant={primaryVariant}
+          onClick={goNext}
+          disabled={nextDisabled}
+          isLoading={submitting}
+        >
+          {primaryLabel}
         </Button>
       </div>
     </div>

--- a/services/platform/app/components/ui/wizard/wizard-progress.tsx
+++ b/services/platform/app/components/ui/wizard/wizard-progress.tsx
@@ -10,6 +10,24 @@ export interface WizardProgressProps {
   /** Accessible name for the step list (translated by caller). */
   ariaLabel: string;
   className?: string;
+  /**
+   * Force the compact progress-bar layout at every breakpoint instead of the
+   * numbered step rail on ≥sm. Use for narrow / onboarding flows where a
+   * discrete "Step 1 of 3" indicator reads cleaner than a full step row.
+   */
+  compact?: boolean;
+  /**
+   * Optional formatter for the compact indicator's text line, e.g.
+   * `(current, total, label) => "Step 1 of 3: Workspace"`. Falls back to the
+   * active step's label plus "current / total".
+   */
+  formatStep?: (current: number, total: number, label: string) => string;
+  /**
+   * Minimal segmented bar: one pill per step, filled up to and including the
+   * active step. No labels or numbers — position alone conveys progress. Use as
+   * a clean, modern top-of-page indicator. Takes precedence over `compact`.
+   */
+  segmented?: boolean;
 }
 
 /**
@@ -24,22 +42,61 @@ export interface WizardProgressProps {
  *
  * Purely presentational — all navigation goes through the wizard context.
  */
-export function WizardProgress({ ariaLabel, className }: WizardProgressProps) {
+export function WizardProgress({
+  ariaLabel,
+  className,
+  compact,
+  formatStep,
+  segmented,
+}: WizardProgressProps) {
   const { steps, activeIndex, activeStep, maxVisitedIndex, goTo } = useWizard();
   const total = steps.length;
   const pct = total > 0 ? ((activeIndex + 1) / total) * 100 : 0;
 
+  // ── Segmented bar: one pill per step, filled through the active step ────
+  if (segmented) {
+    return (
+      <div
+        className={cn('flex gap-1.5', className)}
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuemin={1}
+        aria-valuemax={total}
+        aria-valuenow={activeIndex + 1}
+      >
+        {steps.map((step, index) => (
+          <span
+            key={step.id}
+            aria-hidden="true"
+            className={cn(
+              'h-1 flex-1 rounded-full transition-colors duration-300 ease-out motion-reduce:transition-none',
+              index <= activeIndex ? 'bg-accent-base' : 'bg-border',
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className={className}>
-      {/* ── Mobile: progress bar ───────────────────────────────────── */}
-      <div className="flex flex-col gap-2 sm:hidden">
+      {/* ── Compact progress bar (always when `compact`, else < sm) ──── */}
+      <div className={cn('flex flex-col gap-2', !compact && 'sm:hidden')}>
         <div className="flex items-center justify-between gap-3 text-sm">
-          <span className="text-fg-base min-w-0 truncate font-medium">
-            {activeStep?.label}
-          </span>
-          <span className="text-fg-muted shrink-0 tabular-nums">
-            {activeIndex + 1} / {total}
-          </span>
+          {formatStep ? (
+            <span className="text-fg-base min-w-0 truncate font-medium">
+              {formatStep(activeIndex + 1, total, activeStep?.label ?? '')}
+            </span>
+          ) : (
+            <>
+              <span className="text-fg-base min-w-0 truncate font-medium">
+                {activeStep?.label}
+              </span>
+              <span className="text-fg-muted shrink-0 tabular-nums">
+                {activeIndex + 1} / {total}
+              </span>
+            </>
+          )}
         </div>
         <div
           className="bg-bg-elevated ring-border-strong h-1.5 overflow-hidden rounded-full ring-1"
@@ -56,79 +113,81 @@ export function WizardProgress({ ariaLabel, className }: WizardProgressProps) {
         </div>
       </div>
 
-      {/* ── ≥ sm: numbered steps ───────────────────────────────────── */}
-      <ol
-        role="list"
-        aria-label={ariaLabel}
-        className="hidden items-start sm:flex"
-      >
-        {steps.map((step, index) => {
-          const isActive = index === activeIndex;
-          const isComplete = index < activeIndex;
-          const isReachable = index <= maxVisitedIndex && !isActive;
-          const isFirst = index === 0;
-          const isLast = index === total - 1;
+      {/* ── ≥ sm: numbered step rail (suppressed in compact mode) ──── */}
+      {!compact && (
+        <ol
+          role="list"
+          aria-label={ariaLabel}
+          className="hidden items-start sm:flex"
+        >
+          {steps.map((step, index) => {
+            const isActive = index === activeIndex;
+            const isComplete = index < activeIndex;
+            const isReachable = index <= maxVisitedIndex && !isActive;
+            const isFirst = index === 0;
+            const isLast = index === total - 1;
 
-          return (
-            <li
-              key={step.id}
-              className="flex min-w-0 flex-1 flex-col items-center"
-            >
-              <div className="flex w-full items-center">
+            return (
+              <li
+                key={step.id}
+                className="flex min-w-0 flex-1 flex-col items-center"
+              >
+                <div className="flex w-full items-center">
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'h-px flex-1',
+                      isFirst
+                        ? 'bg-transparent'
+                        : isComplete || isActive
+                          ? 'bg-accent-base/40'
+                          : 'bg-border-strong',
+                    )}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => isReachable && goTo(index)}
+                    disabled={!isReachable}
+                    aria-current={isActive ? 'step' : undefined}
+                    aria-label={step.label}
+                    className={cn(
+                      'focus-visible:ring-ring flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                      isActive && 'bg-accent-base text-accent-fg',
+                      isComplete && 'bg-accent-base/15 text-accent-base',
+                      !isActive &&
+                        !isComplete &&
+                        'bg-bg-elevated text-fg-muted ring-border-strong ring-1',
+                      isReachable && 'cursor-pointer hover:opacity-80',
+                    )}
+                  >
+                    {isComplete ? <Check className="size-3.5" /> : index + 1}
+                  </button>
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'h-px flex-1',
+                      isLast
+                        ? 'bg-transparent'
+                        : isComplete
+                          ? 'bg-accent-base/40'
+                          : 'bg-border-strong',
+                    )}
+                  />
+                </div>
                 <span
                   aria-hidden="true"
                   className={cn(
-                    'h-px flex-1',
-                    isFirst
-                      ? 'bg-transparent'
-                      : isComplete || isActive
-                        ? 'bg-accent-base/40'
-                        : 'bg-border-strong',
-                  )}
-                />
-                <button
-                  type="button"
-                  onClick={() => isReachable && goTo(index)}
-                  disabled={!isReachable}
-                  aria-current={isActive ? 'step' : undefined}
-                  aria-label={step.label}
-                  className={cn(
-                    'focus-visible:ring-ring flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none',
-                    isActive && 'bg-accent-base text-accent-fg',
-                    isComplete && 'bg-accent-base/15 text-accent-base',
-                    !isActive &&
-                      !isComplete &&
-                      'bg-bg-elevated text-fg-muted ring-border-strong ring-1',
-                    isReachable && 'cursor-pointer hover:opacity-80',
+                    'mt-2 max-w-full truncate px-1 text-xs',
+                    isActive ? 'text-fg-base font-medium' : 'text-fg-muted',
                   )}
                 >
-                  {isComplete ? <Check className="size-3.5" /> : index + 1}
-                </button>
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    'h-px flex-1',
-                    isLast
-                      ? 'bg-transparent'
-                      : isComplete
-                        ? 'bg-accent-base/40'
-                        : 'bg-border-strong',
-                  )}
-                />
-              </div>
-              <span
-                aria-hidden="true"
-                className={cn(
-                  'mt-2 max-w-full truncate px-1 text-xs',
-                  isActive ? 'text-fg-base font-medium' : 'text-fg-muted',
-                )}
-              >
-                {step.label}
-              </span>
-            </li>
-          );
-        })}
-      </ol>
+                  {step.label}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
     </div>
   );
 }

--- a/services/platform/app/components/ui/wizard/wizard.tsx
+++ b/services/platform/app/components/ui/wizard/wizard.tsx
@@ -15,6 +15,7 @@ import {
   WizardContext,
   type WizardBeforeNext,
   type WizardContextValue,
+  type WizardPrimaryOverride,
   type WizardStatus,
   type WizardStepMeta,
   useWizard,
@@ -64,6 +65,9 @@ export function Wizard({
   const [maxVisitedIndex, setMaxVisitedIndex] = useState(activeIndex);
   const [status, setStatus] = useState<WizardStatus>('idle');
   const [validity, setValidity] = useState<Record<string, boolean>>({});
+  const [primaries, setPrimaries] = useState<
+    Record<string, WizardPrimaryOverride>
+  >({});
   const beforeNextHandlers = useRef<Record<string, WizardBeforeNext>>({});
 
   // Keep maxVisitedIndex in sync when a controlled `activeIndex` advances
@@ -107,6 +111,22 @@ export function Wizard({
     (id: string) => validity[id] ?? true,
     [validity],
   );
+
+  const setStepPrimary = useCallback(
+    (id: string, override: WizardPrimaryOverride | undefined) => {
+      setPrimaries((prev) => {
+        if (!override) {
+          if (!(id in prev)) return prev;
+          const { [id]: _removed, ...rest } = prev;
+          return rest;
+        }
+        return { ...prev, [id]: override };
+      });
+    },
+    [],
+  );
+
+  const activePrimary = activeStep ? primaries[activeStep.id] : undefined;
 
   // Single guarded path for finishing: the `submitting` guard prevents a
   // double-fire (duplicate side effects from repeated Finish clicks) and the
@@ -187,6 +207,8 @@ export function Wizard({
       setStepValid,
       setStepBeforeNext,
       isStepValid,
+      setStepPrimary,
+      activePrimary,
     }),
     [
       steps,
@@ -203,6 +225,8 @@ export function Wizard({
       setStepValid,
       setStepBeforeNext,
       isStepValid,
+      setStepPrimary,
+      activePrimary,
     ],
   );
 

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -27,7 +27,7 @@ interface NotificationBellProps {
  * asChild>` from reaching the button and quietly dropped the click handler.
  */
 const POPOVER_CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-muted text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
 
 export function NotificationBell({
   organizationId,

--- a/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
+++ b/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
@@ -1,14 +1,18 @@
 'use client';
 
+import { Button } from '@tale/ui/button';
 import { Heading } from '@tale/ui/heading';
 import { Text } from '@tale/ui/text';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useMutation } from 'convex/react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ChevronLeft } from 'lucide-react';
 import { useState } from 'react';
 
 import { TaleLogo } from '@/app/components/ui/logo/tale-logo';
-import { type WizardStepMeta } from '@/app/components/ui/wizard/use-wizard';
+import {
+  useWizard,
+  type WizardStepMeta,
+} from '@/app/components/ui/wizard/use-wizard';
 import { Wizard } from '@/app/components/ui/wizard/wizard';
 import { WizardFooter } from '@/app/components/ui/wizard/wizard-footer';
 import { WizardProgress } from '@/app/components/ui/wizard/wizard-progress';
@@ -49,6 +53,10 @@ export function OnboardingWizard({
   );
 
   const [createdOrgId, setCreatedOrgId] = useState<string | null>(null);
+  // Controlled step index so the page header can host the Back control (it
+  // lives outside the wizard's provider). All wizard navigation routes through
+  // `onIndexChange`, keeping this the single source of truth.
+  const [stepIndex, setStepIndex] = useState(0);
 
   const isFirstRun = mode === 'first-run';
 
@@ -60,6 +68,9 @@ export function OnboardingWizard({
         ]
       : []),
     { id: 'workspace', label: t('steps.workspace') },
+    // Optional: the step shows an explicit Skip alongside the primary
+    // Next/Connect button. The primary stays the forward action; Skip is the
+    // de-emphasized secondary on the row below it.
     { id: 'provider', label: t('steps.provider'), optional: true },
     { id: 'finish', label: t('steps.finish') },
   ];
@@ -114,9 +125,26 @@ export function OnboardingWizard({
 
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="mx-auto flex w-full items-center justify-between px-4 py-3">
-        <TaleLogo />
-        <div className="flex items-center gap-2">
+      {/* Three zones: step Back (left, page chrome) · logo (center) ·
+          back-to-app + avatar (right). */}
+      <header className="grid w-full grid-cols-3 items-center px-4 py-3">
+        <div className="justify-self-start">
+          {stepIndex > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={ChevronLeft}
+              onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
+              className="-ml-2"
+            >
+              {tCommon('actions.back')}
+            </Button>
+          )}
+        </div>
+        <div className="justify-self-center">
+          <TaleLogo />
+        </div>
+        <div className="flex items-center gap-2 justify-self-end">
           {/* add-org mode: the user already has a workspace, so let them bail
               out of the flow and return to the app. first-run has no app yet. */}
           {!isFirstRun ? (
@@ -132,22 +160,20 @@ export function OnboardingWizard({
           {user ? <UserButton align="end" /> : null}
         </div>
       </header>
-      <main className="mx-auto w-full max-w-xl flex-1 px-4 py-12">
-        <Heading level={1} className="mb-2">
-          {t('title')}
-        </Heading>
-        <Text variant="muted" className="mb-8 block">
-          {t('subtitle')}
-        </Text>
-
+      <main className="mx-auto w-full max-w-md flex-1 px-4 pt-20 pb-12">
         <Wizard
           steps={steps}
+          activeIndex={stepIndex}
+          onIndexChange={setStepIndex}
           onFinish={finishOnboarding}
           formatProgress={(current, total, label) =>
             t('progress', { current, total, label })
           }
         >
-          <WizardProgress ariaLabel={t('stepsAriaLabel')} />
+          <div className="flex flex-col gap-8">
+            <WizardProgress segmented ariaLabel={t('stepsAriaLabel')} />
+            <StepHero />
+          </div>
 
           {isFirstRun && <PreferencesStep />}
           {isFirstRun && <AccountStep />}
@@ -160,6 +186,7 @@ export function OnboardingWizard({
           <FinishStep onFinishTo={finishTo} />
 
           <WizardFooter
+            stacked
             backLabel={tCommon('actions.back')}
             nextLabel={tCommon('actions.next')}
             finishLabel={t('finish.goToDashboard')}
@@ -167,6 +194,42 @@ export function OnboardingWizard({
           />
         </Wizard>
       </main>
+    </div>
+  );
+}
+
+/**
+ * The wizard's single title/subtitle, driven by the active step — so each step
+ * shows exactly one heading (the hero) instead of duplicating it inside the
+ * step body. Lives inside `<Wizard>` so it can read the active step.
+ */
+function StepHero() {
+  const { t } = useT('onboarding');
+  const { activeStep } = useWizard();
+
+  const copy: Record<string, { title: string; subtitle: string }> = {
+    preferences: {
+      title: t('preferences.heading'),
+      subtitle: t('preferences.why'),
+    },
+    account: { title: t('account.heading'), subtitle: t('account.why') },
+    workspace: { title: t('title'), subtitle: t('subtitle') },
+    provider: { title: t('provider.heading'), subtitle: t('provider.why') },
+    finish: { title: t('finish.heading'), subtitle: t('finish.subtitle') },
+  };
+  const { title, subtitle } = copy[activeStep?.id ?? ''] ?? {
+    title: '',
+    subtitle: '',
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1.5 text-center">
+      <Heading level={1} size="2xl" weight="semibold">
+        {title}
+      </Heading>
+      <Text variant="muted" className="text-base">
+        {subtitle}
+      </Text>
     </div>
   );
 }

--- a/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
+++ b/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
@@ -5,7 +5,7 @@ import { Heading } from '@tale/ui/heading';
 import { Text } from '@tale/ui/text';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useMutation } from 'convex/react';
-import { ArrowLeft, ChevronLeft } from 'lucide-react';
+import { ChevronLeft, X } from 'lucide-react';
 import { useState } from 'react';
 
 import { TaleLogo } from '@/app/components/ui/logo/tale-logo';
@@ -125,8 +125,9 @@ export function OnboardingWizard({
 
   return (
     <div className="flex min-h-screen flex-col">
-      {/* Three zones: step Back (left, page chrome) · logo (center) ·
-          back-to-app + avatar (right). */}
+      {/* Three zones, two distinct affordances: step Back (left) navigates
+          within the flow; the close (right) leaves it. A back-chevron vs an
+          ✕-close, on opposite sides — so they never read as duplicate "Back"s. */}
       <header className="grid w-full grid-cols-3 items-center px-4 py-3">
         <div className="justify-self-start">
           {stepIndex > 0 && (
@@ -145,19 +146,21 @@ export function OnboardingWizard({
           <TaleLogo />
         </div>
         <div className="flex items-center gap-2 justify-self-end">
-          {/* add-org mode: the user already has a workspace, so let them bail
-              out of the flow and return to the app. first-run has no app yet. */}
+          {/* No session yet on first-run until the account step completes. */}
+          {user ? <UserButton align="end" /> : null}
+          {/* add-org mode only: a close affordance to leave setup and return to
+              the app (first-run has no app to return to yet). Rendered as an ✕,
+              not a "Back", so it can't be mistaken for the step-back control. */}
           {!isFirstRun ? (
             <Link
               to="/dashboard"
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm"
+              aria-label={t('backToApp')}
+              title={t('backToApp')}
+              className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-ring inline-flex size-8 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none"
             >
-              <ArrowLeft className="size-4" aria-hidden />
-              {t('backToApp')}
+              <X className="size-4" aria-hidden />
             </Link>
           ) : null}
-          {/* No session yet on first-run until the account step completes. */}
-          {user ? <UserButton align="end" /> : null}
         </div>
       </header>
       <main className="mx-auto w-full max-w-md flex-1 px-4 pt-20 pb-12">

--- a/services/platform/app/features/organization/components/onboarding/steps/account-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/account-step.tsx
@@ -2,10 +2,8 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@tale/ui/button';
-import { Heading } from '@tale/ui/heading';
 import { Stack } from '@tale/ui/layout';
 import { Separator } from '@tale/ui/separator';
-import { Text } from '@tale/ui/text';
 import { useCallback, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -37,7 +35,6 @@ type AccountFormData = {
  */
 export function AccountStep() {
   const { t } = useT('auth');
-  const { t: tOnboarding } = useT('onboarding');
   const { t: tCommon } = useT('common');
   const queryClient = useReactQueryClient();
   const { data: ssoConfig } = useIsSsoConfigured();
@@ -117,11 +114,7 @@ export function AccountStep() {
 
   return (
     <WizardStep id="account" valid={isValid} onBeforeNext={createAccount}>
-      <Heading level={2} className="text-base">
-        {tOnboarding('account.heading')}
-      </Heading>
-      <Text variant="muted">{tOnboarding('account.why')}</Text>
-
+      {/* Heading + description live in the wizard hero now. */}
       <Stack gap={4}>
         <Input
           id="email"

--- a/services/platform/app/features/organization/components/onboarding/steps/finish-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/finish-step.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { Heading } from '@tale/ui/heading';
-import { Text } from '@tale/ui/text';
 import { Bot, KeyRound, Users } from 'lucide-react';
 
 import { WizardStep } from '@/app/components/ui/wizard/wizard';
@@ -57,18 +55,22 @@ export function FinishStep({ onFinishTo }: FinishStepProps) {
 
   return (
     <WizardStep id="finish">
-      <Heading level={2} className="text-base">
-        {t('finish.heading')}
-      </Heading>
-      <Text variant="muted">{t('finish.subtitle')}</Text>
-      <ul role="list" className="mt-2 flex flex-col gap-3">
+      {/* Heading + subtitle live in the wizard hero now. One bordered panel
+          with divided rows (not three separate cards) reads as a single
+          "what's next" list; each row leads with an icon chip. */}
+      <ul
+        role="list"
+        className="divide-border border-border divide-y overflow-hidden rounded-lg border"
+      >
         {items.map(({ target, icon: Icon, text, cta }) => (
           <li
             key={target}
-            className="border-border flex items-center justify-between gap-3 rounded-md border p-3"
+            className="flex items-center justify-between gap-3 p-3"
           >
-            <span className="flex items-start gap-2">
-              <Icon className="text-fg-muted mt-0.5 size-4" aria-hidden />
+            <span className="flex items-center gap-3">
+              <span className="bg-muted text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+                <Icon className="size-4" aria-hidden />
+              </span>
               <span className="text-sm">{text}</span>
             </span>
             <Button

--- a/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Heading } from '@tale/ui/heading';
 import { Text } from '@tale/ui/text';
-import { ExternalLink, KeyRound } from 'lucide-react';
-import { useState } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import { Input } from '@/app/components/ui/forms/input';
+import { useWizard } from '@/app/components/ui/wizard/use-wizard';
 import { WizardStep } from '@/app/components/ui/wizard/wizard';
 import {
   useFetchProviderModels,
@@ -70,8 +70,22 @@ interface OpenRouterStepProps {
  */
 export function OpenRouterStep({ organizationId }: OpenRouterStepProps) {
   const { t } = useT('onboarding');
+  const { setStepPrimary } = useWizard();
   const [apiKey, setApiKey] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // The primary button is always the forward action: the default "Next" while
+  // the field is empty (leaving the key blank just advances — see the helper
+  // note), relabelled to "Connect" once a key is entered so it's clear it will
+  // save + verify before moving on.
+  useEffect(() => {
+    const hasKey = apiKey.trim().length > 0;
+    setStepPrimary(
+      'provider',
+      hasKey ? { label: t('provider.connect'), variant: 'primary' } : undefined,
+    );
+    return () => setStepPrimary('provider', undefined);
+  }, [apiKey, setStepPrimary, t]);
 
   const { mutateAsync: fetchModels } = useFetchProviderModels();
   const { mutateAsync: saveProviderSecret } = useSaveProviderSecret();
@@ -130,39 +144,40 @@ export function OpenRouterStep({ organizationId }: OpenRouterStepProps) {
 
   return (
     <WizardStep id="provider" onBeforeNext={connectOpenRouter}>
-      <Heading level={2} className="text-base">
-        <KeyRound className="text-fg-muted mr-2 inline size-4" aria-hidden />
-        {t('provider.heading')}
-      </Heading>
-      <Text variant="muted">{t('provider.why')}</Text>
+      {/* Heading + description live in the wizard hero now; the body is just
+          the key field and its helper link, grouped tightly together. */}
+      <div className="flex flex-col gap-2">
+        <Input
+          id="openrouter-key"
+          type="password"
+          label={t('provider.keyLabel')}
+          // Renders a muted, normal-weight "(optional)" hint after the label.
+          required={false}
+          placeholder={t('provider.keyPlaceholder')}
+          value={apiKey}
+          onChange={(e) => {
+            setApiKey(e.target.value);
+            if (error) setError(null);
+          }}
+          autoComplete="off"
+          errorMessage={error ?? undefined}
+        />
 
-      <Input
-        id="openrouter-key"
-        type="password"
-        label={t('provider.keyLabel')}
-        placeholder={t('provider.keyPlaceholder')}
-        value={apiKey}
-        onChange={(e) => {
-          setApiKey(e.target.value);
-          if (error) setError(null);
-        }}
-        autoComplete="off"
-        errorMessage={error ?? undefined}
-        description={t('provider.keyHelp')}
-      />
-
-      <Text variant="muted" className="text-sm">
-        {t('provider.hasKeyQuestion')}{' '}
-        <a
-          href={OPENROUTER_KEYS_URL}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="text-accent-base inline-flex items-center gap-1 font-medium hover:underline"
-        >
-          {t('provider.getKeyLink')}
-          <ExternalLink className="size-3.5" aria-hidden />
-        </a>
-      </Text>
+        {/* The label marks the field optional, so the only helper needed is
+            where to get a key. */}
+        <Text variant="muted" className="text-sm">
+          {t('provider.hasKeyQuestion')}{' '}
+          <a
+            href={OPENROUTER_KEYS_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-accent-base inline-flex items-center gap-1 font-medium hover:underline"
+          >
+            {t('provider.getKeyLink')}
+            <ExternalLink className="size-3.5" aria-hidden />
+          </a>
+        </Text>
+      </div>
     </WizardStep>
   );
 }

--- a/services/platform/app/features/organization/components/onboarding/steps/preferences-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/preferences-step.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { Heading } from '@tale/ui/heading';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
-import { Text } from '@tale/ui/text';
 import { ThemeSwitcher } from '@tale/ui/theme-switcher';
 import { useRef, type KeyboardEvent } from 'react';
 
@@ -74,11 +72,7 @@ export function PreferencesStep() {
 
   return (
     <WizardStep id="preferences">
-      <Heading level={2} className="text-base">
-        {t('preferences.heading')}
-      </Heading>
-      <Text variant="muted">{t('preferences.why')}</Text>
-
+      {/* Heading + description live in the wizard hero now. */}
       <fieldset className="flex flex-col gap-2">
         <legend className="text-fg-base mb-1 text-sm font-medium">
           {t('preferences.languageLabel')}

--- a/services/platform/app/features/organization/components/onboarding/steps/workspace-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/workspace-step.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { Heading } from '@tale/ui/heading';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
-import { Text } from '@tale/ui/text';
 import { useQueryClient } from '@tanstack/react-query';
 import { useMutation } from 'convex/react';
 import { useState } from 'react';
@@ -148,10 +146,6 @@ export function WorkspaceStep({ createdOrgId, onCreated }: WorkspaceStepProps) {
       valid={nameValid && Boolean(user)}
       onBeforeNext={createWorkspace}
     >
-      <Heading level={2} className="text-base">
-        {t('workspace.heading')}
-      </Heading>
-      <Text variant="muted">{t('workspace.why')}</Text>
       <Input
         id="org-name"
         type="text"
@@ -162,15 +156,9 @@ export function WorkspaceStep({ createdOrgId, onCreated }: WorkspaceStepProps) {
         placeholder={tSettings('organization.enterCompanyName')}
         errorMessage={nameError}
         disabled={Boolean(createdOrgId)}
-        description={
-          slug
-            ? tSettings('organization.identifierPreview', { slug })
-            : undefined
-        }
       />
       <Select
         label={t('preferences.languageLabel')}
-        description={t('workspace.languageDescription')}
         options={ORG_LOCALES}
         value={orgLocale}
         onValueChange={setOrgLocale}

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -17,9 +17,9 @@ import { ValidationCheckList } from '@/app/components/ui/feedback/validation-che
 import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
-import { Label } from '@/app/components/ui/forms/label';
 import { useHasCredentialAccount } from '@/app/features/auth/hooks/queries';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
+import { SettingsRow } from '@/app/features/settings/components/settings-row';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { useAuth } from '@/app/hooks/use-convex-auth';
@@ -52,10 +52,10 @@ interface SetPasswordFormData {
 
 // =============================================================================
 // Container — owns the loading state (current user + credential probe) and
-// wraps the real `SettingsPage narrow` view in `<Skeletonize>` so the skeleton
-// inherits the SAME narrow centering and section structure (no horizontal
-// shift on load, and no empty-Input → real-value flash). Skeleton-aware leaves
-// (Input, Button) mask themselves while loading.
+// wraps the real full-width view in `<Skeletonize>` so the skeleton inherits
+// the SAME row structure (no horizontal shift on load, and no empty-Input →
+// real-value flash). Skeleton-aware leaves (Input, Button) mask themselves
+// while loading.
 // =============================================================================
 export function AccountForm() {
   const { data: hasCredential, isLoading: isCredentialLoading } =
@@ -70,13 +70,13 @@ export function AccountForm() {
 }
 
 // =============================================================================
-// Plain presentational view — renders the real `SettingsPage narrow` layout.
+// Plain presentational view — renders the real full-width settings layout.
 // Rendered both live and (wrapped in `<Skeletonize>`) as its own skeleton, so
 // loading and loaded layouts are the SAME tree and cannot drift.
 // =============================================================================
 function AccountFormView({ hasCredential }: { hasCredential: boolean }) {
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <ProfileSection />
       <PasswordSection hasCredential={hasCredential} />
       <TwoFactorSection />
@@ -154,38 +154,56 @@ function ProfileSection() {
         id="account-profile-form"
         onSubmit={handleSubmit((values) => save(values))}
       >
-        <fieldset disabled={editor.isLoading} className="contents space-y-4">
-          <Input
-            id="display-name"
+        {/* Settings-row layout (label + helper text left, control pinned
+            right, divider between rows) mirroring the Organization details
+            block. */}
+        <fieldset
+          disabled={editor.isLoading}
+          className="divide-border divide-y"
+        >
+          <SettingsRow
+            className="py-5"
             label={tSettings('account.profile.name')}
-            placeholder={tSettings('account.profile.namePlaceholder')}
-            disabled={editor.isSaving}
-            errorMessage={errors.name?.message}
-            wrapperClassName="max-w-sm"
-            {...register('name')}
-          />
-          <EmailField email={user?.email ?? ''} />
+            description={tSettings('account.profile.nameDescription')}
+          >
+            <div className="w-full sm:w-80">
+              <Input
+                id="display-name"
+                placeholder={tSettings('account.profile.namePlaceholder')}
+                disabled={editor.isSaving}
+                errorMessage={errors.name?.message}
+                wrapperClassName="w-full"
+                {...register('name')}
+              />
+            </div>
+          </SettingsRow>
+
+          <SettingsRow
+            className="py-5"
+            label={tSettings('account.profile.email')}
+            description={tSettings('account.profile.emailDescription')}
+          >
+            <div className="w-full sm:w-80">
+              <EmailField email={user?.email ?? ''} />
+            </div>
+          </SettingsRow>
         </fieldset>
       </Form>
     </SettingsSection>
   );
 }
 
-/** Read-only email row. Visually mirrors the `CopyableField` pill used for the
+/** Read-only email pill. Visually mirrors the `CopyableField` pill used for the
  *  Organization ID elsewhere in settings — same bg, border, radius, padding —
  *  so any "you can read this but can't edit it here" surface looks consistent.
  *  Doesn't render a copy button because nobody copies their own email out of
- *  Account settings. */
+ *  Account settings. The field label lives on the enclosing `SettingsRow`. */
 function EmailField({ email }: { email: string }) {
-  const { t: tSettings } = useT('settings');
   const loading = useSkeleton();
 
   return (
-    <div className="flex max-w-sm flex-col gap-1.5">
-      <Label>{tSettings('account.profile.email')}</Label>
-      <div className="bg-muted/40 ring-border text-muted-foreground flex w-full items-center rounded-lg border px-3 py-2.25 text-sm">
-        {loading ? <SkeletonText /> : email}
-      </div>
+    <div className="bg-muted/40 ring-border text-muted-foreground flex w-full items-center rounded-lg border px-3 py-2.25 text-sm">
+      {loading ? <SkeletonText /> : email}
     </div>
   );
 }
@@ -201,17 +219,17 @@ function PasswordSection({ hasCredential }: PasswordSectionProps) {
 
   return (
     <SettingsSection
+      className="border-border border-t pt-8"
       title={tSettings('account.security.title')}
       description={tSettings('account.security.description')}
-    >
-      <div>
+      action={
         <Button variant="secondary" onClick={() => setOpen(true)}>
           {hasCredential
             ? tAuth('changePassword.title')
             : tAuth('setPassword.title')}
         </Button>
-      </div>
-
+      }
+    >
       {hasCredential ? (
         <ChangePasswordDialog open={open} onOpenChange={setOpen} />
       ) : (

--- a/services/platform/app/features/settings/account/components/chats-section.tsx
+++ b/services/platform/app/features/settings/account/components/chats-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
+import { HStack } from '@tale/ui/layout';
 import { useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -84,26 +85,28 @@ export function ChatsSection() {
 
   return (
     <SettingsSection
+      className="border-border border-t pt-8"
       title={t('account.chats.title')}
       description={t('account.chats.description')}
+      action={
+        <HStack gap={2}>
+          <Button
+            variant="secondary"
+            disabled={activeCount === 0 || isArchiving}
+            onClick={() => setArchiveOpen(true)}
+          >
+            {t('account.chats.archiveAll')}
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={deletableCount === 0 || isDeleting}
+            onClick={() => setDeleteOpen(true)}
+          >
+            {t('account.chats.deleteAll')}
+          </Button>
+        </HStack>
+      }
     >
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Button
-          variant="secondary"
-          disabled={activeCount === 0 || isArchiving}
-          onClick={() => setArchiveOpen(true)}
-        >
-          {t('account.chats.archiveAll')}
-        </Button>
-        <Button
-          variant="destructive"
-          disabled={deletableCount === 0 || isDeleting}
-          onClick={() => setDeleteOpen(true)}
-        >
-          {t('account.chats.deleteAll')}
-        </Button>
-      </div>
-
       <ConfirmDialog
         open={archiveOpen}
         onOpenChange={setArchiveOpen}

--- a/services/platform/app/features/settings/account/components/passkey-section.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.tsx
@@ -2,11 +2,11 @@
 
 import { Button } from '@tale/ui/button';
 import { HStack, Stack, VStack } from '@tale/ui/layout';
-import { PageSection } from '@tale/ui/page-section';
 import { Text } from '@tale/ui/text';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
@@ -83,50 +83,43 @@ export function PasskeySection() {
   }
 
   return (
-    <PageSection
+    <SettingsSection
+      className="border-border border-t pt-8"
       title={t('passkeys.title')}
       description={t('passkeys.description')}
-      titleSize="base"
-      className="pt-4"
+      action={
+        <Button variant="secondary" onClick={() => setRegisterDialogOpen(true)}>
+          {t('passkeys.addButton')}
+        </Button>
+      }
     >
-      <Stack gap={3}>
-        {!isLoading && passkeys && passkeys.length > 0 && (
-          <Stack gap={2}>
-            {passkeys.map((pk) => (
-              <HStack
-                key={pk.id}
-                justify="between"
-                align="center"
-                className="rounded-md border px-3 py-2"
-              >
-                <VStack gap={0} className="min-w-0">
-                  <Text className="truncate text-sm font-medium">
-                    {pk.name?.trim() || t('passkeys.unnamed')}
-                  </Text>
-                </VStack>
-                <Button variant="ghost" size="sm" onClick={() => revoke(pk.id)}>
-                  {t('passkeys.revokeButton')}
-                </Button>
-              </HStack>
-            ))}
-          </Stack>
-        )}
+      {!isLoading && passkeys && passkeys.length > 0 && (
+        <Stack gap={2}>
+          {passkeys.map((pk) => (
+            <HStack
+              key={pk.id}
+              justify="between"
+              align="center"
+              className="rounded-md border px-3 py-2"
+            >
+              <VStack gap={0} className="min-w-0">
+                <Text className="truncate text-sm font-medium">
+                  {pk.name?.trim() || t('passkeys.unnamed')}
+                </Text>
+              </VStack>
+              <Button variant="ghost" size="sm" onClick={() => revoke(pk.id)}>
+                {t('passkeys.revokeButton')}
+              </Button>
+            </HStack>
+          ))}
+        </Stack>
+      )}
 
-        {!isLoading && (!passkeys || passkeys.length === 0) && (
-          <Text variant="muted" className="text-sm">
-            {t('passkeys.empty')}
-          </Text>
-        )}
-
-        <div>
-          <Button
-            variant="secondary"
-            onClick={() => setRegisterDialogOpen(true)}
-          >
-            {t('passkeys.addButton')}
-          </Button>
-        </div>
-      </Stack>
+      {!isLoading && (!passkeys || passkeys.length === 0) && (
+        <Text variant="muted" className="text-sm">
+          {t('passkeys.empty')}
+        </Text>
+      )}
 
       <PasskeyRegisterDialog
         open={registerDialogOpen}
@@ -136,6 +129,6 @@ export function PasskeySection() {
           invalidate();
         }}
       />
-    </PageSection>
+    </SettingsSection>
   );
 }

--- a/services/platform/app/features/settings/account/components/two-factor-section.tsx
+++ b/services/platform/app/features/settings/account/components/two-factor-section.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { HStack, Stack, VStack } from '@tale/ui/layout';
-import { PageSection } from '@tale/ui/page-section';
+import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
@@ -39,7 +39,6 @@ type EnrollState =
     };
 
 export function TwoFactorSection() {
-  const { t } = useT('twoFactor');
   const { data: status } = useConvexQuery(api.two_factor.queries.getStatus, {});
 
   // SSO-only users: hide the section. The backend also rejects enable
@@ -48,19 +47,10 @@ export function TwoFactorSection() {
   // BackupCodesDialogProvider at the root so it's unaffected.
   if (!status || !status.authenticated || !status.hasCredential) return null;
 
-  return (
-    <PageSection
-      title={t('enrollment.title')}
-      description={t('enrollment.description')}
-      titleSize="base"
-      className="pt-4"
-    >
-      {status.twoFactorEnabled ? (
-        <EnrolledState />
-      ) : (
-        <NotEnrolledState enforced={status.enforced} />
-      )}
-    </PageSection>
+  return status.twoFactorEnabled ? (
+    <EnrolledState />
+  ) : (
+    <NotEnrolledState enforced={status.enforced} />
   );
 }
 
@@ -122,17 +112,21 @@ function NotEnrolledState({ enforced }: { enforced: boolean }) {
   }
 
   return (
-    <Stack gap={3}>
+    <SettingsSection
+      className="border-border border-t pt-8"
+      title={t('enrollment.title')}
+      description={t('enrollment.description')}
+      action={
+        <Button onClick={() => setState({ step: 'password' })}>
+          {t('enrollment.enableButton')}
+        </Button>
+      }
+    >
       {enforced && (
         <Text variant="muted" className="text-sm">
           {t('enrollment.requiredByOrg')}
         </Text>
       )}
-      <div>
-        <Button onClick={() => setState({ step: 'password' })}>
-          {t('enrollment.enableButton')}
-        </Button>
-      </div>
 
       <PasswordPromptDialog
         open={state.step === 'password'}
@@ -154,7 +148,7 @@ function NotEnrolledState({ enforced }: { enforced: boolean }) {
           onSubmit={confirmCode}
         />
       )}
-    </Stack>
+    </SettingsSection>
   );
 }
 
@@ -207,18 +201,24 @@ function EnrolledState() {
   }
 
   return (
-    <Stack gap={3}>
+    <SettingsSection
+      className="border-border border-t pt-8"
+      title={t('enrollment.title')}
+      description={t('enrollment.description')}
+      action={
+        <HStack gap={2}>
+          <Button variant="secondary" onClick={() => setRegenOpen(true)}>
+            {t('enrollment.regenerateButton')}
+          </Button>
+          <Button variant="destructive" onClick={() => setDisableOpen(true)}>
+            {t('enrollment.disableButton')}
+          </Button>
+        </HStack>
+      }
+    >
       <Text variant="muted" className="text-sm">
         {t('enrollment.enabledHint')}
       </Text>
-      <HStack gap={2}>
-        <Button variant="secondary" onClick={() => setRegenOpen(true)}>
-          {t('enrollment.regenerateButton')}
-        </Button>
-        <Button variant="destructive" onClick={() => setDisableOpen(true)}>
-          {t('enrollment.disableButton')}
-        </Button>
-      </HStack>
 
       <PasswordPromptDialog
         open={disableOpen}
@@ -245,7 +245,7 @@ function EnrolledState() {
         onSubmit={regenerate}
         error={error}
       />
-    </Stack>
+    </SettingsSection>
   );
 }
 

--- a/services/platform/app/features/settings/branding/components/branding-settings.tsx
+++ b/services/platform/app/features/settings/branding/components/branding-settings.tsx
@@ -112,7 +112,16 @@ export function BrandingSettings() {
   const branding = brandingQuery.data;
 
   return (
-    <Skeletonize loading={abilityLoading || brandingQuery.isPending}>
+    <Skeletonize
+      loading={abilityLoading || brandingQuery.isPending}
+      // The wrapper div Skeletonize always renders sits between the
+      // `min-h-0 flex-1` ContentArea scroll parent and the `fitToContainer`
+      // SettingsPage. Without these flex classes it collapses to content
+      // height, breaking the height chain the preview pane relies on to
+      // stretch to the bottom edge (it then fell back to a fixed
+      // `min-h` approximation that stopped short, leaving a gap).
+      className="flex min-h-0 flex-1 flex-col"
+    >
       <BrandingSettingsView
         organizationId={organizationId}
         branding={branding ?? undefined}

--- a/services/platform/app/features/settings/components/settings-section.tsx
+++ b/services/platform/app/features/settings/components/settings-section.tsx
@@ -44,7 +44,10 @@ export const SettingsSection = forwardRef<HTMLElement, SettingsSectionProps>(
         {...props}
       >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-          <div className="flex min-w-0 flex-col gap-1">
+          {/* Cap the title/description column at a readable line length so long
+              descriptions don't stretch the full content width (and run up
+              against a right-aligned `action`). */}
+          <div className="flex max-w-2xl min-w-0 flex-col gap-1">
             <h2
               id={headingId}
               className="text-foreground text-base leading-tight font-semibold"

--- a/services/platform/app/features/settings/deployment/components/deployment-settings.tsx
+++ b/services/platform/app/features/settings/deployment/components/deployment-settings.tsx
@@ -198,6 +198,7 @@ function PgSection({
   disabled,
   note,
   showSslMode = true,
+  className,
 }: {
   title: string;
   description?: string;
@@ -219,10 +220,13 @@ function PgSection({
    * offering the control would promise a guarantee we can't deliver.
    */
   showSslMode?: boolean;
+  /** Forwarded to the underlying section root (e.g. a divider border). */
+  className?: string;
 }) {
   const { t } = useT('settings');
   return (
     <PageSection
+      className={className}
       title={title}
       description={description}
       action={
@@ -612,282 +616,319 @@ function DeploymentSettingsView({
   }
 
   return (
-    <SettingsPage narrow>
-      {readOnly ||
-      data?.secretsError === 'encrypted_no_key' ||
-      data?.secretsError === 'unreadable' ? (
-        <Stack gap={3}>
-          {readOnly ? (
-            <Alert
-              variant="info"
-              icon={Info}
-              title={t('dataResidency.readOnly.title')}
-              description={
-                <>
-                  {t('dataResidency.readOnly.before')}{' '}
-                  <code>TALE_DEPLOYMENT_CONFIG_ADMINS</code>{' '}
-                  {t('dataResidency.readOnly.after')}
-                  {data?.email ? (
+    <SettingsPage fitToContainer>
+      {/* Page = a scrollable body + a footer docked to the bottom, so the
+          Save / Apply & restart bar stays pinned to the bottom of the viewport
+          regardless of how short the content is (plain `position: sticky` only
+          pins once the content is tall enough to scroll). */}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto pb-8">
+          {readOnly ||
+          data?.secretsError === 'encrypted_no_key' ||
+          data?.secretsError === 'unreadable' ? (
+            <Stack gap={3}>
+              {readOnly ? (
+                <Alert
+                  variant="info"
+                  icon={Info}
+                  title={t('dataResidency.readOnly.title')}
+                  description={
                     <>
-                      {' '}
-                      {t('dataResidency.readOnly.yourEmail', {
-                        email: data.email,
-                      })}
+                      {t('dataResidency.readOnly.before')}{' '}
+                      <code>TALE_DEPLOYMENT_CONFIG_ADMINS</code>{' '}
+                      {t('dataResidency.readOnly.after')}
+                      {data?.email ? (
+                        <>
+                          {' '}
+                          {t('dataResidency.readOnly.yourEmail', {
+                            email: data.email,
+                          })}
+                        </>
+                      ) : null}
                     </>
-                  ) : null}
-                </>
-              }
-            />
+                  }
+                />
+              ) : null}
+              {data?.secretsError === 'encrypted_no_key' ? (
+                <Alert
+                  variant="warning"
+                  description={t('dataResidency.secretsEncryptedNoKey')}
+                />
+              ) : null}
+              {data?.secretsError === 'unreadable' ? (
+                <Alert
+                  variant="warning"
+                  description={t('dataResidency.secretsUnreadable')}
+                />
+              ) : null}
+            </Stack>
           ) : null}
-          {data?.secretsError === 'encrypted_no_key' ? (
-            <Alert
-              variant="warning"
-              description={t('dataResidency.secretsEncryptedNoKey')}
-            />
-          ) : null}
-          {data?.secretsError === 'unreadable' ? (
-            <Alert
-              variant="warning"
-              description={t('dataResidency.secretsUnreadable')}
-            />
-          ) : null}
-        </Stack>
-      ) : null}
 
-      <PgSection
-        title={t('dataResidency.knowledge.title')}
-        description={t('dataResidency.knowledge.description')}
-        state={knowledge}
-        setState={setKnowledge}
-        secretMasked={
-          secretState['dataStores.knowledgePostgres.password']?.masked
-        }
-        secretPresent={
-          secretState['dataStores.knowledgePostgres.password']?.present
-        }
-        onTest={() => void runTest('knowledgePostgres')}
-        testing={testing === 'knowledgePostgres'}
-        testResult={testResults.knowledgePostgres}
-        disabled={readOnly}
-        note={<Alert description={t('dataResidency.knowledge.paradeDbNote')} />}
-      />
-
-      <PageSection
-        title={t('dataResidency.storage.title')}
-        description={t('dataResidency.storage.description')}
-        action={
-          <Switch
-            label={t('dataResidency.storage.externalS3')}
-            hideLabelOnMobile
-            checked={storage.s3}
+          <PgSection
+            title={t('dataResidency.knowledge.title')}
+            description={t('dataResidency.knowledge.description')}
+            state={knowledge}
+            setState={setKnowledge}
+            secretMasked={
+              secretState['dataStores.knowledgePostgres.password']?.masked
+            }
+            secretPresent={
+              secretState['dataStores.knowledgePostgres.password']?.present
+            }
+            onTest={() => void runTest('knowledgePostgres')}
+            testing={testing === 'knowledgePostgres'}
+            testResult={testResults.knowledgePostgres}
             disabled={readOnly}
-            onCheckedChange={(checked) =>
-              setStorage({ ...storage, s3: checked })
+            note={
+              <Alert description={t('dataResidency.knowledge.paradeDbNote')} />
             }
           />
-        }
-      >
-        {storage.s3 ? (
-          <Stack gap={5}>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Input
-                label={t('dataResidency.storage.region')}
-                value={storage.region}
-                disabled={readOnly}
-                onChange={(e) =>
-                  setStorage({ ...storage, region: e.target.value })
-                }
-              />
-              <Input
-                label={t('dataResidency.storage.endpoint')}
-                value={storage.endpoint}
-                disabled={readOnly}
-                onChange={(e) =>
-                  setStorage({ ...storage, endpoint: e.target.value })
-                }
-              />
-            </div>
-            <Switch
-              label={t('dataResidency.storage.forcePathStyle')}
-              checked={storage.forcePathStyle}
-              disabled={readOnly}
-              onCheckedChange={(checked) =>
-                setStorage({ ...storage, forcePathStyle: checked })
-              }
-            />
-            <FormSection label={t('dataResidency.storage.bucketsLabel')}>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <Input
-                  label={t('dataResidency.storage.bucket.files')}
-                  value={storage.files}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, files: e.target.value })
-                  }
-                />
-                <Input
-                  label={t('dataResidency.storage.bucket.exports')}
-                  value={storage.exports}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, exports: e.target.value })
-                  }
-                />
-                <Input
-                  label={t('dataResidency.storage.bucket.snapshotImports')}
-                  value={storage.snapshotImports}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, snapshotImports: e.target.value })
-                  }
-                />
-                <Input
-                  label={t('dataResidency.storage.bucket.modules')}
-                  value={storage.modules}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, modules: e.target.value })
-                  }
-                />
-                <Input
-                  label={t('dataResidency.storage.bucket.search')}
-                  value={storage.search}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, search: e.target.value })
-                  }
-                />
-              </div>
-            </FormSection>
-            <FormSection label={t('dataResidency.storage.credentialsLabel')}>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <Input
-                  label={t('dataResidency.storage.accessKeyId')}
-                  value={storage.accessKeyId}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, accessKeyId: e.target.value })
-                  }
-                  description={
-                    secretState['dataStores.convexStorage.accessKeyId']?.masked
-                      ? t('dataResidency.storage.accessKeyIdStoredHint', {
-                          masked:
-                            secretState['dataStores.convexStorage.accessKeyId']
-                              .masked,
-                        })
-                      : t('dataResidency.storage.writeOnly')
-                  }
-                />
-                <Input
-                  label={t('dataResidency.storage.secretAccessKey')}
-                  type="password"
-                  value={storage.secretAccessKey}
-                  disabled={readOnly}
-                  onChange={(e) =>
-                    setStorage({ ...storage, secretAccessKey: e.target.value })
-                  }
-                  description={t('dataResidency.storage.writeOnly')}
-                />
-              </div>
-            </FormSection>
-            <HStack gap={3} align="center" className="flex-wrap">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => void runTest('convexStorage')}
-                disabled={readOnly || testing === 'convexStorage'}
-              >
-                {testing === 'convexStorage'
-                  ? t('dataResidency.testing')
-                  : t('dataResidency.storage.testReachability')}
-              </Button>
-              <TestResultLine
-                result={testResults.convexStorage}
-                okLabel={t('dataResidency.storage.reachable')}
-              />
-            </HStack>
-            <Alert
-              variant="warning"
-              description={t('dataResidency.storage.greenfieldWarning')}
-            />
-          </Stack>
-        ) : (
-          <p className="text-muted-foreground text-sm">
-            {t('dataResidency.storage.localStorageNote')}
-          </p>
-        )}
-      </PageSection>
 
-      {/* Advanced Convex metadata DB — reuses the Postgres section chrome; its
+          <PageSection
+            className="border-border border-t pt-8"
+            title={t('dataResidency.storage.title')}
+            description={t('dataResidency.storage.description')}
+            action={
+              <Switch
+                label={t('dataResidency.storage.externalS3')}
+                hideLabelOnMobile
+                checked={storage.s3}
+                disabled={readOnly}
+                onCheckedChange={(checked) =>
+                  setStorage({ ...storage, s3: checked })
+                }
+              />
+            }
+          >
+            {storage.s3 ? (
+              <Stack gap={5}>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <Input
+                    label={t('dataResidency.storage.region')}
+                    value={storage.region}
+                    disabled={readOnly}
+                    onChange={(e) =>
+                      setStorage({ ...storage, region: e.target.value })
+                    }
+                  />
+                  <Input
+                    label={t('dataResidency.storage.endpoint')}
+                    value={storage.endpoint}
+                    disabled={readOnly}
+                    onChange={(e) =>
+                      setStorage({ ...storage, endpoint: e.target.value })
+                    }
+                  />
+                </div>
+                <Switch
+                  label={t('dataResidency.storage.forcePathStyle')}
+                  checked={storage.forcePathStyle}
+                  disabled={readOnly}
+                  onCheckedChange={(checked) =>
+                    setStorage({ ...storage, forcePathStyle: checked })
+                  }
+                />
+                <FormSection label={t('dataResidency.storage.bucketsLabel')}>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <Input
+                      label={t('dataResidency.storage.bucket.files')}
+                      value={storage.files}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({ ...storage, files: e.target.value })
+                      }
+                    />
+                    <Input
+                      label={t('dataResidency.storage.bucket.exports')}
+                      value={storage.exports}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({ ...storage, exports: e.target.value })
+                      }
+                    />
+                    <Input
+                      label={t('dataResidency.storage.bucket.snapshotImports')}
+                      value={storage.snapshotImports}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({
+                          ...storage,
+                          snapshotImports: e.target.value,
+                        })
+                      }
+                    />
+                    <Input
+                      label={t('dataResidency.storage.bucket.modules')}
+                      value={storage.modules}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({ ...storage, modules: e.target.value })
+                      }
+                    />
+                    <Input
+                      label={t('dataResidency.storage.bucket.search')}
+                      value={storage.search}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({ ...storage, search: e.target.value })
+                      }
+                    />
+                  </div>
+                </FormSection>
+                <FormSection
+                  label={t('dataResidency.storage.credentialsLabel')}
+                >
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <Input
+                      label={t('dataResidency.storage.accessKeyId')}
+                      value={storage.accessKeyId}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({ ...storage, accessKeyId: e.target.value })
+                      }
+                      description={
+                        secretState['dataStores.convexStorage.accessKeyId']
+                          ?.masked
+                          ? t('dataResidency.storage.accessKeyIdStoredHint', {
+                              masked:
+                                secretState[
+                                  'dataStores.convexStorage.accessKeyId'
+                                ].masked,
+                            })
+                          : t('dataResidency.storage.writeOnly')
+                      }
+                    />
+                    <Input
+                      label={t('dataResidency.storage.secretAccessKey')}
+                      type="password"
+                      value={storage.secretAccessKey}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setStorage({
+                          ...storage,
+                          secretAccessKey: e.target.value,
+                        })
+                      }
+                      description={t('dataResidency.storage.writeOnly')}
+                    />
+                  </div>
+                </FormSection>
+                <HStack gap={3} align="center" className="flex-wrap">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void runTest('convexStorage')}
+                    disabled={readOnly || testing === 'convexStorage'}
+                  >
+                    {testing === 'convexStorage'
+                      ? t('dataResidency.testing')
+                      : t('dataResidency.storage.testReachability')}
+                  </Button>
+                  <TestResultLine
+                    result={testResults.convexStorage}
+                    okLabel={t('dataResidency.storage.reachable')}
+                  />
+                </HStack>
+                <Alert
+                  variant="warning"
+                  description={t('dataResidency.storage.greenfieldWarning')}
+                />
+              </Stack>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                {t('dataResidency.storage.localStorageNote')}
+              </p>
+            )}
+          </PageSection>
+
+          {/* Advanced Convex metadata DB — reuses the Postgres section chrome; its
           own header switch toggles `enabled`. Titled "(advanced)" rather than
           hidden behind a disclosure so it shares the rhythm of the sections
           above. */}
-      <PgSection
-        title={t('dataResidency.appDb.summary')}
-        description={t('dataResidency.appDb.description')}
-        state={appPg}
-        setState={setAppPg}
-        secretMasked={secretState['dataStores.appPostgres.password']?.masked}
-        secretPresent={secretState['dataStores.appPostgres.password']?.present}
-        onTest={() => void runTest('appPostgres')}
-        testing={testing === 'appPostgres'}
-        testResult={testResults.appPostgres}
-        disabled={readOnly}
-        showSslMode={false}
-        note={
-          <p className="text-muted-foreground text-xs">
-            {t('dataResidency.appDb.databaseNameNote')}{' '}
-            {t('dataResidency.appDb.sslModeNote')}
-          </p>
-        }
-      />
-
-      <Stack gap={4}>
-        {error ? <Alert variant="destructive" description={error} /> : null}
-        {savedOk && !isDirty ? (
-          <Alert
-            description={
-              <>
-                <strong>{t('dataResidency.saved.title')}</strong>{' '}
-                {t('dataResidency.saved.runPrefix')}{' '}
-                <code>docker compose restart convex</code>{' '}
-                {t('dataResidency.saved.orPrefix')}{' '}
-                <code>tale deploy --services convex</code>{' '}
-                {t('dataResidency.saved.tail')}
-              </>
+          <PgSection
+            className="border-border border-t pt-8"
+            title={t('dataResidency.appDb.summary')}
+            description={t('dataResidency.appDb.description')}
+            state={appPg}
+            setState={setAppPg}
+            secretMasked={
+              secretState['dataStores.appPostgres.password']?.masked
+            }
+            secretPresent={
+              secretState['dataStores.appPostgres.password']?.present
+            }
+            onTest={() => void runTest('appPostgres')}
+            testing={testing === 'appPostgres'}
+            testResult={testResults.appPostgres}
+            disabled={readOnly}
+            showSslMode={false}
+            note={
+              <p className="text-muted-foreground text-xs">
+                {t('dataResidency.appDb.databaseNameNote')}{' '}
+                {t('dataResidency.appDb.sslModeNote')}
+              </p>
             }
           />
-        ) : null}
+        </div>
 
-        <HStack gap={3} align="center" className="flex-wrap">
-          <Button
-            onClick={() => void onSave()}
-            disabled={readOnly || saving || !isDirty}
-          >
-            {saving ? t('dataResidency.saving') : t('dataResidency.save')}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={() => setRestartConfirmOpen(true)}
-            // Gate on a clean form: a restart applies the LAST-SAVED on-disk
-            // config, so allowing it while dirty would silently bounce into a
-            // config that differs from what's on screen.
-            disabled={readOnly || restarting || isDirty}
-            title={t('dataResidency.applyRestartTitle')}
-          >
-            {restarting
-              ? t('dataResidency.restarting')
-              : t('dataResidency.applyRestart')}
-          </Button>
-          {isDirty ? (
-            <span className="text-muted-foreground text-sm">
-              {t('dataResidency.applyRestartDirtyHint')}
-            </span>
-          ) : restartMsg ? (
-            <span className="text-muted-foreground text-sm">{restartMsg}</span>
-          ) : null}
-        </HStack>
-      </Stack>
+        {/* Footer docked to the bottom of the page (outside the scroll body)
+            so Save / Apply & restart stay reachable regardless of content
+            height; the top border separates actions from the sections, and
+            `-mx-4 px-4` bleeds the background to the content-area gutters. */}
+        <div className="bg-background border-border -mx-4 border-t px-4 pt-4">
+          <Stack gap={3}>
+            {error ? <Alert variant="destructive" description={error} /> : null}
+            {savedOk && !isDirty ? (
+              <Alert
+                description={
+                  <>
+                    <strong>{t('dataResidency.saved.title')}</strong>{' '}
+                    {t('dataResidency.saved.runPrefix')}{' '}
+                    <code>docker compose restart convex</code>{' '}
+                    {t('dataResidency.saved.orPrefix')}{' '}
+                    <code>tale deploy --services convex</code>{' '}
+                    {t('dataResidency.saved.tail')}
+                  </>
+                }
+              />
+            ) : null}
+
+            {/* Status text on the left (`mr-auto`), actions right-aligned —
+                the standard footer/action-bar layout. Save comes before
+                Apply & restart to match the workflow order (save, then apply). */}
+            <HStack gap={3} align="center" justify="end" className="flex-wrap">
+              {isDirty ? (
+                <span className="text-muted-foreground mr-auto text-sm">
+                  {t('dataResidency.applyRestartDirtyHint')}
+                </span>
+              ) : restartMsg ? (
+                <span className="text-muted-foreground mr-auto text-sm">
+                  {restartMsg}
+                </span>
+              ) : null}
+              <Button
+                onClick={() => void onSave()}
+                disabled={readOnly || saving || !isDirty}
+              >
+                {saving ? t('dataResidency.saving') : t('dataResidency.save')}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setRestartConfirmOpen(true)}
+                // Gate on a clean form: a restart applies the LAST-SAVED on-disk
+                // config, so allowing it while dirty would silently bounce into a
+                // config that differs from what's on screen.
+                disabled={readOnly || restarting || isDirty}
+                title={t('dataResidency.applyRestartTitle')}
+              >
+                {restarting
+                  ? t('dataResidency.restarting')
+                  : t('dataResidency.applyRestart')}
+              </Button>
+            </HStack>
+          </Stack>
+        </div>
+      </div>
 
       <ConfirmDialog
         open={restartConfirmOpen}
@@ -929,7 +970,7 @@ export function DeploymentSettings() {
   // form — that would imply "no overrides configured" when the truth is unknown.
   if (query.isError) {
     return (
-      <SettingsPage narrow>
+      <SettingsPage>
         <Alert
           variant="warning"
           description={t('dataResidency.errors.readFailed', {
@@ -941,7 +982,14 @@ export function DeploymentSettings() {
   }
 
   return (
-    <Skeletonize loading={abilityLoading || query.isPending}>
+    // Flex classes so this wrapper carries ContentArea's bounded height down to
+    // the `fitToContainer` SettingsPage — without them the chain breaks and the
+    // docked footer can't be pushed to the bottom (it collapses to content
+    // height). Same fix as the Branding settings wrapper.
+    <Skeletonize
+      loading={abilityLoading || query.isPending}
+      className="flex min-h-0 flex-1 flex-col"
+    >
       <DeploymentSettingsView data={query.data} />
     </Skeletonize>
   );

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -19,6 +19,7 @@ import { Select } from '@/app/components/ui/forms/select';
 import { useOrganization } from '@/app/features/organization/hooks/queries';
 import { useDeleteOrganization } from '@/app/features/organization/hooks/use-delete-organization';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
+import { SettingsRow } from '@/app/features/settings/components/settings-row';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { MembersSettings } from '@/app/features/settings/organization/components/members-settings';
 import { useMembers } from '@/app/features/settings/organization/hooks/queries';
@@ -76,10 +77,10 @@ function parseMetadata(metadata: unknown): {
 }
 
 // =============================================================================
-// Plain presentational view — renders the real `SettingsPage narrow` layout
+// Plain presentational view — renders the full-width settings-row layout
 // from an injected controller. Rendered both live and (wrapped in
 // `<Skeletonize>`) as its own skeleton, so the skeleton inherits the exact
-// `narrow` centering and section structure — it can't drift horizontally or
+// row structure and control widths — it can't drift horizontally or
 // vertically from the loaded content.
 // =============================================================================
 export function OrganizationSettingsView({
@@ -117,7 +118,13 @@ export function OrganizationSettingsView({
   );
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
+      {/* Settings-row layout: each field is a horizontal row with its
+          label + helper text on the left and the control pinned right, with
+          a divider between rows. The form (name + locale) and the read-only
+          Organization ID share one divided list so they read as one
+          continuous block; Save/Discard live in the settings header via the
+          registered editor. */}
       <SettingsSection
         title={tSettings('organization.detailsTitle')}
         description={tSettings('organization.detailsDescription')}
@@ -126,67 +133,82 @@ export function OrganizationSettingsView({
           id="organization-form"
           onSubmit={handleSubmit((values) => onSave(values))}
         >
-          {/* `max-w-sm` lives on the field column (not each control) so the
-              full-width skeleton masks resolve to the same width as the loaded
-              `max-w-sm` controls — no horizontal shrink when data lands. */}
-          <fieldset
-            disabled={isLoading}
-            className="flex max-w-sm flex-col gap-4"
-          >
-            <Input
-              id="org-name"
+          <fieldset disabled={isLoading} className="divide-border divide-y">
+            <SettingsRow
+              className="py-5"
               label={tSettings('organization.title')}
-              {...register('name')}
-            />
-            {/* Controlled via RHF `Controller`: the field registers itself so
-                dirty tracking is automatic (no `setValue(..., { shouldDirty })`
-                to forget). `field.value ?? ''` keeps Radix controlled from the
-                first render before the form resets to server data. */}
-            <Controller
-              control={control}
-              name="defaultLocale"
-              render={({ field }) => (
-                <Select
-                  id="default-locale"
-                  label={tSettings('organization.defaultLocale')}
-                  value={field.value ?? ''}
-                  onValueChange={(value) => {
-                    // Radix emits a spurious `onValueChange('')` while its value
-                    // and options settle during cold load; drop it (`''` is
-                    // never a valid locale) so it can't false-dirty the form on
-                    // a page the user only opened.
-                    if (!value) return;
-                    field.onChange(value);
-                  }}
-                  disabled={isSaving || isLoading}
-                  options={localeOptions}
+              description={tSettings('organization.nameDescription')}
+            >
+              {/* Fixed-width control column, full-width on mobile where the row
+                stacks. `wrapperClassName="w-full"` lets the bare Input fill it
+                so its skeleton mask matches the loaded width. */}
+              <div className="w-full sm:w-80">
+                <Input
+                  id="org-name"
+                  {...register('name')}
+                  wrapperClassName="w-full"
                 />
-              )}
-            />
+              </div>
+            </SettingsRow>
+
+            <SettingsRow
+              className="py-5"
+              label={tSettings('organization.defaultLocale')}
+              description={tSettings('organization.localeDescription')}
+            >
+              <div className="w-full sm:w-80">
+                {/* Controlled via RHF `Controller`: the field registers itself so
+                  dirty tracking is automatic (no `setValue(..., { shouldDirty })`
+                  to forget). `field.value ?? ''` keeps Radix controlled from the
+                  first render before the form resets to server data. */}
+                <Controller
+                  control={control}
+                  name="defaultLocale"
+                  render={({ field }) => (
+                    <Select
+                      id="default-locale"
+                      value={field.value ?? ''}
+                      onValueChange={(value) => {
+                        // Radix emits a spurious `onValueChange('')` while its
+                        // value and options settle during cold load; drop it
+                        // (`''` is never a valid locale) so it can't false-dirty
+                        // the form on a page the user only opened.
+                        if (!value) return;
+                        field.onChange(value);
+                      }}
+                      disabled={isSaving || isLoading}
+                      options={localeOptions}
+                    />
+                  )}
+                />
+              </div>
+            </SettingsRow>
+
+            <SettingsRow
+              className="py-5"
+              label={tSettings('organization.organizationId')}
+              description={tSettings('organization.organizationIdDescription')}
+            >
+              <div className="w-full sm:w-80">
+                <CopyableField
+                  value={organization?._id ?? ''}
+                  copyAriaLabel={tSettings('organization.copyOrganizationId')}
+                />
+              </div>
+            </SettingsRow>
           </fieldset>
         </Form>
       </SettingsSection>
 
-      <SettingsSection
-        title={tSettings('organization.identifiersTitle')}
-        description={tSettings('organization.identifiersDescription')}
-      >
-        {/* `max-w-sm` on the wrapper (not the field) so the full-width
-            skeleton mask matches the loaded field width — no shrink on load. */}
-        <div className="max-w-sm">
-          <CopyableField
-            label={tSettings('organization.organizationId')}
-            description={tSettings('organization.organizationIdDescription')}
-            value={organization?._id ?? ''}
-            copyAriaLabel={tSettings('organization.copyOrganizationId')}
-          />
-        </div>
-      </SettingsSection>
-
+      {/* Light full-width divider marks the boundary between the
+          organization-details block and the Members section — the within-block
+          rows already use dividers, so without it the two groups blur together
+          across the gap. `pt-8` keeps the heading off the line. */}
       <SettingsSection
         title={tSettings('organization.membersSectionTitle')}
         description={tSettings('organization.membersDescription')}
         gap={5}
+        className="border-border border-t pt-8"
       >
         <MembersSettings
           organizationId={organizationId}

--- a/services/platform/app/features/settings/runtimes/runtimes-settings.tsx
+++ b/services/platform/app/features/settings/runtimes/runtimes-settings.tsx
@@ -96,7 +96,10 @@ export function RuntimesSettings({
         </Text>
       </SettingsSection>
 
-      <SettingsSection title={t('list.title')}>
+      <SettingsSection
+        className="border-border border-t pt-8"
+        title={t('list.title')}
+      >
         {daemons.length === 0 ? (
           <EmptyState
             icon={Cpu}

--- a/services/platform/app/features/settings/teams/components/teams-settings.tsx
+++ b/services/platform/app/features/settings/teams/components/teams-settings.tsx
@@ -36,7 +36,7 @@ export function TeamsSettings({ organizationId }: TeamsSettingsProps) {
   }
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SettingsSection
         title={tNav('teams')}
         description={tSettings('teams.sectionDescription')}

--- a/services/platform/app/features/settings/webdav/components/webdav-settings.tsx
+++ b/services/platform/app/features/settings/webdav/components/webdav-settings.tsx
@@ -16,6 +16,7 @@ import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
+import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
@@ -42,6 +43,7 @@ type RevealedPassword = { password: string; prefix: string } | null;
  */
 export function WebdavSettings(props: WebdavSettingsProps) {
   const { t } = useT('webdav');
+  const { user } = useAuth();
   const rows = useWebdavAppPasswords(props.organizationId);
   const [createOpen, setCreateOpen] = useState(false);
   const [revealed, setRevealed] = useState<RevealedPassword>(null);
@@ -56,14 +58,12 @@ export function WebdavSettings(props: WebdavSettingsProps) {
       >
         <Stack gap={4}>
           <CopyableField label="URL" value={url} mono />
-          <div className="flex flex-col gap-1">
-            <Text as="span" variant="label">
-              {t('connectionDetails.usernameLabel')}
-            </Text>
-            <Text as="span" variant="muted" className="text-sm">
-              {t('connectionDetails.usernameHelp')}
-            </Text>
-          </div>
+          <CopyableField
+            label={t('connectionDetails.usernameLabel')}
+            value={user?.email ?? ''}
+            description={t('connectionDetails.usernameHelp')}
+            copyAriaLabel={t('connectionDetails.copyUsername')}
+          />
           <div className="flex flex-col gap-1">
             <Text as="span" variant="label">
               {t('connectionDetails.passwordLabel')}
@@ -76,6 +76,7 @@ export function WebdavSettings(props: WebdavSettingsProps) {
       </SettingsSection>
 
       <SettingsSection
+        className="border-border border-t pt-8"
         title={t('list.title')}
         description={t('create.description')}
         action={

--- a/services/platform/app/routes/dashboard/$id/settings.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings.tsx
@@ -40,7 +40,10 @@ function SettingsLayout() {
   const usesBoundedLayout =
     location.pathname.includes('/settings/governance') ||
     location.pathname.includes('/settings/api') ||
-    location.pathname.includes('/settings/branding');
+    location.pathname.includes('/settings/branding') ||
+    // Data residency docks its Save / Apply & restart bar to the bottom, so it
+    // needs ContentArea bounded for the page's internal scroll body + footer.
+    location.pathname.includes('/settings/deployment');
 
   return (
     <ActiveEditorProvider>

--- a/services/platform/app/routes/dashboard/$id/settings/api/mcp.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/mcp.tsx
@@ -34,7 +34,7 @@ function ApiMcpPage() {
   // page title) — the settings rail already names the page; the former
   // header action moves into the section header.
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SettingsSection
         title={tNav('mcp')}
         description={tMcp('description')}

--- a/services/platform/app/routes/dashboard/$id/settings/api/runtimes.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/runtimes.tsx
@@ -14,7 +14,7 @@ function ApiRuntimesPage() {
 
   // Access is gated by the parent `api` route layout.
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <RuntimesSettings organizationId={organizationId} />
     </SettingsPage>
   );

--- a/services/platform/app/routes/dashboard/$id/settings/api/webdav.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/webdav.tsx
@@ -33,7 +33,7 @@ function ApiWebdavPage() {
 
   // Access is gated by the parent `api` route layout.
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <WebdavSettings
         organizationId={organizationId}
         orgSlug={orgSlug}

--- a/services/platform/app/routes/dashboard/$id/settings/governance/content-models.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/content-models.tsx
@@ -31,7 +31,7 @@ function ContentModelsRoute() {
   // under the page's skeletonization — a lazy chunk's inner Suspense fallback
   // would otherwise let one editor pop in alone.
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SystemPromptEditor organizationId={organizationId} />
       <DefaultModelEditor organizationId={organizationId} />
       <ModelAccessEditor organizationId={organizationId} />

--- a/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
@@ -33,7 +33,7 @@ function PoliciesLimitsRoute() {
   const { id: organizationId } = Route.useParams();
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <BudgetEditor organizationId={organizationId} />
       <UploadPolicyEditor organizationId={organizationId} />
       <RetentionEditor organizationId={organizationId} />

--- a/services/platform/app/routes/dashboard/$id/settings/governance/run-code-policy.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/run-code-policy.tsx
@@ -199,7 +199,7 @@ function RunCodePolicyRoute() {
   }, [testInput, testBucket, liveDraft]);
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <PageSection
         title={t('runCodePolicy.title')}
         description={t('runCodePolicy.description')}

--- a/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
@@ -16,7 +16,7 @@ function ProvidersIndexRoute() {
   const { t: tSettings } = useT('settings');
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SettingsSection
         title={tNav('providers')}
         description={tSettings('menu.providers.description')}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2225,7 +2225,7 @@
   },
   "onboarding": {
     "title": "Richte deinen Arbeitsbereich ein",
-    "subtitle": "Ein paar schnelle Schritte und du bist startklar.",
+    "subtitle": "Nur ein paar schnelle Schritte, bis dein Arbeitsbereich einsatzbereit ist.",
     "backToApp": "Zurück zur App",
     "stepsAriaLabel": "Onboarding-Schritte",
     "progress": "Schritt {current} von {total}: {label}",
@@ -2253,7 +2253,8 @@
     },
     "provider": {
       "heading": "OpenRouter verbinden",
-      "why": "Ein OpenRouter-Schlüssel schaltet Chat, Bildgenerierung & -bearbeitung, Sprachmodus und mehr über Hunderte Modelle aller großen Anbieter frei. Wir konfigurieren eine empfohlene Auswahl vor, damit du sofort loslegen kannst.",
+      "connect": "Verbinden",
+      "why": "Ein Schlüssel schaltet Hunderte Modelle für Chat, Bilder, Sprache und mehr frei – wir konfigurieren eine empfohlene Auswahl vor, damit du sofort loslegen kannst.",
       "keyLabel": "OpenRouter-API-Schlüssel",
       "keyPlaceholder": "sk-or-...",
       "keyHelp": "Verschlüsselt gespeichert. Leer lassen, um dies später in den Einstellungen einzurichten.",
@@ -4579,6 +4580,8 @@
       "profile": {
         "title": "Profil",
         "description": "Dein Anzeigename und deine E-Mail — sichtbar für deine Teamkollegen.",
+        "nameDescription": "Der Name, der deinen Teamkollegen angezeigt wird.",
+        "emailDescription": "Wird zur Anmeldung und für Benachrichtigungen verwendet.",
         "name": "Anzeigename",
         "namePlaceholder": "Gib deinen Namen ein",
         "email": "E-Mail",
@@ -4607,6 +4610,8 @@
       "title": "Organisation (optional)",
       "detailsTitle": "Organisationsdetails",
       "detailsDescription": "Grundlegende Informationen zu deiner Organisation.",
+      "nameDescription": "Der Anzeigename deiner Organisation.",
+      "localeDescription": "Die Hauptsprache deiner Organisation.",
       "identifiersTitle": "Kennungen",
       "identifiersDescription": "Schreibgeschützte Referenzen für API-Aufrufe oder den Support.",
       "organizationId": "Organisations-ID",
@@ -7033,6 +7038,7 @@
       "title": "Verbindungsdaten",
       "usernameLabel": "Benutzername",
       "usernameHelp": "Deine Tale-Konto-E-Mail (oder dein Benutzername)",
+      "copyUsername": "Benutzername kopieren",
       "passwordLabel": "Passwort",
       "passwordHelp": "Ein App-Passwort, das du unten erzeugst — nicht dein Konto-Passwort."
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2225,7 +2225,7 @@
   },
   "onboarding": {
     "title": "Set up your workspace",
-    "subtitle": "A few quick steps and you're ready to go.",
+    "subtitle": "Just a few quick steps to get your workspace up and running.",
     "backToApp": "Back to app",
     "stepsAriaLabel": "Onboarding steps",
     "progress": "Step {current} of {total}: {label}",
@@ -2253,7 +2253,8 @@
     },
     "provider": {
       "heading": "Connect OpenRouter",
-      "why": "One OpenRouter key unlocks chat, image generation & editing, voice and more across hundreds of models from every major lab. We'll preconfigure a recommended set so you're ready immediately.",
+      "connect": "Connect",
+      "why": "One key unlocks hundreds of models for chat, images, voice, and more — we'll preconfigure a recommended set so you're ready right away.",
       "keyLabel": "OpenRouter API key",
       "keyPlaceholder": "sk-or-...",
       "keyHelp": "Stored encrypted. Leave blank to set this up later in Settings.",
@@ -4840,6 +4841,8 @@
       "profile": {
         "title": "Profile",
         "description": "Your display name and email — visible to your teammates.",
+        "nameDescription": "The name shown to your teammates.",
+        "emailDescription": "Used to sign in and receive notifications.",
         "name": "Display name",
         "namePlaceholder": "Enter your name",
         "email": "Email",
@@ -4868,6 +4871,8 @@
       "title": "Organization name",
       "detailsTitle": "Organization details",
       "detailsDescription": "Basic information about your organization.",
+      "nameDescription": "The display name for your organization.",
+      "localeDescription": "Primary language for your organization.",
       "identifiersTitle": "Identifiers",
       "identifiersDescription": "Read-only references you may need when using the API or contacting support.",
       "organizationId": "Organization ID",
@@ -7033,6 +7038,7 @@
       "title": "Connection details",
       "usernameLabel": "Username",
       "usernameHelp": "Your Tale account email (or username)",
+      "copyUsername": "Copy username",
       "passwordLabel": "Password",
       "passwordHelp": "An app-password you generate below — not your account password."
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2226,7 +2226,7 @@
   },
   "onboarding": {
     "title": "Configure ton espace de travail",
-    "subtitle": "Quelques étapes rapides et c'est prêt.",
+    "subtitle": "Quelques étapes rapides pour préparer ton espace de travail.",
     "backToApp": "Retour à l'application",
     "stepsAriaLabel": "Étapes d'intégration",
     "progress": "Étape {current} sur {total} : {label}",
@@ -2254,7 +2254,8 @@
     },
     "provider": {
       "heading": "Connecter OpenRouter",
-      "why": "Une seule clé OpenRouter débloque le chat, la génération et l'édition d'images, le mode vocal et plus encore, parmi des centaines de modèles de tous les grands laboratoires. Nous préconfigurons une sélection recommandée pour que tu sois prêt immédiatement.",
+      "connect": "Connecter",
+      "why": "Une seule clé débloque des centaines de modèles pour le chat, les images, la voix et plus encore — nous préconfigurons une sélection recommandée pour que tu sois prêt tout de suite.",
       "keyLabel": "Clé API OpenRouter",
       "keyPlaceholder": "sk-or-...",
       "keyHelp": "Stockée chiffrée. Laisse vide pour la configurer plus tard dans les paramètres.",
@@ -4580,6 +4581,8 @@
       "profile": {
         "title": "Profil",
         "description": "Ton nom d'affichage et ton courriel — visibles par tes coéquipiers.",
+        "nameDescription": "Le nom affiché à tes coéquipiers.",
+        "emailDescription": "Utilisé pour te connecter et recevoir des notifications.",
         "name": "Nom d'affichage",
         "namePlaceholder": "Entre ton nom",
         "email": "Courriel",
@@ -4608,6 +4611,8 @@
       "title": "Organisation (facultatif)",
       "detailsTitle": "Détails de l'organisation",
       "detailsDescription": "Informations de base sur ton organisation.",
+      "nameDescription": "Le nom d'affichage de ton organisation.",
+      "localeDescription": "La langue principale de ton organisation.",
       "identifiersTitle": "Identifiants",
       "identifiersDescription": "Références en lecture seule pour les appels API ou le support.",
       "organizationId": "ID de l'organisation",
@@ -7034,6 +7039,7 @@
       "title": "Détails de connexion",
       "usernameLabel": "Nom d'utilisateur",
       "usernameHelp": "L'e-mail de ton compte Tale (ou ton nom d'utilisateur)",
+      "copyUsername": "Copier le nom d'utilisateur",
       "passwordLabel": "Mot de passe",
       "passwordHelp": "Un mot de passe applicatif que tu génères ci-dessous — pas le mot de passe de ton compte."
     },


### PR DESCRIPTION
## Summary

A UX-polish pass across the settings area and the onboarding wizard, plus a few shared light-mode/theming fixes.

**Settings**
- Table-driven pages (Teams, AI providers, MCP, WebDAV, Runtimes, Governance, Data residency) now span the full content width instead of the narrow centered column.
- Section dividers between stacked sections (Organization, Account, WebDAV, Runtimes, Data residency); `SettingsSection` header text is capped at a readable line length.
- Organization page restructured into label-left / control-right settings rows. Account's Security / Two-Factor / Passkey / Chats actions moved into the section header action slot (right-aligned).
- Data residency Save / Apply & restart bar is docked to the bottom via a scrollable body + footer layout.

**Onboarding wizard**
- Numbered step rail replaced with a minimal segmented progress bar.
- A single hero title/subtitle driven by the active step (no duplicate per-step headings); Back moved to the page's top-left; full-width primary action with a centered Skip.
- OpenRouter step: adaptive primary (Next → Connect once a key is entered), optional-labelled field, tightened copy.

**Theming (packages/ui + shared controls)**
- Light-mode popover / select / menu / notification surfaces use `bg-popover` (white) while keeping the elevated muted surface in dark mode.
- Row hover is now distinct from the table header and no longer applies to empty-state rows; the unchecked switch track stays visible when disabled.

Adds `en`/`de`/`fr` message keys for the new copy; `de-CH` inherits from `de`.

## Pre-PR checklist

- [x] Ran format, lint, typecheck (all clean) + the test suite — 72,895 pass; the only failures are 3 pre-existing Convex backend integration-test timeouts (Slack HTTP actions, processing records) that are unrelated to this frontend-only diff.
- [x] No hand-rolled skeletons or magic `h-[…]` on skeletons — uses `<Skeletonize>`; in fact fixes a broken flex-height chain through the Skeletonize wrapper on the Branding/Data-residency pages.
- [x] Updated `services/platform/messages/{en,de,fr}.json` (kept in sync; `de-CH` overrides unchanged).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (visual layout + microcopy polish; no new features, flows, env vars, or APIs).
- [ ] docs opening/closing prose + `@tale/docs` lint/test — N/A (no docs touched).
- [ ] Updated `README.md` / `README.de.md` / `README.fr.md` — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added step-specific primary button overrides and stacked layout option for wizard footers
  * Introduced compact and segmented progress display modes for wizard progress tracking
  * Redesigned settings UI with full-width layout and improved row-based structure
  * Added centralized step hero component for onboarding wizard headers

* **Style**
  * Updated light/dark mode color theming for popovers and navigation menus
  * Enhanced table row hover states with refined visual feedback
  * Improved switch track styling and border handling
  * Added persistent footer docking for deployment settings page

* **Localization**
  * Updated onboarding and settings copy in English, German, and French

<!-- end of auto-generated comment: release notes by coderabbit.ai -->