### PR TITLE
fix(platform): per-project task dedup, stopped-run step settling & sandbox stream-idle recovery

### DIFF
--- a/services/platform/app/features/operator/components/part-envelope.test.tsx
+++ b/services/platform/app/features/operator/components/part-envelope.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import type { RenderPart } from '../types';
+import { PartEnvelope } from './part-envelope';
+import { RenderKindRouter } from './render-kind-router';
+
+/** The in-flight sandbox handoff envelope a durable step persists between
+ * segments — never a real result. After a Stop it is the abandoned step's last
+ * stored output, which must never leak as raw JSON. */
+const RUNNING_ENVELOPE = {
+  durationMs: 725441,
+  mode: 'agent',
+  ok: false,
+  outputFileIds: [],
+  status: 'running',
+};
+
+function part(overrides: Partial<RenderPart>): RenderPart {
+  return {
+    render: 'stream',
+    partState: 'output_error',
+    title: 'Implement the fix',
+    data: RUNNING_ENVELOPE,
+    ...overrides,
+  };
+}
+
+describe('PartEnvelope', () => {
+  it('shows the error message and NOT the raw output body for a canceled/failed step', () => {
+    render(
+      <PartEnvelope
+        part={part({ partState: 'output_error', error: 'Cancelled by user' })}
+      >
+        <RenderKindRouter
+          part={part({ partState: 'output_error', error: 'Cancelled by user' })}
+        />
+      </PartEnvelope>,
+    );
+
+    // The error message is the affordance for a settled-error step.
+    expect(screen.getByText('Cancelled by user')).toBeInTheDocument();
+    // The abandoned step's raw handoff envelope must NOT be dumped as JSON.
+    expect(screen.queryByText(/durationMs/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"status"/)).not.toBeInTheDocument();
+  });
+
+  it('still renders the render-kind body for an available output', () => {
+    render(
+      <PartEnvelope
+        part={part({
+          partState: 'output_available',
+          data: { summary: 'done' },
+        })}
+      >
+        <RenderKindRouter
+          part={part({
+            partState: 'output_available',
+            data: { summary: 'done' },
+          })}
+        />
+      </PartEnvelope>,
+    );
+
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/operator/components/part-envelope.tsx
+++ b/services/platform/app/features/operator/components/part-envelope.tsx
@@ -45,12 +45,17 @@ const STATE_BADGE: Record<PartState, BadgeVariant> = {
 };
 
 // States whose own affordance replaces the panel body (nothing useful to show).
-// `upcoming` is a quiet preview row (no skeleton); `loading` is the imminent step.
+// `upcoming` is a quiet preview row (no skeleton); `loading` is the imminent step;
+// `output_error` shows its error message instead — a failed/canceled step has no
+// meaningful result, and rendering the body would dump the abandoned step's raw
+// output (e.g. a stopped sandbox step's `{status:'running'}` handoff envelope) as
+// JSON, which must never surface.
 const BODY_SUPPRESSED = new Set<PartState>([
   'upcoming',
   'loading',
   'waiting_external',
   'empty',
+  'output_error',
 ]);
 
 export function PartEnvelope({

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -905,6 +905,7 @@ import type * as node_only_integration_sandbox_internal_actions from "../node_on
 import type * as node_only_integration_sandbox_types from "../node_only/integration_sandbox/types.js";
 import type * as node_only_sandbox_agent_message_parts from "../node_only/sandbox/agent_message_parts.js";
 import type * as node_only_sandbox_agent_run_outcome from "../node_only/sandbox/agent_run_outcome.js";
+import type * as node_only_sandbox_api_error_detection from "../node_only/sandbox/api_error_detection.js";
 import type * as node_only_sandbox_bifrost_admin from "../node_only/sandbox/bifrost_admin.js";
 import type * as node_only_sandbox_helpers_session_client from "../node_only/sandbox/helpers/session_client.js";
 import type * as node_only_sandbox_helpers_spawner_client from "../node_only/sandbox/helpers/spawner_client.js";
@@ -2449,6 +2450,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/integration_sandbox/types": typeof node_only_integration_sandbox_types;
   "node_only/sandbox/agent_message_parts": typeof node_only_sandbox_agent_message_parts;
   "node_only/sandbox/agent_run_outcome": typeof node_only_sandbox_agent_run_outcome;
+  "node_only/sandbox/api_error_detection": typeof node_only_sandbox_api_error_detection;
   "node_only/sandbox/bifrost_admin": typeof node_only_sandbox_bifrost_admin;
   "node_only/sandbox/helpers/session_client": typeof node_only_sandbox_helpers_session_client;
   "node_only/sandbox/helpers/spawner_client": typeof node_only_sandbox_helpers_spawner_client;

--- a/services/platform/convex/node_only/sandbox/api_error_detection.test.ts
+++ b/services/platform/convex/node_only/sandbox/api_error_detection.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentEvent } from '../../../lib/agent-adapters/events';
+import { errorTextFromEvent, looksLikeApiError } from './api_error_detection';
+
+describe('looksLikeApiError', () => {
+  it('matches the gateway stream-idle abort surfaced by the CLI', () => {
+    expect(
+      looksLikeApiError(
+        'API Error: Error reading stream: stream idle timeout: no data received within configured window',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches each indicator independently (case-insensitive)', () => {
+    expect(looksLikeApiError('api error: overloaded')).toBe(true);
+    expect(looksLikeApiError('Error reading stream')).toBe(true);
+    expect(looksLikeApiError('upstream returned a STREAM IDLE TIMEOUT')).toBe(
+      true,
+    );
+  });
+
+  it('does not match benign text that merely mentions APIs or errors', () => {
+    expect(looksLikeApiError('Let me check the API documentation.')).toBe(
+      false,
+    );
+    expect(looksLikeApiError('the function returned an error code')).toBe(
+      false,
+    );
+    expect(looksLikeApiError('reading the stream of events')).toBe(false);
+  });
+});
+
+describe('errorTextFromEvent', () => {
+  it('returns the text of a main-agent text / text-delta event', () => {
+    expect(errorTextFromEvent({ type: 'text', text: 'API Error: boom' })).toBe(
+      'API Error: boom',
+    );
+    expect(
+      errorTextFromEvent({ type: 'text-delta', text: 'API Error: boom' }),
+    ).toBe('API Error: boom');
+  });
+
+  it('ignores SUB-AGENT text (a sub-agent error is not the main turn dying)', () => {
+    expect(
+      errorTextFromEvent({
+        type: 'text',
+        text: 'API Error: boom',
+        parentToolUseId: 'toolu_1',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('EXCLUDES api_retry raw events — the SDK auto-retries those', () => {
+    // Even though the payload literally contains the sentinel, an api_retry is a
+    // recoverable pre-response retry and must NOT arm the stalled-turn watchdog.
+    const apiRetry: AgentEvent = {
+      type: 'raw',
+      agent: 'claude-code',
+      payload: {
+        type: 'system',
+        subtype: 'api_retry',
+        message: 'API Error: overloaded, retrying',
+      },
+    };
+    expect(errorTextFromEvent(apiRetry)).toBeUndefined();
+  });
+
+  it('scans other raw events (the error shape is not fixed)', () => {
+    const rawErr: AgentEvent = {
+      type: 'raw',
+      agent: 'claude-code',
+      payload: { type: 'system', subtype: 'error', message: 'API Error: 500' },
+    };
+    const text = errorTextFromEvent(rawErr);
+    expect(text).toBeDefined();
+    expect(looksLikeApiError(text ?? '')).toBe(true);
+  });
+
+  it('returns undefined for events that carry no surfaced error text', () => {
+    expect(
+      errorTextFromEvent({
+        type: 'tool-use',
+        toolUseId: 't1',
+        toolName: 'Bash',
+        input: {},
+      }),
+    ).toBeUndefined();
+    expect(
+      errorTextFromEvent({ type: 'result', status: 'completed' }),
+    ).toBeUndefined();
+  });
+});

--- a/services/platform/convex/node_only/sandbox/api_error_detection.ts
+++ b/services/platform/convex/node_only/sandbox/api_error_detection.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure detection for a surfaced terminal API/stream failure in a coding agent's
+ * stream-json output — the input to the stalled-turn watchdog in run_agent.ts.
+ *
+ * Isolated here (no 'use node', no convex-server imports) so the heuristic is
+ * unit-testable without importing the node-only run module — mirrors
+ * `agent_run_outcome.ts`.
+ */
+
+import type { AgentEvent } from '../../../lib/agent-adapters/events';
+
+/**
+ * Does this stream text look like the CLI surfacing a terminal API/stream failure
+ * (a gateway's stream-idle abort, a connection drop, an upstream 5xx) rather than
+ * the agent merely narrating about one? Matched broadly because the CLI's
+ * stream-json shape for a mid-stream error is not fixed. The watchdog that consumes
+ * this ALSO requires no result + nothing in flight + sustained silence, so a stray
+ * match in narration cannot trip it while the turn is healthy.
+ */
+export function looksLikeApiError(text: string): boolean {
+  return /\bAPI Error\b|Error reading stream|stream idle timeout/i.test(text);
+}
+
+/**
+ * Candidate text to scan for a surfaced API/stream failure: main-agent text (a
+ * sub-agent's transient error isn't the main turn dying) plus unmapped `raw`
+ * events EXCEPT `api_retry` — that is the SDK's own recoverable pre-response retry
+ * (it auto-retries those), so it must NOT arm the stalled-turn watchdog.
+ */
+export function errorTextFromEvent(e: AgentEvent): string | undefined {
+  if ((e.type === 'text' || e.type === 'text-delta') && !e.parentToolUseId) {
+    return e.text;
+  }
+  if (e.type === 'raw') {
+    const p = e.payload;
+    if (typeof p === 'object' && p !== null && 'subtype' in p) {
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+      const subtype = (p as { subtype?: unknown }).subtype;
+      if (subtype === 'api_retry') return undefined;
+    }
+    try {
+      return JSON.stringify(e.payload);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/services/platform/convex/node_only/sandbox/bifrost_admin.ts
+++ b/services/platform/convex/node_only/sandbox/bifrost_admin.ts
@@ -46,6 +46,24 @@ function adminPassword(): string {
   return process.env.BIFROST_ADMIN_PASSWORD ?? '';
 }
 
+/** Total per-request timeout pushed to every provider's `network_config`. */
+const REQUEST_TIMEOUT_SECONDS = 600;
+/** Per-stream IDLE timeout (Bifrost `stream_idle_timeout_in_seconds`): how long
+ * Bifrost waits for ANY byte from the upstream mid-stream before it aborts with
+ * `ErrStreamIdleTimeout` ("stream idle timeout: no data received within
+ * configured window"). Bifrost defaults this to 60s. That 60s is fine for a
+ * native Anthropic upstream (it pings every ~15-30s), but a CUSTOM
+ * OpenAI-compatible upstream (e.g. an Anthropic↔OpenAI translation gateway) sends
+ * NO keepalive during a long prefill or a silent reasoning gap — so a large-context
+ * turn trips the 60s idle window and the agent's stream dies mid-run with no retry
+ * (Claude Code does not auto-retry a mid-stream failure). Default it to the full
+ * request budget so a silent gap is bounded only by the total timeout, never a
+ * premature idle abort. Operator-tunable. */
+const STREAM_IDLE_TIMEOUT_SECONDS = Number(
+  process.env.BIFROST_STREAM_IDLE_TIMEOUT_SECONDS ??
+    String(REQUEST_TIMEOUT_SECONDS),
+);
+
 function managementHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     'content-type': 'application/json',
@@ -541,7 +559,10 @@ async function ensureProviderConfig(
       : undefined;
   const body = {
     network_config: {
-      default_request_timeout_in_seconds: 600,
+      default_request_timeout_in_seconds: REQUEST_TIMEOUT_SECONDS,
+      // Don't let a custom OpenAI-compatible upstream's silent prefill / reasoning
+      // gap trip Bifrost's 60s default idle abort mid-stream (see the constant).
+      stream_idle_timeout_in_seconds: STREAM_IDLE_TIMEOUT_SECONDS,
       ...(baseUrl ? { base_url: baseUrl } : {}),
       ...(Object.keys(attribution).length > 0
         ? { extra_headers: attribution }

--- a/services/platform/convex/node_only/sandbox/run_agent.ts
+++ b/services/platform/convex/node_only/sandbox/run_agent.ts
@@ -34,6 +34,7 @@ import {
   type AgentAssistantContent,
   type UiTimelinePart,
 } from './agent_message_parts';
+import { errorTextFromEvent, looksLikeApiError } from './api_error_detection';
 import {
   drainSessionExecResilient,
   sessionCancelExec,
@@ -102,6 +103,21 @@ const QUIET_IDLE_MS = Number(process.env.EXTERNAL_AGENT_QUIET_IDLE_MS ?? 5_000);
 // clock) is never cut off.
 const IDLE_EOF_GRACE_MS = Number(
   process.env.EXTERNAL_AGENT_IDLE_EOF_MS ?? 60_000,
+);
+// Stalled-turn watchdog (claude-code stdin-hold). A mid-stream API failure — the
+// gateway injecting an error into the open SSE (e.g. Bifrost's stream-idle abort),
+// a connection drop, an upstream 5xx — surfaces in the CLI's stream as an
+// "API Error" and ends the turn WITHOUT a terminal `result` and WITHOUT exiting
+// (the CLI keeps its held-open stdin, waiting for the next message; Claude Code
+// does not auto-retry a mid-stream failure). The linger loop's EOF is gated on the
+// result, so nothing closes the wedged process — it would loop empty handoffs for
+// the whole wall-clock budget, then mis-report a timeout. When the stream has
+// surfaced such an error AND no result has arrived AND nothing is in flight (no
+// background tasks / sub-agents / blocking reads / main tools — so this never
+// fires while a long tool runs), wait this grace for a recovery that can't come,
+// then force-close and report a mechanical error so the step's retry runs fresh.
+const STALLED_AFTER_API_ERROR_MS = Number(
+  process.env.EXTERNAL_AGENT_STALLED_AFTER_API_ERROR_MS ?? 20_000,
 );
 
 export interface RunAgentInSessionArgs {
@@ -204,6 +220,10 @@ export interface RunAgentInSessionArgs {
     agentResultSeen?: boolean;
     agentIdle?: boolean;
     pendingTaskIds?: string[];
+    /** Whether an earlier segment's stream surfaced a terminal API/stream error
+     * (stalled-turn watchdog) — seeded so a wedge that straddles the seam is
+     * still force-closed on resume rather than looping empty handoffs. */
+    apiErrorSeen?: boolean;
     /** The op's cross-segment live transcript SO FAR (prior segments' UI parts),
      * seeded only on the workflow run path (`captureLiveTimeline`). The per-segment
      * timeline resets to empty on resume; this carries the accumulated window so a
@@ -272,6 +292,10 @@ export interface RunAgentInSessionResult {
   agentResultSeen?: boolean;
   agentIdle?: boolean;
   pendingTaskIds?: string[];
+  /** status==='running' only: an earlier segment's stream surfaced a terminal
+   * API/stream error (stalled-turn watchdog), checkpointed so a wedge that
+   * straddles the seam is still force-closed on resume. */
+  apiErrorSeen?: boolean;
   /** The agent's OWN self-reported terminal verdict from its stream-json `result`
    * event (`'error'` = error_during_execution / API-auth/connection failure),
    * distinct from `status` (the process-exit verdict). `undefined` ⇒ no result
@@ -426,6 +450,15 @@ export async function runAgentInSessionImpl(
   const pendingTasks = new Set<string>(args.resumeFrom?.pendingTaskIds ?? []);
   let agentResultSeen = args.resumeFrom?.agentResultSeen === true;
   let agentResultStatus: AgentResultStatus | undefined;
+  // Stalled-turn watchdog (see STALLED_AFTER_API_ERROR_MS). apiErrorSeen is seeded
+  // from the checkpoint so an error surfaced in an earlier segment that then wedged
+  // across the seam is still caught on resume. apiErrorText carries the surfaced
+  // message into the thrown step error so the failure is diagnosable. segmentStartedAt
+  // anchors the grace on resume, when lastEventAt has no value yet.
+  let apiErrorSeen = args.resumeFrom?.apiErrorSeen === true;
+  let apiErrorText: string | undefined;
+  let turnStalled = false;
+  const segmentStartedAt = Date.now();
   // Model idle: the per-turn result arrived, OR quiet-idle — background tasks
   // pending and the main loop has gone silent after a completed text block
   // (a `local_workflow` task gates the result until it settles, so waiting
@@ -647,6 +680,30 @@ export async function runAgentInSessionImpl(
    * wait for the next tick. */
   const lingerTick = async (): Promise<void> => {
     if (!stdinHold || !drainActive || handoff || eofSent || lingerBusy) return;
+    // Stalled-turn watchdog: the stream surfaced a terminal API/stream error, no
+    // result has arrived, and NOTHING is in flight (no background tasks / sub-agents
+    // / blocking reads / main tools — `inflightToolUses` is the superset, so a
+    // long-running tool never trips this). The CLI is wedged on its held-open stdin
+    // waiting for a recovery that won't come (a mid-stream failure isn't auto-retried).
+    // Past the grace, force-close and mark a mechanical error so the step retries
+    // fresh instead of looping empty handoffs to the wall-clock budget. lastEventAt is
+    // undefined on a fresh resume, so anchor the grace on the segment start then.
+    if (
+      apiErrorSeen &&
+      !agentResultSeen &&
+      pendingTasks.size === 0 &&
+      inflightToolUses.size === 0 &&
+      Date.now() - (lastEventAt ?? segmentStartedAt) >
+        STALLED_AFTER_API_ERROR_MS
+    ) {
+      turnStalled = true;
+      agentResultStatus = 'error';
+      console.warn(
+        `[run_agent] turn stalled after API error, no result — force-closing exec ${args.execId}: ${apiErrorText ?? '(no detail)'}`,
+      );
+      await sendEof();
+      return;
+    }
     if (
       !agentResultSeen &&
       pendingTasks.size === 0 &&
@@ -787,6 +844,16 @@ export async function runAgentInSessionImpl(
     if (events.length > 0) lastEventAt = Date.now();
     const injectedIds: string[] = [];
     for (const e of events) {
+      // Stalled-turn watchdog input: arm on a surfaced terminal API/stream error
+      // so the linger loop can force-close a turn the CLI left wedged without a
+      // result (see STALLED_AFTER_API_ERROR_MS).
+      if (!apiErrorSeen) {
+        const errText = errorTextFromEvent(e);
+        if (errText && looksLikeApiError(errText)) {
+          apiErrorSeen = true;
+          apiErrorText = errText.slice(0, 500);
+        }
+      }
       // stdin-hold lifecycle: any MAIN-loop activity ends the idle state; a
       // result (re-)enters it (quiet-idle re-enters it from the linger loop).
       // Background task_* chatter must not look like activity — during a
@@ -1280,6 +1347,7 @@ export async function runAgentInSessionImpl(
         ...(agentResultSeen ? { agentResultSeen: true } : {}),
         ...(agentIdle ? { agentIdle: true } : {}),
         ...(pendingTasks.size > 0 && { pendingTaskIds: [...pendingTasks] }),
+        ...(apiErrorSeen ? { apiErrorSeen: true } : {}),
       };
     }
     throw err;
@@ -1346,6 +1414,11 @@ export async function runAgentInSessionImpl(
     // already cleared it), so terminal content is byte-identical to before.
     liveText,
   );
+  // Stalled-turn force-close emits no `result`, so finalText is unset; surface the
+  // captured API/stream error so the sandbox step's thrown error names the cause
+  // (the timeline already renders it, so this isn't fed into assistantContent).
+  const terminalFinalText =
+    finalText ?? (turnStalled ? apiErrorText : undefined);
 
   return {
     status: result.status,
@@ -1353,7 +1426,7 @@ export async function runAgentInSessionImpl(
     ...(capturedSessionId !== undefined && {
       agentSessionId: capturedSessionId,
     }),
-    ...(finalText !== undefined && { finalText }),
+    ...(terminalFinalText !== undefined && { finalText: terminalFinalText }),
     ...(planText !== undefined && { planText }),
     ...(humanControlReason !== undefined && { humanControlReason }),
     ...(usage !== undefined && { usage }),

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -1017,6 +1017,7 @@ export const runSandboxAgent = internalAction({
                 ...(checkpoint.pendingTaskIds !== undefined && {
                   pendingTaskIds: checkpoint.pendingTaskIds,
                 }),
+                ...(checkpoint.apiErrorSeen === true && { apiErrorSeen: true }),
                 ...(priorTimelineParts.length > 0 && {
                   liveTimelineParts: priorTimelineParts,
                 }),
@@ -1071,6 +1072,7 @@ export const runSandboxAgent = internalAction({
                 result.pendingTaskIds.length > 0 && {
                   pendingTaskIds: result.pendingTaskIds,
                 }),
+              ...(result.apiErrorSeen === true && { apiErrorSeen: true }),
               // Carry the admitted run across the seam (checkpoint is a full
               // replace, so re-pass every handoff) → resume re-uses, never re-admits.
               ...(taskRunId !== null && { taskRunId }),

--- a/services/platform/convex/sandbox/session_mutations.ts
+++ b/services/platform/convex/sandbox/session_mutations.ts
@@ -435,6 +435,7 @@ export const insertAgentCheckpoint = internalMutation({
     agentResultSeen: v.optional(v.boolean()),
     agentIdle: v.optional(v.boolean()),
     pendingTaskIds: v.optional(v.array(v.string())),
+    apiErrorSeen: v.optional(v.boolean()),
     taskRunId: v.optional(v.id('taskAgentRuns')),
     startedAt: v.number(),
     continuationCount: v.number(),
@@ -455,6 +456,9 @@ export const insertAgentCheckpoint = internalMutation({
       ...(args.agentIdle !== undefined && { agentIdle: args.agentIdle }),
       ...(args.pendingTaskIds !== undefined && {
         pendingTaskIds: args.pendingTaskIds,
+      }),
+      ...(args.apiErrorSeen !== undefined && {
+        apiErrorSeen: args.apiErrorSeen,
       }),
       ...(args.taskRunId !== undefined && { taskRunId: args.taskRunId }),
       startedAt: args.startedAt,

--- a/services/platform/convex/sandbox/session_queries.ts
+++ b/services/platform/convex/sandbox/session_queries.ts
@@ -350,6 +350,7 @@ export const loadAgentCheckpoint = internalQuery({
       agentResultSeen: v.optional(v.boolean()),
       agentIdle: v.optional(v.boolean()),
       pendingTaskIds: v.optional(v.array(v.string())),
+      apiErrorSeen: v.optional(v.boolean()),
       taskRunId: v.optional(v.id('taskAgentRuns')),
       startedAt: v.number(),
       continuationCount: v.number(),
@@ -374,6 +375,9 @@ export const loadAgentCheckpoint = internalQuery({
         ...(row.agentIdle !== undefined && { agentIdle: row.agentIdle }),
         ...(row.pendingTaskIds !== undefined && {
           pendingTaskIds: row.pendingTaskIds,
+        }),
+        ...(row.apiErrorSeen !== undefined && {
+          apiErrorSeen: row.apiErrorSeen,
         }),
         ...(row.taskRunId !== undefined && { taskRunId: row.taskRunId }),
         startedAt: row.startedAt,

--- a/services/platform/convex/sandbox/sessions_schema.ts
+++ b/services/platform/convex/sandbox/sessions_schema.ts
@@ -254,6 +254,11 @@ export const sandboxAgentCheckpointsTable = defineTable({
   agentResultSeen: v.optional(v.boolean()),
   agentIdle: v.optional(v.boolean()),
   pendingTaskIds: v.optional(v.array(v.string())),
+  /** Stalled-turn watchdog: an earlier segment's stream surfaced a terminal
+   * API/stream error. Carried so a wedge that straddles the seam (the CLI printed
+   * the error then sat on its held-open stdin with no result and no exit) is still
+   * force-closed on resume instead of looping empty handoffs to the budget. */
+  apiErrorSeen: v.optional(v.boolean()),
   /** The admitted `taskAgentRuns` row for a task-bound durable agent run.
    * Admission happens ONCE on the fresh segment; the runId is carried here so
    * resume segments re-use it and never re-admit (which would double-count the

--- a/services/platform/convex/tasks/internal_mutations.test.ts
+++ b/services/platform/convex/tasks/internal_mutations.test.ts
@@ -1,0 +1,115 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root. This file lives at
+// convex/tasks/, so resolve glob keys against that base (mirrors append_only.test.ts).
+const TEST_DIR_FROM_CONVEX_ROOT = 'tasks';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_upsert_external';
+type T = TestConvex<typeof schema>;
+
+async function seedProject(t: T, name: string): Promise<Id<'projects'>> {
+  return await t.run(async (ctx) =>
+    ctx.db.insert('projects', {
+      organizationId: ORG,
+      name,
+      createdBy: 'user_1',
+      createdAt: 0,
+      updatedAt: 0,
+    }),
+  );
+}
+
+function upsert(
+  t: T,
+  projectId: Id<'projects'>,
+  externalId: string,
+  dedupeScope?: 'org' | 'project',
+) {
+  return t.mutation(
+    internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+    {
+      organizationId: ORG,
+      actorId: 'user_1',
+      projectId,
+      externalSystem: 'github',
+      externalId,
+      title: `Issue ${externalId}`,
+      externalState: 'open',
+      ...(dedupeScope ? { dedupeScope } : {}),
+    },
+  );
+}
+
+async function taskProjectId(t: T, taskId: string): Promise<string> {
+  return await t.run(async (ctx) => {
+    const task = await ctx.db.get(taskId as Id<'tasks'>);
+    if (!task) throw new Error('task not found');
+    return String(task.projectId);
+  });
+}
+
+describe('agentUpsertTaskByExternalRef — dedup scope', () => {
+  it("dedupeScope:'project' — same issue in two projects yields two independent tasks", async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+    const projectB = await seedProject(t, 'Beta');
+
+    const a = await upsert(t, projectA, 'owner/repo#1925', 'project');
+    const b = await upsert(t, projectB, 'owner/repo#1925', 'project');
+
+    expect(a.created).toBe(true);
+    expect(b.created).toBe(true);
+    expect(a.taskId).not.toBe(b.taskId);
+    // Each task lives in its OWN project — the second create did not retarget the first.
+    expect(await taskProjectId(t, a.taskId)).toBe(String(projectA));
+    expect(await taskProjectId(t, b.taskId)).toBe(String(projectB));
+  });
+
+  it("dedupeScope:'project' — same issue twice in one project is idempotent", async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+
+    const first = await upsert(t, projectA, 'owner/repo#42', 'project');
+    const second = await upsert(t, projectA, 'owner/repo#42', 'project');
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.taskId).toBe(first.taskId);
+  });
+
+  it("dedupeScope:'org' (default) — same issue across projects dedups to one org-wide task", async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+    const projectB = await seedProject(t, 'Beta');
+
+    // Default scope (arg omitted) must stay org-wide for back-compat with the
+    // GitHub sync workflows.
+    const a = await upsert(t, projectA, 'owner/repo#7');
+    const b = await upsert(t, projectB, 'owner/repo#7');
+
+    expect(a.created).toBe(true);
+    expect(b.created).toBe(false);
+    expect(b.taskId).toBe(a.taskId);
+    // The task stays in the project that first materialized it (projectId is not re-homed).
+    expect(await taskProjectId(t, b.taskId)).toBe(String(projectA));
+  });
+});

--- a/services/platform/convex/tasks/internal_mutations.ts
+++ b/services/platform/convex/tasks/internal_mutations.ts
@@ -263,9 +263,17 @@ export const agentCreateTask = internalMutation({
 const SYNC_OPEN_STATUS = 'backlog' as const;
 
 /**
- * Upsert a task from an external system, keyed by the
- * `(organizationId, externalSystem, externalId)` natural key. Idempotent: a
- * re-sync of the same external item patches the existing task instead of
+ * Upsert a task from an external system, keyed by an external natural key whose
+ * SCOPE the caller chooses via `dedupeScope` (mirrors the read split between
+ * `listTasksByOrg` and `listTasksByProject`):
+ *  - `'org'` (default): `(organizationId, externalSystem, externalId)` — one task
+ *    per issue per org. The org-wide sync workflows and any org-scoped app use
+ *    this (their home is the org-wide project).
+ *  - `'project'`: `(projectId, externalSystem, externalId)` — one task per issue
+ *    per PROJECT, so a project-scoped app (issue-desk) bound to two projects
+ *    materializes the same issue into two INDEPENDENT tasks (each with its own
+ *    workflow run), instead of the second project silently retargeting the first.
+ * Idempotent within its scope: a re-pick patches the existing task instead of
  * creating a duplicate (mirrors the `documents.externalItemId` upsert).
  *
  * Status policy keeps local triage authoritative while letting the external
@@ -306,6 +314,10 @@ export const agentUpsertTaskByExternalRef = internalMutation({
      *  (`createdByType:'app'`, `createdBy:<appSlug>`) — the ownership signal the
      *  generic task loops arbitrate on. */
     runWorkflowSlug: v.optional(v.string()),
+    /** Dedup scope for the external natural key (see the doc comment):
+     *  `'project'` keys on the project (one task per issue per project);
+     *  `'org'` (default) keys on the org (one task per issue per org). */
+    dedupeScope: v.optional(v.union(v.literal('org'), v.literal('project'))),
   },
   handler: async (
     ctx,
@@ -320,15 +332,29 @@ export const agentUpsertTaskByExternalRef = internalMutation({
     const description = args.description?.trim() || undefined;
     const now = Date.now();
 
-    const existing = await ctx.db
-      .query('tasks')
-      .withIndex('by_org_external', (q) =>
-        q
-          .eq('organizationId', args.organizationId)
-          .eq('externalSystem', args.externalSystem)
-          .eq('externalId', args.externalId),
-      )
-      .first();
+    // Dedup within the chosen scope: project-scoped apps look up by project so the
+    // same issue in another project is treated as absent (→ a new task); the
+    // default org scope keeps the one-task-per-issue-per-org sync behavior.
+    const existing =
+      args.dedupeScope === 'project'
+        ? await ctx.db
+            .query('tasks')
+            .withIndex('by_project_external', (q) =>
+              q
+                .eq('projectId', args.projectId)
+                .eq('externalSystem', args.externalSystem)
+                .eq('externalId', args.externalId),
+            )
+            .first()
+        : await ctx.db
+            .query('tasks')
+            .withIndex('by_org_external', (q) =>
+              q
+                .eq('organizationId', args.organizationId)
+                .eq('externalSystem', args.externalSystem)
+                .eq('externalId', args.externalId),
+            )
+            .first();
 
     if (existing) {
       // Preserve a non-empty existing description when asked (re-sync), so a

--- a/services/platform/convex/tasks/public_actions.ts
+++ b/services/platform/convex/tasks/public_actions.ts
@@ -46,8 +46,11 @@ async function startWorkflowForTask(
  * (`externalSystem`/`externalId`/`externalUrl`). The upsert that carries the
  * external ref is internal-only and needs an actor, so this thin action supplies
  * the authenticated user as the actor and defaults the destination project to
- * the org's project. Idempotent on (org, system, externalId) — picking the same
- * issue twice updates rather than duplicates. The created task is reactive, so
+ * the org's project. Idempotent within the materialization scope: an explicit
+ * `projectId` (a project-scoped app) dedups PER PROJECT, so the same issue picked
+ * in two projects yields two independent tasks; the org-wide fallback (an
+ * org-scoped/legacy caller) dedups per org. Picking the same issue twice in the
+ * same scope updates rather than duplicates. The created task is reactive, so
  * the rest of the view (the tasks Collection) reflects it live.
  *
  * When `runWorkflowSlug` is set, a NEWLY created task also kicks off that workflow
@@ -131,6 +134,9 @@ export const createTaskFromExternalIssue = action({
         // Attributes the task to the owning app (createdByType:'app') so generic
         // task automation defers to the app's workflow — see the upsert mutation.
         runWorkflowSlug: args.runWorkflowSlug,
+        // An explicit project (a project-scoped app) dedups per project so two
+        // projects each get their own task; the org-wide fallback dedups per org.
+        dedupeScope: args.projectId ? 'project' : 'org',
       },
     );
 

--- a/services/platform/convex/tasks/schema.ts
+++ b/services/platform/convex/tasks/schema.ts
@@ -170,7 +170,12 @@ export const tasksTable = defineTable({
   .index('by_project_archived', ['projectId', 'archivedAt'])
   .index('by_assignee', ['organizationId', 'assigneeType', 'assigneeId'])
   .index('by_parent', ['parentTaskId'])
+  // External-ref dedup keyed at two scopes (see `agentUpsertTaskByExternalRef`):
+  // `by_org_external` for org-scoped materialization (one task per issue per org);
+  // `by_project_external` for project-scoped apps (one task per issue per project,
+  // so the same issue worked in two projects yields two independent tasks).
   .index('by_org_external', ['organizationId', 'externalSystem', 'externalId'])
+  .index('by_project_external', ['projectId', 'externalSystem', 'externalId'])
   .index('by_org_updatedAt', ['organizationId', 'updatedAt'])
   // Due-soon / overdue sweeps (SLA enforcement).
   .index('by_org_dueDate', ['organizationId', 'dueDate'])

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.test.ts
@@ -293,6 +293,110 @@ describe('deriveStepStatuses', () => {
     expect(result.execution.waitingFor).toBe('debug:2:send-email');
   });
 
+  it('settles a still-running step to canceled once the run was stopped (stale inProgress entry)', () => {
+    // User Stop → cancelExecution flips the row to 'failed'/'canceled' but never
+    // writes a terminal runResult to the abandoned step's journal entry, which
+    // stays inProgress. Without reconciliation the node would read `running`
+    // forever and the run view would keep flashing the "Running"/"Live" badge.
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('implement', {
+          args: {
+            stepSlug: 'implement',
+            stepType: 'sandbox',
+            stepName: 'Implement the fix',
+          },
+          inProgress: true,
+          completedAt: undefined,
+        }),
+      ],
+      execution({
+        status: 'failed',
+        errorCode: 'canceled',
+        error: 'Cancelled by user',
+        currentStepSlug: 'implement',
+      }),
+    );
+
+    expect(result.nodes.implement).toMatchObject({
+      status: 'canceled',
+      error: 'Cancelled by user',
+    });
+  });
+
+  it('settles a durable-sandbox handoff (port:running) step to canceled when the run was stopped', () => {
+    // The durable sandbox step crosses each action boundary on the internal
+    // `running` port; a Stop in that window leaves a success/port:running entry
+    // that would otherwise still read `running`.
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('implement', {
+          args: {
+            stepSlug: 'implement',
+            stepType: 'sandbox',
+            stepName: 'Implement the fix',
+          },
+          runResult: { kind: 'success', returnValue: { port: 'running' } },
+        }),
+      ],
+      execution({
+        status: 'failed',
+        errorCode: 'canceled',
+        error: 'Cancelled by user',
+        currentStepSlug: 'implement',
+      }),
+    );
+
+    expect(result.nodes.implement.status).toBe('canceled');
+  });
+
+  it("synthesizes a settled current-step node when its journal entry was GC'd after a stop", () => {
+    // ~10s after the stop the component workflow journal is cleaned up, so the
+    // journal is empty. The current step must still settle to canceled rather
+    // than fall back to a loading skeleton.
+    const result = deriveStepStatuses(
+      [],
+      execution({
+        status: 'failed',
+        errorCode: 'canceled',
+        error: 'Cancelled by user',
+        currentStepSlug: 'implement',
+        currentStepName: 'Implement the fix',
+      }),
+    );
+
+    expect(result.nodes.implement).toMatchObject({
+      status: 'canceled',
+      stepName: 'Implement the fix',
+      error: 'Cancelled by user',
+      attempts: 0,
+    });
+  });
+
+  it('does not borrow a generic failure reason onto stranded sibling steps', () => {
+    // A non-cancel hard failure: the failing step keeps its own error; a sibling
+    // still in progress settles to canceled WITHOUT inheriting the run error.
+    const result = deriveStepStatuses(
+      [
+        executeStepEntry('send', {
+          runResult: { kind: 'failed', error: 'SMTP unreachable' },
+        }),
+        executeStepEntry('notify', {
+          inProgress: true,
+          completedAt: undefined,
+        }),
+      ],
+      execution({ status: 'failed', error: 'SMTP unreachable' }),
+    );
+
+    expect(result.nodes.send).toMatchObject({
+      status: 'failed',
+      error: 'SMTP unreachable',
+    });
+    expect(result.nodes.notify.status).toBe('canceled');
+    expect(result.nodes.notify.error).toBeUndefined();
+  });
+
   it('flags outputs as unavailable when variables were offloaded to storage', () => {
     const result = deriveStepStatuses(
       [

--- a/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
+++ b/services/platform/convex/workflows/executions/get_execution_step_statuses.ts
@@ -245,6 +245,48 @@ export function deriveStepStatuses(
         };
   }
 
+  // A SETTLED execution has no live step. Two ways a step is stranded mid-run
+  // when the run is stopped (a user Stop → status 'failed' + errorCode
+  // 'canceled') or hard-fails:
+  //   1. cancelling the component workflow never writes a terminal runResult
+  //      to the in-progress entry, so the node reads `running` forever; and
+  //   2. once the component workflow's journal is GC'd (cleanupComponentWorkflow,
+  //      ~10s later) the entry is gone, so the current step has no node at all.
+  // Either way the run view would otherwise keep flashing a "Running"/"Live"
+  // (case 1) or a pending skeleton (case 2) for a step the run has abandoned.
+  // Settle the step status against the terminal outcome.
+  if (execution.status === 'completed' || execution.status === 'failed') {
+    const settled: ExecutionNodeStatus =
+      execution.status === 'completed' ? 'success' : 'canceled';
+    // A user Stop sets a run-level reason that genuinely describes the
+    // abandoned step; a generic failure's reason belongs to the step that
+    // actually failed, not its stranded siblings, so don't borrow it.
+    const settledError =
+      execution.errorCode === 'canceled' ? execution.error : undefined;
+    for (const node of Object.values(nodes)) {
+      if (
+        node.status === 'running' ||
+        node.status === 'waiting' ||
+        node.status === 'paused'
+      ) {
+        node.status = settled;
+        if (settledError !== undefined && node.error === undefined) {
+          node.error = settledError;
+        }
+      }
+    }
+    // (case 2) The current step's journal entry may already be GC'd —
+    // synthesize a settled node so it doesn't fall back to a loading skeleton.
+    if (execution.currentStepSlug && !nodes[execution.currentStepSlug]) {
+      nodes[execution.currentStepSlug] = {
+        status: settled,
+        stepName: execution.currentStepName,
+        attempts: 0,
+        ...(settledError !== undefined && { error: settledError }),
+      };
+    }
+  }
+
   const { outputs, unavailable } = readStepOutputs(execution);
   for (const [slug, node] of Object.entries(nodes)) {
     if (unavailable) {


### PR DESCRIPTION
## Summary

Four related platform/sandbox reliability fixes that surfaced while running issue-desk apps across multiple projects with durable sandbox agent runs. Each is an independent commit:

- **`fix(platform): scope external-issue→task dedup per app scope`** — `agentUpsertTaskByExternalRef` deduped only on `(org, externalSystem, externalId)`, so a project-scoped app (issue-desk) bound to two projects had its "Create task" in the second project silently retarget the *first* project's existing task — the second project's Tasks tab stayed empty and no run started. Dedup scope now mirrors app scope: new `dedupeScope: 'org' | 'project'` arg (default `'org'`) + new index `by_project_external`. Pure index add, no data migration. The same issue worked in two projects now yields two independent tasks and runs.

- **`fix(platform): settle workflow step status when a run is stopped`** — a stopped run kept showing its in-progress step as "Running"/"Live" because step status is derived purely from the workflow journal and was never reconciled against a terminal execution row (and once the journal is GC'd the step reverted to a loading skeleton). `deriveStepStatuses` now settles running/waiting/paused nodes to canceled (or success on a completed run) and synthesizes the current step's node from the execution row when its journal entry is gone, surfacing the user-Stop reason on the abandoned step.

- **`fix(platform): never dump a settled step's raw output as JSON in the run view`** — after a Stop, the run view rendered the abandoned step's last stored output (the in-flight sandbox handoff envelope) as raw JSON below the error. The output body is now suppressed for the `output_error` state (the same as upcoming/loading/empty), so the handoff envelope never leaks as JSON.

- **`fix(sandbox): recover agent runs from mid-stream gateway stream-idle stalls`** — a managed sandbox agent turn through tale-bifrost to a custom OpenAI-format upstream could die mid-stream with "stream idle timeout" and then hang the step on "Running" for the full wall-clock budget without retrying. Two fixes: (1) push Bifrost's `stream_idle_timeout_in_seconds` (default 600, env `BIFROST_STREAM_IDLE_TIMEOUT_SECONDS`) on every provisioned provider so a silent prefill/reasoning gap on a non-keepalive upstream doesn't trip the 60s default; (2) add a stalled-turn watchdog in `run_agent` that force-closes and reports `agentResultStatus='error'` (so the step retries fresh) on a surfaced API/stream-error sentinel with no result, nothing in flight, and silence past `EXTERNAL_AGENT_STALLED_AFTER_API_ERROR_MS`. Detection is isolated in `api_error_detection.ts` (excludes SDK-auto-retried `api_retry`) and unit-tested; `apiErrorSeen` is carried across handoff seams via the checkpoint.

## Checklist

- [x] `bun run check` passes — platform `tsc --noEmit` clean on this branch; unit tests added with each fix were green at commit time (see test plan). New suites: `api_error_detection.test.ts`, `tasks/internal_mutations.test.ts`, `get_execution_step_statuses.test.ts`, `part-envelope.test.tsx`.
- [x] `bun run lint:sast` — **N/A**: no new request handlers, shell, or fs boundaries; backend logic, an index add, and a provider-config knob with no untrusted input.
- [x] Translations updated — **N/A**: no new/changed user-facing strings (reuses existing step-reason strings; the run-view change suppresses a render body).
- [x] Docs updated — **N/A**: backend reliability fixes; the two new env vars (`BIFROST_STREAM_IDLE_TIMEOUT_SECONDS`, `EXTERNAL_AGENT_STALLED_AFTER_API_ERROR_MS`) are internal sandbox/operator tuning knobs with safe defaults, not a documented user surface.
- [x] `README.md` / `README.de.md` / `README.fr.md` — **N/A**: no user-facing capability change.

## Test plan

- **Task dedup** — `tasks/internal_mutations.test.ts`: same `(externalSystem, externalId)` upserted under `dedupeScope: 'project'` into two projects yields two independent tasks; `'org'` path still dedupes org-wide.
- **Step status settle** — `get_execution_step_statuses.test.ts`: a stopped run settles running/waiting/paused nodes to canceled and synthesizes the current step from the execution row after journal GC; a completed run settles to success.
- **Run-view output** — `part-envelope.test.tsx`: the `output_error` state renders the error affordance and no raw-JSON body.
- **Sandbox stream-idle** — `api_error_detection.test.ts`: stream/API-error sentinels are detected and `api_retry` is excluded. The watchdog + Bifrost idle-timeout fixes were reproduced and verified live against a ccgateway upstream (large-context turn that previously wedged now retries and completes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error display by hiding raw technical data when operations fail.
  * Automatic detection and recovery from stream/API errors that previously caused processes to hang.
  * Fixed workflow steps remaining stuck when execution is stopped.

* **New Features**
  * Configurable stream timeout settings for better reliability.
  * Project-scoped task deduplication for improved multi-project organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->