### PR TITLE
feat(platform): settings full-width sweep, banner alerts, and login UX

### DIFF
--- a/packages/ui/src/components/feedback/alert.tsx
+++ b/packages/ui/src/components/feedback/alert.tsx
@@ -10,12 +10,16 @@ const alertVariants = cva(
   'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
   {
     variants: {
+      // A real banner = a soft tinted fill + a colored icon, with neutral
+      // readable title/body. The accent lives in the background + icon (+
+      // border), not in a wall of colored text.
       variant: {
         default: 'bg-background text-foreground',
         destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
-        warning: 'border-amber-500/50 text-amber-600 [&>svg]:text-amber-600',
-        info: 'border-blue-500/50 text-blue-600 dark:text-blue-400 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400',
+          'border-destructive/25 bg-destructive/10 text-foreground [&>svg]:text-destructive',
+        warning:
+          'border-amber-500/30 bg-amber-50 text-foreground dark:bg-amber-950/30 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-500',
+        info: 'border-blue-500/30 bg-blue-50 text-foreground dark:bg-blue-950/30 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400',
       },
     },
     defaultVariants: {
@@ -62,10 +66,15 @@ export function Alert({
           {title}
         </Heading>
       )}
+      {/* Body is muted for hierarchy under the foreground title — the variant
+          color lives on the border, icon, and tint, not on a wall of colored
+          text. */}
       {description && (
-        <div className="text-sm [&_p]:leading-relaxed">{description}</div>
+        <div className="text-muted-foreground text-sm [&_p]:leading-relaxed">
+          {description}
+        </div>
       )}
-      {children}
+      {children && <div className="text-muted-foreground">{children}</div>}
     </div>
   );
 }

--- a/services/platform/app/features/settings/branding/components/color-picker-input.tsx
+++ b/services/platform/app/features/settings/branding/components/color-picker-input.tsx
@@ -67,10 +67,13 @@ export function ColorPickerInput({
       <button
         type="button"
         onClick={handleSwatchClick}
-        className="h-full w-7 shrink-0 cursor-pointer border-none"
-        style={{
-          backgroundColor: isValidHex ? value : '#FFFFFF',
-        }}
+        className={cn(
+          'h-full w-7 shrink-0 cursor-pointer border-none',
+          // No color set yet → a muted swatch reads as an empty slot instead of
+          // an invisible white block on the white field.
+          !isValidHex && 'bg-muted',
+        )}
+        style={isValidHex ? { backgroundColor: value } : undefined}
         aria-label={`Pick ${label.toLowerCase()}`}
       />
       <input
@@ -92,7 +95,8 @@ export function ColorPickerInput({
           value={displayValue}
           onChange={handleTextChange}
           maxLength={8}
-          className="text-foreground w-[4.5rem] border-none bg-transparent text-sm leading-5 font-normal outline-none"
+          placeholder="6366F1"
+          className="text-foreground placeholder:text-muted-foreground w-[4.5rem] border-none bg-transparent text-sm leading-5 font-normal outline-none"
           aria-label={`${label} hex value`}
         />
       </div>

--- a/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
@@ -121,9 +121,9 @@ function resolveGate(
 
 // =============================================================================
 // Container — owns the Convex reads (preferences + org defaults + memory
-// lists) and the loading state. Wraps the real `SettingsPage narrow` view in
-// `<Skeletonize>` so the skeleton inherits the SAME narrow centering and
-// section structure (no horizontal shift on load).
+// lists) and the loading state. Wraps the real full-width view in
+// `<Skeletonize>` so the skeleton inherits the SAME section structure (no
+// horizontal shift on load).
 // =============================================================================
 function PersonalizationSettingsInner({
   organizationId,
@@ -178,7 +178,7 @@ function PersonalizationSettingsInner({
 }
 
 // =============================================================================
-// Plain presentational view — renders the real `SettingsPage narrow` layout.
+// Plain presentational view — renders the real full-width layout.
 // Rendered both live and (wrapped in `<Skeletonize>`) as its own skeleton, so
 // loading and loaded layouts are the SAME tree and cannot drift. While loading
 // the gate-dependent sections are force-rendered (masked) so they reserve
@@ -206,7 +206,7 @@ function PersonalizationSettingsView({
   const loading = useSkeleton();
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SettingsSection
         title={t('page.title')}
         description={
@@ -421,6 +421,7 @@ function CustomInstructionsSection({
 
   return (
     <SettingsSection
+      className="border-border border-t pt-8"
       title={t('page.customInstructions.title')}
       description={t('page.customInstructions.description')}
     >
@@ -592,7 +593,10 @@ function SavedMemoriesSection({
   const loading = useSkeleton();
 
   return (
-    <SettingsSection title={t('page.memories.title')}>
+    <SettingsSection
+      className="border-border border-t pt-8"
+      title={t('page.memories.title')}
+    >
       {loading ? (
         <MemoryListSkeletonRows />
       ) : memories.length === 0 ? (
@@ -644,7 +648,10 @@ function PendingMemoriesSection({
   const loading = useSkeleton();
 
   return (
-    <SettingsSection title={t('page.pending.title')}>
+    <SettingsSection
+      className="border-border border-t pt-8"
+      title={t('page.pending.title')}
+    >
       {loading ? (
         <MemoryListSkeletonRows />
       ) : memories.length === 0 ? (

--- a/services/platform/app/features/settings/providers/components/model-catalog-card.tsx
+++ b/services/platform/app/features/settings/providers/components/model-catalog-card.tsx
@@ -16,6 +16,8 @@ import { useT } from '@/lib/i18n/client';
 
 interface ModelCatalogCardProps {
   organizationId: string;
+  /** Forwarded to the section root (e.g. a divider border). */
+  className?: string;
 }
 
 /**
@@ -23,7 +25,10 @@ interface ModelCatalogCardProps {
  * last synced from the proven source (OpenRouter) and offers a manual refresh.
  * The cron keeps it fresh automatically; this is the on-demand escape hatch.
  */
-export function ModelCatalogCard({ organizationId }: ModelCatalogCardProps) {
+export function ModelCatalogCard({
+  organizationId,
+  className,
+}: ModelCatalogCardProps) {
   const { t } = useT('settings');
   const { formatDate } = useFormatDate();
   const { data: status } = useConvexQuery(
@@ -87,6 +92,7 @@ export function ModelCatalogCard({ organizationId }: ModelCatalogCardProps) {
   return (
     <PageSection
       as="h2"
+      className={className}
       title={t('providers.modelCatalog.title')}
       description={t('providers.modelCatalog.description')}
     >

--- a/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
+++ b/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
@@ -13,6 +13,7 @@ import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
+import { SettingsRow } from '@/app/features/settings/components/settings-row';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
@@ -63,7 +64,7 @@ function UserEnvSettingsView({
   const { t } = useT('userEnv');
 
   return (
-    <SettingsPage narrow>
+    <SettingsPage>
       <SettingsSection
         title={t('page.title')}
         description={t('page.description')}
@@ -196,13 +197,20 @@ function AddEnvVarForm({ organizationId }: { organizationId: string }) {
           {t('add.whitespaceWarning')}
         </Text>
       )}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* Secret as a full-width settings row (label + help left, toggle pinned
+          right) so the toggle stays anchored to the right edge instead of
+          floating mid-row at full width. Add gets its own right-aligned row. */}
+      <SettingsRow
+        label={t('add.secretLabel')}
+        description={t('add.secretHelp')}
+      >
         <Switch
           checked={isSecret}
           onCheckedChange={setIsSecret}
-          label={t('add.secretLabel')}
-          description={t('add.secretHelp')}
+          aria-label={t('add.secretLabel')}
         />
+      </SettingsRow>
+      <div className="flex justify-end">
         <Button type="submit" variant="primary" disabled={!canSubmit}>
           {t('add.submit')}
         </Button>

--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -1,12 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
-import { Separator } from '@tale/ui/separator';
 import {
   createFileRoute,
   useNavigate,
   useSearch,
 } from '@tanstack/react-router';
+import { AlertCircle } from 'lucide-react';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -15,6 +15,7 @@ import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
 import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
+import { Label } from '@/app/components/ui/forms/label';
 import { AuthFormLayout } from '@/app/features/auth/components/auth-form-layout';
 import {
   useHasAnyUsers,
@@ -313,7 +314,7 @@ export function LogInPage() {
 
   return (
     <AuthFormLayout title={t('login.loginTitle')}>
-      <Stack gap={8}>
+      <Stack gap={6}>
         {signedOutForIdle && (
           <p
             role="status"
@@ -337,51 +338,61 @@ export function LogInPage() {
               })}
             />
 
-            <Input
-              id="password"
-              type="password"
-              label={t('password')}
-              placeholder={t('passwordPlaceholder')}
-              disabled={isSubmitting}
-              autoComplete="current-password"
-              className="shadow-xs"
-              description={
-                <span className="flex justify-end">
-                  <Button
-                    type="button"
-                    variant="link"
-                    size="sm"
-                    onClick={() =>
-                      toast({
-                        title: t('login.forgotPasswordToast.title'),
-                        description: t('login.forgotPasswordToast.description'),
-                        position: 'top-center',
-                      })
-                    }
-                  >
-                    {t('login.forgotPassword')}
-                  </Button>
-                </span>
-              }
-              {...form.register('password', {
-                onChange: () => setLoginError(null),
-              })}
-            />
+            {/* "Forgot password?" sits on the label row (label left, link
+                right) — the standard pattern — so the space directly under the
+                input is free for the error message to read as field feedback. */}
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="password">{t('password')}</Label>
+                <Button
+                  type="button"
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0"
+                  onClick={() =>
+                    toast({
+                      title: t('login.forgotPasswordToast.title'),
+                      description: t('login.forgotPasswordToast.description'),
+                      position: 'top-center',
+                    })
+                  }
+                >
+                  {t('login.forgotPassword')}
+                </Button>
+              </div>
+              <Input
+                id="password"
+                type="password"
+                placeholder={t('passwordPlaceholder')}
+                disabled={isSubmitting}
+                autoComplete="current-password"
+                className="shadow-xs"
+                {...form.register('password', {
+                  onChange: () => setLoginError(null),
+                })}
+              />
+            </div>
 
             {loginError && (
-              <p
+              // Pull up tight against the fields (counteracting the form's
+              // `space-y-4`) so the message reads as feedback on the inputs —
+              // matching the ~6px gap a field-level error uses — rather than
+              // floating midway to the button.
+              <div
                 role="alert"
                 aria-live="polite"
-                className="text-destructive flex items-center gap-1.5 text-sm"
+                className="-mt-2.5 flex flex-col gap-1"
               >
-                {loginError}
-              </p>
-            )}
-
-            {showLockoutHint && (
-              <p aria-live="polite" className="text-muted-foreground text-xs">
-                {t('login.lockoutAdvisory')}
-              </p>
+                <p className="text-destructive flex items-start gap-1.5 text-sm font-medium">
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+                  {loginError}
+                </p>
+                {showLockoutHint && (
+                  <p className="text-muted-foreground pl-[1.375rem] text-xs">
+                    {t('login.lockoutAdvisory')}
+                  </p>
+                )}
+              </div>
             )}
 
             <Button type="submit" fullWidth disabled={isSubmitting || !isValid}>
@@ -390,19 +401,26 @@ export function LogInPage() {
           </Form>
         </FormSection>
 
-        <Button
-          onClick={handlePasskeyLogin}
-          variant="secondary"
-          fullWidth
-          disabled={isSubmitting}
-        >
-          {t('login.continueWithPasskey')}
-        </Button>
+        {/* A single "or" divider separates the credential method above from the
+            alternative sign-in methods grouped below — it reads correctly with
+            one alternative (passkey) or two (passkey + SSO). */}
+        <div className="flex items-center gap-3" aria-hidden="true">
+          <span className="bg-border h-px flex-1" />
+          <span className="text-muted-foreground text-xs">{tCommon('or')}</span>
+          <span className="bg-border h-px flex-1" />
+        </div>
 
-        {showSsoButton && (
-          <>
-            <Separator variant="muted" />
+        <Stack gap={3}>
+          <Button
+            onClick={handlePasskeyLogin}
+            variant="secondary"
+            fullWidth
+            disabled={isSubmitting}
+          >
+            {t('login.continueWithPasskey')}
+          </Button>
 
+          {showSsoButton && (
             <Button
               onClick={handleSsoLogin}
               variant="secondary"
@@ -414,8 +432,8 @@ export function LogInPage() {
               </span>
               {t('login.continueWithSso')}
             </Button>
-          </>
-        )}
+          )}
+        </Stack>
       </Stack>
     </AuthFormLayout>
   );

--- a/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
@@ -23,7 +23,10 @@ function ProvidersIndexRoute() {
       >
         <ProvidersTable organizationId={id} />
       </SettingsSection>
-      <ModelCatalogCard organizationId={id} />
+      <ModelCatalogCard
+        organizationId={id}
+        className="border-border border-t pt-8"
+      />
     </SettingsPage>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1440,6 +1440,7 @@
   },
   "common": {
     "optional": "optional",
+    "or": "oder",
     "dates": {
       "today": "Heute",
       "yesterday": "Gestern"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1440,6 +1440,7 @@
   },
   "common": {
     "optional": "optional",
+    "or": "or",
     "dates": {
       "today": "Today",
       "yesterday": "Yesterday"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1441,6 +1441,7 @@
   },
   "common": {
     "optional": "facultatif",
+    "or": "ou",
     "dates": {
       "today": "Aujourd'hui",
       "yesterday": "Hier"


### PR DESCRIPTION
## Summary

Follow-up UX polish after #1903 (which is merged). Two cohesive areas:

**Settings + shared UI**
- Make **Preferences** and **Environment** full-width (drop `narrow`) to match the rest of the settings pages; add section dividers to **Preferences** and **AI providers** for consistency.
- **Environment** add-var form: render *Secret* as a full-width settings row (label + help left, toggle pinned right) with **Add** on its own row, so the toggle is anchored instead of floating at full width.
- **Branding** color inputs: show a muted swatch + hex placeholder when empty, so the field reads as an empty input rather than a stray "#".
- Restyle the shared **`Alert`** as a proper banner — soft tinted fill + colored icon, foreground title, muted body for hierarchy (was bordered text with a saturated body). Applies to info/warning/destructive app-wide.

**Login**
- Tighten the Log in ↔ passkey spacing and add a single **"or" divider** after the credential form, grouping the alternative methods (passkey + SSO) beneath it.
- Move **"Forgot password?"** onto the password label row so the error can sit directly under the input.
- Present a wrong-credentials error as a clear, iconed message **hugging the field** (neutral fields, message-only) instead of floating mid-form.

Adds the `common.or` key in en/de/fr.

## Pre-PR checklist

- [x] Ran format, lint, and typecheck for `@tale/platform` + `@tale/ui` — all clean.
- [x] No hand-rolled skeletons / magic `h-[…]` — N/A.
- [x] Updated `services/platform/messages/{en,de,fr}.json` (`common.or`; de-CH inherits).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (visual layout + microcopy polish; no new features/flows/APIs).
- [ ] docs lint/test, README — N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added improved sign-in options display on login page with clearer visual organization
  * Added multi-language localization support

* **Improvements**
  * Enhanced alert component styling with softer backgrounds for better visual clarity
  * Improved color picker input handling and placeholder display
  * Refined settings pages layout and presentation for better usability
  * Enhanced login page error feedback and password reset access visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->