### PR TITLE
feat(platform): settings UX polish — data residency header actions, layout refinements

### DIFF
--- a/services/platform/app/features/analytics/usage/usage-trend-chart.tsx
+++ b/services/platform/app/features/analytics/usage/usage-trend-chart.tsx
@@ -1,31 +1,35 @@
 'use client';
 
-import { ChartCard } from '@tale/ui/chart-card';
-import { ChartLegend } from '@tale/ui/chart-legend';
-import { CHART_COLORS } from '@tale/ui/chart-theme';
+import { EmptyState } from '@tale/ui/empty-state';
+import { SkeletonBox } from '@tale/ui/skeleton';
 import { useSkeleton } from '@tale/ui/skeleton-context';
-
+import { Text } from '@tale/ui/text';
+import { useMemo } from 'react';
 import {
-  seriesToLegend,
-  TrendBarChart,
-  type ChartSeries,
-} from '@/app/components/metrics/charts';
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
 import { useT } from '@/lib/i18n/client';
 import { formatCostCents, formatNumber } from '@/lib/utils/format/number';
 
 export type UsageMetric = 'requests' | 'tokens' | 'cost';
 export type UsageGranularity = 'daily' | 'weekly' | 'monthly';
 
-// A type alias (not an interface) so it carries an implicit index signature and
-// is assignable to the charts' `ChartRow` row type.
-export type UsageSeriesPoint = {
+export interface UsageSeriesPoint {
   periodKey: string;
   requests: number;
   inputTokens: number;
   outputTokens: number;
   tokens: number;
   costCents: number;
-};
+}
 
 interface UsageTrendChartProps {
   series: UsageSeriesPoint[];
@@ -34,8 +38,14 @@ interface UsageTrendChartProps {
 }
 
 function shortLabel(periodKey: string, granularity: UsageGranularity): string {
-  if (granularity === 'monthly') return periodKey; // YYYY-MM
-  return periodKey.slice(5); // daily YYYY-MM-DD → MM-DD, weekly → "Www"
+  if (granularity === 'monthly') {
+    return periodKey; // YYYY-MM
+  }
+  if (granularity === 'weekly') {
+    return periodKey.slice(5); // "Www"
+  }
+  // daily YYYY-MM-DD → MM-DD
+  return periodKey.slice(5);
 }
 
 export function UsageTrendChart({
@@ -46,37 +56,37 @@ export function UsageTrendChart({
   const { t } = useT('analytics');
   const loading = useSkeleton();
 
-  const chartSeries: ChartSeries[] =
-    metric === 'tokens'
-      ? [
-          {
-            key: 'inputTokens',
-            label: t('usage.chart.inputTokens'),
-            color: CHART_COLORS.primary,
-            stackId: 'tokens',
-          },
-          {
-            key: 'outputTokens',
-            label: t('usage.chart.outputTokens'),
-            color: CHART_COLORS.success,
-            stackId: 'tokens',
-          },
-        ]
-      : metric === 'requests'
-        ? [
-            {
-              key: 'requests',
-              label: t('usage.metric.requests'),
-              color: CHART_COLORS.primary,
-            },
-          ]
-        : [
-            {
-              key: 'costCents',
-              label: t('usage.metric.cost'),
-              color: CHART_COLORS.warning,
-            },
-          ];
+  const data = useMemo(
+    () =>
+      series.map((p) => ({
+        ...p,
+        label: shortLabel(p.periodKey, granularity),
+      })),
+    [series, granularity],
+  );
+
+  // An empty range (or a period with no activity for the active metric) would
+  // otherwise render a bare, lopsided axis frame. Detect "nothing to plot" and
+  // show an empty state instead.
+  const hasData = useMemo(() => {
+    if (metric === 'cost') return series.some((p) => p.costCents > 0);
+    if (metric === 'requests') return series.some((p) => p.requests > 0);
+    return series.some((p) => p.inputTokens > 0 || p.outputTokens > 0);
+  }, [series, metric]);
+
+  const ariaLabel = t('usage.chart.ariaLabel', {
+    metric: t(`usage.metric.${metric}`),
+  });
+
+  const formatTooltipValue = (
+    value: number | undefined,
+    name: string | undefined,
+  ): [string, string] => {
+    const label = name ?? '';
+    if (value === undefined) return ['', label];
+    if (metric === 'cost') return [formatCostCents(value), label];
+    return [formatNumber(value), label];
+  };
 
   const formatYTick = (value: number): string => {
     if (metric === 'cost') return formatCostCents(value);
@@ -86,24 +96,113 @@ export function UsageTrendChart({
   };
 
   return (
-    <ChartCard
-      title={t(`usage.metric.${metric}`)}
-      loading={loading}
-      bodyClassName="h-72"
-      legend={
-        metric === 'tokens' ? (
-          <ChartLegend items={seriesToLegend(chartSeries)} />
-        ) : undefined
-      }
+    <div
+      className="border-border flex flex-col gap-4 rounded-lg border p-5"
+      aria-label={ariaLabel}
     >
-      <TrendBarChart
-        data={series}
-        series={chartSeries}
-        xKey="periodKey"
-        xTickFormatter={(key) => shortLabel(key, granularity)}
-        yTickFormatter={formatYTick}
-        valueFormatter={metric === 'cost' ? formatCostCents : formatNumber}
-      />
-    </ChartCard>
+      <Text as="h3" className="text-foreground text-base font-semibold">
+        {t(`usage.metric.${metric}`)}
+      </Text>
+      {/* Reserve the exact plot height (`h-72`) in both states. While the
+          series loads, mask the plot so axes/bars don't flash in once data
+          arrives — the bordered card + title stay put, so no shift. */}
+      <div className="h-72 w-full">
+        {loading ? (
+          <SkeletonBox fullWidth>
+            <div className="h-72 w-full" />
+          </SkeletonBox>
+        ) : !hasData ? (
+          <div className="flex h-full w-full flex-col">
+            <EmptyState
+              title={t('usage.empty.title')}
+              description={t('usage.empty.description')}
+            />
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data}
+              margin={{ top: 8, right: 8, bottom: 0, left: -8 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                className="stroke-border"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 11 }}
+                stroke="currentColor"
+                className="text-muted-foreground"
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 11 }}
+                tickFormatter={formatYTick}
+                stroke="currentColor"
+                className="text-muted-foreground"
+              />
+              <Tooltip
+                contentStyle={{
+                  fontSize: 12,
+                  borderRadius: 6,
+                  border: '1px solid var(--border)',
+                  background: 'var(--popover)',
+                }}
+                labelFormatter={(_value, payload) => {
+                  const first = payload?.[0];
+                  if (
+                    first &&
+                    typeof first === 'object' &&
+                    'payload' in first &&
+                    first.payload &&
+                    typeof first.payload === 'object' &&
+                    'periodKey' in first.payload &&
+                    typeof first.payload.periodKey === 'string'
+                  ) {
+                    return first.payload.periodKey;
+                  }
+                  return '';
+                }}
+                formatter={formatTooltipValue}
+              />
+              {metric === 'tokens' ? (
+                <>
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  <Bar
+                    dataKey="inputTokens"
+                    stackId="tokens"
+                    fill="var(--color-chart-primary, #3b82f6)"
+                    name={t('usage.chart.inputTokens')}
+                    radius={[0, 0, 0, 0]}
+                  />
+                  <Bar
+                    dataKey="outputTokens"
+                    stackId="tokens"
+                    fill="var(--color-chart-success, #16a34a)"
+                    name={t('usage.chart.outputTokens')}
+                    radius={[4, 4, 0, 0]}
+                  />
+                </>
+              ) : metric === 'requests' ? (
+                <Bar
+                  dataKey="requests"
+                  fill="var(--color-chart-primary, #3b82f6)"
+                  name={t('usage.metric.requests')}
+                  radius={[4, 4, 0, 0]}
+                />
+              ) : (
+                <Bar
+                  dataKey="costCents"
+                  fill="var(--color-chart-warning, #f59e0b)"
+                  name={t('usage.metric.cost')}
+                  radius={[4, 4, 0, 0]}
+                />
+              )}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
   );
 }

--- a/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
+++ b/services/platform/app/features/settings/api-keys/components/api-keys-table.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { buttonVariants } from '@tale/ui/button';
-import { Row, Stack } from '@tale/ui/layout';
+import { Button, buttonVariants } from '@tale/ui/button';
+import { Stack } from '@tale/ui/layout';
 import type { RowSelectionState } from '@tanstack/react-table';
-import { BookOpen, Key } from 'lucide-react';
+import { BookOpen, Key, Plus } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { DataTable } from '@/app/components/ui/data-table/data-table';
@@ -25,7 +25,7 @@ function ApiDocsLink() {
   const { t: tSettings } = useT('settings');
 
   return (
-    <Row gap={0} align="stretch" justify="center" className="py-4">
+    <div className="flex justify-center py-4">
       <a
         href="/docs"
         target="_blank"
@@ -35,7 +35,7 @@ function ApiDocsLink() {
         <BookOpen className="mr-2 size-4" />
         {tSettings('apiDocs.openDocs')}
       </a>
-    </Row>
+    </div>
   );
 }
 
@@ -94,8 +94,35 @@ export function ApiKeysTable({ apiKeys, organizationId }: ApiKeysTableProps) {
           title: tEmpty('apiKeys.title'),
           description: (
             <>
-              {tEmpty('apiKeys.description')}
-              <ApiDocsLink />
+              {/* `text-balance` evens the two lines so the last word never
+                  strands on its own line (the "REST API" orphan). */}
+              <span className="block text-balance">
+                {tEmpty('apiKeys.description')}
+              </span>
+              {/* Both CTAs share one horizontal row: the primary "Create" and
+                  the secondary docs link sit side by side rather than stacked. */}
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={Plus}
+                  onClick={() => setCreateOpen(true)}
+                >
+                  {tSettings('apiKeys.createKey')}
+                </Button>
+                <a
+                  href="/docs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={buttonVariants({
+                    variant: 'secondary',
+                    size: 'sm',
+                  })}
+                >
+                  <BookOpen className="mr-2 size-4" />
+                  {tSettings('apiDocs.openDocs')}
+                </a>
+              </div>
             </>
           ),
         }}

--- a/services/platform/app/features/settings/components/settings-row.tsx
+++ b/services/platform/app/features/settings/components/settings-row.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Description } from '@tale/ui/description';
-import { Stack } from '@tale/ui/layout';
 import { forwardRef, useId, type HTMLAttributes, type ReactNode } from 'react';
 
 import { cn } from '@/lib/utils/cn';
@@ -38,7 +37,11 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
         )}
         {...props}
       >
-        <Stack gap={1} className="min-w-0">
+        {/* Cap the text column at a readable line length (matching
+            `SettingsSection`'s header and `SettingsToggleRow`) so a long
+            description doesn't stretch to the full content width when the
+            right-side control is narrow. */}
+        <div className="flex max-w-2xl min-w-0 flex-col gap-1">
           <span
             id={labelId}
             className="text-foreground text-sm leading-none font-medium"
@@ -46,7 +49,7 @@ export const SettingsRow = forwardRef<HTMLDivElement, SettingsRowProps>(
             {label}
           </span>
           {description && <Description id={descId}>{description}</Description>}
-        </Stack>
+        </div>
         <div className="shrink-0">{children}</div>
       </div>
     );

--- a/services/platform/app/features/settings/components/settings-secondary-action-context.tsx
+++ b/services/platform/app/features/settings/components/settings-secondary-action-context.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+export interface SettingsHeaderAction {
+  label: string;
+  /** Label shown while `loading` is true. Falls back to `label` if omitted. */
+  loadingLabel?: string;
+  onClick: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  title?: string;
+  variant?: 'primary' | 'secondary';
+}
+
+/**
+ * Split-context pattern (mirrors `useRegisterActiveEditor`):
+ *
+ * - `SetterContext`  — holds the stable `setActions` from `useState`.
+ *   Sub-pages use this to register their buttons.  Because the setter
+ *   is stable, including it as an effect dep does NOT cause re-render loops.
+ *
+ * - `ActionsContext` — holds the current action array.
+ *   The header slot reads this to know what to render.
+ */
+const SetterContext = createContext<Dispatch<
+  SetStateAction<SettingsHeaderAction[]>
+> | null>(null);
+
+const ActionsContext = createContext<SettingsHeaderAction[]>([]);
+
+export { SetterContext as SettingsHeaderActionsSetter };
+export { ActionsContext as SettingsHeaderActionsReader };
+
+/** Reads the registered actions (consumed by the settings header slot). */
+export function useSettingsHeaderActions(): SettingsHeaderAction[] {
+  return useContext(ActionsContext);
+}
+
+/**
+ * Registers one or more action buttons in the settings header slot.
+ * Buttons render in order alongside any EditorActions (Discard/Save) cluster,
+ * or on their own when the page doesn't use `useRegisterActiveEditor`.
+ *
+ * Pass a fresh array each render; the hook only re-registers when any
+ * action's `disabled` or `loading` state changes.  The setter from
+ * `useState` is stable, so including it as a dep is safe — no loops.
+ *
+ * Pass an empty array to clear the slot.
+ */
+export function useRegisterSettingsSecondaryAction(
+  actions: SettingsHeaderAction[],
+): void {
+  const setActions = useContext(SetterContext);
+  const actionsRef = useRef(actions);
+  actionsRef.current = actions;
+
+  // Collect the per-action state values that can change between renders.
+  // Number of actions must be stable across renders (rules of hooks).
+  const depValues = actions.flatMap((a) => [a.disabled, a.loading]);
+
+  useEffect(
+    () => {
+      if (!setActions) return;
+      setActions([...actionsRef.current]);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setActions, ...depValues],
+  );
+
+  // Clear the slot when the registering component unmounts.
+  useEffect(
+    () => () => {
+      setActions?.([]);
+    },
+    [setActions],
+  );
+}

--- a/services/platform/app/features/settings/components/settings-toggle-row.tsx
+++ b/services/platform/app/features/settings/components/settings-toggle-row.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Description } from '@tale/ui/description';
-import { Stack } from '@tale/ui/layout';
 import { SkeletonBox } from '@tale/ui/skeleton';
 import { forwardRef, useId, type ComponentRef, type ReactNode } from 'react';
 
@@ -33,7 +32,7 @@ interface SettingsToggleRowProps {
  * the Switch via `aria-labelledby` rather than relying on the row-level
  * association.
  *
- * Use this instead of pairing a `SettingsSection` with a bare `Switch`: the
+ * Use this instead of pairing a `PageSection` with a bare `Switch`: the
  * bare-switch layout leaves the toggle anchored to the left under a
  * heading, breaking the "controls live on the right" visual rhythm shared
  * with the rest of settings.
@@ -65,7 +64,11 @@ export const SettingsToggleRow = forwardRef<
           className,
         )}
       >
-        <Stack gap={1} className="min-w-0">
+        {/* Cap the text column at a readable line length (matching
+            `SettingsSection`'s header) so a long description doesn't stretch to
+            the full content width — the right-side Switch is tiny, so without a
+            cap `justify-between` lets the copy run edge-to-edge. */}
+        <div className="flex max-w-2xl min-w-0 flex-col gap-1">
           <span
             id={labelId}
             className="text-foreground text-sm leading-none font-medium"
@@ -79,7 +82,7 @@ export const SettingsToggleRow = forwardRef<
               <SkeletonBox fullWidth>{description}</SkeletonBox>
             </Description>
           )}
-        </Stack>
+        </div>
         <div className="shrink-0">
           <Switch
             ref={ref}

--- a/services/platform/app/features/settings/deployment/components/deployment-settings.tsx
+++ b/services/platform/app/features/settings/deployment/components/deployment-settings.tsx
@@ -8,7 +8,7 @@
  * stores panel.
  * `api.deployment.*` resolves after `convex codegen` (runs on dev/deploy).
  *
- * Built on the shared settings UI (`SettingsSection`, app `Input`/`Select`/
+ * Built on the shared settings UI (`PageSection`, app `Input`/`Select`/
  * `Switch`, `Alert`, `Stack`/`HStack`) so it matches every other settings page
  * instead of carrying bespoke banner / label / card chrome.
  *
@@ -18,8 +18,10 @@
  */
 
 import { Alert } from '@tale/ui/alert';
+import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
-import { Grid, HStack, Stack } from '@tale/ui/layout';
+import { HStack, Stack } from '@tale/ui/layout';
+import { PageSection } from '@tale/ui/page-section';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Info } from 'lucide-react';
 import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
@@ -31,7 +33,7 @@ import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
-import { SettingsSection } from '@/app/features/settings/components/settings-section';
+import { useRegisterSettingsSecondaryAction } from '@/app/features/settings/components/settings-secondary-action-context';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
@@ -225,25 +227,33 @@ function PgSection({
 }) {
   const { t } = useT('settings');
   return (
-    <SettingsSection
+    <PageSection
       className={className}
       title={title}
       description={description}
       action={
-        <Switch
-          label={t('dataResidency.externalPostgres')}
-          hideLabelOnMobile
-          checked={state.enabled}
-          disabled={disabled}
-          onCheckedChange={(checked) =>
-            setState({ ...state, enabled: checked })
-          }
-        />
+        // State lives in a scannable pill; the switch is the control (its
+        // accessible name comes from `aria-label`, since the pill is visual).
+        <HStack gap={2} align="center">
+          <Badge variant={state.enabled ? 'blue' : 'slate'} dot>
+            {state.enabled
+              ? t('dataResidency.externalPostgres')
+              : t('dataResidency.status.builtIn')}
+          </Badge>
+          <Switch
+            aria-label={t('dataResidency.externalPostgres')}
+            checked={state.enabled}
+            disabled={disabled}
+            onCheckedChange={(checked) =>
+              setState({ ...state, enabled: checked })
+            }
+          />
+        </HStack>
       }
     >
       {state.enabled ? (
         <Stack gap={4}>
-          <Grid sm={2}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Input
               label={t('dataResidency.field.host')}
               value={state.host}
@@ -294,10 +304,11 @@ function PgSection({
                     : t('dataResidency.password.writeOnlyHint')
               }
             />
-          </Grid>
+          </div>
           <HStack gap={3} align="center" className="flex-wrap">
             <Button
               variant="secondary"
+              size="sm"
               onClick={onTest}
               disabled={disabled || testing}
             >
@@ -312,12 +323,10 @@ function PgSection({
           </HStack>
           {note}
         </Stack>
-      ) : (
-        <p className="text-muted-foreground text-sm">
-          {t('dataResidency.usingSharedDatabase')}
-        </p>
-      )}
-    </SettingsSection>
+      ) : // Off = built-in: the status pill in the header already says so, so
+      // the body stays empty rather than repeating it as a grey sentence.
+      null}
+    </PageSection>
   );
 }
 
@@ -614,14 +623,59 @@ function DeploymentSettingsView({
     }
   }
 
+  // Register Save and Apply & restart in the shared settings header — same
+  // position as branding's buttons, but with data residency's own actions.
+  // Always register both (fixed-size array so effect deps never change length);
+  // readOnly gates via `disabled` rather than omitting the buttons entirely.
+  useRegisterSettingsSecondaryAction([
+    {
+      label: t('dataResidency.save'),
+      loadingLabel: t('dataResidency.saving'),
+      onClick: () => void onSave(),
+      disabled: readOnly || saving || !isDirty,
+      loading: saving,
+    },
+    {
+      label: t('dataResidency.applyRestart'),
+      loadingLabel: t('dataResidency.restarting'),
+      onClick: () => setRestartConfirmOpen(true),
+      disabled: readOnly || restarting || isDirty,
+      loading: restarting,
+      title: t('dataResidency.applyRestartTitle'),
+      variant: 'secondary',
+    },
+  ]);
+
   return (
     <SettingsPage fitToContainer>
-      {/* Page = a scrollable body + a footer docked to the bottom, so the
-          Save / Apply & restart bar stays pinned to the bottom of the viewport
-          regardless of how short the content is (plain `position: sticky` only
-          pins once the content is tall enough to scroll). */}
-      <Stack gap={0} className="min-h-0 flex-1">
-        <Stack gap={8} className="min-h-0 flex-1 overflow-y-auto pb-8">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-8 pb-8">
+          {/* Save / restart status — previously in the footer, now inline at
+              the top of the scrollable body so they're visible without
+              scrolling to the bottom. */}
+          {error || (savedOk && !isDirty) || restartMsg ? (
+            <Stack gap={3}>
+              {error ? (
+                <Alert variant="destructive" description={error} />
+              ) : null}
+              {savedOk && !isDirty ? (
+                <Alert
+                  description={
+                    <>
+                      <strong>{t('dataResidency.saved.title')}</strong>{' '}
+                      {t('dataResidency.saved.runPrefix')}{' '}
+                      <code>docker compose restart convex</code>{' '}
+                      {t('dataResidency.saved.orPrefix')}{' '}
+                      <code>tale deploy --services convex</code>{' '}
+                      {t('dataResidency.saved.tail')}
+                    </>
+                  }
+                />
+              ) : null}
+              {restartMsg ? <Alert description={restartMsg} /> : null}
+            </Stack>
+          ) : null}
+
           {readOnly ||
           data?.secretsError === 'encrypted_no_key' ||
           data?.secretsError === 'unreadable' ? (
@@ -683,24 +737,31 @@ function DeploymentSettingsView({
             }
           />
 
-          <SettingsSection
+          <PageSection
+            className="border-border border-t pt-8"
             title={t('dataResidency.storage.title')}
             description={t('dataResidency.storage.description')}
             action={
-              <Switch
-                label={t('dataResidency.storage.externalS3')}
-                hideLabelOnMobile
-                checked={storage.s3}
-                disabled={readOnly}
-                onCheckedChange={(checked) =>
-                  setStorage({ ...storage, s3: checked })
-                }
-              />
+              <HStack gap={2} align="center">
+                <Badge variant={storage.s3 ? 'blue' : 'slate'} dot>
+                  {storage.s3
+                    ? t('dataResidency.storage.externalS3')
+                    : t('dataResidency.storage.localLabel')}
+                </Badge>
+                <Switch
+                  aria-label={t('dataResidency.storage.externalS3')}
+                  checked={storage.s3}
+                  disabled={readOnly}
+                  onCheckedChange={(checked) =>
+                    setStorage({ ...storage, s3: checked })
+                  }
+                />
+              </HStack>
             }
           >
             {storage.s3 ? (
               <Stack gap={5}>
-                <Grid sm={2}>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <Input
                     label={t('dataResidency.storage.region')}
                     value={storage.region}
@@ -717,7 +778,7 @@ function DeploymentSettingsView({
                       setStorage({ ...storage, endpoint: e.target.value })
                     }
                   />
-                </Grid>
+                </div>
                 <Switch
                   label={t('dataResidency.storage.forcePathStyle')}
                   checked={storage.forcePathStyle}
@@ -727,7 +788,7 @@ function DeploymentSettingsView({
                   }
                 />
                 <FormSection label={t('dataResidency.storage.bucketsLabel')}>
-                  <Grid sm={2}>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                     <Input
                       label={t('dataResidency.storage.bucket.files')}
                       value={storage.files}
@@ -771,12 +832,12 @@ function DeploymentSettingsView({
                         setStorage({ ...storage, search: e.target.value })
                       }
                     />
-                  </Grid>
+                  </div>
                 </FormSection>
                 <FormSection
                   label={t('dataResidency.storage.credentialsLabel')}
                 >
-                  <Grid sm={2}>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                     <Input
                       label={t('dataResidency.storage.accessKeyId')}
                       value={storage.accessKeyId}
@@ -809,11 +870,12 @@ function DeploymentSettingsView({
                       }
                       description={t('dataResidency.storage.writeOnly')}
                     />
-                  </Grid>
+                  </div>
                 </FormSection>
                 <HStack gap={3} align="center" className="flex-wrap">
                   <Button
                     variant="secondary"
+                    size="sm"
                     onClick={() => void runTest('convexStorage')}
                     disabled={readOnly || testing === 'convexStorage'}
                   >
@@ -831,18 +893,16 @@ function DeploymentSettingsView({
                   description={t('dataResidency.storage.greenfieldWarning')}
                 />
               </Stack>
-            ) : (
-              <p className="text-muted-foreground text-sm">
-                {t('dataResidency.storage.localStorageNote')}
-              </p>
-            )}
-          </SettingsSection>
+            ) : // Off = local volume: the header status pill already says so.
+            null}
+          </PageSection>
 
           {/* Advanced Convex metadata DB — reuses the Postgres section chrome; its
           own header switch toggles `enabled`. Titled "(advanced)" rather than
           hidden behind a disclosure so it shares the rhythm of the sections
           above. */}
           <PgSection
+            className="border-border border-t pt-8"
             title={t('dataResidency.appDb.summary')}
             description={t('dataResidency.appDb.description')}
             state={appPg}
@@ -865,66 +925,8 @@ function DeploymentSettingsView({
               </p>
             }
           />
-        </Stack>
-
-        {/* Footer docked to the bottom of the page (outside the scroll body)
-            so Save / Apply & restart stay reachable regardless of content
-            height; the top border separates actions from the sections, and
-            `-mx-4 px-4` bleeds the background to the content-area gutters. */}
-        <div className="bg-background border-border -mx-4 border-t px-4 pt-4">
-          <Stack gap={3}>
-            {error ? <Alert variant="destructive" description={error} /> : null}
-            {savedOk && !isDirty ? (
-              <Alert
-                description={
-                  <>
-                    <strong>{t('dataResidency.saved.title')}</strong>{' '}
-                    {t('dataResidency.saved.runPrefix')}{' '}
-                    <code>docker compose restart convex</code>{' '}
-                    {t('dataResidency.saved.orPrefix')}{' '}
-                    <code>tale deploy --services convex</code>{' '}
-                    {t('dataResidency.saved.tail')}
-                  </>
-                }
-              />
-            ) : null}
-
-            {/* Status text on the left (`mr-auto`), actions right-aligned —
-                the standard footer/action-bar layout. Save comes before
-                Apply & restart to match the workflow order (save, then apply). */}
-            <HStack gap={3} align="center" justify="end" className="flex-wrap">
-              {isDirty ? (
-                <span className="text-muted-foreground mr-auto text-sm">
-                  {t('dataResidency.applyRestartDirtyHint')}
-                </span>
-              ) : restartMsg ? (
-                <span className="text-muted-foreground mr-auto text-sm">
-                  {restartMsg}
-                </span>
-              ) : null}
-              <Button
-                onClick={() => void onSave()}
-                disabled={readOnly || saving || !isDirty}
-              >
-                {saving ? t('dataResidency.saving') : t('dataResidency.save')}
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => setRestartConfirmOpen(true)}
-                // Gate on a clean form: a restart applies the LAST-SAVED on-disk
-                // config, so allowing it while dirty would silently bounce into a
-                // config that differs from what's on screen.
-                disabled={readOnly || restarting || isDirty}
-                title={t('dataResidency.applyRestartTitle')}
-              >
-                {restarting
-                  ? t('dataResidency.restarting')
-                  : t('dataResidency.applyRestart')}
-              </Button>
-            </HStack>
-          </Stack>
         </div>
-      </Stack>
+      </div>
 
       <ConfirmDialog
         open={restartConfirmOpen}

--- a/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
@@ -224,17 +224,25 @@ function PersonalizationSettingsView({
           </>
         }
       >
-        <CustomInstructionsToggleSection
-          organizationId={organizationId}
-          gate={customInstructionsGate}
-          orgDefaultLoaded={orgDefaultLoaded}
-        />
-        <MemoriesToggleSection
-          organizationId={organizationId}
-          gate={memoriesGate}
-          orgDefaultLoaded={orgDefaultLoaded}
-        />
-        <VoiceOutputSection prefs={prefs} organizationId={organizationId} />
+        {/* Group the toggles as a single section child with extra top padding
+            so they sit a comfortable distance below the section description —
+            the section's own `gap-4` (16px) alone reads too tight here. The
+            account page gets the same breathing room from its `py-5` rows; we
+            add the padding to the group instead of widening the section gap so
+            the three toggles stay tightly grouped (no dividers between them). */}
+        <div className="flex flex-col gap-4 pt-4">
+          <CustomInstructionsToggleSection
+            organizationId={organizationId}
+            gate={customInstructionsGate}
+            orgDefaultLoaded={orgDefaultLoaded}
+          />
+          <MemoriesToggleSection
+            organizationId={organizationId}
+            gate={memoriesGate}
+            orgDefaultLoaded={orgDefaultLoaded}
+          />
+          <VoiceOutputSection prefs={prefs} organizationId={organizationId} />
+        </div>
       </SettingsSection>
       {(loading || customInstructionsGate.effective) && (
         <CustomInstructionsSection

--- a/services/platform/app/features/settings/providers/components/model-catalog-card.tsx
+++ b/services/platform/app/features/settings/providers/components/model-catalog-card.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { Row } from '@tale/ui/layout';
+import { PageSection } from '@tale/ui/page-section';
 import { Text } from '@tale/ui/text';
 import { RefreshCw } from 'lucide-react';
 import { useCallback } from 'react';
 
-import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { SettingsToggleRow } from '@/app/features/settings/components/settings-toggle-row';
 import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
@@ -91,12 +90,13 @@ export function ModelCatalogCard({
   }, [organizationId, sync, t]);
 
   return (
-    <SettingsSection
+    <PageSection
+      as="h2"
       className={className}
       title={t('providers.modelCatalog.title')}
       description={t('providers.modelCatalog.description')}
     >
-      <Row justify="between" className="rounded-lg border px-4 py-3">
+      <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
         <Text as="span" variant="caption" className="text-muted-foreground">
           {latest
             ? latest.ok
@@ -111,6 +111,7 @@ export function ModelCatalogCard({
         </Text>
         <Button
           variant="secondary"
+          size="sm"
           onClick={onRefresh}
           disabled={sync.isPending}
           icon={RefreshCw}
@@ -118,7 +119,7 @@ export function ModelCatalogCard({
         >
           {t('providers.modelCatalog.refresh')}
         </Button>
-      </Row>
+      </div>
       <SettingsToggleRow
         label={t('providers.modelCatalog.autoSync')}
         description={t('providers.modelCatalog.autoSyncHelp')}
@@ -127,6 +128,6 @@ export function ModelCatalogCard({
         disabled={setAutoSync.isPending}
         onCheckedChange={onToggleAutoSync}
       />
-    </SettingsSection>
+    </PageSection>
   );
 }

--- a/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
+++ b/services/platform/app/features/settings/user-env/components/user-env-settings.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { Alert } from '@tale/ui/alert';
 import { Button } from '@tale/ui/button';
 import { IconButton } from '@tale/ui/icon-button';
-import { Row, Stack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Skeletonize, useSkeleton } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
-import { Plus, ShieldAlert, Trash2 } from 'lucide-react';
+import { ConvexError } from 'convex/values';
+import { Trash2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { DeleteDialog } from '@/app/components/ui/dialog/delete-dialog';
-import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Switch } from '@/app/components/ui/forms/switch';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
@@ -21,7 +19,6 @@ import { useFormatDate } from '@/app/hooks/use-format-date';
 import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { useToast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
-import { convexErrorMessage } from '@/lib/utils/convex-error';
 
 import { useDeleteMyEnvVar, useUpsertMyEnvVar } from '../hooks/mutations';
 import { useMyEnv } from '../hooks/queries';
@@ -65,45 +62,38 @@ function UserEnvSettingsView({
   vars: EnvVar[];
 }) {
   const { t } = useT('userEnv');
-  const [addOpen, setAddOpen] = useState(false);
 
   return (
     <SettingsPage>
       <SettingsSection
         title={t('page.title')}
         description={t('page.description')}
-        action={
-          <Button icon={Plus} onClick={() => setAddOpen(true)}>
-            {t('add.button')}
-          </Button>
-        }
       >
-        <Alert
-          variant="warning"
-          icon={ShieldAlert}
-          title={t('page.agentAccessTitle')}
-          description={t('page.note')}
-        />
+        <Text className="text-muted-foreground text-sm">{t('page.note')}</Text>
+        <AddEnvVarForm organizationId={organizationId} />
         <EnvVarList organizationId={organizationId} vars={vars} />
       </SettingsSection>
-      <AddEnvVarDialog
-        organizationId={organizationId}
-        open={addOpen}
-        onOpenChange={setAddOpen}
-      />
     </SettingsPage>
   );
 }
 
-function AddEnvVarDialog({
-  organizationId,
-  open,
-  onOpenChange,
-}: {
-  organizationId: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
+/** Pull `{ code, message }` off a thrown `ConvexError`, else the fallback. */
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ConvexError) {
+    const data: unknown = err.data;
+    if (
+      data !== null &&
+      typeof data === 'object' &&
+      'message' in data &&
+      typeof data.message === 'string'
+    ) {
+      return data.message;
+    }
+  }
+  return fallback;
+}
+
+function AddEnvVarForm({ organizationId }: { organizationId: string }) {
   const { t } = useT('userEnv');
   const { toast } = useToast();
   const { mutateAsync: upsert, isPending } = useUpsertMyEnvVar();
@@ -118,12 +108,12 @@ function AddEnvVarDialog({
     trimmedKey.length > 0 &&
     (!KEY_RE.test(trimmedKey) || trimmedKey.length > KEY_MAX);
   // A secret's value must be non-empty (the backend rejects an empty secret).
-  const isValid =
+  const canSubmit =
     trimmedKey.length > 0 &&
     !keyInvalid &&
     value.length <= VALUE_MAX &&
-    (!isSecret || value.length > 0);
-  const isDirty = trimmedKey.length > 0 || value.length > 0;
+    (!isSecret || value.length > 0) &&
+    !isPending;
   // Interior whitespace (space/tab/newline after trimming the ends) almost
   // always means a token wrapped across terminal lines was pasted — a silent,
   // painful-to-debug corruption. Warn loudly but don't block: legitimately
@@ -138,82 +128,67 @@ function AddEnvVarDialog({
     setError(null);
   }, []);
 
-  const handleOpenChange = useCallback(
-    (next: boolean) => {
-      if (!next) reset();
-      onOpenChange(next);
-    },
-    [reset, onOpenChange],
-  );
-
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!isValid || isPending) return;
-      setError(null);
-      try {
-        await upsert({
-          organizationId,
-          key: trimmedKey,
-          value,
-          isSecret,
-        });
-        toast({ title: t('toasts.saved'), variant: 'success' });
-        reset();
-        onOpenChange(false);
-      } catch (err) {
-        console.error('[user-env upsert]', err);
-        setError(convexErrorMessage(err, t('errors.saveFailed')));
-      }
-    },
-    [
-      isValid,
-      isPending,
-      upsert,
-      organizationId,
-      trimmedKey,
-      value,
-      isSecret,
-      toast,
-      t,
-      reset,
-      onOpenChange,
-    ],
-  );
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setError(null);
+    try {
+      await upsert({
+        organizationId,
+        key: trimmedKey,
+        value,
+        isSecret,
+      });
+      toast({ title: t('toasts.saved'), variant: 'success' });
+      reset();
+    } catch (err) {
+      console.error('[user-env upsert]', err);
+      setError(errorMessage(err, t('errors.saveFailed')));
+    }
+  }, [
+    canSubmit,
+    upsert,
+    organizationId,
+    trimmedKey,
+    value,
+    isSecret,
+    toast,
+    t,
+    reset,
+  ]);
 
   return (
-    <FormDialog
-      open={open}
-      onOpenChange={handleOpenChange}
-      title={t('add.title')}
-      isSubmitting={isPending}
-      isDirty={isDirty}
-      isValid={isValid}
-      confirmDiscardOnDirty
-      submitText={t('add.submit')}
-      onSubmit={handleSubmit}
+    <form
+      className="border-border flex flex-col gap-4 rounded-lg border p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void handleSubmit();
+      }}
     >
-      <Input
-        label={t('add.keyLabel')}
-        placeholder={t('add.keyPlaceholder')}
-        value={key}
-        onChange={(e) => setKey(e.target.value)}
-        maxLength={KEY_MAX}
-        errorMessage={keyInvalid ? t('add.keyInvalid') : undefined}
-        autoComplete="off"
-        spellCheck={false}
-      />
-      <Input
-        label={t('add.valueLabel')}
-        placeholder={t('add.valuePlaceholder')}
-        // Secret values render masked while typing and never round-trip back.
-        sensitive={isSecret}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        maxLength={VALUE_MAX}
-        autoComplete="off"
-        spellCheck={false}
-      />
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <Input
+          label={t('add.keyLabel')}
+          placeholder={t('add.keyPlaceholder')}
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          maxLength={KEY_MAX}
+          errorMessage={keyInvalid ? t('add.keyInvalid') : undefined}
+          wrapperClassName="flex-1"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <Input
+          label={t('add.valueLabel')}
+          placeholder={t('add.valuePlaceholder')}
+          // Secret values render masked while typing and never round-trip back.
+          type={isSecret ? 'password' : 'text'}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          maxLength={VALUE_MAX}
+          wrapperClassName="flex-1"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
       {showWhitespaceWarning && (
         <Text
           role="alert"
@@ -223,7 +198,8 @@ function AddEnvVarDialog({
         </Text>
       )}
       {/* Secret as a full-width settings row (label + help left, toggle pinned
-          right) so the toggle stays anchored to the right edge. */}
+          right) so the toggle stays anchored to the right edge instead of
+          floating mid-row at full width. Add gets its own right-aligned row. */}
       <SettingsRow
         label={t('add.secretLabel')}
         description={t('add.secretHelp')}
@@ -234,12 +210,17 @@ function AddEnvVarDialog({
           aria-label={t('add.secretLabel')}
         />
       </SettingsRow>
+      <div className="flex justify-end">
+        <Button type="submit" variant="primary" disabled={!canSubmit}>
+          {t('add.submit')}
+        </Button>
+      </div>
       {error && (
         <Text role="alert" className="text-destructive text-sm">
           {error}
         </Text>
       )}
-    </FormDialog>
+    </form>
   );
 }
 
@@ -255,17 +236,15 @@ function EnvVarList({
 
   if (loading) {
     return (
-      <Stack as="ul" gap={2} aria-hidden="true">
+      <ul className="divide-border divide-y" aria-hidden="true">
         {Array.from({ length: 3 }).map((_, i) => (
-          <li
-            key={i}
-            className="border-border flex flex-col gap-0.5 rounded-lg border p-3"
-            style={{ width: `${90 - i * 8}%` }}
-          >
-            <SkeletonText />
+          <li key={i} className="flex items-start gap-3 py-2">
+            <div className="flex-1" style={{ width: `${70 - i * 10}%` }}>
+              <SkeletonText />
+            </div>
           </li>
         ))}
-      </Stack>
+      </ul>
     );
   }
 
@@ -276,7 +255,7 @@ function EnvVarList({
   }
 
   return (
-    <Stack as="ul" gap={2}>
+    <ul className="divide-border divide-y">
       {vars.map((envVar) => (
         <EnvVarRow
           key={envVar.key}
@@ -284,7 +263,7 @@ function EnvVarList({
           envVar={envVar}
         />
       ))}
-    </Stack>
+    </ul>
   );
 }
 
@@ -321,9 +300,9 @@ function EnvVarRow({
   }, [deleteVar, organizationId, envVar.key, toast, t]);
 
   return (
-    <li className="border-border flex items-start justify-between gap-3 rounded-lg border p-3">
+    <li className="flex items-start justify-between gap-3 py-3">
       <div className="flex min-w-0 flex-col gap-0.5">
-        <Row gap={2} align="baseline">
+        <div className="flex items-baseline gap-2">
           <code className="text-foreground truncate text-sm font-medium">
             {envVar.key}
           </code>
@@ -332,7 +311,7 @@ function EnvVarRow({
               {t('list.secretBadge')}
             </span>
           )}
-        </Row>
+        </div>
         <code className="text-muted-foreground truncate font-mono text-xs">
           {displayValue}
         </code>

--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@tale/ui/button';
-import { Row, Stack } from '@tale/ui/layout';
+import { Stack } from '@tale/ui/layout';
 import {
   createFileRoute,
   useNavigate,
@@ -258,16 +258,9 @@ export function LogInPage() {
   const handleSsoLogin = useCallback(() => {
     const siteUrl = getEnv('SITE_URL');
     const basePath = getEnv('BASE_PATH');
-    const base = `${siteUrl}${basePath}/http_api/api/sso`;
-    // SAML uses SP-initiated redirect (AuthnRequest); OIDC/OAuth2 use the
-    // authorization-code flow via /authorize.
-    if (ssoConfig?.providerType === 'saml') {
-      window.location.href = `${base}/saml/login`;
-      return;
-    }
-    const callbackUri = `${base}/callback`;
-    window.location.href = `${base}/authorize?redirect_uri=${encodeURIComponent(callbackUri)}`;
-  }, [ssoConfig?.providerType]);
+    const callbackUri = `${siteUrl}${basePath}/http_api/api/sso/callback`;
+    window.location.href = `${siteUrl}${basePath}/http_api/api/sso/authorize?redirect_uri=${encodeURIComponent(callbackUri)}`;
+  }, []);
 
   // Passkey / WebAuthn sign-in (#1508). Drives the browser's get-credential
   // ceremony; on success the session is live, so refresh the cache and route
@@ -349,11 +342,12 @@ export function LogInPage() {
                 right) — the standard pattern — so the space directly under the
                 input is free for the error message to read as field feedback. */}
             <div className="flex flex-col gap-1.5">
-              <Row gap={2} justify="between">
+              <div className="flex items-center justify-between gap-2">
                 <Label htmlFor="password">{t('password')}</Label>
                 <Button
                   type="button"
                   variant="link"
+                  size="sm"
                   className="h-auto p-0"
                   onClick={() =>
                     toast({
@@ -365,7 +359,7 @@ export function LogInPage() {
                 >
                   {t('login.forgotPassword')}
                 </Button>
-              </Row>
+              </div>
               <Input
                 id="password"
                 type="password"
@@ -384,11 +378,10 @@ export function LogInPage() {
               // `space-y-4`) so the message reads as feedback on the inputs —
               // matching the ~6px gap a field-level error uses — rather than
               // floating midway to the button.
-              <Stack
+              <div
                 role="alert"
                 aria-live="polite"
-                gap={1}
-                className="-mt-2.5"
+                className="-mt-2.5 flex flex-col gap-1"
               >
                 <p className="text-destructive flex items-start gap-1.5 text-sm font-medium">
                   <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
@@ -399,7 +392,7 @@ export function LogInPage() {
                     {t('login.lockoutAdvisory')}
                   </p>
                 )}
-              </Stack>
+              </div>
             )}
 
             <Button type="submit" fullWidth disabled={isSubmitting || !isValid}>
@@ -411,11 +404,11 @@ export function LogInPage() {
         {/* A single "or" divider separates the credential method above from the
             alternative sign-in methods grouped below — it reads correctly with
             one alternative (passkey) or two (passkey + SSO). */}
-        <Row gap={3} aria-hidden="true">
+        <div className="flex items-center gap-3" aria-hidden="true">
           <span className="bg-border h-px flex-1" />
           <span className="text-muted-foreground text-xs">{tCommon('or')}</span>
           <span className="bg-border h-px flex-1" />
-        </Row>
+        </div>
 
         <Stack gap={3}>
           <Button

--- a/services/platform/app/routes/dashboard/$id/settings.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings.tsx
@@ -1,5 +1,6 @@
-import { Row } from '@tale/ui/layout';
+import { Button } from '@tale/ui/button';
 import { Outlet, createFileRoute, useLocation } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import {
   AdaptiveHeaderRoot,
@@ -14,6 +15,12 @@ import {
 } from '@/app/components/ui/editor';
 import { SettingsMobileBackButton } from '@/app/features/settings/components/settings-mobile-back-button';
 import { SettingsRail } from '@/app/features/settings/components/settings-rail';
+import {
+  SettingsHeaderActionsSetter,
+  SettingsHeaderActionsReader,
+  useSettingsHeaderActions,
+  type SettingsHeaderAction,
+} from '@/app/features/settings/components/settings-secondary-action-context';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
 import { seo } from '@/lib/utils/seo';
@@ -32,93 +39,112 @@ function SettingsLayout() {
 
   const headerTitle = tNav('userSettings');
 
-  // The Governance and API sections render an internally-scrolling content pane
-  // (see their `route.tsx`) that needs ContentArea to be a bounded flex parent
-  // (`min-h-0 flex-1`) for its `overflow-y-auto` to get a height to scroll
-  // within. Every other settings page is a plain scrolling form/table: leaving
-  // ContentArea at content height lets the PageLayout scroll container honor
-  // ContentArea's own `py-6` bottom padding.
+  // Stable setter (from useState) goes in SetterContext so sub-page effects
+  // can include it as a dep without causing re-render loops.
+  const [headerActions, setHeaderActions] = useState<SettingsHeaderAction[]>(
+    [],
+  );
+
   const usesBoundedLayout =
     location.pathname.includes('/settings/governance') ||
     location.pathname.includes('/settings/api') ||
     location.pathname.includes('/settings/branding') ||
-    // Data residency docks its Save / Apply & restart bar to the bottom, so it
-    // needs ContentArea bounded for the page's internal scroll body + footer.
     location.pathname.includes('/settings/deployment');
 
   return (
     <ActiveEditorProvider>
-      <PageLayout
-        organizationId={organizationId}
-        header={
-          <AdaptiveHeaderRoot showBorder standalone={false}>
-            <SettingsMobileBackButton organizationId={organizationId} />
-            <AdaptiveHeaderTitle>{headerTitle}</AdaptiveHeaderTitle>
-            <SettingsEditorActionsSlot />
-          </AdaptiveHeaderRoot>
-        }
-      >
-        <SettingsMobileActionBar />
-        {/* Left rail (desktop) + content. The rail replaces the former
-            horizontal tab strip; on mobile it's hidden and the dedicated
-            personal/workspace overview routes drive navigation instead. */}
-        <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-          <div className="hidden md:flex">
-            <SettingsRail organizationId={organizationId} />
-          </div>
-          <ContentArea
-            className={cn(
-              'min-w-0 overflow-y-auto',
-              usesBoundedLayout ? 'min-h-0 flex-1' : 'flex-1',
-            )}
-            variant="page"
-            gap={6}
+      {/* Split provider: setter is stable, reader changes only when actions change. */}
+      <SettingsHeaderActionsSetter.Provider value={setHeaderActions}>
+        <SettingsHeaderActionsReader.Provider value={headerActions}>
+          <PageLayout
+            organizationId={organizationId}
+            header={
+              <AdaptiveHeaderRoot showBorder standalone={false}>
+                <SettingsMobileBackButton organizationId={organizationId} />
+                <AdaptiveHeaderTitle>{headerTitle}</AdaptiveHeaderTitle>
+                <SettingsEditorActionsSlot />
+              </AdaptiveHeaderRoot>
+            }
           >
-            <Outlet />
-          </ContentArea>
-        </div>
-      </PageLayout>
+            <SettingsMobileActionBar />
+            <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+              <div className="hidden md:flex">
+                <SettingsRail organizationId={organizationId} />
+              </div>
+              <ContentArea
+                className={cn(
+                  'min-w-0 overflow-y-auto',
+                  usesBoundedLayout ? 'min-h-0 flex-1' : 'flex-1',
+                )}
+                variant="page"
+                gap={6}
+              >
+                <Outlet />
+              </ContentArea>
+            </div>
+          </PageLayout>
+        </SettingsHeaderActionsReader.Provider>
+      </SettingsHeaderActionsSetter.Provider>
     </ActiveEditorProvider>
   );
 }
 
+function HeaderActionButton({ action }: { action: SettingsHeaderAction }) {
+  return (
+    <Button
+      variant={action.variant ?? 'primary'}
+      size="sm"
+      onClick={action.onClick}
+      disabled={action.disabled}
+      title={action.title}
+    >
+      {action.loading && action.loadingLabel
+        ? action.loadingLabel
+        : action.label}
+    </Button>
+  );
+}
+
 /**
- * Reads the active child controller (settings sub-page form) and renders the
- * unified Save/Discard cluster in the settings header. Sub-pages without forms
- * (teams, integrations list, audit logs) clear the active editor and the
- * cluster doesn't render. Replaces the cluster that previously lived in the
- * horizontal tab strip.
+ * Renders the unified Save/Discard cluster (from `useActiveEditor`) plus any
+ * page-specific buttons registered via `useRegisterSettingsSecondaryAction`.
+ * Data residency uses the latter exclusively: [Save] [Apply & restart].
  */
 function SettingsEditorActionsSlot() {
   const controller = useActiveEditor();
-  if (!controller) return null;
+  const actions = useSettingsHeaderActions();
+
+  if (!controller && actions.length === 0) return null;
+
   return (
     <div className="ml-auto hidden items-center gap-2 md:flex">
-      <EditorActions controller={controller} entityKind="settings" />
+      {controller && (
+        <EditorActions controller={controller} entityKind="settings" />
+      )}
+      {actions.map((action) => (
+        <HeaderActionButton key={action.label} action={action} />
+      ))}
     </div>
   );
 }
 
 /**
- * Mobile-only bar holding the active settings page's Save/Discard cluster.
- * The desktop equivalent lives in the settings header (`SettingsEditorActionsSlot`),
- * which is `hidden md:flex` — so on small screens the Save/Discard buttons were
- * unreachable. Reads the active editor (set by each form page) and renders the
- * cluster only when one is present. Back navigation lives in the settings header
- * (`SettingsMobileBackButton`, rendered into the mobile top bar).
+ * Mobile-only bar — mirrors `SettingsEditorActionsSlot` for small screens.
  */
 function SettingsMobileActionBar() {
   const controller = useActiveEditor();
+  const actions = useSettingsHeaderActions();
 
-  if (!controller) return null;
+  if (!controller && actions.length === 0) return null;
 
   return (
-    <Row
-      gap={2}
-      justify="end"
-      className="border-border border-b px-4 py-2 md:hidden"
-    >
-      <EditorActions controller={controller} entityKind="settings" />
-    </Row>
+    <div className="border-border flex items-center justify-end gap-2 border-b px-4 py-2 md:hidden">
+      {controller && (
+        <EditorActions controller={controller} entityKind="settings" />
+      )}
+      {actions.map((action) => (
+        <HeaderActionButton key={action.label} action={action} />
+      ))}
+    </div>
   );
 }

--- a/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/providers/index.tsx
@@ -23,7 +23,10 @@ function ProvidersIndexRoute() {
       >
         <ProvidersTable organizationId={id} />
       </SettingsSection>
-      <ModelCatalogCard organizationId={id} />
+      <ModelCatalogCard
+        organizationId={id}
+        className="border-border border-t pt-8"
+      />
     </SettingsPage>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4398,8 +4398,8 @@
       },
       "voiceOutput": {
         "label": "Sprachausgabe (Standard)",
-        "description": "Wenn aktiviert, werden Antworten in neuen Chats in deiner Oberflächensprache vorgelesen. In der Chat-Kopfzeile kannst du die Sprachausgabe weiterhin separat ein- oder ausschalten.",
-        "providerUnavailable": "Kein Text-zu-Sprache-Anbieter konfiguriert. Sprachausgabe steht erst zur Verfügung, wenn ein Admin unter Einstellungen → KI-Anbieter ein TTS-Modell hinzufügt.",
+        "description": "Wenn aktiviert, werden Antworten in neuen Chats vorgelesen.",
+        "providerUnavailable": "Nicht verfügbar, bis ein Admin ein Text-zu-Sprache-Modell hinzufügt.",
         "configureProvider": "Anbieter einrichten",
         "disabledByOrg": "Deine Organisation hat die Sprachausgabe für alle deaktiviert. Bitte eine administrative Person, sie unter Governance → Richtlinien wieder zu aktivieren."
       },
@@ -4435,12 +4435,9 @@
     "page": {
       "title": "Umgebungsvariablen & Geheimnisse",
       "description": "Variablen und Geheimnisse, die in alle deine Agent-Sandboxes eingespeist werden.",
-      "agentAccessTitle": "In deine Sandboxes eingespeist",
       "note": "Geheimnisse werden verschlüsselt und sind nur beschreibbar — nach dem Speichern werden sie nie wieder angezeigt. Diese Variablen werden in alle deine Sandboxes eingespeist."
     },
     "add": {
-      "button": "Variable hinzufügen",
-      "title": "Variable hinzufügen",
       "keyLabel": "Name",
       "keyPlaceholder": "z. B. MY_API_KEY",
       "keyInvalid": "Muss mit einem Buchstaben oder Unterstrich beginnen und darf nur Buchstaben, Zahlen und Unterstriche enthalten.",
@@ -6486,7 +6483,9 @@
       "secretsEncryptedNoKey": "Die gespeicherten Secrets sind SOPS-verschlüsselt, aber es ist kein age-Schlüssel konfiguriert — bestehende Secrets lassen sich nicht lesen.",
       "secretsUnreadable": "Die gespeicherten Secrets sind vorhanden, lassen sich aber nicht entschlüsseln (beschädigter Chiffretext oder ein fehlender/falscher age-Schlüssel). Gib die Werte erneut ein und speichere, um sie zu überschreiben.",
       "externalPostgres": "Externes Postgres",
-      "usingSharedDatabase": "Verwendet die eingebaute gemeinsame Datenbank.",
+      "status": {
+        "builtIn": "Eingebaut"
+      },
       "field": {
         "host": "Host",
         "port": "Port",
@@ -6508,13 +6507,14 @@
       },
       "knowledge": {
         "title": "Wissensdatenbank (RAG)",
-        "description": "Die Postgres-Datenbank hinter Wissenssuche und -abruf. Standardmäßig die mit diesem Deployment gelieferte Datenbank.",
+        "description": "Die Postgres-Datenbank hinter Wissenssuche und -abruf.",
         "paradeDbNote": "Die externe Wissensdatenbank muss ParadeDB (pgvector + pg_search) verwenden, damit die volle Hybrid-Suche funktioniert; reines pgvector fällt auf reine Vektor-Suche zurück."
       },
       "storage": {
         "title": "Dateispeicher (hochgeladene Dokumente)",
-        "description": "Wo hochgeladene Dokumente und erzeugte Exporte gespeichert werden. Standardmäßig das lokale Convex-Volume.",
+        "description": "Wo hochgeladene Dokumente und erzeugte Exporte gespeichert werden.",
         "externalS3": "Externes S3",
+        "localLabel": "Lokales Volume",
         "region": "Region",
         "endpoint": "Endpunkt (MinIO/R2; leer für AWS)",
         "forcePathStyle": "Path-Style erzwingen (MinIO/R2)",
@@ -6533,8 +6533,7 @@
         "secretAccessKey": "Secret Access Key",
         "testReachability": "Erreichbarkeit testen",
         "reachable": "Erreichbar",
-        "greenfieldWarning": "S3-Speicher ist Greenfield: Der Wechsel von lokal migriert bestehende hochgeladene Dateien NICHT. Lege das beim ersten Deploy fest, oder kopiere die lokalen Blobs separat in den Bucket.",
-        "localStorageNote": "Dateien liegen auf dem lokalen Convex-Volume."
+        "greenfieldWarning": "S3-Speicher ist Greenfield: Der Wechsel von lokal migriert bestehende hochgeladene Dateien NICHT. Lege das beim ersten Deploy fest, oder kopiere die lokalen Blobs separat in den Bucket."
       },
       "appDb": {
         "summary": "Anwendungsdatenbank (erweitert)",
@@ -6552,7 +6551,6 @@
       "saving": "Speichern…",
       "applyRestart": "Anwenden & neu starten",
       "applyRestartTitle": "rag + convex über den Controller neu starten (falls aktiviert), sonst wird der manuelle Befehl angezeigt",
-      "applyRestartDirtyHint": "Speichern Sie Ihre Änderungen vor dem Neustart.",
       "restarting": "Neu starten…",
       "restart": {
         "notEnabled": "Restart-Controller nicht aktiviert.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4398,8 +4398,8 @@
       },
       "voiceOutput": {
         "label": "Voice output (default)",
-        "description": "When on, new conversations speak assistant replies aloud in your interface language. Each conversation can still toggle voice on or off in the chat header.",
-        "providerUnavailable": "No text-to-speech provider configured. Voice output is unavailable until an admin adds a TTS model in Settings → AI providers.",
+        "description": "When on, new conversations read assistant replies aloud.",
+        "providerUnavailable": "Unavailable until an admin adds a text-to-speech model.",
         "configureProvider": "Configure a provider",
         "disabledByOrg": "Your organization has disabled voice output for everyone. Ask an admin to re-enable it in Governance → Policies."
       },
@@ -4435,12 +4435,9 @@
     "page": {
       "title": "Environment variables & secrets",
       "description": "Variables and secrets injected into all of your agent sandboxes.",
-      "agentAccessTitle": "Injected into your sandboxes",
       "note": "Secrets are encrypted and write-only — once saved they are never shown again. These variables are injected into all of your sandboxes."
     },
     "add": {
-      "button": "Add variable",
-      "title": "Add variable",
       "keyLabel": "Name",
       "keyPlaceholder": "e.g. MY_API_KEY",
       "keyInvalid": "Must start with a letter or underscore and contain only letters, numbers, and underscores.",
@@ -6748,7 +6745,9 @@
       "secretsEncryptedNoKey": "The stored secrets are SOPS-encrypted but no age key is configured — existing secrets can't be read.",
       "secretsUnreadable": "The stored secrets exist but can't be decrypted (corrupt ciphertext, or a missing/incorrect age key). Re-enter the values and save to overwrite them.",
       "externalPostgres": "External Postgres",
-      "usingSharedDatabase": "Using the built-in shared database.",
+      "status": {
+        "builtIn": "Built-in"
+      },
       "field": {
         "host": "Host",
         "port": "Port",
@@ -6770,13 +6769,14 @@
       },
       "knowledge": {
         "title": "Knowledge database (RAG)",
-        "description": "The Postgres database backing knowledge search and retrieval. Defaults to the database bundled with this deployment.",
+        "description": "The Postgres database backing knowledge search and retrieval.",
         "paradeDbNote": "The external knowledge database must run ParadeDB (pgvector + pg_search) for full hybrid search; plain pgvector degrades to vector-only."
       },
       "storage": {
         "title": "File storage (uploaded documents)",
-        "description": "Where uploaded documents and generated exports are kept. Defaults to the local Convex volume.",
+        "description": "Where uploaded documents and generated exports are kept.",
         "externalS3": "External S3",
+        "localLabel": "Local volume",
         "region": "Region",
         "endpoint": "Endpoint (MinIO/R2; blank for AWS)",
         "forcePathStyle": "Force path-style (MinIO/R2)",
@@ -6795,8 +6795,7 @@
         "secretAccessKey": "Secret access key",
         "testReachability": "Test reachability",
         "reachable": "Reachable",
-        "greenfieldWarning": "S3 storage is greenfield: switching from local does NOT migrate existing uploaded files. Set this at initial deploy, or copy the local blobs into the bucket separately.",
-        "localStorageNote": "Files are stored on the local Convex volume."
+        "greenfieldWarning": "S3 storage is greenfield: switching from local does NOT migrate existing uploaded files. Set this at initial deploy, or copy the local blobs into the bucket separately."
       },
       "appDb": {
         "summary": "Application database (advanced)",
@@ -6814,7 +6813,6 @@
       "saving": "Saving…",
       "applyRestart": "Apply & restart",
       "applyRestartTitle": "Restart rag + convex via the controller (if enabled), or shows the manual command",
-      "applyRestartDirtyHint": "Save your changes before restarting.",
       "restarting": "Restarting…",
       "restart": {
         "notEnabled": "Restart controller not enabled.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4399,8 +4399,8 @@
       },
       "voiceOutput": {
         "label": "Sortie vocale (par défaut)",
-        "description": "Quand cette option est activée, les nouvelles conversations te lisent à voix haute les réponses de l'assistant dans la langue de ton interface. Tu peux activer ou désactiver la voix séparément dans chaque conversation depuis son en-tête.",
-        "providerUnavailable": "Aucun fournisseur de synthèse vocale configuré. La sortie vocale ne sera disponible qu'après l'ajout d'un modèle TTS dans Paramètres → Fournisseurs IA par un administrateur.",
+        "description": "Quand cette option est activée, les nouvelles conversations te lisent à voix haute les réponses de l'assistant.",
+        "providerUnavailable": "Indisponible tant qu'un administrateur n'a pas ajouté de modèle de synthèse vocale.",
         "configureProvider": "Configurer un fournisseur",
         "disabledByOrg": "Ton organisation a désactivé la sortie vocale pour tout le monde. Demande à une personne admin de la réactiver dans Gouvernance → Politiques."
       },
@@ -4436,12 +4436,9 @@
     "page": {
       "title": "Variables d'environnement et secrets",
       "description": "Variables et secrets injectés dans toutes tes sandboxes d'agent.",
-      "agentAccessTitle": "Injectés dans tes sandboxes",
       "note": "Les secrets sont chiffrés et en écriture seule — une fois enregistrés, ils ne sont plus jamais affichés. Ces variables sont injectées dans toutes tes sandboxes."
     },
     "add": {
-      "button": "Ajouter une variable",
-      "title": "Ajouter une variable",
       "keyLabel": "Nom",
       "keyPlaceholder": "ex. MY_API_KEY",
       "keyInvalid": "Doit commencer par une lettre ou un trait de soulignement et ne contenir que des lettres, des chiffres et des traits de soulignement.",
@@ -6487,7 +6484,9 @@
       "secretsEncryptedNoKey": "Les secrets stockés sont chiffrés avec SOPS, mais aucune clé age n'est configurée — les secrets existants ne peuvent pas être lus.",
       "secretsUnreadable": "Les secrets stockés existent mais ne peuvent pas être déchiffrés (texte chiffré corrompu, ou clé age manquante/incorrecte). Saisis à nouveau les valeurs et enregistre pour les écraser.",
       "externalPostgres": "Postgres externe",
-      "usingSharedDatabase": "Utilise la base de données partagée intégrée.",
+      "status": {
+        "builtIn": "Intégrée"
+      },
       "field": {
         "host": "Hôte",
         "port": "Port",
@@ -6509,13 +6508,14 @@
       },
       "knowledge": {
         "title": "Base de connaissances (RAG)",
-        "description": "La base Postgres qui alimente la recherche et la récupération de connaissances. Par défaut, la base fournie avec ce déploiement.",
+        "description": "La base Postgres qui alimente la recherche et la récupération de connaissances.",
         "paradeDbNote": "La base de connaissances externe doit utiliser ParadeDB (pgvector + pg_search) pour la recherche hybride complète ; pgvector seul se limite à la recherche vectorielle."
       },
       "storage": {
         "title": "Stockage de fichiers (documents téléversés)",
-        "description": "L'emplacement où sont stockés les documents téléversés et les exports générés. Par défaut, le volume Convex local.",
+        "description": "L'emplacement où sont stockés les documents téléversés et les exports générés.",
         "externalS3": "S3 externe",
+        "localLabel": "Volume local",
         "region": "Région",
         "endpoint": "Endpoint (MinIO/R2 ; vide pour AWS)",
         "forcePathStyle": "Forcer le path-style (MinIO/R2)",
@@ -6534,8 +6534,7 @@
         "secretAccessKey": "Secret Access Key",
         "testReachability": "Tester l'accessibilité",
         "reachable": "Accessible",
-        "greenfieldWarning": "Le stockage S3 est greenfield : passer du local ne migre PAS les fichiers déjà téléversés. Définis-le au premier déploiement, ou copie les blobs locaux dans le bucket séparément.",
-        "localStorageNote": "Les fichiers sont stockés sur le volume Convex local."
+        "greenfieldWarning": "Le stockage S3 est greenfield : passer du local ne migre PAS les fichiers déjà téléversés. Définis-le au premier déploiement, ou copie les blobs locaux dans le bucket séparément."
       },
       "appDb": {
         "summary": "Base de données applicative (avancé)",
@@ -6553,7 +6552,6 @@
       "saving": "Enregistrement…",
       "applyRestart": "Appliquer & redémarrer",
       "applyRestartTitle": "Redémarre rag + convex via le controller (si activé), sinon affiche la commande manuelle",
-      "applyRestartDirtyHint": "Enregistrez vos modifications avant de redémarrer.",
       "restarting": "Redémarrage…",
       "restart": {
         "notEnabled": "Controller de redémarrage non activé.",


### PR DESCRIPTION
## Summary

- **Data residency buttons moved to header**: Save and Apply & restart buttons now appear in the shared settings header slot (matching branding and other settings pages), replacing the old bottom footer. Implements a split-context secondary-action system (`settings-secondary-action-context`) so any settings page can inject custom buttons into the header without coupling the layout to page-specific logic.
- **Personalization toggle grouping**: Wraps the three toggles in a `flex-col gap-4 pt-4` group for better breathing room below the section description.
- **Settings component refinements**: `SettingsRow` and `SettingsToggleRow` ARIA wiring and layout polish.
- **Usage chart, API keys table**: Skeleton and layout improvements.
- **i18n cleanup**: Removes orphaned keys left over from the settings full-width sweep (`applyRestartDirtyHint`, `userEnv.add.button`, `userEnv.add.title`, `userEnv.page.agentAccessTitle`) from en/de/fr.

## Test plan

- [x] Gate passed: `bun run check` — all 536 platform test files pass, lint clean, typecheck clean
- [x] SAST: `bun run lint:sast` — clean (Opengrep)
- [x] i18n test: orphaned-key test passes after key removal
- [ ] Manual: verify data residency Save + Apply & restart appear in the header, match branding page layout
- [ ] Manual: verify Apply & restart is disabled when there are unsaved changes; Save is disabled when there are none