### PR TITLE
feat(platform): agent editor — internal/external type switch + folder breadcrumb

### DIFF
--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -52,6 +52,7 @@ const AGENT_TAB_DIRTY_KEYS = {
     'description',
     'avatarUrl',
     'primaryBehavior',
+    'agentKind',
     'visibleInChat',
     'roleRestriction',
     'composerMode',
@@ -164,6 +165,14 @@ export function AgentNavigation({
   // are unaffected (encodeURIComponent is a no-op for them).
   const basePath = `/dashboard/${organizationId}/agents/${encodeURIComponent(agentId)}`;
 
+  // Only chat agents run the platform tool loop, so the loop-only tabs (Skills,
+  // Knowledge, Response Tuning) are no-ops for the other types and are hidden.
+  // The Tools tab stays for external agents (it carries their integration
+  // bindings — the sandbox MCP grant set) but image-generation has nothing
+  // there, so it drops too.
+  const isChat = (config.primaryBehavior ?? 'chat') === 'chat';
+  const isExternalAgent = config.primaryBehavior === 'external-agent';
+
   const navigationItems: TabNavigationItem[] = [
     {
       label: t('agents.navigation.general'),
@@ -177,36 +186,48 @@ export function AgentNavigation({
       matchMode: 'exact',
       dirtyKeys: AGENT_TAB_DIRTY_KEYS.instructions,
     },
-    {
-      label: t('agents.navigation.tools'),
-      href: `${basePath}/tools`,
-      matchMode: 'exact',
-      dirtyKeys: AGENT_TAB_DIRTY_KEYS.tools,
-    },
-    {
-      label: t('agents.navigation.skills'),
-      href: `${basePath}/skills`,
-      matchMode: 'exact',
-      dirtyKeys: AGENT_TAB_DIRTY_KEYS.skills,
-    },
-    {
-      label: t('agents.navigation.knowledge'),
-      href: `${basePath}/knowledge`,
-      matchMode: 'exact',
-      dirtyKeys: AGENT_TAB_DIRTY_KEYS.knowledge,
-    },
+    ...(isChat || isExternalAgent
+      ? [
+          {
+            label: t('agents.navigation.tools'),
+            href: `${basePath}/tools`,
+            matchMode: 'exact' as const,
+            dirtyKeys: AGENT_TAB_DIRTY_KEYS.tools,
+          },
+        ]
+      : []),
+    ...(isChat
+      ? [
+          {
+            label: t('agents.navigation.skills'),
+            href: `${basePath}/skills`,
+            matchMode: 'exact' as const,
+            dirtyKeys: AGENT_TAB_DIRTY_KEYS.skills,
+          },
+          {
+            label: t('agents.navigation.knowledge'),
+            href: `${basePath}/knowledge`,
+            matchMode: 'exact' as const,
+            dirtyKeys: AGENT_TAB_DIRTY_KEYS.knowledge,
+          },
+        ]
+      : []),
     {
       label: t('agents.navigation.delegation'),
       href: `${basePath}/delegation`,
       matchMode: 'exact',
       dirtyKeys: AGENT_TAB_DIRTY_KEYS.delegation,
     },
-    {
-      label: t('agents.navigation.responseTuning'),
-      href: `${basePath}/response-tuning`,
-      matchMode: 'exact',
-      dirtyKeys: AGENT_TAB_DIRTY_KEYS.responseTuning,
-    },
+    ...(isChat
+      ? [
+          {
+            label: t('agents.navigation.responseTuning'),
+            href: `${basePath}/response-tuning`,
+            matchMode: 'exact' as const,
+            dirtyKeys: AGENT_TAB_DIRTY_KEYS.responseTuning,
+          },
+        ]
+      : []),
     {
       label: t('agents.navigation.conversationStarters'),
       href: `${basePath}/conversation-starters`,

--- a/services/platform/app/features/agents/components/tool-selector.tsx
+++ b/services/platform/app/features/agents/components/tool-selector.tsx
@@ -28,6 +28,15 @@ interface ToolSelectorProps {
   organizationId: string;
   hiddenTools?: Set<string>;
   disabled?: boolean;
+  /**
+   * Platform tools (`toolNames`) + Workflows run only in the chat tool loop, so
+   * external agents must not list them (the save schema rejects a non-empty
+   * list). Default `true`; the agent editor passes `false` for both on an
+   * external agent, leaving only the integration bindings — which an external
+   * agent DOES use as its sandbox MCP grant set.
+   */
+  showPlatformTools?: boolean;
+  showWorkflows?: boolean;
 }
 
 // Tools grouped by the business domain they act on, ordered most- to
@@ -128,6 +137,8 @@ export function ToolSelector({
   organizationId,
   hiddenTools,
   disabled,
+  showPlatformTools = true,
+  showWorkflows = true,
 }: ToolSelectorProps) {
   const { t } = useT('settings');
   // Tool labels live in the shared `chat.tools.*` namespace (one vocabulary for
@@ -211,13 +222,15 @@ export function ToolSelector({
         onToggle={toggleIntegrationBinding}
         t={t}
       />
-      <WorkflowBindingsSection
-        workflows={workflows}
-        isLoading={workflowsLoading}
-        selectedBindingsSet={selectedWorkflowBindingsSet}
-        onToggle={toggleWorkflowBinding}
-        t={t}
-      />
+      {showWorkflows && (
+        <WorkflowBindingsSection
+          workflows={workflows}
+          isLoading={workflowsLoading}
+          selectedBindingsSet={selectedWorkflowBindingsSet}
+          onToggle={toggleWorkflowBinding}
+          t={t}
+        />
+      )}
     </Stack>
   );
 
@@ -232,31 +245,41 @@ export function ToolSelector({
       ]
     : Array.from(categorized.entries());
 
+  // External agents hide the platform-tools catalog, so the integration
+  // bindings below shouldn't wait on the tools query they never read.
+  const skeletonLoading = showPlatformTools && isLoading;
+
   return (
-    <Skeletonize loading={isLoading} label={t('agents.form.sectionTools')}>
+    <Skeletonize
+      loading={skeletonLoading}
+      label={t('agents.form.sectionTools')}
+    >
       <fieldset disabled={disabled}>
         <Stack gap={4}>
-          {displayCategories.map(([category, toolNames]) => (
-            <CheckboxGroup
-              key={category}
-              label={t(`agents.tools.categories.${category}`)}
-              options={toolNames.map((name) => ({
-                value: name,
-                label: isLoading ? 'Tool name' : toolDisplayName(tTools, name),
-                disabled: isLoading,
-              }))}
-              value={
-                isLoading
-                  ? []
-                  : toolNames.filter((name) => selectedSet.has(name))
-              }
-              onValueChange={(values) =>
-                handleCategoryChange(toolNames, values)
-              }
-            />
-          ))}
+          {showPlatformTools &&
+            displayCategories.map(([category, toolNames]) => (
+              <CheckboxGroup
+                key={category}
+                label={t(`agents.tools.categories.${category}`)}
+                options={toolNames.map((name) => ({
+                  value: name,
+                  label: isLoading
+                    ? 'Tool name'
+                    : toolDisplayName(tTools, name),
+                  disabled: isLoading,
+                }))}
+                value={
+                  isLoading
+                    ? []
+                    : toolNames.filter((name) => selectedSet.has(name))
+                }
+                onValueChange={(values) =>
+                  handleCategoryChange(toolNames, values)
+                }
+              />
+            ))}
 
-          {!isLoading && bindingsSections}
+          {(!showPlatformTools || !isLoading) && bindingsSections}
         </Stack>
       </fieldset>
     </Skeletonize>

--- a/services/platform/app/features/agents/utils/next-config-for-behavior.test.ts
+++ b/services/platform/app/features/agents/utils/next-config-for-behavior.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentJsonConfig } from '@/convex/agents/file_utils';
+import { agentJsonSchema } from '@/lib/shared/schemas/agents';
+
+import { nextConfigForBehavior } from './next-config-for-behavior';
+
+// Mimic the editor's shallow-merge `updateConfig` so `undefined` keys in the
+// patch actually clear the field (the real save path validates this merged
+// object against `agentJsonSchema`).
+function applyPatch(
+  base: AgentJsonConfig,
+  patch: Partial<AgentJsonConfig>,
+): AgentJsonConfig {
+  return { ...base, ...patch };
+}
+
+const chatWithLoopConfig: AgentJsonConfig = {
+  displayName: 'Helper',
+  systemInstructions: 'Assist the user.',
+  supportedModels: ['openrouter:anthropic/claude-sonnet-4.6'],
+  toolNames: ['task_read'],
+  workflows: ['some-workflow'],
+  integrationBindings: ['github'],
+};
+
+const externalAgentConfig: AgentJsonConfig = {
+  displayName: 'Software Developer',
+  systemInstructions: 'Work the task.',
+  primaryBehavior: 'external-agent',
+  agentKind: 'claude-code',
+  authMode: 'managed',
+  integrationBindings: ['github'],
+  supportedModels: ['openrouter:anthropic/claude-sonnet-4.6'],
+};
+
+const byoExternalNoModelConfig: AgentJsonConfig = {
+  displayName: 'BYO Coder',
+  primaryBehavior: 'external-agent',
+  agentKind: 'claude-code',
+  authMode: 'byo',
+  supportedModels: [],
+};
+
+describe('nextConfigForBehavior', () => {
+  it('chat → external-agent clears loop-only tools/workflows and defaults the runtime, keeping integrations + models', () => {
+    const patch = nextConfigForBehavior(chatWithLoopConfig, 'external-agent');
+    const merged = applyPatch(chatWithLoopConfig, patch);
+
+    expect(merged.toolNames).toBeUndefined();
+    expect(merged.workflows).toBeUndefined();
+    expect(merged.agentKind).toBe('claude-code');
+    expect(merged.integrationBindings).toEqual(['github']);
+    expect(agentJsonSchema.safeParse(merged).success).toBe(true);
+  });
+
+  it('keeps an existing agentKind when re-entering external-agent', () => {
+    const opencode: AgentJsonConfig = {
+      ...chatWithLoopConfig,
+      agentKind: 'opencode',
+    };
+    const patch = nextConfigForBehavior(opencode, 'external-agent');
+    expect(applyPatch(opencode, patch).agentKind).toBe('opencode');
+  });
+
+  it('external-agent → chat clears agentKind/authMode and stays valid', () => {
+    const patch = nextConfigForBehavior(externalAgentConfig, 'chat');
+    const merged = applyPatch(externalAgentConfig, patch);
+
+    expect(merged.primaryBehavior).toBe('chat');
+    expect(merged.agentKind).toBeUndefined();
+    expect(merged.authMode).toBeUndefined();
+    expect(agentJsonSchema.safeParse(merged).success).toBe(true);
+  });
+
+  it('chat → image-generation clears tools, workflows, integrations, agentKind, authMode', () => {
+    const patch = nextConfigForBehavior(chatWithLoopConfig, 'image-generation');
+    const merged = applyPatch(chatWithLoopConfig, patch);
+
+    expect(merged.toolNames).toBeUndefined();
+    expect(merged.workflows).toBeUndefined();
+    expect(merged.integrationBindings).toBeUndefined();
+    expect(merged.agentKind).toBeUndefined();
+    expect(merged.authMode).toBeUndefined();
+    expect(agentJsonSchema.safeParse(merged).success).toBe(true);
+  });
+
+  it('documents the byo-external(no model) → chat trap: the ≥1-model rule now bites', () => {
+    const patch = nextConfigForBehavior(byoExternalNoModelConfig, 'chat');
+    const merged = applyPatch(byoExternalNoModelConfig, patch);
+
+    // The switch itself is clean (agentKind/authMode cleared); it's the
+    // empty model list — legal only for byo-external — that fails. The UI warns
+    // about this before switching and lets the honest save error surface.
+    const result = agentJsonSchema.safeParse(merged);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.includes('supportedModels'),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/services/platform/app/features/agents/utils/next-config-for-behavior.ts
+++ b/services/platform/app/features/agents/utils/next-config-for-behavior.ts
@@ -1,0 +1,66 @@
+import type { AgentJsonConfig } from '@/convex/agents/file_utils';
+
+export type AgentPrimaryBehavior = NonNullable<
+  AgentJsonConfig['primaryBehavior']
+>;
+
+/**
+ * The config patch to apply when the agent's `primaryBehavior` changes.
+ *
+ * The whole config is validated by `agentJsonSchema` at save time, and the
+ * editor's `updateConfig` SHALLOW-MERGES — so a field that must be dropped has
+ * to be set to `undefined` explicitly, not omitted. This helper returns exactly
+ * the keys to clear/set so the resulting config passes the schema's
+ * `superRefine` cross-field rules:
+ *
+ *  - `external-agent` and `image-generation` bypass the platform tool loop, so
+ *    `toolNames` / `workflows` must be empty (hard error otherwise).
+ *    `image-generation` additionally forbids `integrationBindings`;
+ *    `external-agent` KEEPS them (they are the sandbox MCP grant set).
+ *  - `agentKind` / `authMode` are valid ONLY for `external-agent`.
+ *
+ * Tool-loop-only retrieval/tuning fields (`webSearchMode`, `knowledgeMode`,
+ * `responseTuning`, `skillBindings`, `structuredResponsesEnabled`, …) are NOT
+ * rejected by the schema for non-chat agents, so we deliberately leave them
+ * untouched — they are merely hidden in the UI, not erased (clearing them would
+ * be silent data loss on a round-trip through External and back).
+ *
+ * `supportedModels` is never touched here: every agent needs ≥1 model except a
+ * byo-external one, and re-deriving models on a type switch is the caller's
+ * concern (it surfaces a warning when the switch would leave models empty).
+ */
+export function nextConfigForBehavior(
+  current: AgentJsonConfig,
+  target: AgentPrimaryBehavior,
+): Partial<AgentJsonConfig> {
+  switch (target) {
+    case 'chat':
+      return {
+        primaryBehavior: 'chat',
+        agentKind: undefined,
+        authMode: undefined,
+      };
+    case 'external-agent':
+      return {
+        primaryBehavior: 'external-agent',
+        toolNames: undefined,
+        workflows: undefined,
+        // Default the runtime when entering External; keep an existing choice
+        // (e.g. round-tripping External → Chat → External).
+        agentKind: current.agentKind ?? 'claude-code',
+      };
+    case 'image-generation':
+      return {
+        primaryBehavior: 'image-generation',
+        toolNames: undefined,
+        workflows: undefined,
+        integrationBindings: undefined,
+        agentKind: undefined,
+        authMode: undefined,
+      };
+    default: {
+      const _exhaustive: never = target;
+      throw new Error(`Unhandled agent behavior: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -15,8 +15,12 @@ import {
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
 import { AgentNavigation } from '@/app/features/agents/components/agent-navigation';
-import { useReadAgent } from '@/app/features/agents/hooks/queries';
+import {
+  useListAgents,
+  useReadAgent,
+} from '@/app/features/agents/hooks/queries';
 import { AgentConfigProvider } from '@/app/features/agents/hooks/use-agent-config-context';
+import { toConfigurableAgent } from '@/app/features/agents/utils/agent-list-item';
 import { configKeys } from '@/app/hooks/config-query-keys';
 import { api } from '@/convex/_generated/api';
 import { useT } from '@/lib/i18n/client';
@@ -69,6 +73,22 @@ function AgentDetailLayout() {
         : '',
     [agentConfig, i18nCtx.language],
   );
+  // The agent's folder (e.g. `workforce`) is metadata on the roster row, NOT
+  // part of the slug — a global agent at `agents/workforce/software-developer`
+  // still has the flat slug `software-developer`. So resolve the folder from the
+  // agent list (already cached from the List view) and break it into clickable
+  // segments: "Agents / Workforce / <Name>" jumps back to the rest of the
+  // folder. No folder (root agent) → [] → breadcrumb unchanged.
+  const { agents: rawAgents } = useListAgents(organizationId);
+  const folderSegments = useMemo(() => {
+    for (const raw of rawAgents ?? []) {
+      const agent = toConfigurableAgent(raw);
+      if (agent?.name === agentId) {
+        return agent.folder ? agent.folder.split('/') : [];
+      }
+    }
+    return [];
+  }, [rawAgents, agentId]);
 
   // Terminal load failure — not a loading state, so no skeleton here.
   if (!isLoading && (loadFailed || !agentConfig)) {
@@ -99,6 +119,20 @@ function AgentDetailLayout() {
         >
           {t('agents.title')}&nbsp;&nbsp;
         </Link>
+        {folderSegments.map((segment, i) => {
+          const path = folderSegments.slice(0, i + 1).join('/');
+          return (
+            <Link
+              key={path}
+              to="/dashboard/$id/agents/all"
+              params={{ id: organizationId }}
+              search={{ folder: path }}
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring hidden cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset md:inline"
+            >
+              /&nbsp;&nbsp;{segment}&nbsp;&nbsp;
+            </Link>
+          );
+        })}
         <span className="text-foreground">
           <span className="hidden md:inline">/&nbsp;&nbsp;</span>
           {/* `contents` so the Skeletonize wrapper adds no block box — its

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
@@ -5,8 +5,10 @@ import { Link } from '@tanstack/react-router';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
+import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
+import { RadioGroup } from '@/app/components/ui/forms/radio-group';
 import { Select } from '@/app/components/ui/forms/select';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { Textarea } from '@/app/components/ui/forms/textarea';
@@ -18,6 +20,10 @@ import {
 } from '@/app/features/agents/hooks/mutations';
 import { useAgentBinding } from '@/app/features/agents/hooks/queries';
 import { useAgentConfig } from '@/app/features/agents/hooks/use-agent-config-context';
+import {
+  nextConfigForBehavior,
+  type AgentPrimaryBehavior,
+} from '@/app/features/agents/utils/next-config-for-behavior';
 import { TeamMultiSelect } from '@/app/features/documents/components/team-multi-select';
 import { useOrganization } from '@/app/features/organization/hooks/queries';
 import { useTeamFilter } from '@/app/hooks/use-team-filter';
@@ -258,12 +264,124 @@ function GeneralTab() {
     updateConfig({ timeoutMs: clamped * 60_000 });
   }, [timeoutMinutes, updateConfig]);
 
+  // Agent type (primaryBehavior) — Internal (chat, runs the platform tool loop)
+  // vs External agent (Claude Code / OpenCode in a sandbox) vs Image generation.
+  // Switching rewires which config applies, so it goes through a confirm dialog
+  // and a Zod-safe field cleanup (see nextConfigForBehavior).
+  const primaryBehavior: AgentPrimaryBehavior =
+    config.primaryBehavior ?? 'chat';
+  const isExternalAgent = primaryBehavior === 'external-agent';
+  const agentKind = config.agentKind ?? 'claude-code';
+  const [pendingBehavior, setPendingBehavior] =
+    useState<AgentPrimaryBehavior | null>(null);
+
+  const agentTypeOptions = useMemo(
+    () => [
+      {
+        value: 'chat',
+        label: t('agents.form.agentType.internalLabel'),
+        description: t('agents.form.agentType.internalDescription'),
+      },
+      {
+        value: 'external-agent',
+        label: t('agents.form.agentType.externalLabel'),
+        description: t('agents.form.agentType.externalDescription'),
+      },
+      {
+        value: 'image-generation',
+        label: t('agents.form.agentType.imageLabel'),
+        description: t('agents.form.agentType.imageDescription'),
+      },
+    ],
+    [t],
+  );
+
+  const agentKindOptions = useMemo(
+    () => [
+      { value: 'claude-code', label: t('agents.form.agentKind.claudeCode') },
+      { value: 'opencode', label: t('agents.form.agentKind.openCode') },
+    ],
+    [t],
+  );
+
+  const handleTypeSelect = useCallback(
+    (value: string) => {
+      if (
+        value !== 'chat' &&
+        value !== 'external-agent' &&
+        value !== 'image-generation'
+      ) {
+        return;
+      }
+      if (value === primaryBehavior) return;
+      setPendingBehavior(value);
+    },
+    [primaryBehavior],
+  );
+
+  const confirmTypeSwitch = useCallback(() => {
+    if (!pendingBehavior) return;
+    // Functional form so the cleanup reads the latest config (it keeps an
+    // existing agentKind when re-entering External).
+    updateConfig((prev) => nextConfigForBehavior(prev, pendingBehavior));
+    setPendingBehavior(null);
+  }, [pendingBehavior, updateConfig]);
+
+  const handleAgentKindChange = useCallback(
+    (value: string) => {
+      if (value !== 'claude-code' && value !== 'opencode') return;
+      updateConfig({ agentKind: value });
+    },
+    [updateConfig],
+  );
+
+  // Switching INTO a type that requires ≥1 model, from a byo-external agent
+  // that legally has none, would fail the save — warn up front.
+  const switchLeavesNoModel =
+    (pendingBehavior === 'chat' || pendingBehavior === 'image-generation') &&
+    (config.supportedModels ?? []).length === 0;
+
+  const pendingDescription = !pendingBehavior
+    ? null
+    : `${
+        pendingBehavior === 'external-agent'
+          ? t('agents.form.agentType.switchToExternalDescription')
+          : pendingBehavior === 'chat'
+            ? t('agents.form.agentType.switchToChatDescription')
+            : t('agents.form.agentType.switchToImageDescription')
+      }${switchLeavesNoModel ? ` ${t('agents.form.agentType.noModelWarning')}` : ''}`;
+
   return (
     <ContentArea variant="narrow" gap={6}>
       <SectionHeader
         title={t('agents.form.sectionGeneral')}
         description={t('agents.form.sectionGeneralDescription')}
       />
+
+      <PageSection
+        title={t('agents.form.agentType.sectionTitle')}
+        description={t('agents.form.agentType.sectionDescription')}
+        gap={6}
+      >
+        <FormSection>
+          <RadioGroup
+            value={primaryBehavior}
+            onValueChange={handleTypeSelect}
+            options={agentTypeOptions}
+          />
+        </FormSection>
+        {isExternalAgent && (
+          <FormSection>
+            <Select
+              options={agentKindOptions}
+              label={t('agents.form.agentKind.label')}
+              description={t('agents.form.agentKind.description')}
+              value={agentKind}
+              onValueChange={handleAgentKindChange}
+            />
+          </FormSection>
+        )}
+      </PageSection>
 
       <FormSection>
         <Switch
@@ -377,6 +495,17 @@ function GeneralTab() {
           />
         </FormSection>
       </PageSection>
+
+      <ConfirmDialog
+        open={pendingBehavior !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingBehavior(null);
+        }}
+        title={t('agents.form.agentType.switchTitle')}
+        description={pendingDescription ?? undefined}
+        confirmText={t('agents.form.agentType.switchConfirm')}
+        onConfirm={confirmTypeSwitch}
+      />
     </ContentArea>
   );
 }

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/instructions.tsx
@@ -378,6 +378,7 @@ function InstructionsTab() {
   // bypasses it and uses the user's own sandbox credentials with a raw model
   // passthrough.
   const isExternalAgent = config.primaryBehavior === 'external-agent';
+  const isChat = (config.primaryBehavior ?? 'chat') === 'chat';
   const authMode = config.authMode ?? 'managed';
   const isByo = isExternalAgent && authMode === 'byo';
 
@@ -526,28 +527,30 @@ function InstructionsTab() {
         )}
       </PageSection>
 
-      <PageSection
-        title={t('agents.form.sectionStructuredResponses')}
-        description={t('agents.form.sectionStructuredResponsesDescription')}
-      >
-        <Switch
-          checked={structuredResponsesEnabled}
-          onCheckedChange={(checked) =>
-            updateConfig({ structuredResponsesEnabled: checked })
-          }
-          label={t('agents.form.structuredResponsesEnabled')}
-          description={t('agents.form.structuredResponsesEnabledHelp')}
-        />
-        {structuredResponsesEnabled && (
-          <CodeBlock
-            label={t('agents.form.structuredResponsesInjectedPrompt')}
-            copyValue={STRUCTURED_RESPONSE_INSTRUCTIONS}
-            copyLabel={t('agents.form.copyPrompt')}
-          >
-            {STRUCTURED_RESPONSE_INSTRUCTIONS}
-          </CodeBlock>
-        )}
-      </PageSection>
+      {isChat && (
+        <PageSection
+          title={t('agents.form.sectionStructuredResponses')}
+          description={t('agents.form.sectionStructuredResponsesDescription')}
+        >
+          <Switch
+            checked={structuredResponsesEnabled}
+            onCheckedChange={(checked) =>
+              updateConfig({ structuredResponsesEnabled: checked })
+            }
+            label={t('agents.form.structuredResponsesEnabled')}
+            description={t('agents.form.structuredResponsesEnabledHelp')}
+          />
+          {structuredResponsesEnabled && (
+            <CodeBlock
+              label={t('agents.form.structuredResponsesInjectedPrompt')}
+              copyValue={STRUCTURED_RESPONSE_INSTRUCTIONS}
+              copyLabel={t('agents.form.copyPrompt')}
+            >
+              {STRUCTURED_RESPONSE_INSTRUCTIONS}
+            </CodeBlock>
+          )}
+        </PageSection>
+      )}
 
       <PromptLibraryDialog
         open={promptLibraryOpen}

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/tools.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/tools.tsx
@@ -23,6 +23,11 @@ function ToolsTab() {
   const { t } = useT('settings');
   const { config, updateConfig } = useAgentConfig();
 
+  // Only chat agents run the platform tool loop. External agents keep just
+  // their integration bindings (the sandbox MCP grant set); the platform-tool,
+  // workflow, and web-search controls are no-ops for them, so hide them.
+  const isChat = (config.primaryBehavior ?? 'chat') === 'chat';
+
   const webSearchMode =
     config.webSearchMode ??
     (config.toolNames?.includes('web') ? 'tool' : 'off');
@@ -60,37 +65,43 @@ function ToolsTab() {
     <ContentArea variant="narrow" gap={6}>
       <SectionHeader
         title={t('agents.form.sectionTools')}
-        description={t('agents.form.sectionToolsDescription')}
+        description={
+          isChat
+            ? t('agents.form.sectionToolsDescription')
+            : t('agents.form.sectionToolsExternalDescription')
+        }
       />
 
-      <PageSection
-        gap={3}
-        title={t('agents.tools.webSearchMode')}
-        description={
-          <>
-            {t('agents.tools.webSearchModeDescription')}
-            {'. '}
-            {t('agents.tools.webSearchHint')}{' '}
-            <Link
-              to="/dashboard/$id/websites"
-              params={{ id: organizationId }}
-              className="text-primary hover:underline"
-            >
-              {t('agents.tools.webSearchHintLink')}
-            </Link>
-          </>
-        }
-      >
-        <RadioGroup
-          value={webSearchMode}
-          onValueChange={(value) => {
-            if (isRetrievalMode(value)) {
-              updateConfig({ webSearchMode: value });
-            }
-          }}
-          options={webModeOptions}
-        />
-      </PageSection>
+      {isChat && (
+        <PageSection
+          gap={3}
+          title={t('agents.tools.webSearchMode')}
+          description={
+            <>
+              {t('agents.tools.webSearchModeDescription')}
+              {'. '}
+              {t('agents.tools.webSearchHint')}{' '}
+              <Link
+                to="/dashboard/$id/websites"
+                params={{ id: organizationId }}
+                className="text-primary hover:underline"
+              >
+                {t('agents.tools.webSearchHintLink')}
+              </Link>
+            </>
+          }
+        >
+          <RadioGroup
+            value={webSearchMode}
+            onValueChange={(value) => {
+              if (isRetrievalMode(value)) {
+                updateConfig({ webSearchMode: value });
+              }
+            }}
+            options={webModeOptions}
+          />
+        </PageSection>
+      )}
 
       <ToolSelector
         value={config.toolNames ?? []}
@@ -103,6 +114,8 @@ function ToolsTab() {
         onWorkflowBindingsChange={(workflows) => updateConfig({ workflows })}
         organizationId={organizationId}
         hiddenTools={hiddenTools}
+        showPlatformTools={isChat}
+        showWorkflows={isChat}
       />
     </ContentArea>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5067,6 +5067,7 @@
         "sectionModelDescription": "Konfiguriere die KI-Modelle für diesen Agent. Das erste Modell ist das primäre Modell für die Generierung. Zusätzliche Modelle dienen als geordnete Fallbacks — wenn das primäre Modell nicht verfügbar ist, versucht der Agent automatisch das nächste Modell in der Liste.",
         "sectionTools": "Tools",
         "sectionToolsDescription": "Auswählen, welche Tools dieser Agent verwenden kann",
+        "sectionToolsExternalDescription": "Externe Agenten laufen in einer Sandbox und nutzen nur gebundene Integrationen. Plattform-Tools und Workflows gelten hier nicht.",
         "sectionIntegrationBindings": "Gebundene Integrationen",
         "sectionIntegrationBindingsDescription": "Bestimmte Integrationen als dedizierte Tools binden. Der Agent muss den Integrationsnamen nicht angeben.",
         "noIntegrationsAvailable": "Keine aktiven Integrationen verfügbar.",
@@ -5140,6 +5141,28 @@
           "modelLabel": "Anbieter-Modell-ID",
           "modelPlaceholder": "z. B. claude-opus-4-20250514",
           "modelNote": "BYO leitet über deine eigenen Anmeldedaten unter Umgebung & Geheimnisse — Modellauswahl, Abrechnung und Nutzungssteuerung gehen auf deine Anmeldedaten über; die Plattform stellt nur die Laufzeitumgebung bereit."
+        },
+        "agentType": {
+          "sectionTitle": "Agententyp",
+          "sectionDescription": "Wie dieser Agent läuft. Interne Agenten laufen über die Tool-Schleife der Plattform; externe Agenten führen einen Coding-Agenten in einer Sandbox aus.",
+          "internalLabel": "Interner Agent",
+          "internalDescription": "Läuft auf der Plattform mit Chat-Tools, Wissen und Workflows.",
+          "externalLabel": "Externer Agent",
+          "externalDescription": "Führt Claude Code oder OpenCode in einer isolierten Sandbox aus und nutzt gebundene Integrationen.",
+          "imageLabel": "Bildgenerierung",
+          "imageDescription": "Leitet die Nachricht direkt an ein Bildmodell weiter.",
+          "switchTitle": "Agententyp ändern?",
+          "switchToExternalDescription": "Dadurch läuft der Agent künftig in einer Sandbox; seine Plattform-Tools und Workflows werden entfernt. Gebundene Integrationen bleiben erhalten.",
+          "switchToChatDescription": "Dadurch läuft der Agent künftig über die Tool-Schleife der Plattform; seine externe Laufzeit- und Anmeldedaten-Einstellungen werden entfernt.",
+          "switchToImageDescription": "Dadurch wird der Agent auf Bildgenerierung umgestellt; seine Tools, Workflows, Integrationen und externen Laufzeiteinstellungen werden entfernt.",
+          "noModelWarning": "Dieser Agent hat kein Modell — füge vor dem Speichern eines auf dem Tab Anweisungen hinzu, sonst schlägt das Speichern fehl.",
+          "switchConfirm": "Typ ändern"
+        },
+        "agentKind": {
+          "label": "Externe Laufzeit",
+          "description": "Welcher Coding-Agent die Turns dieses Agenten in der Sandbox ausführt.",
+          "claudeCode": "Claude Code",
+          "openCode": "OpenCode"
         }
       },
       "delegation": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5329,6 +5329,7 @@
         "sectionModelDescription": "Configure the AI models for this agent. The first model is the primary model used for generation. Additional models serve as ordered fallbacks — if the primary model is unavailable, the agent automatically tries the next model in the list.",
         "sectionTools": "Tools",
         "sectionToolsDescription": "Select which tools this agent can use",
+        "sectionToolsExternalDescription": "External agents run in a sandbox and only use bound integrations. Platform tools and workflows don't apply.",
         "sectionIntegrationBindings": "Bound integrations",
         "sectionIntegrationBindingsDescription": "Bind specific integrations as dedicated tools. The agent won't need to specify the integration name.",
         "noIntegrationsAvailable": "No active integrations available.",
@@ -5402,6 +5403,28 @@
           "modelLabel": "Provider model id",
           "modelPlaceholder": "e.g. claude-opus-4-20250514",
           "modelNote": "BYO routes through your own credentials set in Environment & Secrets — model selection, billing, and usage governance move to your credentials; the platform only provides the runtime."
+        },
+        "agentType": {
+          "sectionTitle": "Agent type",
+          "sectionDescription": "How this agent runs. Internal agents run on the platform tool loop; external agents run a coding agent in a sandbox.",
+          "internalLabel": "Internal agent",
+          "internalDescription": "Runs on the platform with chat tools, knowledge, and workflows.",
+          "externalLabel": "External agent",
+          "externalDescription": "Runs Claude Code or OpenCode in an isolated sandbox, using bound integrations.",
+          "imageLabel": "Image generation",
+          "imageDescription": "Routes the message straight to an image model.",
+          "switchTitle": "Change agent type?",
+          "switchToExternalDescription": "This will switch the agent to run in a sandbox and clear its platform tools and workflows. Bound integrations are kept.",
+          "switchToChatDescription": "This will switch the agent to run on the platform tool loop and clear its external runtime and credential settings.",
+          "switchToImageDescription": "This will switch the agent to image generation and clear its tools, workflows, integrations, and external runtime settings.",
+          "noModelWarning": "This agent has no model set — add one on the Instructions tab before saving, or the save will fail.",
+          "switchConfirm": "Change type"
+        },
+        "agentKind": {
+          "label": "External runtime",
+          "description": "Which coding agent runs this agent's turns in the sandbox.",
+          "claudeCode": "Claude Code",
+          "openCode": "OpenCode"
         }
       },
       "delegation": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5068,6 +5068,7 @@
         "sectionModelDescription": "Configure les modèles IA pour cet agent. Le premier modèle est le modèle principal utilisé pour la génération. Les modèles supplémentaires servent de modèles de secours ordonnés — si le modèle principal est indisponible, l'agent essaie automatiquement le modèle suivant dans la liste.",
         "sectionTools": "Outils",
         "sectionToolsDescription": "Sélectionne les outils que cet agent peut utiliser",
+        "sectionToolsExternalDescription": "Les agents externes s'exécutent dans un bac à sable et n'utilisent que les intégrations liées. Les outils de la plateforme et les workflows ne s'appliquent pas.",
         "sectionIntegrationBindings": "Intégrations liées",
         "sectionIntegrationBindingsDescription": "Lie des intégrations spécifiques en tant qu'outils dédiés. L'agent n'aura pas besoin de spécifier le nom de l'intégration.",
         "noIntegrationsAvailable": "Aucune intégration active disponible.",
@@ -5141,6 +5142,28 @@
           "modelLabel": "Identifiant de modèle du fournisseur",
           "modelPlaceholder": "ex. claude-opus-4-20250514",
           "modelNote": "BYO passe par tes propres identifiants définis dans Environnement et secrets — la sélection du modèle, la facturation et la gouvernance de l'usage basculent vers tes identifiants ; la plateforme ne fournit que l'environnement d'exécution."
+        },
+        "agentType": {
+          "sectionTitle": "Type d'agent",
+          "sectionDescription": "Comment cet agent s'exécute. Les agents internes utilisent la boucle d'outils de la plateforme ; les agents externes exécutent un agent de code dans un bac à sable.",
+          "internalLabel": "Agent interne",
+          "internalDescription": "S'exécute sur la plateforme avec les outils de chat, les connaissances et les workflows.",
+          "externalLabel": "Agent externe",
+          "externalDescription": "Exécute Claude Code ou OpenCode dans un bac à sable isolé, en utilisant les intégrations liées.",
+          "imageLabel": "Génération d'images",
+          "imageDescription": "Achemine le message directement vers un modèle d'image.",
+          "switchTitle": "Changer le type d'agent ?",
+          "switchToExternalDescription": "L'agent s'exécutera désormais dans un bac à sable et ses outils de plateforme et workflows seront effacés. Les intégrations liées sont conservées.",
+          "switchToChatDescription": "L'agent utilisera désormais la boucle d'outils de la plateforme et ses paramètres d'exécution externe et d'identifiants seront effacés.",
+          "switchToImageDescription": "L'agent passera à la génération d'images et ses outils, workflows, intégrations et paramètres d'exécution externe seront effacés.",
+          "noModelWarning": "Cet agent n'a aucun modèle — ajoutes-en un dans l'onglet Instructions avant d'enregistrer, sinon l'enregistrement échouera.",
+          "switchConfirm": "Changer le type"
+        },
+        "agentKind": {
+          "label": "Exécution externe",
+          "description": "Quel agent de code exécute les tours de cet agent dans le bac à sable.",
+          "claudeCode": "Claude Code",
+          "openCode": "OpenCode"
         }
       },
       "delegation": {


### PR DESCRIPTION
## Summary

Two UX improvements to make the AI Workforce roster easier to understand and configure from the agent editor.

### 1. Folder-aware breadcrumb on the agent detail page
The agent List groups agents by folder (`chat`, `workforce`, app folders), but the detail page header only showed `Agents / <Name>`. It now renders the folder too — e.g. **Agents / Workforce / Software Developer** — with each segment linking back to the List filtered to that folder, so you can jump to the rest of the workforce.

Root cause of the first attempt missing the folder: a global agent at `agents/workforce/software-developer.json` keeps the **flat** slug `software-developer` — the folder is **not** in the slug. It's metadata on the roster row (the same `folder` field the List view groups by), so the breadcrumb now resolves it from `useListAgents` (already cached from the List) via the existing `toConfigurableAgent` helper. Root agents (no folder) render unchanged.

### 2. Distinguish & switch internal vs external agents; hide unsupported config
`primaryBehavior` (Internal `chat` / External agent / Image generation) was only settable by hand-editing JSON — every UI-created agent was `chat`.

- **General tab** now exposes an **Agent type** selector and, for external agents, the **External runtime** (Claude Code / OpenCode).
- Switching goes through a confirm dialog and a Zod-safe field cleanup (`nextConfigForBehavior`) so the atomic save never trips the schema's cross-field rules — clears `toolNames`/`workflows` for external/image, `agentKind`/`authMode` for chat, `integrationBindings` for image, etc. A pure helper + unit tests assert each transition parses, and document the byo-external→chat "needs a model" trap (warned in the dialog).
- **Type-aware hiding** (external agents bypass the platform tool loop, so loop-only config is a no-op): the **Skills**, **Knowledge**, and **Response Tuning** tabs are hidden; the **Tools** tab keeps only Integration Bindings (Platform Tools / Workflows / Web search hidden); the structured-responses section is hidden. Image-generation drops the Tools tab too.

> On skills specifically: external agents do **not** consume the agent's `skillBindings` (that drives the platform tool loop's `expand_skill`). The skills auto-staged into the sandbox are derived from the org's **integrations** and governed by Integration Bindings (kept visible) — so hiding the Skills tab is correct.

### i18n
New `settings.agents.form.agentType` / `agentKind` keys + an external tools description, in **en / de / fr** (key parity verified).

## Verification
- `tsc --noEmit` clean; `oxlint --type-aware` 0 errors.
- Unit tests: new `nextConfigForBehavior` 5/5 (each transition parses against `agentJsonSchema`); existing `agent-navigation` + `use-agent-config-context` 12/12.
- JSON validity + cross-locale key parity checked.

## Test plan
1. Open a workforce agent → breadcrumb reads `Agents / Workforce / <Name>`; clicking **Workforce** lands on `/agents/all?folder=workforce`. A root agent is unchanged.
2. Open a chat agent → type = Internal, all tabs present. Switch to **External agent** → confirm dialog → External runtime select appears; Skills/Knowledge/Response-Tuning tabs disappear; Tools shows only Integration Bindings; **Save succeeds**. Switch back to Internal → Save succeeds. Switch to **Image generation** → Tools tab also gone; Save succeeds with a model set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent type selection to configure agents as chat or external agents
  * External agents now run in isolated sandbox with access to bound integrations only
  * New external runtime selector to choose execution environment (Claude Code or OpenCode)
  * Enhanced folder-based breadcrumb navigation in agent dashboard
  * Dynamic UI that adapts tabs and settings based on selected agent type

* **Tests**
  * Added comprehensive test coverage for agent configuration transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->