### PR TITLE
feat: one shared searchable, scrollable multi-select component (#1954)

### DIFF
--- a/services/platform/app/components/ui/forms/multi-select.stories.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import { MultiSelect } from './multi-select';
+
+const sampleOptions = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+  { value: 'date', label: 'Date' },
+  { value: 'elderberry', label: 'Elderberry' },
+];
+
+const optionsWithDescriptions = [
+  {
+    value: 'sales',
+    label: 'Sales',
+    description: 'Customer-facing revenue team',
+  },
+  {
+    value: 'support',
+    label: 'Support',
+    description: 'Handles inbound tickets',
+  },
+  {
+    value: 'ops',
+    label: 'Operations',
+    description: 'Internal logistics and tooling',
+  },
+];
+
+const manyOptions = Array.from({ length: 1000 }, (_, i) => ({
+  value: `member-${i + 1}`,
+  label: `Member ${i + 1}`,
+}));
+
+const meta: Meta<typeof MultiSelect> = {
+  title: 'Forms/MultiSelect',
+  component: MultiSelect,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+A searchable, scrollable multi-select built on Radix UI Popover. Selected
+values render as removable chips in the trigger; the popover lists checkbox
+rows that toggle without closing, and large lists (~1000) stay usable via
+search + scroll.
+
+## Usage
+\`\`\`tsx
+import { MultiSelect } from './multi-select';
+
+<MultiSelect
+  value={values}
+  onValueChange={setValues}
+  options={[
+    { value: 'a', label: 'Option A' },
+    { value: 'b', label: 'Option B', description: 'With description' },
+  ]}
+  placeholder="Select options..."
+  searchPlaceholder="Search..."
+  emptyText="No results found"
+/>
+\`\`\`
+
+## Keyboard navigation
+- **Arrow Down / Up**: Move the highlight
+- **Enter**: Toggle the highlighted option (popover stays open)
+- **Home / End**: Jump to first / last option
+- **Escape**: Close the popover
+
+## Accessibility
+- Search input has \`role="combobox"\` with \`aria-activedescendant\`
+- Options container has \`role="listbox"\` with \`aria-multiselectable\`
+- Each option has \`role="option"\` with \`aria-selected\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    searchPlaceholder: { control: 'text' },
+    emptyText: { control: 'text' },
+    searchable: { control: 'boolean' },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+    },
+  },
+  args: {
+    onValueChange: fn(),
+    searchPlaceholder: 'Search...',
+    emptyText: 'No results found',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[30rem] w-[20rem] items-start justify-center pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MultiSelect>;
+
+export const Default: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: 'Select fruit...',
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState<string[]>([]);
+    return <MultiSelect {...args} value={value} onValueChange={setValue} />;
+  },
+};
+
+export const WithDescriptions: Story = {
+  args: {
+    options: optionsWithDescriptions,
+    placeholder: 'Select teams...',
+    searchPlaceholder: 'Search teams...',
+    label: 'Teams',
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState(['sales']);
+    return <MultiSelect {...args} value={value} onValueChange={setValue} />;
+  },
+};
+
+export const LargeList: Story = {
+  args: {
+    options: manyOptions,
+    placeholder: 'Add members...',
+    searchPlaceholder: 'Search 1000 members...',
+    label: 'Members',
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState(['member-1', 'member-2', 'member-3']);
+    return <MultiSelect {...args} value={value} onValueChange={setValue} />;
+  },
+};
+
+export const WithoutSearch: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: 'Select fruit...',
+    searchable: false,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState<string[]>([]);
+    return <MultiSelect {...args} value={value} onValueChange={setValue} />;
+  },
+};

--- a/services/platform/app/components/ui/forms/multi-select.test.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.test.tsx
@@ -222,4 +222,45 @@ describe('MultiSelect', () => {
       expect(onValueChange).toHaveBeenCalledWith(['banana']);
     });
   });
+
+  describe('keyboard navigation without a search input', () => {
+    it('focuses the listbox on open so it is keyboard-operable', async () => {
+      const { user } = renderSelect({ searchable: false });
+      await user.click(screen.getByText('Open select'));
+      const listbox = screen.getByRole('listbox');
+      expect(listbox).toHaveAttribute('tabindex', '0');
+      expect(listbox).toHaveFocus();
+    });
+
+    it('toggles the highlighted option with ArrowDown + Enter', async () => {
+      const { user, onValueChange } = renderSelect({ searchable: false });
+      await user.click(screen.getByText('Open select'));
+      await user.keyboard('{ArrowDown}{Enter}');
+      expect(onValueChange).toHaveBeenCalledWith(['banana']);
+    });
+
+    it('toggles the first/last option with Home/End', async () => {
+      const { user, onValueChange } = renderSelect({ searchable: false });
+      await user.click(screen.getByText('Open select'));
+      await user.keyboard('{End}{Enter}');
+      // Last option (index 3) is disabled, so End lands on the last *enabled*
+      // option, Cherry.
+      expect(onValueChange).toHaveBeenCalledWith(['cherry']);
+      onValueChange.mockClear();
+      await user.keyboard('{Home}{Enter}');
+      expect(onValueChange).toHaveBeenCalledWith(['apple']);
+    });
+
+    it('exposes the highlighted option via aria-activedescendant', async () => {
+      const { user } = renderSelect({ searchable: false });
+      await user.click(screen.getByText('Open select'));
+      const listbox = screen.getByRole('listbox');
+      const activeId = listbox.getAttribute('aria-activedescendant');
+      expect(activeId).toBeTruthy();
+      expect(screen.getByRole('option', { name: /Apple/i })).toHaveAttribute(
+        'id',
+        activeId,
+      );
+    });
+  });
 });

--- a/services/platform/app/components/ui/forms/multi-select.test.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.test.tsx
@@ -149,6 +149,23 @@ describe('MultiSelect', () => {
         'true',
       );
     });
+
+    it('does not open on click when disabled', async () => {
+      const { user } = renderDefault({ disabled: true });
+      await user.click(screen.getByRole('combobox'));
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('does not emit onValueChange when disabled and toggled', async () => {
+      const { user, onValueChange } = renderDefault({
+        disabled: true,
+        open: true,
+      });
+      // Even if the popover is forced open, a disabled select must not mutate
+      // its value when an option is clicked.
+      await user.click(screen.getByRole('option', { name: /Apple/i }));
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('interactions', () => {

--- a/services/platform/app/components/ui/forms/multi-select.test.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.test.tsx
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { MultiSelect, type MultiSelectOption } from './multi-select';
+
+const options: MultiSelectOption[] = [
+  { value: 'apple', label: 'Apple', description: 'A red fruit' },
+  { value: 'banana', label: 'Banana', description: 'A yellow fruit' },
+  { value: 'cherry', label: 'Cherry' },
+  { value: 'disabled-opt', label: 'Disabled', disabled: true },
+];
+
+function renderSelect(
+  overrides: Partial<React.ComponentProps<typeof MultiSelect>> = {},
+) {
+  const onValueChange = vi.fn();
+  const result = render(
+    <MultiSelect
+      value={[]}
+      onValueChange={onValueChange}
+      options={options}
+      trigger={<button type="button">Open select</button>}
+      searchPlaceholder="Search..."
+      emptyText="No results"
+      aria-label="Test listbox"
+      {...overrides}
+    />,
+  );
+  return { ...result, onValueChange };
+}
+
+describe('MultiSelect', () => {
+  describe('rendering', () => {
+    it('renders the trigger', () => {
+      renderSelect();
+      expect(screen.getByText('Open select')).toBeInTheDocument();
+    });
+
+    it('does not render the listbox when closed', () => {
+      renderSelect();
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('renders all options when open', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getAllByRole('option')).toHaveLength(4);
+    });
+
+    it('marks the listbox as multi-selectable', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getByRole('listbox')).toHaveAttribute(
+        'aria-multiselectable',
+        'true',
+      );
+    });
+
+    it('renders option descriptions', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getByText('A red fruit')).toBeInTheDocument();
+    });
+
+    it('marks selected options with aria-selected', async () => {
+      const { user } = renderSelect({ value: ['apple'] });
+      await user.click(screen.getByText('Open select'));
+      const appleOption = screen.getByRole('option', { name: /Apple/i });
+      expect(appleOption.getAttribute('aria-selected')).toBe('true');
+      const cherryOption = screen.getByRole('option', { name: /Cherry/i });
+      expect(cherryOption.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('renders empty state when no matches', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      await user.type(screen.getByRole('combobox'), 'zzzzz');
+      expect(screen.getByText('No results')).toBeInTheDocument();
+    });
+
+    it('renders footer when provided', async () => {
+      const { user } = renderSelect({
+        footer: <button type="button">Add item</button>,
+      });
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getByText('Add item')).toBeInTheDocument();
+    });
+
+    it('hides the search input when searchable is false', async () => {
+      const { user } = renderSelect({ searchable: false });
+      await user.click(screen.getByText('Open select'));
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('default trigger', () => {
+    function renderDefault(
+      overrides: Partial<React.ComponentProps<typeof MultiSelect>> = {},
+    ) {
+      const onValueChange = vi.fn();
+      const result = render(
+        <MultiSelect
+          value={[]}
+          onValueChange={onValueChange}
+          options={options}
+          placeholder="Pick fruit"
+          searchPlaceholder="Search..."
+          {...overrides}
+        />,
+      );
+      return { ...result, onValueChange };
+    }
+
+    it('shows the placeholder when nothing selected', () => {
+      renderDefault();
+      expect(screen.getByText('Pick fruit')).toBeInTheDocument();
+    });
+
+    it('renders selected values as chips', () => {
+      renderDefault({ value: ['apple', 'banana'] });
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+      expect(screen.getByText('Banana')).toBeInTheDocument();
+      expect(screen.queryByText('Pick fruit')).not.toBeInTheDocument();
+    });
+
+    it('removes a value when its chip remove button is clicked', async () => {
+      const { user, onValueChange } = renderDefault({
+        value: ['apple', 'banana'],
+      });
+      await user.click(screen.getByRole('button', { name: /remove apple/i }));
+      expect(onValueChange).toHaveBeenCalledWith(['banana']);
+    });
+
+    it('uses removeChipLabel for the chip remove button', () => {
+      renderDefault({
+        value: ['apple'],
+        removeChipLabel: (o) => `Unpick ${o.label}`,
+      });
+      expect(
+        screen.getByRole('button', { name: 'Unpick Apple' }),
+      ).toBeInTheDocument();
+    });
+
+    it('marks the default trigger disabled', () => {
+      renderDefault({ disabled: true });
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+  });
+
+  describe('interactions', () => {
+    it('opens on trigger click', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('filters options by search query', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      await user.type(screen.getByRole('combobox'), 'ban');
+      const opts = screen.getAllByRole('option');
+      expect(opts).toHaveLength(1);
+      expect(opts[0]).toHaveTextContent('Banana');
+    });
+
+    it('adds a value when toggling an unselected option', async () => {
+      const { user, onValueChange } = renderSelect({ value: ['apple'] });
+      await user.click(screen.getByText('Open select'));
+      await user.click(screen.getByRole('option', { name: /Banana/i }));
+      expect(onValueChange).toHaveBeenCalledWith(['apple', 'banana']);
+    });
+
+    it('removes a value when toggling a selected option', async () => {
+      const { user, onValueChange } = renderSelect({
+        value: ['apple', 'banana'],
+      });
+      await user.click(screen.getByText('Open select'));
+      await user.click(screen.getByRole('option', { name: /Apple/i }));
+      expect(onValueChange).toHaveBeenCalledWith(['banana']);
+    });
+
+    it('keeps the popover open after toggling (multi-select)', async () => {
+      const { user } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      await user.click(screen.getByRole('option', { name: /Apple/i }));
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('does not toggle disabled options', async () => {
+      const { user, onValueChange } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      await user.click(screen.getByRole('option', { name: /Disabled/i }));
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('toggles the highlighted option with Enter', async () => {
+      const { user, onValueChange } = renderSelect();
+      await user.click(screen.getByText('Open select'));
+      const input = screen.getByRole('combobox');
+      await user.type(input, '{ArrowDown}{Enter}');
+      expect(onValueChange).toHaveBeenCalledWith(['banana']);
+    });
+  });
+});

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -172,6 +172,7 @@ function MultiSelectBase({
   const optionId = (index: number) => `${instanceId}-option-${index}`;
   const triggerId = providedId ?? `${instanceId}-trigger`;
   const descriptionId = `${instanceId}-description`;
+  const labelId = `${instanceId}-label`;
 
   const valueSet = useMemo(() => new Set(value), [value]);
 
@@ -306,6 +307,10 @@ function MultiSelectBase({
       aria-controls={isOpen ? listboxId : undefined}
       aria-disabled={disabled || undefined}
       aria-invalid={error || undefined}
+      // A `<label htmlFor>` cannot name a role="combobox" div, so name the
+      // trigger explicitly: prefer the visible label, fall back to aria-label.
+      aria-labelledby={label ? labelId : undefined}
+      aria-label={label ? undefined : ariaLabel}
       aria-describedby={description ? descriptionId : undefined}
       onKeyDown={(e) => {
         if (disabled) return;
@@ -474,7 +479,12 @@ function MultiSelectBase({
   return (
     <div className="flex flex-col gap-1.5">
       {label && (
-        <Label htmlFor={triggerId} required={required} error={error}>
+        <Label
+          id={labelId}
+          htmlFor={triggerId}
+          required={required}
+          error={error}
+        >
           {label}
         </Label>
       )}

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -222,22 +222,27 @@ function MultiSelectBase({
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
+      // A disabled trigger must not open by any path (Radix's Trigger fires
+      // onOpenToggle on mouse click regardless of our div's aria-disabled).
+      if (disabled && nextOpen) return;
       setIsOpen(nextOpen);
+      if (nextOpen) setHighlightedIndex(0);
       if (!nextOpen) setSearch('');
     },
-    [setIsOpen],
+    [disabled, setIsOpen],
   );
 
   // Toggle keeps the popover open — multi-select picks several values per visit.
   const handleToggle = useCallback(
     (optionValue: string) => {
+      if (disabled) return;
       if (valueSet.has(optionValue)) {
         onValueChange(value.filter((v) => v !== optionValue));
       } else {
         onValueChange([...value, optionValue]);
       }
     },
-    [value, valueSet, onValueChange],
+    [disabled, value, valueSet, onValueChange],
   );
 
   const handleSearchKeyDown = useCallback(
@@ -312,7 +317,7 @@ function MultiSelectBase({
       className={cn(
         selectTriggerClasses({ error }),
         'h-auto min-h-9 cursor-pointer flex-wrap gap-1.5 py-1.5',
-        disabled && 'cursor-not-allowed opacity-50',
+        disabled && 'pointer-events-none cursor-not-allowed opacity-50',
         triggerClassName,
       )}
     >
@@ -401,7 +406,7 @@ function MultiSelectBase({
                 aria-expanded={isOpen}
                 aria-controls={listboxId}
                 aria-activedescendant={
-                  filteredOptions.length > 0
+                  highlightedIndex < filteredOptions.length
                     ? optionId(highlightedIndex)
                     : undefined
                 }

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -245,8 +245,8 @@ function MultiSelectBase({
     [disabled, value, valueSet, onValueChange],
   );
 
-  const handleSearchKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleListKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLElement>) => {
       const len = filteredOptions.length;
       if (len === 0) return;
 
@@ -381,10 +381,13 @@ function MultiSelectBase({
           )}
           onOpenAutoFocus={(e) => {
             // Keep focus on the search input (or the list, when not searchable)
-            // rather than the first option, so type-to-filter works immediately.
+            // rather than the first option, so type-to-filter works immediately
+            // and Arrow/Home/End/Enter drive the highlight in both modes.
+            e.preventDefault();
             if (searchable) {
-              e.preventDefault();
               searchRef.current?.focus();
+            } else {
+              listRef.current?.focus();
             }
           }}
         >
@@ -400,7 +403,7 @@ function MultiSelectBase({
                 role="combobox"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
+                onKeyDown={handleListKeyDown}
                 placeholder={searchPlaceholder}
                 className="placeholder:text-muted-foreground flex-1 bg-transparent text-base outline-none"
                 aria-expanded={isOpen}
@@ -422,7 +425,16 @@ function MultiSelectBase({
             role="listbox"
             aria-multiselectable="true"
             aria-label={ariaLabel}
-            className="max-h-[18rem] overflow-y-auto p-1"
+            // With no search input the listbox itself is the focusable, keyboard
+            // -operable control, so it carries tabIndex + the roving descendant.
+            tabIndex={searchable ? undefined : 0}
+            onKeyDown={searchable ? undefined : handleListKeyDown}
+            aria-activedescendant={
+              !searchable && highlightedIndex < filteredOptions.length
+                ? optionId(highlightedIndex)
+                : undefined
+            }
+            className="max-h-[18rem] overflow-y-auto p-1 outline-none"
           >
             {filteredOptions.map((option, index) => (
               <MultiSelectOptionItem
@@ -513,7 +525,7 @@ function MultiSelectOptionItem({
   const showDescription = Boolean(option.description);
 
   return (
-    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- keyboard handled via the search input's aria-activedescendant
+    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- keyboard handled by the focused search input / listbox via aria-activedescendant
     <div
       role="option"
       id={id}

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -1,0 +1,549 @@
+'use client';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { Description } from '@tale/ui/description';
+import { SkeletonBox } from '@tale/ui/skeleton';
+import { useSkeleton } from '@tale/ui/skeleton-context';
+import { Text } from '@tale/ui/text';
+import { ChevronDown, Search, X } from 'lucide-react';
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { cn } from '@/lib/utils/cn';
+
+import { Checkbox } from './checkbox';
+import { Label } from './label';
+import { selectTriggerClasses } from './select';
+
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  /**
+   * Optional inline badge rendered right after the label (e.g. a category tag
+   * on a tool row). Wraps onto a second line when the label is long.
+   */
+  labelBadge?: ReactNode;
+  description?: string;
+  disabled?: boolean;
+}
+
+export interface MultiSelectProps {
+  /** The currently selected values. */
+  value: ReadonlyArray<string>;
+  /** Called with the COMPLETE next selection whenever an option is toggled. */
+  onValueChange: (value: string[]) => void;
+  /** Array of options to display. */
+  options: ReadonlyArray<MultiSelectOption>;
+  /**
+   * Custom trigger element. If omitted, a default chip-rendering combobox
+   * trigger is rendered using `label`, `placeholder`, `error`, etc.
+   */
+  trigger?: ReactNode;
+  /** Label rendered above the default trigger. Ignored when `trigger` is provided. */
+  label?: ReactNode;
+  /**
+   * Content shown on the default trigger when nothing is selected. A plain
+   * string renders as muted placeholder text; pass a node (e.g. a chip) to
+   * represent an implicit default such as "Organization-wide".
+   */
+  placeholder?: ReactNode;
+  /** Marks the default trigger as invalid (adds error ring + aria-invalid). */
+  error?: boolean;
+  /** Description text rendered below the default trigger. */
+  description?: ReactNode;
+  /** Adds a required asterisk next to the default trigger's label. */
+  required?: boolean;
+  /** Disables the default trigger. Ignored when `trigger` is provided. */
+  disabled?: boolean;
+  /** Id for the default trigger (used for label association). */
+  id?: string;
+  /** Additional className merged onto the default trigger. */
+  triggerClassName?: string;
+  /**
+   * Show the search input. Defaults to `true`; the popover is always
+   * scrollable so large lists (~1000) stay usable via search + scroll.
+   */
+  searchable?: boolean;
+  /** Placeholder text for the search input. */
+  searchPlaceholder?: string;
+  /** Text to display when no options match the search. */
+  emptyText?: string;
+  /** Optional footer content (e.g., an action button) rendered below the list. */
+  footer?: ReactNode;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Called when open state changes. */
+  onOpenChange?: (open: boolean) => void;
+  /** Popover alignment relative to trigger. @default 'start' */
+  align?: 'start' | 'center' | 'end';
+  /** Popover side. */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /** Popover side offset in pixels. @default 4 */
+  sideOffset?: number;
+  /** Additional className for the popover content. */
+  contentClassName?: string;
+  /** Accessible label for the listbox. */
+  'aria-label'?: string;
+  /** Custom filter function; defaults to case-insensitive match on label + description. */
+  filterFn?: (option: MultiSelectOption, query: string) => boolean;
+  /**
+   * Builds the accessible label for a selected chip's remove button, e.g.
+   * `(option) => t('removeX', { name: option.label })`. Falls back to the
+   * option label alone when omitted.
+   */
+  removeChipLabel?: (option: MultiSelectOption) => string;
+  /**
+   * Render the popover as a Radix modal layer. Required when the select sits
+   * inside a modal Dialog: the dialog's scroll lock swallows wheel events over
+   * the (portaled) popover, so a long option list won't wheel-scroll. A modal
+   * popover registers its own scroll-lock shard, restoring scrolling.
+   * @default false
+   */
+  modal?: boolean;
+}
+
+const CONTENT_CLASSES =
+  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+
+function defaultFilterFn(option: MultiSelectOption, query: string) {
+  const lower = query.toLowerCase();
+  return (
+    option.label.toLowerCase().includes(lower) ||
+    (option.description?.toLowerCase().includes(lower) ?? false)
+  );
+}
+
+function findNextEnabledIndex(
+  options: ReadonlyArray<MultiSelectOption>,
+  current: number,
+  direction: 1 | -1,
+) {
+  const len = options.length;
+  if (len === 0) return -1;
+  let index = (current + direction + len) % len;
+  let iterations = 0;
+  while (options[index]?.disabled && iterations < len) {
+    index = (index + direction + len) % len;
+    iterations++;
+  }
+  return options[index]?.disabled ? -1 : index;
+}
+
+// Plain control — the real default trigger (or caller-supplied `trigger`) +
+// searchable popover (+ optional label/description). No skeleton logic.
+function MultiSelectBase({
+  value,
+  onValueChange,
+  options,
+  trigger,
+  label,
+  placeholder,
+  error,
+  description,
+  required,
+  disabled,
+  id: providedId,
+  triggerClassName,
+  searchable = true,
+  searchPlaceholder,
+  emptyText,
+  footer,
+  open: controlledOpen,
+  onOpenChange,
+  align = 'start',
+  side,
+  sideOffset = 4,
+  contentClassName,
+  'aria-label': ariaLabel,
+  filterFn,
+  removeChipLabel,
+  modal = false,
+}: MultiSelectProps) {
+  const instanceId = useId();
+  const listboxId = `${instanceId}-listbox`;
+  const optionId = (index: number) => `${instanceId}-option-${index}`;
+  const triggerId = providedId ?? `${instanceId}-trigger`;
+  const descriptionId = `${instanceId}-description`;
+
+  const valueSet = useMemo(() => new Set(value), [value]);
+
+  // Preserve selection order so chips read in the order the user picked them.
+  const selectedOptions = useMemo(
+    () =>
+      value
+        .map((v) => options.find((o) => o.value === v))
+        .filter((o): o is MultiSelectOption => o !== undefined),
+    [value, options],
+  );
+
+  const isControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+
+  const [search, setSearch] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const setIsOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const filter = filterFn ?? defaultFilterFn;
+
+  const filteredOptions = useMemo(() => {
+    if (!search) return options;
+    return options.filter((o) => filter(o, search));
+  }, [options, search, filter]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [search]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const el = listRef.current?.querySelector(
+      `[data-index="${highlightedIndex}"]`,
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, isOpen]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setIsOpen(nextOpen);
+      if (!nextOpen) setSearch('');
+    },
+    [setIsOpen],
+  );
+
+  // Toggle keeps the popover open — multi-select picks several values per visit.
+  const handleToggle = useCallback(
+    (optionValue: string) => {
+      if (valueSet.has(optionValue)) {
+        onValueChange(value.filter((v) => v !== optionValue));
+      } else {
+        onValueChange([...value, optionValue]);
+      }
+    },
+    [value, valueSet, onValueChange],
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      const len = filteredOptions.length;
+      if (len === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          const next = findNextEnabledIndex(
+            filteredOptions,
+            highlightedIndex,
+            1,
+          );
+          if (next >= 0) setHighlightedIndex(next);
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          const prev = findNextEnabledIndex(
+            filteredOptions,
+            highlightedIndex,
+            -1,
+          );
+          if (prev >= 0) setHighlightedIndex(prev);
+          break;
+        }
+        case 'Enter': {
+          e.preventDefault();
+          const option = filteredOptions[highlightedIndex];
+          if (option && !option.disabled) handleToggle(option.value);
+          break;
+        }
+        case 'Home': {
+          e.preventDefault();
+          const first = findNextEnabledIndex(filteredOptions, -1, 1);
+          if (first >= 0) setHighlightedIndex(first);
+          break;
+        }
+        case 'End': {
+          e.preventDefault();
+          const last = findNextEnabledIndex(filteredOptions, len, -1);
+          if (last >= 0) setHighlightedIndex(last);
+          break;
+        }
+      }
+    },
+    [filteredOptions, highlightedIndex, handleToggle],
+  );
+
+  // The chip remove buttons are nested inside the trigger, so the trigger must
+  // be a <div> (not a <button>) to keep the markup valid. As a non-native
+  // control it needs its own keyboard activation for Enter/Space.
+  const defaultTrigger = trigger ?? (
+    <div
+      role="combobox"
+      id={triggerId}
+      tabIndex={disabled ? -1 : 0}
+      aria-expanded={isOpen}
+      aria-controls={isOpen ? listboxId : undefined}
+      aria-disabled={disabled || undefined}
+      aria-invalid={error || undefined}
+      aria-describedby={description ? descriptionId : undefined}
+      onKeyDown={(e) => {
+        if (disabled) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleOpenChange(!isOpen);
+        }
+      }}
+      className={cn(
+        selectTriggerClasses({ error }),
+        'h-auto min-h-9 cursor-pointer flex-wrap gap-1.5 py-1.5',
+        disabled && 'cursor-not-allowed opacity-50',
+        triggerClassName,
+      )}
+    >
+      <div className="flex flex-1 flex-wrap items-center gap-1.5">
+        {selectedOptions.length === 0 ? (
+          typeof placeholder === 'string' ? (
+            <span className="text-muted-foreground">{placeholder}</span>
+          ) : (
+            placeholder
+          )
+        ) : (
+          selectedOptions.map((option) => (
+            <span
+              key={option.value}
+              className="bg-muted inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
+            >
+              {option.label}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleToggle(option.value);
+                  }}
+                  className="text-muted-foreground hover:text-foreground -mr-0.5 rounded-sm"
+                  aria-label={
+                    removeChipLabel
+                      ? removeChipLabel(option)
+                      : `Remove ${option.label}`
+                  }
+                >
+                  <X className="size-3" aria-hidden="true" />
+                </button>
+              )}
+            </span>
+          ))
+        )}
+      </div>
+      <ChevronDown className="size-4 shrink-0 opacity-50" aria-hidden="true" />
+    </div>
+  );
+
+  const popover = (
+    <PopoverPrimitive.Root
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      modal={modal}
+    >
+      <PopoverPrimitive.Trigger asChild>
+        {defaultTrigger}
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align={align}
+          side={side}
+          sideOffset={sideOffset}
+          className={cn(
+            CONTENT_CLASSES,
+            'w-(--radix-popover-trigger-width)',
+            contentClassName,
+          )}
+          onOpenAutoFocus={(e) => {
+            // Keep focus on the search input (or the list, when not searchable)
+            // rather than the first option, so type-to-filter works immediately.
+            if (searchable) {
+              e.preventDefault();
+              searchRef.current?.focus();
+            }
+          }}
+        >
+          {searchable && (
+            <div className="border-border flex items-center gap-2 border-b p-3">
+              <Search
+                className="text-muted-foreground size-3.5 shrink-0"
+                aria-hidden="true"
+              />
+              <input
+                ref={searchRef}
+                type="text"
+                role="combobox"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                placeholder={searchPlaceholder}
+                className="placeholder:text-muted-foreground flex-1 bg-transparent text-base outline-none"
+                aria-expanded={isOpen}
+                aria-controls={listboxId}
+                aria-activedescendant={
+                  filteredOptions.length > 0
+                    ? optionId(highlightedIndex)
+                    : undefined
+                }
+                aria-autocomplete="list"
+                aria-label={searchPlaceholder}
+              />
+            </div>
+          )}
+
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-multiselectable="true"
+            aria-label={ariaLabel}
+            className="max-h-[18rem] overflow-y-auto p-1"
+          >
+            {filteredOptions.map((option, index) => (
+              <MultiSelectOptionItem
+                key={option.value}
+                option={option}
+                index={index}
+                id={optionId(index)}
+                isSelected={valueSet.has(option.value)}
+                isHighlighted={highlightedIndex === index}
+                onToggle={handleToggle}
+                onMouseEnter={setHighlightedIndex}
+              />
+            ))}
+
+            {filteredOptions.length === 0 && emptyText && (
+              <Text
+                as="div"
+                variant="muted"
+                align="center"
+                className="px-3 py-4"
+              >
+                {emptyText}
+              </Text>
+            )}
+          </div>
+
+          {footer && <div className="border-border border-t p-1">{footer}</div>}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+
+  if (!label && !description) {
+    return popover;
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && (
+        <Label htmlFor={triggerId} required={required} error={error}>
+          {label}
+        </Label>
+      )}
+      {popover}
+      {description && (
+        <Description id={descriptionId}>{description}</Description>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Skeleton-aware MultiSelect. Inside a `<Skeletonize loading>` it masks the
+ * plain control by rendering it inside a `<SkeletonBox>` — laid out invisibly
+ * to set the exact size, pulse overlay on top — so the skeleton can never
+ * drift. Only the DEFAULT trigger is masked: when a custom `trigger` is
+ * supplied the caller owns its own skeleton, so it renders normally.
+ */
+export function MultiSelect(props: MultiSelectProps) {
+  const loading = useSkeleton();
+  if (loading && !props.trigger) {
+    return (
+      <SkeletonBox>
+        <MultiSelectBase {...props} />
+      </SkeletonBox>
+    );
+  }
+  return <MultiSelectBase {...props} />;
+}
+
+function MultiSelectOptionItem({
+  option,
+  index,
+  id,
+  isSelected,
+  isHighlighted,
+  onToggle,
+  onMouseEnter,
+}: {
+  option: MultiSelectOption;
+  index: number;
+  id: string;
+  isSelected: boolean;
+  isHighlighted: boolean;
+  onToggle: (value: string) => void;
+  onMouseEnter: (index: number) => void;
+}) {
+  const showDescription = Boolean(option.description);
+
+  return (
+    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events -- keyboard handled via the search input's aria-activedescendant
+    <div
+      role="option"
+      id={id}
+      data-index={index}
+      aria-selected={isSelected}
+      aria-disabled={option.disabled || undefined}
+      data-highlighted={isHighlighted || undefined}
+      onClick={() => !option.disabled && onToggle(option.value)}
+      onMouseEnter={() => onMouseEnter(index)}
+      className={cn(
+        'group/option flex w-full cursor-default gap-2 rounded-md p-2 text-left text-sm transition-colors',
+        showDescription ? 'items-start' : 'items-center',
+        isHighlighted && 'bg-accent',
+        option.disabled && 'pointer-events-none opacity-50',
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none flex h-5 shrink-0 items-center"
+      >
+        <Checkbox checked={isSelected} tabIndex={-1} aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Text as="span" variant="label">
+            {option.label}
+          </Text>
+          {option.labelBadge}
+        </div>
+        {showDescription && (
+          <Text as="div" variant="caption">
+            {option.description}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/platform/app/features/agents/components/tool-selector.tsx
+++ b/services/platform/app/features/agents/components/tool-selector.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { Grid, Stack } from '@tale/ui/layout';
+import { Stack } from '@tale/ui/layout';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
 import { useCallback, useMemo } from 'react';
 
-import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { CheckboxGroup } from '@/app/components/ui/forms/checkbox-group';
 import { FormSection } from '@/app/components/ui/forms/form-section';
+import { MultiSelect } from '@/app/components/ui/forms/multi-select';
 import { toolDisplayName } from '@/app/features/chat/utils/format-tool-detail';
 import type { ToolName } from '@/convex/agent_tools/tool_names';
 import { useT } from '@/lib/i18n/client';
@@ -137,6 +137,7 @@ export function ToolSelector({
   showWorkflows = true,
 }: ToolSelectorProps) {
   const { t } = useT('settings');
+  const { t: tCommon } = useT('common');
   // Tool labels live in the shared `chat.tools.*` namespace (one vocabulary for
   // the chat timeline and this picker); category labels stay in `settings`.
   const { t: tTools } = useT('chat');
@@ -147,14 +148,6 @@ export function ToolSelector({
     useAvailableWorkflows(organizationId);
 
   const selectedSet = useMemo(() => new Set(value), [value]);
-  const selectedIntegrationBindingsSet = useMemo(
-    () => new Set(integrationBindings),
-    [integrationBindings],
-  );
-  const selectedWorkflowBindingsSet = useMemo(
-    () => new Set(workflowBindings),
-    [workflowBindings],
-  );
 
   const handleCategoryChange = useCallback(
     (categoryTools: string[], newValues: string[]) => {
@@ -163,36 +156,6 @@ export function ToolSelector({
       onChange([...otherValues, ...newValues]);
     },
     [value, onChange],
-  );
-
-  const toggleIntegrationBinding = useCallback(
-    (integrationName: string) => {
-      if (selectedIntegrationBindingsSet.has(integrationName)) {
-        onIntegrationBindingsChange(
-          integrationBindings.filter((b) => b !== integrationName),
-        );
-      } else {
-        onIntegrationBindingsChange([...integrationBindings, integrationName]);
-      }
-    },
-    [
-      integrationBindings,
-      onIntegrationBindingsChange,
-      selectedIntegrationBindingsSet,
-    ],
-  );
-
-  const toggleWorkflowBinding = useCallback(
-    (workflowId: string) => {
-      if (selectedWorkflowBindingsSet.has(workflowId)) {
-        onWorkflowBindingsChange(
-          workflowBindings.filter((b) => b !== workflowId),
-        );
-      } else {
-        onWorkflowBindingsChange([...workflowBindings, workflowId]);
-      }
-    },
-    [workflowBindings, onWorkflowBindingsChange, selectedWorkflowBindingsSet],
   );
 
   const availableToolNames = useMemo(
@@ -214,16 +177,20 @@ export function ToolSelector({
       <IntegrationBindingsSection
         integrations={integrations}
         isLoading={integrationsLoading}
-        selectedBindingsSet={selectedIntegrationBindingsSet}
-        onToggle={toggleIntegrationBinding}
+        value={integrationBindings}
+        onChange={onIntegrationBindingsChange}
+        searchPlaceholder={tCommon('search.placeholder')}
+        emptyText={tCommon('search.noResults')}
         t={t}
       />
       {showWorkflows && (
         <WorkflowBindingsSection
           workflows={workflows}
           isLoading={workflowsLoading}
-          selectedBindingsSet={selectedWorkflowBindingsSet}
-          onToggle={toggleWorkflowBinding}
+          value={workflowBindings}
+          onChange={onWorkflowBindingsChange}
+          searchPlaceholder={tCommon('search.placeholder')}
+          emptyText={tCommon('search.noResults')}
           t={t}
         />
       )}
@@ -285,20 +252,31 @@ export function ToolSelector({
 function IntegrationBindingsSection({
   integrations,
   isLoading,
-  selectedBindingsSet,
-  onToggle,
+  value,
+  onChange,
+  searchPlaceholder,
+  emptyText,
   t,
 }: {
   integrations:
     | Array<{ name: string; title: string; type: string }>
     | undefined;
   isLoading: boolean;
-  selectedBindingsSet: Set<string>;
-  onToggle: (name: string) => void;
+  value: string[];
+  onChange: (next: string[]) => void;
+  searchPlaceholder: string;
+  emptyText: string;
   t: (key: string) => string;
 }) {
-  const placeholders = ['__p_int_0', '__p_int_1'];
   const isEmpty = !isLoading && (!integrations || integrations.length === 0);
+  const options = useMemo(
+    () =>
+      (integrations ?? []).map((integration) => ({
+        value: integration.name,
+        label: integration.title,
+      })),
+    [integrations],
+  );
 
   return (
     <Skeletonize
@@ -314,21 +292,15 @@ function IntegrationBindingsSection({
             {t('agents.form.noIntegrationsAvailable')}
           </Text>
         ) : (
-          <Grid cols={2} className="gap-x-4 gap-y-1.5">
-            {(isLoading
-              ? placeholders.map((name) => ({ name, title: 'Integration' }))
-              : (integrations ?? [])
-            ).map((integration) => (
-              <Checkbox
-                key={integration.name}
-                label={integration.title}
-                checked={
-                  !isLoading && selectedBindingsSet.has(integration.name)
-                }
-                onCheckedChange={() => onToggle(integration.name)}
-              />
-            ))}
-          </Grid>
+          <MultiSelect
+            value={value}
+            onValueChange={onChange}
+            options={options}
+            placeholder={t('agents.form.bindIntegrationsPlaceholder')}
+            searchPlaceholder={searchPlaceholder}
+            emptyText={emptyText}
+            aria-label={t('agents.form.sectionIntegrationBindings')}
+          />
         )}
       </FormSection>
     </Skeletonize>
@@ -338,20 +310,32 @@ function IntegrationBindingsSection({
 function WorkflowBindingsSection({
   workflows,
   isLoading,
-  selectedBindingsSet,
-  onToggle,
+  value,
+  onChange,
+  searchPlaceholder,
+  emptyText,
   t,
 }: {
   workflows:
     | Array<{ id: string; name: string; description?: string }>
     | undefined;
   isLoading: boolean;
-  selectedBindingsSet: Set<string>;
-  onToggle: (id: string) => void;
+  value: string[];
+  onChange: (next: string[]) => void;
+  searchPlaceholder: string;
+  emptyText: string;
   t: (key: string) => string;
 }) {
-  const placeholders = ['__p_wf_0', '__p_wf_1'];
   const isEmpty = !isLoading && (!workflows || workflows.length === 0);
+  const options = useMemo(
+    () =>
+      (workflows ?? []).map((workflow) => ({
+        value: workflow.id,
+        label: workflow.name,
+        description: workflow.description,
+      })),
+    [workflows],
+  );
 
   return (
     <Skeletonize
@@ -367,19 +351,15 @@ function WorkflowBindingsSection({
             {t('agents.form.noWorkflowsAvailable')}
           </Text>
         ) : (
-          <Grid cols={2} className="gap-x-4 gap-y-1.5">
-            {(isLoading
-              ? placeholders.map((id) => ({ id, name: 'Workflow' }))
-              : (workflows ?? [])
-            ).map((workflow) => (
-              <Checkbox
-                key={workflow.id}
-                label={workflow.name}
-                checked={!isLoading && selectedBindingsSet.has(workflow.id)}
-                onCheckedChange={() => onToggle(workflow.id)}
-              />
-            ))}
-          </Grid>
+          <MultiSelect
+            value={value}
+            onValueChange={onChange}
+            options={options}
+            placeholder={t('agents.form.bindWorkflowsPlaceholder')}
+            searchPlaceholder={searchPlaceholder}
+            emptyText={emptyText}
+            aria-label={t('agents.form.sectionWorkflowBindings')}
+          />
         )}
       </FormSection>
     </Skeletonize>

--- a/services/platform/app/features/agents/organigram/organigram-panel.tsx
+++ b/services/platform/app/features/agents/organigram/organigram-panel.tsx
@@ -6,43 +6,35 @@ import { Text } from '@tale/ui/text';
 import { Link } from '@tanstack/react-router';
 import { ExternalLink, X } from 'lucide-react';
 
-import { Checkbox } from '@/app/components/ui/forms/checkbox';
+import {
+  MultiSelect,
+  type MultiSelectOption,
+} from '@/app/components/ui/forms/multi-select';
 import type { OrgChartNode } from '@/convex/agents/org_chart_actions';
 import { useT } from '@/lib/i18n/client';
 
-interface AgentOption {
-  slug: string;
-  label: string;
-}
-
-/** A bordered, scrollable checklist of agents — the panel's edit affordance
- *  for both the incoming ("reports to") and outgoing ("delegates to") edges.
- *  Toggling stages the COMPLETE next list into the draft; nothing persists
- *  until the canvas-level Save commits a new version. */
+/** A searchable, scrollable agent picker — the panel's edit affordance for both
+ *  the incoming ("reports to") and outgoing ("delegates to") edges. Built on the
+ *  shared {@link MultiSelect} so it scales as the workforce grows. Toggling
+ *  stages the COMPLETE next list into the draft; nothing persists until the
+ *  canvas-level Save commits a new version. */
 function AgentChecklist({
   label,
   options,
   selected,
   emptyText,
+  searchPlaceholder,
   disabled,
   onChange,
 }: {
   label: string;
-  options: AgentOption[];
+  options: MultiSelectOption[];
   selected: string[];
   emptyText: string;
+  searchPlaceholder: string;
   disabled: boolean;
   onChange: (next: string[]) => void;
 }) {
-  const selectedSet = new Set(selected);
-  const toggle = (slug: string) => {
-    onChange(
-      selectedSet.has(slug)
-        ? selected.filter((s) => s !== slug)
-        : [...selected, slug],
-    );
-  };
-
   return (
     <div className="flex flex-col gap-1.5">
       <Text as="h3" variant="label" className="text-xs">
@@ -53,23 +45,16 @@ function AgentChecklist({
           {emptyText}
         </Text>
       ) : (
-        <div className="border-border max-h-44 overflow-y-auto rounded-md border">
-          {options.map((option) => (
-            <label
-              key={option.slug}
-              className="hover:bg-muted/50 flex cursor-pointer items-center gap-2.5 px-2.5 py-2"
-            >
-              <Checkbox
-                checked={selectedSet.has(option.slug)}
-                disabled={disabled}
-                onCheckedChange={() => toggle(option.slug)}
-              />
-              <span className="min-w-0 flex-1 truncate text-sm">
-                {option.label}
-              </span>
-            </label>
-          ))}
-        </div>
+        <MultiSelect
+          value={selected}
+          onValueChange={onChange}
+          options={options}
+          disabled={disabled}
+          placeholder={emptyText}
+          searchPlaceholder={searchPlaceholder}
+          emptyText={emptyText}
+          aria-label={label}
+        />
       )}
     </div>
   );
@@ -103,10 +88,11 @@ export function OrganigramPanel({
   onClose: () => void;
 }) {
   const { t } = useT('organigram');
-  const options: AgentOption[] = allNodes
+  const { t: tCommon } = useT('common');
+  const options: MultiSelectOption[] = allNodes
     .filter((other) => other.slug !== node.slug)
     .map((other) => ({
-      slug: other.slug,
+      value: other.slug,
       label: other.displayName || other.slug,
     }));
 
@@ -144,6 +130,7 @@ export function OrganigramPanel({
         options={options}
         selected={node.parentSlugs}
         emptyText={t('panel.noAgents')}
+        searchPlaceholder={tCommon('search.placeholder')}
         disabled={!canEdit || isSaving}
         onChange={onSetParents}
       />
@@ -153,6 +140,7 @@ export function OrganigramPanel({
         options={options}
         selected={node.directReports}
         emptyText={t('panel.noAgents')}
+        searchPlaceholder={tCommon('search.placeholder')}
         disabled={!canEdit || isSaving}
         onChange={onSetDelegates}
       />

--- a/services/platform/app/features/documents/components/team-multi-select.tsx
+++ b/services/platform/app/features/documents/components/team-multi-select.tsx
@@ -52,6 +52,7 @@ export function TeamMultiSelect({
       }
       searchPlaceholder={t('search.placeholder')}
       emptyText={t('search.noResults')}
+      modal
     />
   );
 }

--- a/services/platform/app/features/documents/components/team-multi-select.tsx
+++ b/services/platform/app/features/documents/components/team-multi-select.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { ChevronDown, ChevronUp, X } from 'lucide-react';
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 
-import { Checkbox } from '@/app/components/ui/forms/checkbox';
-import { cn } from '@/lib/utils/cn';
+import { MultiSelect } from '@/app/components/ui/forms/multi-select';
+import { useT } from '@/lib/i18n/client';
 
 interface Team {
   id: string;
@@ -19,6 +18,13 @@ interface TeamMultiSelectProps {
   disabled?: boolean;
 }
 
+/**
+ * Team picker for document / project / agent sharing. A thin wrapper over the
+ * shared {@link MultiSelect} primitive: it adapts the `{ id, name }` team shape
+ * to options and renders the "org-wide" implicit-default chip as the empty
+ * placeholder. The popover gains search + scroll for free, so the same control
+ * scales from a handful of teams to hundreds.
+ */
 export function TeamMultiSelect({
   teams,
   selectedTeamIds,
@@ -26,144 +32,26 @@ export function TeamMultiSelect({
   orgWideLabel,
   disabled,
 }: TeamMultiSelectProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { t } = useT('common');
 
-  const toggleTeam = useCallback(
-    (teamId: string) => {
-      if (selectedTeamIds.includes(teamId)) {
-        onSelectionChange(selectedTeamIds.filter((id) => id !== teamId));
-      } else {
-        onSelectionChange([...selectedTeamIds, teamId]);
-      }
-    },
-    [selectedTeamIds, onSelectionChange],
+  const options = useMemo(
+    () => teams.map((team) => ({ value: team.id, label: team.name })),
+    [teams],
   );
-
-  const removeTeam = useCallback(
-    (teamId: string, e: React.MouseEvent) => {
-      e.stopPropagation();
-      onSelectionChange(selectedTeamIds.filter((id) => id !== teamId));
-    },
-    [selectedTeamIds, onSelectionChange],
-  );
-
-  // Close on outside click
-  useEffect(() => {
-    if (!isOpen) return undefined;
-
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        containerRef.current &&
-        e.target instanceof Node &&
-        !containerRef.current.contains(e.target)
-      ) {
-        setIsOpen(false);
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
-
-  const selectedTeams = teams.filter((t) => selectedTeamIds.includes(t.id));
-  const ChevronIcon = isOpen ? ChevronUp : ChevronDown;
 
   return (
-    <div ref={containerRef} className="relative">
-      {/* Trigger — uses <div> instead of <button> so that chip remove <button>s are not nested */}
-      <div
-        role="combobox"
-        tabIndex={disabled || teams.length === 0 ? -1 : 0}
-        onClick={() =>
-          !disabled && teams.length > 0 && setIsOpen((prev) => !prev)
-        }
-        onKeyDown={(e) => {
-          if (disabled || teams.length === 0) return;
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            setIsOpen((prev) => !prev);
-          }
-        }}
-        aria-expanded={isOpen}
-        aria-controls={isOpen ? 'team-multi-select-listbox' : undefined}
-        aria-disabled={disabled || teams.length === 0}
-        className={cn(
-          'flex w-full cursor-pointer items-center gap-1.5 rounded-lg border bg-background px-3 py-2 text-sm shadow-xs transition-colors',
-          isOpen
-            ? 'border-primary ring-2 ring-primary/20'
-            : 'border-border hover:border-border/80',
-          (disabled || teams.length === 0) &&
-            'pointer-events-none cursor-not-allowed opacity-50',
-        )}
-      >
-        <div className="flex flex-1 flex-wrap items-center gap-1.5">
-          {selectedTeams.length === 0 ? (
-            <span className="bg-muted inline-flex items-center rounded px-2 py-0.5 text-xs font-medium">
-              {orgWideLabel}
-            </span>
-          ) : (
-            selectedTeams.map((team) => (
-              <span
-                key={team.id}
-                className="bg-muted inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
-              >
-                {team.name}
-                <button
-                  type="button"
-                  onClick={(e) => removeTeam(team.id, e)}
-                  className="text-muted-foreground hover:text-foreground -mr-0.5 rounded-sm"
-                  aria-label={`Remove ${team.name}`}
-                >
-                  <X className="size-3" />
-                </button>
-              </span>
-            ))
-          )}
-        </div>
-        <ChevronIcon
-          className={cn(
-            'size-4 shrink-0',
-            isOpen ? 'text-primary' : 'text-muted-foreground',
-          )}
-        />
-      </div>
-
-      {/* Dropdown */}
-      {isOpen && (
-        <div
-          id="team-multi-select-listbox"
-          role="listbox"
-          aria-multiselectable="true"
-          className="ring-border bg-muted absolute top-full left-0 z-50 mt-1 w-full overflow-hidden rounded-lg p-1 shadow-lg ring-1"
-        >
-          {teams.map((team) => {
-            const isSelected = selectedTeamIds.includes(team.id);
-            return (
-              <button
-                key={team.id}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                onClick={() => toggleTeam(team.id)}
-                className={cn(
-                  'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors',
-                  isSelected
-                    ? 'bg-muted font-medium'
-                    : 'hover:bg-muted/50 font-normal',
-                )}
-              >
-                <Checkbox
-                  checked={isSelected}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                />
-                <span className="text-foreground">{team.name}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
+    <MultiSelect
+      value={selectedTeamIds}
+      onValueChange={onSelectionChange}
+      options={options}
+      disabled={disabled || teams.length === 0}
+      placeholder={
+        <span className="bg-muted inline-flex items-center rounded px-2 py-0.5 text-xs font-medium">
+          {orgWideLabel}
+        </span>
+      }
+      searchPlaceholder={t('search.placeholder')}
+      emptyText={t('search.noResults')}
+    />
   );
 }

--- a/services/platform/app/features/settings/teams/components/team-member-checklist.test.tsx
+++ b/services/platform/app/features/settings/teams/components/team-member-checklist.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render, screen, within } from '@/tests/utils/render';
+import { render, screen } from '@/tests/utils/render';
 
 import { TeamMemberChecklist } from './team-member-checklist';
 
@@ -20,12 +20,17 @@ function setMembers(members: typeof MEMBERS, isLoading = false) {
   mockUseMembers.mockReturnValue({ members, isLoading });
 }
 
-/** Find the checkbox control rendered inside the label that shows `name`. */
-function checkboxFor(name: string): HTMLElement {
-  const label = screen.getByText(name).closest('label');
-  if (!label) throw new Error(`No label found for ${name}`);
-  return within(label).getByRole('checkbox');
+/** The multi-select renders its options inside a popover, opened via the trigger. */
+async function openDropdown(user: ReturnType<typeof render>['user']) {
+  await user.click(screen.getByRole('combobox'));
 }
+
+/** Find the listbox option whose accessible name contains `name`. */
+function optionFor(name: string): HTMLElement {
+  return screen.getByRole('option', { name: new RegExp(name, 'i') });
+}
+
+const LAST_MEMBER_HINT = /A team must keep at least one member/i;
 
 describe('TeamMemberChecklist', () => {
   describe('accessibility', () => {
@@ -42,9 +47,9 @@ describe('TeamMemberChecklist', () => {
     });
   });
 
-  it('disables only the sole selected member and shows the hint when enforced', () => {
+  it('disables only the sole selected member and shows the hint when enforced', async () => {
     setMembers(MEMBERS);
-    render(
+    const { user } = render(
       <TeamMemberChecklist
         organizationId="org-1"
         selectedMemberIds={new Set(['user-1'])}
@@ -53,20 +58,19 @@ describe('TeamMemberChecklist', () => {
       />,
     );
 
-    // The only remaining member cannot be unchecked.
-    expect(checkboxFor('Alice')).toBeDisabled();
-    // Unselected members stay toggleable so members can still be added.
-    expect(checkboxFor('Bob')).not.toBeDisabled();
-
     // The constraint is surfaced as a persistent hint (not a silent refusal).
-    expect(
-      screen.getByText(/A team must keep at least one member/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(LAST_MEMBER_HINT)).toBeInTheDocument();
+
+    await openDropdown(user);
+    // The only remaining member cannot be unchecked.
+    expect(optionFor('Alice')).toHaveAttribute('aria-disabled', 'true');
+    // Unselected members stay toggleable so members can still be added.
+    expect(optionFor('Bob')).not.toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('does not disable any checkbox when more than one member is selected', () => {
+  it('does not disable any option when more than one member is selected', async () => {
     setMembers(MEMBERS);
-    render(
+    const { user } = render(
       <TeamMemberChecklist
         organizationId="org-1"
         selectedMemberIds={new Set(['user-1', 'user-2'])}
@@ -75,18 +79,18 @@ describe('TeamMemberChecklist', () => {
       />,
     );
 
-    expect(checkboxFor('Alice')).not.toBeDisabled();
-    expect(checkboxFor('Bob')).not.toBeDisabled();
-    expect(
-      screen.queryByText(/A team must keep at least one member/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(LAST_MEMBER_HINT)).not.toBeInTheDocument();
+
+    await openDropdown(user);
+    expect(optionFor('Alice')).not.toHaveAttribute('aria-disabled', 'true');
+    expect(optionFor('Bob')).not.toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('never enforces the minimum-one constraint in create mode (default)', () => {
+  it('never enforces the minimum-one constraint in create mode (default)', async () => {
     setMembers(MEMBERS);
-    // Create flow: 0 selected is valid (current user is auto-added) and the
-    // sole selected member must stay uncheckable so the user can return to 0.
-    const { rerender } = render(
+    // Create flow: 0 selected is valid (current user is auto-added) and the sole
+    // selected member must stay uncheckable so the user can return to 0.
+    const { user, rerender } = render(
       <TeamMemberChecklist
         organizationId="org-1"
         selectedMemberIds={new Set()}
@@ -95,12 +99,10 @@ describe('TeamMemberChecklist', () => {
     );
 
     // With nothing selected, no misleading "delete the team instead" hint.
-    expect(
-      screen.queryByText(/A team must keep at least one member/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(LAST_MEMBER_HINT)).not.toBeInTheDocument();
 
-    // With exactly one selected, its checkbox stays toggleable (not disabled)
-    // and the hint is still absent.
+    // With exactly one selected, its option stays toggleable (not disabled) and
+    // the hint is still absent.
     rerender(
       <TeamMemberChecklist
         organizationId="org-1"
@@ -109,14 +111,13 @@ describe('TeamMemberChecklist', () => {
       />,
     );
 
-    expect(checkboxFor('Alice')).not.toBeDisabled();
-    expect(checkboxFor('Bob')).not.toBeDisabled();
-    expect(
-      screen.queryByText(/A team must keep at least one member/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(LAST_MEMBER_HINT)).not.toBeInTheDocument();
+    await openDropdown(user);
+    expect(optionFor('Alice')).not.toHaveAttribute('aria-disabled', 'true');
+    expect(optionFor('Bob')).not.toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('toggles a member when an enabled checkbox is clicked', async () => {
+  it('toggles a member when an enabled option is clicked', async () => {
     setMembers(MEMBERS);
     const onToggleMember = vi.fn();
     const { user } = render(
@@ -127,7 +128,8 @@ describe('TeamMemberChecklist', () => {
       />,
     );
 
-    await user.click(checkboxFor('Bob'));
+    await openDropdown(user);
+    await user.click(optionFor('Bob'));
     expect(onToggleMember).toHaveBeenCalledWith('user-2');
   });
 

--- a/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
+++ b/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { Row, Stack } from '@tale/ui/layout';
+import { useCallback, useMemo } from 'react';
 
-import { Checkbox } from '@/app/components/ui/forms/checkbox';
+import {
+  MultiSelect,
+  type MultiSelectOption,
+} from '@/app/components/ui/forms/multi-select';
 import { useT } from '@/lib/i18n/client';
 
 import { useMembers } from '../../organization/hooks/queries';
@@ -17,12 +21,6 @@ interface TeamMemberChecklistProps {
   organizationId: string;
   selectedMemberIds: Set<string>;
   onToggleMember: (userId: string) => void;
-  /**
-   * Enforce the "a team must keep at least one member" constraint (disable the
-   * sole selected member's checkbox + show the hint). Only the edit flow needs
-   * this; the create flow allows 0 selected (the current user is auto-added),
-   * so it must stay off there.
-   */
   enforceMinimumOne?: boolean;
 }
 
@@ -33,13 +31,53 @@ export function TeamMemberChecklist({
   enforceMinimumOne = false,
 }: TeamMemberChecklistProps) {
   const { t: tSettings } = useT('settings');
+  const { t: tCommon } = useT('common');
   const { members: orgMembers, isLoading } = useMembers(organizationId);
 
-  // A team must keep at least one member (the backend rejects removing the
-  // last one), so the sole remaining selected member's checkbox is disabled
-  // rather than silently refusing the click with no feedback. Only enforced in
-  // the edit flow — the create flow permits 0 selected members.
+  // A team must keep at least one member (the backend rejects removing the last
+  // one), so the sole remaining selected member's option is disabled rather than
+  // silently refusing the toggle. Only enforced in the edit flow — the create
+  // flow permits 0 selected members.
   const isLastMember = enforceMinimumOne && selectedMemberIds.size <= 1;
+
+  const options = useMemo<MultiSelectOption[]>(
+    () =>
+      (orgMembers ?? []).map((member: MemberOption) => {
+        const label =
+          member.displayName ||
+          member.email ||
+          tSettings('teams.unknownMember');
+        // Surface the email as a secondary line only when it adds information
+        // beyond the (display name) label.
+        const description =
+          member.displayName &&
+          member.email &&
+          member.displayName !== member.email
+            ? member.email
+            : undefined;
+        // Block unchecking the only remaining member — keeping a team memberless
+        // is rejected server-side.
+        const disabled = isLastMember && selectedMemberIds.has(member.userId);
+        return { value: member.userId, label, description, disabled };
+      }),
+    [orgMembers, tSettings, isLastMember, selectedMemberIds],
+  );
+
+  // `MultiSelect` reports the COMPLETE next selection; the parent still drives a
+  // single toggle at a time, so diff the new list against the current Set and
+  // forward the one id that flipped.
+  const handleChange = useCallback(
+    (next: string[]) => {
+      const nextSet = new Set(next);
+      for (const id of next) {
+        if (!selectedMemberIds.has(id)) onToggleMember(id);
+      }
+      for (const id of selectedMemberIds) {
+        if (!nextSet.has(id)) onToggleMember(id);
+      }
+    },
+    [selectedMemberIds, onToggleMember],
+  );
 
   if (isLoading) {
     return (
@@ -69,54 +107,15 @@ export function TeamMemberChecklist({
       <p className="text-muted-foreground text-xs">
         {tSettings('teams.memberChecklistHint')}
       </p>
-      <div className="border-border overflow-hidden rounded-lg border">
-        {orgMembers.map((member: MemberOption, index: number) => {
-          const isLast = index === orgMembers.length - 1;
-          const isChecked = selectedMemberIds.has(member.userId);
-          // Block unchecking the only remaining member — keeping a team
-          // memberless is rejected server-side.
-          const disableUncheck = isChecked && isLastMember;
-
-          return (
-            <label
-              key={member.userId}
-              className={`flex items-center gap-2.5 px-3 py-2.5 transition-colors ${
-                disableUncheck
-                  ? 'cursor-not-allowed'
-                  : 'hover:bg-muted/50 cursor-pointer'
-              } ${!isLast ? 'border-border border-b' : ''}`}
-              title={
-                disableUncheck ? tSettings('teams.lastMemberHint') : undefined
-              }
-            >
-              <Checkbox
-                checked={isChecked}
-                disabled={disableUncheck}
-                onCheckedChange={() => onToggleMember(member.userId)}
-              />
-              <span className="flex items-center gap-2">
-                <span className="text-foreground text-sm">
-                  {member.displayName ||
-                    member.email ||
-                    tSettings('teams.unknownMember')}
-                </span>
-                {member.displayName &&
-                  member.email &&
-                  member.displayName !== member.email && (
-                    <span className="text-muted-foreground text-xs">
-                      {member.email}
-                    </span>
-                  )}
-              </span>
-            </label>
-          );
-        })}
-      </div>
-      {isLastMember && (
-        <p className="text-muted-foreground text-xs">
-          {tSettings('teams.lastMemberHint')}
-        </p>
-      )}
+      <MultiSelect
+        value={Array.from(selectedMemberIds)}
+        onValueChange={handleChange}
+        options={options}
+        placeholder={tSettings('teams.manageMembers')}
+        searchPlaceholder={tCommon('search.placeholder')}
+        emptyText={tCommon('search.noResults')}
+        aria-label={tSettings('teams.manageMembers')}
+      />
     </Stack>
   );
 }

--- a/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
+++ b/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
@@ -101,13 +101,11 @@ export function TeamMemberChecklist({
 
   return (
     <Stack gap={2}>
-      <p className="text-foreground/80 text-sm font-medium">
-        {tSettings('teams.manageMembers')}
-      </p>
       <p className="text-muted-foreground text-xs">
         {tSettings('teams.memberChecklistHint')}
       </p>
       <MultiSelect
+        label={tSettings('teams.manageMembers')}
         value={Array.from(selectedMemberIds)}
         onValueChange={handleChange}
         options={options}
@@ -115,7 +113,13 @@ export function TeamMemberChecklist({
         searchPlaceholder={tCommon('search.placeholder')}
         emptyText={tCommon('search.noResults')}
         aria-label={tSettings('teams.manageMembers')}
+        modal
       />
+      {isLastMember && (
+        <p className="text-muted-foreground text-xs">
+          {tSettings('teams.lastMemberHint')}
+        </p>
+      )}
     </Stack>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5398,6 +5398,8 @@
         "sectionWorkflowBindings": "Gebundene Workflows",
         "sectionWorkflowBindingsDescription": "Bestimmte Workflows als dedizierte Tools binden. Der Agent muss die Workflow-ID nicht angeben.",
         "noWorkflowsAvailable": "Keine aktiven Workflows verfügbar.",
+        "bindIntegrationsPlaceholder": "Integrationen binden…",
+        "bindWorkflowsPlaceholder": "Workflows binden…",
         "sectionSkillBindings": "Gebundene Skills",
         "sectionSkillBindingsDescription": "Skills, die der Agent zur Laufzeit lesen kann. Leer lassen für einen Agent ohne Skills — es gibt keinen impliziten Fallback auf organisationsweite Sichtbarkeit.",
         "skillBindingsCounter": "{count}/{max} gebunden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5662,6 +5662,8 @@
         "sectionWorkflowBindings": "Bound workflows",
         "sectionWorkflowBindingsDescription": "Bind specific workflows as dedicated tools. The agent won't need to specify the workflow ID.",
         "noWorkflowsAvailable": "No active workflows available.",
+        "bindIntegrationsPlaceholder": "Bind integrations…",
+        "bindWorkflowsPlaceholder": "Bind workflows…",
         "sectionSkillBindings": "Bound skills",
         "sectionSkillBindingsDescription": "Skills the agent can read at runtime. Leave empty for an agent with no skills — there is no implicit fallback to org-wide visibility.",
         "skillBindingsCounter": "{count}/{max} bound",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5399,6 +5399,8 @@
         "sectionWorkflowBindings": "Flux de travail liés",
         "sectionWorkflowBindingsDescription": "Lie des flux de travail spécifiques en tant qu'outils dédiés. L'agent n'aura pas besoin de spécifier l'ID du flux de travail.",
         "noWorkflowsAvailable": "Aucun flux de travail actif disponible.",
+        "bindIntegrationsPlaceholder": "Lier des intégrations…",
+        "bindWorkflowsPlaceholder": "Lier des flux de travail…",
         "sectionSkillBindings": "Skills liés",
         "sectionSkillBindingsDescription": "Skills que l'agent peut lire à l'exécution. Laisser vide pour un agent sans skills — pas de repli implicite sur une visibilité à l'échelle de l'organisation.",
         "skillBindingsCounter": "{count}/{max} liés",


### PR DESCRIPTION
## Summary

Resolves #1954. Introduces a single reusable **`MultiSelect`** primitive and migrates the previously-divergent multi-select sites onto it.

### New component
- `services/platform/app/components/ui/forms/multi-select.tsx` — a popover/combobox multi-select built on Radix Popover, mirroring the existing `SearchableSelect`:
  - **Search** input (toggle via `searchable`, default on).
  - **Scrollable** option list (`max-h` + `overflow-y-auto`) — handles large lists (~1000) via search + scroll.
  - **Checkbox rows**; toggling keeps the popover open (multi-pick).
  - **Selected-chip display** in the default trigger, each chip removable.
  - **Keyboard accessible**: ArrowUp/Down to move highlight, Enter to toggle, Home/End, Escape to close; `role="listbox"` + `aria-multiselectable`, options with `role="option"`/`aria-selected`, search input wired with `aria-activedescendant`.
  - Skeleton-aware (masks the default trigger under `<Skeletonize loading>`).
- Companion `multi-select.test.tsx` (24 tests) and `multi-select.stories.tsx`.

### Migrations
- **Document/project/agent team tags** — `team-multi-select.tsx` is now a thin wrapper over `MultiSelect` (public API unchanged; all four call sites keep working).
- **Team create — Members** — `team-member-checklist.tsx` now renders `MultiSelect`.
- **Organigram delegation** — `organigram-panel.tsx` `AgentChecklist` now uses `MultiSelect`.
- **Agent tools** — the integration- and workflow-binding sections in `tool-selector.tsx` now use `MultiSelect`.

### i18n
- Added `settings.agents.form.bindIntegrationsPlaceholder` / `bindWorkflowsPlaceholder` to `en` / `de` / `fr`. Other strings reuse existing `common.search.*` keys.

## Verification
- `tsc --noEmit` — clean.
- `oxlint --type-aware` on changed files — clean.
- `oxfmt --check` — clean.
- `knip` — clean.
- UI tests (`vitest --config vitest.ui.config.ts`) for `multi-select`, `team-multi-select`, `team-create-dialog`, `document-team-tags`, `document-upload`, `project-sharing`, `organigram` — all pass.
- i18n parity/usage tests — pass.