### PR TITLE
fix: relabel 2FA manual secret to "Or enter manually:" and make it copyable (#1947)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/features/settings/account/components/two-factor-section.tsx
+++ b/services/platform/app/features/settings/account/components/two-factor-section.tsx
@@ -5,6 +5,7 @@ import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useState } from 'react';
 
+import { CopyableField } from '@/app/components/ui/data-display/copyable-field';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
@@ -348,14 +349,11 @@ function VerifyTotpDialog({
           <QRCodeSVG value={qrURI} size={180} level="M" />
         </div>
         {secret && (
-          <VStack gap={1} align="center" className="w-full min-w-0">
-            <Text variant="muted" className="text-xs">
-              {t('setup.manualEntry')}
-            </Text>
-            <code className="bg-muted block w-full rounded border px-2 py-1 text-center text-xs break-all select-all">
-              {secret}
-            </code>
-          </VStack>
+          <CopyableField
+            value={secret}
+            label={t('setup.manualEntry')}
+            className="w-full min-w-0"
+          />
         )}
       </VStack>
       <Input

--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -23,6 +23,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import { useState } from 'react';
 import { z } from 'zod';
 
+import { CopyableField } from '@/app/components/ui/data-display/copyable-field';
 import { Input } from '@/app/components/ui/forms/input';
 import { LogoLink } from '@/app/components/ui/logo/logo-link';
 import { PasskeyRegisterDialog } from '@/app/features/settings/account/components/passkey-register-dialog';
@@ -210,14 +211,11 @@ function TwoFactorEnrollPage() {
                     />
                   </div>
                   {extractSecret(step.totpURI) && (
-                    <VStack gap={1} align="center">
-                      <Text variant="muted" className="text-xs">
-                        {t('setup.manualEntry')}
-                      </Text>
-                      <code className="bg-muted rounded border px-2 py-1 text-xs select-all">
-                        {extractSecret(step.totpURI)}
-                      </code>
-                    </VStack>
+                    <CopyableField
+                      value={extractSecret(step.totpURI) ?? ''}
+                      label={t('setup.manualEntry')}
+                      className="w-full min-w-0"
+                    />
                   )}
                 </VStack>
                 <Input

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6944,7 +6944,7 @@
     "setup": {
       "title": "Zwei-Faktor-Authentifizierung einrichten",
       "qrInstructions": "Scanne den QR-Code mit einer Authenticator-App (Google Authenticator, 1Password, Authy) und gib anschließend den 6-stelligen Code unten ein.",
-      "manualEntry": "Kein Scan möglich? Gib dieses Geheimnis manuell ein:",
+      "manualEntry": "Oder manuell eingeben:",
       "verifyCodeLabel": "Bestätigungscode",
       "verifyButton": "Prüfen und aktivieren"
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7206,7 +7206,7 @@
     "setup": {
       "title": "Set up two-factor authentication",
       "qrInstructions": "Scan the QR code with an authenticator app (Google Authenticator, 1Password, Authy), then enter the 6-digit code below.",
-      "manualEntry": "Can't scan? Enter this secret manually:",
+      "manualEntry": "Or enter manually:",
       "verifyCodeLabel": "Verification code",
       "verifyButton": "Verify and enable"
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6945,7 +6945,7 @@
     "setup": {
       "title": "Configurer l'authentification à double facteur",
       "qrInstructions": "Scanne le code QR avec une application d'authentification (Google Authenticator, 1Password, Authy), puis saisis le code à 6 chiffres ci-dessous.",
-      "manualEntry": "Impossible de scanner ? Saisis ce secret manuellement :",
+      "manualEntry": "Ou saisir manuellement :",
       "verifyCodeLabel": "Code de vérification",
       "verifyButton": "Vérifier et activer"
     },

--- a/services/platform/tests/e2e/specs/auth-account.spec.ts
+++ b/services/platform/tests/e2e/specs/auth-account.spec.ts
@@ -218,12 +218,18 @@ test.describe('two-factor authentication', () => {
       .fill(password);
     await enableButton.click();
 
-    // Verify step: the manual-entry secret is rendered in a <code> element next
-    // to the manual-entry hint. Read it and derive a live TOTP code.
+    // Verify step: the manual-entry secret is rendered in a copyable field
+    // (a button) labelled by the manual-entry hint. The button's visible text
+    // is the secret itself (the label lives in a sibling <label> referenced via
+    // aria-labelledby). Read it and derive a live TOTP code.
     await expect(page.getByText(t('twoFactor.setup.manualEntry'))).toBeVisible({
       timeout: TIMEOUT.VISIBLE,
     });
-    const secret = (await page.locator('code').first().innerText()).trim();
+    const secret = (
+      await page
+        .getByRole('button', { name: t('twoFactor.setup.manualEntry') })
+        .innerText()
+    ).trim();
     expect(secret, 'the enroll page should reveal the base32 secret').toMatch(
       /^[A-Z2-7]+$/,
     );


### PR DESCRIPTION
## Summary
Resolves #1947.

- Relabels the 2FA manual-entry secret prompt to **"Or enter manually:"** across all affected locales (en, de, fr).
- Replaces the read-only `<code>` (select-all) block in `VerifyTotpDialog` with the existing `CopyableField` component so the secret has a one-click copy button — matching the org ID / member-credentials pattern.

## Acceptance criteria
- [x] Label reads "Or enter manually:".
- [x] The secret has a working copy button.

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on the changed component — 0 warnings / 0 errors