### PR TITLE
fix(platform): remove member sorting from the team members table (#1953)

### DIFF
--- a/services/platform/app/features/settings/organization/components/member-table.test.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.test.tsx
@@ -52,29 +52,19 @@ describe('MemberTable', () => {
               displayName: 'Bob',
             }),
           ]}
-          sortOrder="asc"
-          onSortChange={vi.fn()}
         />,
       );
       await checkAccessibility(container, axeOptions);
     });
 
     it('passes axe audit when empty', async () => {
-      const { container } = render(
-        <MemberTable members={[]} sortOrder="asc" onSortChange={vi.fn()} />,
-      );
+      const { container } = render(<MemberTable members={[]} />);
       await checkAccessibility(container, axeOptions);
     });
 
     it('passes axe audit when loading', async () => {
       const { container } = render(
-        <MemberTable
-          members={[]}
-          sortOrder="asc"
-          onSortChange={vi.fn()}
-          isLoading
-          approxRowCount={5}
-        />,
+        <MemberTable members={[]} isLoading approxRowCount={5} />,
       );
       await checkAccessibility(container, axeOptions);
     });

--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { Button } from '@tale/ui/button';
 import { Stack, HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import type { ColumnDef, RowSelectionState } from '@tanstack/react-table';
-import { ChevronDownIcon, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
 import { useMemo, useCallback, useState } from 'react';
 
 import { TableTimestampCell } from '@/app/components/ui/data-display/table-date-cell';
@@ -41,18 +40,14 @@ interface MemberContext {
 
 interface MemberTableProps {
   members: Member[];
-  sortOrder: 'asc' | 'desc';
   memberContext?: MemberContext | null;
-  onSortChange: (sortOrder: 'asc' | 'desc') => void;
   isLoading?: boolean;
   approxRowCount?: number;
 }
 
 export function MemberTable({
   members,
-  sortOrder,
   memberContext,
-  onSortChange,
   isLoading,
   approxRowCount,
 }: MemberTableProps) {
@@ -61,9 +56,6 @@ export function MemberTable({
   const { t: tEmpty } = useT('emptyStates');
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const removeMember = useRemoveMember();
-  const handleSort = useCallback(() => {
-    onSortChange(sortOrder === 'asc' ? 'desc' : 'asc');
-  }, [sortOrder, onSortChange]);
 
   const handleClearSelection = useCallback(() => {
     setRowSelection({});
@@ -94,20 +86,7 @@ export function MemberTable({
       createSelectColumn<Member>(),
       {
         id: 'member',
-        header: () => (
-          <Button
-            variant="ghost"
-            className="text-muted-foreground hover:text-foreground h-auto p-0 font-medium"
-            onClick={handleSort}
-          >
-            {tTables('headers.member')}
-            <ChevronDownIcon
-              className={`ml-1 size-4 transition-transform ${
-                sortOrder === 'desc' ? 'rotate-180' : ''
-              }`}
-            />
-          </Button>
-        ),
+        header: tTables('headers.member'),
         cell: ({ row }) => {
           const member = row.original;
           return (
@@ -176,7 +155,7 @@ export function MemberTable({
         ),
       },
     ],
-    [handleSort, sortOrder, memberContext, tTables, tSettings],
+    [memberContext, tTables, tSettings],
   );
 
   return (

--- a/services/platform/app/features/settings/organization/components/members-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/members-settings.tsx
@@ -38,7 +38,6 @@ export function MembersSettings({
 }: MembersSettingsProps) {
   const { t: tSettings } = useT('settings');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [isAddMemberDialogOpen, setIsAddMemberDialogOpen] = useState(false);
 
   const debouncedSearch = useDebounce(searchQuery, 300);
@@ -60,11 +59,9 @@ export function MembersSettings({
     return [...filtered].sort((a, b) => {
       const nameA = a.displayName || a.email || '';
       const nameB = b.displayName || b.email || '';
-      return sortOrder === 'asc'
-        ? nameA.localeCompare(nameB)
-        : nameB.localeCompare(nameA);
+      return nameA.localeCompare(nameB);
     });
-  }, [allMembers, debouncedSearch, sortOrder]);
+  }, [allMembers, debouncedSearch]);
 
   return (
     <Stack gap={4}>
@@ -85,7 +82,6 @@ export function MembersSettings({
 
       <MemberTable
         members={members || []}
-        sortOrder={sortOrder}
         isLoading={isMembersLoading}
         approxRowCount={5}
         memberContext={
@@ -110,9 +106,6 @@ export function MembersSettings({
               }
             : undefined
         }
-        onSortChange={(newSortOrder) => {
-          setSortOrder(newSortOrder);
-        }}
       />
 
       <AddMemberDialog


### PR DESCRIPTION
## Summary

Removes the member sort control from the team members table per #1953.

- Drop the sortable header button (`ChevronDownIcon` toggle) in `member-table.tsx`; the member column now renders a plain text header.
- Remove the now-dead `sortOrder`/`onSortChange` props, `handleSort` callback, and unused `Button`/`ChevronDownIcon` imports.
- Remove the `sortOrder` state from `members-settings.tsx`; the member list keeps a stable ascending alphabetical default order.
- Update `member-table.test.tsx` to drop the removed props.

## Acceptance criteria
- [x] No sort affordance in the team members table.
- [x] No dead props/state left behind.

## Verification
- `tsc --noEmit` — passes
- `oxlint --type-aware` on changed files — 0 warnings/errors
- `vitest` UI tests for member-table — 3 passed

Closes #1953