### PR TITLE
fix(platform): require organization name (#1951)

### DIFF
--- a/services/platform/app/features/settings/components/settings-row.tsx
+++ b/services/platform/app/features/settings/components/settings-row.tsx
@@ -3,6 +3,7 @@
 import { Description } from '@tale/ui/description';
 import { forwardRef, useId, type HTMLAttributes, type ReactNode } from 'react';
 
+import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 
 interface SettingsRowProps extends Omit<
@@ -11,6 +12,8 @@ interface SettingsRowProps extends Omit<
 > {
   label: ReactNode;
   description?: ReactNode;
+  /** Append a red required asterisk to the label (mirrors `Label`'s required). */
+  required?: boolean;
   /** Right-side control (switch, button, copy field, link). */
   children: ReactNode;
 }
@@ -21,7 +24,8 @@ interface SettingsRowProps extends Omit<
  * narrow viewports so the right-side control wraps cleanly.
  */
 export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
-  ({ label, description, children, className, ...props }, ref) => {
+  ({ label, description, required, children, className, ...props }, ref) => {
+    const { t } = useT('common');
     const id = useId();
     const labelId = `${id}-label`;
     const descId = description ? `${id}-desc` : undefined;
@@ -47,6 +51,14 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
             className="text-foreground text-sm leading-none font-medium"
           >
             {label}
+            {required && (
+              <span
+                className="ml-1 text-red-600"
+                aria-label={t('aria.required')}
+              >
+                *
+              </span>
+            )}
           </span>
           {description && <Description id={descId}>{description}</Description>}
         </div>

--- a/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { useFormEditor } from '@/app/components/ui/editor';
+import { organizationNameSchema } from '@/lib/shared/schemas/organizations';
+import enMessages from '@/messages/en.json';
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { fireEvent, render, screen, waitFor } from '@/tests/utils/render';
 
 import { OrganizationSettingsView } from './organization-settings';
+
+// Resolve user-facing labels through the translation layer rather than
+// hardcoding English, matching the platform i18n rule for tests.
+const orgNameLabel = enMessages.settings.organization.title;
+const nameRequiredMessage = enMessages.settings.organization.nameRequired;
 
 // The view now embeds the Members section, which subscribes to Convex via
 // `useMembers`. This suite renders the view in isolation (no Convex provider)
@@ -40,6 +47,7 @@ function Harness() {
       memberContext={null}
       canDelete={false}
       isCurrentOrganization
+      onSave={save}
     />
   );
 }
@@ -65,6 +73,7 @@ function LoadHarness({ orgName }: { orgName: string }) {
       memberContext={null}
       canDelete={false}
       isCurrentOrganization
+      onSave={save}
     />
   );
 }
@@ -85,7 +94,7 @@ describe('OrganizationSettingsView page load', () => {
     // The org-name field, labeled by `settings.organization.title`, resolves to
     // the current (non-empty) org name once the form applies its baseline.
     const orgNameField = screen.getByRole('textbox', {
-      name: 'Organization name',
+      name: orgNameLabel,
     });
     await waitFor(() => expect(orgNameField).toHaveValue('Acme Industries'));
     // Mirror the E2E's "non-empty value" intent.
@@ -95,24 +104,19 @@ describe('OrganizationSettingsView page load', () => {
   });
 });
 
-// The container wires `useFormEditor` with a Zod schema that makes the org name
-// required (`z.string().trim().min(1, …)`); the view then surfaces the error
-// via `errorMessage={formState.errors.name?.message}` and the editor's `isValid`
-// gates the global Save button. The page-load/locale harnesses above
-// deliberately omit the schema, so this harness mirrors the *production*
-// wiring — same shape, same message key — to exercise the required-name branch
-// the container now ships (#1951).
-const NAME_REQUIRED_MESSAGE = 'Organization name is required';
-
-const requiredSchema = z.object({
-  name: z.string().trim().min(1, NAME_REQUIRED_MESSAGE),
+// Build the harness schema from the same shared `organizationNameSchema` the
+// real container wires in, with the i18n message resolved through the
+// translation layer — so the test guards the actual validation rule and never
+// drifts on a hardcoded English literal.
+const organizationSchema = z.object({
+  name: organizationNameSchema(nameRequiredMessage),
   defaultLocale: z.string(),
 });
 
-function RequiredHarness({ orgName }: { orgName: string }) {
+function ValidationHarness({ orgName }: { orgName: string }) {
   const editor = useFormEditor<Form>({
     data: { name: orgName, defaultLocale: 'en' },
-    schema: requiredSchema,
+    schema: organizationSchema,
     save,
   });
   holder.current = editor;
@@ -124,72 +128,63 @@ function RequiredHarness({ orgName }: { orgName: string }) {
       memberContext={null}
       canDelete={false}
       isCurrentOrganization
+      onSave={save}
     />
   );
 }
 
-describe('OrganizationSettingsView required org name', () => {
-  it('starts valid with a non-empty name', async () => {
-    render(<RequiredHarness orgName="Acme" />);
+describe('OrganizationSettingsView name validation', () => {
+  it('blocks an empty org name with an inline error and an invalid form', async () => {
+    render(<ValidationHarness orgName="Acme" />);
     await waitFor(() => expect(holder.current?.isLoading).toBe(false));
-    await waitFor(() => expect(holder.current?.isValid).toBe(true));
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-  });
-
-  it('goes invalid and shows the required error when the name is cleared', async () => {
-    render(<RequiredHarness orgName="Acme" />);
-    await waitFor(() => expect(holder.current?.isLoading).toBe(false));
+    expect(holder.current?.isValid).toBe(true);
 
     const orgNameField = screen.getByRole('textbox', {
-      name: 'Organization name',
+      name: orgNameLabel,
     });
     fireEvent.change(orgNameField, { target: { value: '' } });
-    // onTouched (#1943): the field error renders only after the first blur,
-    // while `isValid` (Save gating) stays accurate on every change.
+    // onTouched (#1943): the field error renders only after the first blur.
     fireEvent.blur(orgNameField);
 
-    // (a) The editor's validity flips false → the global Save button is gated.
-    await waitFor(() => expect(holder.current?.isValid).toBe(false));
-    // (b) The `organization.nameRequired` message renders on the name field.
     await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        NAME_REQUIRED_MESSAGE,
-      ),
+      expect(screen.getByText(nameRequiredMessage)).toBeInTheDocument(),
     );
+    expect(holder.current?.isValid).toBe(false);
   });
 
-  it('treats a whitespace-only name as empty (trimmed) and stays invalid', async () => {
-    render(<RequiredHarness orgName="Acme" />);
+  it('treats a whitespace-only org name as invalid', async () => {
+    render(<ValidationHarness orgName="Acme" />);
     await waitFor(() => expect(holder.current?.isLoading).toBe(false));
+    expect(holder.current?.isValid).toBe(true);
 
     const orgNameField = screen.getByRole('textbox', {
-      name: 'Organization name',
+      name: orgNameLabel,
     });
+    // The schema trims before checking `.min(1)`, so a name of only spaces must
+    // fail exactly as an empty string does — the trim is the rule this PR adds.
     fireEvent.change(orgNameField, { target: { value: '   ' } });
-    // onTouched (#1943): blur to surface the field error.
+    // onTouched (#1943): the field error renders only after the first blur.
     fireEvent.blur(orgNameField);
 
-    await waitFor(() => expect(holder.current?.isValid).toBe(false));
     await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        NAME_REQUIRED_MESSAGE,
-      ),
+      expect(screen.getByText(nameRequiredMessage)).toBeInTheDocument(),
     );
+    expect(holder.current?.isValid).toBe(false);
   });
 
-  it('recovers to valid once a real name is typed back', async () => {
-    render(<RequiredHarness orgName="Acme" />);
+  it('clears the error once a non-empty name is entered', async () => {
+    render(<ValidationHarness orgName="Acme" />);
     await waitFor(() => expect(holder.current?.isLoading).toBe(false));
 
     const orgNameField = screen.getByRole('textbox', {
-      name: 'Organization name',
+      name: orgNameLabel,
     });
     fireEvent.change(orgNameField, { target: { value: '' } });
     await waitFor(() => expect(holder.current?.isValid).toBe(false));
 
-    fireEvent.change(orgNameField, { target: { value: 'Acme Industries' } });
+    fireEvent.change(orgNameField, { target: { value: 'New name' } });
     await waitFor(() => expect(holder.current?.isValid).toBe(true));
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(nameRequiredMessage)).not.toBeInTheDocument();
   });
 });
 

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -5,9 +5,10 @@ import { Skeletonize } from '@tale/ui/skeleton-context';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
+import { CopyableField } from '@/app/components/ui/data-display/copyable-field';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import {
   useFormEditor,
@@ -29,6 +30,7 @@ import { useToast } from '@/app/hooks/use-toast';
 import { authClient } from '@/lib/auth-client';
 import { useT } from '@/lib/i18n/client';
 import { SUPPORTED_AGENT_LOCALES } from '@/lib/shared/constants/agents';
+import { organizationNameSchema } from '@/lib/shared/schemas/organizations';
 import { getOrganizationDefaultLocale } from '@/lib/shared/utils/get-organization-default-locale';
 
 type Organization = {
@@ -90,6 +92,7 @@ export function OrganizationSettingsView({
   memberContext,
   canDelete,
   isCurrentOrganization,
+  onSave,
 }: {
   controller: OrganizationController;
   organization: Organization;
@@ -99,13 +102,18 @@ export function OrganizationSettingsView({
   canDelete: boolean;
   /** Whether this is the org the user is currently viewing (drives post-delete nav). */
   isCurrentOrganization: boolean;
+  onSave: (values: OrganizationFormData) => Promise<void>;
 }) {
   const { t: tSettings } = useT('settings');
   const { t: tGlobal } = useT('global');
-  const { t: tCommon } = useT('common');
 
   const { form, isLoading, isSaving } = controller;
-  const { register, control, formState } = form;
+  const {
+    handleSubmit,
+    register,
+    control,
+    formState: { errors },
+  } = form;
 
   const localeOptions = useMemo(
     () =>
@@ -120,29 +128,24 @@ export function OrganizationSettingsView({
     <SettingsPage>
       {/* Settings-row layout: each field is a horizontal row with its
           label + helper text on the left and the control pinned right, with
-          a divider between rows. The form (name + locale) reads as one
-          continuous divided block; Save/Discard live in the settings header
-          via the registered editor. */}
+          a divider between rows. The form (name + locale) and the read-only
+          Organization ID share one divided list so they read as one
+          continuous block; Save/Discard live in the settings header via the
+          registered editor. */}
       <SettingsSection
         title={tSettings('organization.detailsTitle')}
         description={tSettings('organization.detailsDescription')}
       >
-        <Form id="organization-form" onSubmit={controller.submit}>
+        <Form
+          id="organization-form"
+          onSubmit={handleSubmit((values) => onSave(values))}
+        >
           <fieldset disabled={isLoading} className="divide-border divide-y">
             <SettingsRow
               className="py-5"
-              label={
-                <>
-                  {tSettings('organization.title')}
-                  <span
-                    className="ml-1 text-red-600"
-                    aria-label={tCommon('aria.required')}
-                  >
-                    *
-                  </span>
-                </>
-              }
+              label={tSettings('organization.title')}
               description={tSettings('organization.nameDescription')}
+              required
             >
               {/* Fixed-width control column, full-width on mobile where the row
                 stacks. `wrapperClassName="w-full"` lets the bare Input fill it
@@ -152,7 +155,7 @@ export function OrganizationSettingsView({
                   id="org-name"
                   aria-label={tSettings('organization.title')}
                   required
-                  errorMessage={formState.errors.name?.message}
+                  errorMessage={errors.name?.message}
                   {...register('name')}
                   wrapperClassName="w-full"
                 />
@@ -189,6 +192,19 @@ export function OrganizationSettingsView({
                       options={localeOptions}
                     />
                   )}
+                />
+              </div>
+            </SettingsRow>
+
+            <SettingsRow
+              className="py-5"
+              label={tSettings('organization.organizationId')}
+              description={tSettings('organization.organizationIdDescription')}
+            >
+              <div className="w-full sm:w-80">
+                <CopyableField
+                  value={organization?._id ?? ''}
+                  copyAriaLabel={tSettings('organization.copyOrganizationId')}
                 />
               </div>
             </SettingsRow>
@@ -308,6 +324,15 @@ export function OrganizationSettings({
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
+  const organizationSchema = useMemo(
+    () =>
+      z.object({
+        name: organizationNameSchema(tSettings('organization.nameRequired')),
+        defaultLocale: z.string(),
+      }),
+    [tSettings],
+  );
+
   const ability = useAbility();
   const abilityLoading = useAbilityLoading();
   const { data: organization, isLoading: isOrgLoading } =
@@ -346,7 +371,7 @@ export function OrganizationSettings({
         await authClient.organization.update({
           organizationId: organization._id,
           data: {
-            name: data.name.trim() || undefined,
+            name: data.name.trim(),
             metadata: updatedMetadata,
           },
         });
@@ -367,20 +392,9 @@ export function OrganizationSettings({
     [existingMetadata, organization, queryClient, toast, tToast],
   );
 
-  // Organization name is required: an empty value blocks Save (`isValid`)
-  // and surfaces a field error, mirroring the account profile-name rule.
-  const orgSchema = useMemo(
-    () =>
-      z.object({
-        name: z.string().trim().min(1, tSettings('organization.nameRequired')),
-        defaultLocale: z.string(),
-      }),
-    [tSettings],
-  );
-
   const editor = useFormEditor<OrganizationFormData>({
     data: initialData,
-    schema: orgSchema,
+    schema: organizationSchema,
     save,
   });
 
@@ -409,6 +423,7 @@ export function OrganizationSettings({
         // The settings route is always scoped to the org the user is currently
         // in (`/dashboard/$id/...`), so deleting it must route them elsewhere.
         isCurrentOrganization
+        onSave={save}
       />
     </Skeletonize>
   );

--- a/services/platform/convex/auth.test.ts
+++ b/services/platform/convex/auth.test.ts
@@ -12,7 +12,9 @@ vi.mock('better-auth', () => ({
 }));
 
 vi.mock('better-auth/plugins', () => ({
-  organization: vi.fn(() => ({})),
+  // Return the config so tests can reach `organizationHooks` (the real plugin
+  // would consume them internally and expose nothing).
+  organization: vi.fn((config: unknown) => config),
   twoFactor: vi.fn(() => ({})),
 }));
 
@@ -94,6 +96,63 @@ describe('auth trustedOrigins', () => {
       expect(origin).not.toContain('*');
     }
 
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('beforeUpdateOrganization name guard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  // Pull the `beforeUpdateOrganization` hook out of the org plugin config the
+  // mock above passes through, so we can exercise the server-side gate directly
+  // — the acceptance criterion requires an empty name to be blocked on the
+  // server too, and neither the client unit tests nor the Playwright E2E reach
+  // this branch.
+  async function getBeforeUpdateOrganization() {
+    vi.stubEnv('SITE_URL', 'https://app.example.com');
+    const { getAuthOptions } = await import('./auth');
+    const options = getAuthOptions({} as never);
+    // oxlint-disable-next-line typescript/no-explicit-any -- test reaches into the loose better-auth plugin config
+    const orgPlugin = (options.plugins as any[]).find(
+      (plugin) => plugin?.organizationHooks?.beforeUpdateOrganization,
+    );
+    expect(orgPlugin).toBeDefined();
+    return orgPlugin.organizationHooks.beforeUpdateOrganization as (
+      data: unknown,
+    ) => Promise<void>;
+  }
+
+  it('rejects a whitespace-only name', async () => {
+    const beforeUpdate = await getBeforeUpdateOrganization();
+    await expect(
+      beforeUpdate({ organization: { name: '   ' } }),
+    ).rejects.toThrow();
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects a non-string name', async () => {
+    const beforeUpdate = await getBeforeUpdateOrganization();
+    await expect(
+      beforeUpdate({ organization: { name: 123 } }),
+    ).rejects.toThrow();
+    vi.unstubAllEnvs();
+  });
+
+  it('trims and persists a valid name', async () => {
+    const beforeUpdate = await getBeforeUpdateOrganization();
+    const data = { organization: { name: '  Acme  ' } };
+    await beforeUpdate(data);
+    expect(data.organization.name).toBe('Acme');
+    vi.unstubAllEnvs();
+  });
+
+  it('leaves a name-absent (locale-only) update untouched', async () => {
+    const beforeUpdate = await getBeforeUpdateOrganization();
+    const data = { organization: { metadata: { defaultLocale: 'de' } } };
+    await expect(beforeUpdate(data)).resolves.toBeUndefined();
+    expect(data.organization).toEqual({ metadata: { defaultLocale: 'de' } });
     vi.unstubAllEnvs();
   });
 });

--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -708,6 +708,20 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
             // through a `Record<string, unknown>` view so the field
             // shape matches Better Auth's loose update payload type.
             const orgPatch = data.organization as Record<string, unknown>;
+            // Org name is required: reject a rename that clears it (empty or
+            // whitespace-only). Mirrors the client-side `.min(1)` validation so
+            // an empty name can't slip past the auth boundary via a direct API
+            // call. Only enforced when `name` is part of the patch — a name-less
+            // update (e.g. locale-only) leaves the stored name untouched.
+            const rawName = orgPatch.name;
+            if (rawName !== undefined) {
+              if (typeof rawName !== 'string' || rawName.trim().length === 0) {
+                throw new APIError('BAD_REQUEST', {
+                  message: 'Organization name is required.',
+                });
+              }
+              orgPatch.name = rawName.trim();
+            }
             const rawSlug = orgPatch.slug;
             if (typeof rawSlug !== 'string') return;
             const normalizedSlug = rawSlug.toLowerCase();

--- a/services/platform/convex/auth.ts
+++ b/services/platform/convex/auth.ts
@@ -15,6 +15,7 @@ import {
 
 import { assertValidOrgSlug } from '../lib/shared/constants/org-slug';
 import { isReservedOrgSlug } from '../lib/shared/constants/reserved-org-slugs';
+import { organizationNameSchema } from '../lib/shared/schemas/organizations';
 import { sessionIdleWindowSeconds } from '../lib/shared/session-idle';
 import { getOrganizationDefaultLocale } from '../lib/shared/utils/get-organization-default-locale';
 import { isRecord, getString } from '../lib/utils/type-utils';
@@ -713,14 +714,16 @@ export const getAuthOptions = (ctx: GenericCtx<DataModel>) => {
             // an empty name can't slip past the auth boundary via a direct API
             // call. Only enforced when `name` is part of the patch — a name-less
             // update (e.g. locale-only) leaves the stored name untouched.
-            const rawName = orgPatch.name;
-            if (rawName !== undefined) {
-              if (typeof rawName !== 'string' || rawName.trim().length === 0) {
+            if (orgPatch.name !== undefined) {
+              const parsedName = organizationNameSchema().safeParse(
+                orgPatch.name,
+              );
+              if (!parsedName.success) {
                 throw new APIError('BAD_REQUEST', {
                   message: 'Organization name is required.',
                 });
               }
-              orgPatch.name = rawName.trim();
+              orgPatch.name = parsedName.data;
             }
             const rawSlug = orgPatch.slug;
             if (typeof rawSlug !== 'string') return;

--- a/services/platform/lib/shared/schemas/organizations.ts
+++ b/services/platform/lib/shared/schemas/organizations.ts
@@ -10,3 +10,13 @@ const memberRoleLiterals = [
 ] as const;
 export const memberRoleSchema = z.enum(memberRoleLiterals);
 export type MemberRole = z.infer<typeof memberRoleSchema>;
+
+/**
+ * Organization name is required: non-empty once trimmed. Shared so the client
+ * settings form and the Convex `beforeUpdateOrganization` hook enforce the same
+ * rule from a single source — neither layer can drift from the other. The
+ * optional `message` lets the client inject a localized error; the server
+ * relies on `safeParse` success/failure and supplies its own message.
+ */
+export const organizationNameSchema = (message?: string) =>
+  z.string().trim().min(1, message);


### PR DESCRIPTION
## Summary

Resolves #1951 — the organization name is now enforced as **required**, client- and server-side.

## Changes

- **Client validation** (`organization-settings.tsx`): added a Zod schema (`name: z.string().trim().min(1)`) wired through `useFormEditor`, so an empty/whitespace name blocks Save and surfaces an inline error via the existing `Input` `errorMessage` path. The save now sends the trimmed name unconditionally (no longer `|| undefined`).
- **Required label** (`settings-row.tsx`): added an optional `required` prop that renders the red `*` asterisk (mirrors the `Label` primitive, with a translated `aria-label`); the org-name row opts in.
- **Server enforcement** (`convex/auth.ts`, `beforeUpdateOrganization`): rejects an org rename that clears the name (empty/whitespace) with `APIError('BAD_REQUEST')` and trims the stored value, so the rule can't be bypassed via a direct API call. Only enforced when `name` is part of the patch (locale-only updates are untouched).
- **i18n**: added `settings.organization.nameRequired` to `en`/`de`/`fr`. Also fixed the German/French `settings.organization.title`, which still read "Organisation (optional)" / "(facultatif)" — corrected to "Organisationsname" / "Nom de l'organisation" to match the now-required English label.

## Tests

- New unit tests in `organization-settings.test.tsx`: empty name → inline error + `isValid: false`; entering a name clears the error and re-validates.
- Ran the platform UI suite (`organization-settings`, `settings-row`) — 12 passing — plus the i18n parity suite (34 passing) and `bun run typecheck` (clean).

## Acceptance criteria

- [x] Saving an empty org name is blocked client- and server-side with a clear message.

## Notes

- Docs: N/A — no docs page documented the org-name field's optionality.
- Migrations: N/A — no schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization name field now requires input with validation that displays error messages when empty or whitespace-only.

* **Localization**
  * Added organization name validation messages in English, German, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->