### PR TITLE
feat(platform): in-app help & learning center with eLearning content (#1922)

### DIFF
--- a/services/platform/app/components/user-button.test.tsx
+++ b/services/platform/app/components/user-button.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/lib/i18n/client', () => ({
       const translations: Record<string, string> = {
         // auth.userButton.*
         'userButton.defaultName': 'User',
+        'userButton.helpLearning': 'Help & learning center',
         'userButton.helpFeedback': 'Help & feedback',
         'userButton.logOut': 'Log out',
         'userButton.manageAccount': 'Manage account',
@@ -344,7 +345,11 @@ describe('UserButton', () => {
         within(menu).getByRole('menuitem', { name: 'Language' }),
       ).toBeInTheDocument();
 
-      // Session items: asserted present, never activated.
+      // Session items: asserted present, never activated. The in-app learning
+      // center sits alongside the external feedback link.
+      expect(
+        within(menu).getByRole('menuitem', { name: 'Help & learning center' }),
+      ).toBeInTheDocument();
       expect(
         within(menu).getByRole('menuitem', { name: 'Help & feedback' }),
       ).toBeInTheDocument();

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -14,6 +14,7 @@ import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import {
   LogOut,
   HelpCircle,
+  GraduationCap,
   Monitor,
   Sun,
   Moon,
@@ -550,6 +551,15 @@ export function UserButton({
       });
     }
     helpGroup.push(
+      {
+        type: 'item',
+        label: t('userButton.helpLearning'),
+        icon: GraduationCap,
+        onClick: () => {
+          void navigate({ to: '/dashboard/help' });
+        },
+        className: 'py-2.5',
+      },
       {
         type: 'item',
         label: t('userButton.helpFeedback'),

--- a/services/platform/app/features/help/components/lesson-video.test.tsx
+++ b/services/platform/app/features/help/components/lesson-video.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
+
+import { LessonVideo } from './lesson-video';
+
+describe('LessonVideo', () => {
+  it('renders a "coming soon" placeholder when no video is configured', () => {
+    render(<LessonVideo lessonTitle="What is a large language model?" />);
+    // The placeholder copy comes from the real `help.video.unavailable` string.
+    expect(screen.getByRole('note')).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).toBeInTheDocument();
+    // No <video> element is mounted in the placeholder branch.
+    expect(document.querySelector('video')).toBeNull();
+  });
+
+  it('renders a self-hosted video element when a source is provided', () => {
+    render(
+      <LessonVideo
+        videoSrc="/help-videos/intro.mp4"
+        lessonTitle="What is a large language model?"
+      />,
+    );
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.querySelector('source')?.getAttribute('src')).toBe(
+      '/help-videos/intro.mp4',
+    );
+    // Labelled for assistive tech via the lesson title.
+    expect(video?.getAttribute('aria-label')).toContain(
+      'What is a large language model?',
+    );
+  });
+
+  it('placeholder passes the axe audit', async () => {
+    const { container } = render(
+      <LessonVideo lessonTitle="Limitations and hallucinations" />,
+    );
+    await checkAccessibility(container);
+  });
+});

--- a/services/platform/app/features/help/components/lesson-video.tsx
+++ b/services/platform/app/features/help/components/lesson-video.tsx
@@ -1,0 +1,63 @@
+import { VStack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { Video } from 'lucide-react';
+
+import { useT } from '@/lib/i18n/client';
+
+interface LessonVideoProps {
+  /**
+   * Same-origin URL of a self-hosted walkthrough clip, or `undefined` when no
+   * clip has been produced yet. External (cross-origin) sources are
+   * intentionally unsupported — the platform's CSP pins `media-src` to `'self'`
+   * for offline / self-hosted deployments.
+   */
+  videoSrc?: string;
+  /** Accessible title of the lesson, used to label the video region. */
+  lessonTitle: string;
+}
+
+/**
+ * Renders a lesson's video walkthrough.
+ *
+ * When `videoSrc` is set it plays a self-hosted clip with native controls;
+ * otherwise it shows an accessible "coming soon" placeholder so the lesson
+ * still reads as a structured learning unit. Keeping the embed self-hosted
+ * (rather than a YouTube/Vimeo iframe) is the deliberate choice for this
+ * product: the deployment CSP blocks third-party frames and media, and many
+ * installs run fully offline.
+ */
+export function LessonVideo({ videoSrc, lessonTitle }: LessonVideoProps) {
+  const { t } = useT('help');
+
+  if (!videoSrc) {
+    return (
+      <div
+        role="note"
+        className="border-border-base bg-bg-elevated/40 flex aspect-video w-full items-center justify-center rounded-lg border"
+      >
+        <VStack gap={2} align="center" className="max-w-sm px-6 text-center">
+          <Video aria-hidden className="text-fg-muted size-8" />
+          <Text variant="muted" className="text-sm">
+            {t('video.unavailable')}
+          </Text>
+        </VStack>
+      </div>
+    );
+  }
+
+  return (
+    <video
+      controls
+      preload="metadata"
+      aria-label={t('video.label', { title: lessonTitle })}
+      className="border-border-base aspect-video w-full rounded-lg border bg-black"
+    >
+      <source src={videoSrc} />
+      {/* Self-hosted captions ship alongside each clip as a sibling WebVTT
+          file, so a same-origin `.vtt` next to the video satisfies both the
+          caption requirement and the `media-src 'self'` CSP. */}
+      <track kind="captions" src={`${videoSrc}.vtt`} default />
+      {t('video.unsupported')}
+    </video>
+  );
+}

--- a/services/platform/app/features/help/content.test.ts
+++ b/services/platform/app/features/help/content.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import enMessages from '../../../messages/en.json';
+import { ALL_LESSON_IDS, HELP_CATEGORIES, findLesson } from './content';
+
+// The curriculum table addresses its copy through dynamic i18n keys
+// (`help.categories.<id>.*`, `help.lessons.<id>.*`), which the orphan-key
+// scanner can't follow — so these tests are the guard that every id in the
+// table actually resolves to a real message. A typo'd id would otherwise
+// render a raw key in the UI and pass every other check.
+const help = enMessages.help as {
+  categories: Record<string, { title: string; description: string }>;
+  lessons: Record<string, { title: string; summary: string; body: string }>;
+};
+
+describe('help curriculum', () => {
+  it('every category id maps to a localized title and description', () => {
+    for (const category of HELP_CATEGORIES) {
+      expect(help.categories[category.id]?.title).toBeTruthy();
+      expect(help.categories[category.id]?.description).toBeTruthy();
+    }
+  });
+
+  it('every lesson id maps to a localized title, summary, and body', () => {
+    for (const category of HELP_CATEGORIES) {
+      for (const lesson of category.lessons) {
+        const copy = help.lessons[lesson.id];
+        expect(copy?.title).toBeTruthy();
+        expect(copy?.summary).toBeTruthy();
+        expect(copy?.body).toBeTruthy();
+      }
+    }
+  });
+
+  it('exposes a flat lesson-id list with no duplicates', () => {
+    const unique = new Set(ALL_LESSON_IDS);
+    expect(unique.size).toBe(ALL_LESSON_IDS.length);
+    expect(ALL_LESSON_IDS.length).toBeGreaterThan(0);
+  });
+
+  it('covers the three pillars from issue #1922', () => {
+    const ids = HELP_CATEGORIES.map((c) => c.id);
+    expect(ids).toEqual(['fundamentals', 'platform', 'responsibleAi']);
+  });
+
+  describe('findLesson', () => {
+    it('resolves a known lesson to its category', () => {
+      const result = findLesson('whatAreLlms');
+      expect(result?.category.id).toBe('fundamentals');
+      expect(result?.lesson.id).toBe('whatAreLlms');
+    });
+
+    it('returns null for an unknown id', () => {
+      expect(findLesson('does-not-exist')).toBeNull();
+    });
+  });
+});

--- a/services/platform/app/features/help/content.ts
+++ b/services/platform/app/features/help/content.ts
@@ -1,0 +1,99 @@
+import {
+  BookOpen,
+  GraduationCap,
+  ShieldCheck,
+  type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * Curriculum for the in-app Help & learning center (`/dashboard/help`).
+ *
+ * Only the *structure* lives here — ids, ordering, icons, reading time, and the
+ * optional self-hosted video source. All human-facing text (category titles,
+ * lesson titles/summaries, and the markdown body) is resolved at render time
+ * from the `help` i18n namespace so the curriculum stays fully localized:
+ *
+ *   help.categories.<categoryId>.{title,description}
+ *   help.lessons.<lessonId>.{title,summary,body}
+ *
+ * Those keys are looked up dynamically, so the `help.categories` and
+ * `help.lessons` prefixes are listed in `lib/i18n/keys-dynamic.txt` for the
+ * orphan-key scanner.
+ *
+ * Video posture: the platform ships a strict CSP (`media-src 'self'`,
+ * `frame-src 'self'`) for its offline / self-hosted deployments, so external
+ * embeds (YouTube, Vimeo, …) are intentionally blocked. A lesson's `videoSrc`
+ * must therefore be a **same-origin** path to a self-hosted clip (e.g. a file
+ * under `services/platform/public/`). Lessons without a `videoSrc` render a
+ * "coming soon" placeholder instead — see `LessonVideo`.
+ */
+export interface HelpLesson {
+  /** Stable id; the i18n key segment under `help.lessons.<id>`. */
+  id: string;
+  /**
+   * Optional same-origin URL of a self-hosted walkthrough clip. Omit until a
+   * clip has been produced; the lesson then renders a placeholder. Must be
+   * served from the app's own origin to satisfy the `media-src 'self'` CSP.
+   */
+  videoSrc?: string;
+  /** Estimated minutes to read / watch — shown as a hint next to the title. */
+  durationMinutes: number;
+}
+
+export interface HelpCategory {
+  /** Stable id; the i18n key segment under `help.categories.<id>`. */
+  id: string;
+  icon: LucideIcon;
+  lessons: HelpLesson[];
+}
+
+/**
+ * The three pillars from issue #1922: LLM fundamentals, platform how-tos, and
+ * the opportunities & risks of AI (responsible-use guidance).
+ */
+export const HELP_CATEGORIES: readonly HelpCategory[] = [
+  {
+    id: 'fundamentals',
+    icon: GraduationCap,
+    lessons: [
+      { id: 'whatAreLlms', durationMinutes: 5 },
+      { id: 'howLlmsWork', durationMinutes: 6 },
+      { id: 'limitations', durationMinutes: 5 },
+    ],
+  },
+  {
+    id: 'platform',
+    icon: BookOpen,
+    lessons: [
+      { id: 'gettingStarted', durationMinutes: 4 },
+      { id: 'chattingWithAgents', durationMinutes: 5 },
+      { id: 'knowledgeBase', durationMinutes: 5 },
+      { id: 'automations', durationMinutes: 6 },
+    ],
+  },
+  {
+    id: 'responsibleAi',
+    icon: ShieldCheck,
+    lessons: [
+      { id: 'opportunities', durationMinutes: 5 },
+      { id: 'risks', durationMinutes: 6 },
+      { id: 'bestPractices', durationMinutes: 5 },
+    ],
+  },
+];
+
+/** Flat, ordered list of every lesson id — handy for default selection. */
+export const ALL_LESSON_IDS: readonly string[] = HELP_CATEGORIES.flatMap((c) =>
+  c.lessons.map((l) => l.id),
+);
+
+/** Look up the `{ category, lesson }` pair for a lesson id, or `null`. */
+export function findLesson(
+  lessonId: string,
+): { category: HelpCategory; lesson: HelpLesson } | null {
+  for (const category of HELP_CATEGORIES) {
+    const lesson = category.lessons.find((l) => l.id === lessonId);
+    if (lesson) return { category, lesson };
+  }
+  return null;
+}

--- a/services/platform/app/routeTree.gen.ts
+++ b/services/platform/app/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as IndexRouteImport } from './routes/index';
 import { Route as DashboardIndexRouteImport } from './routes/dashboard/index';
 import { Route as ForcedChangePasswordIdRouteImport } from './routes/forced-change-password.$id';
 import { Route as DashboardSwitchingRouteImport } from './routes/dashboard/switching';
+import { Route as DashboardHelpRouteImport } from './routes/dashboard/help';
 import { Route as DashboardCreateOrganizationRouteImport } from './routes/dashboard/create-organization';
 import { Route as DashboardChangelogRouteImport } from './routes/dashboard/changelog';
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id';
@@ -181,6 +182,11 @@ const ForcedChangePasswordIdRoute = ForcedChangePasswordIdRouteImport.update({
 const DashboardSwitchingRoute = DashboardSwitchingRouteImport.update({
   id: '/switching',
   path: '/switching',
+  getParentRoute: () => DashboardRoute,
+} as any);
+const DashboardHelpRoute = DashboardHelpRouteImport.update({
+  id: '/help',
+  path: '/help',
   getParentRoute: () => DashboardRoute,
 } as any);
 const DashboardCreateOrganizationRoute =
@@ -857,9 +863,10 @@ export interface FileRoutesByFullPath {
   '/2fa': typeof Auth2faRoute;
   '/log-in': typeof AuthLogInRoute;
   '/sign-up': typeof AuthSignUpRoute;
-  '/dashboard/$id': typeof DashboardIdKnowledgeRouteWithChildren;
+  '/dashboard/$id': typeof DashboardIdRouteWithChildren;
   '/dashboard/changelog': typeof DashboardChangelogRoute;
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute;
+  '/dashboard/help': typeof DashboardHelpRoute;
   '/dashboard/switching': typeof DashboardSwitchingRoute;
   '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute;
   '/dashboard/': typeof DashboardIndexRoute;
@@ -982,6 +989,7 @@ export interface FileRoutesByTo {
   '/sign-up': typeof AuthSignUpRoute;
   '/dashboard/changelog': typeof DashboardChangelogRoute;
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute;
+  '/dashboard/help': typeof DashboardHelpRoute;
   '/dashboard/switching': typeof DashboardSwitchingRoute;
   '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute;
   '/dashboard': typeof DashboardIndexRoute;
@@ -1095,6 +1103,7 @@ export interface FileRoutesById {
   '/dashboard/$id': typeof DashboardIdRouteWithChildren;
   '/dashboard/changelog': typeof DashboardChangelogRoute;
   '/dashboard/create-organization': typeof DashboardCreateOrganizationRoute;
+  '/dashboard/help': typeof DashboardHelpRoute;
   '/dashboard/switching': typeof DashboardSwitchingRoute;
   '/forced-change-password/$id': typeof ForcedChangePasswordIdRoute;
   '/dashboard/': typeof DashboardIndexRoute;
@@ -1222,6 +1231,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/dashboard/changelog'
     | '/dashboard/create-organization'
+    | '/dashboard/help'
     | '/dashboard/switching'
     | '/forced-change-password/$id'
     | '/dashboard/'
@@ -1344,6 +1354,7 @@ export interface FileRouteTypes {
     | '/sign-up'
     | '/dashboard/changelog'
     | '/dashboard/create-organization'
+    | '/dashboard/help'
     | '/dashboard/switching'
     | '/forced-change-password/$id'
     | '/dashboard'
@@ -1456,6 +1467,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/dashboard/changelog'
     | '/dashboard/create-organization'
+    | '/dashboard/help'
     | '/dashboard/switching'
     | '/forced-change-password/$id'
     | '/dashboard/'
@@ -1650,6 +1662,13 @@ declare module '@tanstack/react-router' {
       path: '/switching';
       fullPath: '/dashboard/switching';
       preLoaderRoute: typeof DashboardSwitchingRouteImport;
+      parentRoute: typeof DashboardRoute;
+    };
+    '/dashboard/help': {
+      id: '/dashboard/help';
+      path: '/help';
+      fullPath: '/dashboard/help';
+      preLoaderRoute: typeof DashboardHelpRouteImport;
       parentRoute: typeof DashboardRoute;
     };
     '/dashboard/create-organization': {
@@ -2935,6 +2954,7 @@ interface DashboardRouteChildren {
   DashboardIdRoute: typeof DashboardIdRouteWithChildren;
   DashboardChangelogRoute: typeof DashboardChangelogRoute;
   DashboardCreateOrganizationRoute: typeof DashboardCreateOrganizationRoute;
+  DashboardHelpRoute: typeof DashboardHelpRoute;
   DashboardSwitchingRoute: typeof DashboardSwitchingRoute;
   DashboardIndexRoute: typeof DashboardIndexRoute;
 }
@@ -2943,6 +2963,7 @@ const DashboardRouteChildren: DashboardRouteChildren = {
   DashboardIdRoute: DashboardIdRouteWithChildren,
   DashboardChangelogRoute: DashboardChangelogRoute,
   DashboardCreateOrganizationRoute: DashboardCreateOrganizationRoute,
+  DashboardHelpRoute: DashboardHelpRoute,
   DashboardSwitchingRoute: DashboardSwitchingRoute,
   DashboardIndexRoute: DashboardIndexRoute,
 };

--- a/services/platform/app/routes/dashboard/help.tsx
+++ b/services/platform/app/routes/dashboard/help.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { Row, Stack, VStack } from '@tale/ui/layout';
+import { Markdown } from '@tale/ui/markdown';
+import { Text } from '@tale/ui/text';
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { ArrowUpRight, Clock } from 'lucide-react';
+import { useMemo } from 'react';
+import { z } from 'zod';
+
+import { LessonVideo } from '@/app/features/help/components/lesson-video';
+import {
+  ALL_LESSON_IDS,
+  HELP_CATEGORIES,
+  findLesson,
+} from '@/app/features/help/content';
+import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
+import { seo } from '@/lib/utils/seo';
+
+// External feedback channel — the learning center is the in-app surface, but
+// the "Contact us" link still hands off to the marketing-site contact form for
+// anything the curriculum doesn't cover.
+const CONTACT_URL = 'https://tale.dev/contact';
+
+const searchSchema = z.object({
+  lesson: z.string().optional(),
+});
+
+export const Route = createFileRoute('/dashboard/help')({
+  validateSearch: searchSchema,
+  head: () => ({ meta: seo('help') }),
+  component: HelpPage,
+});
+
+function HelpPage() {
+  const { t } = useT('help');
+  const { lesson: lessonParam } = Route.useSearch();
+
+  // Resolve the active lesson: the `?lesson=` param when it points at a real
+  // lesson, otherwise the first lesson of the curriculum.
+  const activeId =
+    lessonParam && findLesson(lessonParam) ? lessonParam : ALL_LESSON_IDS[0];
+  const active = useMemo(() => findLesson(activeId), [activeId]);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-6xl px-4 py-10">
+        <VStack gap={2} className="mb-8">
+          <h1 className="text-fg-base text-2xl font-semibold">{t('title')}</h1>
+          <Text variant="muted">{t('subtitle')}</Text>
+        </VStack>
+
+        <div className="flex flex-col gap-8 md:flex-row md:items-start">
+          <HelpNav activeId={activeId} />
+
+          <main className="min-w-0 flex-1">
+            {active ? (
+              <LessonContent lessonId={active.lesson.id} />
+            ) : (
+              <Text variant="muted">{t('empty')}</Text>
+            )}
+
+            <ContactCallout />
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The table-of-contents sidebar: every category and its lessons, each lesson a
+ * deep link that swaps the `?lesson=` search param (client-side, no reload).
+ */
+function HelpNav({ activeId }: { activeId: string }) {
+  const { t } = useT('help');
+
+  return (
+    <nav
+      aria-label={t('navLabel')}
+      className="md:bg-bg-elevated/30 md:border-border-base shrink-0 md:w-72 md:rounded-lg md:border md:p-4"
+    >
+      <Stack gap={6}>
+        {HELP_CATEGORIES.map((category) => {
+          const Icon = category.icon;
+          return (
+            <VStack key={category.id} gap={2}>
+              <Row gap={2} align="center">
+                <Icon aria-hidden className="text-fg-muted size-4 shrink-0" />
+                <Text className="text-fg-base text-sm font-semibold">
+                  {t(`categories.${category.id}.title`)}
+                </Text>
+              </Row>
+              <ul className="border-border-base ml-2 flex flex-col border-l pl-3">
+                {category.lessons.map((lesson) => {
+                  const isActive = lesson.id === activeId;
+                  return (
+                    <li key={lesson.id}>
+                      <Link
+                        to="/dashboard/help"
+                        search={{ lesson: lesson.id }}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={cn(
+                          'block rounded-md px-2 py-1.5 text-sm transition-colors',
+                          isActive
+                            ? 'bg-accent text-fg-base font-medium'
+                            : 'text-fg-muted hover:text-fg-base hover:bg-accent/50',
+                        )}
+                      >
+                        {t(`lessons.${lesson.id}.title`)}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </VStack>
+          );
+        })}
+      </Stack>
+    </nav>
+  );
+}
+
+/** The selected lesson: title, reading time, video walkthrough, and body. */
+function LessonContent({ lessonId }: { lessonId: string }) {
+  const { t } = useT('help');
+  const entry = findLesson(lessonId);
+  if (!entry) return <Text variant="muted">{t('empty')}</Text>;
+
+  const { lesson } = entry;
+  const title = t(`lessons.${lessonId}.title`);
+
+  return (
+    <article className="min-w-0">
+      <VStack gap={2} className="mb-5">
+        <h2 className="text-fg-base text-xl font-semibold">{title}</h2>
+        <Row gap={2} align="center">
+          <Clock aria-hidden className="text-fg-muted size-3.5 shrink-0" />
+          <Text variant="muted" className="text-xs">
+            {t('minutes', { count: lesson.durationMinutes })}
+          </Text>
+        </Row>
+      </VStack>
+
+      <div className="mb-6">
+        <LessonVideo videoSrc={lesson.videoSrc} lessonTitle={title} />
+      </div>
+
+      <Markdown>{t(`lessons.${lessonId}.body`)}</Markdown>
+    </article>
+  );
+}
+
+/** A persistent hand-off card for questions the curriculum doesn't answer. */
+function ContactCallout() {
+  const { t } = useT('help');
+  return (
+    <div className="border-border-base bg-bg-elevated/40 mt-10 rounded-lg border p-5">
+      <VStack gap={2} align="start">
+        <Text className="text-fg-base text-sm font-semibold">
+          {t('contact.title')}
+        </Text>
+        <Text variant="muted" className="text-sm">
+          {t('contact.description')}
+        </Text>
+        <a
+          href={CONTACT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-fg-base hover:text-fg-muted mt-1 inline-flex items-center gap-1 text-sm font-medium underline underline-offset-2"
+        >
+          {t('contact.action')}
+          <ArrowUpRight aria-hidden className="size-3.5" />
+        </a>
+      </VStack>
+    </div>
+  );
+}

--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -10,6 +10,13 @@
 # --- dynamic prefixes ---
 metadata
 
+# `t(`categories.${category.id}.title`)` / `t(`lessons.${lessonId}.body`)` in
+# the Help & learning center (app/routes/dashboard/help.tsx) — the lesson and
+# category ids come from the curriculum table in app/features/help/content.ts,
+# so the scanner sees a runtime template and can't tie the literals back.
+help.categories
+help.lessons
+
 # `roles.${role.toLowerCase()}` in member-table.tsx — the `owner` role is
 # never referenced as a string literal because it can't be assigned through
 # the UI (only inherited from the org creator), so the regex scanner can't

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -529,6 +529,7 @@
         "done": "Verstanden"
       },
       "helpFeedback": "Hilfe & Feedback",
+      "helpLearning": "Hilfe- & Lernzentrum",
       "currentVersion": "Aktuelle Version: v{version}",
       "whatsNew": "Neuigkeiten",
       "updateAvailable": "Update verfügbar",
@@ -1041,6 +1042,89 @@
       "viewOnGitHub": "Auf GitHub ansehen ↗",
       "viewAllOnGitHub": "Ältere Releases auf GitHub ansehen ↗",
       "githubLink": "Releases auf GitHub öffnen"
+    }
+  },
+  "help": {
+    "title": "Hilfe- & Lernzentrum",
+    "subtitle": "Einführung, KI-Kompetenz und Schritt-für-Schritt-Anleitungen – direkt in Tale integriert.",
+    "empty": "Wählen Sie links eine Lektion aus, um zu beginnen.",
+    "navLabel": "Themen des Lernzentrums",
+    "minutes": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}",
+    "video": {
+      "label": "Video-Anleitung: {title}",
+      "unavailable": "Eine Video-Anleitung für diese Lektion folgt in Kürze. Lesen Sie in der Zwischenzeit den Leitfaden unten.",
+      "unsupported": "Ihr Browser kann dieses Video nicht abspielen. Der Leitfaden unten behandelt dieselben Inhalte."
+    },
+    "contact": {
+      "title": "Noch eine Frage?",
+      "description": "Sie finden hier nicht, wonach Sie suchen? Melden Sie sich – unser Team hilft Ihnen weiter.",
+      "action": "Kontakt aufnehmen"
+    },
+    "categories": {
+      "fundamentals": {
+        "title": "KI-Grundlagen",
+        "description": "Was große Sprachmodelle sind, wie sie funktionieren und wo ihre Grenzen liegen."
+      },
+      "platform": {
+        "title": "Tale nutzen",
+        "description": "Praktische Anleitungen für die alltäglichen Funktionen der Plattform."
+      },
+      "responsibleAi": {
+        "title": "Chancen & Risiken von KI",
+        "description": "Holen Sie das Beste aus KI heraus und nutzen Sie sie sicher und verantwortungsvoll."
+      }
+    },
+    "lessons": {
+      "whatAreLlms": {
+        "title": "Was ist ein großes Sprachmodell?",
+        "summary": "Eine verständliche Einführung in die Technologie hinter Tale.",
+        "body": "Ein **großes Sprachmodell** (LLM) ist ein KI-System, das mit sehr großen Textmengen trainiert wurde. Aus diesem Training lernt es die statistischen Muster der Sprache – welche Wörter und Ideen typischerweise aufeinanderfolgen – und erzeugt damit Stück für Stück neuen Text.\n\nWenn Sie eine Nachricht eingeben, schlägt das Modell nichts in einer Datenbank \"richtiger Antworten\" nach. Stattdessen sagt es die wahrscheinlichste Fortsetzung Ihres Textes voraus – Token für Token – auf Basis des Gelernten und des Kontexts, den Sie bereitstellen.\n\n**Warum das für Sie wichtig ist:**\n\n- Das Modell ist ein leistungsfähiger Mustererkenner, keine Suchmaschine und kein Taschenrechner.\n- Es liefert die besten Ergebnisse, wenn Sie klare Anweisungen und relevanten Kontext geben.\n- Dieselbe Frage kann jedes Mal eine leicht andere Antwort liefern – das ist erwartetes Verhalten, kein Fehler."
+      },
+      "howLlmsWork": {
+        "title": "Wie Sprachmodelle Antworten erzeugen",
+        "summary": "Prompts, Kontext und warum die Formulierung das Ergebnis beeinflusst.",
+        "body": "Jede Antwort beginnt mit Ihrem **Prompt** – der Nachricht, die Sie senden – zusammen mit dem **Kontext**, den das Modell sehen kann, etwa frühere Nachrichten im Gespräch, die Anweisungen eines Projekts oder Dokumente aus der Wissensdatenbank.\n\nDas Modell liest all das und erzeugt eine Antwort, die das Gespräch natürlich fortsetzt. Ein paar Ideen helfen Ihnen zu durchgängig guten Ergebnissen:\n\n- **Seien Sie konkret.** \"Fasse diesen Vertrag in fünf Stichpunkten für Laien zusammen\" ist besser als \"fasse das zusammen\".\n- **Geben Sie Kontext.** Fügen Sie den relevanten Text ein oder verweisen Sie auf die passende Wissensquelle, statt vorauszusetzen, dass das Modell es bereits weiß.\n- **Iterieren Sie.** Stimmt die erste Antwort noch nicht, sagen Sie, was zu ändern ist. Das Modell behält das Gespräch im Blick.\n- **Legen Sie die Rolle fest.** Wenn Sie dem Modell sagen, in welcher Rolle es handelt (\"du bist ein sorgfältiger technischer Prüfer\"), prägt das Ton und Tiefe."
+      },
+      "limitations": {
+        "title": "Grenzen und Halluzinationen",
+        "summary": "Wo Modelle irren und wie Sie die Kontrolle behalten.",
+        "body": "Sprachmodelle sind nützlich, aber nicht unfehlbar. Ihre Grenzen zu kennen ist die wichtigste Kompetenz im Umgang mit KI.\n\n- **Halluzinationen.** Ein Modell kann etwas Falsches mit voller Überzeugung behaupten. Es erzeugt plausibel klingenden Text – das ist nicht dasselbe wie eine geprüfte Tatsache.\n- **Wissensstand.** Ein Modell kennt nur das, was in seinen Trainingsdaten enthalten war, sofern Sie ihm keine neueren Informationen liefern.\n- **Kein echtes Verständnis.** Es verarbeitet sprachliche Muster; es \"weiß\" Dinge nicht so wie ein Mensch.\n- **Empfindlichkeit gegenüber Formulierungen.** Kleine Änderungen am Prompt können die Antwort verändern.\n\n**So bleiben Sie sicher:** Behandeln Sie KI-Ausgaben als gut informierten Entwurf, nicht als letzte Instanz. Prüfen Sie Fakten, Zahlen, Namen und Zitate, bevor Sie sich darauf verlassen – besonders bei allem Folgenreichen."
+      },
+      "gettingStarted": {
+        "title": "Erste Schritte mit Tale",
+        "summary": "Finden Sie sich im Arbeitsbereich zurecht.",
+        "body": "Tale vereint Chat, Wissen, Agenten und Automatisierungen in einem Arbeitsbereich. Hier der schnellste Weg zum Nutzen:\n\n1. **Starten Sie einen Chat.** Öffnen Sie die Chat-Oberfläche und stellen Sie eine Frage in einfacher Sprache – wie bei einer kompetenten Kollegin oder einem Kollegen.\n2. **Wählen Sie den richtigen Agenten.** Verschiedene Agenten sind auf verschiedene Aufgaben abgestimmt. Wählen Sie den, dessen Zweck zu Ihrer Aufgabe passt.\n3. **Fügen Sie Wissen hinzu.** Verbinden Sie Dokumente, Websites und strukturierte Daten, damit Agenten aus *Ihren* Informationen antworten, nicht nur aus ihrem allgemeinen Training.\n4. **Erkunden Sie die Seitennavigation.** Unterhaltungen, Wissen, Agenten und Automatisierungen haben jeweils einen eigenen Bereich – wechseln Sie über die linke Leiste.\n\nSie können jederzeit über das Kontomenü in der Ecke der App zu diesem Lernzentrum zurückkehren."
+      },
+      "chattingWithAgents": {
+        "title": "Mit Agenten chatten",
+        "summary": "Holen Sie aus jedem Gespräch bessere Ergebnisse.",
+        "body": "Der Chat ist das Herzstück von Tale. Ein paar Gewohnheiten machen einen großen Unterschied:\n\n- **Eine Aufgabe pro Thread.** Halten Sie ein Gespräch auf ein einziges Ziel fokussiert, damit der Kontext relevant bleibt.\n- **Hängen Sie Relevantes an.** Ziehen Sie eine Datei hinein oder verweisen Sie auf eine Wissensquelle, damit der Agent mit echtem Material arbeitet.\n- **Verfeinern Sie direkt.** Antworten Sie mit Korrekturen – \"kürzer\", \"förmlicher\", \"ergänze die Zahlen aus Q2\" – statt neu zu beginnen.\n- **Prüfen Sie vor dem Handeln.** Lesen Sie die Antwort kritisch und überprüfen Sie alles, worauf Sie sich verlassen.\n\nWenn ein Agent eine heikle Aktion vorschlägt, kann Tale zunächst für Ihre Freigabe pausieren – Sie behalten die Kontrolle darüber, was tatsächlich passiert."
+      },
+      "knowledgeBase": {
+        "title": "Ihre Wissensdatenbank aufbauen",
+        "summary": "Verankern Sie Antworten in Ihren eigenen Informationen.",
+        "body": "Von Haus aus kennt ein Agent nur sein allgemeines Training. Die **Wissensdatenbank** ermöglicht es ihm, aus Ihren Dokumenten, Websites, Produkten, Kunden und anderen strukturierten Daten zu antworten.\n\n- **Quellen hinzufügen** im Bereich Wissen – Dokumente hochladen, aus verbundenen Apps importieren oder eine Website zum Crawlen hinzufügen.\n- **Aktuell halten.** Synchronisieren oder laden Sie neu, wenn sich die zugrunde liegenden Informationen ändern, damit Antworten nicht veralten.\n- **Nach Bedarf eingrenzen.** Verknüpfen Sie das passende Wissen mit dem passenden Agenten oder Projekt, statt alles überall.\n\nAntworten in eigenen Quellen zu verankern ist der wirksamste Weg, Halluzinationen zu verringern und Antworten zu erhalten, die widerspiegeln, wie *Ihre* Organisation tatsächlich arbeitet."
+      },
+      "automations": {
+        "title": "Wiederkehrende Arbeit automatisieren",
+        "summary": "Machen Sie aus einer manuellen Aufgabe einen wiederholbaren Ablauf.",
+        "body": "**Automatisierungen** lassen Tale eine Abfolge von Schritten für Sie ausführen – nach Zeitplan, ausgelöst durch ein Ereignis oder auf Abruf –, sodass Routinearbeit geschieht, ohne dass Sie jeden Schritt steuern.\n\n1. **Beschreiben Sie das Ergebnis.** Beginnen Sie mit dem, was passieren soll, nicht mit den einzelnen Klicks.\n2. **Wählen Sie einen Auslöser.** Per Timer, als Reaktion auf ein Ereignis oder manuell.\n3. **Fügen Sie Freigabeschritte hinzu** für alles, was nicht unbeaufsichtigt laufen soll – Tale pausiert und fragt zuerst einen Menschen.\n4. **Beobachten Sie die Kennzahlen.** Jede Automatisierung meldet ihre Ausführungen, sodass Sie sehen, was lief, und eingreifen können, wenn etwas nicht stimmt.\n\nFangen Sie klein mit einem zuverlässigen Ablauf an, bestätigen Sie das erwartete Verhalten und bauen Sie dann aus."
+      },
+      "opportunities": {
+        "title": "Die Chancen von KI",
+        "summary": "Wo KI wirklich hilft.",
+        "body": "Gut eingesetzt ist KI ein Kraftverstärker. Die größten Gewinne sind meist:\n\n- **Entwerfen und Zusammenfassen.** Erste Entwürfe, Zusammenfassungen und Umformulierungen in Sekunden, sodass Sie bearbeiten statt vor einem leeren Blatt zu sitzen.\n- **Informationen finden und verknüpfen.** Das Relevante aus langen Dokumenten oder verstreuten Quellen herausziehen.\n- **Wiederkehrende Arbeit.** Klassifizieren, Extrahieren und Weiterleiten in einem Umfang, der von Hand mühsam wäre.\n- **Niedrigere Einstiegshürde.** Fragen in einfacher Sprache stellen, statt eine Abfragesyntax oder ein neues Werkzeug zu lernen.\n\nDer rote Faden: KI übernimmt die Schwerarbeit eines ersten Durchgangs, und ein Mensch liefert Urteilsvermögen, Kontext und die endgültige Entscheidung."
+      },
+      "risks": {
+        "title": "Die Risiken von KI – und wie Sie sie beherrschen",
+        "summary": "KI verantwortungsvoll nutzen und typische Fallstricke vermeiden.",
+        "body": "Dieselbe Stärke, die KI nützlich macht, bringt echte Risiken mit sich. Sie zu kennen macht den Umgang erst *verantwortungsvoll*.\n\n- **Falsche Ausgaben.** Modelle können überzeugend falsch liegen. Prüfen Sie alles Folgenreiche, bevor Sie danach handeln.\n- **Sensible Daten.** Überlegen Sie genau, welche Informationen Sie teilen, und halten Sie sich an die Datenschutzregeln Ihrer Organisation.\n- **Übermäßiges Vertrauen.** KI unterstützt Entscheidungen; sie sollte nicht stillschweigend jene treffen, die menschliches Urteil, Fairness oder Verantwortung erfordern.\n- **Verzerrungen.** Trainingsdaten tragen die Verzerrungen ihrer Quelle. Bleiben Sie wachsam gegenüber einseitigen oder unfairen Ausgaben.\n- **Datenschutz und Compliance.** Behandeln Sie KI wie jedes andere System, das personenbezogene oder regulierte Daten berührt.\n\nTale bietet Leitplanken – Freigabeschritte, eingegrenztes Wissen und Prüfprotokolle –, doch die wichtigste Absicherung ist ein informierter Mensch im Prozess."
+      },
+      "bestPractices": {
+        "title": "Best Practices für verantwortungsvolle Nutzung",
+        "summary": "Eine kurze Checkliste für den Alltag.",
+        "body": "Behalten Sie diese Gewohnheiten bei, und Sie nutzen die Vorteile von KI, ohne die Kontrolle zu verlieren:\n\n- **Prüfen, bevor Sie vertrauen.** Kontrollieren Sie Fakten, Zahlen, Namen und Zitate – besonders bei allem, was Ihr Haus verlässt.\n- **Halten Sie einen Menschen im Prozess** für Entscheidungen mit echten Folgen.\n- **Achten Sie auf die Daten.** Teilen Sie nur Informationen, die Sie teilen dürfen, und verankern Sie Antworten möglichst in freigegebenen Wissensquellen.\n- **Seien Sie transparent.** Lassen Sie Menschen wissen, wenn KI an Arbeit beteiligt war, die sie betrifft.\n- **Nutzen Sie Freigabeschritte** für heikle oder unumkehrbare Aktionen.\n- **Geben Sie Feedback.** Korrigieren Sie falsche Antworten – bessere Prompts und besser eingegrenztes Wissen summieren sich mit der Zeit.\n\nVerantwortungsvolle KI ist keine einmalige Einstellung, sondern eine Arbeitsweise."
+      }
     }
   },
   "chat": {
@@ -4184,6 +4268,10 @@
     "changelog": {
       "title": "Was ist neu",
       "description": "Release Notes für aktuelle Tale-Updates."
+    },
+    "help": {
+      "title": "Hilfe- & Lernzentrum",
+      "description": "Einführung, KI-Kompetenz und Anleitungen – direkt in Tale integriert."
     },
     "login": {
       "title": "Anmelden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -529,6 +529,7 @@
         "done": "Got it"
       },
       "helpFeedback": "Help & feedback",
+      "helpLearning": "Help & learning center",
       "currentVersion": "Current version: v{version}",
       "whatsNew": "What's new",
       "updateAvailable": "Update available",
@@ -1041,6 +1042,89 @@
       "viewOnGitHub": "View on GitHub ↗",
       "viewAllOnGitHub": "View older releases on GitHub ↗",
       "githubLink": "Open releases on GitHub"
+    }
+  },
+  "help": {
+    "title": "Help & learning center",
+    "subtitle": "Onboarding, AI literacy, and step-by-step how-to guides — built right into Tale.",
+    "empty": "Select a lesson from the list to get started.",
+    "navLabel": "Learning center topics",
+    "minutes": "{count, plural, one {# min read} other {# min read}}",
+    "video": {
+      "label": "Video walkthrough: {title}",
+      "unavailable": "A video walkthrough for this lesson is coming soon. Read the guide below in the meantime.",
+      "unsupported": "Your browser can't play this video. The written guide below covers the same material."
+    },
+    "contact": {
+      "title": "Still have a question?",
+      "description": "Can't find what you're looking for here? Reach out and our team will help.",
+      "action": "Contact us"
+    },
+    "categories": {
+      "fundamentals": {
+        "title": "AI fundamentals",
+        "description": "What large language models are, how they work, and where their limits lie."
+      },
+      "platform": {
+        "title": "Using Tale",
+        "description": "Practical how-to guides for the everyday features of the platform."
+      },
+      "responsibleAi": {
+        "title": "Opportunities & risks of AI",
+        "description": "Get the most out of AI while using it safely and responsibly."
+      }
+    },
+    "lessons": {
+      "whatAreLlms": {
+        "title": "What is a large language model?",
+        "summary": "A plain-language introduction to the technology behind Tale.",
+        "body": "A **large language model** (LLM) is an AI system trained on a very large amount of text. From that training it learns the statistical patterns of language — which words and ideas tend to follow others — and uses those patterns to generate new text one piece at a time.\n\nWhen you type a message, the model doesn't look anything up in a database of \"correct answers\". Instead it predicts the most likely continuation of your text, token by token, based on everything it learned during training plus the context you provide.\n\n**Why this matters for you:**\n\n- The model is a powerful pattern-matcher, not a search engine or a calculator.\n- It is at its best when you give it clear instructions and relevant context.\n- The same question can produce slightly different answers each time — that is expected behaviour, not a bug."
+      },
+      "howLlmsWork": {
+        "title": "How language models generate answers",
+        "summary": "Prompts, context, and why phrasing changes the result.",
+        "body": "Every response starts from your **prompt** — the message you send — together with any **context** the model can see, such as earlier messages in the conversation, a project's instructions, or documents from the knowledge base.\n\nThe model reads all of that and produces a reply that continues the conversation naturally. A few ideas help you get consistently good results:\n\n- **Be specific.** \"Summarise this contract in five bullet points for a non-lawyer\" beats \"summarise this\".\n- **Give context.** Paste the relevant text, or point the agent at the right knowledge source, rather than assuming it already knows.\n- **Iterate.** If the first answer isn't quite right, say what to change. The model keeps the conversation in mind.\n- **Set the role.** Telling the model who it is acting as (\"you are a careful technical reviewer\") shapes tone and depth."
+      },
+      "limitations": {
+        "title": "Limitations and hallucinations",
+        "summary": "Where models go wrong and how to stay in control.",
+        "body": "Language models are useful, but they are not infallible. Knowing their limits is the single most important AI-literacy skill.\n\n- **Hallucinations.** A model can state something false with complete confidence. It generates plausible-sounding text, which is not the same as verified fact.\n- **Knowledge cut-off.** A model only knows what was in its training data unless you supply newer information directly.\n- **No true understanding.** It manipulates patterns in language; it does not \"know\" things the way a person does.\n- **Sensitivity to wording.** Small changes to a prompt can change the answer.\n\n**How to stay safe:** treat AI output as a well-informed draft, not a final authority. Verify facts, figures, names, and quotes before you rely on them — especially for anything consequential."
+      },
+      "gettingStarted": {
+        "title": "Getting started with Tale",
+        "summary": "Find your way around the workspace.",
+        "body": "Tale brings chat, knowledge, agents, and automations together in one workspace. Here is the quickest path to value:\n\n1. **Start a chat.** Open the chat surface and ask a question in plain language — just like messaging a knowledgeable colleague.\n2. **Pick the right agent.** Different agents are tuned for different jobs. Choose one whose purpose matches your task.\n3. **Add knowledge.** Connect documents, websites, and structured data so agents can answer from *your* information, not just their general training.\n4. **Explore the side navigation.** Conversations, knowledge, agents, and automations each have their own area — switch between them from the left rail.\n\nYou can always return to this learning center from the account menu in the corner of the app."
+      },
+      "chattingWithAgents": {
+        "title": "Chatting with agents",
+        "summary": "Get better results from every conversation.",
+        "body": "Chatting is the heart of Tale. A few habits make a big difference:\n\n- **One task per thread.** Keep a conversation focused on a single goal so the context stays relevant.\n- **Attach what matters.** Drag in a file or reference a knowledge source so the agent works from real material.\n- **Refine in place.** Reply with corrections — \"shorter\", \"more formal\", \"add the figures from Q2\" — instead of starting over.\n- **Review before you act.** Read the answer critically and check anything you'll rely on.\n\nWhen an agent proposes a sensitive action, Tale can pause for your approval first — you stay in control of what actually happens."
+      },
+      "knowledgeBase": {
+        "title": "Building your knowledge base",
+        "summary": "Ground answers in your own information.",
+        "body": "Out of the box an agent only knows its general training. The **knowledge base** lets it answer from your documents, websites, products, customers, and other structured data.\n\n- **Add sources** under the Knowledge area — upload documents, import from connected apps, or add a website to crawl.\n- **Keep them current.** Re-sync or re-upload when the underlying information changes, so answers don't drift out of date.\n- **Scope by need.** Attach the right knowledge to the right agent or project, rather than everything everywhere.\n\nGrounding answers in your own sources is the most effective way to reduce hallucinations and get responses that reflect how *your* organisation actually works."
+      },
+      "automations": {
+        "title": "Automating repetitive work",
+        "summary": "Turn a manual task into a repeatable workflow.",
+        "body": "**Automations** let Tale run a sequence of steps for you — on a schedule, on a trigger, or on demand — so routine work happens without you driving every step.\n\n1. **Describe the outcome.** Start from what you want to happen, not the individual clicks.\n2. **Choose a trigger.** Run on a timer, in response to an event, or manually.\n3. **Add approval gates** for any step that should not run unattended — Tale will pause and ask a human first.\n4. **Watch the metrics.** Each automation reports its executions so you can see what ran and step in if something looks off.\n\nStart small with one reliable workflow, confirm it behaves as expected, then expand."
+      },
+      "opportunities": {
+        "title": "The opportunities of AI",
+        "summary": "Where AI genuinely helps.",
+        "body": "Used well, AI is a force multiplier. The biggest wins tend to be:\n\n- **Drafting and summarising.** First drafts, summaries, and rewrites in seconds, leaving you to edit rather than start from a blank page.\n- **Finding and connecting information.** Pulling the relevant detail out of long documents or scattered sources.\n- **Repetitive work.** Classifying, extracting, and routing at a scale that would be tedious by hand.\n- **Lowering the barrier to entry.** Asking questions in plain language instead of learning a query syntax or a new tool.\n\nThe common thread: AI handles the heavy lifting of a first pass, and a person provides judgement, context, and the final decision."
+      },
+      "risks": {
+        "title": "The risks of AI — and how to manage them",
+        "summary": "Use AI responsibly and avoid common pitfalls.",
+        "body": "The same power that makes AI useful brings real risks. Knowing them is what makes use *responsible*.\n\n- **Incorrect output.** Models can be confidently wrong. Verify anything consequential before acting on it.\n- **Sensitive data.** Be deliberate about what information you share, and follow your organisation's data-handling rules.\n- **Over-reliance.** AI assists decisions; it should not silently make the ones that need human judgement, fairness, or accountability.\n- **Bias.** Training data carries the biases of its source. Stay alert to skewed or unfair output.\n- **Privacy and compliance.** Treat AI like any other system that touches personal or regulated data.\n\nTale provides guardrails — approval gates, scoped knowledge, and audit trails — but the most important safeguard is an informed human in the loop."
+      },
+      "bestPractices": {
+        "title": "Responsible-use best practices",
+        "summary": "A short checklist for everyday use.",
+        "body": "Keep these habits and you'll get the upside of AI while staying in control:\n\n- **Verify before you trust.** Check facts, figures, names, and quotes — especially for anything that leaves your hands.\n- **Keep a human in the loop** for decisions that carry real consequences.\n- **Mind the data.** Only share information you're permitted to, and prefer grounding answers in approved knowledge sources.\n- **Be transparent.** Let people know when AI was involved in work that affects them.\n- **Use approval gates** for sensitive or irreversible actions.\n- **Give feedback.** When an answer is wrong, correct it — better prompts and better-scoped knowledge compound over time.\n\nResponsible AI isn't a one-time setting; it's a way of working."
+      }
     }
   },
   "chat": {
@@ -4184,6 +4268,10 @@
     "changelog": {
       "title": "What's new",
       "description": "Release notes for recent Tale updates."
+    },
+    "help": {
+      "title": "Help & learning center",
+      "description": "Onboarding, AI literacy, and how-to guides built into Tale."
     },
     "login": {
       "title": "Log in",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -530,6 +530,7 @@
         "done": "Compris"
       },
       "helpFeedback": "Aide et retours",
+      "helpLearning": "Centre d'aide et d'apprentissage",
       "currentVersion": "Version actuelle : v{version}",
       "whatsNew": "Nouveautés",
       "updateAvailable": "Mise à jour disponible",
@@ -1042,6 +1043,89 @@
       "viewOnGitHub": "Voir sur GitHub ↗",
       "viewAllOnGitHub": "Voir les versions plus anciennes sur GitHub ↗",
       "githubLink": "Ouvrir les notes de version sur GitHub"
+    }
+  },
+  "help": {
+    "title": "Centre d'aide et d'apprentissage",
+    "subtitle": "Prise en main, culture de l'IA et guides pas à pas — intégrés directement dans Tale.",
+    "empty": "Sélectionnez une leçon dans la liste pour commencer.",
+    "navLabel": "Thèmes du centre d'apprentissage",
+    "minutes": "{count, plural, one {# min de lecture} other {# min de lecture}}",
+    "video": {
+      "label": "Tutoriel vidéo : {title}",
+      "unavailable": "Un tutoriel vidéo pour cette leçon arrive bientôt. En attendant, lisez le guide ci-dessous.",
+      "unsupported": "Votre navigateur ne peut pas lire cette vidéo. Le guide ci-dessous couvre le même contenu."
+    },
+    "contact": {
+      "title": "Encore une question ?",
+      "description": "Vous ne trouvez pas ce que vous cherchez ici ? Contactez-nous, notre équipe vous aidera.",
+      "action": "Nous contacter"
+    },
+    "categories": {
+      "fundamentals": {
+        "title": "Fondamentaux de l'IA",
+        "description": "Ce que sont les grands modèles de langage, comment ils fonctionnent et où sont leurs limites."
+      },
+      "platform": {
+        "title": "Utiliser Tale",
+        "description": "Des guides pratiques pour les fonctionnalités du quotidien de la plateforme."
+      },
+      "responsibleAi": {
+        "title": "Opportunités et risques de l'IA",
+        "description": "Tirez le meilleur de l'IA tout en l'utilisant de façon sûre et responsable."
+      }
+    },
+    "lessons": {
+      "whatAreLlms": {
+        "title": "Qu'est-ce qu'un grand modèle de langage ?",
+        "summary": "Une introduction en langage clair à la technologie derrière Tale.",
+        "body": "Un **grand modèle de langage** (LLM) est un système d'IA entraîné sur une très grande quantité de texte. De cet entraînement, il apprend les schémas statistiques du langage — quels mots et quelles idées ont tendance à se suivre — et s'en sert pour générer un nouveau texte, fragment par fragment.\n\nLorsque vous saisissez un message, le modèle ne consulte pas une base de \"bonnes réponses\". Il prédit la suite la plus probable de votre texte, token par token, à partir de ce qu'il a appris et du contexte que vous fournissez.\n\n**Pourquoi cela compte pour vous :**\n\n- Le modèle est un puissant détecteur de schémas, pas un moteur de recherche ni une calculatrice.\n- Il donne le meilleur lorsque vous fournissez des instructions claires et un contexte pertinent.\n- Une même question peut produire une réponse légèrement différente à chaque fois — c'est un comportement attendu, pas un défaut."
+      },
+      "howLlmsWork": {
+        "title": "Comment les modèles génèrent leurs réponses",
+        "summary": "Prompts, contexte, et pourquoi la formulation change le résultat.",
+        "body": "Chaque réponse part de votre **prompt** — le message que vous envoyez — ainsi que du **contexte** visible par le modèle : les messages précédents, les instructions d'un projet ou des documents de la base de connaissances.\n\nLe modèle lit tout cela et produit une réponse qui poursuit naturellement la conversation. Quelques principes pour des résultats régulièrement bons :\n\n- **Soyez précis.** \"Résume ce contrat en cinq points pour un non-juriste\" vaut mieux que \"résume ça\".\n- **Donnez du contexte.** Collez le texte pertinent ou pointez l'agent vers la bonne source, plutôt que de supposer qu'il sait déjà.\n- **Itérez.** Si la première réponse ne convient pas, dites quoi changer. Le modèle garde la conversation en mémoire.\n- **Définissez le rôle.** Indiquer au modèle en quelle qualité il agit (\"tu es un relecteur technique rigoureux\") façonne le ton et la profondeur."
+      },
+      "limitations": {
+        "title": "Limites et hallucinations",
+        "summary": "Où les modèles se trompent et comment garder le contrôle.",
+        "body": "Les modèles de langage sont utiles, mais pas infaillibles. Connaître leurs limites est la compétence la plus importante en matière de culture de l'IA.\n\n- **Hallucinations.** Un modèle peut affirmer une fausseté avec une assurance totale. Il génère un texte plausible, ce qui n'est pas la même chose qu'un fait vérifié.\n- **Date de connaissance.** Un modèle ne connaît que ce qui figurait dans ses données d'entraînement, sauf si vous lui fournissez des informations plus récentes.\n- **Pas de réelle compréhension.** Il manipule des schémas de langage ; il ne \"sait\" pas les choses comme un humain.\n- **Sensibilité à la formulation.** De petits changements de prompt peuvent changer la réponse.\n\n**Pour rester prudent :** traitez la sortie de l'IA comme un brouillon bien informé, pas comme une autorité finale. Vérifiez faits, chiffres, noms et citations avant de vous y fier — surtout pour tout ce qui a des conséquences."
+      },
+      "gettingStarted": {
+        "title": "Premiers pas avec Tale",
+        "summary": "Repérez-vous dans l'espace de travail.",
+        "body": "Tale réunit le chat, les connaissances, les agents et les automatisations dans un seul espace de travail. Voici le chemin le plus rapide vers la valeur :\n\n1. **Démarrez un chat.** Ouvrez l'interface de chat et posez une question en langage clair — comme à un collègue compétent.\n2. **Choisissez le bon agent.** Différents agents sont réglés pour différentes tâches. Choisissez celui dont la vocation correspond à la vôtre.\n3. **Ajoutez des connaissances.** Connectez documents, sites web et données structurées pour que les agents répondent à partir de *vos* informations, et non seulement de leur entraînement général.\n4. **Explorez la navigation latérale.** Conversations, connaissances, agents et automatisations ont chacun leur espace — passez de l'un à l'autre depuis le rail de gauche.\n\nVous pouvez revenir à tout moment à ce centre d'apprentissage depuis le menu du compte, dans le coin de l'application."
+      },
+      "chattingWithAgents": {
+        "title": "Discuter avec les agents",
+        "summary": "Tirez de meilleurs résultats de chaque conversation.",
+        "body": "Le chat est au cœur de Tale. Quelques habitudes font une grande différence :\n\n- **Une tâche par fil.** Gardez une conversation centrée sur un seul objectif pour que le contexte reste pertinent.\n- **Joignez l'essentiel.** Glissez un fichier ou référencez une source de connaissances pour que l'agent travaille sur du matériel réel.\n- **Affinez sur place.** Répondez par des corrections — \"plus court\", \"plus formel\", \"ajoute les chiffres du T2\" — au lieu de recommencer.\n- **Vérifiez avant d'agir.** Lisez la réponse d'un œil critique et contrôlez tout ce sur quoi vous comptez.\n\nLorsqu'un agent propose une action sensible, Tale peut s'arrêter pour obtenir votre approbation — vous gardez le contrôle de ce qui se produit réellement."
+      },
+      "knowledgeBase": {
+        "title": "Construire votre base de connaissances",
+        "summary": "Ancrez les réponses dans vos propres informations.",
+        "body": "Par défaut, un agent ne connaît que son entraînement général. La **base de connaissances** lui permet de répondre à partir de vos documents, sites web, produits, clients et autres données structurées.\n\n- **Ajoutez des sources** dans l'espace Connaissances — importez des documents, depuis des applications connectées, ou ajoutez un site web à explorer.\n- **Gardez-les à jour.** Resynchronisez ou réimportez quand l'information sous-jacente change, pour que les réponses ne deviennent pas obsolètes.\n- **Délimitez selon le besoin.** Associez la bonne connaissance au bon agent ou projet, plutôt que tout, partout.\n\nAncrer les réponses dans vos propres sources est le moyen le plus efficace de réduire les hallucinations et d'obtenir des réponses qui reflètent le fonctionnement réel de *votre* organisation."
+      },
+      "automations": {
+        "title": "Automatiser le travail répétitif",
+        "summary": "Transformez une tâche manuelle en flux reproductible.",
+        "body": "Les **automatisations** permettent à Tale d'exécuter une suite d'étapes pour vous — selon un calendrier, sur déclencheur ou à la demande — afin que le travail de routine se fasse sans que vous pilotiez chaque étape.\n\n1. **Décrivez le résultat.** Partez de ce que vous voulez obtenir, pas des clics individuels.\n2. **Choisissez un déclencheur.** Selon une minuterie, en réaction à un événement, ou manuellement.\n3. **Ajoutez des étapes d'approbation** pour toute action qui ne doit pas s'exécuter sans surveillance — Tale s'arrête et consulte d'abord un humain.\n4. **Suivez les indicateurs.** Chaque automatisation rapporte ses exécutions, pour voir ce qui a tourné et intervenir si quelque chose cloche.\n\nCommencez petit avec un flux fiable, confirmez le comportement attendu, puis élargissez."
+      },
+      "opportunities": {
+        "title": "Les opportunités de l'IA",
+        "summary": "Là où l'IA aide vraiment.",
+        "body": "Bien utilisée, l'IA est un multiplicateur de force. Les gains les plus nets sont généralement :\n\n- **Rédaction et synthèse.** Premiers jets, résumés et reformulations en quelques secondes, vous laissant éditer plutôt que partir d'une page blanche.\n- **Trouver et relier l'information.** Extraire le détail pertinent de longs documents ou de sources éparses.\n- **Travail répétitif.** Classer, extraire et router à une échelle fastidieuse à la main.\n- **Abaisser la barrière d'entrée.** Poser des questions en langage clair au lieu d'apprendre une syntaxe de requête ou un nouvel outil.\n\nLe fil conducteur : l'IA assure le gros œuvre d'un premier passage, et un humain apporte le jugement, le contexte et la décision finale."
+      },
+      "risks": {
+        "title": "Les risques de l'IA — et comment les maîtriser",
+        "summary": "Utiliser l'IA de façon responsable et éviter les pièges courants.",
+        "body": "La puissance même qui rend l'IA utile s'accompagne de risques réels. Les connaître est ce qui rend l'usage *responsable*.\n\n- **Sorties erronées.** Les modèles peuvent se tromper avec assurance. Vérifiez tout ce qui a des conséquences avant d'agir.\n- **Données sensibles.** Soyez attentif à ce que vous partagez et respectez les règles de traitement des données de votre organisation.\n- **Dépendance excessive.** L'IA assiste les décisions ; elle ne doit pas prendre en silence celles qui exigent jugement, équité ou responsabilité humaine.\n- **Biais.** Les données d'entraînement portent les biais de leur source. Restez vigilant face aux sorties partiales ou injustes.\n- **Vie privée et conformité.** Traitez l'IA comme tout autre système touchant à des données personnelles ou réglementées.\n\nTale fournit des garde-fous — étapes d'approbation, connaissances délimitées et journaux d'audit —, mais la protection la plus importante reste un humain informé dans la boucle."
+      },
+      "bestPractices": {
+        "title": "Bonnes pratiques d'un usage responsable",
+        "summary": "Une courte liste de contrôle pour le quotidien.",
+        "body": "Gardez ces habitudes et vous profiterez des atouts de l'IA tout en gardant le contrôle :\n\n- **Vérifiez avant de faire confiance.** Contrôlez faits, chiffres, noms et citations — surtout pour ce qui quitte vos mains.\n- **Gardez un humain dans la boucle** pour les décisions à réelles conséquences.\n- **Faites attention aux données.** Ne partagez que ce que vous avez le droit de partager, et privilégiez l'ancrage dans des sources approuvées.\n- **Soyez transparent.** Faites savoir aux personnes concernées quand l'IA est intervenue dans un travail qui les affecte.\n- **Utilisez des étapes d'approbation** pour les actions sensibles ou irréversibles.\n- **Donnez votre avis.** Corrigez une réponse erronée — de meilleurs prompts et des connaissances mieux délimitées s'additionnent avec le temps.\n\nL'IA responsable n'est pas un réglage ponctuel, c'est une manière de travailler."
+      }
     }
   },
   "chat": {
@@ -4185,6 +4269,10 @@
     "changelog": {
       "title": "Nouveautés",
       "description": "Notes de version pour les récentes mises à jour de Tale."
+    },
+    "help": {
+      "title": "Centre d'aide et d'apprentissage",
+      "description": "Prise en main, culture de l'IA et guides intégrés à Tale."
     },
     "login": {
       "title": "Connexion",

--- a/services/platform/tests/e2e/specs/page-loads.spec.ts
+++ b/services/platform/tests/e2e/specs/page-loads.spec.ts
@@ -94,6 +94,14 @@ function routeCases(): readonly RouteCase[] {
       path: () => '/docs',
       anchor: (page) => page.locator('main.swagger-ui-standalone').first(),
     },
+    {
+      // The in-app Help & learning center (issue #1922). Org-independent like
+      // changelog; its <h1> renders immediately from static i18n content.
+      key: 'help',
+      path: () => '/dashboard/help',
+      anchor: (page) =>
+        page.getByRole('heading', { name: t('help.title'), level: 1 }).first(),
+    },
   ];
 }
 


### PR DESCRIPTION
## Summary

Resolves #1922 — adds an **in-app Help & learning center** at `/dashboard/help`, the end-user learning surface the issue asked for. It covers the three pillars from the issue:

- **AI fundamentals** — what LLMs are, how they generate answers, limitations & hallucinations.
- **Using Tale** — getting started, chatting with agents, building the knowledge base, automations.
- **Opportunities & risks of AI** — where AI helps, the risks, and responsible-use best practices.

The account menu (`user-button`) now links to this in-app center alongside the existing external feedback link, replacing the old "help points only to `tale.dev/contact`" state.

## Video hosting decision

The platform CSP pins `media-src` and `frame-src` to `'self'` for offline / self-hosted deployments, so **external embeds (YouTube/Vimeo) are intentionally unsupported**. `LessonVideo` plays **self-hosted** clips via a native `<video>` element (with same-origin WebVTT captions) and falls back to an accessible "coming soon" placeholder until clips are produced. This keeps the feature consistent with the air-gapped posture.

## What's included

- `app/routes/dashboard/help.tsx` — localized master-detail learning portal (curriculum sidebar + lesson content), deep-linkable via `?lesson=`.
- `app/features/help/content.ts` — curriculum structure; all copy resolved from the new `help` i18n namespace.
- `app/features/help/components/lesson-video.tsx` — self-hosted video / placeholder.
- Full **en / de / fr** translations + `metadata.help`; dynamic key prefixes allowlisted in `keys-dynamic.txt`.
- `user-button` account-menu entry → in-app learning center.

## Tests

- `content.test.ts` — every curriculum id resolves to a real localized message (guards the dynamic-key wiring).
- `lesson-video.test.tsx` — placeholder & self-hosted branches + axe a11y audit.
- `user-button.test.tsx` — menu now exposes the learning-center item.
- `page-loads.spec.ts` — e2e render-smoke for `/dashboard/help`.

Locally green: `tsc --noEmit`, `oxlint` (changed files), i18n parity/usage (`messages.test.ts`), and the UI test suite above.

## Follow-ups

- Self-hosted walkthrough clips (`videoSrc`) can be dropped in per lesson once produced.
- A developer/admin docs-site page under `docs/` could cross-link to this center.