### PR TITLE
fix(platform): display env vars/secrets and passkeys as compact headerless tables (#1950)

### DIFF
--- a/services/platform/app/components/env/env-var-list-editor.tsx
+++ b/services/platform/app/components/env/env-var-list-editor.tsx
@@ -14,11 +14,11 @@ import { Button } from '@tale/ui/button';
 import { Checkbox } from '@tale/ui/checkbox';
 import { Input } from '@tale/ui/input';
 import { HStack, VStack } from '@tale/ui/layout';
-import { SkeletonText } from '@tale/ui/skeleton';
-import { Text } from '@tale/ui/text';
+import { Table, TableBody, TableCell, TableRow } from '@tale/ui/table';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
 import { useRegisterDirtySource } from '@/app/components/ui/editor/use-dirty-source';
 import { Select } from '@/app/components/ui/forms/select';
 import { toast } from '@/app/hooks/use-toast';
@@ -133,6 +133,8 @@ export function EnvVarListEditor({
 
   const [localRows, setLocalRows] = useState<Row[]>([]);
   const [saving, setSaving] = useState(false);
+  // Index of the row awaiting remove confirmation (null = no dialog open).
+  const [pendingRemove, setPendingRemove] = useState<number | null>(null);
   // While the user has unsaved edits, server (re)loads must not clobber them.
   // After a save we clear this so the post-write reactive update re-snapshots
   // with the freshly-computed secret previews.
@@ -197,6 +199,22 @@ export function EnvVarListEditor({
     markDirty();
     setLocalRows((rs) => rs.filter((_, j) => j !== i));
   };
+  // A blank, never-saved row carries no data — drop it immediately. Any row with
+  // content (a typed key, or one loaded from the server) goes through a
+  // confirmation modal before it's removed.
+  const requestRemove = (i: number): void => {
+    const r = localRows[i];
+    if (r && r.existingKey === null && r.key.trim() === '') {
+      removeRow(i);
+      return;
+    }
+    setPendingRemove(i);
+  };
+  const confirmRemove = (): void => {
+    if (pendingRemove === null) return;
+    removeRow(pendingRemove);
+    setPendingRemove(null);
+  };
 
   const onSave = async (): Promise<void> => {
     const active = localRows.filter((r) => r.key.trim() !== '');
@@ -256,158 +274,169 @@ export function EnvVarListEditor({
 
   const busy = saving || disabled;
 
-  if (isLoading && localRows.length === 0) {
-    return <SkeletonText lines={3} />;
-  }
+  // Headerless, no-skeleton, no-empty-state table (#1950): when there are no
+  // rows the table isn't rendered at all — only the Add/Save controls remain.
+  const renderRow = (r: Row, i: number) => {
+    const isBinding = r.tokenSourceSlug !== undefined;
+    // When the surface supports token sources, a single per-row "type"
+    // chooser (Value / Secret / a source) replaces the Secret checkbox —
+    // the user picks ONE: type a value, or draw from a rotating pool. The
+    // value field shows only for Value/Secret. Surfaces without sources keep
+    // the plain value + Secret-checkbox layout.
+    const hasSources = tokenSources !== undefined && tokenSources.length > 0;
+    const rowType = isBinding
+      ? 'token-source'
+      : r.isSecret
+        ? 'secret'
+        : 'value';
+    const onTypeChange = (v: string): void => {
+      if (!v) return; // ignore Radix's spurious '' during flux
+      if (v === 'value') {
+        patch(i, {
+          isSecret: false,
+          tokenSourceSlug: undefined,
+          masked: false,
+          ...(r.isSecret && { secretDirty: true, value: '' }),
+        });
+      } else if (v === 'secret') {
+        patch(i, {
+          isSecret: true,
+          secretDirty: true,
+          tokenSourceSlug: undefined,
+          ...(r.masked && { value: '', masked: false }),
+        });
+      } else if (v === 'token-source') {
+        // Default to the first source; the second dropdown lets the user
+        // change it. (Only reachable when hasSources, so [0] exists.)
+        const firstSlug = tokenSources?.[0]?.slug;
+        if (firstSlug !== undefined) {
+          patch(i, {
+            tokenSourceSlug: firstSlug,
+            isSecret: true,
+            value: '',
+            masked: false,
+            secretDirty: false,
+          });
+        }
+      }
+    };
+    return (
+      <TableRow key={i} data-no-hover>
+        <TableCell className="w-48 align-middle">
+          <Input
+            placeholder={t('keyPlaceholder')}
+            value={r.key}
+            disabled={busy}
+            className="font-mono"
+            onChange={(e) => patch(i, { key: e.target.value })}
+          />
+        </TableCell>
+        {hasSources && (
+          <TableCell className="w-0 align-middle">
+            <Select
+              aria-label={t('valueType')}
+              className="w-40 shrink-0"
+              disabled={busy}
+              value={rowType}
+              options={[
+                { value: 'value', label: t('typeValue') },
+                { value: 'secret', label: t('secret') },
+                { value: 'token-source', label: t('typeTokenSource') },
+              ]}
+              onValueChange={onTypeChange}
+            />
+          </TableCell>
+        )}
+        <TableCell className="align-middle">
+          {isBinding ? (
+            // Second dropdown: WHICH token source (shown only once the type
+            // is "Token source"). Keeps sources out of the type list.
+            <Select
+              aria-label={t('typeTokenSource')}
+              className="w-full"
+              disabled={busy}
+              value={r.tokenSourceSlug ?? ''}
+              options={(tokenSources ?? []).map((s) => ({
+                value: s.slug,
+                label: s.displayName,
+              }))}
+              onValueChange={(v) => {
+                if (v) patch(i, { tokenSourceSlug: v });
+              }}
+            />
+          ) : (
+            <Input
+              type={r.isSecret && !r.masked ? 'password' : 'text'}
+              placeholder={t('valuePlaceholder')}
+              value={r.value}
+              disabled={busy}
+              className="font-mono"
+              onFocus={() => {
+                if (r.masked) patchDisplay(i, { value: '', masked: false });
+              }}
+              onChange={(e) =>
+                patch(i, {
+                  value: e.target.value,
+                  masked: false,
+                  ...(r.isSecret && { secretDirty: true }),
+                })
+              }
+              onBlur={() => {
+                if (
+                  r.isSecret &&
+                  r.existingKey !== null &&
+                  !r.secretDirty &&
+                  r.value === ''
+                ) {
+                  patchDisplay(i, { value: r.maskedDisplay, masked: true });
+                }
+              }}
+            />
+          )}
+        </TableCell>
+        {!hasSources && (
+          <TableCell className="w-0 align-middle">
+            <label className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-xs">
+              <Checkbox
+                checked={r.isSecret}
+                disabled={busy}
+                onCheckedChange={(c) =>
+                  patch(i, {
+                    isSecret: c === true,
+                    secretDirty: true,
+                    ...(r.masked && { value: '', masked: false }),
+                  })
+                }
+              />
+              {t('secret')}
+            </label>
+          </TableCell>
+        )}
+        <TableCell className="w-0 align-middle">
+          <Button
+            size="icon"
+            variant="ghost"
+            disabled={busy}
+            aria-label={t('remove')}
+            onClick={() => requestRemove(i)}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </TableCell>
+      </TableRow>
+    );
+  };
+
+  const pendingRow =
+    pendingRemove !== null ? localRows[pendingRemove] : undefined;
 
   return (
     <VStack gap={2}>
-      {localRows.length === 0 && (
-        <Text variant="muted" className="text-sm">
-          {t('none')}
-        </Text>
+      {localRows.length > 0 && (
+        <Table>
+          <TableBody>{localRows.map((r, i) => renderRow(r, i))}</TableBody>
+        </Table>
       )}
-      {localRows.map((r, i) => {
-        const isBinding = r.tokenSourceSlug !== undefined;
-        // When the surface supports token sources, a single per-row "type"
-        // chooser (Value / Secret / a source) replaces the Secret checkbox —
-        // the user picks ONE: type a value, or draw from a rotating pool. The
-        // value field shows only for Value/Secret. Surfaces without sources keep
-        // the plain value + Secret-checkbox layout.
-        const hasSources =
-          tokenSources !== undefined && tokenSources.length > 0;
-        const rowType = isBinding
-          ? 'token-source'
-          : r.isSecret
-            ? 'secret'
-            : 'value';
-        const onTypeChange = (v: string): void => {
-          if (!v) return; // ignore Radix's spurious '' during flux
-          if (v === 'value') {
-            patch(i, {
-              isSecret: false,
-              tokenSourceSlug: undefined,
-              masked: false,
-              ...(r.isSecret && { secretDirty: true, value: '' }),
-            });
-          } else if (v === 'secret') {
-            patch(i, {
-              isSecret: true,
-              secretDirty: true,
-              tokenSourceSlug: undefined,
-              ...(r.masked && { value: '', masked: false }),
-            });
-          } else if (v === 'token-source') {
-            // Default to the first source; the second dropdown lets the user
-            // change it. (Only reachable when hasSources, so [0] exists.)
-            const firstSlug = tokenSources?.[0]?.slug;
-            if (firstSlug !== undefined) {
-              patch(i, {
-                tokenSourceSlug: firstSlug,
-                isSecret: true,
-                value: '',
-                masked: false,
-                secretDirty: false,
-              });
-            }
-          }
-        };
-        return (
-          <HStack key={i} gap={2} className="items-center">
-            <Input
-              placeholder={t('keyPlaceholder')}
-              value={r.key}
-              disabled={busy}
-              className="font-mono"
-              onChange={(e) => patch(i, { key: e.target.value })}
-            />
-            {hasSources && (
-              <Select
-                aria-label={t('valueType')}
-                className="w-40 shrink-0"
-                disabled={busy}
-                value={rowType}
-                options={[
-                  { value: 'value', label: t('typeValue') },
-                  { value: 'secret', label: t('secret') },
-                  { value: 'token-source', label: t('typeTokenSource') },
-                ]}
-                onValueChange={onTypeChange}
-              />
-            )}
-            {isBinding ? (
-              // Second dropdown: WHICH token source (shown only once the type is
-              // "Token source"). Keeps sources out of the type list.
-              <Select
-                aria-label={t('typeTokenSource')}
-                className="flex-1"
-                disabled={busy}
-                value={r.tokenSourceSlug ?? ''}
-                options={(tokenSources ?? []).map((s) => ({
-                  value: s.slug,
-                  label: s.displayName,
-                }))}
-                onValueChange={(v) => {
-                  if (v) patch(i, { tokenSourceSlug: v });
-                }}
-              />
-            ) : (
-              <Input
-                type={r.isSecret && !r.masked ? 'password' : 'text'}
-                placeholder={t('valuePlaceholder')}
-                value={r.value}
-                disabled={busy}
-                className="font-mono"
-                onFocus={() => {
-                  if (r.masked) patchDisplay(i, { value: '', masked: false });
-                }}
-                onChange={(e) =>
-                  patch(i, {
-                    value: e.target.value,
-                    masked: false,
-                    ...(r.isSecret && { secretDirty: true }),
-                  })
-                }
-                onBlur={() => {
-                  if (
-                    r.isSecret &&
-                    r.existingKey !== null &&
-                    !r.secretDirty &&
-                    r.value === ''
-                  ) {
-                    patchDisplay(i, { value: r.maskedDisplay, masked: true });
-                  }
-                }}
-              />
-            )}
-            {!hasSources && (
-              <label className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-xs">
-                <Checkbox
-                  checked={r.isSecret}
-                  disabled={busy}
-                  onCheckedChange={(c) =>
-                    patch(i, {
-                      isSecret: c === true,
-                      secretDirty: true,
-                      ...(r.masked && { value: '', masked: false }),
-                    })
-                  }
-                />
-                {t('secret')}
-              </label>
-            )}
-            <Button
-              size="icon"
-              variant="ghost"
-              disabled={busy}
-              aria-label={t('remove')}
-              onClick={() => removeRow(i)}
-            >
-              <Trash2 className="size-4" />
-            </Button>
-          </HStack>
-        );
-      })}
       <HStack gap={2} className="justify-between">
         <Button
           variant="ghost"
@@ -422,6 +451,21 @@ export function EnvVarListEditor({
           {saving ? t('saving') : t('save')}
         </Button>
       </HStack>
+      <DeleteDialog
+        open={pendingRemove !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemove(null);
+        }}
+        title={t('confirmRemoveTitle')}
+        description={t('confirmRemoveDescription')}
+        preview={
+          pendingRow
+            ? { primary: pendingRow.key.trim() || t('keyPlaceholder') }
+            : undefined
+        }
+        deleteText={t('remove')}
+        onDelete={confirmRemove}
+      />
     </VStack>
   );
 }

--- a/services/platform/app/features/settings/account/components/passkey-section.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.tsx
@@ -2,8 +2,7 @@
 
 import { Button } from '@tale/ui/button';
 import { IconButton } from '@tale/ui/icon-button';
-import { HStack, Stack, VStack } from '@tale/ui/layout';
-import { Text } from '@tale/ui/text';
+import { Table, TableBody, TableCell, TableRow } from '@tale/ui/table';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -109,34 +108,27 @@ export function PasskeySection() {
       }
     >
       {!isLoading && passkeys && passkeys.length > 0 && (
-        <Stack gap={2}>
-          {passkeys.map((pk) => (
-            <HStack
-              key={pk.id}
-              justify="between"
-              align="center"
-              className="rounded-md border px-3 py-2"
-            >
-              <VStack gap={0} className="min-w-0">
-                <Text className="truncate text-sm font-medium">
-                  {pk.name?.trim() || t('passkeys.unnamed')}
-                </Text>
-              </VStack>
-              <IconButton
-                icon={Trash2}
-                variant="ghost"
-                aria-label={t('passkeys.revokeButton')}
-                onClick={() => setRevokeTarget(pk)}
-              />
-            </HStack>
-          ))}
-        </Stack>
-      )}
-
-      {!isLoading && (!passkeys || passkeys.length === 0) && (
-        <Text variant="muted" className="text-sm">
-          {t('passkeys.empty')}
-        </Text>
+        <Table>
+          <TableBody>
+            {passkeys.map((pk) => (
+              <TableRow key={pk.id} data-no-hover>
+                <TableCell className="text-sm font-medium">
+                  <span className="block truncate">
+                    {pk.name?.trim() || t('passkeys.unnamed')}
+                  </span>
+                </TableCell>
+                <TableCell className="w-0 text-right">
+                  <IconButton
+                    icon={Trash2}
+                    variant="ghost"
+                    aria-label={t('passkeys.revokeButton')}
+                    onClick={() => setRevokeTarget(pk)}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       )}
 
       <PasskeyRegisterDialog
@@ -151,7 +143,7 @@ export function PasskeySection() {
       <DeleteDialog
         open={revokeTarget !== null}
         onOpenChange={(open) => {
-          if (!open) setRevokeTarget(null);
+          if (!open && !isRevoking) setRevokeTarget(null);
         }}
         title={t('passkeys.revokeConfirmTitle')}
         description={t('passkeys.revokeConfirmDescription', {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7356,7 +7356,6 @@
       "revokeButton": "Entfernen",
       "revokeConfirmTitle": "Passkey entfernen?",
       "revokeConfirmDescription": "Dadurch wird „{name}\" entfernt und kann nicht mehr zur Anmeldung verwendet werden. War es dein einziger zweiter Faktor, wirst du möglicherweise erneut zur Einrichtung der Zwei-Faktor-Authentifizierung aufgefordert.",
-      "empty": "Noch keine Passkeys registriert.",
       "unnamed": "Passkey",
       "registered": "Passkey registriert",
       "revoked": "Passkey entfernt",
@@ -8216,7 +8215,8 @@
     "accessDenied": "Sie benötigen Entwickler- oder Admin-Zugriff, um Sandboxes zu verwalten."
   },
   "envEditor": {
-    "none": "Noch keine Umgebungsvariablen.",
+    "confirmRemoveTitle": "Variable entfernen?",
+    "confirmRemoveDescription": "Sie wird beim Speichern deiner Änderungen entfernt. Dies kann nicht rückgängig gemacht werden.",
     "keyPlaceholder": "NAME",
     "valuePlaceholder": "Wert",
     "secret": "Geheim",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7623,7 +7623,6 @@
       "revokeButton": "Remove",
       "revokeConfirmTitle": "Remove passkey?",
       "revokeConfirmDescription": "This removes \"{name}\" and it can no longer be used to sign in. If it was your only second factor, you may be prompted to set up two-factor authentication again.",
-      "empty": "No passkeys registered yet.",
       "unnamed": "Passkey",
       "registered": "Passkey registered",
       "revoked": "Passkey removed",
@@ -8219,7 +8218,8 @@
     "accessDenied": "You need developer or admin access to manage sandboxes."
   },
   "envEditor": {
-    "none": "No environment variables yet.",
+    "confirmRemoveTitle": "Remove variable?",
+    "confirmRemoveDescription": "It will be removed when you save your changes. This can't be undone.",
     "keyPlaceholder": "NAME",
     "valuePlaceholder": "value",
     "secret": "Secret",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7357,7 +7357,6 @@
       "revokeButton": "Supprimer",
       "revokeConfirmTitle": "Supprimer le passkey ?",
       "revokeConfirmDescription": "Cela supprime « {name} » qui ne pourra plus être utilisé pour se connecter. S'il s'agissait de ton seul second facteur, il se peut que tu doives reconfigurer la double authentification.",
-      "empty": "Aucun passkey enregistré pour l'instant.",
       "unnamed": "Passkey",
       "registered": "Passkey enregistré",
       "revoked": "Passkey supprimé",
@@ -8217,7 +8216,8 @@
     "accessDenied": "Vous avez besoin d’un accès développeur ou admin pour gérer les sandboxes."
   },
   "envEditor": {
-    "none": "Aucune variable d'environnement pour l'instant.",
+    "confirmRemoveTitle": "Supprimer la variable ?",
+    "confirmRemoveDescription": "Elle sera supprimée lorsque tu enregistreras tes modifications. Cette action est irréversible.",
     "keyPlaceholder": "NOM",
     "valuePlaceholder": "valeur",
     "secret": "Secret",


### PR DESCRIPTION
## Summary

Resolves #1950. Both env vars/secrets (the shared `EnvVarListEditor`, used by the agent/workflow env editors) and the account passkeys list now render as compact **headerless tables** following one shared minimal convention:

- **No header row, no skeleton, no empty state, no search/filter.**
- **When there are zero items, the table is not rendered at all** (the env editor keeps only its Add/Save controls; the passkey section renders nothing).
- **Deletion via a remove icon button per row, gated by a confirmation modal** (`DeleteDialog`).

## Changes

- `app/components/env/env-var-list-editor.tsx` — rows moved into `@tale/ui/table` (`Table`/`TableBody`/`TableRow`/`TableCell`); removed the `SkeletonText` loading state and the empty-state text; the table renders only when `localRows.length > 0`. The per-row trash button now opens a `DeleteDialog`; a brand-new blank row is dropped immediately (no data to confirm).
- `app/features/settings/account/components/passkey-section.tsx` — card list replaced with a headerless table; empty-state text removed; the ghost "Remove" text button is now a trash icon button gated by `DeleteDialog`.
- `messages/{en,de,fr}.json` — removed the now-dead `envEditor.none` / `twoFactor.passkeys.empty` keys; added `envEditor.confirmRemove{Title,Description}` and `twoFactor.passkeys.confirmRevoke{Title,Description}` in all three base locales.

## Verification

- `bunx tsc --noEmit` (platform) — clean.
- `oxlint --type-aware` on both changed files — 0 warnings, 0 errors.
- `oxfmt --check` on changed files + locale JSON — clean.
- i18n key parity across en/de/fr verified.