### PR TITLE
fix: add back navigation to "what's new" changelog page (#1965)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/features/changelog/components/changelog-back-button.test.tsx
+++ b/services/platform/app/features/changelog/components/changelog-back-button.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChangelogBackButton } from './changelog-back-button';
+
+const mockBack = vi.fn();
+const mockNavigate = vi.fn();
+const canGoBack = { value: true };
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ history: { back: mockBack } }),
+  useCanGoBack: () => canGoBack.value,
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({ t: (key: string) => `${ns}.${key}` }),
+}));
+
+describe('ChangelogBackButton', () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockNavigate.mockClear();
+    canGoBack.value = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('pops history when there is somewhere to go back to', () => {
+    render(<ChangelogBackButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the dashboard home when history is empty', () => {
+    canGoBack.value = false;
+    render(<ChangelogBackButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/dashboard' });
+  });
+});

--- a/services/platform/app/features/changelog/components/changelog-back-button.tsx
+++ b/services/platform/app/features/changelog/components/changelog-back-button.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCanGoBack, useNavigate, useRouter } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+import { useCallback } from 'react';
+
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * Back affordance for the full-page "What's new" changelog view. That page is
+ * reached from the post-upgrade toast (and can be deep-linked), so without this
+ * the user is stranded with no way out.
+ *
+ * Navigation is history-based on purpose: it returns the user to wherever they
+ * came from. When there's no entry to pop (deep link / fresh tab) we fall back
+ * to the dashboard home so the button always leads somewhere.
+ */
+export function ChangelogBackButton() {
+  const { t } = useT('changelog');
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+  const navigate = useNavigate();
+
+  const handleBack = useCallback(() => {
+    if (canGoBack) {
+      router.history.back();
+    } else {
+      void navigate({ to: '/dashboard' });
+    }
+  }, [canGoBack, router, navigate]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleBack}
+      className="text-fg-muted hover:text-fg-base mb-6 inline-flex w-fit items-center gap-1 text-sm"
+    >
+      <ArrowLeft className="size-4" />
+      {t('viewer.back')}
+    </button>
+  );
+}

--- a/services/platform/app/routes/dashboard/changelog.tsx
+++ b/services/platform/app/routes/dashboard/changelog.tsx
@@ -10,6 +10,7 @@ import { useAction } from 'convex/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 
+import { ChangelogBackButton } from '@/app/features/changelog/components/changelog-back-button';
 import { ReleaseBody } from '@/app/features/changelog/components/release-body';
 import { useChangelogNotification } from '@/app/hooks/use-changelog-notification';
 import { api } from '@/convex/_generated/api';
@@ -166,6 +167,7 @@ function ChangelogPage() {
   if (error) {
     return (
       <div className="mx-auto max-w-3xl px-4 py-10">
+        <ChangelogBackButton />
         <VStack gap={4}>
           <h1 className="text-fg-base text-2xl font-semibold">
             {t('viewer.heading')}
@@ -210,6 +212,7 @@ function ChangelogPage() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-3xl px-4 py-10">
+        <ChangelogBackButton />
         <VStack gap={2} className="mb-6">
           <h1 className="text-fg-base text-2xl font-semibold">
             {t('viewer.heading')}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1032,6 +1032,7 @@
       "action": "Anzeigen"
     },
     "viewer": {
+      "back": "Zurück",
       "heading": "Was ist neu",
       "subheading": "{count, plural, one {# Update} other {# Updates}} seit v{from}",
       "subheadingNew": "Release Notes für v{to}",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1032,6 +1032,7 @@
       "action": "View"
     },
     "viewer": {
+      "back": "Back",
       "heading": "What's new",
       "subheading": "{count, plural, one {# update} other {# updates}} since v{from}",
       "subheadingNew": "Release notes for v{to}",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1033,6 +1033,7 @@
       "action": "Voir"
     },
     "viewer": {
+      "back": "Retour",
       "heading": "Nouveautés",
       "subheading": "{count, plural, one {# mise à jour} other {# mises à jour}} depuis v{from}",
       "subheadingNew": "Notes de version pour v{to}",


### PR DESCRIPTION
## Summary

Closes #1965.

The full-page "What's new" changelog view (`/dashboard/changelog`) had no way to navigate back — once the user opened it (from the post-upgrade toast or a deep link) they were stranded.

This adds a back affordance at the top of the page:

- New `ChangelogBackButton` component (`app/features/changelog/components/changelog-back-button.tsx`) that uses TanStack Router's `useRouter().history.back()` to return the user to wherever they came from, falling back to `/dashboard` (via `useCanGoBack()`) when there is no history entry to pop (deep link / fresh tab).
- Rendered at the top of both the main and error states of the changelog page.
- New `changelog.viewer.back` i18n key added to `en`, `de`, and `fr` (de-CH inherits — no override needed).

## Acceptance criteria

- [x] From "What's new" the user can return to where they came from.

## Tests / checks run locally

- `changelog-back-button.test.tsx` — happy path (pops history) + fallback (navigates to `/dashboard`). Both pass.
- `bunx tsc --noEmit` (typecheck) — green.
- `oxlint --type-aware` on changed files — clean.
- `oxfmt --check` on changed files — clean.
- `knip` — clean.
- `lib/i18n/messages.test.ts` (parity + usage enforce) — green.