### PR TITLE
fix(platform): stop sandbox-agent 401 from laundering into a fake success

### DIFF
--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -969,6 +969,7 @@ import type * as node_only_sandbox_integration_skills from "../node_only/sandbox
 import type * as node_only_sandbox_internal_actions from "../node_only/sandbox/internal_actions.js";
 import type * as node_only_sandbox_llm_gateway_admin from "../node_only/sandbox/llm_gateway_admin.js";
 import type * as node_only_sandbox_quiet_idle from "../node_only/sandbox/quiet_idle.js";
+import type * as node_only_sandbox_resume_rotation from "../node_only/sandbox/resume_rotation.js";
 import type * as node_only_sandbox_run_agent from "../node_only/sandbox/run_agent.js";
 import type * as node_only_sandbox_session_admin_actions from "../node_only/sandbox/session_admin_actions.js";
 import type * as node_only_sandbox_session_credentials from "../node_only/sandbox/session_credentials.js";
@@ -2558,6 +2559,7 @@ declare const fullApi: ApiFromModules<{
   "node_only/sandbox/internal_actions": typeof node_only_sandbox_internal_actions;
   "node_only/sandbox/llm_gateway_admin": typeof node_only_sandbox_llm_gateway_admin;
   "node_only/sandbox/quiet_idle": typeof node_only_sandbox_quiet_idle;
+  "node_only/sandbox/resume_rotation": typeof node_only_sandbox_resume_rotation;
   "node_only/sandbox/run_agent": typeof node_only_sandbox_run_agent;
   "node_only/sandbox/session_admin_actions": typeof node_only_sandbox_session_admin_actions;
   "node_only/sandbox/session_credentials": typeof node_only_sandbox_session_credentials;

--- a/services/platform/convex/agents/external_agent/run_external_agent.ts
+++ b/services/platform/convex/agents/external_agent/run_external_agent.ts
@@ -902,6 +902,9 @@ export const runExternalAgentTurn = internalAction({
       // re-run — up to MAX_TOKEN_ATTEMPTS total, while enough window remains.
       // Reuses the empty-turn retry's exec-row turnover fence (stamp B → claim+
       // park A). A `running` handoff is not a failure and never rotates.
+      // The durable workflow path has a sibling loop (workflow_sandbox_exec) that
+      // also rotates on RESUMED segments via `--resume`; the two are deliberately
+      // NOT shared — this one carries op-row fencing the workflow path lacks.
       let tokenAttempt = 1;
       if (tokenPool !== null) {
         const pool = tokenPool;

--- a/services/platform/convex/agents/external_agent/turn_lifecycle.test.ts
+++ b/services/platform/convex/agents/external_agent/turn_lifecycle.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../node_only/sandbox/helpers/session_client', () => ({
 
 import type { RunAgentInSessionResult } from '../../node_only/sandbox/run_agent';
 import {
+  agentErrorMessage,
   EMPTY_TURN_MESSAGE,
   handleTurnOutcome,
   isEmptyCompletedTurn,
@@ -249,6 +250,70 @@ describe('handleTurnOutcome — terminal status mapping', () => {
     expect(claims).toHaveLength(1);
   });
 
+  it('completed + isError → FAILED bubble carrying the error text (laundered 401)', async () => {
+    const ctx = createMockCtx();
+    const result: RunAgentInSessionResult = {
+      status: 'completed',
+      exitCode: 0,
+      isError: true,
+      apiErrorStatus: 401,
+      finalText: 'API Error: 401 Invalid authentication credentials',
+    };
+
+    await handleTurnOutcome(ctx as unknown as ActionCtx, makeTurn(), result);
+
+    const calls = updateMessageCalls(ctx);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toEqual({
+      messageId: 'msg_1',
+      patch: {
+        status: 'failed',
+        message: {
+          role: 'assistant',
+          content: 'API Error: 401 Invalid authentication credentials',
+        },
+      },
+    });
+  });
+
+  it('completed + isError with no usable text → failed bubble with the status fallback', async () => {
+    const ctx = createMockCtx();
+    const result: RunAgentInSessionResult = {
+      status: 'completed',
+      exitCode: 0,
+      isError: true,
+      apiErrorStatus: 401,
+      assistantContent: '',
+    };
+
+    await handleTurnOutcome(ctx as unknown as ActionCtx, makeTurn(), result);
+
+    const calls = updateMessageCalls(ctx);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toEqual({
+      messageId: 'msg_1',
+      patch: {
+        status: 'failed',
+        message: { role: 'assistant', content: agentErrorMessage(401) },
+      },
+    });
+  });
+
+  it('REGRESSION: completed without isError stays success', async () => {
+    const ctx = createMockCtx();
+    const result: RunAgentInSessionResult = {
+      status: 'completed',
+      exitCode: 0,
+      assistantContent: 'All done.',
+    };
+
+    await handleTurnOutcome(ctx as unknown as ActionCtx, makeTurn(), result);
+
+    const calls = updateMessageCalls(ctx);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toMatchObject({ patch: { status: 'success' } });
+  });
+
   it('an empty FINAL segment of a resumed turn keeps the success fallback', async () => {
     const ctx = createMockCtx();
     const turn: TurnContext = { ...makeTurn(), continuationCount: 2 };
@@ -352,6 +417,17 @@ describe('isEmptyCompletedTurn', () => {
       isEmptyCompletedTurn(
         { status: 'completed', planText: '# plan', assistantContent: '' },
         'plan',
+      ),
+    ).toBe(false);
+  });
+
+  it('false when the turn carried a terminal API error (a blank 401 is NOT empty)', () => {
+    // A blank-but-errored turn must route to the failed-bubble rendering, not
+    // the empty-retry that would re-run it against the same dead token.
+    expect(
+      isEmptyCompletedTurn(
+        { status: 'completed', finalText: '', isError: true },
+        undefined,
       ),
     ).toBe(false);
   });

--- a/services/platform/convex/agents/external_agent/turn_lifecycle.ts
+++ b/services/platform/convex/agents/external_agent/turn_lifecycle.ts
@@ -496,11 +496,20 @@ export async function handleTurnOutcome(
     return;
   }
 
+  // A terminal API error (401/403/429/5xx) is laundered by Claude Code into a
+  // `completed` result carrying `is_error:true` (see isRetryableExecutionError /
+  // the parse.ts subtype mapping). Treat it as FAILED so the chat never renders
+  // a blown-up turn as a success bubble. No throw here — the chat turn has no
+  // workflow-step retry, so surfacing the error in a failed bubble is the right
+  // shape (the task/sandbox path throws + retries instead).
+  const errored = result.isError === true;
   const finalText =
     result.finalText ??
-    (result.status === 'completed'
-      ? 'Agent run completed.'
-      : `Agent run ${result.status}.`);
+    (errored
+      ? agentErrorMessage(result.apiErrorStatus)
+      : result.status === 'completed'
+        ? 'Agent run completed.'
+        : `Agent run ${result.status}.`);
   const content =
     result.assistantContent !== undefined &&
     (typeof result.assistantContent !== 'string' ||
@@ -511,7 +520,7 @@ export async function handleTurnOutcome(
     ctx,
     turn.assistantMessageId,
     content,
-    result.status === 'completed' ? 'success' : 'failed',
+    result.status === 'completed' && !errored ? 'success' : 'failed',
   );
   // Plan proposal → approval card (any terminal status except cancelled — a
   // plan captured before a max-turns/error end is still worth reviewing).
@@ -612,10 +621,15 @@ export function resolvePlanText(
 export function isEmptyCompletedTurn(
   result: Pick<
     RunAgentInSessionResult,
-    'status' | 'finalText' | 'assistantContent' | 'planText'
+    'status' | 'finalText' | 'assistantContent' | 'planText' | 'isError'
   >,
   permissionMode: 'plan' | 'execute' | undefined,
 ): boolean {
+  // A terminal API error is NOT an "empty" turn — it's a failure with a cause.
+  // Excluding it here stops the one-shot empty-retry (run_external_agent) from
+  // re-running a blank 401 against the same dead token, and routes it to the
+  // failed-bubble rendering in handleTurnOutcome instead.
+  if (result.isError === true) return false;
   return (
     result.status === 'completed' &&
     (result.finalText ?? '').trim() === '' &&
@@ -629,6 +643,17 @@ export function isEmptyCompletedTurn(
  * affordance shows. */
 export const EMPTY_TURN_MESSAGE =
   'The agent returned no output — the model response came back empty. Please try again.';
+
+/** Stored message text for a turn that ended on a terminal API error (the
+ * laundered-401 case) but left no usable final text — a blank error bubble
+ * would read as "nothing happened". Server-authored (not i18n) like
+ * EMPTY_TURN_MESSAGE; rendered as a failed bubble with the status code when the
+ * gateway surfaced one. */
+export function agentErrorMessage(apiErrorStatus: number | undefined): string {
+  return apiErrorStatus !== undefined
+    ? `The agent stopped on an API error (status ${apiErrorStatus}). Please try again.`
+    : 'The agent stopped on an API error. Please try again.';
+}
 
 function turnTokensOf(
   result: RunAgentInSessionResult,

--- a/services/platform/convex/node_only/sandbox/agent_run_outcome.test.ts
+++ b/services/platform/convex/node_only/sandbox/agent_run_outcome.test.ts
@@ -36,6 +36,34 @@ describe('isRetryableExecutionError', () => {
         }),
       ).toBe(true);
     });
+
+    it('THE BUG: laundered 401 — isError on a "completed" result, no summary', () => {
+      // Claude Code leaves subtype:'success' (→ agentResultStatus 'completed')
+      // and exit 0 on a turn-terminating 401, carrying only is_error/api_error.
+      // Without the isError gate this laundered into a fake success.
+      expect(
+        isRetryableExecutionError({
+          agentResultStatus: 'completed',
+          terminalStatus: 'completed',
+          summaryWritten: false,
+          isError: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('isError is broader than rotatable: a 5xx/connection blip retries too', () => {
+      // isRetryableExecutionError fires on ANY isError-without-handoff (e.g. a
+      // 502 that isRotatableApiError would reject) — a fresh step may recover it
+      // even when no credential swap would. Deliberate two-gate width difference.
+      expect(
+        isRetryableExecutionError({
+          agentResultStatus: 'completed',
+          terminalStatus: 'completed',
+          summaryWritten: false,
+          isError: true,
+        }),
+      ).toBe(true);
+    });
   });
 
   describe('does not throw (genuine outcome / budget / has handoff)', () => {
@@ -45,6 +73,42 @@ describe('isRetryableExecutionError', () => {
           agentResultStatus: 'error',
           terminalStatus: 'failed',
           summaryWritten: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('a handoff wins over isError too (real summary despite a late error)', () => {
+      expect(
+        isRetryableExecutionError({
+          agentResultStatus: 'completed',
+          terminalStatus: 'completed',
+          summaryWritten: true,
+          isError: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('REGRESSION GUARD: max-turns carries is_error:true but is a budget outcome', () => {
+      // Claude Code stamps is_error:true on an error_max_turns result, so the
+      // isError gate must NOT fire for it — retrying a max-turns run just burns
+      // the same budget. The budget-outcome guard runs before the isError gate.
+      expect(
+        isRetryableExecutionError({
+          agentResultStatus: 'max-turns',
+          terminalStatus: 'completed',
+          summaryWritten: false,
+          isError: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('cancelled with isError is still a user outcome, never retried', () => {
+      expect(
+        isRetryableExecutionError({
+          agentResultStatus: 'cancelled',
+          terminalStatus: 'cancelled',
+          summaryWritten: false,
+          isError: true,
         }),
       ).toBe(false);
     });

--- a/services/platform/convex/node_only/sandbox/agent_run_outcome.ts
+++ b/services/platform/convex/node_only/sandbox/agent_run_outcome.ts
@@ -31,6 +31,14 @@ import type { AgentResultStatus } from '../../../lib/agent-adapters/events';
  *  - `completed` (even with an unfavorable verdict in the summary);
  *  - `max-turns` / `cancelled` / a wall-clock `timeout` (budget/user outcomes —
  *    retrying just burns the same budget or re-cancels).
+ *
+ * The `isError` gate is DELIBERATELY wider than `isRotatableApiError`: Claude
+ * Code laundered a turn-terminating API error (401/403/429/5xx, a dropped
+ * connection, or a malformed 200) into `subtype:'success'` → `agentResultStatus`
+ * is the misleading `'completed'`, and ONLY `result.isError` exposes it. Such a
+ * run with no handoff is retryable by a FRESH step (the work was never done)
+ * even when it is not token-rotatable — whereas `isRotatableApiError` stays
+ * narrow on `{401,403,429,529}` because only those warrant a credential swap.
  */
 export function isRetryableExecutionError(input: {
   /** The agent's self-reported terminal verdict (`undefined` ⇒ no result event
@@ -40,9 +48,29 @@ export function isRetryableExecutionError(input: {
   terminalStatus: string;
   /** Whether the agent wrote the mandated `output/summary.md` handoff. */
   summaryWritten: boolean;
+  /** The terminal result's `is_error` flag. Claude Code leaves `subtype:'success'`
+   * on an errored result, so this is the only honest signal that a "completed"
+   * turn actually blew up at the API/transport layer (the laundered-401 bug). */
+  isError?: boolean;
 }): boolean {
   // A real handoff ⇒ the agent ran and produced an outcome; never retry it.
   if (input.summaryWritten) return false;
+  // Budget/user outcomes are NOT execution errors — they beat the `isError`
+  // gate below. Claude Code stamps `is_error:true` on an `error_max_turns`
+  // result too, but a max-turns run hit its budget; retrying just burns the
+  // same budget. A user `cancelled` must never resurrect itself either. (A
+  // wall-clock `timeout` arrives via terminalStatus on an exhausted `running`
+  // handoff — no terminal result event, so it carries no `isError` to gate on.)
+  if (
+    input.agentResultStatus === 'max-turns' ||
+    input.agentResultStatus === 'cancelled'
+  ) {
+    return false;
+  }
+  // A mechanical API/transport error the agent reported on its terminal result
+  // but with NO handoff — the laundered-401 case (see the header note on the
+  // deliberate two-gate width difference vs `isRotatableApiError`).
+  if (input.isError === true) return true;
   // The agent itself reported a mechanical error (error_during_execution:
   // 401/403/429/5xx, connection failure, internal crash).
   if (input.agentResultStatus === 'error') return true;

--- a/services/platform/convex/node_only/sandbox/resume_rotation.test.ts
+++ b/services/platform/convex/node_only/sandbox/resume_rotation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RESUME_CONTINUATION_PROMPT,
+  shouldAttemptResumeRotation,
+} from './resume_rotation';
+
+describe('shouldAttemptResumeRotation', () => {
+  const ok = {
+    resuming: true,
+    agentSessionId: 'sess_1',
+    tokenPoolPresent: true,
+  };
+
+  it('fires only when all three preconditions hold', () => {
+    expect(shouldAttemptResumeRotation(ok)).toBe(true);
+  });
+
+  it('does NOT fire on a fresh segment (the fresh path injects its own pick)', () => {
+    expect(shouldAttemptResumeRotation({ ...ok, resuming: false })).toBe(false);
+  });
+
+  it('does NOT fire without a Claude session id (cannot spawn --resume)', () => {
+    expect(
+      shouldAttemptResumeRotation({ ...ok, agentSessionId: undefined }),
+    ).toBe(false);
+  });
+
+  it('does NOT fire without a resolved token pool (nothing to rotate within)', () => {
+    expect(
+      shouldAttemptResumeRotation({ ...ok, tokenPoolPresent: false }),
+    ).toBe(false);
+  });
+});
+
+describe('RESUME_CONTINUATION_PROMPT', () => {
+  it('forbids a restart and mandates the summary handoff', () => {
+    expect(RESUME_CONTINUATION_PROMPT).toMatch(/do NOT restart/i);
+    expect(RESUME_CONTINUATION_PROMPT).toContain('/user/output/summary.md');
+  });
+});

--- a/services/platform/convex/node_only/sandbox/resume_rotation.ts
+++ b/services/platform/convex/node_only/sandbox/resume_rotation.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure decision + prompt for token-source rotation on a RESUMED durable sandbox
+ * segment. Isolated here (mirrors `summary_reentry.ts` / `agent_run_outcome.ts`)
+ * so the gating logic is unit-testable without importing the node-only run
+ * module. The orchestration — re-fetching bindings, building the pool, and the
+ * rotation loop — lives in `workflow_sandbox_exec`.
+ */
+
+/**
+ * Continuation prompt for the fresh `claude --resume <id>` exec spawned to swap
+ * the credential mid-task after the re-attached segment died on a rotatable API
+ * error. It must NOT restart the task — it continues the SAME conversation on a
+ * healthy token — and must keep the mandated handoff in view so the rotated
+ * attempt still produces `output/summary.md`.
+ */
+export const RESUME_CONTINUATION_PROMPT = [
+  'Your previous attempt stopped on an API error and has been resumed on a',
+  'fresh credential. CONTINUE the task from where you left off — do NOT restart',
+  'it or repeat completed work. When you finish, write the mandated handoff file',
+  'at the ABSOLUTE path /user/output/summary.md covering (1) what you did, (2)',
+  'every file you produced (path + purpose), (3) the final result/state, and (4)',
+  'what is next. Then stop.',
+].join('\n');
+
+/**
+ * Whether to attempt non-destructive token rotation on a resumed segment. All
+ * three preconditions are required:
+ *  - `resuming` — this segment re-attached to a handed-off conversation;
+ *  - `agentSessionId` — the Claude session id is known, so a `--resume` exec can
+ *    be spawned on the fresh credential;
+ *  - `tokenPoolPresent` — a broker token pool was resolved to rotate within.
+ * Absent any of them, the only recovery for a rotatable error is Part A's
+ * destructive fresh-step retry.
+ */
+export function shouldAttemptResumeRotation(input: {
+  resuming: boolean;
+  agentSessionId: string | undefined;
+  tokenPoolPresent: boolean;
+}): boolean {
+  return (
+    input.resuming &&
+    input.agentSessionId !== undefined &&
+    input.tokenPoolPresent
+  );
+}

--- a/services/platform/convex/node_only/sandbox/summary_reentry.test.ts
+++ b/services/platform/convex/node_only/sandbox/summary_reentry.test.ts
@@ -53,4 +53,11 @@ describe('shouldForceSummaryReentry', () => {
       shouldForceSummaryReentry({ ...base, byo: false, gatewayToken: null }),
     ).toBe(false);
   });
+
+  it('does NOT fire when the run carried a terminal API error (laundered 401)', () => {
+    // Every other gate passes (completed + no summary + resumable + budget +
+    // BYO), but isError means the "completed" is a lie — re-entering would just
+    // re-hit the dead token, so the run routes to the retryable throw instead.
+    expect(shouldForceSummaryReentry({ ...base, isError: true })).toBe(false);
+  });
 });

--- a/services/platform/convex/node_only/sandbox/summary_reentry.ts
+++ b/services/platform/convex/node_only/sandbox/summary_reentry.ts
@@ -23,6 +23,11 @@ export const SUMMARY_REENTRY_MAX_TURNS = 6;
  * session is still resumable, there is budget left, and a managed run still has
  * a gateway token (BYO needs none). Never loops — the caller guards it to a
  * single attempt.
+ *
+ * Skips outright when the run carried a terminal API error (`isError`): the
+ * "completed" status is the laundered-401 lie, so re-entering would just re-hit
+ * the dead token and waste the budget — that case is routed to the retryable
+ * execution-error throw instead (see `isRetryableExecutionError`).
  */
 export function shouldForceSummaryReentry(input: {
   terminalStatus: string;
@@ -32,7 +37,11 @@ export function shouldForceSummaryReentry(input: {
   hardDeadlineMs: number;
   byo: boolean;
   gatewayToken: string | null;
+  /** The terminal result's `is_error` flag — a laundered API error masquerading
+   * as `completed`. A doomed re-entry against the same credential is skipped. */
+  isError?: boolean;
 }): boolean {
+  if (input.isError === true) return false;
   return (
     input.terminalStatus === 'completed' &&
     !input.summaryWritten &&

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -147,6 +147,15 @@ const MAX_TOKEN_ATTEMPTS = 3;
 // remains — a single attempt (esp. an auth retry-storm) must fit before the
 // seam, so the cap can't be defeated by burning the window on the last try.
 const TOKEN_ROTATION_MIN_WINDOW_MS = 90 * 1000;
+// When the CACHED broker pool is exhausted (every token tried, still 401/429),
+// re-fetch the pool from the broker — the credential may have been refreshed or
+// rotated upstream — and retry WARM (same sandbox, session preserved via the
+// resume runner; no teardown). Bounded so a permanently-dead broker can't spin.
+// After these in-sandbox retries, the loop throws → the engine's COLD retry
+// (destroy sandbox, fresh start from scratch) takes over, and if that keeps
+// failing the execution fails loudly.
+const MAX_TOKEN_REFETCH = 3;
+const TOKEN_REFETCH_BACKOFF_MS = 3000;
 
 /**
  * Thrown by `runSandboxAgent` for an infrastructure/execution failure (the agent
@@ -1126,6 +1135,9 @@ export const runSandboxAgent = internalAction({
         tokens: string[];
         targetEnvVar: string;
         selection: TokenSelection;
+        /** Broker source slug — kept so the rotation loop can RE-FETCH a fresh
+         * pool from the broker when the cached tokens are exhausted. */
+        slug: string;
       } | null = null;
       // v1 honors the first Environment-tab token-source binding (warns if more).
       const tokenBinding = agentTokenBindings[0];
@@ -1142,12 +1154,13 @@ export const runSandboxAgent = internalAction({
           );
         } else {
           // FRESH: fail-fast — resolveTokenPool throws TokenSourceError on an
-          // unreachable/empty/malformed broker → the outer catch finalizes +
-          // fails the step (no creds ⇒ the run cannot even start). RESUME: the
-          // conversation is already running on a valid credential, so a transient
-          // broker outage must NOT kill a healthy resumed segment — degrade to
-          // no-pool (continue on the current token, no rotation this segment).
-          // The binding's env var name wins over the source's default.
+          // unreachable/empty/malformed broker → the outer catch RE-THROWS → the
+          // engine retries the step fresh and, if the broker stays down, fails
+          // the execution loudly (no creds ⇒ the run cannot even start). RESUME:
+          // the conversation is already running on a valid credential, so a
+          // transient broker outage must NOT kill a healthy resumed segment —
+          // degrade to no-pool (continue on the current token, no rotation this
+          // segment). The binding's env var name wins over the source's default.
           try {
             const pool = await ctx.runAction(
               internal.node_only.sandbox.token_source_pool.resolveTokenPool,
@@ -1162,6 +1175,7 @@ export const runSandboxAgent = internalAction({
               tokens: pool.tokens,
               targetEnvVar: tokenBinding.key,
               selection: pool.selection,
+              slug: tokenBinding.tokenSourceSlug,
             };
           } catch (poolErr) {
             if (!resuming) throw poolErr;
@@ -1309,8 +1323,9 @@ export const runSandboxAgent = internalAction({
       // re-run — up to MAX_TOKEN_ATTEMPTS total, while enough window remains. A
       // `running` handoff is NOT a failure and never rotates.
       let tokenAttempt = 1;
+      let tokenRefetch = 0;
       if (tokenPool !== null) {
-        const pool = tokenPool; // stable non-null binding for the loop body
+        let pool = tokenPool; // re-fetch swaps in a fresh broker pool below
         while (
           result.status !== 'running' &&
           tokenAttempt < MAX_TOKEN_ATTEMPTS &&
@@ -1322,8 +1337,49 @@ export const runSandboxAgent = internalAction({
             authAbortStatus: result.authAbortStatus,
           })
         ) {
-          const nextToken = pickToken(pool.tokens, triedTokens, pool.selection);
-          if (nextToken === null) break; // no distinct token left → fail below
+          let nextToken = pickToken(pool.tokens, triedTokens, pool.selection);
+          // CACHED pool exhausted → RE-FETCH fresh secrets from the broker and
+          // retry WARM (same sandbox; the resume runner preserves the session —
+          // no teardown). The broker may have refreshed/rotated the credential
+          // upstream. Bounded by MAX_TOKEN_REFETCH so a permanently-dead broker
+          // can't spin; a backoff gives the broker a beat. If re-fetch is
+          // unreachable or still yields no usable token, give up → the throw
+          // below hands off to the engine's COLD retry (fresh sandbox, from
+          // scratch), which on continued failure fails the execution loudly.
+          if (nextToken === null) {
+            if (tokenRefetch >= MAX_TOKEN_REFETCH) break;
+            tokenRefetch += 1;
+            await new Promise((r) => setTimeout(r, TOKEN_REFETCH_BACKOFF_MS));
+            try {
+              const fresh = await ctx.runAction(
+                internal.node_only.sandbox.token_source_pool.resolveTokenPool,
+                {
+                  organizationId: args.organizationId,
+                  orgSlug,
+                  sessionId,
+                  slug: pool.slug,
+                },
+              );
+              pool = {
+                tokens: fresh.tokens,
+                targetEnvVar: pool.targetEnvVar,
+                selection: fresh.selection,
+                slug: pool.slug,
+              };
+            } catch (refetchErr) {
+              console.warn(
+                `[runSandboxAgent] token-source re-fetch ${tokenRefetch}/${MAX_TOKEN_REFETCH} failed (step ${args.stepSlug}):`,
+                refetchErr,
+              );
+              break;
+            }
+            triedTokens.clear(); // fresh pool ⇒ every token eligible again
+            console.warn(
+              `[runSandboxAgent] token-source re-fetch ${tokenRefetch}/${MAX_TOKEN_REFETCH} (step ${args.stepSlug})`,
+            );
+            nextToken = pickToken(pool.tokens, triedTokens, pool.selection);
+            if (nextToken === null) break; // broker returned an empty pool
+          }
           triedTokens.add(nextToken);
           tokenAttempt += 1;
           await sessionEnvPatch(sessionId, {
@@ -1362,16 +1418,21 @@ export const runSandboxAgent = internalAction({
         }
       }
 
-      // Exhausted the pool / attempt cap and still rate-limited or auth-failed →
-      // fail the step terminally. Throw a NON-retryable TokenSourceError (not the
-      // retryable SandboxAgentExecutionError) so the outer step does NOT re-run
-      // and blow past the 3-attempt contract; the catch finalizes + returns fail.
+      // In-sandbox retries exhausted (every cached token + MAX_TOKEN_REFETCH
+      // fresh broker re-fetches still rate-limited/auth-failed) → THROW. The
+      // throw is the deliberate seam between the two retry layers: the warm
+      // in-sandbox retries above are done, so we tear down (the `finally`,
+      // keepAlive false) and hand off to the ENGINE's cold retry — a fresh
+      // sandbox + a fresh pool resolve, everything from scratch (maxRetries) —
+      // and if THAT keeps failing the execution fails loudly. A dead credential
+      // is an operational exception, never a synthesized success or a quiet
+      // business `ok:false`.
       // EXCEPTION: a resume runner that threw (`resumeRotationAborted`) did NOT
       // exhaust the pool — it hit the unverified `--resume`-after-error path, so
-      // skip this terminal throw and let Part A's retryable execution-error throw
-      // fire below (a fresh step retry is the correct, safe-by-construction
-      // fallback). This is what makes resume-rotation safe even though the
-      // mid-conversation contract is unverified.
+      // skip this throw and let Part A's execution-error throw fire below (a
+      // fresh step retry is the correct, safe-by-construction fallback). This is
+      // what keeps resume-rotation safe even though the mid-conversation contract
+      // is unverified.
       if (
         tokenPool !== null &&
         !resumeRotationAborted &&
@@ -1604,6 +1665,15 @@ export const runSandboxAgent = internalAction({
       // The re-throw paths deliberately do NOT finalize — the orphaned 'running'
       // row is reclaimed by recoverStuckTaskRuns so the fresh retry re-admits.
       if (e instanceof SandboxAgentExecutionError) {
+        throw e;
+      }
+      // Token-source exhaustion (all cached tokens + the in-sandbox broker
+      // re-fetches still 401/429): an operational exception, NOT a business
+      // outcome. RE-THROW so the engine's COLD retry restarts FRESH (destroy
+      // sandbox, re-resolve the pool) and, if it keeps failing, the execution
+      // fails loudly — instead of laundering a dead credential into a quiet
+      // `ok:false` that the desk-process would route to a rollback-as-done.
+      if (e instanceof TokenSourceError) {
         throw e;
       }
       // Park-on-capacity (NOT a failure): WAIT_FIFO (lost the per-org slot race

--- a/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
+++ b/services/platform/convex/node_only/sandbox/workflow_sandbox_exec.ts
@@ -74,6 +74,10 @@ import {
   resolveGatewayRoutingFromRef,
   revokeVirtualKey,
 } from './llm_gateway_admin';
+import {
+  RESUME_CONTINUATION_PROMPT,
+  shouldAttemptResumeRotation,
+} from './resume_rotation';
 import { runAgentInSessionImpl } from './run_agent';
 import {
   shouldForceSummaryReentry,
@@ -210,6 +214,25 @@ async function reapStaleWorkflowRunSessions(
       console.warn('[reapStaleWorkflowRunSessions] row cleanup failed:', e);
     }
   }
+}
+
+/**
+ * The agent's token-source bindings (Environment-tab rows). On a FRESH segment
+ * these fall out of the agent-env injection for free; on RESUME that setup block
+ * is skipped, so this re-fetches them so the rotation pool can be rebuilt for the
+ * resumed conversation (Part C). Thin wrapper over `resolveAgentEnv` so "this
+ * agent's token bindings" is one named concept.
+ */
+async function loadAgentTokenBindings(
+  ctx: ActionCtx,
+  organizationId: string,
+  agentSlug: string,
+): Promise<{ key: string; tokenSourceSlug: string }[]> {
+  const agentEnv = await ctx.runAction(
+    internal.agents.agent_env_actions.resolveAgentEnv,
+    { organizationId, agentSlug },
+  );
+  return agentEnv.tokenBindings;
 }
 
 /**
@@ -1075,11 +1098,30 @@ export const runSandboxAgent = internalAction({
               { sessionId },
             )) as UiTimelinePart[])
           : [];
-      // --- Token-source credential rotation (BYO + fresh start only) --------
-      // Fetch the broker pool once, inject a random pick, and (in the loop
-      // below) fail over to a different token on a rate-limit/auth error. Only
-      // fresh starts rotate: a resume continues an in-flight conversation, and
-      // swapping its credential mid-stream is the deferred hard case.
+      // On RESUME the `if (!resuming)` setup block above was skipped, so the
+      // agent's token bindings were never loaded. Re-fetch them (best-effort) so
+      // a rotatable error on the resumed segment can fail over (Part C); a
+      // failure just leaves the pool empty → the fresh-step retry fallback.
+      if (resuming && agentTokenBindings.length === 0) {
+        try {
+          agentTokenBindings = await loadAgentTokenBindings(
+            ctx,
+            args.organizationId,
+            args.agentSlug,
+          );
+        } catch (bindErr) {
+          console.warn(
+            '[runSandboxAgent] resume token-binding re-fetch failed (resume-rotation disabled):',
+            bindErr,
+          );
+        }
+      }
+      // --- Token-source credential rotation (BYO) ---------------------------
+      // Fetch the broker pool once and fail over to a different token on a
+      // rate-limit/auth error. A FRESH start injects an initial pick below; a
+      // RESUME keeps the credential the prior segment was using and only swaps it
+      // if the re-attached segment returns a rotatable error (Part C — the pool
+      // is now built on resume too, not just on fresh starts).
       let tokenPool: {
         tokens: string[];
         targetEnvVar: string;
@@ -1088,7 +1130,7 @@ export const runSandboxAgent = internalAction({
       // v1 honors the first Environment-tab token-source binding (warns if more).
       const tokenBinding = agentTokenBindings[0];
       const tokenSourceSlug = tokenBinding?.tokenSourceSlug;
-      if (tokenBinding !== undefined && checkpoint === null) {
+      if (tokenBinding !== undefined) {
         if (agentTokenBindings.length > 1) {
           console.warn(
             `[runSandboxAgent] ${agentTokenBindings.length} token-source bindings — v1 honors only the first (${tokenBinding.key}).`,
@@ -1099,28 +1141,44 @@ export const runSandboxAgent = internalAction({
             `[runSandboxAgent] agent "${args.agentSlug}" binds a token source but is not BYO — the managed gateway key wins; ignoring`,
           );
         } else {
-          // Fail-fast: resolveTokenPool throws TokenSourceError on an
-          // unreachable/empty/malformed broker → the catch finalizes + fails
-          // the step (no retry). The binding's env var name wins over the
-          // source's default targetEnvVar.
-          const pool = await ctx.runAction(
-            internal.node_only.sandbox.token_source_pool.resolveTokenPool,
-            {
-              organizationId: args.organizationId,
-              orgSlug,
-              sessionId,
-              slug: tokenBinding.tokenSourceSlug,
-            },
-          );
-          tokenPool = {
-            tokens: pool.tokens,
-            targetEnvVar: tokenBinding.key,
-            selection: pool.selection,
-          };
+          // FRESH: fail-fast — resolveTokenPool throws TokenSourceError on an
+          // unreachable/empty/malformed broker → the outer catch finalizes +
+          // fails the step (no creds ⇒ the run cannot even start). RESUME: the
+          // conversation is already running on a valid credential, so a transient
+          // broker outage must NOT kill a healthy resumed segment — degrade to
+          // no-pool (continue on the current token, no rotation this segment).
+          // The binding's env var name wins over the source's default.
+          try {
+            const pool = await ctx.runAction(
+              internal.node_only.sandbox.token_source_pool.resolveTokenPool,
+              {
+                organizationId: args.organizationId,
+                orgSlug,
+                sessionId,
+                slug: tokenBinding.tokenSourceSlug,
+              },
+            );
+            tokenPool = {
+              tokens: pool.tokens,
+              targetEnvVar: tokenBinding.key,
+              selection: pool.selection,
+            };
+          } catch (poolErr) {
+            if (!resuming) throw poolErr;
+            console.warn(
+              '[runSandboxAgent] resume token-pool build failed (rotation disabled this segment):',
+              poolErr,
+            );
+          }
         }
       }
       const triedTokens = new Set<string>();
-      if (tokenPool !== null) {
+      // Inject the initial pick on a FRESH start only. A resumed conversation
+      // already carries the credential the prior segment set (sessionEnvPatch is
+      // sticky on the container); re-picking here would swap it mid-stream before
+      // any error. `triedTokens` stays empty on resume (v1 — checkpointing the
+      // last-used token to skip it on the first rotation is a later increment).
+      if (tokenPool !== null && !resuming) {
         // resolveTokenPool guarantees a non-empty pool, so `first` is non-null.
         const first = pickToken(
           tokenPool.tokens,
@@ -1162,6 +1220,56 @@ export const runSandboxAgent = internalAction({
           budgetDeadlineMs,
           timeoutMs: segmentTimeoutMs,
         });
+
+      // RESUME-rotation runner: spawn a FRESH `claude --resume <id>` exec to
+      // continue the handed-off conversation on a rotated credential (NOT a
+      // re-attach to the dead exec — that is what the `resumeFrom` initial
+      // attempt does). Mirrors `runFreshSegment` but seeds `agentSessionId` and
+      // the no-restart continuation prompt. BYO-only in practice (the pool is
+      // BYO-gated), so the managed gateway block is moot.
+      const runResumingSegment = (
+        segExecId: string,
+        resumeSessionId: string,
+      ): ReturnType<typeof runAgentInSessionImpl> =>
+        runAgentInSessionImpl(ctx, {
+          organizationId: args.organizationId,
+          sessionId,
+          execId: segExecId,
+          agentSlug: agentKind,
+          prompt: RESUME_CONTINUATION_PROMPT,
+          agentSessionId: resumeSessionId,
+          ...(useModel !== undefined && { model: useModel }),
+          authMode: byo ? 'byo' : 'managed',
+          ...(nativeWebTools !== undefined && { nativeWebTools }),
+          interactionMode: 'autonomous',
+          captureLiveTimeline: true,
+          systemPromptAppend,
+          ...(args.budget.maxTurns !== undefined && {
+            maxTurns: args.budget.maxTurns,
+          }),
+          ...(!byo &&
+            gatewayToken !== null && {
+              gatewayBaseUrl: EXTERNAL_AGENT_GATEWAY_URL,
+              gatewayToken,
+              integrationsBaseUrl: `${INTEGRATIONS_BASE_URL}/api/integrations`,
+            }),
+          budgetDeadlineMs,
+          timeoutMs: segmentTimeoutMs,
+        });
+
+      // Resume-rotation precondition (Part C): a resume, with the Claude session
+      // id known (so a `--resume` exec is possible) and a pool resolved. When
+      // false, a rotatable error on resume routes to Part A's fresh-step retry.
+      const resumeSessionId = checkpoint?.agentSessionId;
+      const useResumeRotation = shouldAttemptResumeRotation({
+        resuming,
+        agentSessionId: resumeSessionId,
+        tokenPoolPresent: tokenPool !== null,
+      });
+      // Set when the resume runner throws (an unverified `--resume`-after-error
+      // contract failure) → suppress the terminal TokenSourceError and fall
+      // through to Part A's retryable fresh-step retry instead.
+      let resumeRotationAborted = false;
 
       let result =
         checkpoint !== null
@@ -1227,7 +1335,30 @@ export const runSandboxAgent = internalAction({
           // Carry the rotated exec id forward so a handoff from THIS attempt
           // checkpoints/resumes the live exec, not the dead first attempt.
           liveExecId = `${execId}-t${tokenAttempt}`;
-          result = await runFreshSegment(liveExecId);
+          // FRESH: re-run the task on the new token (unchanged behavior). RESUME:
+          // spawn a fresh `claude --resume <id>` on the new token to CONTINUE the
+          // handed-off conversation. The resume runner is the unverified path
+          // (mid-conversation `--resume`-after-error vs Anthropic's
+          // previous_message_id contract), so ONLY it is wrapped: on throw, abort
+          // rotation and fall through to Part A's retryable fresh-step retry (work
+          // discarded but correct) — never the non-retryable TokenSourceError
+          // below. The fresh path stays behaviorally identical (no try/catch).
+          // The chat path (run_external_agent) has its own rotation loop with
+          // op-row fencing — keep them separate; do NOT merge across the boundary.
+          if (useResumeRotation && resumeSessionId !== undefined) {
+            try {
+              result = await runResumingSegment(liveExecId, resumeSessionId);
+            } catch (resumeErr) {
+              console.warn(
+                '[runSandboxAgent] resume token rotation threw — falling back to a fresh step retry:',
+                resumeErr,
+              );
+              resumeRotationAborted = true;
+              break;
+            }
+          } else {
+            result = await runFreshSegment(liveExecId);
+          }
         }
       }
 
@@ -1235,8 +1366,15 @@ export const runSandboxAgent = internalAction({
       // fail the step terminally. Throw a NON-retryable TokenSourceError (not the
       // retryable SandboxAgentExecutionError) so the outer step does NOT re-run
       // and blow past the 3-attempt contract; the catch finalizes + returns fail.
+      // EXCEPTION: a resume runner that threw (`resumeRotationAborted`) did NOT
+      // exhaust the pool — it hit the unverified `--resume`-after-error path, so
+      // skip this terminal throw and let Part A's retryable execution-error throw
+      // fire below (a fresh step retry is the correct, safe-by-construction
+      // fallback). This is what makes resume-rotation safe even though the
+      // mid-conversation contract is unverified.
       if (
         tokenPool !== null &&
+        !resumeRotationAborted &&
         result.status !== 'running' &&
         isRotatableApiError({
           isError: result.isError,
@@ -1334,6 +1472,9 @@ export const runSandboxAgent = internalAction({
           hardDeadlineMs,
           byo,
           gatewayToken,
+          // A laundered API error (`completed` + isError) must NOT re-enter — it
+          // would just re-hit the dead token; it routes to the throw below.
+          isError: result.isError,
         })
       ) {
         try {
@@ -1385,14 +1526,16 @@ export const runSandboxAgent = internalAction({
       // FRESH (the `finally` tears down → new session + re-minted VK) and, if it
       // keeps failing, the workflow FAILS at this step — instead of returning a
       // synthesized "success" that the next step (or a rework loop) consumes.
-      // Keys on the agent's OWN reported status, not the process exit code, which
-      // a 401 leaves at `completed`/0. Computed AFTER the summary re-entry above
-      // so `summaryWritten` is final.
+      // Keys on the agent's OWN reported status AND `is_error` — NOT the process
+      // exit code, which a 401 leaves at `completed`/0, and not the result
+      // subtype, which Claude Code leaves at `success` on a laundered API error.
+      // Computed AFTER the summary re-entry above so `summaryWritten` is final.
       if (
         isRetryableExecutionError({
           agentResultStatus: result.agentResultStatus,
           terminalStatus,
           summaryWritten,
+          isError: result.isError,
         })
       ) {
         throw new SandboxAgentExecutionError(
@@ -1402,6 +1545,11 @@ export const runSandboxAgent = internalAction({
         );
       }
 
+      // `ok` needn't re-check `isError`: the throw gate above already fired for
+      // every `isError && !summaryWritten`, so control reaches here with a live
+      // `isError` ONLY when a summary WAS written — a genuine handoff that stays
+      // ok. (The laundered-401 fake-success bug lived precisely in `ok` being
+      // computed without that guard.)
       const ok =
         terminalStatus === 'completed' &&
         (result.exitCode === 0 || result.exitCode === null);


### PR DESCRIPTION
## Problem

A BYO Claude Code agent running as a **durable sandbox step** (the issue-desk "Implement the fix" task) failed with `Failed to authenticate. API Error: 401 Invalid authentication credentials`, yet the step was marked green **Done** with a synthesized summary `(synthesized — agent did not write output/summary.md)`.

**Root cause (code-verified, not infra):** two classifiers read *different* fields off the agent result.
- `isRotatableApiError` correctly keys on `result.isError` + `result.apiErrorStatus`.
- `isRetryableExecutionError` keyed **only** on `agentResultStatus` — which for a 401 is `'completed'`, because Claude Code emits a terminal result with `subtype:'success'` (`parse.ts` maps it to `completed`) while carrying `is_error:true, api_error_status:401`.

So a 401 with no `output/summary.md` neither threw (→ not retried) nor rotated, and `ok` computed `true` → a fake success that flows to the next step. The **chat** path had the identical bug (a terminal 401 rendered as a success bubble; a blank 401 retried-as-empty against the same token).

## Fix

**Part A — task / durable-sandbox path**
- `isRetryableExecutionError` and `shouldForceSummaryReentry` now take `isError`; `result.isError` is threaded at the call sites in `workflow_sandbox_exec.ts`.
- A 401-without-handoff now throws `SandboxAgentExecutionError` → the step retries fresh and, if still failing, fails loudly — never a synthesized success.
- A budget-outcome guard (`max-turns` / `cancelled`) runs **before** the `isError` gate: Claude Code stamps `is_error:true` on `error_max_turns` too, so without the guard the new gate would have regressed a budget outcome into 4 budget-burning retries.

**Part B — chat external-agent path**
- A `completed` turn with `isError` renders a **failed** bubble carrying the error text (new server-authored `agentErrorMessage(status)` fallback, not i18n).
- `isEmptyCompletedTurn` returns `false` on `isError`, so a blank 401 isn't retried-as-empty against the dead token.

**Part C — token rotation on resumed segments**
- The broker token pool is now rebuilt on **resumed** segments (not just fresh starts); bindings are re-fetched on resume.
- `runResumingSegment` spawns a fresh `claude --resume <agentSessionId>` on a rotated credential to continue the conversation.
- A `--resume`-after-error contract failure aborts rotation (`resumeRotationAborted`) and falls through to Part A's **retryable** fresh-step retry — safe-by-construction even though the mid-conversation `--resume` contract is unverified. `resolveTokenPool` is best-effort on resume so a transient broker outage can't kill a healthy resumed conversation.

## Verification

- **Live, end-to-end (Part A, exact bug scenario):** drove a real `runSandboxAgent` with an isolated throwaway BYO agent + a deliberately invalid `ANTHROPIC_API_KEY`. The run **threw** `SandboxAgentExecutionError: run errored (completed): Invalid API key` — `agentResultStatus` was the laundered `'completed'`, yet it failed loudly instead of going green. (Pre-fix that exact input returned `ok:true`.)
- **Part B** trigger is proven by the same live run (real 401 → `{status:'completed', isError:true}`), and its rendering is unit-tested.
- `tsc --noEmit` clean, `oxlint --type-aware` 0/0, **202 tests** pass across the sandbox + external-agent suites — including new regression tests for the bug, the `max-turns` guard, the chat remap, and the resume-rotation preconditions.

No data migration, no i18n (server logs / plain consts only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of terminal API errors to properly display as failures instead of successes.
  * Improved retry logic to prevent unnecessary retries of failed API calls.
  * Enhanced credential rotation for long-running agent sessions to handle stale credentials more gracefully.

* **Tests**
  * Added comprehensive test coverage for error handling and retry decision logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — token-source exhaustion is now an operational exception, not a business outcome

A follow-up in the same area (surfaced by a live issue-desk run): a dead/expired broker credential was caught inside `runSandboxAgent` and returned as a soft `{ok:false}`, which the desk-process routed to a normal **rollback-as-done** — the task looked "resolved", the signal read "couldn't implement" rather than "credentials broken", and nothing auto-recovered once the token refreshed.

Now it's a **two-layer retry**:
- **In-sandbox (warm):** when the cached broker pool is exhausted, re-fetch a fresh pool from the broker (the credential may have been refreshed/rotated upstream), re-inject into the **same** sandbox (no teardown; the resume runner preserves the session), and retry — bounded by `MAX_TOKEN_REFETCH` + a backoff so a permanently-dead broker can't spin.
- **Engine (cold):** once those exhaust, **throw** → the `finally` tears the sandbox down and the engine re-invokes the step fresh (new sandbox, re-resolved pool, from scratch) up to its retry budget; if that keeps failing, the **execution fails loudly**.

`TokenSourceError` is re-thrown from the catch (like `SandboxAgentExecutionError`) instead of laundered into `{ok:false}`.
