### PR TITLE
feat(platform): provider request-body map + reasoning max_completion_tokens

### DIFF
--- a/docs/de/self-hosted/configuration/providers.md
+++ b/docs/de/self-hosted/configuration/providers.md
@@ -43,6 +43,25 @@ Jedes Modell kann optionale Metadaten deklarieren, die das komplexitätsbasierte
 
 Diese Felder bleiben auch von selbst aktuell: Einmal pro Woche führt Tale frische OpenRouter-Fakten in die Anbieter-Config jeder Organisation zusammen — fügt neuere Flaggschiff-Versionen hinzu, blendet abgelöste aus und aktualisiert Capability-Werte — und verändert dabei nur die Felder, die du nicht angepasst hast. Schalte das pro Organisation mit dem **Wöchentliche Auto-Synchronisierung**-Schalter auf der Modellkatalog-Karte unter **Einstellungen > Anbieter** aus.
 
+Wenn `maxOutputTokens` nicht gesetzt ist, begrenzt Tale die Ausgabe auf **32'768** Tokens. Setze `0`, um gar keine Begrenzung zu senden. Senke den Wert auf das tatsächliche Limit deines Deployments, falls der Anbieter zu grosse Werte ablehnt (z. B. ein Azure-GPT-4o-Deployment mit `max_tokens is too large`).
+
+### Request-Body-Map
+
+Manche Endpunkte erwarten eine etwas andere Anfrageform als die übliche OpenAI-kompatible. Ein Modell — oder der Anbieter als Standard — kann eine `requestBodyMap` deklarieren, die den finalen Request-Body beim Versand umschreibt:
+
+```json
+{
+  "requestBodyMap": {
+    "rename": { "max_tokens": "max_completion_tokens" },
+    "remove": ["frequency_penalty"]
+  }
+}
+```
+
+`rename` benennt einen Feldnamen in einen anderen um (wird zuerst angewendet); `remove` entfernt Felder, die der Endpunkt ablehnt. Eine modell-spezifische `requestBodyMap` überschreibt die auf Anbieter-Ebene bei kollidierenden Schlüsseln. Anders als `providerOptions` erreichen diese Anweisungen den Anbieter nie — sie schreiben den Body direkt um und sind damit der unterstützte Weg, ein reserviertes Feld wie `max_tokens` zu ändern.
+
+Der klassische Fall ist ein OpenAI-/Azure-**Reasoning**-Deployment (o-Serie, GPT-5), das `max_tokens` ablehnt und `max_completion_tokens` verlangt. Wenn du das Modell als Reasoning-Modell kennzeichnest (den `reasoning`-Knopf setzt), wendet Tale genau diese Umbenennung automatisch an — `requestBodyMap` brauchst du dann nur noch für andere Endpunkt-Eigenheiten.
+
 ## Die Secrets-Datei
 
 `providers/<name>.secrets.json` ist ein flaches JSON-Objekt mit dem API-Schlüssel unter dem Feldnamen, den der Anbieter erwartet:

--- a/docs/en/self-hosted/configuration/providers.md
+++ b/docs/en/self-hosted/configuration/providers.md
@@ -43,6 +43,25 @@ Each model may declare optional metadata that complexity-based routing and the A
 
 These fields also stay current on their own: once a week Tale merges fresh OpenRouter facts into each org's provider config — adding newer flagship versions, hiding superseded ones, and refreshing capability values — touching only the fields you have not customised. Turn it off per-org with the **Weekly auto-sync** toggle on the model-catalog card under **Settings > Providers**.
 
+When `maxOutputTokens` is unset, Tale caps output at **32,768** tokens. Set `0` to send no cap at all. Lower it to your deployment's real ceiling if the provider rejects large values (e.g. an Azure GPT-4o deployment returning `max_tokens is too large`).
+
+### Request body map
+
+Some endpoints expect a slightly different request shape than the standard OpenAI-compatible one. A model — or the provider, as a default — may declare a `requestBodyMap` that rewrites the final request body on the way out:
+
+```json
+{
+  "requestBodyMap": {
+    "rename": { "max_tokens": "max_completion_tokens" },
+    "remove": ["frequency_penalty"]
+  }
+}
+```
+
+`rename` maps a field name to another (applied first); `remove` drops fields the endpoint rejects. A per-model `requestBodyMap` overrides the provider-level one on conflicting keys. Unlike `providerOptions`, these instructions never reach the provider — they rewrite the body in place, so this is the supported way to change a reserved field like `max_tokens`.
+
+The classic case is an OpenAI / Azure **reasoning** deployment (o-series, GPT-5), which rejects `max_tokens` and requires `max_completion_tokens`. If you flag the model as a reasoning model (set its `reasoning` knob), Tale applies that exact rename automatically — so you only need `requestBodyMap` for other endpoint quirks.
+
 ## The secrets file
 
 `providers/<name>.secrets.json` is a flat JSON object with the API key under the field name the provider expects:

--- a/docs/fr/self-hosted/configuration/providers.md
+++ b/docs/fr/self-hosted/configuration/providers.md
@@ -43,6 +43,25 @@ Chaque modèle peut déclarer des métadonnées optionnelles utilisées par le r
 
 Ces champs restent aussi à jour tout seuls : une fois par semaine, Tale fusionne les nouvelles données OpenRouter dans la config fournisseur de chaque organisation — ajoutant les nouvelles versions phares, masquant celles remplacées et actualisant les valeurs de capacités — en ne touchant que les champs que tu n'as pas personnalisés. Désactive-le par organisation avec l'interrupteur **Synchronisation auto hebdomadaire** sur la carte du catalogue de modèles dans **Paramètres > Fournisseurs**.
 
+Quand `maxOutputTokens` n'est pas défini, Tale plafonne la sortie à **32 768** tokens. Mets `0` pour n'envoyer aucune limite. Réduis la valeur au plafond réel de ton déploiement si le fournisseur rejette les valeurs trop élevées (par ex. un déploiement Azure GPT-4o renvoyant `max_tokens is too large`).
+
+### Mappage du corps de requête
+
+Certains points de terminaison attendent une forme de requête légèrement différente de la forme OpenAI-compatible standard. Un modèle — ou le fournisseur, comme valeur par défaut — peut déclarer un `requestBodyMap` qui réécrit le corps de requête final à l'envoi :
+
+```json
+{
+  "requestBodyMap": {
+    "rename": { "max_tokens": "max_completion_tokens" },
+    "remove": ["frequency_penalty"]
+  }
+}
+```
+
+`rename` renomme un champ en un autre (appliqué en premier) ; `remove` supprime les champs que le point de terminaison rejette. Un `requestBodyMap` par modèle l'emporte sur celui au niveau du fournisseur en cas de clés en conflit. Contrairement à `providerOptions`, ces instructions n'atteignent jamais le fournisseur — elles réécrivent le corps sur place, ce qui en fait la manière prise en charge de modifier un champ réservé comme `max_tokens`.
+
+Le cas classique est un déploiement de **raisonnement** OpenAI / Azure (série o, GPT-5), qui rejette `max_tokens` et exige `max_completion_tokens`. Si tu marques le modèle comme modèle de raisonnement (en réglant son bouton `reasoning`), Tale applique ce renommage automatiquement — tu n'as alors besoin de `requestBodyMap` que pour d'autres particularités de point de terminaison.
+
 ## Le fichier de secrets
 
 `providers/<name>.secrets.json` est un objet JSON plat avec la clé API sous le nom de champ que le fournisseur attend :

--- a/services/db/docker-entrypoint.sh
+++ b/services/db/docker-entrypoint.sh
@@ -103,7 +103,16 @@ run_init_scripts() {
     for script in "$INIT_SCRIPTS_DIR"/*.sql; do
         [ -f "$script" ] || continue
         echo "  $(basename "$script")"
-        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$script" 2>&1 | grep -E "^(ERROR|FATAL|NOTICE)" || true
+        # ON_ERROR_STOP + an explicit exit-code check: a failing init script (e.g.
+        # the connection dropping mid-run, or a bad statement) MUST propagate so
+        # the caller never publishes /tmp/.db_ready against a half-initialized
+        # cluster. The previous `psql ... | grep || true` swallowed both psql's
+        # exit code (it became grep's) and every SQL error, which let a failed
+        # `02-create-convex-database.sql` set readiness with no `tale_platform`.
+        if ! psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$script"; then
+            echo "ERROR: init script failed: $(basename "$script")" >&2
+            return 1
+        fi
     done
     echo "Init scripts complete."
 }
@@ -180,17 +189,37 @@ apply_migrations_for_role() {
     esac
 }
 
-# Run init scripts in the background after PostgreSQL starts.
-# We wait until the target database is actually accessible (not just pg_isready)
-# to avoid racing with docker-entrypoint.sh's first-time init which creates
-# the POSTGRES_USER and POSTGRES_DB after starting a temporary server.
+# Run init scripts in the background, once the REAL server is up.
+#
+# On first-time init the upstream postgres entrypoint runs a TEMPORARY bootstrap
+# server to create POSTGRES_USER/POSTGRES_DB, then stops it before exec'ing the
+# real server. That bootstrap server is started with `listen_addresses=''`, so it
+# is reachable on the local UNIX socket but NEVER on TCP. Gating on a socket probe
+# (`psql -d "$POSTGRES_DB"`) therefore races first-time init: the loop can latch
+# onto the bootstrap server and run the init scripts against it just as the
+# entrypoint tears it down — `02-create-convex-database.sql` dies mid-run and
+# `tale_platform` is never created, yet readiness still gets published. Probing
+# TCP on 127.0.0.1 instead proves the *real* server is up (the bootstrap server
+# can't answer there), eliminating the race.
+#
+# Init + migrations are then retried as a unit, and /tmp/.db_ready is touched ONLY
+# after both genuinely succeed, so dependents (gated on `.db_ready`) never start
+# against a half-initialized cluster.
 (
     trap 'exit 0' SIGTERM SIGINT
-    until psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\q' 2>/dev/null; do
+    until pg_isready -h 127.0.0.1 -p 5432 -U "$POSTGRES_USER" >/dev/null 2>&1; do
         sleep 1
     done
-    run_init_scripts
-    apply_migrations_for_role
+    attempt=0
+    until run_init_scripts && apply_migrations_for_role; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge 30 ]; then
+            echo "ERROR: database init did not complete after ${attempt} attempts; not marking ready." >&2
+            exit 1
+        fi
+        echo "Database init incomplete (attempt ${attempt}); retrying in 2s..." >&2
+        sleep 2
+    done
     touch /tmp/.db_ready
     echo "Database ready."
 ) &

--- a/services/platform/app/components/ui/forms/json-input.tsx
+++ b/services/platform/app/components/ui/forms/json-input.tsx
@@ -172,6 +172,7 @@ interface JsonTextEditorProps {
   fontSize: number;
   inputId: string;
   describedBy: string | undefined;
+  placeholder: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
@@ -183,6 +184,7 @@ function JsonTextEditor({
   fontSize,
   inputId,
   describedBy,
+  placeholder,
   onChange,
   onKeyDown,
 }: JsonTextEditorProps) {
@@ -213,7 +215,7 @@ function JsonTextEditor({
         fontSize: `${fontSize}px`,
         lineHeight: '1.4',
       }}
-      placeholder={JSON.stringify({ key: 'value' }, null, 2)}
+      placeholder={placeholder}
     />
   );
 }
@@ -237,7 +239,9 @@ function computeValidation(
       } catch (err) {
         if (err instanceof z.ZodError) {
           const validationError = err.issues
-            .map((e) => `${e.path.join('.')}: ${e.message}`)
+            .map((e) =>
+              e.path.length ? `${e.path.join('.')}: ${e.message}` : e.message,
+            )
             .join(', ');
           return {
             isValid: false,
@@ -295,6 +299,7 @@ function JsonInputBase({
   rows = 4,
   fontSize = 12,
   id,
+  placeholder = JSON.stringify({ key: 'value' }, null, 2),
 }: JsonInputProps) {
   const { t } = useT('common');
   const generatedId = useId();
@@ -495,6 +500,7 @@ function JsonInputBase({
             fontSize={fontSize}
             inputId={resolvedId}
             describedBy={describedBy}
+            placeholder={placeholder}
             onChange={handleTextareaChange}
             onKeyDown={handleTextareaKeyDown}
           />

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.test.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.test.ts
@@ -238,16 +238,29 @@ describe('sanitizeChatError', () => {
         i18nKey: 'errorHintTokenLimit',
       });
     });
+  });
 
-    it('still classifies a genuine output-limit error as tokenLimit', () => {
+  describe('output cap too high errors', () => {
+    it('classifies "max_tokens is too large ... supports at most N completion tokens" as outputCapTooHigh', () => {
+      // The CONFIGURED cap exceeds the model's real ceiling — the operator
+      // should lower maxOutputTokens, not the end-user shorten their request.
+      // Must NOT be mislabeled tokenLimit ("output token limit exceeded").
       expect(
         sanitizeChatError(
           'max_tokens is too large: 200000. This model supports at most 128000 completion tokens.',
         ),
       ).toEqual({
-        category: 'tokenLimit',
-        i18nKey: 'errorHintTokenLimit',
+        category: 'outputCapTooHigh',
+        i18nKey: 'errorHintOutputCapTooHigh',
       });
+    });
+
+    it('does not shadow the unsupported-parameter classifier', () => {
+      expect(
+        sanitizeChatError(
+          "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+        ).category,
+      ).toBe('unsupportedParameter');
     });
   });
 

--- a/services/platform/app/features/chat/utils/sanitize-chat-error.ts
+++ b/services/platform/app/features/chat/utils/sanitize-chat-error.ts
@@ -4,6 +4,7 @@ type ErrorCategory =
   | 'authError'
   | 'modelNotFound'
   | 'unsupportedParameter'
+  | 'outputCapTooHigh'
   | 'tokenLimit'
   | 'rateLimited'
   | 'contentFilter'
@@ -52,6 +53,17 @@ const ERROR_PATTERNS: { pattern: RegExp; category: ErrorCategory }[] = [
       /unsupported parameter|is not supported with this model|unsupported_parameter|unknown parameter|unrecognized request argument/i,
     category: 'unsupportedParameter',
   },
+  // The CONFIGURED output cap exceeds the model's real ceiling, e.g. Azure/
+  // OpenAI "max_tokens is too large: 32768 ... supports at most 16384 completion
+  // tokens". This is an operator-config problem (lower the model's
+  // `maxOutputTokens`), NOT an end-user "shorten your request" token-limit. Must
+  // precede `tokenLimit`, whose bare `max_tokens` alternative would otherwise
+  // mislabel it as "output token limit exceeded".
+  {
+    pattern:
+      /max_tokens.*too large|too large.*max_tokens|supports at most.*completion tokens|reduce.*max_tokens/i,
+    category: 'outputCapTooHigh',
+  },
   {
     pattern: /fewer max_tokens|token.*limit|max_tokens/i,
     category: 'tokenLimit',
@@ -85,6 +97,7 @@ const CATEGORY_I18N_KEY: Record<ErrorCategory, string> = {
   authError: 'errorHintAuthError',
   modelNotFound: 'errorHintModelNotFound',
   unsupportedParameter: 'errorHintUnsupportedParameter',
+  outputCapTooHigh: 'errorHintOutputCapTooHigh',
   tokenLimit: 'errorHintTokenLimit',
   rateLimited: 'errorHintRateLimited',
   contentFilter: 'errorHintContentFilter',

--- a/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
@@ -55,6 +55,7 @@ import {
 import { modelTagLabel } from '../../utils/model-tag-label';
 import {
   ModelProviderOptionsField,
+  ModelRequestBodyMapField,
   providerOptionsToJsonString,
 } from '../provider-options-editor';
 
@@ -72,6 +73,8 @@ interface ModelFormState {
   secretsEnv: string;
   apiKey: string;
   providerOptionsJson: string;
+  /** Wire-field rename/remove map (rewrites the request body); JSON string. */
+  requestBodyMapJson: string;
   /** Hidden from model pickers (still resolvable). Set on superseded models. */
   hidden: boolean;
   // Routing & capabilities (chat models). Strings mirror the input controls;
@@ -103,6 +106,7 @@ const EMPTY_MODEL_FORM: ModelFormState = {
   secretsEnv: '',
   apiKey: '',
   providerOptionsJson: '',
+  requestBodyMapJson: '',
   hidden: false,
   tier: '',
   qualityScore: '',
@@ -399,6 +403,7 @@ export function ModelsSection({
         secretsEnv: model.secretsEnv ?? '',
         apiKey: '',
         providerOptionsJson: providerOptionsToJsonString(model.providerOptions),
+        requestBodyMapJson: providerOptionsToJsonString(model.requestBodyMap),
         hidden: model.hidden ?? false,
         tier: model.tier ?? '',
         qualityScore:
@@ -481,6 +486,30 @@ export function ModelsSection({
           return;
         }
       }
+      let requestBodyMap:
+        | { rename?: Record<string, string>; remove?: string[] }
+        | undefined;
+      const trimmedRequestBodyMap = form.requestBodyMapJson.trim();
+      if (trimmedRequestBodyMap) {
+        try {
+          const parsed: unknown = JSON.parse(trimmedRequestBodyMap);
+          if (isRecord(parsed) && Object.keys(parsed).length > 0) {
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shape is checked client-side by requestBodyMapClientSchema and authoritatively by providerJsonSchema.parse on save
+            requestBodyMap = parsed as {
+              rename?: Record<string, string>;
+              remove?: string[];
+            };
+          }
+        } catch (parseErr) {
+          toast({
+            title: t('providers.requestBodyMap.invalidJson'),
+            description:
+              parseErr instanceof Error ? parseErr.message : String(parseErr),
+            variant: 'destructive',
+          });
+          return;
+        }
+      }
       const reasoning = form.reasoningKnob
         ? {
             knob: form.reasoningKnob,
@@ -540,6 +569,7 @@ export function ModelsSection({
         hidden: form.hidden || undefined,
         cost,
         providerOptions,
+        requestBodyMap,
         tier: form.tier || undefined,
         qualityScore: form.qualityScore.trim()
           ? Number(form.qualityScore)
@@ -1340,6 +1370,9 @@ export function ModelsSection({
                     />
                     <Input
                       label={t('providers.modelCapabilities.maxOutputTokens')}
+                      description={t(
+                        'providers.modelCapabilities.maxOutputTokensHelp',
+                      )}
                       type="number"
                       value={form.maxOutputTokens}
                       onChange={(e) =>
@@ -1348,8 +1381,8 @@ export function ModelsSection({
                           maxOutputTokens: e.target.value,
                         }))
                       }
-                      placeholder="e.g., 32768"
-                      min={1}
+                      placeholder="e.g., 16384"
+                      min={0}
                     />
                   </HStack>
 
@@ -1523,6 +1556,20 @@ export function ModelsSection({
                   ),
                   guideLabel: t('providers.providerOptions.guideLabel'),
                   helpText: t('providers.providerOptions.modelLevelHelp'),
+                }}
+              />
+              <ModelRequestBodyMapField
+                value={form.requestBodyMapJson}
+                onChange={(next) =>
+                  setForm((f) => ({ ...f, requestBodyMapJson: next }))
+                }
+                copy={{
+                  title: t('providers.requestBodyMap.modelLevelTitle'),
+                  description: t(
+                    'providers.requestBodyMap.modelLevelDescription',
+                  ),
+                  guideLabel: t('providers.requestBodyMap.guideLabel'),
+                  helpText: t('providers.requestBodyMap.modelLevelHelp'),
                 }}
               />
             </Stack>

--- a/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-detail-drawer/models-section.tsx
@@ -49,6 +49,7 @@ import {
 import { useProviderConfig } from '../../hooks/use-provider-config-context';
 import {
   dispatchForbiddenDeveloperSettings,
+  dispatchInvalidProviderConfig,
   dispatchOrgAccessError,
   dispatchVersionConflict,
 } from '../../utils/error-dispatch';
@@ -226,6 +227,7 @@ export function ModelsSection({
         if (dispatchOrgAccessError(err, tAccessDenied)) return;
         if (dispatchForbiddenDeveloperSettings(err, t)) return;
         if (dispatchVersionConflict(err, t)) return;
+        if (dispatchInvalidProviderConfig(err, t)) return;
         toast({ title: t('providers.saveFailed'), variant: 'destructive' });
       }
     },
@@ -359,6 +361,7 @@ export function ModelsSection({
       if (dispatchOrgAccessError(err, tAccessDenied)) return;
       if (dispatchForbiddenDeveloperSettings(err, t)) return;
       if (dispatchVersionConflict(err, t)) return;
+      if (dispatchInvalidProviderConfig(err, t)) return;
       toast({ title: t('providers.saveFailed'), variant: 'destructive' });
     } finally {
       setSyncingAll(false);
@@ -617,6 +620,7 @@ export function ModelsSection({
         if (dispatchOrgAccessError(err, tAccessDenied)) return;
         if (dispatchForbiddenDeveloperSettings(err, t)) return;
         if (dispatchVersionConflict(err, t)) return;
+        if (dispatchInvalidProviderConfig(err, t)) return;
         toast({ title: t('providers.saveFailed'), variant: 'destructive' });
       }
     },

--- a/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
@@ -17,14 +17,49 @@ import { isRecord } from '@/lib/utils/type-utils';
 // "is JSON, is an object" so we don't ship obviously malformed input.
 const providerOptionsClientSchema = z.record(z.string(), z.unknown());
 
-// Light client-side shape check for the request-body map (rename/remove); the
-// server `providerJsonSchema.parse` is authoritative (rejects prototype keys).
+// Client-side shape check for the request-body map. It flags the common mistake
+// (putting `max_tokens` at the top level instead of under `rename`) inline in
+// the JSON editor with a message that states the correct structure, instead of
+// letting it through to a server-side rejection. Built as a record + refine so
+// we control the wording (and stay version-agnostic). The server
+// `providerJsonSchema.parse` stays authoritative (it also rejects
+// prototype-pollution keys).
+const REQUEST_BODY_MAP_SHAPE_HINT =
+  'Only "rename" and "remove" are allowed. To rename a field, nest it under "rename" — e.g. { "rename": { "max_tokens": "max_completion_tokens" } }. To drop a field, list it under "remove" — e.g. { "remove": ["frequency_penalty"] }.';
+
 const requestBodyMapClientSchema = z
-  .object({
-    rename: z.record(z.string(), z.string()).optional(),
-    remove: z.array(z.string()).optional(),
-  })
-  .partial();
+  .record(z.string(), z.unknown())
+  .superRefine((value, ctx) => {
+    for (const key of Object.keys(value)) {
+      if (key !== 'rename' && key !== 'remove') {
+        ctx.addIssue({ code: 'custom', message: REQUEST_BODY_MAP_SHAPE_HINT });
+      }
+    }
+    const rename = value.rename;
+    if (
+      rename !== undefined &&
+      (typeof rename !== 'object' || rename === null || Array.isArray(rename))
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: '"rename" must be an object of { "oldName": "newName" }.',
+        path: ['rename'],
+      });
+    }
+    if (value.remove !== undefined && !Array.isArray(value.remove)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: '"remove" must be an array of field names to drop.',
+        path: ['remove'],
+      });
+    }
+  });
+
+const REQUEST_BODY_MAP_PLACEHOLDER = JSON.stringify(
+  { rename: { max_tokens: 'max_completion_tokens' } },
+  null,
+  2,
+);
 import { Card } from '@tale/ui/card';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
@@ -507,6 +542,7 @@ export function ModelRequestBodyMapField({
         value={value}
         onChange={onChange}
         schema={requestBodyMapClientSchema}
+        placeholder={REQUEST_BODY_MAP_PLACEHOLDER}
         rows={5}
         fontSize={12}
       />

--- a/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-options-editor.tsx
@@ -16,6 +16,15 @@ import { isRecord } from '@/lib/utils/type-utils';
 // authoritative gate (it carries the deny-list). This schema only catches
 // "is JSON, is an object" so we don't ship obviously malformed input.
 const providerOptionsClientSchema = z.record(z.string(), z.unknown());
+
+// Light client-side shape check for the request-body map (rename/remove); the
+// server `providerJsonSchema.parse` is authoritative (rejects prototype keys).
+const requestBodyMapClientSchema = z
+  .object({
+    rename: z.record(z.string(), z.string()).optional(),
+    remove: z.array(z.string()).optional(),
+  })
+  .partial();
 import { Card } from '@tale/ui/card';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
@@ -471,6 +480,34 @@ export function ModelProviderOptionsField({
         onChange={onChange}
         schema={providerOptionsClientSchema}
         rows={6}
+        fontSize={12}
+      />
+      <CollapsibleGuide label={copy.guideLabel} content={copy.helpText} />
+    </Stack>
+  );
+}
+
+/**
+ * Inline JSON editor for a model's `requestBodyMap` (rename/remove wire fields).
+ * Same framing as {@link ModelProviderOptionsField}; distinct because the value
+ * is meta-config that rewrites the request body rather than passthrough fields.
+ */
+export function ModelRequestBodyMapField({
+  value,
+  onChange,
+  copy,
+}: ModelEditorProps) {
+  return (
+    <Stack gap={2} className="border-border border-t pt-4">
+      <Text className="text-sm font-semibold">{copy.title}</Text>
+      <Text className="text-muted-foreground text-sm whitespace-pre-line">
+        {copy.description}
+      </Text>
+      <JsonInput
+        value={value}
+        onChange={onChange}
+        schema={requestBodyMapClientSchema}
+        rows={5}
         fontSize={12}
       />
       <CollapsibleGuide label={copy.guideLabel} content={copy.helpText} />

--- a/services/platform/app/features/settings/providers/utils/error-dispatch.ts
+++ b/services/platform/app/features/settings/providers/utils/error-dispatch.ts
@@ -86,6 +86,47 @@ export function dispatchOrgAccessError(
 }
 
 /**
+ * Surface the SPECIFIC field rejection when the server rejects a provider/model
+ * save with `INVALID_PROVIDER_CONFIG` (the `providerJsonSchema` Zod gate), e.g.
+ * a `requestBodyMap` with `max_tokens` at the top level instead of under
+ * `rename`. Without this, the detailed `{ path, message }` issues only reach the
+ * server log and the user sees a generic "save failed". Returns `true` if
+ * handled. The issue messages are server-generated (English, technical) and
+ * shown verbatim — same convention as raw JSON.parse errors elsewhere.
+ */
+export function dispatchInvalidProviderConfig(
+  err: unknown,
+  t: (key: string) => string,
+): boolean {
+  const data = readConvexErrorData(err);
+  if (data?.code !== 'INVALID_PROVIDER_CONFIG') return false;
+  let description: string | undefined;
+  const issues = data.issues;
+  if (Array.isArray(issues)) {
+    const lines: string[] = [];
+    for (const issue of issues) {
+      if (issue == null || typeof issue !== 'object') continue;
+      const rawPath = 'path' in issue ? issue.path : undefined;
+      const rawMessage = 'message' in issue ? issue.message : undefined;
+      const path = Array.isArray(rawPath)
+        ? rawPath.join('.')
+        : typeof rawPath === 'string'
+          ? rawPath
+          : '';
+      const message = typeof rawMessage === 'string' ? rawMessage : '';
+      lines.push(path ? `${path}: ${message}` : message);
+    }
+    description = lines.join('\n') || undefined;
+  }
+  toast({
+    title: t('providers.invalidConfigTitle'),
+    description,
+    variant: 'destructive',
+  });
+  return true;
+}
+
+/**
  * Surface a "reload to see latest" toast when the server rejects with
  * `PROVIDER_VERSION_CONFLICT`. Triggered when another tab/operator changed
  * the provider config between our load and our save (or deleted it).

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1001,6 +1001,7 @@ import type * as providers_failover from "../providers/failover.js";
 import type * as providers_file_actions from "../providers/file_actions.js";
 import type * as providers_file_utils from "../providers/file_utils.js";
 import type * as providers_provider_attribution from "../providers/provider_attribution.js";
+import type * as providers_request_body_transform from "../providers/request_body_transform.js";
 import type * as providers_resolve_model from "../providers/resolve_model.js";
 import type * as providers_resolve_model_node from "../providers/resolve_model_node.js";
 import type * as providers_secret_io from "../providers/secret_io.js";
@@ -2496,6 +2497,7 @@ declare const fullApi: ApiFromModules<{
   "providers/file_actions": typeof providers_file_actions;
   "providers/file_utils": typeof providers_file_utils;
   "providers/provider_attribution": typeof providers_provider_attribution;
+  "providers/request_body_transform": typeof providers_request_body_transform;
   "providers/resolve_model": typeof providers_resolve_model;
   "providers/resolve_model_node": typeof providers_resolve_model_node;
   "providers/secret_io": typeof providers_secret_io;

--- a/services/platform/convex/providers/file_actions.ts
+++ b/services/platform/convex/providers/file_actions.ts
@@ -71,6 +71,7 @@ import {
   serializeProviderJson,
   validateProviderName,
 } from './file_utils';
+import { mergeRequestBodyMap } from './request_body_transform';
 // Type-only import (erased at runtime — no circular dependency) so the
 // in-process resolver shares the canonical ResolvedModelData shape.
 import type { ResolvedModelData } from './resolve_model';
@@ -106,7 +107,7 @@ const modelRoutingMetadataValidator = {
  * `resolveModelByTag` so the two action return validators can't drift. Mirrors
  * `ResolvedModelData` in `resolve_model.ts`.
  */
-const resolvedModelDataValidator = v.object({
+export const resolvedModelDataValidator = v.object({
   providerName: v.string(),
   baseUrl: v.string(),
   apiKey: v.string(),
@@ -142,6 +143,12 @@ const resolvedModelDataValidator = v.object({
     ),
   ),
   providerOptions: v.optional(v.record(v.string(), v.any())),
+  requestBodyMap: v.optional(
+    v.object({
+      rename: v.optional(v.record(v.string(), v.string())),
+      remove: v.optional(v.array(v.string())),
+    }),
+  ),
   reasoning: v.optional(
     v.object({
       knob: v.union(
@@ -587,6 +594,10 @@ function buildResolvedTagModel(
     providerOptions: mergeModelLevel(
       provider.config.providerOptions,
       definition.providerOptions,
+    ),
+    requestBodyMap: mergeRequestBodyMap(
+      provider.config.requestBodyMap,
+      definition.requestBodyMap,
     ),
     reasoning: definition.reasoning,
     promptCaching: definition.promptCaching,
@@ -1155,6 +1166,10 @@ export async function resolveModelDataInline(
       instructionsByLocale: definition.instructionsByLocale,
       audioFormat: definition.audioFormat,
       providerOptions,
+      requestBodyMap: mergeRequestBodyMap(
+        provider.config.requestBodyMap,
+        definition.requestBodyMap,
+      ),
       reasoning: definition.reasoning,
       promptCaching: definition.promptCaching,
       tier: definition.tier,

--- a/services/platform/convex/providers/request_body_transform.test.ts
+++ b/services/platform/convex/providers/request_body_transform.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createWireTransformFetch,
+  mergeRequestBodyMap,
+  transformRequestBody,
+  type WireTransformModelData,
+} from './request_body_transform';
+
+const reasoning = { knob: 'effort' as const };
+
+describe('transformRequestBody', () => {
+  it('returns an equivalent body and does not mutate the input when there is no config', () => {
+    const body = { model: 'gpt-4o', max_tokens: 4096 };
+    const out = transformRequestBody(body, {});
+    expect(out).toEqual({ model: 'gpt-4o', max_tokens: 4096 });
+    expect(out).not.toBe(body);
+    expect(body).toEqual({ model: 'gpt-4o', max_tokens: 4096 });
+  });
+
+  it('renames a field via requestBodyMap.rename', () => {
+    const out = transformRequestBody(
+      { max_tokens: 4096, model: 'x' },
+      { requestBodyMap: { rename: { max_tokens: 'max_completion_tokens' } } },
+    );
+    expect(out).toEqual({ max_completion_tokens: 4096, model: 'x' });
+    expect(out).not.toHaveProperty('max_tokens');
+  });
+
+  it('removes fields via requestBodyMap.remove (after rename)', () => {
+    const out = transformRequestBody(
+      { max_tokens: 4096, frequency_penalty: 0.2 },
+      {
+        requestBodyMap: {
+          rename: { max_tokens: 'max_completion_tokens' },
+          remove: ['frequency_penalty'],
+        },
+      },
+    );
+    expect(out).toEqual({ max_completion_tokens: 4096 });
+  });
+
+  it('applies the reasoning default: max_tokens → max_completion_tokens', () => {
+    const out = transformRequestBody({ max_tokens: 8192 }, { reasoning });
+    expect(out).toEqual({ max_completion_tokens: 8192 });
+  });
+
+  it('does NOT rename for a non-reasoning model (gpt-4o is untouched)', () => {
+    const out = transformRequestBody({ max_tokens: 8192 }, {});
+    expect(out).toEqual({ max_tokens: 8192 });
+  });
+
+  it('lets an operator rename of max_tokens suppress the reasoning default', () => {
+    // Operator maps max_tokens → something else; the auto-rename must not then
+    // re-add max_completion_tokens from a now-absent max_tokens.
+    const out = transformRequestBody(
+      { max_tokens: 8192 },
+      { reasoning, requestBodyMap: { rename: { max_tokens: 'maxTokens' } } },
+    );
+    expect(out).toEqual({ maxTokens: 8192 });
+  });
+
+  it('does not clobber an existing max_completion_tokens with the reasoning default', () => {
+    const out = transformRequestBody(
+      { max_tokens: 8192, max_completion_tokens: 100 },
+      { reasoning },
+    );
+    expect(out).toEqual({ max_tokens: 8192, max_completion_tokens: 100 });
+  });
+
+  it('no-ops on a body without max_tokens (image-shaped request)', () => {
+    const out = transformRequestBody(
+      { model: 'dall-e-3', prompt: 'a cat', size: '1024x1024' },
+      { reasoning },
+    );
+    expect(out).toEqual({
+      model: 'dall-e-3',
+      prompt: 'a cat',
+      size: '1024x1024',
+    });
+  });
+});
+
+describe('mergeRequestBodyMap', () => {
+  it('returns undefined when both sides are absent', () => {
+    expect(mergeRequestBodyMap(undefined, undefined)).toBeUndefined();
+  });
+
+  it('merges rename sub-keys with the model level winning', () => {
+    const merged = mergeRequestBodyMap(
+      { rename: { max_tokens: 'max_completion_tokens', a: 'b' } },
+      { rename: { a: 'c' } },
+    );
+    expect(merged).toEqual({
+      rename: { max_tokens: 'max_completion_tokens', a: 'c' },
+    });
+  });
+
+  it('replaces the remove array wholesale (model wins)', () => {
+    const merged = mergeRequestBodyMap(
+      { remove: ['x', 'y'] },
+      { remove: ['z'] },
+    );
+    expect(merged).toEqual({ remove: ['z'] });
+  });
+
+  it('keeps the provider remove when the model omits it', () => {
+    const merged = mergeRequestBodyMap(
+      { remove: ['x'] },
+      { rename: { a: 'b' } },
+    );
+    expect(merged).toEqual({ remove: ['x'], rename: { a: 'b' } });
+  });
+});
+
+describe('createWireTransformFetch', () => {
+  function captureFetch() {
+    const calls: { input: unknown; init?: RequestInit }[] = [];
+    const fn = vi.fn(async (input: unknown, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response('{}');
+    });
+    return { fn, calls };
+  }
+
+  it('transforms a string JSON body and forwards the result to the inner fetch', async () => {
+    const { fn, calls } = captureFetch();
+    const modelData: WireTransformModelData = { reasoning };
+    const wire = createWireTransformFetch(modelData, fn as never);
+    await wire('https://x/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({ max_tokens: 1024 }),
+    });
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      max_completion_tokens: 1024,
+    });
+  });
+
+  it('passes non-string bodies through untouched (multipart/FormData)', async () => {
+    const { fn, calls } = captureFetch();
+    const wire = createWireTransformFetch(
+      { requestBodyMap: { rename: { a: 'b' } } },
+      fn as never,
+    );
+    const form = new FormData();
+    await wire('https://x/v1/audio/transcriptions', {
+      method: 'POST',
+      body: form,
+    });
+    expect(calls[0].init?.body).toBe(form);
+  });
+
+  it('passes a non-JSON string body through untouched', async () => {
+    const { fn, calls } = captureFetch();
+    const wire = createWireTransformFetch({ reasoning }, fn as never);
+    await wire('https://x', { method: 'POST', body: 'not json' });
+    expect(calls[0].init?.body).toBe('not json');
+  });
+
+  it('returns the inner fetch unchanged when there is no transform work', () => {
+    const { fn } = captureFetch();
+    const wire = createWireTransformFetch({}, fn as never);
+    expect(wire).toBe(fn);
+  });
+});

--- a/services/platform/convex/providers/request_body_transform.ts
+++ b/services/platform/convex/providers/request_body_transform.ts
@@ -1,0 +1,143 @@
+import type { ReasoningCapabilityConfig } from '../../lib/shared/schemas/providers';
+
+/**
+ * Why this lives at the `fetch` boundary: the `@ai-sdk/openai-compatible`
+ * adapter serializes the output cap as the wire field `max_tokens`
+ * unconditionally, and `providerOptions` (the other extension point) is spread
+ * onto the wire AND deny-listed against reserved keys — so it cannot rename
+ * `max_tokens`. The injected `fetch` is the only place the final body exists as
+ * a JSON string, so a parse → mutate → re-stringify pass here is the one
+ * mechanism that can rewrite reserved wire fields without leaking config to the
+ * provider. Paired with `createCompatibleProvider` in `resolve_model.ts`.
+ */
+
+/** Declarative request-body transform; see `requestBodyMapSchema`. */
+export interface RequestBodyMap {
+  rename?: Record<string, string>;
+  remove?: string[];
+}
+
+/** The subset of resolved model data the wire transform reads. */
+export interface WireTransformModelData {
+  requestBodyMap?: RequestBodyMap;
+  reasoning?: ReasoningCapabilityConfig;
+}
+
+/**
+ * Merge a provider-default `requestBodyMap` with a per-model one, mirroring
+ * `mergeModelLevel`'s precedence (model wins): `rename` sub-keys merge, `remove`
+ * arrays replace wholesale. Returns `undefined` when nothing remains. Typed for
+ * the precise shape so resolvers stay cast-free.
+ */
+export function mergeRequestBodyMap(
+  providerLevel: RequestBodyMap | undefined,
+  modelLevel: RequestBodyMap | undefined,
+): RequestBodyMap | undefined {
+  if (!providerLevel && !modelLevel) return undefined;
+  const rename = { ...providerLevel?.rename, ...modelLevel?.rename };
+  const remove = modelLevel?.remove ?? providerLevel?.remove;
+  const out: RequestBodyMap = {};
+  if (Object.keys(rename).length > 0) out.rename = rename;
+  if (remove && remove.length > 0) out.remove = remove;
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
+type FetchFn = (
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+) => Promise<Response>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Apply, in order: (1) the operator's `requestBodyMap` — `rename` then `remove`;
+ * (2) a reasoning-model default that renames any residual `max_tokens` to
+ * `max_completion_tokens`. Pure: returns a shallow copy, never mutates `body`.
+ *
+ * The reasoning default fires only when the model is flagged reasoning AND the
+ * operator hasn't already remapped `max_tokens` — `modelData.reasoning` is set
+ * only when an operator declares the reasoning knob or the catalog reports
+ * reasoning support, so a plain chat model (e.g. gpt-4o) is never touched.
+ */
+export function transformRequestBody(
+  body: Record<string, unknown>,
+  modelData: WireTransformModelData,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...body };
+
+  // Layer 1 — operator overlay. Rename first so an explicit `remove` can still
+  // drop the renamed-to field if desired.
+  const rename = modelData.requestBodyMap?.rename;
+  if (rename) {
+    for (const [from, to] of Object.entries(rename)) {
+      if (from === to) continue;
+      if (Object.prototype.hasOwnProperty.call(out, from)) {
+        out[to] = out[from];
+        delete out[from];
+      }
+    }
+  }
+  const remove = modelData.requestBodyMap?.remove;
+  if (remove) {
+    for (const key of remove) delete out[key];
+  }
+
+  // Layer 2 — reasoning default (OpenAI / Azure reasoning deployments reject
+  // `max_tokens` and require `max_completion_tokens`).
+  if (
+    modelData.reasoning &&
+    Object.prototype.hasOwnProperty.call(out, 'max_tokens') &&
+    !Object.prototype.hasOwnProperty.call(out, 'max_completion_tokens')
+  ) {
+    out.max_completion_tokens = out.max_tokens;
+    delete out.max_tokens;
+  }
+
+  return out;
+}
+
+/**
+ * Wrap `fetch` so the outgoing JSON body passes through `transformRequestBody`.
+ * Only string JSON bodies are transformed — multipart/transcription bodies are
+ * non-string `FormData` and pass through untouched (same assumption as
+ * `createDebugFetch`). An optional `innerFetch` (e.g. the wire-debug logger) is
+ * composed so it observes and forwards the TRANSFORMED body.
+ *
+ * Returns the inner/global fetch unchanged when there is nothing to do, so a
+ * model with no `requestBodyMap` and no reasoning flag adds zero overhead.
+ */
+export function createWireTransformFetch(
+  modelData: WireTransformModelData,
+  innerFetch?: FetchFn,
+): FetchFn {
+  const hasWork =
+    modelData.reasoning !== undefined ||
+    modelData.requestBodyMap?.rename !== undefined ||
+    modelData.requestBodyMap?.remove !== undefined;
+  if (!hasWork) return innerFetch ?? fetch;
+
+  return async (input, init) => {
+    const next = transformInit(init, modelData);
+    return (innerFetch ?? fetch)(input, next);
+  };
+}
+
+function transformInit(
+  init: RequestInit | undefined,
+  modelData: WireTransformModelData,
+): RequestInit | undefined {
+  if (!init || typeof init.body !== 'string') return init;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(init.body);
+  } catch {
+    return init; // non-JSON string body — leave untouched
+  }
+  if (!isPlainObject(parsed)) return init;
+  return {
+    ...init,
+    body: JSON.stringify(transformRequestBody(parsed, modelData)),
+  };
+}

--- a/services/platform/convex/providers/resolve_model.ts
+++ b/services/platform/convex/providers/resolve_model.ts
@@ -28,6 +28,7 @@ import {
   interleavedThinkingHeaders,
   providerAttributionHeaders,
 } from './provider_attribution';
+import { createWireTransformFetch } from './request_body_transform';
 
 export interface ResolvedModelData {
   providerName: string;
@@ -82,6 +83,15 @@ export interface ResolvedModelData {
    * the deny-list strip before handing it to streamText/generateText.
    */
   providerOptions?: Record<string, unknown>;
+  /**
+   * Resolver-merged request-body transform (provider-level ⊕ model-level via
+   * `mergeModelLevel`). Applied to the final serialized wire body by
+   * `createWireTransformFetch` — renames/removes fields for endpoints whose wire
+   * shape differs (e.g. `max_tokens` → `max_completion_tokens` for reasoning
+   * deployments). Top-level (not inside `providerOptions`) because, unlike
+   * providerOptions, it must NOT reach the provider. See `requestBodyMapSchema`.
+   */
+  requestBodyMap?: { rename?: Record<string, string>; remove?: string[] };
   /**
    * Resolved reasoning capability for the Adaptive Reasoning Governor (operator
    * provider JSON, with the OpenRouter catalog cache layered under it). Absent
@@ -357,7 +367,15 @@ function createCompatibleProvider(
   //   if (modelData.apiFormat === 'anthropic') return createAnthropicProvider(modelData);
   // (add `@ai-sdk/anthropic` + gate the OpenAI-REST-only resolvers — image /
   // embeddings / transcription / TTS — for anthropic providers).
-  const debugFetch = createDebugFetch(modelData.providerName);
+  // Always install the wire-transform fetch (it applies requestBodyMap +
+  // the reasoning max_tokens→max_completion_tokens default) and compose the
+  // optional wire-debug logger inside it so logs reflect the transformed body.
+  // When the model has no transform work the helper returns the inner/global
+  // fetch unchanged, so there's zero overhead on the common path.
+  const wireFetch = createWireTransformFetch(
+    modelData,
+    createDebugFetch(modelData.providerName),
+  );
   return createOpenAICompatible({
     name: modelData.providerName,
     baseURL: modelData.baseUrl,
@@ -370,7 +388,7 @@ function createCompatibleProvider(
       ? { supportsStructuredOutputs: opts.supportsStructuredOutputs }
       : {}),
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- @ai-sdk/openai-compatible types `fetch` as `typeof fetch` which carries an irrelevant `preconnect` static; the wrapped function is structurally compatible for runtime fetch calls
-    ...(debugFetch ? { fetch: debugFetch as typeof fetch } : {}),
+    fetch: wireFetch as typeof fetch,
   });
 }
 

--- a/services/platform/convex/providers/select_model_by_tag.test.ts
+++ b/services/platform/convex/providers/select_model_by_tag.test.ts
@@ -2,7 +2,7 @@ import { ConvexError } from 'convex/values';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { MissingApiKeyError, shouldFailoverToNextModel } from './errors';
-import { selectModelByTag } from './file_actions';
+import { resolvedModelDataValidator, selectModelByTag } from './file_actions';
 
 // Issue #1711 regression: a provider can be kept loaded by ONE model's env key
 // (`providerHasEnvKey` is provider-OR-any-model). `selectModelByTag` must skip a
@@ -156,5 +156,15 @@ describe('selectModelByTag — keyless-skip resolution (#1711)', () => {
     expect(() => selectModelByTag(candidates, 'chat', undefined)).toThrow(
       ConvexError,
     );
+  });
+});
+
+describe('resolvedModelDataValidator', () => {
+  // Regression guard: `requestBodyMap` is a TOP-LEVEL field, so it is stripped
+  // at the ctx.runAction boundary (tag/id resolution) unless it's in this closed
+  // validator. Dropping it here would silently disable the wire transform on the
+  // V8/tag paths while the in-process chat path keeps working — hard to spot.
+  it('carries requestBodyMap so it survives action-boundary serialization', () => {
+    expect(resolvedModelDataValidator.fields).toHaveProperty('requestBodyMap');
   });
 });

--- a/services/platform/lib/shared/schemas/providers.test.ts
+++ b/services/platform/lib/shared/schemas/providers.test.ts
@@ -435,7 +435,7 @@ describe('providerJsonSchema', () => {
           expect(result.success).toBe(false);
           if (!result.success) {
             expect(result.error.issues[0].message).toContain(
-              "would overwrite the request body's",
+              'is part of the request body',
             );
           }
         });
@@ -491,7 +491,9 @@ describe('providerJsonSchema', () => {
         expect(result.success).toBe(false);
         if (!result.success) {
           const messages = result.error.issues.map((i) => i.message);
-          expect(messages.some((m) => m.includes('overwrite'))).toBe(true);
+          expect(
+            messages.some((m) => m.includes('is part of the request body')),
+          ).toBe(true);
           expect(
             messages.some((m) => m.includes('set it at the agent level')),
           ).toBe(true);
@@ -540,6 +542,67 @@ describe('providerJsonSchema', () => {
         });
         expect(result.success).toBe(false);
       });
+    });
+  });
+
+  describe('requestBodyMap', () => {
+    it('accepts a provider-level rename + remove map', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        requestBodyMap: {
+          rename: { max_tokens: 'max_completion_tokens' },
+          remove: ['frequency_penalty'],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a per-model requestBodyMap', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        models: [
+          {
+            id: 'test/model-1',
+            displayName: 'Test Model 1',
+            tags: ['chat'],
+            requestBodyMap: { rename: { max_tokens: 'max_completion_tokens' } },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a prototype-pollution key as a rename source', () => {
+      // `constructor` (unlike `__proto__`) becomes a real own key in a literal.
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        requestBodyMap: { rename: { constructor: 'x' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a prototype-pollution key as a rename target', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        requestBodyMap: { rename: { max_tokens: '__proto__' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a prototype-pollution key in remove', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        requestBodyMap: { remove: ['prototype'] },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown keys (strict)', () => {
+      const result = providerJsonSchema.safeParse({
+        ...baseProvider,
+        requestBodyMap: { renaem: { a: 'b' } },
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -147,7 +147,7 @@ function denyListRefine(
     } else if (BODY_OVERWRITE_SET.has(key)) {
       ctx.addIssue({
         code: 'custom',
-        message: `'${key}' would overwrite the request body's '${key}' field. Configure it via the agent's model/temperature/maxOutputTokens fields, not providerOptions.`,
+        message: `'${key}' is part of the request body Tale assembles and cannot be set via providerOptions. To cap output length, set the model's "Max output tokens" capability (Settings → Providers → edit model). To rename or drop a wire field for a quirky endpoint (e.g. max_tokens → max_completion_tokens), use the model's 'requestBodyMap'.`,
         path: [...pathPrefix, key],
       });
     } else if (pathPrefix.length === 0 && Array.isArray(sub)) {
@@ -224,6 +224,48 @@ function deepCheckPrototypePollution(
 const providerOptionsSchema = z
   .record(z.string(), z.unknown())
   .superRefine((value, ctx) => denyListRefine(value, ctx))
+  .optional();
+
+/**
+ * Declarative transform applied to the FINAL serialized request body on the way
+ * to the provider (see `convex/providers/request_body_transform.ts`),
+ * provider-default ⊕ per-model. Unlike `providerOptions` — which is spread onto
+ * the wire and is therefore deny-listed against clobbering reserved fields —
+ * this is meta-config that never reaches the provider: it renames/removes body
+ * fields AFTER the SDK assembles them. It is thus the sanctioned way to rewrite
+ * a reserved field for a quirky endpoint, e.g.
+ * `{ rename: { max_tokens: 'max_completion_tokens' } }` for an OpenAI / Azure
+ * reasoning deployment. `remove` deletes fields the endpoint rejects. Only
+ * object-prototype keys are forbidden (same defense-in-depth as providerOptions).
+ *
+ *   - `rename`: `{ <fromKey>: <toKey> }` — applied first.
+ *   - `remove`: `['<key>', …]` — applied after rename.
+ */
+export const requestBodyMapSchema = z
+  .object({
+    rename: z.record(z.string(), z.string()).optional(),
+    remove: z.array(z.string()).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    for (const [from, to] of Object.entries(value.rename ?? {})) {
+      if (PROTOTYPE_POLLUTION_SET.has(from)) {
+        addPrototypePollutionIssue(ctx, ['rename'], from);
+      }
+      if (PROTOTYPE_POLLUTION_SET.has(to)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `'${to}' is a reserved object-prototype key and is not allowed as a rename target.`,
+          path: ['rename', from],
+        });
+      }
+    }
+    for (const key of value.remove ?? []) {
+      if (PROTOTYPE_POLLUTION_SET.has(key)) {
+        addPrototypePollutionIssue(ctx, ['remove'], key);
+      }
+    }
+  })
   .optional();
 
 /**
@@ -495,6 +537,11 @@ const modelDefinitionSchema = z.object({
    */
   audioFormat: z.enum(audioFormatLiterals).optional(),
   providerOptions: providerOptionsSchema,
+  /**
+   * Per-model request-body transform; see `requestBodyMapSchema`. Overrides the
+   * provider-level `requestBodyMap` on conflicting sub-keys.
+   */
+  requestBodyMap: requestBodyMapSchema,
 });
 
 export type ModelDefinition = z.infer<typeof modelDefinitionSchema>;
@@ -543,6 +590,12 @@ export const providerJsonSchema = z
      * deny-list and authoring conventions.
      */
     providerOptions: providerOptionsSchema,
+    /**
+     * Provider-level request-body transform applied to every model in this file
+     * as a default; each model's own `requestBodyMap` overrides on conflicting
+     * sub-keys. See `requestBodyMapSchema`.
+     */
+    requestBodyMap: requestBodyMapSchema,
     models: z
       .array(modelDefinitionSchema)
       .min(1)

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -241,7 +241,7 @@ const providerOptionsSchema = z
  *   - `rename`: `{ <fromKey>: <toKey> }` — applied first.
  *   - `remove`: `['<key>', …]` — applied after rename.
  */
-export const requestBodyMapSchema = z
+const requestBodyMapSchema = z
   .object({
     rename: z.record(z.string(), z.string()).optional(),
     remove: z.array(z.string()).optional(),

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1392,6 +1392,7 @@
     "errorHintCreditExhausted": "Das Guthaben des KI-Anbieters wurde überschritten. Kontaktiere deinen Administrator, um Guthaben aufzuladen.",
     "errorHintMissingApiKey": "Für diese Organisation ist noch kein API-Schlüssel konfiguriert. Öffne Einstellungen → KI-Anbieter und füge einen hinzu, um den Chat zu starten.",
     "errorHintModelNotFound": "Das ausgewählte Modell wurde nicht gefunden oder ist nicht verfügbar. Kontaktiere deinen Administrator.",
+    "errorHintOutputCapTooHigh": "Die konfigurierten maximalen Ausgabe-Tokens sind höher als dieses Modell unterstützt. Bitte deinen Administrator, die maximalen Ausgabe-Tokens des Modells zu senken.",
     "errorHintProviderError": "Der KI-Anbieter hat vorübergehend technische Probleme. Bitte versuche es in einem Moment erneut.",
     "errorHintRateLimited": "Zu viele Anfragen. Bitte warte einen Moment und versuche es erneut.",
     "errorHintTokenLimit": "Das Token-Limit des Modells wurde überschritten. Versuche eine kürzere Anfrage oder bitte deinen Administrator, die Modelleinstellungen anzupassen.",
@@ -5378,6 +5379,7 @@
         "qualityScore": "Qualitäts-Score",
         "contextWindow": "Kontextfenster (Tokens)",
         "maxOutputTokens": "Max. Ausgabe-Tokens",
+        "maxOutputTokensHelp": "Begrenzt die Antwortlänge. Leer lassen für den Standardwert 32768; 0 für keine Begrenzung. Senke den Wert auf das tatsächliche Limit deines Deployments, falls der Anbieter zu grosse Werte ablehnt.",
         "reasoning": "Reasoning-Steuerung",
         "reasoningHelp": "Wie dieses Modell zum Reasoning angewiesen wird. Lass es leer, damit der Katalog entscheidet.",
         "notSet": "Nicht gesetzt",
@@ -5493,6 +5495,13 @@
         "discardConfirmAction": "Verwerfen",
         "discardConfirmKeep": "Weiter bearbeiten",
         "objectRequiredError": "Provider-Optionen müssen ein JSON-Objekt sein."
+      },
+      "requestBodyMap": {
+        "modelLevelTitle": "Erweitert — Request-Body-Map",
+        "modelLevelDescription": "Benenne Felder der finalen Anfrage an dieses Modell um oder entferne sie — für Endpunkte mit abweichendem Wire-Format. Anders als Provider-Optionen erreicht dies den Anbieter nie als Daten; es schreibt den Body direkt um.",
+        "guideLabel": "So funktioniert die Request-Body-Map",
+        "modelLevelHelp": "Zwei optionale Schlüssel:\n\n- **rename** — benennt einen Feldnamen in einen anderen um (wird zuerst angewendet). Der klassische Fall ist ein OpenAI-/Azure-Reasoning-Deployment, das `max_completion_tokens` statt `max_tokens` erwartet:\n\n```json\n{ \"rename\": { \"max_tokens\": \"max_completion_tokens\" } }\n```\n\n- **remove** — entfernt Felder, die der Endpunkt ablehnt:\n\n```json\n{ \"remove\": [\"frequency_penalty\"] }\n```\n\nModelle mit einer Reasoning-Capability erhalten die Umbenennung `max_tokens` → `max_completion_tokens` bereits automatisch. Leere Eingabe entfernt die Einstellung.",
+        "invalidJson": "Request-Body-Map ist kein gültiges JSON"
       },
       "versionConflictTitle": "Provider wurde geändert",
       "versionConflictDescription": "Lade die Seite neu, um die aktuelle Version zu sehen, und wende deine Änderungen erneut an.",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5474,6 +5474,7 @@
       "modelDescriptionPlaceholder": "z. B. Multimodales Modell mit Bildverarbeitung",
       "general": "Allgemein",
       "saveFailed": "Anbieter konnte nicht gespeichert werden",
+      "invalidConfigTitle": "Ungültige Anbieter-Konfiguration",
       "deleteFailed": "Anbieter konnte nicht gelöscht werden",
       "secretSaveFailed": "API-Schlüssel konnte nicht gespeichert werden",
       "forbiddenDeveloperSettings": "Du hast keine Berechtigung, die Anbieter-Konfiguration zu ändern.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5735,6 +5735,7 @@
       "modelDescriptionPlaceholder": "e.g., Multimodal model with vision capabilities",
       "general": "General",
       "saveFailed": "Failed to save provider",
+      "invalidConfigTitle": "Invalid provider configuration",
       "deleteFailed": "Failed to delete provider",
       "secretSaveFailed": "Failed to save API key",
       "forbiddenDeveloperSettings": "You don't have permission to modify provider configuration.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1412,6 +1412,7 @@
     "errorHintCreditExhausted": "The AI provider's credit limit was exceeded. Contact your administrator to add credits.",
     "errorHintMissingApiKey": "No API key is configured for this organization yet. Open Settings → AI providers and add one to start chatting.",
     "errorHintModelNotFound": "The selected model was not found or is unavailable. Contact your administrator.",
+    "errorHintOutputCapTooHigh": "This model's configured max output tokens is higher than the model supports. Ask your administrator to lower the model's Max output tokens setting.",
     "errorHintProviderError": "The AI provider is temporarily experiencing issues. Please try again in a moment.",
     "errorHintRateLimited": "Too many requests. Please wait a moment and try again.",
     "errorHintTokenLimit": "The model's output token limit was exceeded. Try a shorter request or ask your administrator to adjust the model settings.",
@@ -5639,6 +5640,7 @@
         "qualityScore": "Quality score",
         "contextWindow": "Context window (tokens)",
         "maxOutputTokens": "Max output tokens",
+        "maxOutputTokensHelp": "Caps response length. Leave blank for the 32768 default; set 0 for no cap. Lower it to your deployment's real ceiling if the provider rejects large values.",
         "reasoning": "Reasoning control",
         "reasoningHelp": "How this model is told to reason. Leave unset to let the catalog decide.",
         "notSet": "Not set",
@@ -5754,6 +5756,13 @@
         "discardConfirmAction": "Discard",
         "discardConfirmKeep": "Keep editing",
         "objectRequiredError": "Provider options must be a JSON object."
+      },
+      "requestBodyMap": {
+        "modelLevelTitle": "Advanced — Request body map",
+        "modelLevelDescription": "Rename or remove fields on the final request Tale sends to this model — for endpoints whose wire format differs. Unlike Provider Options, this never reaches the provider as data; it rewrites the body in place.",
+        "guideLabel": "How the request body map works",
+        "modelLevelHelp": "Two optional keys:\n\n- **rename** — map one field name to another (applied first). The classic case is an OpenAI/Azure reasoning deployment that wants `max_completion_tokens` instead of `max_tokens`:\n\n```json\n{ \"rename\": { \"max_tokens\": \"max_completion_tokens\" } }\n```\n\n- **remove** — drop fields the endpoint rejects:\n\n```json\n{ \"remove\": [\"frequency_penalty\"] }\n```\n\nModels flagged with a reasoning capability already get the `max_tokens` → `max_completion_tokens` rename automatically. Empty input clears the override.",
+        "invalidJson": "Request body map is not valid JSON"
       },
       "versionConflictTitle": "Provider was modified",
       "versionConflictDescription": "Reload the page to see the latest version, then re-apply your changes.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1393,6 +1393,7 @@
     "errorHintCreditExhausted": "Le plafond de crédits du fournisseur d'IA a été dépassé. Contacte ton administrateur pour ajouter des crédits.",
     "errorHintMissingApiKey": "Aucune clé API n'est encore configurée pour cette organisation. Ouvre Paramètres → Fournisseurs IA et ajoute-en une pour commencer à discuter.",
     "errorHintModelNotFound": "Le modèle sélectionné est introuvable ou indisponible. Contacte ton administrateur.",
+    "errorHintOutputCapTooHigh": "Le nombre maximal de tokens en sortie configuré est supérieur à ce que ce modèle prend en charge. Demande à ton administrateur de réduire le nombre maximal de tokens en sortie du modèle.",
     "errorHintProviderError": "Le fournisseur d'IA rencontre temporairement des problèmes. Merci de réessayer dans un instant.",
     "errorHintRateLimited": "Trop de requêtes. Merci de patienter un moment et réessayer.",
     "errorHintTokenLimit": "La limite de tokens en sortie du modèle a été dépassée. Essaie une requête plus courte ou demande à ton administrateur d'ajuster les paramètres du modèle.",
@@ -5379,6 +5380,7 @@
         "qualityScore": "Score de qualité",
         "contextWindow": "Fenêtre de contexte (tokens)",
         "maxOutputTokens": "Tokens de sortie max.",
+        "maxOutputTokensHelp": "Limite la longueur de la réponse. Laisse vide pour la valeur par défaut de 32768 ; mets 0 pour aucune limite. Réduis-la au plafond réel de ton déploiement si le fournisseur rejette les valeurs trop élevées.",
         "reasoning": "Contrôle du raisonnement",
         "reasoningHelp": "Comment ce modèle est invité à raisonner. Laisse vide pour laisser le catalogue décider.",
         "notSet": "Non défini",
@@ -5494,6 +5496,13 @@
         "discardConfirmAction": "Abandonner",
         "discardConfirmKeep": "Continuer l'édition",
         "objectRequiredError": "Les options du fournisseur doivent être un objet JSON."
+      },
+      "requestBodyMap": {
+        "modelLevelTitle": "Avancé — Mappage du corps de requête",
+        "modelLevelDescription": "Renomme ou supprime des champs de la requête finale envoyée à ce modèle — pour les points de terminaison dont le format diffère. Contrairement aux options du fournisseur, ceci n'atteint jamais le fournisseur en tant que données ; cela réécrit le corps sur place.",
+        "guideLabel": "Comment fonctionne le mappage du corps de requête",
+        "modelLevelHelp": "Deux clés optionnelles :\n\n- **rename** — renomme un champ en un autre (appliqué en premier). Le cas classique est un déploiement de raisonnement OpenAI/Azure qui attend `max_completion_tokens` au lieu de `max_tokens` :\n\n```json\n{ \"rename\": { \"max_tokens\": \"max_completion_tokens\" } }\n```\n\n- **remove** — supprime les champs que le point de terminaison rejette :\n\n```json\n{ \"remove\": [\"frequency_penalty\"] }\n```\n\nLes modèles dotés d'une capacité de raisonnement reçoivent déjà automatiquement le renommage `max_tokens` → `max_completion_tokens`. Une entrée vide efface le réglage.",
+        "invalidJson": "Le mappage du corps de requête n'est pas un JSON valide"
       },
       "versionConflictTitle": "Le fournisseur a été modifié",
       "versionConflictDescription": "Recharge la page pour voir la dernière version, puis réapplique tes modifications.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5475,6 +5475,7 @@
       "modelDescriptionPlaceholder": "ex., Modèle multimodal avec capacités de vision",
       "general": "Général",
       "saveFailed": "Échec de l'enregistrement du fournisseur",
+      "invalidConfigTitle": "Configuration du fournisseur invalide",
       "deleteFailed": "Échec de la suppression du fournisseur",
       "secretSaveFailed": "Échec de l'enregistrement de la clé API",
       "forbiddenDeveloperSettings": "Tu n'as pas l'autorisation de modifier la configuration du fournisseur.",


### PR DESCRIPTION
## Why

Custom OpenAI-compatible providers always serialize the output cap as `max_tokens`, but OpenAI/Azure **reasoning** deployments (o-series, GPT-5) reject it and require `max_completion_tokens` — so every chat fails, even "Hallo". Separately, the model-blind `32768` default `400`s on models with a lower ceiling (e.g. Azure gpt-4o ~16384), and that gets mislabeled in chat as "output token limit was exceeded". Reported by a self-hosted customer integrating Azure AI Foundry.

## What

- **Wire-transform chokepoint** (`request_body_transform.ts`): a declarative provider/per-model `requestBodyMap` (`{ rename, remove }`) applied to the final serialized body at the provider `fetch` boundary — the only seam that can rewrite reserved wire fields (`providerOptions` is spread onto the wire and deny-listed). Reasoning-flagged models get `max_tokens` → `max_completion_tokens` automatically.
- `requestBodyMap` is threaded **top-level** through the schema, the resolved-model validator, and both resolver build sites so it survives the `ctx.runAction` boundary (with a regression guard).
- **Error classification**: "max_tokens is too large …" `400`s become a new `outputCapTooHigh` category with operator-facing guidance instead of `tokenLimit`.
- **DX**: fixed the misleading providerOptions deny-list message; exposed the per-model `requestBodyMap` field and `maxOutputTokens` "0 = no cap" in the model editor; the JSON editor validates the `requestBodyMap` shape inline with a message that states the correct structure, and any server-side `INVALID_PROVIDER_CONFIG` is surfaced with the specific field + reason (not a generic "Save failed").

## Answers to the customer's questions
- **Default output cap**: `32768` when `maxOutputTokens` is unset (`0` = no cap).
- **Where to set it**: per-model under Settings → Providers → edit model → Model Capabilities.
- **Reasoning models**: flag the model as reasoning (auto-rename) or set `requestBodyMap: { "rename": { "max_tokens": "max_completion_tokens" } }`.

## Test plan
- Unit: `transformRequestBody`/merge/fetch-wrapper, schema (incl. prototype-pollution), the resolved-model-validator survival guard, and the error reclassification — all green.
- Gate: tsc clean, oxlint 0/0, oxfmt clean; docs structural suite + i18n parity (en/de/fr) pass; `api.d.ts` regenerated.
- **Pending**: live E2E against a real Azure reasoning endpoint (no such endpoint available locally; wire behavior is covered by the fetch-wrapper unit test).

## Ripple
- i18n: `errorHintOutputCapTooHigh`, `invalidConfigTitle`, `requestBodyMap.*` + `maxOutputTokensHelp` (en/de/fr)
- Docs: `providers.md` (en/de/fr) — `requestBodyMap`, reasoning auto-rename, `maxOutputTokens` `0 = no cap`
- No data migration (file-based provider config; additive optional field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request body mapping configuration to rename or remove fields in provider requests.
  * Per-model overrides for request body transformations.
  * Improved error detection for output token limit misconfigurations.

* **Documentation**
  * Expanded provider configuration guides in German, English, and French.

* **Improvements**
  * Better error messaging for invalid provider configurations.
  * Enhanced form validation and editor placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->