### PR TITLE
fix(sandbox): define exact timing.executeMs semantics across backends (#1848)

### DIFF
--- a/services/sandbox/src/backend/kubernetes/k8s-backend.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-backend.ts
@@ -968,11 +968,18 @@ export class KubernetesBackend implements ExecutionBackend {
       },
       timing: {
         stageMs: h?.stageMs ?? 0,
-        // Approximates the docker path's pre-harvest semantics; the residual
-        // (pod scheduling/startup) is documented on ExecutionBackend.execute.
+        // Prefer the exact measurement from the harvest container (runner
+        // start → runner exit, written by RUNNER_WRAPPER). Falls back to an
+        // approximation for older spawner images still on cluster: subtract
+        // stage, harvest, and upload time from the total wall-clock, leaving
+        // pod scheduling + image pull as the only unaccounted residual.
         executeMs: Math.max(
           0,
-          durationMs - (h?.harvestMs ?? 0) - (h?.uploadMs ?? 0),
+          h?.executeMs ??
+            durationMs -
+              (h?.stageMs ?? 0) -
+              (h?.harvestMs ?? 0) -
+              (h?.uploadMs ?? 0),
         ),
         harvestMs: h?.harvestMs ?? 0,
         uploadMs: h?.uploadMs ?? 0,

--- a/services/sandbox/src/backend/kubernetes/k8s-harvest.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-harvest.ts
@@ -29,6 +29,7 @@ import { EXEC_SPEC_PATH, parseExecSpec, type ExecSpec } from './exec-spec.ts';
 import {
   EXIT_CODE_PATH,
   PRESTAGE_PATH,
+  RUNNER_STARTED_PATH,
   STDERR_PATH,
   formatResultLine,
   formatStartedLine,
@@ -124,10 +125,26 @@ async function readPrestage(): Promise<PrestageFile> {
   }
 }
 
+async function readRunnerStartedAtMs(): Promise<number | undefined> {
+  try {
+    const raw = (await readFile(RUNNER_STARTED_PATH, 'utf8')).trim();
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return n;
+  } catch (err) {
+    if (!isENOENT(err)) {
+      console.warn('[sandbox.harvest] runner-started-at read error:', err);
+    }
+  }
+  return undefined;
+}
+
 async function run(spec: ExecSpec): Promise<K8sHarvestResult> {
   const { req, caps } = spec;
 
   const { exitCode, timedOut } = await waitForExitCode(spec.timeoutMs);
+  // Capture immediately after the runner exits so executeMs reflects actual
+  // container run time rather than harvest work time.
+  const runnerFinishedAtMs = Date.now();
   // Progress marker: tells the spawner we're past the exit-code wait (so a
   // dead runner can't be the reason we're silent) and carries the real exit
   // code so it survives even a later harvest crash.
@@ -140,6 +157,11 @@ async function run(spec: ExecSpec): Promise<K8sHarvestResult> {
 
   const stderr = await readCapped(STDERR_PATH, caps.stderrMaxBytes);
   const prestage = await readPrestage();
+  const runnerStartedAtMs = await readRunnerStartedAtMs();
+  const executeMs =
+    runnerStartedAtMs !== undefined
+      ? Math.max(0, runnerFinishedAtMs - runnerStartedAtMs)
+      : undefined;
 
   // Mirror the docker path (local-workspace-run.ts): a harvest crash must not
   // erase the result line — degrade to readFailed and ship the real exitCode,
@@ -197,6 +219,7 @@ async function run(spec: ExecSpec): Promise<K8sHarvestResult> {
     stageMs: prestage.stageMs,
     harvestMs,
     uploadMs: harvested.uploadMs,
+    ...(executeMs !== undefined && { executeMs }),
     ...(steps !== undefined && { steps }),
     ...(prestage.priorStage !== undefined && {
       priorStage: prestage.priorStage,

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
@@ -145,6 +145,11 @@ describe('buildSandboxPod', () => {
     expect(c.command?.[2]).toContain('/entrypoint.sh "$0" "$1" "$2" "$3"');
     expect(c.command?.[2]).toContain('2>/user/.runtime/tale/stderr.log');
     expect(c.command?.[2]).toContain('echo $? > /user/.runtime/tale/exit-code');
+    // runner-started-at written immediately before entrypoint so harvest can
+    // compute exact executeMs without including pod scheduling or stage init.
+    expect(c.command?.[2]).toContain(
+      'date +%s%3N > /user/.runtime/tale/runner-started-at',
+    );
     // No sentinel handshake — staging is an initContainer now.
     expect(c.command?.[2]).not.toContain('.staged');
     expect(c.command?.[2]).not.toContain('exec /entrypoint.sh');

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
@@ -42,7 +42,12 @@ import type {
 import type { Language, SpawnerConfig } from '../../types.ts';
 import type { CacheStores } from '../types.ts';
 import { EXEC_SPEC_MOUNT_DIR, secretNameFor } from './exec-spec.ts';
-import { EXIT_CODE_PATH, STDERR_PATH, TALE_DIR } from './k8s-protocol.ts';
+import {
+  EXIT_CODE_PATH,
+  RUNNER_STARTED_PATH,
+  STDERR_PATH,
+  TALE_DIR,
+} from './k8s-protocol.ts';
 
 interface SandboxPodInput {
   executionId: string;
@@ -94,8 +99,12 @@ export function podNameFor(executionId: string): string {
 // replaces only that child, so `sh -c` resumes here to capture the exit code.
 // stderr → a file (kept out of the K8s log stream, which is stdout-only for
 // clean phase parsing). $0..$3 come from the Pod `args` trailer below.
+// The runner-started-at timestamp (epoch ms, GNU date +%s%3N) is written just
+// before the entrypoint is called so the harvest sidecar can compute the exact
+// container execution time without including pod scheduling or stage init.
 const RUNNER_WRAPPER = [
   `mkdir -p ${TALE_DIR}`,
+  `date +%s%3N > ${RUNNER_STARTED_PATH}`,
   `/entrypoint.sh "$0" "$1" "$2" "$3" 2>${STDERR_PATH}`,
   `echo $? > ${EXIT_CODE_PATH}`,
 ].join('\n');

--- a/services/sandbox/src/backend/kubernetes/k8s-protocol.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-protocol.test.ts
@@ -37,6 +37,7 @@ const sample: K8sHarvestResult = {
   reportFailed: false,
   readFailed: false,
   stageMs: 120,
+  executeMs: 900,
   harvestMs: 45,
   uploadMs: 30,
   steps: [{ path: 'a.py', status: 'completed', exitCode: 0, durationMs: 10 }],

--- a/services/sandbox/src/backend/kubernetes/k8s-protocol.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-protocol.ts
@@ -18,6 +18,14 @@ export const TALE_DIR = '/user/.runtime/tale';
 export const EXIT_CODE_PATH = `${TALE_DIR}/exit-code`;
 export const STDERR_PATH = `${TALE_DIR}/stderr.log`;
 export const PRESTAGE_PATH = `${TALE_DIR}/prestage.json`;
+/**
+ * Written by the runner wrapper (RUNNER_WRAPPER in k8s-pod-spec.ts) just before
+ * calling the runtime entrypoint. Content: epoch milliseconds as a decimal
+ * string. Read by the harvest container to compute exact executeMs (container
+ * start → exit) without including pod scheduling or stage init time.
+ * Absent on older spawner images — harvest falls back to the approximation.
+ */
+export const RUNNER_STARTED_PATH = `${TALE_DIR}/runner-started-at`;
 
 /** What the stage initContainer persists for the harvest container to forward. */
 export interface PrestageFile {
@@ -105,6 +113,13 @@ export interface K8sHarvestResult {
   stageMs: number;
   harvestMs: number;
   uploadMs: number;
+  /**
+   * Exact container execution time in ms: from the runner-started-at timestamp
+   * (written by RUNNER_WRAPPER before calling the runtime entrypoint) to when
+   * the harvest container detected the runner's exit-code file. Absent when
+   * the runner-started-at file is missing (older spawner images on cluster).
+   */
+  executeMs?: number;
   steps?: SandboxStepResult[];
   priorStage?: PriorStageResult;
 }

--- a/services/sandbox/src/backend/local-workspace-run.ts
+++ b/services/sandbox/src/backend/local-workspace-run.ts
@@ -158,6 +158,10 @@ export async function runLocalWorkspaceExecution(
         stderrMaxBytes: cfg.stderrMaxBytes,
       },
     );
+    // Capture here (container already running) so executeMs excludes staging
+    // time. Aligns with the k8s path where runner-started-at is written just
+    // before the runtime entrypoint starts.
+    const runStartedAtMs = Date.now();
     const result: RunResult = await launched.wait({
       outerTimeoutMs: timeoutMs + 30_000,
       signal: opts.signal,
@@ -171,7 +175,9 @@ export async function runLocalWorkspaceExecution(
     });
     scanner.finalize();
 
-    const durationMs = Date.now() - startedAtMs;
+    const runEndedAtMs = Date.now();
+    const durationMs = runEndedAtMs - startedAtMs;
+    const executeMs = Math.max(0, runEndedAtMs - runStartedAtMs);
     const exitCode = result.exitCode;
 
     const stdoutWithoutPhases = stripPhaseMarkers(result.stdout);
@@ -266,7 +272,7 @@ export async function runLocalWorkspaceExecution(
       uploadStats: harvestUploadStats,
       timing: {
         stageMs,
-        executeMs: Math.max(0, durationMs),
+        executeMs,
         harvestMs,
         uploadMs,
       },


### PR DESCRIPTION
## Summary

Fixes #1848. Defines and enforces consistent `timing.executeMs` semantics across the Kubernetes and local-workspace backends so the field measures actual container execution time rather than a less-precise wall-clock approximation.

### What changed

**Kubernetes backend** (`k8s-pod-spec.ts`, `k8s-harvest.ts`, `k8s-protocol.ts`, `k8s-backend.ts`):
- `RUNNER_WRAPPER` now writes `date +%s%3N` to `runner-started-at` immediately before calling the runtime entrypoint.
- The harvest sidecar reads that file and computes `executeMs = finishedAt - startedAt`, excluding pod scheduling, image pull, and stage init time.
- `K8sHarvestResult` gains an optional `executeMs` field (absent on older spawner images).
- `k8s-backend.ts` prefers the exact harvest measurement and falls back to `durationMs − stageMs − harvestMs − uploadMs` for pods without the new file. The fallback also fixes a pre-existing bug where `stageMs` was not subtracted.

**Local-workspace backend** (`local-workspace-run.ts`):
- Records `runStartedAtMs` after container launch (post-staging) and `runEndedAtMs` after the run completes. `executeMs = runEndedAtMs − runStartedAtMs`, excluding staging time.

**Tests** (`k8s-protocol.test.ts`, `k8s-pod-spec.test.ts`):
- Added `executeMs` to the protocol round-trip fixture to cover the new optional field.
- Added assertion that the runner-started-at write is present in `RUNNER_WRAPPER`.

## Test plan

- [x] `bun test` in `services/sandbox` — 324 pass, 0 fail
- [x] `bun run typecheck` in `services/sandbox` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Execution time metrics now more accurately isolate actual task runtime from pod initialization and staging delays, providing clearer performance insights across all execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->