### PR TITLE
fix: prefill passkey name from device info (#1948)

### DIFF
--- a/services/platform/app/features/settings/account/components/passkey-register-dialog.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-register-dialog.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
+import { deriveDeviceLabel } from '@/lib/utils/device-label';
 
 /**
  * 'any' lets the browser offer every available authenticator (platform
@@ -41,6 +42,15 @@ export function PasskeyRegisterDialog({
   const [attachment, setAttachment] = useState<AttachmentChoice>('any');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Pre-fill the name with a best-effort device label (#1948) each time the
+  // dialog opens, but never clobber a value the user has already typed. The
+  // field stays editable and falls back to its placeholder when the label is
+  // empty (unrecognized User-Agent).
+  useEffect(() => {
+    if (!open || typeof navigator === 'undefined') return;
+    setName((current) => current || deriveDeviceLabel(navigator.userAgent));
+  }, [open]);
 
   function reset() {
     setName('');

--- a/services/platform/lib/utils/device-label.test.ts
+++ b/services/platform/lib/utils/device-label.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveDeviceLabel } from './device-label';
+
+describe('deriveDeviceLabel', () => {
+  it('returns an empty string for missing or empty input', () => {
+    expect(deriveDeviceLabel('')).toBe('');
+    expect(deriveDeviceLabel(undefined)).toBe('');
+    expect(deriveDeviceLabel(null)).toBe('');
+  });
+
+  it('labels Chrome on macOS', () => {
+    const ua =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    expect(deriveDeviceLabel(ua)).toBe('Chrome on macOS');
+  });
+
+  it('labels Safari on iPhone', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+    expect(deriveDeviceLabel(ua)).toBe('Safari on iPhone');
+  });
+
+  it('labels Chrome on Windows', () => {
+    const ua =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    expect(deriveDeviceLabel(ua)).toBe('Chrome on Windows');
+  });
+
+  it('prefers Edge over Chrome when both tokens are present', () => {
+    const ua =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0';
+    expect(deriveDeviceLabel(ua)).toBe('Edge on Windows');
+  });
+
+  it('detects Firefox on Linux', () => {
+    const ua =
+      'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0';
+    expect(deriveDeviceLabel(ua)).toBe('Firefox on Linux');
+  });
+
+  it('detects Chrome on Android', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36';
+    expect(deriveDeviceLabel(ua)).toBe('Chrome on Android');
+  });
+
+  it('detects Chrome on iOS (CriOS) as Chrome on iPhone', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.0.0 Mobile/15E148 Safari/604.1';
+    expect(deriveDeviceLabel(ua)).toBe('Chrome on iPhone');
+  });
+
+  it('falls back to the OS alone when the browser is unrecognized', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) SomeUnknownAgent/1.0';
+    expect(deriveDeviceLabel(ua)).toBe('Windows');
+  });
+
+  it('returns an empty string when nothing is recognized', () => {
+    expect(deriveDeviceLabel('CustomBot/1.0')).toBe('');
+  });
+});

--- a/services/platform/lib/utils/device-label.ts
+++ b/services/platform/lib/utils/device-label.ts
@@ -1,0 +1,50 @@
+/**
+ * Best-effort, human-readable device label derived from a browser User-Agent
+ * string — used to pre-fill the "Passkey name" field (#1948) with something
+ * recognizable like "Chrome on macOS" or "Safari on iPhone". The result is
+ * always editable and callers fall back to a placeholder when it is empty
+ * (e.g. an unrecognized or missing User-Agent).
+ */
+
+/** Maps a User-Agent to a coarse browser name, or '' when unrecognized. */
+function detectBrowser(userAgent: string): string {
+  // Order matters: Edge/Opera/Brave masquerade as Chrome, and iOS Chrome
+  // (CriOS) / Firefox (FxiOS) wrap WebKit, so the specific tokens win first.
+  if (/\bEdg(?:e|A|iOS)?\//.test(userAgent)) return 'Edge';
+  if (/\b(?:OPR|Opera)\//.test(userAgent)) return 'Opera';
+  if (/\b(?:Firefox|FxiOS)\//.test(userAgent)) return 'Firefox';
+  if (/\b(?:Chrome|CriOS|Chromium)\//.test(userAgent)) return 'Chrome';
+  if (/\bSafari\//.test(userAgent) && /\bVersion\//.test(userAgent)) {
+    return 'Safari';
+  }
+  return '';
+}
+
+/** Maps a User-Agent to a coarse OS / device name, or '' when unrecognized. */
+function detectOS(userAgent: string): string {
+  // Check the mobile/tablet tokens before the desktop ones: iPadOS reports
+  // "Macintosh" in some configurations, and Android contains "Linux".
+  if (/\biPhone\b/.test(userAgent)) return 'iPhone';
+  if (/\biPad\b/.test(userAgent)) return 'iPad';
+  if (/\bAndroid\b/.test(userAgent)) return 'Android';
+  if (/\b(?:Macintosh|Mac OS X)\b/.test(userAgent)) return 'macOS';
+  if (/\bWindows\b/.test(userAgent)) return 'Windows';
+  if (/\bCrOS\b/.test(userAgent)) return 'ChromeOS';
+  if (/\bLinux\b/.test(userAgent)) return 'Linux';
+  return '';
+}
+
+/**
+ * Returns a best-effort label such as "Chrome on macOS". Falls back to just
+ * the browser or just the OS when only one is recognized, and to '' when
+ * neither is — letting the caller use its placeholder instead.
+ */
+export function deriveDeviceLabel(
+  userAgent: string | undefined | null,
+): string {
+  if (!userAgent) return '';
+  const browser = detectBrowser(userAgent);
+  const os = detectOS(userAgent);
+  if (browser && os) return `${browser} on ${os}`;
+  return browser || os || '';
+}


### PR DESCRIPTION
## Summary

Resolves #1948 — the "Passkey name" field now pre-fills with a best-effort, editable device label (e.g. "Chrome on macOS", "Safari on iPhone") derived from the browser User-Agent, instead of starting empty.

## Changes
- Add `lib/utils/device-label.ts` — pure `deriveDeviceLabel(userAgent)` helper mapping a User-Agent to a coarse `Browser on OS` label, with sensible fallbacks (browser-only, OS-only, or empty for unrecognized agents).
- Wire it into `PasskeyRegisterDialog`: on open, prefill the name field with the derived label without clobbering anything the user typed. The field stays editable and falls back to the existing placeholder when the label is empty.
- Add unit tests covering Chrome/Edge/Firefox/Safari across macOS/Windows/Linux/iPhone/Android plus fallback cases.

## Acceptance criteria
- [x] Opening the register dialog shows a sensible, editable default name.

## Verification
- `vitest --project server lib/utils/device-label.test.ts` — 10 passed
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passkey registration now automatically suggests a device label based on your current browser and device when creating a new passkey, helping to identify passphrases. You can still customize this name if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->