### PR TITLE
fix: rename all "Added on" labels to "Added" (#1956)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5066,7 +5066,7 @@
       "columns": {
         "name": "Name",
         "members": "Mitglieder",
-        "created": "Hinzugefügt am"
+        "created": "Hinzugefügt"
       },
       "editTeam": "Team bearbeiten",
       "deleteTeam": "Team löschen",
@@ -6069,7 +6069,7 @@
       "columns": {
         "name": "Name",
         "key": "Schlüssel",
-        "created": "Hinzugefügt am",
+        "created": "Hinzugefügt",
         "lastUsed": "Zuletzt verwendet"
       },
       "form": {
@@ -6841,7 +6841,7 @@
       "teams": "Teams",
       "uploadedBy": "Hochgeladen von",
       "actions": "Aktionen",
-      "created": "Hinzugefügt am",
+      "created": "Hinzugefügt",
       "description": "Beschreibung",
       "email": "E-Mail",
       "product": "Produkt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5328,7 +5328,7 @@
       "columns": {
         "name": "Name",
         "members": "Members",
-        "created": "Added on"
+        "created": "Added"
       },
       "editTeam": "Edit team",
       "deleteTeam": "Delete team",
@@ -6331,7 +6331,7 @@
       "columns": {
         "name": "Name",
         "key": "Key",
-        "created": "Added on",
+        "created": "Added",
         "lastUsed": "Last used"
       },
       "form": {
@@ -7103,7 +7103,7 @@
       "teams": "Teams",
       "uploadedBy": "Uploaded by",
       "actions": "Actions",
-      "created": "Added on",
+      "created": "Added",
       "description": "Description",
       "email": "Email",
       "product": "Product",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5067,7 +5067,7 @@
       "columns": {
         "name": "Nom",
         "members": "Membres",
-        "created": "Ajouté le"
+        "created": "Ajouté"
       },
       "editTeam": "Modifier l'équipe",
       "deleteTeam": "Supprimer l'équipe",
@@ -6070,7 +6070,7 @@
       "columns": {
         "name": "Nom",
         "key": "Clé",
-        "created": "Ajouté le",
+        "created": "Ajouté",
         "lastUsed": "Dernière utilisation"
       },
       "form": {
@@ -6842,7 +6842,7 @@
       "teams": "Équipes",
       "uploadedBy": "Téléversé par",
       "actions": "Actions",
-      "created": "Ajouté le",
+      "created": "Ajouté",
       "description": "Description",
       "email": "Courriel",
       "product": "Produit",


### PR DESCRIPTION
Resolves #1956

Renames all "Added on" column/label strings to "Added" across locales.

## Changes
- `en.json`: `Added on` → `Added` (common.labels.created, settings.api.columns.created, settings.organization.teams.columns.created)
- `de.json`: `Hinzugefügt am` → `Hinzugefügt`
- `fr.json`: `Ajouté le` → `Ajouté`

## Acceptance criteria
- [x] No "Added on" remains anywhere.
- [x] All locales updated consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the “Created” column label in Teams, API keys, and Tasks tables across English, German, and French.
  * The label now uses a shorter, more general wording, making the interface cleaner and less date-specific.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->