### PR TITLE
fix(platform): route all pdfjs consumers through a shared loader (fixes DOMMatrix indexing failure)

### DIFF
--- a/services/platform/convex/crawler/lib/document_metadata.ts
+++ b/services/platform/convex/crawler/lib/document_metadata.ts
@@ -30,21 +30,12 @@
 import { XMLParser } from 'fast-xml-parser';
 import type { PDFPageProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 
-type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
-let pdfjsModulePromise: Promise<PdfjsModule> | undefined;
-/**
- * Lazily load pdfjs so its DOM-global setup (DOMMatrix/OffscreenCanvas, the
- * optional `@napi-rs/canvas` probe) runs only when an action actually parses a
- * PDF — never during Convex's module *analyze* pass, where those globals are
- * undefined and a top-level pdfjs import throws `DOMMatrix is not defined`.
- * pdfjs is bundled (tree-shaken) rather than externalized to keep the module
- * upload under the backend's size limit.
- */
-function loadPdfjs(): Promise<PdfjsModule> {
-  return (pdfjsModulePromise ??= import('pdfjs-dist/legacy/build/pdf.mjs'));
-}
-
 import { GuardedZip } from '../../lib/knowledge/extraction/ooxml';
+// pdfjs must be loaded through the shared loader so its DOM polyfills + fake
+// worker are installed before the first import; a bare `import('pdfjs-dist/…')`
+// here would poison the process-wide module cache with `DOMMatrix is not
+// defined` (see pdfjs_loader.ts).
+import { loadPdfjs } from '../../lib/knowledge/extraction/pdfjs_loader';
 
 const MIN_YEAR = 1970;
 const MAX_YEAR = 2100;

--- a/services/platform/convex/lib/knowledge/extraction/pdf.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdf.ts
@@ -18,41 +18,8 @@
 
 import type { PDFPageProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 
-import { installPdfjsDomGlobals } from './pdfjs_dom_polyfill';
-
-type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
-let pdfjsModulePromise: Promise<PdfjsModule> | undefined;
-/**
- * Lazily load pdfjs so its DOM-global setup runs only when an action actually
- * parses a PDF — never during Convex's module *analyze* pass, where those
- * globals are undefined and a top-level pdfjs import throws `DOMMatrix is not
- * defined`. pdfjs is bundled (tree-shaken) rather than externalized to keep the
- * module upload under the backend's size limit.
- *
- * Before importing pdfjs we install pure-JS `DOMMatrix`/`ImageData`/`Path2D`
- * globals: pdfjs's own polyfill does `require("@napi-rs/canvas")` (a native
- * module Convex does NOT ship to the node-action runtime — see
- * {@link installPdfjsDomGlobals}), so without this every PDF fails with
- * `DOMMatrix is not defined`. pdfjs only sets its globals when absent, so ours
- * win and the native require is skipped.
- */
-function loadPdfjs(): Promise<PdfjsModule> {
-  installPdfjsDomGlobals();
-  return (pdfjsModulePromise ??= (async () => {
-    // pdfjs's fake worker would dynamically `import('./pdf.worker.mjs')` at
-    // getDocument time — a sibling file that doesn't exist in the Convex action
-    // bundle, so it fails with "Setting up fake worker failed". Pre-load the
-    // worker module and expose it as `globalThis.pdfjsWorker`: pdfjs's
-    // PDFWorker._setupFakeWorkerGlobal then uses its `WorkerMessageHandler`
-    // in-process and skips the file import. The worker is bundled with the
-    // action because we import it statically here.
-    const worker = await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
-    (globalThis as Record<string, unknown>).pdfjsWorker = worker;
-    return import('pdfjs-dist/legacy/build/pdf.mjs');
-  })());
-}
-
 import type { VisionClient } from '../vision/client';
+import { loadPdfjs } from './pdfjs_loader';
 
 export type ProgressCallback = (pagesDone: number, totalPages: number) => void;
 

--- a/services/platform/convex/lib/knowledge/extraction/pdfjs_loader.ts
+++ b/services/platform/convex/lib/knowledge/extraction/pdfjs_loader.ts
@@ -1,0 +1,53 @@
+'use node';
+
+/**
+ * The single safe entry point for loading pdfjs-dist inside a Convex 'use node'
+ * action. Every pdfjs importer MUST go through this — never
+ * `import('pdfjs-dist/...')` directly.
+ *
+ * pdfjs's setup runs ONCE per process, at module-evaluation time on first
+ * import, and is then cached process-wide (ESM caches evaluation, including
+ * failures). That setup (a) polyfills `DOMMatrix`/`ImageData`/`Path2D` via
+ * `require("@napi-rs/canvas")` — a NATIVE module Convex does NOT ship to the
+ * bundled action runtime — and (b) constructs `new DOMMatrix()` at top level.
+ * With no native canvas and no pre-installed global, that top-level
+ * construction throws `ReferenceError: DOMMatrix is not defined` and the whole
+ * pdfjs import rejects for the lifetime of the process.
+ *
+ * Because the first importer wins, a single pdfjs consumer that skips the
+ * polyfill poisons the cached module for every other consumer in the same
+ * process (e.g. in-process metadata extraction running before RAG text
+ * extraction). Routing all consumers through this loader — which installs the
+ * pure-JS DOM polyfills and pre-loads the worker BEFORE the first import —
+ * guarantees pdfjs always evaluates in a working state regardless of which
+ * action reaches it first.
+ */
+
+import { installPdfjsDomGlobals } from './pdfjs_dom_polyfill';
+
+export type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
+
+let pdfjsModulePromise: Promise<PdfjsModule> | undefined;
+
+/**
+ * Lazily load pdfjs with the DOM globals and fake worker it needs in the Convex
+ * node-action runtime. Lazy so this never runs during Convex's module *analyze*
+ * pass (where the globals are undefined and a top-level pdfjs import would
+ * throw). pdfjs is bundled (tree-shaken) rather than externalized to keep the
+ * module upload under the backend's size limit.
+ */
+export function loadPdfjs(): Promise<PdfjsModule> {
+  installPdfjsDomGlobals();
+  return (pdfjsModulePromise ??= (async () => {
+    // pdfjs's fake worker would dynamically `import('./pdf.worker.mjs')` at
+    // getDocument time — a sibling file that doesn't exist in the action
+    // bundle, so it fails with "Setting up fake worker failed". Pre-load the
+    // worker module and expose it as `globalThis.pdfjsWorker`: pdfjs's
+    // PDFWorker._setupFakeWorkerGlobal then uses its `WorkerMessageHandler`
+    // in-process and skips the file import. The worker is bundled with the
+    // action because we import it statically here.
+    const worker = await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
+    (globalThis as Record<string, unknown>).pdfjsWorker = worker;
+    return import('pdfjs-dist/legacy/build/pdf.mjs');
+  })());
+}


### PR DESCRIPTION
## Problem

PDF indexing for RAG fails with **`Uncaught ReferenceError: DOMMatrix is not defined`** (surfaced on a document's RAG status as "Indexing failed").

## Root cause

`pdfjs-dist` sets up `DOMMatrix`/`ImageData`/`Path2D` **at module-evaluation time** — once per process, then the result (including a thrown evaluation) is cached process-wide. It does `require("@napi-rs/canvas")` (a native addon Convex does **not** ship into the extracted node action) and constructs a top-level `new DOMMatrix()`. With no pre-installed polyfill, pdfjs only `warn`s about the missing native canvas and then the top-level `new DOMMatrix()` throws.

`extraction/pdf.ts` (the RAG text-extraction path) correctly installed a pure-JS polyfill + preloaded the fake worker **before** importing pdfjs. But the in-process crawler port `crawler/lib/document_metadata.ts` (added when the standalone crawler was folded in-process) **copied `loadPdfjs` and dropped both**.

On upload, `extractFileMetadata` (→ `document_metadata.ts`) and `uploadFileToRag` (→ `pdf.ts`) are scheduled together and share a warm Convex isolate. When the **un-polyfilled** metadata path evaluates pdfjs first, it poisons the cached module process-wide, so the correctly-polyfilled RAG path then inherits the failure — which is why the error shows up attributed to RAG indexing.

## Fix

Centralize a single `loadPdfjs()` in **`extraction/pdfjs_loader.ts`** and use it from both consumers, removing the duplication that drifted. This guarantees the DOM polyfill + fake worker are installed before pdfjs is ever evaluated, regardless of which action reaches it first.

## Why it wasn't caught

`@napi-rs/canvas` is installed in local `node_modules`, so under vitest pdfjs gets a **native** `DOMMatrix` and this class of bug is invisible. It only manifests in the Convex action runtime, where the native module isn't shipped. `document_metadata`'s tests also never exercised its pdfjs path (only OOXML / `parsePdfDate`).

## Verification

- `tsc --noEmit` ✅, `oxlint --type-aware` ✅ (0), 16/16 relevant unit tests ✅, opengrep SAST ✅ (0).
- Mechanism-level before/after, run against the **real** repo code with `@napi-rs/canvas` blocked to mimic the action runtime:
  - **Bug reproduced** — bare import + no polyfill → `DOMMatrix is not defined` (exact UI error).
  - **Fixed** — metadata extraction first, then RAG text extraction, **both succeed in one process**; `DOMMatrix` is provided by the JS polyfill. Process poisoning eliminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated PDF processing library initialization logic into a shared module to improve code maintainability and consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->