### PR TITLE
fix: make Upload skill control a normal button (not a single-item dropdown) (#1955)

### DIFF
--- a/services/platform/app/features/skills/components/skills-action-menu.tsx
+++ b/services/platform/app/features/skills/components/skills-action-menu.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { Upload } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
-import {
-  DataTableActionMenu,
-  type DataTableActionMenuItem,
-} from '@/app/components/ui/data-table/data-table-action-menu';
+import { DataTableActionMenu } from '@/app/components/ui/data-table/data-table-action-menu';
 import { useT } from '@/lib/i18n/client';
 
 import { SkillUploadDialog } from './skill-upload/skill-upload-dialog';
@@ -25,20 +22,14 @@ export function SkillsActionMenu({
   const { t } = useT('settings');
 
   const label = t('skills.uploadSkill', { defaultValue: 'Upload skill' });
-  const menuItems = useMemo<DataTableActionMenuItem[]>(
-    () => [
-      {
-        label,
-        icon: Upload,
-        onClick: () => setUploadOpen(true),
-      },
-    ],
-    [label],
-  );
 
   return (
     <>
-      <DataTableActionMenu label={label} icon={Upload} menuItems={menuItems} />
+      <DataTableActionMenu
+        label={label}
+        icon={Upload}
+        onClick={() => setUploadOpen(true)}
+      />
       <SkillUploadDialog
         open={uploadOpen}
         onOpenChange={setUploadOpen}


### PR DESCRIPTION
## Summary

Resolves #1955.

The "Upload skill" control was a `DataTableActionMenu` dropdown with a single "Upload skill" item. This replaces it with a plain button that opens the upload dialog directly — using the `DataTableActionMenu` simple-button mode (`onClick` instead of `menuItems`), so styling stays consistent with the table toolbar and no chevron/dropdown is rendered.

## Acceptance criteria
- [x] "Upload skill" is a single button.
- [x] No dropdown chevron / menu.

## Verification
- `oxlint --type-aware` on the changed file: clean.
- `tsc --noEmit`: clean.
- UI test `skills-table.test.tsx` (asserts the `button` named "Upload skill" + axe audit): 2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the skills action menu implementation for a cleaner, more direct menu rendering approach.
  * Improved internal handling of menu actions while keeping the visible behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->