### PR TITLE
fix(platform): clear the full-page drop overlay after a composer drop

### DIFF
--- a/services/platform/app/hooks/use-page-file-drop.test.ts
+++ b/services/platform/app/hooks/use-page-file-drop.test.ts
@@ -28,6 +28,36 @@ describe('usePageFileDrop', () => {
     expect(onFilesDropped.mock.calls[0][0]).toEqual([file]);
   });
 
+  it('clears the overlay even when a region drop zone stops propagation', () => {
+    // Regression: dropping ONTO the chat composer (a FileUpload.DropZone that
+    // calls stopPropagation on drop) stopped the window bubble handler from
+    // running, so isDragOver never reset and the full-page overlay stuck until
+    // reload. The capture-phase reset must still clear it.
+    const onFilesDropped = vi.fn();
+    const { result } = renderHook(() => usePageFileDrop({ onFilesDropped }));
+
+    const region = document.createElement('div');
+    document.body.appendChild(region);
+    region.addEventListener('drop', (e) => e.stopPropagation());
+
+    act(() => {
+      fireEvent.dragEnter(window, { dataTransfer: fileTransfer([]) });
+    });
+    expect(result.current.isDragOver).toBe(true);
+
+    const file = new File(['hi'], 'note.txt', { type: 'text/plain' });
+    act(() => {
+      fireEvent.drop(region, { dataTransfer: fileTransfer([file]) });
+    });
+
+    // Overlay cleared despite the region zone swallowing the bubble...
+    expect(result.current.isDragOver).toBe(false);
+    // ...and the window handler did NOT also upload (the region zone owns it).
+    expect(onFilesDropped).not.toHaveBeenCalled();
+
+    document.body.removeChild(region);
+  });
+
   it('ignores drags that carry no files (text/links/internal dnd)', () => {
     const onFilesDropped = vi.fn();
     const { result } = renderHook(() => usePageFileDrop({ onFilesDropped }));

--- a/services/platform/app/hooks/use-page-file-drop.ts
+++ b/services/platform/app/hooks/use-page-file-drop.ts
@@ -24,7 +24,9 @@ interface UsePageFileDropOptions {
  *    cursor crosses child elements.
  *  - A region-scoped `FileUpload.DropZone` that calls `stopPropagation()` on a
  *    drop (e.g. the chat composer) still wins for drops landing on it; only
- *    drops elsewhere bubble to this window handler.
+ *    drops elsewhere bubble to this window handler. The overlay reset runs in
+ *    the CAPTURE phase so it still clears on those region-zone drops (a missing
+ *    reset there left the full-page overlay stuck until reload).
  *  - Prevents the browser's default "navigate to the dropped file" while
  *    mounted, so a stray drop never blows away the app.
  */
@@ -71,23 +73,35 @@ export function usePageFileDrop(options: UsePageFileDropOptions): {
     const onDrop = (e: DragEvent) => {
       if (!carriesFiles(e)) return;
       e.preventDefault();
-      dragDepth.current = 0;
-      setIsDragOver(false);
       const all = Array.from(e.dataTransfer?.files ?? []);
       const accept = acceptRef.current;
       const files = accept ? all.filter(accept) : all;
       if (files.length > 0) onFilesDroppedRef.current(files);
+    };
+    // Overlay reset runs in the CAPTURE phase: a drop ALWAYS ends the drag, so
+    // the overlay must clear even when a region-scoped DropZone (the chat
+    // composer) calls stopPropagation() on its drop — which would otherwise
+    // stop the bubble-phase `onDrop` above from ever running, leaving the
+    // overlay stuck until a page reload. Capture runs window->target, BEFORE
+    // the target's stopPropagation, so it always fires. Reset only here (no
+    // file handling) so a region-zone drop never double-uploads: the bubble
+    // `onDrop` still owns the upload for drops that DON'T hit a region zone.
+    const onDropResetCapture = () => {
+      dragDepth.current = 0;
+      setIsDragOver(false);
     };
 
     window.addEventListener('dragenter', onDragEnter);
     window.addEventListener('dragover', onDragOver);
     window.addEventListener('dragleave', onDragLeave);
     window.addEventListener('drop', onDrop);
+    window.addEventListener('drop', onDropResetCapture, true);
     return () => {
       window.removeEventListener('dragenter', onDragEnter);
       window.removeEventListener('dragover', onDragOver);
       window.removeEventListener('dragleave', onDragLeave);
       window.removeEventListener('drop', onDrop);
+      window.removeEventListener('drop', onDropResetCapture, true);
     };
   }, [disabled]);
 


### PR DESCRIPTION
## Summary

Dragging a file onto the chat composer left the full-page **"Drop files here to upload"** overlay stuck — covering the page and blocking all interaction until a manual reload. The file still attached (the composer handled the drop), but the overlay never dismissed.

## Root cause

The full-page overlay is `PageDropOverlay`, driven by the window-level `usePageFileDrop` hook (`chat-interface.tsx:480/1159`). The chat composer's `FileUpload.DropZone` calls `e.stopPropagation()` on its `drop` (`file-upload.tsx:187`) so the file lands on the composer rather than the window handler. But `stopPropagation()` also prevents the window's **bubble-phase** `drop` listener from ever running — so `isDragOver` / `dragDepth` never reset, and the overlay sticks until reload. The hook's own design note even anticipated the "region zone wins" routing, but missed that the reset then never fires.

## Fix

Reset the overlay state (`dragDepth = 0; setIsDragOver(false)`) in a **capture-phase** window `drop` listener. The capture phase runs window → target, *before* any child's `stopPropagation()`, so the reset always fires regardless of who handles the drop. The existing bubble-phase handler still owns the upload for drops that **don't** hit a region zone, so there's no double-upload.

```
window.addEventListener('drop', onDrop);                 // bubble: upload (non-region drops)
window.addEventListener('drop', onDropResetCapture, true); // capture: reset always
```

## Testing

- New regression test in `use-page-file-drop.test.ts`: drops onto a child element that `stopPropagation()`s and asserts (a) the overlay clears and (b) the window handler does **not** also upload. Fails without the fix, passes with it.
- `app/hooks/use-page-file-drop.test.ts` — 5/5 pass · platform tsc 0 · lint 0

## Notes

- Pre-existing frontend bug — unrelated to the recently-merged backend attachment PR (#2119); separate PR as discussed.
