### PR TITLE
fix: remove search and multi-select from the token sources table (#1958)

### DIFF
--- a/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
+++ b/services/platform/app/features/settings/token-sources/components/token-sources-manager.tsx
@@ -16,16 +16,12 @@ import { IconButton } from '@tale/ui/icon-button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useQueryClient } from '@tanstack/react-query';
-import type { ColumnDef, Row, RowSelectionState } from '@tanstack/react-table';
+import type { ColumnDef, Row } from '@tanstack/react-table';
 import { Ellipsis, Pencil, Plus, Trash2, Variable, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import {
-  ACTIONS_COLUMN_SIZE,
-  createSelectColumn,
-} from '@/app/components/ui/data-table/column-builders';
+import { ACTIONS_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
-import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
@@ -154,22 +150,12 @@ export function TokenSourcesManager({
   // null = closed; { slug: null } = create; { slug } = edit.
   const [panel, setPanel] = useState<{ slug: string | null } | null>(null);
   const [deleteRow, setDeleteRow] = useState<TokenSourceRow | null>(null);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const rows = useMemo<TokenSourceRow[]>(() => sources ?? [], [sources]);
 
   const invalidate = useCallback(async (): Promise<void> => {
     await queryClient.invalidateQueries({ queryKey: listKey });
   }, [queryClient, listKey]);
-
-  const handleClearSelection = useCallback(() => setRowSelection({}), []);
-
-  const handleBulkDeleteItem = useCallback(
-    async (slug: string) => {
-      await deleteSource({ organizationId, slug });
-    },
-    [deleteSource, organizationId],
-  );
 
   const handleDelete = useCallback(async (): Promise<void> => {
     if (!deleteRow) return;
@@ -226,7 +212,6 @@ export function TokenSourcesManager({
 
   const columnsWithActions = useMemo<ColumnDef<TokenSourceRow>[]>(
     () => [
-      createSelectColumn<TokenSourceRow>(),
       ...columns,
       {
         id: 'actions',
@@ -245,10 +230,6 @@ export function TokenSourcesManager({
   const list = useListPage<TokenSourceRow>({
     dataSource: { type: 'query', data: isLoading ? undefined : rows },
     pageSize: 50,
-    search: {
-      fields: ['displayName', 'endpoint'],
-      placeholder: t('tokenSources.search'),
-    },
     entityLabel: t('tokenSources.entityLabel'),
   });
 
@@ -257,9 +238,6 @@ export function TokenSourcesManager({
       <DataTable
         {...list.tableProps}
         columns={columnsWithActions}
-        enableRowSelection
-        rowSelection={rowSelection}
-        onRowSelectionChange={setRowSelection}
         getRowId={(row) => row.slug}
         onRowClick={(row) => setPanel({ slug: row.original.slug })}
         actionMenu={
@@ -273,14 +251,6 @@ export function TokenSourcesManager({
           title: t('tokenSources.emptyTitle'),
           description: t('tokenSources.empty'),
         }}
-        footer={
-          <BulkDeleteBar
-            rowSelection={rowSelection}
-            onClearSelection={handleClearSelection}
-            onDeleteItem={handleBulkDeleteItem}
-            onDeleteComplete={handleClearSelection}
-          />
-        }
       />
 
       <ConfirmDialog

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4966,7 +4966,6 @@
       "empty": "Noch keine Token-Quellen. Füge eine hinzu, um Agenten einen rotierenden Anmeldedaten-Pool zu geben.",
       "edit": "Bearbeiten",
       "delete": "Löschen",
-      "search": "Token-Quellen suchen…",
       "entityLabel": "Token-Quelle",
       "emptyTitle": "Noch keine Token-Quellen",
       "actions": "Token-Quellen-Aktionen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5228,7 +5228,6 @@
       "empty": "No token sources yet. Add one to give agents a rotating credential pool.",
       "edit": "Edit",
       "delete": "Delete",
-      "search": "Search token sources…",
       "entityLabel": "token source",
       "emptyTitle": "No token sources yet",
       "actions": "Token source actions",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4967,7 +4967,6 @@
       "empty": "Aucune source de jetons pour l'instant. Ajoutes-en une pour donner aux agents un pool d'identifiants rotatif.",
       "edit": "Modifier",
       "delete": "Supprimer",
-      "search": "Rechercher des sources de jetons…",
       "entityLabel": "source de jetons",
       "emptyTitle": "Aucune source de jetons pour l'instant",
       "actions": "Actions de la source de jetons",


### PR DESCRIPTION
## Summary

Removes the unneeded search input and multi-select / bulk-delete from the **Settings → Token sources** table, per #1958.

- Dropped `createSelectColumn` from the columns and the `enableRowSelection` / `rowSelection` / `onRowSelectionChange` props on `DataTable`.
- Removed the `BulkDeleteBar` footer along with `handleClearSelection` / `handleBulkDeleteItem` and the `rowSelection` state.
- Removed the `search` config from `useListPage`.
- Removed the now-unused `tokenSources.search` translation key from `en` / `de` / `fr` messages.

Per-row edit/delete (via the row actions menu and confirm dialog) is unchanged.

## Acceptance criteria
- [x] Token sources table has no search.
- [x] Token sources table has no multi-select / bulk actions.

## Verification
- `bunx tsc --noEmit` (platform): clean.
- `bunx oxlint --type-aware` on the touched feature dir: 0 warnings, 0 errors.
- `token-sources-manager.test.tsx`: passing.
- All message JSON files validate.

Closes #1958