### PR TITLE
fix: remove search and multi-select from the AI providers table (#1957)

### DIFF
--- a/services/platform/app/features/settings/providers/components/providers-table.tsx
+++ b/services/platform/app/features/settings/providers/components/providers-table.tsx
@@ -5,16 +5,12 @@ import { DropdownMenu, type DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { IconButton } from '@tale/ui/icon-button';
 import { useQueryClient } from '@tanstack/react-query';
-import type { Row, RowSelectionState } from '@tanstack/react-table';
+import type { Row } from '@tanstack/react-table';
 import { Ellipsis, Pencil, Plus, Server, Trash2, Zap } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
-import {
-  ACTIONS_COLUMN_SIZE,
-  createSelectColumn,
-} from '@/app/components/ui/data-table/column-builders';
+import { ACTIONS_COLUMN_SIZE } from '@/app/components/ui/data-table/column-builders';
 import { DataTable } from '@/app/components/ui/data-table/data-table';
-import { BulkDeleteBar } from '@/app/components/ui/data-table/data-table-bulk-actions';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { useListPage } from '@/app/hooks/use-list-page';
 import { toast } from '@/app/hooks/use-toast';
@@ -71,25 +67,7 @@ export function ProvidersTable({
   const [detailProvider, setDetailProvider] = useState(
     initialDetailProvider ?? null,
   );
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const deleteProviderMutation = useDeleteProvider();
-
-  const handleClearSelection = useCallback(() => {
-    setRowSelection({});
-  }, []);
-
-  const handleBulkDeleteItem = useCallback(
-    async (providerName: string) => {
-      // Per-row delete reuses the same mutation as the single-row dialog so
-      // server-side audit logging stays consistent. The bar surfaces a
-      // destructive toast for the batch on failure.
-      await deleteProviderMutation.mutateAsync({
-        organizationId,
-        providerName,
-      });
-    },
-    [deleteProviderMutation, organizationId],
-  );
 
   const providers = useMemo(() => {
     if (!rawProviders) return [];
@@ -153,9 +131,6 @@ export function ProvidersTable({
 
   const columnsWithActions = useMemo(
     () => [
-      // Multi-row select — canonical 40px column matching every other entity
-      // table. Enables bulk-delete via the `BulkDeleteBar` footer.
-      createSelectColumn<ProviderRow>(),
       ...columns,
       {
         id: 'actions',
@@ -178,10 +153,6 @@ export function ProvidersTable({
   const list = useListPage<ProviderRow>({
     dataSource: { type: 'query', data: isLoading ? undefined : providers },
     pageSize,
-    search: {
-      fields: ['displayName', 'baseUrl'],
-      placeholder: t('providers.searchProvider'),
-    },
     entityLabel: t('providers.entityLabel'),
   });
 
@@ -191,14 +162,6 @@ export function ProvidersTable({
         {...list.tableProps}
         columns={columnsWithActions}
         stickyLayout={stickyLayout}
-        enableRowSelection
-        rowSelection={rowSelection}
-        onRowSelectionChange={setRowSelection}
-        // Providers are keyed by `name`, not `_id` — RowSelectionState uses
-        // the row's `id` field by default, which TanStack derives from the
-        // row's accessor when no `getRowId` is supplied. Pin it to `name`
-        // explicitly so the bulk handler receives the same string the
-        // delete mutation expects.
         getRowId={(row) => row.name}
         onRowClick={handleRowClick}
         actionMenu={
@@ -212,14 +175,6 @@ export function ProvidersTable({
           title: tEmpty('providers.title'),
           description: tEmpty('providers.description'),
         }}
-        footer={
-          <BulkDeleteBar
-            rowSelection={rowSelection}
-            onClearSelection={handleClearSelection}
-            onDeleteItem={handleBulkDeleteItem}
-            onDeleteComplete={handleClearSelection}
-          />
-        }
       />
 
       <ProviderAddPanel

--- a/services/platform/app/features/settings/providers/hooks/use-providers-table-config.tsx
+++ b/services/platform/app/features/settings/providers/hooks/use-providers-table-config.tsx
@@ -10,7 +10,6 @@ import type { ProviderRow } from '../components/providers-table';
 
 interface ProvidersTableConfig {
   columns: ColumnDef<ProviderRow>[];
-  searchPlaceholder: string;
   stickyLayout: boolean;
   pageSize: number;
 }
@@ -59,7 +58,6 @@ export function useProvidersTableConfig(): ProvidersTableConfig {
 
   return {
     columns,
-    searchPlaceholder: t('providers.searchProvider'),
     stickyLayout: false,
     pageSize: 50,
   };

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5974,7 +5974,6 @@
       "testSystemError": "Der Verbindungstest konnte nicht ausgeführt werden. Überprüfe die Basis-URL und den API-Schlüssel des Anbieters und versuche es erneut.",
       "addKey": "API-Schlüssel hinzufügen",
       "apiKeyEnter": "API-Schlüssel eingeben",
-      "searchProvider": "Anbieter suchen...",
       "created": "Anbieter erstellt",
       "modelCount": "{count, plural, one {# Modell} other {# Modelle}}",
       "removeModel": "Modell entfernen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6236,7 +6236,6 @@
       "testSystemError": "The connection test couldn't run. Check the provider's base URL and API key, then try again.",
       "addKey": "Add API key",
       "apiKeyEnter": "Enter API key",
-      "searchProvider": "Search providers...",
       "created": "Provider created",
       "modelCount": "{count, plural, one {# model} other {# models}}",
       "removeModel": "Remove model",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5975,7 +5975,6 @@
       "testSystemError": "Le test de connexion n'a pas pu s'exécuter. Vérifie l'URL de base et la clé API du fournisseur, puis réessaie.",
       "addKey": "Ajouter une clé API",
       "apiKeyEnter": "Saisis la clé API",
-      "searchProvider": "Rechercher des fournisseurs...",
       "created": "Fournisseur créé",
       "modelCount": "{count, plural, one {# modèle} other {# modèles}}",
       "removeModel": "Supprimer le modèle",


### PR DESCRIPTION
## Summary
Removes the search input and the multi-select / bulk-delete affordances from the AI providers table, per #1957.

## Changes
- `providers-table.tsx`: drop the `createSelectColumn` checkbox column, the `BulkDeleteBar` footer, and the row-selection state/handlers; remove the `search` config from `useListPage`.
- `use-providers-table-config.tsx`: remove the now-unused `searchPlaceholder` from the config.
- `messages/{en,de,fr}.json`: remove the now-unused `providers.searchProvider` string from all locales.

## Acceptance criteria
- [x] AI providers table has no search.
- [x] AI providers table has no multi-select / bulk actions.

## Verification
- `oxlint --type-aware` on the affected feature: clean.
- `vitest run` on the providers table/list tests: 7 passed.
- Full project typecheck deferred to CI (exceeds local memory ceiling).

Closes #1957