### PR TITLE
fix: make the "Enable two-factor" button secondary (#1946)

### DIFF
--- a/services/platform/app/features/settings/account/components/two-factor-section.tsx
+++ b/services/platform/app/features/settings/account/components/two-factor-section.tsx
@@ -117,7 +117,10 @@ function NotEnrolledState({ enforced }: { enforced: boolean }) {
       title={t('enrollment.title')}
       description={t('enrollment.description')}
       action={
-        <Button onClick={() => setState({ step: 'password' })}>
+        <Button
+          variant="secondary"
+          onClick={() => setState({ step: 'password' })}
+        >
           {t('enrollment.enableButton')}
         </Button>
       }


### PR DESCRIPTION
## Summary

Changes the "Enable two-factor" button in the Account settings Two-Factor section to use the `secondary` variant instead of the default (primary) variant.

Resolves #1946

## Changes
- `services/platform/app/features/settings/account/components/two-factor-section.tsx`: added `variant="secondary"` to the enable button.

## Acceptance criteria
- [x] The "Enable two-factor" button renders as secondary.