### PR TITLE
fix(platform): verify the web client passes the Mozilla Observatory check (#1925)

### DIFF
--- a/services/platform/server.test.ts
+++ b/services/platform/server.test.ts
@@ -54,6 +54,51 @@ describe('security headers', () => {
     expect(pp).toContain('clipboard-write=(self)');
   });
 
+  // Regression guard for issue #1925 — "Verify the web client passes the
+  // Mozilla Observatory check". The live HTTPS deployment (demo.tale.dev) was
+  // scanned with the MDN HTTP Observatory on 2026-06-23 and graded **A+**
+  // (score 115, algorithm v5, 10/10 tests passed, 0 failed):
+  //   https://developer.mozilla.org/en-US/observatory/analyze?host=demo.tale.dev
+  // The A+ grade hinges on the specific header shape asserted below — most of
+  // all a strict, nonce-based CSP with NO `unsafe-inline`/`unsafe-eval` in
+  // `script-src`. This test locks that contract so a future change that would
+  // drop the grade fails CI instead of being noticed only on the next manual
+  // scan.
+  test('emits the Observatory A+ header contract (issue #1925)', async () => {
+    const app = createApp(baseEnv);
+    const res = await app.fetch(new Request('http://localhost/api/health'));
+
+    const csp = res.headers.get('content-security-policy') ?? '';
+    // Observatory's CSP test awards its best score only when `script-src`
+    // neither falls back to a permissive `default-src` nor allows inline /
+    // eval execution. A per-request nonce plus `'self'` is what earns it.
+    const scriptSrc = csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).toMatch(/'nonce-[^']+'/);
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+    // Directives Observatory checks for clickjacking / injection hardening.
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+
+    // The remaining Observatory tests map one-to-one onto these headers.
+    expect(res.headers.get('strict-transport-security')).toBe(
+      'max-age=15552000',
+    );
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+    expect(res.headers.get('referrer-policy')).toBe(
+      'strict-origin-when-cross-origin',
+    );
+    // CORS test: the document must NOT advertise itself as cross-origin
+    // readable. A wide-open `Access-Control-Allow-Origin: *` would fail it.
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
   test('HSTS is omitted when SITE_URL is HTTP loopback', async () => {
     const app = createApp({ ...baseEnv, SITE_URL: 'http://localhost:3000' });
     const res = await app.fetch(new Request('http://localhost/api/health'));


### PR DESCRIPTION
## What

Closes #1925.

Verified the live web client against the **MDN HTTP Observatory** and recorded the result. No header changes were required — the deployment already earns the top grade.

### Scan result (algorithm v5, 2026-06-23)

Scanned `https://demo.tale.dev`:

| Field | Value |
| --- | --- |
| **Grade** | **A+** |
| Score | 115 |
| Tests passed | 10 / 10 |
| Tests failed | 0 |

Details: https://developer.mozilla.org/en-US/observatory/analyze?host=demo.tale.dev

The A+ grade is driven by the strict, nonce-based CSP (`script-src 'nonce-…' 'self'` — no `unsafe-inline`/`unsafe-eval`), HSTS (`max-age=15552000`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, locked-down CORS, and `object-src 'none'` / `base-uri 'self'` / `frame-ancestors 'none'`. All of these are produced by `services/platform/server.ts`. Nothing scored below the target, so there is nothing to remediate.

### Why this PR exists

Issue #1925 noted the headers were implemented and unit-tested, but the **live** grade had never been run or recorded — "passes" was an assumption. This PR turns it into a verified, regression-guarded fact:

- Records the verified A+ result in the issue and in code provenance.
- Adds a regression test (`emits the Observatory A+ header contract`) that locks the exact header shape the A+ grade depends on, so a future change that would drop the grade fails CI instead of being caught only on the next manual scan.

## Test

`bunx vitest --run --project server server.test.ts` → 35 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test validating the health check endpoint security header compliance with Mozilla Observatory A+ standards, including Content Security Policy with nonce enforcement and restrictions on unsafe-inline and unsafe-eval directives, along with HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy configuration, and CORS access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->