### PR TITLE
fix: rename branding "Clear all" action to "Reset" (#1962)

### DIFF
--- a/services/platform/app/features/settings/branding/components/branding-form.tsx
+++ b/services/platform/app/features/settings/branding/components/branding-form.tsx
@@ -372,7 +372,7 @@ export function BrandingForm({
               variant="secondary"
               onClick={() => void handleClearBranding()}
             >
-              {tCommon('actions.clearAll')}
+              {tCommon('actions.reset')}
             </Button>
           </HStack>
         )}


### PR DESCRIPTION
## Summary
Renames the branding action label from "Clear all" to "Reset" per #1962.

The shared `common.actions.clearAll` key is reused by the data-table bulk-actions and filter components (`data-table-bulk-actions.tsx`, `data-table-filters.tsx`), so it was **not** renamed. Instead, the branding form now uses the existing `common.actions.reset` key (already present as "Reset" / "Zurücksetzen" / "Réinitialiser" in all locales), avoiding any ripple to other usages.

## Changes
- `services/platform/app/features/settings/branding/components/branding-form.tsx`: use `tCommon('actions.reset')` instead of `tCommon('actions.clearAll')`.

## Acceptance criteria
- [x] The branding action reads "Reset".
- [x] No unintended changes to other "Clear all" usages.

Closes #1962

## Verification
- `bunx vitest --run --config vitest.ui.config.ts branding-form` → 9 passed
- `bunx oxlint --type-aware` on the changed file → 0 warnings, 0 errors