### PR TITLE
fix(platform): seed enterprise sso form select/switch with defined defaults (#2095)

### DIFF
--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
@@ -319,6 +319,42 @@ describe('EnterpriseSsoForm validation + save', () => {
     });
   });
 
+  it('does not log uncontrolled→controlled warnings when config resolves after load', async () => {
+    // Regression (#2095): the Select/Switch fields must be controlled from the
+    // first render. When `config` is undefined the seeded `data` is undefined,
+    // so `field.value` is undefined — without a defined fallback the controls
+    // mount uncontrolled, then warn once `config` hydrates them.
+    // Radix's `useControllableState` reports the transition via `console.warn`
+    // (React's native uncontrolled→controlled warning targets DOM inputs; these
+    // are button-based Radix controls), so spy on `warn`.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { rerender } = renderForm(undefined);
+
+      // Resolve the config — the form seeds its real values.
+      rerender(
+        <AbilityContext.Provider value={adminAbility}>
+          <ActiveEditorProvider>
+            <HeaderSlot />
+            <EnterpriseSsoForm organizationId="org-1" config={connectedOidc} />
+          </ActiveEditorProvider>
+        </AbilityContext.Provider>,
+      );
+
+      await screen.findByDisplayValue('Acme SSO');
+
+      const warned = warnSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === 'string' && /uncontrolled.*controlled/i.test(arg),
+        ),
+      );
+      expect(warned).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('blocks the test action and does not call testConnection when invalid', async () => {
     testConnMock.mockClear();
     const { user } = renderForm(unconfigured);

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -605,6 +605,9 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
                   id="sso-protocol"
                   label={t('integrations.enterpriseSso.protocolLabel')}
                   description={t('integrations.enterpriseSso.protocolHelp')}
+                  // Default to a defined value so the Select is controlled from
+                  // the first render — `field.value` is undefined while `data`
+                  // is still loading (avoids the uncontrolled→controlled warning).
                   value={field.value ?? 'entra-id'}
                   onValueChange={(value) => {
                     const next = narrowStringUnion<UiProtocol>(
@@ -716,7 +719,9 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
                 name="pkce"
                 render={({ field }) => (
                   <Switch
-                    checked={field.value}
+                    // `false` until `data` loads so the Switch stays controlled
+                    // from the first render (no uncontrolled→controlled warning).
+                    checked={field.value ?? false}
                     onCheckedChange={field.onChange}
                     label={t('integrations.enterpriseSso.pkceLabel')}
                   />
@@ -795,6 +800,9 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
                 <Select
                   id="sso-default-role"
                   label={t('integrations.enterpriseSso.defaultRoleLabel')}
+                  // Default to a defined value so the Select is controlled from
+                  // the first render — `field.value` is undefined while `data`
+                  // is still loading (avoids the uncontrolled→controlled warning).
                   value={field.value ?? 'member'}
                   onValueChange={(value) => {
                     const r = narrowStringUnion<PlatformRole>(value, [
@@ -814,6 +822,8 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
               name="autoRole"
               render={({ field }) => (
                 <Switch
+                  // `false` until `data` loads so the Switch stays controlled
+                  // from the first render (no uncontrolled→controlled warning).
                   checked={field.value ?? false}
                   onCheckedChange={field.onChange}
                   label={t('integrations.enterpriseSso.autoRoleLabel')}
@@ -826,6 +836,8 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
               name="autoTeam"
               render={({ field }) => (
                 <Switch
+                  // `false` until `data` loads so the Switch stays controlled
+                  // from the first render (no uncontrolled→controlled warning).
                   checked={field.value ?? false}
                   onCheckedChange={field.onChange}
                   label={t('integrations.enterpriseSso.autoTeamLabel')}


### PR DESCRIPTION
## Summary

Fixes #2095 — the Enterprise SSO settings form logged five React/Radix `uncontrolled→controlled` warnings on load.

While the parent config query is loading, the seeded `data` is `undefined`, so each `Controller`'s `field.value` is `undefined`. The Radix `Select` and `Switch` controls therefore mounted **uncontrolled**, then flipped to **controlled** once the config hydrated — Radix's `useControllableState` emits a `console.warn` on that transition (2 Selects + 3 Switches = 5 warnings).

## Fix

Provide a defined fallback at each render point so the controls are controlled from the first render:
- Selects (`protocol`, `defaultRole`): `value={field.value ?? ''}`
- Switches (`pkce`, `autoRole`, `autoTeam`): `checked={field.value ?? false}`

`editor.isLoading` (which drives the disabled/loading state) still derives from `data === undefined`, so the loading behaviour is unchanged — only the per-field control values gain a defined default.

## Test

Added a regression test that mounts the form with `config={undefined}`, resolves it, and asserts no `uncontrolled→controlled` warning is logged (spying on `console.warn`, which is where Radix reports it). Verified it fails without the fix and passes with it.

## Verification
- `vitest --project client` (form test file): 9 passed
- `oxlint --type-aware`: 0 warnings, 0 errors
- `tsc --noEmit`: clean