### PR TITLE
fix: move organization ID to API keys section description with copy button (#1952)

### DIFF
--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -7,7 +7,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
 
 import { AccessDenied } from '@/app/components/layout/access-denied';
-import { CopyableField } from '@/app/components/ui/data-display/copyable-field';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import {
   useFormEditor,
@@ -121,10 +120,9 @@ export function OrganizationSettingsView({
     <SettingsPage>
       {/* Settings-row layout: each field is a horizontal row with its
           label + helper text on the left and the control pinned right, with
-          a divider between rows. The form (name + locale) and the read-only
-          Organization ID share one divided list so they read as one
-          continuous block; Save/Discard live in the settings header via the
-          registered editor. */}
+          a divider between rows. The form (name + locale) reads as one
+          continuous divided block; Save/Discard live in the settings header
+          via the registered editor. */}
       <SettingsSection
         title={tSettings('organization.detailsTitle')}
         description={tSettings('organization.detailsDescription')}
@@ -182,19 +180,6 @@ export function OrganizationSettingsView({
                       options={localeOptions}
                     />
                   )}
-                />
-              </div>
-            </SettingsRow>
-
-            <SettingsRow
-              className="py-5"
-              label={tSettings('organization.organizationId')}
-              description={tSettings('organization.organizationIdDescription')}
-            >
-              <div className="w-full sm:w-80">
-                <CopyableField
-                  value={organization?._id ?? ''}
-                  copyAriaLabel={tSettings('organization.copyOrganizationId')}
                 />
               </div>
             </SettingsRow>

--- a/services/platform/app/routes/dashboard/$id/settings/api/rest.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/api/rest.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { CopyableText } from '@/app/components/ui/data-display/copyable-field';
 import { ApiKeysTable } from '@/app/features/settings/api-keys/components/api-keys-table';
 import { useApiKeys } from '@/app/features/settings/api-keys/hooks/use-api-keys';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
@@ -27,7 +28,18 @@ function ApiRestPage() {
     <SettingsPage>
       <SettingsSection
         title={tNav('apiKeys')}
-        description={tSettings('menu.apiKeys.description')}
+        description={
+          // The organization ID lives here (not in org settings) because it's
+          // what callers reference when authenticating against the API. Copy
+          // affordance reuses the shared `CopyableText` pill.
+          <div className="flex flex-col gap-2">
+            <span>{tSettings('menu.apiKeys.description')}</span>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span>{tSettings('organization.organizationId')}:</span>
+              <CopyableText value={organizationId} />
+            </div>
+          </div>
+        }
       >
         <ApiKeysTable apiKeys={apiKeys} organizationId={organizationId} />
       </SettingsSection>

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5012,8 +5012,6 @@
       "nameDescription": "Der Anzeigename deiner Organisation.",
       "localeDescription": "Die Hauptsprache deiner Organisation.",
       "organizationId": "Organisations-ID",
-      "organizationIdDescription": "Verwende diese ID in API-Anfragen und Integrationen.",
-      "copyOrganizationId": "Organisations-ID kopieren",
       "membersSectionTitle": "Mitglieder",
       "membersDescription": "Personen, die Zugriff auf diese Organisation haben.",
       "membersEntityLabel": "Mitglieder",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5274,8 +5274,6 @@
       "nameDescription": "The display name for your organization.",
       "localeDescription": "Primary language for your organization.",
       "organizationId": "Organization ID",
-      "organizationIdDescription": "Reference this ID in API requests and integrations.",
-      "copyOrganizationId": "Copy organization ID",
       "membersSectionTitle": "Members",
       "membersDescription": "People who have access to this organization.",
       "membersEntityLabel": "members",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5013,8 +5013,6 @@
       "nameDescription": "Le nom d'affichage de ton organisation.",
       "localeDescription": "La langue principale de ton organisation.",
       "organizationId": "ID de l'organisation",
-      "organizationIdDescription": "Utilise cet ID dans les requêtes API et les intégrations.",
-      "copyOrganizationId": "Copier l'ID de l'organisation",
       "membersSectionTitle": "Membres",
       "membersDescription": "Personnes ayant accès à cette organisation.",
       "membersEntityLabel": "membres",


### PR DESCRIPTION
## Summary
Resolves #1952.

Moves the organization ID out of **Organization settings** and surfaces it in the **API keys** section description, where it's most relevant (it's what callers reference when authenticating against the API), with a copy button.

## Changes
- Removed the read-only "Organization ID" `SettingsRow` (and now-unused `CopyableField` import) from `organization-settings.tsx`.
- Added the org ID to the API keys (REST) section description in `api/rest.tsx`, rendered with the shared `CopyableText` copy affordance.
- Removed the now-unused `organizationIdDescription` / `copyOrganizationId` i18n keys from en/de/fr.

## Acceptance criteria
- [x] Org ID no longer appears in org settings.
- [x] Org ID appears in the API keys section description, copyable.

## Verification
- `tsc --noEmit` ✅
- `oxlint --type-aware` (changed files) ✅
- `oxfmt --check` (changed files) ✅
- UI tests (`vitest` ui config, organization-settings) ✅