### PR TITLE
fix: localize model catalog last-synced date and add colon (#1959)

### DIFF
--- a/services/platform/app/hooks/use-format-date.ts
+++ b/services/platform/app/hooks/use-format-date.ts
@@ -2,13 +2,14 @@
 
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { Dayjs } from 'dayjs';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 import {
   formatDate,
   formatDateSmart,
   formatDateHeader,
+  loadDayjsLocale,
   DatePreset,
   FormatDateOptions,
   DateTranslations,
@@ -21,6 +22,25 @@ import {
 export function useFormatDate() {
   const { locale } = useLocale();
   const { t } = useT('common');
+
+  // dayjs locales are registered lazily (see `loadDayjsLocale`), and that
+  // registration is a global side-effect that does not, on its own, re-render
+  // React. Without this, a date can paint with the eagerly-loaded `en` locale
+  // before the active locale's data arrives and then stay stuck in English
+  // (e.g. a German "Last synced" line showing an English-formatted date). We
+  // load the locale here and bump a counter once it's ready so dependent
+  // formatting re-runs with the correct locale. Already-loaded locales resolve
+  // synchronously, so this is a no-op beyond a single mount-time re-render.
+  const [, setLocaleReady] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    void loadDayjsLocale(locale).then(() => {
+      if (!cancelled) setLocaleReady((n) => n + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [locale]);
 
   const timezone = useMemo(
     () => Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5803,7 +5803,7 @@
         "refresh": "Jetzt aktualisieren",
         "synced": "{count} Modelle synchronisiert.",
         "syncFailed": "Synchronisierung fehlgeschlagen: {error}",
-        "lastSynced": "Zuletzt synchronisiert {when} · {count} Modelle.",
+        "lastSynced": "Zuletzt synchronisiert: {when} · {count} Modelle.",
         "lastFailed": "Letzter Versuch fehlgeschlagen um {when}.",
         "neverSynced": "Noch nicht synchronisiert — aktualisiert sich täglich automatisch.",
         "autoSync": "Wöchentliche Auto-Synchronisierung der Anbieter-Konfiguration",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6065,7 +6065,7 @@
         "refresh": "Refresh now",
         "synced": "Synced {count} models.",
         "syncFailed": "Sync failed: {error}",
-        "lastSynced": "Last synced {when} · {count} models.",
+        "lastSynced": "Last synced: {when} · {count} models.",
         "lastFailed": "Last attempt failed at {when}.",
         "neverSynced": "Not synced yet — refreshes automatically each day.",
         "autoSync": "Weekly auto-sync of provider config",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5804,7 +5804,7 @@
         "refresh": "Actualiser maintenant",
         "synced": "{count} modèles synchronisés.",
         "syncFailed": "Échec de la synchronisation : {error}",
-        "lastSynced": "Dernière synchro {when} · {count} modèles.",
+        "lastSynced": "Dernière synchro : {when} · {count} modèles.",
         "lastFailed": "Dernière tentative échouée à {when}.",
         "neverSynced": "Pas encore synchronisé — s'actualise automatiquement chaque jour.",
         "autoSync": "Synchronisation auto hebdomadaire de la config fournisseur",


### PR DESCRIPTION
## Summary
Fixes #1959 — the model-catalog "last synced" line rendered its date in English regardless of the active locale and was missing a colon after the label.

## Changes
- **`useFormatDate`**: the active locale's dayjs data is registered lazily as a global side-effect that does not re-render React. A date could therefore paint with the eagerly-loaded `en` locale before the active locale's data arrived and stay stuck in English (e.g. a German "Zuletzt synchronisiert" line showing an English-formatted date). The hook now loads the locale and bumps a counter once it's ready, so dependent formatting re-runs with the correct locale. Already-loaded locales resolve synchronously, so this is a no-op beyond a single mount-time re-render. This fixes the catalog card and every other consumer of the formatter.
- **Locale strings** (`en`, `de`, `fr`): added the colon to `settings.providers.modelCatalog.lastSynced` (e.g. `Zuletzt synchronisiert: {when} · {count} Modelle.`).

## Acceptance criteria
- [x] German UI shows a German-formatted date and a colon after the label.
- [x] English (and other locales) render correctly and are unaffected by regressions.

## Verification
- `tsc --noEmit` (platform) — clean
- `oxlint --type-aware` on changed files — 0 warnings/errors
- `vitest` i18n parity suite (`lib/i18n/messages.test.ts`) — 23 passed
- Locale JSON validity confirmed for en/de/fr