### PR TITLE
feat(platform): interactive PDF links, sensitive-field masking, branch-aware canvas

### DIFF
--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -40,8 +40,18 @@ describe('Input', () => {
   });
 
   describe('password input', () => {
+    // A genuine account-password field opts into the password manager with an
+    // explicit autoComplete; this keeps the real `type="password"` ↔ `"text"`
+    // toggle (the `sensitive` carve-out below covers credential fields that
+    // must NOT trigger the password manager).
     it('renders password input with toggle', () => {
-      render(<Input type="password" label="Password" />);
+      render(
+        <Input
+          type="password"
+          label="Password"
+          autoComplete="current-password"
+        />,
+      );
       const input = screen.getByLabelText(/^Password\b/);
       expect(input).toHaveAttribute('type', 'password');
       expect(
@@ -50,7 +60,13 @@ describe('Input', () => {
     });
 
     it('toggles password visibility', async () => {
-      const { user } = render(<Input type="password" label="Password" />);
+      const { user } = render(
+        <Input
+          type="password"
+          label="Password"
+          autoComplete="current-password"
+        />,
+      );
       const input = screen.getByLabelText(/^Password\b/);
       const toggle = screen.getByRole('button', { name: /show password/i });
 
@@ -86,6 +102,44 @@ describe('Input', () => {
       expect(input.style.color).toBe('red');
       await user.click(toggle);
       expect(input.style.color).toBe('red');
+    });
+  });
+
+  describe('sensitive fields', () => {
+    // Sensitive secrets (API keys, tokens) must NOT trip the browser's
+    // saved-password dropdown, so they render as `type="text"` (masked via CSS
+    // `-webkit-text-security`, which jsdom can't observe) rather than a real
+    // `type="password"`. We assert the observable contract: the `type="text"`
+    // carve-out, the password-manager opt-out attrs, and the reveal toggle.
+    it('renders an explicit sensitive field as text, not type=password', () => {
+      render(<Input sensitive label="API key" />);
+      const input = screen.getByLabelText(/^API key\b/);
+      expect(input).toHaveAttribute('type', 'text');
+    });
+
+    it('treats a bare password field (no autoComplete) as sensitive', () => {
+      render(<Input type="password" label="Secret" />);
+      const input = screen.getByLabelText(/^Secret\b/);
+      // Rendered as text (CSS-masked), not a real password field — this is what
+      // dodges Chrome's saved-password dropdown.
+      expect(input).toHaveAttribute('type', 'text');
+    });
+
+    it('exposes a reveal toggle on a sensitive field', async () => {
+      const { user } = render(<Input sensitive label="API key" />);
+      const toggle = screen.getByRole('button', { name: /show password/i });
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('opts out of password managers on sensitive fields', () => {
+      render(<Input sensitive label="API key" />);
+      const input = screen.getByLabelText(/^API key\b/);
+      expect(input).toHaveAttribute('autocomplete', 'off');
+      expect(input).toHaveAttribute('data-1p-ignore');
+      expect(input).toHaveAttribute('data-lpignore', 'true');
     });
   });
 
@@ -221,7 +275,12 @@ describe('Input', () => {
         defaultValues: { password: 'secret123' },
       });
       return (
-        <Input type="password" label="Password" {...register('password')} />
+        <Input
+          type="password"
+          label="Password"
+          autoComplete="current-password"
+          {...register('password')}
+        />
       );
     }
 

--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -140,6 +140,8 @@ describe('Input', () => {
       expect(input).toHaveAttribute('autocomplete', 'off');
       expect(input).toHaveAttribute('data-1p-ignore');
       expect(input).toHaveAttribute('data-lpignore', 'true');
+      expect(input).toHaveAttribute('data-form-type', 'other');
+      expect(input).toHaveAttribute('data-bwignore', 'true');
     });
   });
 

--- a/services/platform/app/components/ui/forms/input.tsx
+++ b/services/platform/app/components/ui/forms/input.tsx
@@ -45,6 +45,13 @@ const inputVariants = cva(
 type BaseProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> &
   VariantProps<typeof inputVariants> & {
     passwordToggle?: boolean;
+    /**
+     * Mark the field as holding a secret (API key, token, credential). Suppresses
+     * the browser's "save password" prompt and password-manager autofill overlays
+     * so the value is never cached in the credential store. `type="password"`
+     * fields are treated as sensitive automatically.
+     */
+    sensitive?: boolean;
     errorMessage?: string;
     isInvalid?: boolean;
     label?: string;
@@ -63,6 +70,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
       className,
       type,
       passwordToggle = true,
+      sensitive,
       autoComplete,
       variant,
       size,
@@ -88,9 +96,61 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
     const isPassword = type === 'password';
     const [show, setShow] = useState(false);
     const [showShake, setShowShake] = useState(false);
-    const inputType = isPassword ? (show ? 'text' : 'password') : type;
+
+    // A field is "sensitive" when it holds a secret that is NOT an account
+    // password — API keys, tokens, connector credentials. The caller opts in
+    // via `sensitive`, OR it's a `type="password"` field that did NOT declare
+    // an explicit `autoComplete`. The explicit-autoComplete carve-out keeps
+    // genuine account forms working: login / 2FA / reset pass
+    // `autoComplete="current-password"` / `"new-password"` because they *want*
+    // the password manager to fill and save. Every credential-config field
+    // passes no autoComplete, so it's protected automatically.
+    const isSensitive = sensitive || (isPassword && autoComplete == null);
+
+    // The crux of the fix: Chrome treats ANY `type="password"` as an account
+    // password and shows its saved-password dropdown / "Suggest strong
+    // password" on focus — and largely ignores `autocomplete` hints telling it
+    // otherwise. So a sensitive field is rendered as `type="text"` and masked
+    // purely with CSS (`-webkit-text-security`). To the browser it's plain
+    // text → no password dropdown, no save prompt, no strong-password
+    // suggestion — but it still shows as dots and the eye toggle still reveals
+    // it. Genuine `type="password"` fields keep real type-switching so the
+    // password manager continues to work as expected.
+    const inputType = isSensitive
+      ? 'text'
+      : isPassword
+        ? show
+          ? 'text'
+          : 'password'
+        : type;
+    // For sensitive fields, mask via CSS unless revealed. For real password
+    // fields, clear the browser's autofill `-webkit-text-security` overlay when
+    // the value is revealed (it persists even after `type` flips to "text").
+    const securityStyle: { WebkitTextSecurity?: 'disc' | 'none' } | undefined =
+      isSensitive
+        ? { WebkitTextSecurity: show ? 'none' : 'disc' }
+        : isPassword && show
+          ? { WebkitTextSecurity: 'none' }
+          : undefined;
+    // Whether to render the eye reveal button: any masked field that opts into
+    // the toggle (sensitive secrets or genuine passwords).
+    const showToggle = (isSensitive || isPassword) && passwordToggle;
+
     const resolvedAutoComplete =
-      autoComplete ?? (isPassword ? 'off' : undefined);
+      autoComplete ?? (isSensitive ? 'off' : undefined);
+    // Belt-and-suspenders for password managers, which key off field
+    // name/label rather than just `type`: explicitly opt out of 1Password /
+    // LastPass / Bitwarden / Dashlane. (The `type="text"` switch above is what
+    // actually stops the browser's own password dropdown.)
+    const sensitiveAttrs = isSensitive
+      ? {
+          autoComplete: resolvedAutoComplete,
+          'data-1p-ignore': true,
+          'data-lpignore': 'true',
+          'data-form-type': 'other',
+          'data-bwignore': 'true',
+        }
+      : { autoComplete: resolvedAutoComplete };
     const hasError = !!errorMessage;
     const showInvalid = hasError || !!isInvalid;
     // Merge caller-supplied `aria-describedby` with the internal ids so a
@@ -111,7 +171,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
       return undefined;
     }, [showInvalid, errorMessage]);
 
-    if (isPassword && passwordToggle) {
+    if (showToggle) {
       return (
         <div className={cn('flex flex-col gap-1.5', wrapperClassName)}>
           {label && (
@@ -128,7 +188,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
             <input
               id={id}
               type={inputType}
-              autoComplete={resolvedAutoComplete}
+              {...sensitiveAttrs}
               className={cn(
                 inputVariants({ variant, size }),
                 showInvalid &&
@@ -143,13 +203,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
               aria-describedby={describedBy}
               aria-errormessage={hasError ? errorId : undefined}
               {...props}
-              // Force-clear browser autofill masking when password is revealed.
-              // Chrome/Safari apply `-webkit-text-security: disc` via their autofill
-              // overlay, which persists even after `type` changes to "text".
-              style={{
-                ...style,
-                ...(show && { WebkitTextSecurity: 'none' }),
-              }}
+              style={{ ...style, ...securityStyle }}
             />
             <Tooltip
               content={show ? t('aria.hidePassword') : t('aria.showPassword')}
@@ -203,8 +257,8 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
         )}
         <input
           id={id}
-          type={type}
-          autoComplete={resolvedAutoComplete}
+          type={inputType}
+          {...sensitiveAttrs}
           className={cn(
             inputVariants({ variant, size }),
             showInvalid && 'border-destructive focus-visible:ring-destructive',
@@ -217,7 +271,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
           aria-describedby={describedBy}
           aria-errormessage={hasError ? errorId : undefined}
           {...props}
-          style={style}
+          style={{ ...style, ...securityStyle }}
         />
         {errorMessage && (
           <p

--- a/services/platform/app/components/ui/forms/search-input.tsx
+++ b/services/platform/app/components/ui/forms/search-input.tsx
@@ -71,12 +71,13 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       return undefined;
     }, [hasError, errorMessage]);
 
+    // Search is not a secret, so we don't mask it — but we still suppress
+    // password-manager autofill the same way: readonly until focus.
     const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
       e.currentTarget.removeAttribute('readonly');
       setIsReadOnly(false);
       onFocus?.(e);
     };
-
     const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
       setIsReadOnly(true);
       onBlur?.(e);
@@ -98,10 +99,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             ref={ref}
             id={id}
             type="text"
-            autoComplete="new-password"
+            autoComplete="off"
             data-1p-ignore
             data-lpignore="true"
             data-form-type="other"
+            data-bwignore="true"
             readOnly={isReadOnly}
             className={cn(
               'pl-10 max-w-70 h-9',

--- a/services/platform/app/features/documents/components/document-preview-pdf.tsx
+++ b/services/platform/app/features/documents/components/document-preview-pdf.tsx
@@ -33,6 +33,8 @@ import React, {
 
 import { useT } from '@/lib/i18n/client';
 
+import './pdf-layers.css';
+import { PdfLinkPopup, type PdfLinkPopupState } from './pdf-link-popup';
 import { PreviewPane } from './preview-pane';
 
 interface ViewerState {
@@ -101,6 +103,26 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const renderTaskRef = useRef<RenderTask | null>(null);
+  // Container sized to the CSS footprint of the page; the canvas plus the text
+  // and annotation layers all stack inside it so the selectable text and the
+  // clickable links line up pixel-for-pixel with the rasterised page. The text
+  // and annotation layer <div>s are created and appended here by the pdfjs
+  // builders (see renderTextAndAnnotationLayers).
+  const pageWrapRef = useRef<HTMLDivElement | null>(null);
+
+  const [linkPopup, setLinkPopup] = useState<PdfLinkPopupState | null>(null);
+  const pdfLibRef = useRef<typeof import('pdfjs-dist') | null>(null);
+  // pdfjs's high-level layer builders + a navigation-less link service live in
+  // the viewer entrypoint, loaded lazily alongside the core library.
+  const pdfViewerRef = useRef<
+    typeof import('pdfjs-dist/web/pdf_viewer.mjs') | null
+  >(null);
+  const linkServiceRef = useRef<InstanceType<
+    (typeof import('pdfjs-dist/web/pdf_viewer.mjs'))['SimpleLinkService']
+  > | null>(null);
+  const textLayerBuilderRef = useRef<InstanceType<
+    (typeof import('pdfjs-dist/web/pdf_viewer.mjs'))['TextLayerBuilder']
+  > | null>(null);
 
   const renderPageRef = useRef<
     ((params: RenderParams) => Promise<void>) | undefined
@@ -162,12 +184,85 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
       canvas.height = Math.ceil(scaledViewport.height);
 
       ctx.drawImage(bufferCanvas, 0, 0);
+
+      // Size the layer wrapper to the page's CSS footprint so the text and
+      // annotation layers overlay the canvas exactly.
+      if (pageWrapRef.current) {
+        pageWrapRef.current.style.width = `${cssWidth}px`;
+        pageWrapRef.current.style.height = `${cssHeight}px`;
+      }
+
+      await renderTextAndAnnotationLayers(page, params.scale);
     } catch (error) {
       console.error('Error rendering page:', error);
     } finally {
       dispatch({ type: 'RENDER_COMPLETE' });
     }
   };
+
+  // Renders the selectable text layer and the interactive annotation (link)
+  // layer over the rasterised canvas using pdfjs's own layer builders. The
+  // builders own the DOM nodes (created and appended via `onAppend`) and, for
+  // the text layer, the selection-smoothing handlers (the `.selecting` toggle +
+  // `endOfContent` element) that make a drag track the pointer instead of
+  // snapping. The viewport is at the CSS scale (without the device-pixel
+  // multiplier) so the layers map onto the canvas's displayed size.
+  const renderTextAndAnnotationLayers = useCallback(
+    async (page: PDFPageProxy, scale: number) => {
+      const viewer = pdfViewerRef.current;
+      const linkService = linkServiceRef.current;
+      const wrap = pageWrapRef.current;
+      if (!viewer || !linkService || !wrap) return;
+
+      // pdfjs derives layer + glyph layout from `--scale-factor` (the wrapper's
+      // CSS rules turn it into `--total-scale-factor`).
+      wrap.style.setProperty('--scale-factor', String(scale));
+
+      const cssViewport = page.getViewport({ scale });
+
+      // Tear down the previous render's layer nodes (the builders append fresh
+      // ones each time). Cancelling the text builder also detaches its global
+      // selection listeners.
+      textLayerBuilderRef.current?.cancel();
+      wrap
+        .querySelectorAll('.textLayer, .annotationLayer')
+        .forEach((node) => node.remove());
+
+      // Text layer (selection).
+      try {
+        const textBuilder = new viewer.TextLayerBuilder({
+          pdfPage: page,
+          onAppend: (div: HTMLDivElement) => wrap.append(div),
+        });
+        textLayerBuilderRef.current = textBuilder;
+        await textBuilder.render({ viewport: cssViewport });
+      } catch (err) {
+        // A re-render cancels the previous text layer; that's expected.
+        const isAbort = err instanceof Error && err.name === 'AbortException';
+        if (!isAbort) {
+          console.warn('Failed to render PDF text layer:', err);
+        }
+      }
+
+      // Annotation layer (links). SimpleLinkService stamps real hrefs onto the
+      // link <a>s; navigation is still intercepted by our own click handler.
+      try {
+        const annotationBuilder = new viewer.AnnotationLayerBuilder({
+          pdfPage: page,
+          linkService,
+          renderForms: false,
+          onAppend: (div: HTMLDivElement) => wrap.append(div),
+        });
+        await annotationBuilder.render({
+          viewport: cssViewport,
+          intent: 'display',
+        });
+      } catch (err) {
+        console.warn('Failed to render PDF annotation layer:', err);
+      }
+    },
+    [],
+  );
 
   const queueRenderPage = useCallback(
     (params: RenderParams) => {
@@ -196,8 +291,20 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const lib = await import('pdfjs-dist');
+      const [lib, viewer] = await Promise.all([
+        import('pdfjs-dist'),
+        import('pdfjs-dist/web/pdf_viewer.mjs'),
+      ]);
       if (cancelled) return;
+      pdfLibRef.current = lib;
+      pdfViewerRef.current = viewer;
+      // Navigation-less link service: it builds link <a>s with correct hrefs
+      // (inherited addLinkAttributes) but never owns navigation — our click
+      // handler shows a popup instead. LinkTarget.BLANK (2) renders externals
+      // as new-tab anchors.
+      const linkService = new viewer.SimpleLinkService();
+      linkService.externalLinkTarget = 2;
+      linkServiceRef.current = linkService;
       lib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
       try {
         const doc = await lib.getDocument(url).promise;
@@ -223,6 +330,9 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
           renderTaskRef.current.cancel();
         }
       } catch {}
+      // Detach the text layer's global selection listeners.
+      textLayerBuilderRef.current?.cancel();
+      textLayerBuilderRef.current = null;
       bufferCanvasRef.current = null;
     };
   }, []);
@@ -265,6 +375,22 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
     const bounded = Math.min(Math.max(value, 1), state.totalPages || 1);
     dispatch({ type: 'SET_PAGE', page: bounded });
     queueRenderPage({ pageNum: bounded, scale: state.scale });
+  };
+
+  // Intercept clicks on links inside the annotation layer. Rather than letting
+  // the browser navigate away from the preview, surface a popup offering to
+  // copy the destination or open it in a new tab.
+  const onAnnotationLayerClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target;
+    const anchor = target instanceof Element ? target.closest('a') : null;
+    const href = anchor?.getAttribute('href');
+    if (!anchor || !href) return;
+    // Only intercept external/absolute URLs; in-document jumps (which the link
+    // service renders as "#...") shouldn't open a popup.
+    if (href.startsWith('#')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setLinkPopup({ url: anchor.href, x: e.clientX, y: e.clientY });
   };
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -334,11 +460,21 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
     <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
       <PreviewPane className="overflow-x-auto">
         <div className="flex min-h-full w-fit min-w-full justify-center">
-          <canvas
-            ref={canvasRef}
-            className="block h-auto"
-            style={{ maxWidth: `calc(48rem * ${state.scale})` }}
-          />
+          {/* Sized imperatively to the page's CSS footprint after each render so
+              the canvas and the pdfjs-appended text/annotation layers share
+              identical dimensions and stay pixel-aligned. The click handler is
+              delegation only — the real interactive elements are the
+              pdfjs-generated, keyboard-focusable <a> link anchors nested inside;
+              this wrapper carries no semantics of its own. Wide pages overflow
+              into the pane's horizontal scroll. */}
+          {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- delegates to nested focusable <a> link annotations */}
+          <div
+            ref={pageWrapRef}
+            className="pdfLayerWrap relative block shrink-0"
+            onClick={onAnnotationLayerClick}
+          >
+            <canvas ref={canvasRef} className="block size-full" />
+          </div>
         </div>
         {!state.pdfDoc && (
           // Document-shaped pulse matching the rendered page footprint, so the
@@ -426,6 +562,9 @@ export const DocumentPreviewPDF = ({ url }: { url: string }) => {
           </HStack>
         </HStack>
       </div>
+      {linkPopup && (
+        <PdfLinkPopup state={linkPopup} onClose={() => setLinkPopup(null)} />
+      )}
     </div>
   );
 };

--- a/services/platform/app/features/documents/components/pdf-layers.css
+++ b/services/platform/app/features/documents/components/pdf-layers.css
@@ -1,0 +1,142 @@
+/* Positioning + selection rules for the PDF text and annotation (link) layers
+ * that pdfjs's TextLayerBuilder / AnnotationLayerBuilder render on top of the
+ * page canvas.
+ *
+ * This is the minimal subset of pdfjs-dist's `web/pdf_viewer.css` that those two
+ * builders actually depend on — copied verbatim so the class names match what
+ * the builders emit (`.textLayer`, `.annotationLayer`, `.endOfContent`, the
+ * `.selecting` toggle, etc.). We inline the subset rather than importing the
+ * full 7k-line viewer stylesheet (which is overwhelmingly toolbar/sidebar/
+ * editor UI we don't use) so the bundle only carries what the preview needs.
+ *
+ * The selection-smoothing behaviour (the `.endOfContent` element, the
+ * `.textLayer.selecting` class, and the `.selecting ~ .annotationLayer section`
+ * rule that suspends link hit-testing mid-drag) is what makes text selection
+ * track the pointer cleanly instead of snapping — it is driven by
+ * TextLayerBuilder, so these rules must stay byte-aligned with its expectations.
+ */
+
+/* Wrapper around the canvas + both layers. Defines the scale variables pdfjs
+ * derives layout from; the component sets `--scale-factor` per render. Mirrors
+ * the variables the full viewer sets on its `.page` element. */
+.pdfLayerWrap {
+  --user-unit: 1;
+  --total-scale-factor: calc(var(--scale-factor) * var(--user-unit));
+  --scale-round-x: 1px;
+  --scale-round-y: 1px;
+}
+
+.pdfLayerWrap .textLayer {
+  position: absolute;
+  text-align: initial;
+  inset: 0;
+  overflow: clip;
+  opacity: 1;
+  line-height: 1;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+  transform-origin: 0 0;
+  caret-color: CanvasText;
+  z-index: 2;
+  --min-font-size: 1;
+  --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+  --min-font-size-inv: calc(1 / var(--min-font-size));
+}
+
+.pdfLayerWrap .textLayer :is(span, br) {
+  color: transparent;
+  position: absolute;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+}
+
+.pdfLayerWrap .textLayer > :not(.markedContent),
+.pdfLayerWrap .textLayer .markedContent span:not(.markedContent) {
+  z-index: 1;
+  --font-height: 0;
+  font-size: calc(var(--text-scale-factor) * var(--font-height));
+  --scale-x: 1;
+  --rotate: 0deg;
+  transform: rotate(var(--rotate)) scaleX(var(--scale-x))
+    scale(var(--min-font-size-inv));
+}
+
+.pdfLayerWrap .textLayer .markedContent {
+  display: contents;
+}
+
+.pdfLayerWrap .textLayer span[role='img'] {
+  user-select: none;
+  cursor: default;
+}
+
+.pdfLayerWrap .textLayer ::selection {
+  background: rgba(0, 100, 255, 0.3);
+}
+
+.pdfLayerWrap .textLayer br::selection {
+  background: transparent;
+}
+
+.pdfLayerWrap .textLayer .endOfContent {
+  display: block;
+  position: absolute;
+  inset: 100% 0 0;
+  z-index: 0;
+  cursor: default;
+  user-select: none;
+}
+
+.pdfLayerWrap .textLayer.selecting .endOfContent {
+  top: 0;
+}
+
+.pdfLayerWrap .annotationLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* The layer spans the whole page but must NOT swallow pointer events, or it
+   * would block text selection in the layer beneath it. Only the link sections
+   * below re-enable pointer events. */
+  pointer-events: none;
+  transform-origin: 0 0;
+  z-index: 3;
+}
+
+.pdfLayerWrap .annotationLayer section {
+  position: absolute;
+  text-align: initial;
+  pointer-events: auto;
+  box-sizing: border-box;
+  transform-origin: 0 0;
+  user-select: none;
+}
+
+/* While a selection is being dragged, suspend link hit-testing so the drag
+ * isn't interrupted when it crosses a link. */
+.pdfLayerWrap .textLayer.selecting ~ .annotationLayer section {
+  pointer-events: none;
+}
+
+.pdfLayerWrap .annotationLayer .linkAnnotation > a {
+  position: absolute;
+  font-size: 1em;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.pdfLayerWrap .annotationLayer .linkAnnotation:not(.hasBorder) > a:hover {
+  opacity: 0.2;
+  background-color: rgb(255 255 0);
+}
+
+.pdfLayerWrap .annotationLayer .linkAnnotation.hasBorder:hover {
+  background-color: rgb(255 255 0 / 0.2);
+}
+
+.pdfLayerWrap .annotationLayer .hasBorder {
+  background-size: 100% 100%;
+}

--- a/services/platform/app/features/documents/components/pdf-link-popup.test.tsx
+++ b/services/platform/app/features/documents/components/pdf-link-popup.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { PdfLinkPopup } from './pdf-link-popup';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) =>
+      ({
+        'preview.link.copy': 'Copy link',
+        'preview.link.copied': 'Copied',
+        'preview.link.visit': 'Visit link',
+      })[key] ?? key,
+  }),
+}));
+
+// Render the popup the way the app does: inside a Radix Dialog (the document
+// preview surface). This is the context where button clicks were being stolen.
+function renderInDialog(onClose: () => void) {
+  return render(
+    <DialogPrimitive.Root open>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Content aria-describedby={undefined}>
+          <DialogPrimitive.Title>Preview</DialogPrimitive.Title>
+          <PdfLinkPopup
+            state={{ url: 'https://example.com', x: 100, y: 100 }}
+            onClose={onClose}
+          />
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>,
+  );
+}
+
+describe('PdfLinkPopup inside a dialog', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  it('copies the link when the Copy button is clicked (does not close first)', () => {
+    const onClose = vi.fn();
+    renderInDialog(onClose);
+
+    const copyBtn = screen.getByRole('button', { name: /copy link/i });
+    fireEvent.pointerDown(copyBtn);
+    fireEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('does not dismiss when interacting inside the popup', () => {
+    const onClose = vi.fn();
+    renderInDialog(onClose);
+
+    const visitBtn = screen.getByRole('button', { name: /visit link/i });
+    // A pointerdown inside the popup must not trigger the outside-click close.
+    fireEvent.pointerDown(visitBtn);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/documents/components/pdf-link-popup.tsx
+++ b/services/platform/app/features/documents/components/pdf-link-popup.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { Copy, ExternalLink } from 'lucide-react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+
+export interface PdfLinkPopupState {
+  url: string;
+  /** Viewport (clientX/Y) coordinates of the click that opened the popup. */
+  x: number;
+  y: number;
+}
+
+/**
+ * Small floating popup shown when a link inside the PDF is clicked. Instead of
+ * navigating away immediately (which is jarring inside a document preview), we
+ * surface the destination and let the user choose to copy it or open it in a
+ * new tab.
+ *
+ * Rendered inline (NOT portalled to <body>) so it stays inside the preview
+ * dialog's DOM + React tree. A body-level portal lands outside Radix's dialog
+ * content, where the dialog marks it `aria-hidden` and its dismissable layer
+ * treats clicks as "outside" — which was stealing the button clicks. The
+ * trade-off: the dialog content box is `transform`ed, so it (not the viewport)
+ * becomes the containing block for our `position: fixed`. We correct for that
+ * after first paint by measuring the drift between where the popup actually
+ * rendered and the intended viewport coordinates.
+ */
+export const PdfLinkPopup = ({
+  state,
+  onClose,
+}: {
+  state: PdfLinkPopupState;
+  onClose: () => void;
+}) => {
+  const { t } = useT('documents');
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [correction, setCorrection] = useState({ dx: 0, dy: 0 });
+
+  // Anchor near the click, clamped into the viewport so the popup never spills
+  // off-screen for links near the page edges.
+  const POPUP_WIDTH = 232;
+  const targetLeft = Math.min(
+    Math.max(8, state.x),
+    window.innerWidth - POPUP_WIDTH - 8,
+  );
+  const targetTop = Math.min(state.y + 6, window.innerHeight - 72);
+
+  // If a transformed ancestor shifted our fixed-position box, measure the drift
+  // and offset by it so the popup lands at the intended viewport coordinates.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const dx = targetLeft - rect.left;
+    const dy = targetTop - rect.top;
+    if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
+      setCorrection((prev) => ({ dx: prev.dx + dx, dy: prev.dy + dy }));
+    }
+  }, [targetLeft, targetTop]);
+
+  // Dismiss on outside click, scroll, or Escape. Registration is deferred to
+  // the next frame so the very click that opened the popup can't immediately
+  // close it.
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target;
+      if (
+        ref.current &&
+        target instanceof Node &&
+        !ref.current.contains(target)
+      ) {
+        onClose();
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    const frame = requestAnimationFrame(() => {
+      document.addEventListener('pointerdown', onPointerDown, true);
+      document.addEventListener('keydown', onKeyDown);
+      window.addEventListener('scroll', onClose, true);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', onClose, true);
+    };
+  }, [onClose]);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(state.url);
+      setCopied(true);
+      window.setTimeout(onClose, 900);
+    } catch (err) {
+      console.error('Failed to copy link:', err);
+    }
+  };
+
+  const onVisit = () => {
+    window.open(state.url, '_blank', 'noopener,noreferrer');
+    onClose();
+  };
+
+  return (
+    // The click/pointerdown handlers are containment only (stop the dialog's
+    // dismissable layer from treating these as outside-clicks); they carry no
+    // interactive semantics of their own — the real controls are the focusable
+    // <button>s inside.
+    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- containment only; interactive children are the buttons
+    <div
+      ref={ref}
+      role="dialog"
+      style={{
+        position: 'fixed',
+        left: targetLeft + correction.dx,
+        top: targetTop + correction.dy,
+        width: POPUP_WIDTH,
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      className="ring-border bg-muted text-popover-foreground animate-in fade-in-0 zoom-in-95 z-60 cursor-default rounded-md p-1 shadow-md ring-1 select-none motion-reduce:animate-none"
+    >
+      <div
+        className="text-muted-foreground truncate px-1.5 pt-1 pb-1.5 text-[11px]"
+        title={state.url}
+      >
+        {state.url}
+      </div>
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          onClick={onCopy}
+          className="flex flex-1 cursor-pointer items-center justify-center gap-1 rounded px-2 py-1 text-xs transition hover:bg-white/10"
+        >
+          <Copy className="size-3" />
+          {copied ? t('preview.link.copied') : t('preview.link.copy')}
+        </button>
+        <button
+          type="button"
+          onClick={onVisit}
+          className="flex flex-1 cursor-pointer items-center justify-center gap-1 rounded px-2 py-1 text-xs transition hover:bg-white/10"
+        >
+          <ExternalLink className="size-3" />
+          {t('preview.link.visit')}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/openrouter-step.tsx
@@ -159,7 +159,6 @@ export function OpenRouterStep({ organizationId }: OpenRouterStepProps) {
             setApiKey(e.target.value);
             if (error) setError(null);
           }}
-          autoComplete="off"
           errorMessage={error ?? undefined}
         />
 

--- a/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
@@ -641,7 +641,6 @@ export function ProviderAddPanel({
               {...register('apiKey')}
               placeholder={t('providers.apiKeyPlaceholder')}
               errorMessage={errors.apiKey?.message}
-              autoComplete="off"
             />
 
             {/* ── Models section ─────────────────────────────── */}

--- a/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
+++ b/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
@@ -180,7 +180,7 @@ function AddEnvVarForm({ organizationId }: { organizationId: string }) {
           label={t('add.valueLabel')}
           placeholder={t('add.valuePlaceholder')}
           // Secret values render masked while typing and never round-trip back.
-          type={isSecret ? 'password' : 'text'}
+          sensitive={isSecret}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           maxLength={VALUE_MAX}

--- a/services/platform/app/features/workspace/components/canvas-pane.tsx
+++ b/services/platform/app/features/workspace/components/canvas-pane.tsx
@@ -7,6 +7,7 @@ import { Download, PanelRightOpen, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import { useBranchContext } from '@/app/features/chat/context/branch-context';
 import { useStreamingTools } from '@/app/features/chat/context/streaming-tool-context';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
@@ -39,7 +40,14 @@ function CanvasPaneComponent({ organizationId }: CanvasPaneProps) {
     from: '/dashboard/$id/chat/$threadId',
     shouldThrow: false,
   });
-  const threadId = threadMatch?.params?.threadId;
+  const routeThreadId = threadMatch?.params?.threadId;
+
+  // Files written on a branch live on the branch-tip thread, not the route
+  // thread. Resolve to the same active-branch thread the message list uses so
+  // branch-tip files stay visible after streaming; fall back to the route param
+  // before the branch chain resolves.
+  const { activeBranchThreadId } = useBranchContext();
+  const threadId = activeBranchThreadId ?? routeThreadId;
 
   const {
     isOpen,

--- a/services/platform/app/routes/dashboard/$id/chat.tsx
+++ b/services/platform/app/routes/dashboard/$id/chat.tsx
@@ -350,8 +350,12 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
           )}
         </AnimatePresence>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <BranchProvider threadId={threadId} organizationId={organizationId}>
+        {/* BranchProvider wraps the message column AND the right-side panes so
+            the canvas resolves files against the same active-branch thread the
+            message list uses. Without this, the canvas reads files from the raw
+            route threadId and branch-tip files vanish after streaming. */}
+        <BranchProvider threadId={threadId} organizationId={organizationId}>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             <BudgetBanner organizationId={organizationId} />
             <LayoutErrorBoundary organizationId={organizationId}>
               <ThreadGate
@@ -360,28 +364,28 @@ function ChatLayoutContent({ organizationId }: { organizationId: string }) {
                 newChatCount={newChatCount}
               />
             </LayoutErrorBoundary>
-          </BranchProvider>
-        </div>
+          </div>
 
-        <PlanPane />
-        <CanvasPane organizationId={organizationId} />
-        {/* Read-only workspace-files explorer — gated to external-agent threads
-            with a session. On desktop the collapsed strip IS the open affordance
-            (no composer pill); the mobile Sheet below carries it under `md`. */}
-        {!isMobile && sandboxPanesAvailable && (
-          <LayoutErrorBoundary organizationId={organizationId}>
-            <WorkspaceFilesPane />
-          </LayoutErrorBoundary>
-        )}
-        {/* Read-only live-browser stream — independent right-side pane, gated
-            identically. At most one of it / workspace-files is open at a time
-            (see the mutual-exclusion effects above). Desktop only; the mobile
-            Sheet below carries it under `md`. */}
-        {!isMobile && sandboxPanesAvailable && (
-          <LayoutErrorBoundary organizationId={organizationId}>
-            <LiveBrowserPane />
-          </LayoutErrorBoundary>
-        )}
+          <PlanPane />
+          <CanvasPane organizationId={organizationId} />
+          {/* Read-only workspace-files explorer — gated to external-agent threads
+              with a session. On desktop the collapsed strip IS the open affordance
+              (no composer pill); the mobile Sheet below carries it under `md`. */}
+          {!isMobile && sandboxPanesAvailable && (
+            <LayoutErrorBoundary organizationId={organizationId}>
+              <WorkspaceFilesPane />
+            </LayoutErrorBoundary>
+          )}
+          {/* Read-only live-browser stream — independent right-side pane, gated
+              identically. At most one of it / workspace-files is open at a time
+              (see the mutual-exclusion effects above). Desktop only; the mobile
+              Sheet below carries it under `md`. */}
+          {!isMobile && sandboxPanesAvailable && (
+            <LayoutErrorBoundary organizationId={organizationId}>
+              <LiveBrowserPane />
+            </LayoutErrorBoundary>
+          )}
+        </BranchProvider>
       </div>
 
       {/* Mobile: present the workspace-files pane in a right Sheet like the

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2142,6 +2142,11 @@
       "document": "Dokument",
       "title": "Dokumentvorschau",
       "dragToolbar": "Werkzeugleiste verschieben",
+      "link": {
+        "copy": "Link kopieren",
+        "copied": "Kopiert",
+        "visit": "Link öffnen"
+      },
       "sidebar": {
         "document": "Dokument",
         "size": "Größe",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2142,6 +2142,11 @@
       "document": "Document",
       "title": "Document preview",
       "dragToolbar": "Drag toolbar",
+      "link": {
+        "copy": "Copy link",
+        "copied": "Copied",
+        "visit": "Visit link"
+      },
       "sidebar": {
         "document": "Document",
         "size": "Size",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2143,6 +2143,11 @@
       "document": "Document",
       "title": "Aperçu du document",
       "dragToolbar": "Déplacer la barre d'outils",
+      "link": {
+        "copy": "Copier le lien",
+        "copied": "Copié",
+        "visit": "Ouvrir le lien"
+      },
       "sidebar": {
         "document": "Document",
         "size": "Taille",

--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -120,7 +120,7 @@
 	# HTTP: Convex Dashboard static assets at root paths (logo, icons)
 	# Dashboard HTML references these at root but they're served under /convex-dashboard/
 	@convexDashboardAssets {
-		path /convex-logo-only.svg /convex-light.svg /apple-touch-icon.png
+		path /convex-logo-only.svg /convex-light.svg /convex-dark.svg /favicon.ico /apple-touch-icon.png /manifest.webmanifest
 	}
 	handle @convexDashboardAssets {
 		uri replace / /convex-dashboard/ 1


### PR DESCRIPTION
## Summary

Three related platform improvements developed in one session.

### PDF preview — selectable text & interactive links
- Renders pdfjs's text + annotation (link) layers over the rasterised page canvas so document text is **selectable** and links are **clickable**, pixel-aligned via an imperatively-sized wrapper.
- Inlines only the minimal subset of pdfjs's viewer CSS the two layer builders actually need (instead of the full ~7k-line viewer stylesheet) — see [`pdf-layers.css`](services/platform/app/features/documents/components/pdf-layers.css).
- Link clicks open a small popup offering **Copy link** / **Visit link** rather than navigating away from the preview. The popup renders inline (not portalled) to stay inside the Radix dialog, with transform-drift correction after first paint — see [`pdf-link-popup.tsx`](services/platform/app/features/documents/components/pdf-link-popup.tsx).

### Sensitive input masking
- New `Input` `sensitive` prop: secrets (API keys, tokens) render as `type="text"` masked with CSS `-webkit-text-security`, so Chrome never shows its saved-password dropdown or strong-password suggestion. Bare `type="password"` fields with no explicit `autoComplete` are treated as sensitive automatically; genuine account-password fields (explicit `autoComplete`) keep real type switching.
- Belt-and-suspenders password-manager opt-out attrs (1Password / LastPass / Bitwarden / Dashlane).
- Removes now-redundant `autoComplete="off"` from provider / OpenRouter key fields; user-env secret field switches from `type="password"` to `sensitive`. `SearchInput` stops using `autoComplete="new-password"`.

### Branch-aware canvas
- Wraps the right-side panes (canvas, plan, workspace files, live browser) in `BranchProvider` so the canvas resolves files against the same active-branch thread the message list uses. Branch-tip files no longer vanish after streaming.

### Proxy
- Serves `convex-dark.svg`, `favicon.ico`, `manifest.webmanifest` for the Convex dashboard at root paths.

## Pre-PR checklist
- [x] Ran `bun run check` (format, lint, typecheck, tests). All green except a pre-existing flaky `message-bubble.test.tsx` (passes in isolation; times out only under heavy parallel load — unrelated to this diff).
- [x] No hand-rolled skeletons — N/A (no new loading states).
- [x] Updated `services/platform/messages/{en,de,fr}.json` (PDF link popup copy).
- [ ] Updated `/docs/{en,de,fr}/` — N/A (no user-facing doc surface change).
- [x] Docs opening/closing/loanword tests — N/A (no docs touched).
- [ ] Ran docs lint/test — N/A.
- [ ] Updated `README.*` — N/A.

## Test plan
- Open a PDF document preview → text is selectable; clicking a link surfaces the copy/visit popup; in-document jumps don't open a popup.
- Enter an API key in provider/OpenRouter/user-env secret fields → no browser save-password prompt, dots mask the value, eye toggle reveals it.
- Write a file from an agent on a branch → it stays visible in the canvas after streaming completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive PDF link handling with copy and visit options in document preview
  * Added text selection capability in PDF documents
  * Added sensitive field protection for API keys and tokens to prevent unwanted password-manager autofill overlays

* **Bug Fixes**
  * Fixed canvas pane to correctly display files from the active branch

* **Documentation**
  * Added link action labels in German and French interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->