### PR TITLE
fix(sandbox): add per-process ulimit parity with the docker backend (#1851)

### DIFF
--- a/services/sandbox/docs/kubernetes.md
+++ b/services/sandbox/docs/kubernetes.md
@@ -37,14 +37,16 @@ the run stops promptly, but the owning replica then sees its Pod vanish and
 resolves the run as `failed`/`HARVEST_READ_FAILED` rather than `cancelled` (it
 never learns the cancel intent — a known, accepted limitation).
 
-**Resource-limit parity (known delta vs docker):** the runner Pod enforces
-cpu/memory limits and a `sizeLimit` on the `/user` emptyDir
-(`SANDBOX_K8S_WORKSPACE_SIZE_LIMIT`, default `4Gi` — exceeding it evicts the
-Pod). There is **no Kubernetes equivalent** of the docker path's per-process
-ulimits (`pids-limit=128`, `fsize=100MB`, `cpu-time=600s`): a fork-heavy or
-single-giant-file workload behaves differently on the two backends. Operators
-needing those bounds should use gVisor (`SANDBOX_RUNTIME=runsc`) and
-namespace-level quotas.
+**Resource-limit parity with docker:** the runner Pod enforces cpu/memory
+limits and a `sizeLimit` on the `/user` emptyDir (`SANDBOX_K8S_WORKSPACE_SIZE_LIMIT`,
+default `4Gi` — exceeding it evicts the Pod). `RUNNER_WRAPPER` also injects
+`ulimit -u 128 -f 204800 -t 600 -c 0` before launching the entrypoint, which
+sets the same per-process limits as the Docker backend's `--pids-limit=128`,
+`--ulimit fsize=104857600`, `--ulimit cpu=600`, and `--ulimit core=0:0`. The
+busybox sh built-in lowers limits without requiring elevated capabilities, and
+all descendant processes (python/node) inherit them. gVisor (`SANDBOX_RUNTIME=runsc`)
+adds further isolation benefits (syscall filtering, separate kernel) but is no
+longer required solely to obtain these resource bounds.
 
 ## RBAC (namespaced Role — no cluster scope, no `pods/exec`)
 

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.test.ts
@@ -264,6 +264,14 @@ describe('buildSandboxPod', () => {
     }
   });
 
+  test('RUNNER_WRAPPER enforces per-process ulimits matching docker-args.ts', () => {
+    const c = runner(buildSandboxPod(cfg, goodInput));
+    const script = c.command?.[2] ?? '';
+    // Parity with --pids-limit=128, --ulimit fsize=104857600 (204800 blocks),
+    // --ulimit cpu=600, --ulimit core=0 from docker-args.ts.
+    expect(script).toContain('ulimit -u 128 -f 204800 -t 600 -c 0');
+  });
+
   test('RUNNER_WRAPPER invariant: a surviving wrapper always exits 0 (echo is last)', () => {
     // The runner-dead short-circuit in k8s-backend.ts depends on this: the
     // wrapper's LAST command is the echo into the exit-code file, so a

--- a/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-pod-spec.ts
@@ -96,6 +96,11 @@ export function podNameFor(executionId: string): string {
 // clean phase parsing). $0..$3 come from the Pod `args` trailer below.
 const RUNNER_WRAPPER = [
   `mkdir -p ${TALE_DIR}`,
+  // Per-process resource parity with docker-args.ts: --pids-limit=128,
+  // --ulimit fsize=104857600 (204800 × 512-byte blocks), --ulimit cpu=600,
+  // --ulimit core=0. busybox sh's built-in ulimit only lowers limits, so this
+  // never requires extra capabilities under the hardened securityContext.
+  `ulimit -u 128 -f 204800 -t 600 -c 0`,
   `/entrypoint.sh "$0" "$1" "$2" "$3" 2>${STDERR_PATH}`,
   `echo $? > ${EXIT_CODE_PATH}`,
 ].join('\n');
@@ -143,8 +148,8 @@ export function buildSandboxPod(
     // sizeLimit bounds everything the execution writes (deps installs, temp
     // files, outputs — the entrypoint points HOME/TMPDIR/PIP_TARGET here).
     // Exceeding it evicts the pod; the spawner's runner-dead path classifies
-    // that instead of burning the full timeout. K8s analogue of the docker
-    // path's fsize ulimit (which has no per-process equivalent here).
+    // that instead of burning the full timeout. Complements the per-process
+    // fsize ulimit in RUNNER_WRAPPER (total-workspace vs per-file cap).
     {
       name: 'workspace',
       emptyDir: { sizeLimit: cfg.k8s.workspaceSizeLimit },


### PR DESCRIPTION
## Summary

- Closes #1851
- Injects `ulimit -u 128 -f 204800 -t 600 -c 0` into `RUNNER_WRAPPER` in `k8s-pod-spec.ts`, giving the k8s runner the same per-process limits as the docker backend:
  - `-u 128` → pids (matches `--pids-limit=128`)
  - `-f 204800` → fsize 100 MiB in 512-byte blocks (matches `--ulimit fsize=104857600`)
  - `-t 600` → CPU time seconds (matches `--ulimit cpu=600`)
  - `-c 0` → core dump size (matches `--ulimit core=0:0`)
- Uses busybox sh's built-in `ulimit`, which only lowers limits — no extra capabilities required under the hardened `securityContext`
- Updates the stale workspace `emptyDir` comment (previously said fsize had "no per-process equivalent here")
- Adds a regression test asserting the `ulimit` line is present in `RUNNER_WRAPPER`

## Test plan

- [x] `bun test src/backend/kubernetes/k8s-pod-spec.test.ts` — all 20 tests pass (19 pre-existing + 1 new)
- [x] Full sandbox test suite: 301 pass, 3 pre-existing failures (missing `@kubernetes/client-node` dep + parse-error fixtures) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test to validate enforcement of process resource limits in sandbox runner environments

* **Bug Fixes**
  * Runner container now enforces explicit per-process resource constraints, including limits on memory usage, file size, execution time, and core dump generation, ensuring consistent behavior across deployment environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->