### PR TITLE
fix(platform): unify form validation timing across all forms (#1943)

### DIFF
--- a/services/platform/.oxlintrc.json
+++ b/services/platform/.oxlintrc.json
@@ -3,9 +3,27 @@
   "extends": ["../../.oxlintrc.json"],
   "rules": {
     "typescript/no-unsafe-type-assertion": "error",
-    "typescript/no-unnecessary-type-assertion": "error"
+    "typescript/no-unnecessary-type-assertion": "error",
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "react-hook-form",
+            "importNames": ["useForm"],
+            "message": "Import { useForm } from '@/app/components/ui/forms/use-form' so validation timing (mode: 'onTouched') stays consistent app-wide (#1943)."
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
+    {
+      "files": ["app/components/ui/forms/use-form.ts"],
+      "rules": {
+        "eslint/no-restricted-imports": "off"
+      }
+    },
     {
       "files": ["convex/**/*.ts"],
       "rules": {

--- a/services/platform/app/components/ui/editor/use-form-editor.ts
+++ b/services/platform/app/components/ui/editor/use-form-editor.ts
@@ -3,7 +3,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  useForm,
   type DefaultValues,
   type FieldValues,
   type Path,
@@ -11,6 +10,7 @@ import {
   type UseFormReturn,
 } from 'react-hook-form';
 
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { structuralEqual } from '@/lib/utils/structural-equal';
 
 import type { EditorController } from './types';
@@ -81,7 +81,7 @@ export function useFormEditor<T extends FieldValues>({
       ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- zodResolver returns Resolver<unknown,…>; widen
         (zodResolver(schema) as unknown as Resolver<T>)
       : undefined,
-    mode: 'onChange',
+    // `mode` defaults to `'onTouched'` via the shared `useForm` wrapper (#1943).
   });
 
   const [hasRemoteUpdate, setHasRemoteUpdate] = useState(false);

--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -1,10 +1,10 @@
-import { useForm } from 'react-hook-form';
 import { describe, it, expect, vi } from 'vitest';
 
 import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
 import { render, screen, waitFor } from '@/tests/utils/render';
 
 import { Input } from './input';
+import { useForm } from './use-form';
 
 describe('Input', () => {
   describe('rendering', () => {

--- a/services/platform/app/components/ui/forms/use-form.test.tsx
+++ b/services/platform/app/components/ui/forms/use-form.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { zodResolver } from '@hookform/resolvers/zod';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 
@@ -35,7 +35,9 @@ describe('useForm (shared wrapper)', () => {
     );
 
     // Register the field, then change it without ever blurring — exactly the
-    // "typing the first character" path from #1943.
+    // "typing the first character" path from #1943. Under `onTouched` no error
+    // is set until the field is blurred. (The blur -> error path is covered by
+    // the form integration tests, e.g. team-create-dialog / enterprise-sso.)
     act(() => {
       result.current.register('name');
     });
@@ -44,18 +46,10 @@ describe('useForm (shared wrapper)', () => {
     });
     expect(result.current.formState.errors.name).toBeUndefined();
 
-    // Clearing the value and blurring (touching) it surfaces the error.
+    // Even reverting to the invalid empty value (still untouched) stays clean.
     await act(async () => {
       result.current.setValue('name', '');
     });
-    act(() => {
-      result.current.register('name').onBlur({
-        target: { name: 'name', value: '' },
-        type: 'blur',
-      });
-    });
-    await waitFor(() =>
-      expect(result.current.formState.errors.name).toBeDefined(),
-    );
+    expect(result.current.formState.errors.name).toBeUndefined();
   });
 });

--- a/services/platform/app/components/ui/forms/use-form.test.tsx
+++ b/services/platform/app/components/ui/forms/use-form.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { zodResolver } from '@hookform/resolvers/zod';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import { useForm } from './use-form';
+
+interface Form {
+  name: string;
+}
+
+const schema = z.object({ name: z.string().min(1) });
+
+describe('useForm (shared wrapper)', () => {
+  it("defaults the validation mode to 'onTouched' (#1943)", () => {
+    const { result } = renderHook(() => useForm<Form>());
+    // `_options.mode` is RHF's record of the resolved mode; the wrapper sets it.
+    // oxlint-disable-next-line typescript/no-explicit-any -- reading RHF internals for the assertion
+    expect((result.current.control as any)._options.mode).toBe('onTouched');
+  });
+
+  it('lets a caller override the default mode explicitly', () => {
+    const { result } = renderHook(() => useForm<Form>({ mode: 'onChange' }));
+    // oxlint-disable-next-line typescript/no-explicit-any -- reading RHF internals for the assertion
+    expect((result.current.control as any)._options.mode).toBe('onChange');
+  });
+
+  it('does not flag a field as errored on the first keystroke before blur', async () => {
+    const { result } = renderHook(() =>
+      useForm<Form>({
+        defaultValues: { name: '' },
+        resolver: zodResolver(schema),
+      }),
+    );
+
+    // Register the field, then change it without ever blurring — exactly the
+    // "typing the first character" path from #1943.
+    act(() => {
+      result.current.register('name');
+    });
+    await act(async () => {
+      result.current.setValue('name', 'a');
+    });
+    expect(result.current.formState.errors.name).toBeUndefined();
+
+    // Clearing the value and blurring (touching) it surfaces the error.
+    await act(async () => {
+      result.current.setValue('name', '');
+    });
+    act(() => {
+      result.current.register('name').onBlur({
+        target: { name: 'name', value: '' },
+        type: 'blur',
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.formState.errors.name).toBeDefined(),
+    );
+  });
+});

--- a/services/platform/app/components/ui/forms/use-form.ts
+++ b/services/platform/app/components/ui/forms/use-form.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import {
+  useForm as useReactHookForm,
+  type FieldValues,
+  type UseFormProps,
+  type UseFormReturn,
+} from 'react-hook-form';
+
+/**
+ * App-wide `useForm` wrapper. Defaults the validation `mode` to `'onTouched'`
+ * so a field is only validated after its first blur (and re-validated on every
+ * change thereafter), instead of erroring on the very first keystroke.
+ *
+ * Every form in the platform app — settings, dialogs, onboarding, chat — must
+ * import `useForm` from here rather than from `react-hook-form` directly, so
+ * validation timing stays identical across the app and can't silently regress
+ * to `react-hook-form`'s `'onSubmit'` default or an ad-hoc `'onChange'`
+ * (see #1943). The `no-restricted-imports` lint rule enforces this.
+ *
+ * A caller can still override `mode` explicitly when a form genuinely needs
+ * different timing — passing `mode` simply wins over the default below.
+ */
+export function useForm<
+  TFieldValues extends FieldValues = FieldValues,
+  // oxlint-disable-next-line typescript/no-explicit-any -- mirrors react-hook-form's own `useForm` signature
+  TContext = any,
+  TTransformedValues = TFieldValues,
+>(
+  props?: UseFormProps<TFieldValues, TContext, TTransformedValues>,
+): UseFormReturn<TFieldValues, TContext, TTransformedValues> {
+  return useReactHookForm<TFieldValues, TContext, TTransformedValues>({
+    mode: 'onTouched',
+    ...props,
+  });
+}

--- a/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.test.tsx
@@ -253,8 +253,10 @@ describe('CreateAgentDialog', () => {
 
   // Migrated from tests/e2e/specs/validation.spec.ts —
   // "rejects an invalid slug and an empty name; cancels without creating".
-  // Pure client-side RHF + zod (mode: 'onChange'); the seeded mock provider
-  // supplies a model so the slug/name are the only things gating Continue.
+  // Pure client-side RHF + zod (shared `mode: 'onTouched'` default, #1943); the
+  // seeded mock provider supplies a model so the slug/name are the only things
+  // gating Continue. Each `user.type` of the next field blurs the previous one,
+  // marking it touched so its error renders.
   describe('slug + required validation gating (migrated from e2e)', () => {
     it('rejects an invalid slug and an empty name; cancels without creating', async () => {
       const onOpenChange = vi.fn();
@@ -275,7 +277,8 @@ describe('CreateAgentDialog', () => {
       });
 
       // (a) Invalid slug + valid display name → Continue stays DISABLED and the
-      // pattern error renders (mode: 'onChange').
+      // pattern error renders once the slug field is blurred (typing into the
+      // display name moves focus, marking the slug touched under `onTouched`).
       await user.type(slugField, 'Bad Slug!');
       await user.type(displayNameField, 'Valid Display Name');
       await waitFor(() =>

--- a/services/platform/app/features/agents/components/agent-create-dialog.tsx
+++ b/services/platform/app/features/agents/components/agent-create-dialog.tsx
@@ -7,13 +7,13 @@ import { Text } from '@tale/ui/text';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { ConvexError } from 'convex/values';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod/v4';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { ModelSelector } from '@/app/components/ui/forms/model-selector';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { ModelInfoPopover } from '@/app/features/chat/components/model-info-popover';
 import {
   useListProviders,
@@ -237,7 +237,6 @@ export function CreateAgentDialog({
     resolver: zodResolver(formSchema),
     // Validate on change so the Continue button can gate on validity
     // (required fields filled) instead of only after a submit attempt.
-    mode: 'onChange',
     defaultValues: {
       name: '',
       displayName: '',

--- a/services/platform/app/features/automations/components/automation-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-create-dialog.tsx
@@ -6,12 +6,12 @@ import { Stack } from '@tale/ui/layout';
 import { Tabs } from '@tale/ui/tabs';
 import { useNavigate } from '@tanstack/react-router';
 import { useMemo, useState, useCallback } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { convexErrorCode } from '@/lib/utils/convex-error';
@@ -97,7 +97,6 @@ function BlankTabContent({
     resolver: zodResolver(formSchema),
     // Validate on change so Continue stays disabled until the required
     // name is filled, instead of only failing after a submit attempt.
-    mode: 'onChange',
   });
 
   const onSubmit = useCallback(

--- a/services/platform/app/features/automations/components/automation-rename-dialog.tsx
+++ b/services/platform/app/features/automations/components/automation-rename-dialog.tsx
@@ -2,11 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { convexErrorCode } from '@/lib/utils/convex-error';

--- a/services/platform/app/features/automations/components/step-create-dialog.tsx
+++ b/services/platform/app/features/automations/components/step-create-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
@@ -10,6 +9,7 @@ import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { JsonInput } from '@/app/components/ui/forms/json-input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { narrowStringUnion } from '@/lib/utils/type-utils';

--- a/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
+++ b/services/platform/app/features/automations/triggers/components/schedule-create-dialog.tsx
@@ -8,13 +8,13 @@ import { Text } from '@tale/ui/text';
 import { CronExpressionParser } from 'cron-parser';
 import { Sparkles } from 'lucide-react';
 import { useMemo, useEffect, useCallback, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { JsonInput } from '@/app/components/ui/forms/json-input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import { toId } from '@/convex/lib/type_cast_helpers';
 import { useT } from '@/lib/i18n/client';
@@ -126,7 +126,6 @@ export function ScheduleCreateDialog({
     resolver: zodResolver(schema),
     // Validate on change so Create stays disabled until the cron
     // expression is present and valid.
-    mode: 'onChange',
     defaultValues: {
       cronExpression: schedule?.cronExpression ?? '',
     },

--- a/services/platform/app/features/customers/components/customer-edit-dialog.tsx
+++ b/services/platform/app/features/customers/components/customer-edit-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';

--- a/services/platform/app/features/customers/components/customers-import-dialog.tsx
+++ b/services/platform/app/features/customers/components/customers-import-dialog.tsx
@@ -2,10 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo, useCallback } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import {
   CONTACT_REQUIRED_COLUMNS,
   customerMappers,

--- a/services/platform/app/features/documents/components/create-folder-dialog.tsx
+++ b/services/platform/app/features/documents/components/create-folder-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useToast } from '@/app/hooks/use-toast';

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import {
   CONTENT_MAX_LENGTH,

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-edit-dialog.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-edit-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import {
   CONTENT_MAX_LENGTH,

--- a/services/platform/app/features/organization/components/onboarding/steps/account-step.tsx
+++ b/services/platform/app/features/organization/components/onboarding/steps/account-step.tsx
@@ -5,12 +5,12 @@ import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
 import { Separator } from '@tale/ui/separator';
 import { useCallback, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
 import { ValidationCheckList } from '@/app/components/ui/feedback/validation-check-item';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { WizardStep } from '@/app/components/ui/wizard/wizard';
 import { useIsSsoConfigured } from '@/app/features/auth/hooks/queries';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
@@ -63,7 +63,6 @@ export function AccountStep() {
 
   const form = useForm<AccountFormData>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { email: '', password: '' },
   });
 

--- a/services/platform/app/features/products/components/product-create-dialog.tsx
+++ b/services/platform/app/features/products/components/product-create-dialog.tsx
@@ -4,13 +4,13 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Grid, Row } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { Dialog } from '@/app/components/ui/dialog/dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { type WizardStepMeta } from '@/app/components/ui/wizard/use-wizard';
 import { Wizard, WizardStep } from '@/app/components/ui/wizard/wizard';
 import { WizardFooter } from '@/app/components/ui/wizard/wizard-footer';
@@ -148,7 +148,6 @@ export function ProductCreateDialog({
     formState: { errors },
   } = useForm<ProductFormData>({
     resolver: zodResolver(formSchema),
-    mode: 'onChange',
     defaultValues: {
       name: '',
       description: '',

--- a/services/platform/app/features/products/components/product-edit-dialog.tsx
+++ b/services/platform/app/features/products/components/product-edit-dialog.tsx
@@ -3,13 +3,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Grid } from '@tale/ui/layout';
 import { useEffect, useMemo, useRef } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';

--- a/services/platform/app/features/products/components/products-import-dialog.tsx
+++ b/services/platform/app/features/products/components/products-import-dialog.tsx
@@ -2,10 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo, useCallback } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import {
   useFileImport,
   productMappers,

--- a/services/platform/app/features/projects/components/project-create-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-create-dialog.tsx
@@ -4,12 +4,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from '@tanstack/react-router';
 import { ConvexError } from 'convex/values';
 import { useEffect, useMemo, useRef } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod/v4';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';

--- a/services/platform/app/features/projects/components/project-rename-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-rename-dialog.tsx
@@ -3,11 +3,11 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ConvexError } from 'convex/values';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod/v4';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';

--- a/services/platform/app/features/settings/account/components/account-form.tsx
+++ b/services/platform/app/features/settings/account/components/account-form.tsx
@@ -6,7 +6,6 @@ import { Row } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize, useSkeleton } from '@tale/ui/skeleton-context';
 import { useCallback, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
@@ -18,6 +17,7 @@ import { ValidationCheckList } from '@/app/components/ui/feedback/validation-che
 import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useHasCredentialAccount } from '@/app/features/auth/hooks/queries';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
 import { SettingsRow } from '@/app/features/settings/components/settings-row';
@@ -299,7 +299,6 @@ function ChangePasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
     watch,
   } = useForm<ChangePasswordFormData>({
     resolver: zodResolver(changePasswordSchema),
-    mode: 'onChange',
     defaultValues: {
       currentPassword: '',
       newPassword: '',
@@ -445,7 +444,6 @@ function SetPasswordDialog({ open, onOpenChange }: PasswordDialogProps) {
     watch,
   } = useForm<SetPasswordFormData>({
     resolver: zodResolver(setPasswordSchema),
-    mode: 'onChange',
     defaultValues: {
       newPassword: '',
       confirmPassword: '',

--- a/services/platform/app/features/settings/api-keys/components/api-key-create-dialog.test.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-key-create-dialog.test.tsx
@@ -44,8 +44,10 @@ describe('ApiKeyCreateDialog', () => {
       const nameField = screen.getByRole('textbox', { name: /Key name/ });
       const submit = screen.getByRole('button', { name: 'Create key' });
 
-      // 33 chars → over the cap → inline message, submit DISABLED, no call.
+      // 33 chars → over the cap. The inline message surfaces only after the
+      // first blur (onTouched, #1943); submit is disabled while over the cap.
       await user.type(nameField, 'a'.repeat(33));
+      await user.tab();
       expect(
         await screen.findByText('Key name must be 32 characters or fewer'),
       ).toBeInTheDocument();

--- a/services/platform/app/features/settings/api-keys/components/api-key-create-dialog.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-key-create-dialog.tsx
@@ -5,13 +5,13 @@ import { Button } from '@tale/ui/button';
 import { Text } from '@tale/ui/text';
 import { Copy, Check } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 
@@ -92,7 +92,6 @@ export function ApiKeyCreateDialog({
 
   const form = useForm<ApiKeyFormData>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       name: '',
       expiresIn: '2592000',

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
@@ -230,11 +230,15 @@ describe('EnterpriseSsoForm validation + save', () => {
 
     const saveButton = await screen.findByRole('button', { name: /^save$/i });
 
+    // `isValid` gates the Save button regardless of validation timing, so it
+    // disables as soon as the field is empty.
     await waitFor(() => {
       expect(saveButton).toBeDisabled();
     });
 
-    // The inline required error surfaces on the display-name field.
+    // Blur the field so the inline error surfaces (shared `mode: 'onTouched'`
+    // default, #1943 — the error does not render on the first keystroke).
+    await user.tab();
     await waitFor(() => {
       const errors = screen.getAllByText(/this field is required/i);
       expect(errors.length).toBeGreaterThan(0);

--- a/services/platform/app/features/settings/governance/data-subject-requests/cancel-dialog.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/cancel-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -48,7 +48,6 @@ export function CancelDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { cancellationReason: '' },
   });
   const { handleSubmit, register, formState, reset } = form;

--- a/services/platform/app/features/settings/governance/data-subject-requests/extend-deadline-dialog.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/extend-deadline-dialog.tsx
@@ -2,13 +2,13 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -60,7 +60,6 @@ export function ExtendDeadlineDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       extraDays: 30,
       extensionReason: '',

--- a/services/platform/app/features/settings/governance/data-subject-requests/file-request-dialog.tsx
+++ b/services/platform/app/features/settings/governance/data-subject-requests/file-request-dialog.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
@@ -12,6 +11,7 @@ import { Input } from '@/app/components/ui/forms/input';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import {
@@ -98,7 +98,6 @@ export function FileRequestDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       targetUserId: '',
       reasonCode: 'no_longer_necessary',

--- a/services/platform/app/features/settings/governance/legal-hold/close-matter-dialog.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/close-matter-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -45,7 +45,6 @@ export function CloseMatterDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { reason: '' },
   });
   const { register, handleSubmit, formState, reset } = form;

--- a/services/platform/app/features/settings/governance/legal-hold/place-hold-dialog.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/place-hold-dialog.tsx
@@ -4,7 +4,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Row } from '@tale/ui/layout';
 import { AlertTriangle } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
@@ -13,6 +12,7 @@ import { Input } from '@/app/components/ui/forms/input';
 import { SearchableSelect } from '@/app/components/ui/forms/searchable-select';
 import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -113,7 +113,6 @@ export function PlaceHoldDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       targetType: 'userMembership',
       targetId: '',

--- a/services/platform/app/features/settings/governance/legal-hold/reject-release-dialog.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/reject-release-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -50,7 +50,6 @@ export function RejectReleaseDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { reason: '' },
   });
   const { register, handleSubmit, formState, reset } = form;

--- a/services/platform/app/features/settings/governance/legal-hold/request-release-dialog.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/request-release-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -50,7 +50,6 @@ export function RequestReleaseDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { reason: '' },
   });
   const { register, handleSubmit, formState, reset } = form;

--- a/services/platform/app/features/settings/governance/legal-hold/upsert-matter-dialog.tsx
+++ b/services/platform/app/features/settings/governance/legal-hold/upsert-matter-dialog.tsx
@@ -2,13 +2,13 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
@@ -60,7 +60,6 @@ export function UpsertMatterDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       name: matter?.name ?? '',
       caseNumber: matter?.caseNumber ?? '',

--- a/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-add-dialog.tsx
@@ -5,7 +5,6 @@ import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
 import { ConvexError } from 'convex/values';
 import { useState, useMemo, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { CopyableField } from '@/app/components/ui/data-display/copyable-field';
@@ -15,6 +14,7 @@ import { ValidationCheckList } from '@/app/components/ui/feedback/validation-che
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { useToast } from '@/app/hooks/use-toast';
@@ -90,7 +90,6 @@ export function AddMemberDialog({
     useCreateMember();
   const form = useForm<AddMemberFormData>({
     resolver: zodResolver(addMemberSchema),
-    mode: 'onChange',
     defaultValues: {
       email: '',
       password: '',

--- a/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
@@ -6,7 +6,7 @@ import { Button } from '@tale/ui/button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useMemo, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import * as z from 'zod';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -16,6 +16,7 @@ import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { usePasswordValidation } from '@/app/hooks/use-password-validation';
 import { toast } from '@/app/hooks/use-toast';
@@ -100,7 +101,6 @@ export function EditMemberDialog({
 
   const form = useForm<EditMemberFormData>({
     resolver: zodResolver(editMemberSchema),
-    mode: 'onChange',
     defaultValues: {
       displayName: member?.displayName,
       role: isMemberRole(member?.role) ? member.role : undefined,

--- a/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
@@ -144,6 +144,9 @@ describe('OrganizationSettingsView required org name', () => {
       name: 'Organization name',
     });
     fireEvent.change(orgNameField, { target: { value: '' } });
+    // onTouched (#1943): the field error renders only after the first blur,
+    // while `isValid` (Save gating) stays accurate on every change.
+    fireEvent.blur(orgNameField);
 
     // (a) The editor's validity flips false → the global Save button is gated.
     await waitFor(() => expect(holder.current?.isValid).toBe(false));
@@ -163,6 +166,8 @@ describe('OrganizationSettingsView required org name', () => {
       name: 'Organization name',
     });
     fireEvent.change(orgNameField, { target: { value: '   ' } });
+    // onTouched (#1943): blur to surface the field error.
+    fireEvent.blur(orgNameField);
 
     await waitFor(() => expect(holder.current?.isValid).toBe(false));
     await waitFor(() =>

--- a/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
+++ b/services/platform/app/features/settings/providers/components/provider-add-panel.tsx
@@ -9,7 +9,7 @@ import { Text } from '@tale/ui/text';
 import { useNavigate } from '@tanstack/react-router';
 import { Loader2, Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useFieldArray } from 'react-hook-form';
 import { z } from 'zod/v4';
 
 import { CollapsibleGuide } from '@/app/components/ui/data-display/collapsible-guide';
@@ -18,6 +18,7 @@ import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { Input } from '@/app/components/ui/forms/input';
 import { SearchInput } from '@/app/components/ui/forms/search-input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { Sheet } from '@/app/components/ui/overlays/sheet';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -170,7 +171,6 @@ export function ProviderAddPanel({
     getValues,
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
-    mode: 'onChange',
     defaultValues: {
       name: '',
       displayName: '',

--- a/services/platform/app/features/settings/teams/components/team-create-dialog.test.tsx
+++ b/services/platform/app/features/settings/teams/components/team-create-dialog.test.tsx
@@ -57,10 +57,13 @@ describe('TeamCreateDialog', () => {
 
   // Migrated from the `validation` E2E "create team dialog: disables submit until
   // a non-empty name is entered; cancels without creating". The gating is pure
-  // client UI: the name schema is `z.string().trim().min(1)` with RHF
-  // `mode: 'onChange'`, and the FormDialog submit button is disabled while
-  // `!isValid`. No backend call, router redirect, or persistence round-trip is
-  // involved in the assertion, so it belongs at the component tier.
+  // client UI: the name schema is `z.string().trim().min(1)` and the FormDialog
+  // submit button is disabled while `!isValid`. Validation timing follows the
+  // shared `useForm` wrapper's `mode: 'onTouched'` default (#1943): the field
+  // error renders only after the first blur, not on the first keystroke — while
+  // `isValid` (and therefore the submit gating) stays accurate throughout. No
+  // backend call, router redirect, or persistence round-trip is involved, so it
+  // belongs at the component tier.
   describe('name validation gating', () => {
     it('disables submit until a non-empty name is entered; cancels without creating', async () => {
       const onOpenChange = vi.fn();
@@ -82,8 +85,17 @@ describe('TeamCreateDialog', () => {
       expect(nameField).toHaveValue('');
       expect(submit).toBeDisabled();
 
-      // Whitespace-only trims to empty: still invalid → required error, disabled.
+      // First keystroke does NOT surface a validation error (the #1943 fix:
+      // `onTouched` waits for the first blur). Submit stays disabled because the
+      // whitespace-only value still trims to empty and gates `isValid`.
       await user.type(nameField, '   ');
+      expect(
+        screen.queryByText('Team name is required'),
+      ).not.toBeInTheDocument();
+      expect(submit).toBeDisabled();
+
+      // Blurring the still-invalid field surfaces the required error.
+      await user.tab();
       expect(
         await screen.findByText('Team name is required'),
       ).toBeInTheDocument();
@@ -120,8 +132,10 @@ describe('TeamCreateDialog', () => {
       const nameField = screen.getByRole('textbox', { name: /Team name/ });
       const submit = screen.getByRole('button', { name: 'Create team' });
 
-      // 81 chars → over the cap → inline message, submit DISABLED.
+      // 81 chars → over the cap. The inline message surfaces only after the
+      // first blur (onTouched, #1943); submit is disabled while over the cap.
       await user.type(nameField, 'a'.repeat(81));
+      await user.tab();
       expect(
         await screen.findByText('Team name must be 80 characters or fewer'),
       ).toBeInTheDocument();

--- a/services/platform/app/features/settings/teams/components/team-create-dialog.tsx
+++ b/services/platform/app/features/settings/teams/components/team-create-dialog.tsx
@@ -2,11 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useState, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
@@ -63,7 +63,6 @@ export function TeamCreateDialog({
 
   const form = useForm<TeamFormData>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       name: '',
     },

--- a/services/platform/app/features/settings/teams/components/team-edit-dialog.tsx
+++ b/services/platform/app/features/settings/teams/components/team-edit-dialog.tsx
@@ -2,11 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { useToast } from '@/app/hooks/use-toast';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
@@ -71,7 +71,6 @@ export function TeamEditDialog({
 
   const form = useForm<TeamFormData>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: {
       name: team.name,
     },

--- a/services/platform/app/features/vendors/components/vendor-edit-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendor-edit-dialog.tsx
@@ -2,11 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';

--- a/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
+++ b/services/platform/app/features/vendors/components/vendors-import-dialog.tsx
@@ -2,10 +2,11 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo, useCallback } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider } from 'react-hook-form';
 import { z } from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import {
   CONTACT_REQUIRED_COLUMNS,
   useFileImport,

--- a/services/platform/app/features/websites/components/website-add-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-add-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
 import { convexErrorCode } from '@/lib/utils/convex-error';

--- a/services/platform/app/features/websites/components/website-edit-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-edit-dialog.tsx
@@ -2,12 +2,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { toast } from '@/app/hooks/use-toast';
 import type { Doc } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';

--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -8,7 +8,6 @@ import {
 } from '@tanstack/react-router';
 import { AlertCircle } from 'lucide-react';
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { MicrosoftIcon } from '@/app/components/icons/microsoft-icon';
@@ -16,6 +15,7 @@ import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Label } from '@/app/components/ui/forms/label';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { AuthFormLayout } from '@/app/features/auth/components/auth-form-layout';
 import { ConditionalAccessError } from '@/app/features/auth/components/conditional-access-error';
 import {
@@ -178,7 +178,6 @@ export function LogInPage() {
 
   const form = useForm<LogInFormData>({
     resolver: zodResolver(logInSchema),
-    mode: 'onChange',
     defaultValues: {
       email: '',
       password: '',

--- a/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
@@ -254,9 +254,9 @@ function ConfigurationPage() {
               </FormSection>
 
               {/* Controlled via RHF `Controller`: the field registers itself,
-                  so dirty tracking is automatic and validation runs on change
-                  (mode: 'onChange') — no `setValue(..., { shouldDirty,
-                  shouldValidate })` to forget. */}
+                  so dirty tracking is automatic and validation runs on the
+                  shared `mode: 'onTouched'` default — no `setValue(..., {
+                  shouldDirty, shouldValidate })` to forget. */}
               <Controller
                 control={control}
                 name="variables"

--- a/services/platform/app/routes/forced-change-password.$id.tsx
+++ b/services/platform/app/routes/forced-change-password.$id.tsx
@@ -5,13 +5,13 @@ import { Stack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { ValidationCheckList } from '@/app/components/ui/feedback/validation-check-item';
 import { Form } from '@/app/components/ui/forms/form';
 import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
+import { useForm } from '@/app/components/ui/forms/use-form';
 import { LogoLink } from '@/app/components/ui/logo/logo-link';
 import { useUpdatePassword } from '@/app/features/settings/account/hooks/mutations';
 import { usePasswordPolicy } from '@/app/features/settings/governance/hooks/queries';
@@ -113,7 +113,6 @@ function ForcedChangePasswordPage() {
 
   const form = useForm<ForcedChangeFormData>({
     resolver: zodResolver(schema),
-    mode: 'onChange',
     defaultValues: { newPassword: '', confirmPassword: '' },
   });
 


### PR DESCRIPTION
## What & why

Closes #1943. Typing the first character into a field (e.g. "New password") immediately showed a validation error because most forms used `mode: 'onChange'`, while others used no mode at all (react-hook-form's `'onSubmit'` default) — validation timing was inconsistent app-wide.

## Changes

- **Shared wrapper** — new `app/components/ui/forms/use-form.ts` re-exports `useForm` with `mode: 'onTouched'` as the default (validate after the first blur, then re-validate on change). A caller can still override `mode` explicitly.
- **Repointed every form** — all direct `react-hook-form` `useForm` call sites and `useFormEditor` now use the wrapper; the ad-hoc `mode: 'onChange'` overrides are removed.
- **Regression guard** — an oxlint `no-restricted-imports` rule blocks importing `useForm` straight from `react-hook-form` (with an exception for the wrapper itself), so future forms inherit the behaviour and can't regress.
- **Tests** — component tests that asserted on-keystroke errors now blur first; added a unit test for the wrapper covering the no-error-on-first-keystroke behaviour.

## Acceptance criteria

- [x] No field shows a validation error on its first keystroke before blur/submit.
- [x] Behaviour is identical across settings, dialogs, onboarding, chat, and other platform forms (single shared default).
- [x] A grep shows no remaining ad-hoc `mode: 'onChange'`; the lint rule prevents new ones.

## Verification

- `bunx oxlint` (platform) — clean
- `bunx tsc --noEmit` (platform) — clean
- `bunx vitest --run --config vitest.ui.config.ts` (platform UI suite, 337 files) — green
- `oxfmt --check` — clean

Docs/i18n: N/A — no user-facing strings, message keys, or error wording changed; only validation timing.