### PR TITLE
feat(platform): in-process website crawl scheduler + crawler fallout fixes

### DIFF
--- a/services/db/migrations/knowledge-db/private_knowledge/00000000000001_knowledge_private_baseline.sql
+++ b/services/db/migrations/knowledge-db/private_knowledge/00000000000001_knowledge_private_baseline.sql
@@ -27,6 +27,28 @@ CREATE TABLE IF NOT EXISTS private_knowledge.documents (
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Converge columns onto a pre-existing `documents` table.
+-- On deployments created by the old per-service RAG migrations
+-- (services/rag/migrations/*, consolidated into this baseline in #1883) the
+-- table already exists, so the CREATE TABLE IF NOT EXISTS above is a no-op and
+-- never adds columns introduced by later RAG migrations. They must be added
+-- here BEFORE any index/constraint below depends on them — e.g. the GIN index
+-- idx_pk_docs_metadata (added by 20260611000002_add_document_metadata) fails
+-- with `column "metadata" does not exist` (42703) on a DB that had only reached
+-- 20260611000001_add_documents_folder_path. Every column is nullable or carries
+-- a constant DEFAULT, so adding it to a populated table is a safe, metadata-only
+-- change. Mirrors the CHECK-constraint convergence in the public_web baseline.
+ALTER TABLE private_knowledge.documents
+    ADD COLUMN IF NOT EXISTS error              TEXT,
+    ADD COLUMN IF NOT EXISTS org_slug           TEXT        NOT NULL DEFAULT 'default',
+    ADD COLUMN IF NOT EXISTS progress_phase     TEXT,
+    ADD COLUMN IF NOT EXISTS progress_detail    TEXT,
+    ADD COLUMN IF NOT EXISTS source_created_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS source_modified_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS ocr_applied        BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS folder_path        TEXT,
+    ADD COLUMN IF NOT EXISTS metadata           JSONB       NOT NULL DEFAULT '{}';
+
 -- UNIQUE (id, org_slug) — FK target for chunks composite FK
 DO $$
 BEGIN
@@ -69,6 +91,17 @@ CREATE TABLE IF NOT EXISTS private_knowledge.chunks (
     suffix_overlap TEXT NOT NULL DEFAULT '',
     UNIQUE(document_id, chunk_index)
 );
+
+-- Converge columns onto a pre-existing `chunks` table (see the documents note
+-- above). org_slug was added by 20260528000001_enforce_org_slug; the overlap
+-- columns by 20260424000001_add_chunk_core_overlap_columns. org_slug must exist
+-- before the composite FK and idx_pk_chunks_org_doc below reference it. All are
+-- defaulted, so adding them to a populated table is safe.
+ALTER TABLE private_knowledge.chunks
+    ADD COLUMN IF NOT EXISTS org_slug       TEXT NOT NULL DEFAULT 'default',
+    ADD COLUMN IF NOT EXISTS core_content   TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS prefix_overlap TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS suffix_overlap TEXT NOT NULL DEFAULT '';
 
 -- Composite FK so chunks.org_slug must match documents.org_slug
 DO $$

--- a/services/db/migrations/knowledge-db/public_web/00000000000002_knowledge_web_baseline.sql
+++ b/services/db/migrations/knowledge-db/public_web/00000000000002_knowledge_web_baseline.sql
@@ -103,6 +103,15 @@ CREATE TABLE IF NOT EXISTS public_web.chunks (
     FOREIGN KEY (domain, url) REFERENCES public_web.website_urls(domain, url) ON DELETE CASCADE
 );
 
+-- Converge the overlap columns onto a pre-existing public_web.chunks table.
+-- Added by 20260424000001_add_chunk_core_overlap_columns (consolidated into this
+-- baseline in #1883); CREATE TABLE IF NOT EXISTS above skips them on a crawler
+-- DB that predates that migration. All are defaulted, so the add is safe.
+ALTER TABLE public_web.chunks
+    ADD COLUMN IF NOT EXISTS core_content   TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS prefix_overlap TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS suffix_overlap TEXT NOT NULL DEFAULT '';
+
 CREATE INDEX IF NOT EXISTS idx_pw_chunks_domain ON public_web.chunks(domain);
 CREATE INDEX IF NOT EXISTS idx_pw_chunks_url ON public_web.chunks(url);
 CREATE INDEX IF NOT EXISTS idx_pw_chunks_url_content_hash ON public_web.chunks(url, content_hash);

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -295,6 +295,7 @@ import type * as crawler_helpers_content_filter from "../crawler/helpers/content
 import type * as crawler_helpers_fetch_rendered_html from "../crawler/helpers/fetch_rendered_html.js";
 import type * as crawler_helpers_structured_data from "../crawler/helpers/structured_data.js";
 import type * as crawler_index_pages from "../crawler/index_pages.js";
+import type * as crawler_scan_scheduler from "../crawler/scan_scheduler.js";
 import type * as crawler_lib_discovery from "../crawler/lib/discovery.js";
 import type * as crawler_lib_document_metadata from "../crawler/lib/document_metadata.js";
 import type * as crawler_lib_docx_generate from "../crawler/lib/docx_generate.js";
@@ -1850,6 +1851,7 @@ declare const fullApi: ApiFromModules<{
   "crawler/helpers/fetch_rendered_html": typeof crawler_helpers_fetch_rendered_html;
   "crawler/helpers/structured_data": typeof crawler_helpers_structured_data;
   "crawler/index_pages": typeof crawler_index_pages;
+  "crawler/scan_scheduler": typeof crawler_scan_scheduler;
   "crawler/lib/discovery": typeof crawler_lib_discovery;
   "crawler/lib/document_metadata": typeof crawler_lib_document_metadata;
   "crawler/lib/docx_generate": typeof crawler_lib_docx_generate;

--- a/services/platform/convex/crawler/lib/indexing_service.ts
+++ b/services/platform/convex/crawler/lib/indexing_service.ts
@@ -354,6 +354,66 @@ export async function indexWebsite(
   };
 }
 
+export interface IndexPageInput {
+  url: string;
+  title: string | null;
+  content: string;
+}
+
+/**
+ * Index a specific set of already-fetched pages (chunk + embed),
+ * concurrency-bounded (INDEXING_CONCURRENCY). Unlike `indexWebsite` — which
+ * rescans EVERY crawled page of the domain on each call (O(total), so calling
+ * it per batch in the incremental scan loop would be O(n²)) — this touches only
+ * the pages passed in (O(batch)). Used by the incremental scan scheduler to
+ * index each freshly-fetched batch without re-walking the whole corpus.
+ * Indexing failures are logged and counted, never thrown, so one bad page can't
+ * abort the batch.
+ */
+export async function indexPages(
+  orgSlug: string,
+  domain: string,
+  pages: IndexPageInput[],
+): Promise<IndexWebsiteResult> {
+  let indexed = 0;
+  let skipped = 0;
+  let failed = 0;
+  let totalChunks = 0;
+
+  const results = await runWithConcurrency(
+    pages,
+    INDEXING_CONCURRENCY,
+    (page) => indexPage(orgSlug, domain, page.url, page.title, page.content),
+  );
+
+  for (const result of results) {
+    if (result.error !== undefined && result.value === undefined) {
+      logger.error(
+        `Indexing task failed for ${domain}: ${stringifyError(result.error)}`,
+      );
+      failed += 1;
+    } else if (result.value) {
+      const r = result.value;
+      if (r.status === 'indexed') {
+        indexed += 1;
+        totalChunks += r.chunks_indexed;
+      } else if (r.status === 'skipped') {
+        skipped += 1;
+      } else {
+        failed += 1;
+      }
+    }
+  }
+
+  return {
+    domain,
+    pages_indexed: indexed,
+    pages_skipped: skipped,
+    pages_failed: failed,
+    total_chunks: totalChunks,
+  };
+}
+
 interface SettledResult<T> {
   value?: T;
   error?: unknown;

--- a/services/platform/convex/crawler/lib/website_store.ts
+++ b/services/platform/convex/crawler/lib/website_store.ts
@@ -20,8 +20,11 @@
  *
  * Timestamps: postgres.js returns `Date` objects for `timestamptz`. The Python
  * return shapes used epoch *seconds* (`.timestamp()`), so `last_crawled_at` is
- * converted to `date ? date.getTime() / 1000 : null`. JSONB params are passed as
- * `JSON.stringify(obj)` with a `::jsonb` cast (mirrors the RAG port).
+ * converted to `date ? date.getTime() / 1000 : null`. JSONB params are passed
+ * via `sql.json(obj)`, NOT `JSON.stringify(obj)`: postgres.js re-encodes a
+ * pre-stringified string into a JSONB *scalar string*, which then breaks
+ * `jsonb_set` / `@>` on the column ("cannot set path in scalar"). `sql.json`
+ * serializes the object to a proper JSONB object.
  */
 
 import type { Sql } from 'postgres';
@@ -201,6 +204,31 @@ export async function getUrlsNeedingRecrawl(
   return rows.map((r) => r.url);
 }
 
+/**
+ * Count not-yet-crawled URLs for `domain` (`content_hash IS NULL`) that are
+ * still within the fail-count budget — i.e. the crawl work remaining. The scan
+ * loop uses this to decide whether to schedule another bounded continuation
+ * (keep filling the site) or stop at `idle` (whole site indexed / only
+ * permanently-failing URLs left). `maxFailCount` MUST match the value passed to
+ * `getUrlsNeedingRecrawl` so a URL excluded from the crawl list is also excluded
+ * from the remaining count — otherwise the loop would never terminate.
+ */
+export async function countUncrawledUrls(
+  domain: string,
+  maxFailCount = 10,
+): Promise<number> {
+  const sql = getKnowledgePool();
+  const rows = await withRetry(() =>
+    sql.unsafe<{ count: string }[]>(
+      `SELECT COUNT(*) AS count FROM ${SCHEMA}.website_urls
+                   WHERE domain = $1 AND status != 'deleted'
+                     AND content_hash IS NULL AND fail_count < $2`,
+      [domain, maxFailCount],
+    ),
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
 export async function incrementFailCount(
   domain: string,
   urls: string[],
@@ -240,6 +268,12 @@ export async function updateContentHashes(
     return;
   }
   const sql = getKnowledgePool();
+  // `metadata`/`structured_data` are arbitrary crawled JSON (typed `unknown`);
+  // pass them to sql.json (-> a proper JSONB object) at this DB boundary.
+  type JsonParam = Parameters<typeof sql.json>[0];
+  const toJsonParam = (v: unknown) =>
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    v == null ? null : sql.json(v as JsonParam);
   await withRetry(async () => {
     for (const u of updates) {
       await sql.unsafe(
@@ -257,8 +291,8 @@ export async function updateContentHashes(
           u.title ?? null,
           u.content ?? null,
           u.word_count ?? null,
-          u.metadata == null ? null : JSON.stringify(u.metadata),
-          u.structured_data == null ? null : JSON.stringify(u.structured_data),
+          toJsonParam(u.metadata),
+          toJsonParam(u.structured_data),
         ],
       );
     }

--- a/services/platform/convex/crawler/scan_scheduler.ts
+++ b/services/platform/convex/crawler/scan_scheduler.ts
@@ -1,0 +1,182 @@
+'use node';
+
+// Website scan scheduler — the in-process port of the former standalone crawler
+// service's poll loop (it scanned every "due" website on an interval). When the
+// crawler moved in-process, the per-step actions (discover/fetch/index) were
+// ported but this driver was not, so registered websites never got crawled.
+// `scanDueWebsites` (a Convex cron) restores that: it finds due websites and
+// schedules `scanWebsite` for each.
+
+import { v } from 'convex/values';
+
+import { internal } from '../_generated/api';
+import { internalAction } from '../_generated/server';
+import {
+  countUncrawledUrls,
+  getDueWebsites,
+  getUrlsNeedingRecrawl,
+  updateLastScanned,
+  updateScanStatus,
+} from './lib/website_store';
+
+const envInt = (name: string, fallback: number): number => {
+  const n = Number(process.env[name]);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+// Discovery (sitemap parse) is cheap, so discover the WHOLE site up front — the
+// original standalone crawler ran `discover_urls(max_urls=-1)` (unlimited) and a
+// per-scan cap of 100 was a regression that pinned every multi-hundred-page site
+// at exactly 100. Bound only by a generous safety cap so a pathological sitemap
+// can't blow one action's memory. Override via `CRAWLER_MAX_DISCOVER_URLS`.
+const MAX_DISCOVER_URLS = envInt('CRAWLER_MAX_DISCOVER_URLS', 10_000);
+// Crawling (fetch + render + chunk + embed each page) is expensive, so bound it
+// PER ACTION to stay within the Convex node-action budget. `scanWebsite`
+// self-continues across fresh actions until the whole site is indexed, so the
+// per-action cap limits action duration, NOT total coverage. Override via
+// `CRAWLER_MAX_PAGES_PER_SCAN`.
+const MAX_PAGES_PER_SCAN = envInt('CRAWLER_MAX_PAGES_PER_SCAN', 100);
+const FETCH_BATCH_SIZE = 20;
+// Hard cap on the self-continuation chain length from a single trigger, so a
+// huge site can't schedule an unbounded action chain in one go; the next cron
+// tick resumes any remainder. Override via `CRAWLER_MAX_SCAN_CONTINUATIONS`
+// (default 50 ⇒ up to 50 × MAX_PAGES_PER_SCAN = 5000 pages per trigger).
+const MAX_SCAN_CONTINUATIONS = envInt('CRAWLER_MAX_SCAN_CONTINUATIONS', 50);
+// A URL that fails this many fetches is dropped from both the crawl list and the
+// remaining-work count, so a permanently-broken page can't wedge the loop.
+const MAX_FETCH_FAIL_COUNT = 10;
+
+/**
+ * Scan ONE website incrementally. On the first action of a chain
+ * (`continuation === 0`) it discovers the FULL URL set (cheap sitemap parse;
+ * `ON CONFLICT DO NOTHING` dedups, so re-discovery is idempotent and picks up
+ * newly-published pages). Every action then crawls a bounded batch of
+ * not-yet-crawled URLs (fetch → chunk → embed into the `public_web` corpus) and,
+ * if uncrawled pages remain, schedules itself again in a fresh action — so a
+ * multi-thousand-page site is fully indexed across a chain of budget-sized
+ * actions instead of being capped at one action's worth.
+ *
+ * A failure is recorded on the website row (status 'error') rather than thrown,
+ * so the scheduler treats each site independently.
+ */
+export const scanWebsite = internalAction({
+  args: {
+    domain: v.string(),
+    orgSlug: v.string(),
+    // Position in the self-continuation chain (0 = first action of this scan).
+    continuation: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (
+    ctx,
+    { domain, orgSlug, continuation = 0 },
+  ): Promise<null> => {
+    // Best-effort push of the live corpus state onto the per-org Convex
+    // `websites` row the UI reads. Called after every fetch batch so the
+    // Indexed count climbs smoothly during the crawl (not only at continuation
+    // boundaries), and once more at the end for the terminal idle/error state.
+    // Wrapped so a sync hiccup never masks the real scan outcome.
+    const pushRowSync = async (): Promise<void> => {
+      try {
+        await ctx.runAction(
+          internal.websites.internal_actions.syncWebsiteRowForDomain,
+          { orgSlug, domain },
+        );
+      } catch (syncErr) {
+        const message =
+          syncErr instanceof Error ? syncErr.message : String(syncErr);
+        console.error(
+          `[scanWebsite] convex-row sync failed for ${domain}: ${message}`,
+        );
+      }
+    };
+
+    // Refresh status (and `updated_at`) on every continuation so a long chain is
+    // never mistaken for a stuck 'scanning' row by getDueWebsites' >2h check.
+    await updateScanStatus(domain, 'scanning');
+    try {
+      // 1. Discover the full frontier once per chain.
+      if (continuation === 0) {
+        await ctx.runAction(internal.crawler.index_pages.discoverUrls, {
+          domain,
+          maxUrls: MAX_DISCOVER_URLS,
+        });
+      }
+
+      // 2. Crawl a bounded batch of pages that still need crawling (uncrawled
+      //    first, then stale), skipping URLs past the fail-count budget.
+      const toCrawl = await getUrlsNeedingRecrawl(
+        domain,
+        MAX_PAGES_PER_SCAN,
+        null,
+        MAX_FETCH_FAIL_COUNT,
+      );
+      for (let i = 0; i < toCrawl.length; i += FETCH_BATCH_SIZE) {
+        await ctx.runAction(internal.crawler.index_pages.fetchUrls, {
+          domain,
+          urls: toCrawl.slice(i, i + FETCH_BATCH_SIZE),
+        });
+        // Surface progress to the UI after each batch (fetchUrls has just set
+        // content_hash on these pages, so crawled_count climbs immediately).
+        await pushRowSync();
+      }
+
+      // 3. Index newly-fetched content (idempotent; skips unchanged pages).
+      await ctx.runAction(internal.crawler.index_pages.indexWebsite, {
+        orgSlug,
+        domain,
+      });
+      await updateLastScanned(domain);
+
+      // 4. More to crawl? Continue in a fresh action (stays in budget) until the
+      //    whole site is indexed or the continuation cap is hit; else go idle.
+      const remaining = await countUncrawledUrls(domain, MAX_FETCH_FAIL_COUNT);
+      if (
+        toCrawl.length > 0 &&
+        remaining > 0 &&
+        continuation < MAX_SCAN_CONTINUATIONS
+      ) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.crawler.scan_scheduler.scanWebsite,
+          { domain, orgSlug, continuation: continuation + 1 },
+        );
+      } else {
+        await updateScanStatus(domain, 'idle');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[scanWebsite] scan failed for ${domain}: ${message}`);
+      await updateScanStatus(domain, 'error', message);
+    }
+    // Final push for the terminal state (idle / error + final counts). The
+    // per-batch syncs above keep the UI live during the crawl; this captures the
+    // last batch's index results and the resolved status. Outside the try so a
+    // sync hiccup never masks the real scan outcome.
+    await pushRowSync();
+    return null;
+  },
+});
+
+/**
+ * Cron entry: scan every website whose `scan_interval` has elapsed (or that has
+ * been stuck mid-scan > 2h — see getDueWebsites). Each due site is marked
+ * `scanning` up front (so the next cron tick won't re-pick it) and scanned in
+ * its own scheduled action, so one slow/failing site never blocks the others.
+ */
+export const scanDueWebsites = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx): Promise<null> => {
+    const due = await getDueWebsites();
+    for (const w of due) {
+      await updateScanStatus(w.domain, 'scanning');
+      await ctx.scheduler.runAfter(
+        0,
+        internal.crawler.scan_scheduler.scanWebsite,
+        { domain: w.domain, orgSlug: w.owner_org_slug },
+      );
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/crawler/scan_scheduler.ts
+++ b/services/platform/convex/crawler/scan_scheduler.ts
@@ -11,6 +11,7 @@ import { v } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
+import { indexPages } from './lib/indexing_service';
 import {
   countUncrawledUrls,
   getDueWebsites,
@@ -30,18 +31,20 @@ const envInt = (name: string, fallback: number): number => {
 // at exactly 100. Bound only by a generous safety cap so a pathological sitemap
 // can't blow one action's memory. Override via `CRAWLER_MAX_DISCOVER_URLS`.
 const MAX_DISCOVER_URLS = envInt('CRAWLER_MAX_DISCOVER_URLS', 10_000);
-// Crawling (fetch + render + chunk + embed each page) is expensive, so bound it
-// PER ACTION to stay within the Convex node-action budget. `scanWebsite`
-// self-continues across fresh actions until the whole site is indexed, so the
-// per-action cap limits action duration, NOT total coverage. Override via
-// `CRAWLER_MAX_PAGES_PER_SCAN`.
-const MAX_PAGES_PER_SCAN = envInt('CRAWLER_MAX_PAGES_PER_SCAN', 100);
+// Crawling (fetch + chunk + embed each page) is expensive. Bound each action by
+// WALL-CLOCK rather than page count: a Convex node action is hard-killed near
+// ~10 min WITHOUT running its catch/reschedule, so a fixed 100-page batch on a
+// slow site overran the budget and the chain died with status stuck 'scanning'.
+// We crawl in small batches until this budget elapses, then reschedule a fresh
+// action — so coverage is unbounded across the chain while each action stays
+// safely within the kill limit. Override via `CRAWLER_SCAN_ACTION_BUDGET_MS`.
+const SCAN_ACTION_BUDGET_MS = envInt('CRAWLER_SCAN_ACTION_BUDGET_MS', 300_000);
 const FETCH_BATCH_SIZE = 20;
 // Hard cap on the self-continuation chain length from a single trigger, so a
 // huge site can't schedule an unbounded action chain in one go; the next cron
-// tick resumes any remainder. Override via `CRAWLER_MAX_SCAN_CONTINUATIONS`
-// (default 50 ⇒ up to 50 × MAX_PAGES_PER_SCAN = 5000 pages per trigger).
-const MAX_SCAN_CONTINUATIONS = envInt('CRAWLER_MAX_SCAN_CONTINUATIONS', 50);
+// tick (or a manual re-scan) resumes any remainder. Override via
+// `CRAWLER_MAX_SCAN_CONTINUATIONS`.
+const MAX_SCAN_CONTINUATIONS = envInt('CRAWLER_MAX_SCAN_CONTINUATIONS', 100);
 // A URL that fails this many fetches is dropped from both the crawl list and the
 // remaining-work count, so a permanently-broken page can't wedge the loop.
 const MAX_FETCH_FAIL_COUNT = 10;
@@ -94,6 +97,7 @@ export const scanWebsite = internalAction({
     // Refresh status (and `updated_at`) on every continuation so a long chain is
     // never mistaken for a stuck 'scanning' row by getDueWebsites' >2h check.
     await updateScanStatus(domain, 'scanning');
+    const deadline = Date.now() + SCAN_ACTION_BUDGET_MS;
     try {
       // 1. Discover the full frontier once per chain.
       if (continuation === 0) {
@@ -103,39 +107,50 @@ export const scanWebsite = internalAction({
         });
       }
 
-      // 2. Crawl a bounded batch of pages that still need crawling (uncrawled
-      //    first, then stale), skipping URLs past the fail-count budget.
-      const toCrawl = await getUrlsNeedingRecrawl(
-        domain,
-        MAX_PAGES_PER_SCAN,
-        null,
-        MAX_FETCH_FAIL_COUNT,
-      );
-      for (let i = 0; i < toCrawl.length; i += FETCH_BATCH_SIZE) {
-        await ctx.runAction(internal.crawler.index_pages.fetchUrls, {
+      // 2. Crawl + index not-yet-crawled pages in small batches until the
+      //    wall-clock budget elapses or the site is fully crawled. Each fetched
+      //    page is indexed individually (chunk + embed) right after fetch — O(new
+      //    pages) and resilient: if the action is killed mid-loop, the next
+      //    continuation simply re-selects whatever is still uncrawled.
+      while (Date.now() < deadline) {
+        if ((await countUncrawledUrls(domain, MAX_FETCH_FAIL_COUNT)) === 0) {
+          break;
+        }
+        // Uncrawled / never-attempted URLs sort first (NULLS FIRST), so failed
+        // pages are retried only after fresh ones and drop out past the budget.
+        const batch = await getUrlsNeedingRecrawl(
           domain,
-          urls: toCrawl.slice(i, i + FETCH_BATCH_SIZE),
-        });
-        // Surface progress to the UI after each batch (fetchUrls has just set
-        // content_hash on these pages, so crawled_count climbs immediately).
+          FETCH_BATCH_SIZE,
+          null,
+          MAX_FETCH_FAIL_COUNT,
+        );
+        if (batch.length === 0) break;
+
+        const fetched = await ctx.runAction(
+          internal.crawler.index_pages.fetchUrls,
+          { domain, urls: batch },
+        );
+        // Index just the pages we fetched (chunk + embed), concurrency-bounded.
+        // Indexing the batch directly is O(batch); calling indexWebsite here
+        // would rescan the whole corpus each time (O(n²) over the chain).
+        await indexPages(
+          orgSlug,
+          domain,
+          fetched.pages.map((page) => ({
+            url: page.url,
+            title: page.title ?? null,
+            content: page.content,
+          })),
+        );
+        await updateLastScanned(domain);
+        // Surface progress to the UI after each batch (crawled_count just grew).
         await pushRowSync();
       }
 
-      // 3. Index newly-fetched content (idempotent; skips unchanged pages).
-      await ctx.runAction(internal.crawler.index_pages.indexWebsite, {
-        orgSlug,
-        domain,
-      });
-      await updateLastScanned(domain);
-
-      // 4. More to crawl? Continue in a fresh action (stays in budget) until the
-      //    whole site is indexed or the continuation cap is hit; else go idle.
+      // 3. More to crawl? Continue in a fresh action (resets the budget) until
+      //    the whole site is indexed or the continuation cap is hit; else idle.
       const remaining = await countUncrawledUrls(domain, MAX_FETCH_FAIL_COUNT);
-      if (
-        toCrawl.length > 0 &&
-        remaining > 0 &&
-        continuation < MAX_SCAN_CONTINUATIONS
-      ) {
+      if (remaining > 0 && continuation < MAX_SCAN_CONTINUATIONS) {
         await ctx.scheduler.runAfter(
           0,
           internal.crawler.scan_scheduler.scanWebsite,

--- a/services/platform/convex/crons.ts
+++ b/services/platform/convex/crons.ts
@@ -48,6 +48,16 @@ cron(
   {},
 );
 
+// Website crawl scheduler - scan every website whose interval has elapsed (or
+// that is stuck mid-scan). In-process replacement for the former standalone
+// crawler service's poll loop; without this, registered websites never crawl.
+cron(
+  'scan due websites (every 5 min)',
+  '*/5 * * * *',
+  internal.crawler.scan_scheduler.scanDueWebsites,
+  {},
+);
+
 // Central retention cleanup - single entry point that dispatches to all
 // enabled categories (documents, chat history, audit logs, workflow logs,
 // usage ledger, login attempts, temp files) based on each org's

--- a/services/platform/convex/lib/helpers/org_slug.ts
+++ b/services/platform/convex/lib/helpers/org_slug.ts
@@ -118,3 +118,30 @@ export async function orgSlugFromIdOrNull(
     throw err;
   }
 }
+
+/**
+ * Resolve an org `slug` back to its Better Auth `_id` — the inverse of
+ * {@link orgSlugFromId}.
+ *
+ * Background contexts that are keyed by slug (the in-process crawler stores
+ * `website_org_memberships.org_slug`, not the org id) need the id to read the
+ * per-org `websites` rows, which are indexed `by_organizationId`. Returns
+ * `null` when no org has that slug (deleted / renamed) so callers can no-op
+ * rather than throw — these are best-effort background syncs, not user-facing
+ * reads.
+ *
+ * **Does NOT verify membership** — same caveat as `orgSlugFromId`. Only call
+ * with a slug obtained from a trusted server-side source (e.g. the corpus
+ * membership table this deployment owns), never from a request body.
+ */
+export async function orgIdFromSlug(
+  ctx: CtxWithRunQuery,
+  slug: string,
+): Promise<string | null> {
+  const row = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+    model: 'organization',
+    where: [{ field: 'slug', value: slug, operator: 'eq' }],
+  });
+  if (!isRecord(row)) return null;
+  return getString(row, '_id') || null;
+}

--- a/services/platform/convex/websites/internal_actions.ts
+++ b/services/platform/convex/websites/internal_actions.ts
@@ -3,7 +3,7 @@ import { v } from 'convex/values';
 import { internal } from '../_generated/api';
 import type { Id } from '../_generated/dataModel';
 import { internalAction, type ActionCtx } from '../_generated/server';
-import { orgSlugFromId } from '../lib/helpers/org_slug';
+import { orgIdFromSlug, orgSlugFromId } from '../lib/helpers/org_slug';
 import type {
   CrawlerWebsiteInfo,
   FetchChunksResult,
@@ -439,6 +439,40 @@ export const syncSingleWebsite = internalAction({
         },
       });
     }
+  },
+});
+
+/**
+ * Sync the per-org `websites` row for `domain` straight from the corpus, keyed
+ * by `orgSlug` (not org id). Called by the in-process scan scheduler the moment
+ * a crawl finishes: the scheduler is corpus-keyed (`website_org_memberships`
+ * stores `org_slug`), so it resolves the org id here, finds the owning org's
+ * row, and reuses `syncSingleWebsite`'s patch.
+ *
+ * Without this, a cron-driven scan only updated the corpus and never the
+ * Convex `websites` row the UI reads, so a freshly-crawled site showed `Idle`
+ * / `0` indexed until the next hourly frontend poll (debounced by
+ * `lastStatusSyncAt`). No-ops when the slug or row can't be resolved (org
+ * deleted, domain not tracked by that org) — this is a best-effort push.
+ */
+export const syncWebsiteRowForDomain = internalAction({
+  args: {
+    orgSlug: v.string(),
+    domain: v.string(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const organizationId = await orgIdFromSlug(ctx, args.orgSlug);
+    if (!organizationId) return;
+    const website = await ctx.runQuery(
+      internal.websites.internal_queries.getWebsiteByDomain,
+      { organizationId, domain: args.domain },
+    );
+    if (!website) return;
+    await ctx.runAction(internal.websites.internal_actions.syncSingleWebsite, {
+      websiteId: website._id,
+      domain: args.domain,
+      organizationId,
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

Restore the website poll loop that was lost when the crawler moved in-process. The per-step actions (discover / fetch / index) were ported into Convex, but the driver that scans every "due" website on an interval was not — so registered websites never got crawled. This PR adds that driver back as an in-process cron, plus the supporting helpers and the fallout fixes uncovered along the way.

## Changes

**In-process crawl scheduler**
- `crawler/scan_scheduler.ts` (new): `scanDueWebsites` cron entry finds due sites and schedules `scanWebsite` per site; `scanWebsite` discovers the full frontier once, crawls budget-sized batches, and self-continues across fresh actions until the whole site is indexed (bounded by a continuation cap). Replaces the old per-scan cap of 100 that pinned multi-hundred-page sites at exactly 100.
- `crons.ts`: register `scanDueWebsites` every 5 minutes.

**Supporting helpers**
- `crawler/lib/website_store.ts`: add `countUncrawledUrls` (remaining-work check that drives the self-continuation/idle decision); fix JSONB params to use `sql.json` instead of `JSON.stringify` — postgres.js re-encodes a pre-stringified string into a JSONB *scalar string*, breaking `jsonb_set` / `@>` on the column.
- `lib/helpers/org_slug.ts`: add `orgIdFromSlug` (inverse of `orgSlugFromId`) so the corpus-keyed scheduler can resolve the org id to read `websites` rows.
- `websites/internal_actions.ts`: add `syncWebsiteRowForDomain` so a finished crawl pushes live corpus state onto the per-org Convex `websites` row the UI reads, instead of showing `Idle` / `0` until the next hourly frontend poll.

**Knowledge-db baseline convergence**
- The consolidated dbmate baselines use `CREATE TABLE IF NOT EXISTS`, a no-op on DBs created by the old per-service rag/crawler migrations, so columns added by later migrations were never applied and dependent indexes/constraints failed (e.g. `column "metadata" does not exist`). Add idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` convergence before the dependent indexes in both the `private_knowledge` and `public_web` baselines.

## Notes

- `convex/_generated/api.d.ts` is regenerated (new `crawler/scan_scheduler` module), included per repo convention.
- dbmate migrations are atomic; the baseline `ALTER`s are idempotent and metadata-only (every added column is nullable or carries a constant DEFAULT), safe to apply to populated tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Website crawler now automatically discovers uncrawled URLs and fetches content in bounded batches
- Scheduling runs every 5 minutes with self-continuing scans that handle failures gracefully
- Real-time status updates visible in the UI
- Error tracking and recovery with detailed messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->