### PR TITLE
fix(ui): add disabledReason tooltip explaining why a control is disabled (#1949)

### DIFF
--- a/packages/ui/src/components/forms/checkbox.test.tsx
+++ b/packages/ui/src/components/forms/checkbox.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
 
 import { Checkbox } from './checkbox';
 import { Label } from './label';
@@ -19,6 +19,68 @@ describe('Checkbox', () => {
           <Checkbox id="terms" />
           <Label htmlFor="terms">Accept terms</Label>
         </div>,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('keeps native disabled when no reason is given', () => {
+      render(<Checkbox aria-label="Accept terms" disabled />);
+      expect(screen.getByRole('checkbox')).toBeDisabled();
+    });
+
+    it('soft-disables (aria-disabled, focusable) with a reason', () => {
+      render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+        />,
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeDisabled();
+      expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+      expectFocusable(checkbox);
+    });
+
+    it('surfaces the reason as a tooltip on focus', async () => {
+      const { user } = render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+        />,
+      );
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Read the terms first');
+    });
+
+    it('does not toggle a soft-disabled checkbox on click or Space', async () => {
+      const onCheckedChange = vi.fn();
+      const { user } = render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+          onCheckedChange={onCheckedChange}
+        />,
+      );
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+      checkbox.focus();
+      await user.keyboard(' ');
+      expect(onCheckedChange).not.toHaveBeenCalled();
+    });
+
+    it('passes axe audit for a soft-disabled checkbox', async () => {
+      const { container } = render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+        />,
       );
       await checkAccessibility(container);
     });

--- a/packages/ui/src/components/forms/checkbox.test.tsx
+++ b/packages/ui/src/components/forms/checkbox.test.tsx
@@ -77,6 +77,63 @@ describe('Checkbox', () => {
       expect(onCheckedChange).not.toHaveBeenCalled();
     });
 
+    it('does not toggle a soft-disabled checkbox on Enter', async () => {
+      const onCheckedChange = vi.fn();
+      const { user } = render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+          onCheckedChange={onCheckedChange}
+        />,
+      );
+      const checkbox = screen.getByRole('checkbox');
+      checkbox.focus();
+      await user.keyboard('{Enter}');
+      expect(onCheckedChange).not.toHaveBeenCalled();
+    });
+
+    it('describes the focused soft-disabled checkbox via aria-describedby', async () => {
+      const { user } = render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabled
+          disabledReason="Read the terms first"
+        />,
+      );
+      await user.tab();
+      const checkbox = screen.getByRole('checkbox');
+      // Radix wires the open tooltip to the trigger via aria-describedby so the
+      // reason reaches screen-reader users on focus, not just on hover.
+      const describedBy = checkbox.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      const description = describedBy
+        ? document.getElementById(describedBy)
+        : null;
+      expect(description).toHaveTextContent('Read the terms first');
+    });
+
+    it('ignores the reason while enabled', () => {
+      render(
+        <Checkbox
+          aria-label="Accept terms"
+          disabledReason="Read the terms first"
+        />,
+      );
+      expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(
+        <Checkbox aria-label="Accept terms" disabled disabledReason="   " />,
+      );
+      const checkbox = screen.getByRole('checkbox');
+      // A blank reason explains nothing, so the control must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(checkbox).toBeDisabled();
+      expect(checkbox).not.toHaveAttribute('aria-disabled');
+    });
+
     it('passes axe audit for a soft-disabled checkbox', async () => {
       const { container } = render(
         <Checkbox

--- a/packages/ui/src/components/forms/checkbox.test.tsx
+++ b/packages/ui/src/components/forms/checkbox.test.tsx
@@ -27,7 +27,10 @@ describe('Checkbox', () => {
   describe('disabledReason', () => {
     it('keeps native disabled when no reason is given', () => {
       render(<Checkbox aria-label="Accept terms" disabled />);
-      expect(screen.getByRole('checkbox')).toBeDisabled();
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeDisabled();
+      // Native `disabled` already conveys the state; no redundant aria-disabled.
+      expect(checkbox).not.toHaveAttribute('aria-disabled');
     });
 
     it('soft-disables (aria-disabled, focusable) with a reason', () => {

--- a/packages/ui/src/components/forms/checkbox.tsx
+++ b/packages/ui/src/components/forms/checkbox.tsx
@@ -9,7 +9,10 @@ import {
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
-import { DisabledReasonTooltip } from '../overlays/disabled-reason';
+import {
+  DisabledReasonTooltip,
+  hasDisabledReason,
+} from '../overlays/disabled-reason';
 
 export interface CheckboxProps extends ComponentPropsWithoutRef<
   typeof CheckboxPrimitive.Root
@@ -40,7 +43,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
   ) => {
     // Soft-disable keeps the control focusable + hoverable (so the reason
     // tooltip reaches pointer and keyboard users) while blocking activation.
-    const softDisabled = Boolean(disabled) && disabledReason != null;
+    const softDisabled = Boolean(disabled) && hasDisabledReason(disabledReason);
     // Calling preventDefault here also stops Radix's composed toggle handler,
     // so the checked state can't change while soft-disabled.
     const blockActivation = (event: SyntheticEvent & { key?: string }) => {

--- a/packages/ui/src/components/forms/checkbox.tsx
+++ b/packages/ui/src/components/forms/checkbox.tsx
@@ -55,7 +55,10 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
           <CheckboxPrimitive.Root
             ref={ref}
             disabled={softDisabled ? undefined : disabled}
-            aria-disabled={disabled || undefined}
+            // Only the soft-disabled branch needs `aria-disabled`; a natively
+            // `disabled` control already conveys the state, so emitting it there
+            // too would be redundant with the native attribute.
+            aria-disabled={softDisabled || undefined}
             onClick={softDisabled ? blockActivation : onClick}
             onKeyDown={softDisabled ? blockActivation : onKeyDown}
             className={cn(

--- a/packages/ui/src/components/forms/checkbox.tsx
+++ b/packages/ui/src/components/forms/checkbox.tsx
@@ -1,37 +1,82 @@
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { Check, Minus } from 'lucide-react';
-import { type ComponentPropsWithoutRef, forwardRef } from 'react';
+import {
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type SyntheticEvent,
+  forwardRef,
+} from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
+import { DisabledReasonTooltip } from '../overlays/disabled-reason';
+
+export interface CheckboxProps extends ComponentPropsWithoutRef<
+  typeof CheckboxPrimitive.Root
+> {
+  /**
+   * Explains *why* the checkbox is disabled, surfaced in a tooltip on hover AND
+   * focus and to screen readers (#1949). Only takes effect while the checkbox
+   * is `disabled`; ignored otherwise, so callers can pass it unconditionally.
+   *
+   * A natively-`disabled` control emits no pointer events and leaves the tab
+   * order, so no tooltip could reach it. When a disabled checkbox carries a
+   * `disabledReason` we therefore keep it focusable (still rendered visually
+   * disabled and inert to clicks/Space), swap `disabled` for `aria-disabled`,
+   * and let the shared Tooltip wire up `aria-describedby`.
+   */
+  disabledReason?: ReactNode;
+}
 
 /**
  * Skeleton-aware Checkbox. Always wraps the real control in a `<SkeletonBox>`:
  * idle, the box is `display: contents`; inside a `<Skeletonize loading>` it
  * masks the control with an overlay at its exact size.
  */
-export const Checkbox = forwardRef<
-  HTMLButtonElement,
-  ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SkeletonBox>
-    <CheckboxPrimitive.Root
-      ref={ref}
-      className={cn(
-        'peer h-4 w-4 shrink-0 rounded border border-[color:var(--color-border-strong)] bg-[color:var(--color-bg-base)] shadow-sm transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:ring-offset-2',
-        'disabled:cursor-not-allowed disabled:opacity-50',
-        'data-[state=checked]:bg-[color:var(--color-accent-base)] data-[state=checked]:text-[color:var(--color-accent-fg)] data-[state=checked]:border-[color:var(--color-accent-base)]',
-        'data-[state=indeterminate]:bg-[color:var(--color-accent-base)] data-[state=indeterminate]:text-[color:var(--color-accent-fg)]',
-        className,
-      )}
-      {...props}
-    >
-      <CheckboxPrimitive.Indicator className="flex items-center justify-center [&[data-state=checked]_.check]:block [&[data-state=indeterminate]_.minus]:block">
-        <Check className="check hidden h-3 w-3" aria-hidden />
-        <Minus className="minus hidden h-3 w-3" aria-hidden />
-      </CheckboxPrimitive.Indicator>
-    </CheckboxPrimitive.Root>
-  </SkeletonBox>
-));
+export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
+  (
+    { className, disabled, disabledReason, onClick, onKeyDown, ...props },
+    ref,
+  ) => {
+    // Soft-disable keeps the control focusable + hoverable (so the reason
+    // tooltip reaches pointer and keyboard users) while blocking activation.
+    const softDisabled = Boolean(disabled) && disabledReason != null;
+    // Calling preventDefault here also stops Radix's composed toggle handler,
+    // so the checked state can't change while soft-disabled.
+    const blockActivation = (event: SyntheticEvent & { key?: string }) => {
+      // Space activates a checkbox; let other keys (Tab, arrows) through.
+      if ('key' in event && event.key !== ' ' && event.key !== 'Enter') return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    return (
+      <SkeletonBox>
+        <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>
+          <CheckboxPrimitive.Root
+            ref={ref}
+            disabled={softDisabled ? undefined : disabled}
+            aria-disabled={disabled || undefined}
+            onClick={softDisabled ? blockActivation : onClick}
+            onKeyDown={softDisabled ? blockActivation : onKeyDown}
+            className={cn(
+              'peer h-4 w-4 shrink-0 rounded border border-[color:var(--color-border-strong)] bg-[color:var(--color-bg-base)] shadow-sm transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:ring-offset-2',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+              'data-[state=checked]:bg-[color:var(--color-accent-base)] data-[state=checked]:text-[color:var(--color-accent-fg)] data-[state=checked]:border-[color:var(--color-accent-base)]',
+              'data-[state=indeterminate]:bg-[color:var(--color-accent-base)] data-[state=indeterminate]:text-[color:var(--color-accent-fg)]',
+              className,
+            )}
+            {...props}
+          >
+            <CheckboxPrimitive.Indicator className="flex items-center justify-center [&[data-state=checked]_.check]:block [&[data-state=indeterminate]_.minus]:block">
+              <Check className="check hidden h-3 w-3" aria-hidden />
+              <Minus className="minus hidden h-3 w-3" aria-hidden />
+            </CheckboxPrimitive.Indicator>
+          </CheckboxPrimitive.Root>
+        </DisabledReasonTooltip>
+      </SkeletonBox>
+    );
+  },
+);
 Checkbox.displayName = 'Checkbox';

--- a/packages/ui/src/components/forms/input.test.tsx
+++ b/packages/ui/src/components/forms/input.test.tsx
@@ -51,6 +51,16 @@ describe('Input', () => {
       expect(input).not.toHaveAttribute('aria-disabled');
     });
 
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(<Input aria-label="Email" disabled disabledReason="   " />);
+      const input = screen.getByRole('textbox');
+      // A blank reason explains nothing, so the control must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(input).toBeDisabled();
+      expect(input).not.toHaveAttribute('aria-disabled');
+      expect(input).not.toHaveAttribute('readonly');
+    });
+
     it('passes axe audit for a soft-disabled input', async () => {
       const { container } = render(
         <Input aria-label="Email" disabled disabledReason="Verify first" />,

--- a/packages/ui/src/components/forms/input.test.tsx
+++ b/packages/ui/src/components/forms/input.test.tsx
@@ -18,6 +18,8 @@ describe('Input', () => {
       render(<Input aria-label="Email" disabled />);
       const input = screen.getByRole('textbox');
       expect(input).toBeDisabled();
+      // Native `disabled` already conveys the state; no redundant aria-disabled.
+      expect(input).not.toHaveAttribute('aria-disabled');
     });
 
     it('soft-disables (aria-disabled, focusable, readOnly) with a reason', () => {

--- a/packages/ui/src/components/forms/input.test.tsx
+++ b/packages/ui/src/components/forms/input.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
 
 import { Input } from './input';
 
@@ -9,6 +9,50 @@ describe('Input', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<Input aria-label="Email" type="email" />);
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('keeps native disabled when no reason is given', () => {
+      render(<Input aria-label="Email" disabled />);
+      const input = screen.getByRole('textbox');
+      expect(input).toBeDisabled();
+    });
+
+    it('soft-disables (aria-disabled, focusable, readOnly) with a reason', () => {
+      render(
+        <Input aria-label="Email" disabled disabledReason="Verify first" />,
+      );
+      const input = screen.getByRole('textbox');
+      // Not natively disabled, so it stays focusable and emits events…
+      expect(input).not.toBeDisabled();
+      // …but is announced as disabled and can't be edited.
+      expect(input).toHaveAttribute('aria-disabled', 'true');
+      expect(input).toHaveAttribute('readonly');
+      expectFocusable(input);
+    });
+
+    it('surfaces the reason as a tooltip on focus', async () => {
+      const { user } = render(
+        <Input aria-label="Email" disabled disabledReason="Verify first" />,
+      );
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Verify first');
+    });
+
+    it('ignores the reason while enabled', () => {
+      render(<Input aria-label="Email" disabledReason="Verify first" />);
+      const input = screen.getByRole('textbox');
+      expect(input).not.toBeDisabled();
+      expect(input).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('passes axe audit for a soft-disabled input', async () => {
+      const { container } = render(
+        <Input aria-label="Email" disabled disabledReason="Verify first" />,
+      );
       await checkAccessibility(container);
     });
   });

--- a/packages/ui/src/components/forms/input.tsx
+++ b/packages/ui/src/components/forms/input.tsx
@@ -1,9 +1,23 @@
-import { type InputHTMLAttributes, forwardRef } from 'react';
+import { type InputHTMLAttributes, type ReactNode, forwardRef } from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
+import { DisabledReasonTooltip } from '../overlays/disabled-reason';
 
-export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * Explains *why* the field is disabled, surfaced in a tooltip on hover AND
+   * focus and to screen readers (#1949). Only takes effect while the field is
+   * `disabled`; ignored otherwise, so callers can pass it unconditionally.
+   *
+   * A natively-`disabled` field emits no pointer events and leaves the tab
+   * order, so no tooltip could reach it. When a disabled field carries a
+   * `disabledReason` we therefore keep it focusable and `readOnly` (still
+   * rendered visually disabled and inert to edits), swap `disabled` for
+   * `aria-disabled`, and let the shared Tooltip wire up `aria-describedby`.
+   */
+  disabledReason?: ReactNode;
+}
 
 /**
  * Skeleton-aware Input. Always wraps the real field in a `<SkeletonBox>`: idle,
@@ -11,22 +25,36 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement>;
  * `<Skeletonize loading>` it masks the field with an overlay at its exact size.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = 'text', ...props }, ref) => (
-    <SkeletonBox fullWidth>
-      <input
-        ref={ref}
-        type={type}
-        className={cn(
-          'h-9 w-full rounded-lg border px-3 py-2 text-base md:text-sm',
-          'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',
-          className,
-        )}
-        {...props}
-      />
-    </SkeletonBox>
-  ),
+  (
+    { className, type = 'text', disabled, disabledReason, readOnly, ...props },
+    ref,
+  ) => {
+    // Soft-disable keeps the field focusable + hoverable (so the reason tooltip
+    // reaches pointer and keyboard users) while `readOnly` blocks edits.
+    const softDisabled = Boolean(disabled) && disabledReason != null;
+    return (
+      <SkeletonBox fullWidth>
+        <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>
+          <input
+            ref={ref}
+            type={type}
+            disabled={softDisabled ? undefined : disabled}
+            aria-disabled={disabled || undefined}
+            readOnly={softDisabled ? true : readOnly}
+            className={cn(
+              'h-9 w-full rounded-lg border px-3 py-2 text-base md:text-sm',
+              'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+              'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',
+              className,
+            )}
+            {...props}
+          />
+        </DisabledReasonTooltip>
+      </SkeletonBox>
+    );
+  },
 );
 Input.displayName = 'Input';

--- a/packages/ui/src/components/forms/input.tsx
+++ b/packages/ui/src/components/forms/input.tsx
@@ -2,7 +2,10 @@ import { type InputHTMLAttributes, type ReactNode, forwardRef } from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
-import { DisabledReasonTooltip } from '../overlays/disabled-reason';
+import {
+  DisabledReasonTooltip,
+  hasDisabledReason,
+} from '../overlays/disabled-reason';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
@@ -31,7 +34,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   ) => {
     // Soft-disable keeps the field focusable + hoverable (so the reason tooltip
     // reaches pointer and keyboard users) while `readOnly` blocks edits.
-    const softDisabled = Boolean(disabled) && disabledReason != null;
+    const softDisabled = Boolean(disabled) && hasDisabledReason(disabledReason);
     return (
       <SkeletonBox fullWidth>
         <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>

--- a/packages/ui/src/components/forms/input.tsx
+++ b/packages/ui/src/components/forms/input.tsx
@@ -39,7 +39,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             ref={ref}
             type={type}
             disabled={softDisabled ? undefined : disabled}
-            aria-disabled={disabled || undefined}
+            // Only the soft-disabled branch needs `aria-disabled`; a natively
+            // `disabled` field already conveys the state, so emitting it there
+            // too would be redundant with the native attribute.
+            aria-disabled={softDisabled || undefined}
             readOnly={softDisabled ? true : readOnly}
             className={cn(
               'h-9 w-full rounded-lg border px-3 py-2 text-base md:text-sm',

--- a/packages/ui/src/components/forms/slider.test.tsx
+++ b/packages/ui/src/components/forms/slider.test.tsx
@@ -90,6 +90,27 @@ describe('Slider', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('is readOnly while soft-disabled (freezes the value, no React warning)', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      expect(slider).toHaveAttribute('readonly');
+      // A controlled `value` without `onChange` (swallowed while soft-disabled)
+      // would make React log a console error — `readOnly` must silence it.
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
     it('ignores the reason while enabled', () => {
       render(
         <Slider

--- a/packages/ui/src/components/forms/slider.test.tsx
+++ b/packages/ui/src/components/forms/slider.test.tsx
@@ -33,7 +33,10 @@ describe('Slider', () => {
           disabled
         />,
       );
-      expect(screen.getByRole('slider')).toBeDisabled();
+      const slider = screen.getByRole('slider');
+      expect(slider).toBeDisabled();
+      // Native `disabled` already conveys the state; no redundant aria-disabled.
+      expect(slider).not.toHaveAttribute('aria-disabled');
     });
 
     it('soft-disables (aria-disabled, focusable) with a reason', () => {

--- a/packages/ui/src/components/forms/slider.test.tsx
+++ b/packages/ui/src/components/forms/slider.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
@@ -91,6 +92,68 @@ describe('Slider', () => {
       slider.focus();
       await user.keyboard('{ArrowRight}{ArrowLeft}');
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it.each(['Home', 'End', 'PageUp', 'PageDown'])(
+      'does not change value via %s while soft-disabled',
+      (key) => {
+        const onChange = vi.fn();
+        render(
+          <Slider
+            aria-label="Temperature"
+            value={40}
+            min={0}
+            max={100}
+            onChange={onChange}
+            disabled
+            disabledReason="Enable advanced mode first"
+          />,
+        );
+        const slider = screen.getByRole('slider');
+        // The key handler must `preventDefault` so the browser never moves the
+        // thumb — a cancelled event reports `false` from `fireEvent`.
+        const notCancelled = fireEvent.keyDown(slider, { key });
+        expect(notCancelled).toBe(false);
+        expect(onChange).not.toHaveBeenCalled();
+      },
+    );
+
+    it('blocks pointer drag while soft-disabled', () => {
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      // Drag is the slider's primary interaction; the `onPointerDown` guard must
+      // `preventDefault` so the browser never starts a drag.
+      const notCancelled = fireEvent.pointerDown(slider);
+      expect(notCancelled).toBe(false);
+    });
+
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="   "
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      // A blank reason explains nothing, so the control must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(slider).toBeDisabled();
+      expect(slider).not.toHaveAttribute('aria-disabled');
     });
 
     it('is readOnly while soft-disabled (freezes the value, no React warning)', () => {

--- a/packages/ui/src/components/forms/slider.test.tsx
+++ b/packages/ui/src/components/forms/slider.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
 
 import { Slider } from './slider';
 
@@ -15,6 +15,105 @@ describe('Slider', () => {
           min={0}
           max={100}
           onChange={() => {}}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('keeps native disabled when no reason is given', () => {
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+        />,
+      );
+      expect(screen.getByRole('slider')).toBeDisabled();
+    });
+
+    it('soft-disables (aria-disabled, focusable) with a reason', () => {
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      expect(slider).not.toBeDisabled();
+      expect(slider).toHaveAttribute('aria-disabled', 'true');
+      expectFocusable(slider);
+    });
+
+    it('surfaces the reason as a tooltip on focus', async () => {
+      const { user } = render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Enable advanced mode first');
+    });
+
+    it('does not change value via arrow keys while soft-disabled', async () => {
+      const onChange = vi.fn();
+      const { user } = render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={onChange}
+          disabled
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      slider.focus();
+      await user.keyboard('{ArrowRight}{ArrowLeft}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores the reason while enabled', () => {
+      render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabledReason="Enable advanced mode first"
+        />,
+      );
+      expect(screen.getByRole('slider')).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('passes axe audit for a soft-disabled slider', async () => {
+      const { container } = render(
+        <Slider
+          aria-label="Temperature"
+          value={40}
+          min={0}
+          max={100}
+          onChange={() => {}}
+          disabled
+          disabledReason="Enable advanced mode first"
         />,
       );
       await checkAccessibility(container);

--- a/packages/ui/src/components/forms/slider.tsx
+++ b/packages/ui/src/components/forms/slider.tsx
@@ -230,6 +230,12 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
               value={value}
               disabled={softDisabled ? undefined : disabled}
               aria-disabled={disabled || undefined}
+              // The range stays value-controlled while soft-disabled, so React
+              // would warn about a `value` with no `onChange`. `readOnly`
+              // silences that without changing behaviour — drag is already
+              // blocked via `onPointerDown` and arrow keys via `onKeyDown` —
+              // matching how `input.tsx`/`textarea.tsx` freeze their fields.
+              readOnly={softDisabled ? true : undefined}
               onChange={softDisabled ? undefined : handleChange}
               onPointerDown={(event) => {
                 if (softDisabled) {

--- a/packages/ui/src/components/forms/slider.tsx
+++ b/packages/ui/src/components/forms/slider.tsx
@@ -1,6 +1,7 @@
 import {
   type ChangeEvent,
   type InputHTMLAttributes,
+  type KeyboardEvent,
   type ReactNode,
   forwardRef,
   useEffect,
@@ -10,6 +11,7 @@ import {
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
+import { DisabledReasonTooltip } from '../overlays/disabled-reason';
 
 export interface SliderProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -34,10 +36,36 @@ export interface SliderProps extends Omit<
   valueLabel?: ReactNode;
   /** Time in ms to keep the value label visible after interaction. Default 1500. */
   valueLabelHideDelay?: number;
+  /**
+   * Explains *why* the slider is disabled, surfaced in a tooltip on hover AND
+   * focus and to screen readers (#1949). Only takes effect while the slider is
+   * `disabled`; ignored otherwise, so callers can pass it unconditionally.
+   *
+   * A natively-`disabled` range emits no pointer events and leaves the tab
+   * order, so no tooltip could reach it. When a disabled slider carries a
+   * `disabledReason` we therefore keep it focusable (still rendered visually
+   * disabled and inert — the value can't change via drag or arrow keys), swap
+   * `disabled` for `aria-disabled`, and let the shared Tooltip wire up
+   * `aria-describedby`.
+   */
+  disabledReason?: ReactNode;
 }
 
 const THUMB_DIAMETER_PX = 20;
 const THUMB_HALF_PX = THUMB_DIAMETER_PX / 2;
+
+// Keys a native range responds to by changing its value — blocked while a
+// slider is soft-disabled so keyboard users can't nudge an inert control.
+const VALUE_KEYS = new Set([
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+]);
 
 function clampPct(pct: number): number {
   if (pct < 0) return 0;
@@ -95,9 +123,12 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
       valueLabel,
       valueLabelHideDelay = 1500,
       className,
+      disabled,
+      disabledReason,
       onPointerDown,
       onFocus,
       onBlur,
+      onKeyDown,
       ...rest
     },
     ref,
@@ -124,6 +155,12 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
       flashLabel();
       onChange(event);
     }
+
+    // Soft-disable keeps the range focusable + hoverable (so the reason tooltip
+    // reaches pointer and keyboard users) while making it inert: the control is
+    // value-controlled, so swallowing onChange freezes the thumb against drag,
+    // and blocking the value keys stops keyboard nudges.
+    const softDisabled = Boolean(disabled) && disabledReason != null;
 
     const range = max - min;
     const pct = range > 0 ? ((value - min) / range) * 100 : 0;
@@ -183,33 +220,52 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
             </div>
           ) : null}
 
-          <input
-            ref={ref}
-            type="range"
-            min={min}
-            max={max}
-            step={step}
-            value={value}
-            onChange={handleChange}
-            onPointerDown={(event) => {
-              flashLabel();
-              onPointerDown?.(event);
-            }}
-            onFocus={(event) => {
-              flashLabel();
-              onFocus?.(event);
-            }}
-            onBlur={(event) => {
-              setShowLabel(false);
-              if (hideTimerRef.current) {
-                clearTimeout(hideTimerRef.current);
-                hideTimerRef.current = null;
-              }
-              onBlur?.(event);
-            }}
-            className={cn(inputClasses, className)}
-            {...rest}
-          />
+          <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>
+            <input
+              ref={ref}
+              type="range"
+              min={min}
+              max={max}
+              step={step}
+              value={value}
+              disabled={softDisabled ? undefined : disabled}
+              aria-disabled={disabled || undefined}
+              onChange={softDisabled ? undefined : handleChange}
+              onPointerDown={(event) => {
+                if (softDisabled) {
+                  event.preventDefault();
+                  return;
+                }
+                flashLabel();
+                onPointerDown?.(event);
+              }}
+              onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+                if (softDisabled && VALUE_KEYS.has(event.key)) {
+                  event.preventDefault();
+                  return;
+                }
+                onKeyDown?.(event);
+              }}
+              onFocus={(event) => {
+                flashLabel();
+                onFocus?.(event);
+              }}
+              onBlur={(event) => {
+                setShowLabel(false);
+                if (hideTimerRef.current) {
+                  clearTimeout(hideTimerRef.current);
+                  hideTimerRef.current = null;
+                }
+                onBlur?.(event);
+              }}
+              className={cn(
+                inputClasses,
+                'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+                className,
+              )}
+              {...rest}
+            />
+          </DisabledReasonTooltip>
         </div>
       </div>
     );

--- a/packages/ui/src/components/forms/slider.tsx
+++ b/packages/ui/src/components/forms/slider.tsx
@@ -229,7 +229,10 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
               step={step}
               value={value}
               disabled={softDisabled ? undefined : disabled}
-              aria-disabled={disabled || undefined}
+              // Only the soft-disabled branch needs `aria-disabled`; a natively
+              // `disabled` control already conveys the state, so emitting it
+              // there too would be redundant with the native attribute.
+              aria-disabled={softDisabled || undefined}
               // The range stays value-controlled while soft-disabled, so React
               // would warn about a `value` with no `onChange`. `readOnly`
               // silences that without changing behaviour — drag is already

--- a/packages/ui/src/components/forms/slider.tsx
+++ b/packages/ui/src/components/forms/slider.tsx
@@ -11,7 +11,10 @@ import {
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
-import { DisabledReasonTooltip } from '../overlays/disabled-reason';
+import {
+  DisabledReasonTooltip,
+  hasDisabledReason,
+} from '../overlays/disabled-reason';
 
 export interface SliderProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -160,7 +163,7 @@ const SliderBase = forwardRef<HTMLInputElement, SliderProps>(
     // reaches pointer and keyboard users) while making it inert: the control is
     // value-controlled, so swallowing onChange freezes the thumb against drag,
     // and blocking the value keys stops keyboard nudges.
-    const softDisabled = Boolean(disabled) && disabledReason != null;
+    const softDisabled = Boolean(disabled) && hasDisabledReason(disabledReason);
 
     const range = max - min;
     const pct = range > 0 ? ((value - min) / range) * 100 : 0;

--- a/packages/ui/src/components/forms/textarea.test.tsx
+++ b/packages/ui/src/components/forms/textarea.test.tsx
@@ -47,6 +47,16 @@ describe('Textarea', () => {
       expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-disabled');
     });
 
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(<Textarea aria-label="Bio" disabled disabledReason="   " />);
+      const textarea = screen.getByRole('textbox');
+      // A blank reason explains nothing, so the control must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(textarea).toBeDisabled();
+      expect(textarea).not.toHaveAttribute('aria-disabled');
+      expect(textarea).not.toHaveAttribute('readonly');
+    });
+
     it('passes axe audit for a soft-disabled textarea', async () => {
       const { container } = render(
         <Textarea aria-label="Bio" disabled disabledReason="Unlock first" />,

--- a/packages/ui/src/components/forms/textarea.test.tsx
+++ b/packages/ui/src/components/forms/textarea.test.tsx
@@ -16,7 +16,10 @@ describe('Textarea', () => {
   describe('disabledReason', () => {
     it('keeps native disabled when no reason is given', () => {
       render(<Textarea aria-label="Bio" disabled />);
-      expect(screen.getByRole('textbox')).toBeDisabled();
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeDisabled();
+      // Native `disabled` already conveys the state; no redundant aria-disabled.
+      expect(textarea).not.toHaveAttribute('aria-disabled');
     });
 
     it('soft-disables (aria-disabled, focusable, readOnly) with a reason', () => {

--- a/packages/ui/src/components/forms/textarea.test.tsx
+++ b/packages/ui/src/components/forms/textarea.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { checkAccessibility, expectFocusable } from '@/tests/utils/a11y';
+import { render, screen } from '@/tests/utils/render';
 
 import { Textarea } from './textarea';
 
@@ -9,6 +9,45 @@ describe('Textarea', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(<Textarea aria-label="Bio" />);
+      await checkAccessibility(container);
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('keeps native disabled when no reason is given', () => {
+      render(<Textarea aria-label="Bio" disabled />);
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('soft-disables (aria-disabled, focusable, readOnly) with a reason', () => {
+      render(
+        <Textarea aria-label="Bio" disabled disabledReason="Unlock first" />,
+      );
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).not.toBeDisabled();
+      expect(textarea).toHaveAttribute('aria-disabled', 'true');
+      expect(textarea).toHaveAttribute('readonly');
+      expectFocusable(textarea);
+    });
+
+    it('surfaces the reason as a tooltip on focus', async () => {
+      const { user } = render(
+        <Textarea aria-label="Bio" disabled disabledReason="Unlock first" />,
+      );
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Unlock first');
+    });
+
+    it('ignores the reason while enabled', () => {
+      render(<Textarea aria-label="Bio" disabledReason="Unlock first" />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('passes axe audit for a soft-disabled textarea', async () => {
+      const { container } = render(
+        <Textarea aria-label="Bio" disabled disabledReason="Unlock first" />,
+      );
       await checkAccessibility(container);
     });
   });

--- a/packages/ui/src/components/forms/textarea.tsx
+++ b/packages/ui/src/components/forms/textarea.tsx
@@ -39,7 +39,10 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             ref={ref}
             rows={rows}
             disabled={softDisabled ? undefined : disabled}
-            aria-disabled={disabled || undefined}
+            // Only the soft-disabled branch needs `aria-disabled`; a natively
+            // `disabled` field already conveys the state, so emitting it there
+            // too would be redundant with the native attribute.
+            aria-disabled={softDisabled || undefined}
             readOnly={softDisabled ? true : readOnly}
             className={cn(
               'min-h-[96px] w-full rounded-lg border px-3 py-2 text-base md:text-sm',

--- a/packages/ui/src/components/forms/textarea.tsx
+++ b/packages/ui/src/components/forms/textarea.tsx
@@ -1,9 +1,23 @@
-import { type TextareaHTMLAttributes, forwardRef } from 'react';
+import { type TextareaHTMLAttributes, type ReactNode, forwardRef } from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
+import { DisabledReasonTooltip } from '../overlays/disabled-reason';
 
-export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /**
+   * Explains *why* the field is disabled, surfaced in a tooltip on hover AND
+   * focus and to screen readers (#1949). Only takes effect while the field is
+   * `disabled`; ignored otherwise, so callers can pass it unconditionally.
+   *
+   * A natively-`disabled` field emits no pointer events and leaves the tab
+   * order, so no tooltip could reach it. When a disabled field carries a
+   * `disabledReason` we therefore keep it focusable and `readOnly` (still
+   * rendered visually disabled and inert to edits), swap `disabled` for
+   * `aria-disabled`, and let the shared Tooltip wire up `aria-describedby`.
+   */
+  disabledReason?: ReactNode;
+}
 
 /**
  * Skeleton-aware Textarea. Always wraps the real field in a `<SkeletonBox>`:
@@ -11,22 +25,36 @@ export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
  * masks the field with an overlay at its exact size (incl. `rows`).
  */
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, rows = 4, ...props }, ref) => (
-    <SkeletonBox fullWidth>
-      <textarea
-        ref={ref}
-        rows={rows}
-        className={cn(
-          'min-h-[96px] w-full rounded-lg border px-3 py-2 text-base md:text-sm',
-          'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',
-          className,
-        )}
-        {...props}
-      />
-    </SkeletonBox>
-  ),
+  (
+    { className, rows = 4, disabled, disabledReason, readOnly, ...props },
+    ref,
+  ) => {
+    // Soft-disable keeps the field focusable + hoverable (so the reason tooltip
+    // reaches pointer and keyboard users) while `readOnly` blocks edits.
+    const softDisabled = Boolean(disabled) && disabledReason != null;
+    return (
+      <SkeletonBox fullWidth>
+        <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>
+          <textarea
+            ref={ref}
+            rows={rows}
+            disabled={softDisabled ? undefined : disabled}
+            aria-disabled={disabled || undefined}
+            readOnly={softDisabled ? true : readOnly}
+            className={cn(
+              'min-h-[96px] w-full rounded-lg border px-3 py-2 text-base md:text-sm',
+              'border-[color:var(--color-border-input)] bg-[color:var(--color-bg-base)] text-[color:var(--color-fg-base)] placeholder:text-[color:var(--color-fg-subtle)] shadow-sm transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-base)]/30 focus-visible:border-[color:var(--color-accent-base)]',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+              'aria-invalid:border-[color:var(--color-danger)] aria-invalid:ring-[color:var(--color-danger)]/20',
+              className,
+            )}
+            {...props}
+          />
+        </DisabledReasonTooltip>
+      </SkeletonBox>
+    );
+  },
 );
 Textarea.displayName = 'Textarea';

--- a/packages/ui/src/components/forms/textarea.tsx
+++ b/packages/ui/src/components/forms/textarea.tsx
@@ -2,7 +2,10 @@ import { type TextareaHTMLAttributes, type ReactNode, forwardRef } from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
-import { DisabledReasonTooltip } from '../overlays/disabled-reason';
+import {
+  DisabledReasonTooltip,
+  hasDisabledReason,
+} from '../overlays/disabled-reason';
 
 export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /**
@@ -31,7 +34,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ) => {
     // Soft-disable keeps the field focusable + hoverable (so the reason tooltip
     // reaches pointer and keyboard users) while `readOnly` blocks edits.
-    const softDisabled = Boolean(disabled) && disabledReason != null;
+    const softDisabled = Boolean(disabled) && hasDisabledReason(disabledReason);
     return (
       <SkeletonBox fullWidth>
         <DisabledReasonTooltip reason={disabledReason} active={softDisabled}>

--- a/packages/ui/src/components/overlays/disabled-reason.tsx
+++ b/packages/ui/src/components/overlays/disabled-reason.tsx
@@ -25,6 +25,24 @@ export interface DisabledReasonTooltipProps {
 }
 
 /**
+ * Whether a `disabledReason` is meaningful enough to soft-disable a control.
+ *
+ * Soft-disabling trades a native `disabled` (inert, out of the tab order) for a
+ * focusable `aria-disabled` control whose only justification is the reason it
+ * surfaces. An absent reason — `null`/`undefined`, a boolean, or an
+ * empty/whitespace-only string — would leave the control inert *and* focusable
+ * while explaining nothing, which is strictly worse than a native disable. In
+ * that case callers should fall back to the native `disabled` behaviour, so the
+ * shared primitives gate `softDisabled` on this helper rather than a bare null
+ * check.
+ */
+export function hasDisabledReason(reason: ReactNode): boolean {
+  if (reason == null || typeof reason === 'boolean') return false;
+  if (typeof reason === 'string') return reason.trim() !== '';
+  return true;
+}
+
+/**
  * Wraps a soft-disabled control in the shared Tooltip so the reason it's
  * disabled reaches pointer and keyboard users alike (#1949).
  *
@@ -43,7 +61,7 @@ export function DisabledReasonTooltip({
   side,
   children,
 }: DisabledReasonTooltipProps): ReactElement {
-  if (!active || reason == null) return children;
+  if (!active || !hasDisabledReason(reason)) return children;
   return (
     <TooltipPrimitive.Provider delayDuration={300}>
       <TooltipPrimitive.Root>

--- a/packages/ui/src/components/overlays/disabled-reason.tsx
+++ b/packages/ui/src/components/overlays/disabled-reason.tsx
@@ -1,0 +1,57 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { type ReactElement, type ReactNode } from 'react';
+
+import { TooltipContent } from './tooltip';
+
+export interface DisabledReasonTooltipProps {
+  /**
+   * The reason the control is disabled, shown in the tooltip and wired to the
+   * trigger via `aria-describedby` (Radix does this while the tip is open).
+   */
+  reason: ReactNode;
+  /**
+   * Whether the affordance is live — true only when the control is both
+   * disabled AND carries a `reason`. When false the child renders bare, so
+   * callers can wrap unconditionally.
+   */
+  active: boolean;
+  /** Side the tooltip opens on (default `top`). */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /**
+   * The single focusable control to wrap. It must forward its ref and spread
+   * props (every shared form primitive does) so Radix can attach the trigger.
+   */
+  children: ReactElement;
+}
+
+/**
+ * Wraps a soft-disabled control in the shared Tooltip so the reason it's
+ * disabled reaches pointer and keyboard users alike (#1949).
+ *
+ * A natively-`disabled` control emits no pointer events and leaves the tab
+ * order, so neither a hover nor a focus tooltip could ever reach it. The shared
+ * form/button primitives therefore "soft-disable" instead — they keep the
+ * control focusable and swap the native `disabled` attribute for
+ * `aria-disabled` while making activation inert — and hand the control here to
+ * surface the reason. The shared Radix tooltip wires up `aria-describedby` so
+ * screen-reader users hear the reason on focus, exactly as sighted users see it
+ * on hover.
+ */
+export function DisabledReasonTooltip({
+  reason,
+  active,
+  side,
+  children,
+}: DisabledReasonTooltipProps): ReactElement {
+  if (!active || reason == null) return children;
+  return (
+    <TooltipPrimitive.Provider delayDuration={300}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipContent side={side}>{reason}</TooltipContent>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}

--- a/packages/ui/src/components/primitives/button.stories.tsx
+++ b/packages/ui/src/components/primitives/button.stories.tsx
@@ -74,6 +74,11 @@ import { Button } from '@/app/components/ui/primitives';
       control: 'boolean',
       description: 'Disables the button',
     },
+    disabledReason: {
+      control: 'text',
+      description:
+        'Why the button is disabled — shown as a tooltip on hover/focus and announced to screen readers (only while disabled)',
+    },
     collapseLabel: {
       control: 'boolean',
       description:
@@ -170,6 +175,33 @@ export const Disabled: Story = {
       </Button>
     </div>
   ),
+};
+
+export const DisabledWithReason: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button disabled disabledReason="Pick an agent before sending">
+        Send
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        title="Delete"
+        disabled
+        disabledReason="You can only delete your own messages"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass `disabledReason` to explain *why* a disabled control is off. The reason shows as a tooltip on hover AND focus and is announced to screen readers. Because a natively-disabled button emits no events and leaves the tab order, a button with a `disabledReason` is kept focusable and switched to `aria-disabled` (still visually disabled and inert). Tab to or hover the buttons to see the reason.',
+      },
+    },
+  },
 };
 
 export const AsLink: Story = {

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -361,6 +361,54 @@ describe('Button', () => {
       expect(handleClick).not.toHaveBeenCalled();
     });
 
+    it('does not activate a soft-disabled button on Space', async () => {
+      const handleClick = vi.fn();
+      const { user } = render(
+        <Button
+          onClick={handleClick}
+          disabled
+          disabledReason="Pick an agent first"
+        >
+          Send
+        </Button>,
+      );
+      const button = screen.getByRole('button');
+      button.focus();
+      await user.keyboard(' ');
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('describes the focused soft-disabled button via aria-describedby', async () => {
+      const { user } = render(
+        <Button disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      await user.tab();
+      const button = screen.getByRole('button');
+      // Radix wires the open tooltip to the trigger via aria-describedby so the
+      // reason reaches screen-reader users on focus, not just on hover.
+      const describedBy = button.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      const description = describedBy
+        ? document.getElementById(describedBy)
+        : null;
+      expect(description).toHaveTextContent('Pick an agent first');
+    });
+
+    it('suppresses the reason tooltip under asChild (Slot)', () => {
+      // asChild renders a Radix Slot (typically another overlay's trigger);
+      // soft-disable can't work through it, so no tooltip trigger is added.
+      render(
+        <Button asChild disabled disabledReason="Pick an agent first">
+          <a href="/test">Link</a>
+        </Button>,
+      );
+      const link = screen.getByRole('link', { name: 'Link' });
+      expect(link).toBeInTheDocument();
+      expect(screen.queryByRole('tooltip')).toBeNull();
+    });
+
     it('ignores the reason while the button is enabled', () => {
       render(<Button disabledReason="Pick an agent first">Send</Button>);
       const button = screen.getByRole('button');

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -318,6 +318,18 @@ describe('Button', () => {
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(
+        <Button disabled disabledReason="   ">
+          Send
+        </Button>,
+      );
+      const button = screen.getByRole('button');
+      // A blank reason explains nothing, so the button must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(button).toBeDisabled();
+    });
+
     it('soft-disables (aria-disabled, focusable) when a reason is given', () => {
       render(
         <Button disabled disabledReason="Pick an agent first">

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -378,6 +378,26 @@ describe('Button', () => {
       expect(handleClick).not.toHaveBeenCalled();
     });
 
+    it('defaults a soft-disabled button to type="button" so it cannot implicitly submit', () => {
+      render(
+        <Button disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      // A soft-disabled button keeps emitting events, so without an explicit
+      // type it would act as an implicit submit button inside a <form>.
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+
+    it('lets an explicit type win over the soft-disabled default', () => {
+      render(
+        <Button type="submit" disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
     it('describes the focused soft-disabled button via aria-describedby', async () => {
       const { user } = render(
         <Button disabled disabledReason="Pick an agent first">

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -309,6 +309,74 @@ describe('Button', () => {
       expect(button.className).toContain('disabled:active:scale-100');
     });
   });
+
+  describe('disabledReason', () => {
+    it('keeps native disabled when no reason is given', () => {
+      render(<Button disabled>Disabled</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('soft-disables (aria-disabled, focusable) when a reason is given', () => {
+      render(
+        <Button disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      const button = screen.getByRole('button');
+      // Not natively disabled, so it stays in the tab order and emits events…
+      expect(button).not.toBeDisabled();
+      // …but is still announced as disabled to assistive tech.
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      expectFocusable(button);
+    });
+
+    it('surfaces the reason as a tooltip on focus', async () => {
+      const { user } = render(
+        <Button disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Pick an agent first');
+    });
+
+    it('does not activate a soft-disabled button on click or Enter', async () => {
+      const handleClick = vi.fn();
+      const { user } = render(
+        <Button
+          onClick={handleClick}
+          disabled
+          disabledReason="Pick an agent first"
+        >
+          Send
+        </Button>,
+      );
+      const button = screen.getByRole('button');
+      await user.click(button);
+      button.focus();
+      await user.keyboard('{Enter}');
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('ignores the reason while the button is enabled', () => {
+      render(<Button disabledReason="Pick an agent first">Send</Button>);
+      const button = screen.getByRole('button');
+      expect(button).not.toBeDisabled();
+      expect(button).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('passes axe audit for a soft-disabled button', async () => {
+      const { container } = render(
+        <Button disabled disabledReason="Pick an agent first">
+          Send
+        </Button>,
+      );
+      await checkAccessibility(container);
+    });
+  });
 });
 
 describe('LinkButton', () => {

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -10,7 +10,7 @@ import { SkeletonBox } from '../feedback/skeleton';
 import { TooltipContent } from '../overlays/tooltip';
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-150 active:scale-[0.97] active:duration-75 motion-reduce:active:scale-100 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100 disabled:hover:opacity-50 leading-none ring-offset-background cursor-pointer',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-150 active:scale-[0.97] active:duration-75 motion-reduce:active:scale-100 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100 disabled:hover:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:active:scale-100 aria-disabled:hover:opacity-50 leading-none ring-offset-background cursor-pointer',
   {
     variants: {
       // One height fits all (`h-9`), with a single smaller variant (`h-8`) for
@@ -83,6 +83,21 @@ interface ButtonOwnProps
   tooltip?: React.ReactNode;
   /** Side the tooltip opens on (default `top`). */
   tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
+  /**
+   * Explains *why* the button is disabled, surfaced in a tooltip on hover AND
+   * focus and to screen readers (#1949). Only takes effect while the button is
+   * `disabled`; ignored otherwise, so callers can pass it unconditionally.
+   *
+   * A natively-`disabled` button emits no pointer events and leaves the tab
+   * order, so neither a hover nor a focus tooltip could ever reach it. When a
+   * disabled button carries a `disabledReason` we therefore keep it focusable,
+   * swap the native `disabled` attribute for `aria-disabled` (still rendered
+   * visually disabled and inert to clicks/Enter/Space), and let the shared
+   * Tooltip wire up `aria-describedby` — so the reason reaches pointer and
+   * keyboard users alike. Overrides `tooltip`/`title` for the visible tip while
+   * disabled. Has no effect under `asChild` (the button is a Radix `Slot`).
+   */
+  disabledReason?: React.ReactNode;
 }
 
 type ButtonSize = NonNullable<VariantProps<typeof buttonVariants>['size']>;
@@ -104,8 +119,13 @@ export type ButtonProps = ButtonOwnProps &
   );
 
 // Loose internal props — the wrapper has already resolved title → aria-label
-// and stripped the tooltip props, so the base never sees them.
-type ButtonBaseProps = ButtonOwnProps & { size?: ButtonSize | null };
+// and stripped the tooltip props, so the base never sees them. `softDisabled`
+// is set by the wrapper when a disabled button must stay focusable/hoverable to
+// surface a `disabledReason` tooltip (see the Button wrapper below).
+type ButtonBaseProps = ButtonOwnProps & {
+  size?: ButtonSize | null;
+  softDisabled?: boolean;
+};
 
 // Plain control — the real button. No skeleton/tooltip logic of its own.
 const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
@@ -120,12 +140,31 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
       iconClassName,
       fullWidth = false,
       collapseLabel = false,
+      softDisabled = false,
+      disabled,
+      disabledReason: _disabledReason,
+      onClick,
+      onKeyDown,
       children,
       ...props
     },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button';
+    const isDisabled = isLoading || disabled;
+    // Soft-disable keeps the control in the tab order and emitting pointer
+    // events (so a disabledReason tooltip reaches both pointer and keyboard
+    // users) while making activation inert — the native `disabled` attribute
+    // would remove it from the tab order and silence all events.
+    const soft = softDisabled && Boolean(isDisabled) && !asChild;
+    const blockActivation = (
+      event: React.SyntheticEvent & { key?: string },
+    ) => {
+      // Space/Enter activate a button; let other keys (Tab, arrows) through.
+      if ('key' in event && event.key !== ' ' && event.key !== 'Enter') return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
     const iconClass = cn(
       'size-4',
       children && (collapseLabel ? 'sm:mr-2' : 'mr-2'),
@@ -166,9 +205,11 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
           fullWidth && 'w-full',
         )}
         ref={ref}
-        disabled={isLoading || props.disabled}
+        disabled={soft ? undefined : isDisabled || undefined}
         aria-busy={isLoading || undefined}
-        aria-disabled={isLoading || props.disabled || undefined}
+        aria-disabled={isDisabled || undefined}
+        onClick={soft ? blockActivation : onClick}
+        onKeyDown={soft ? blockActivation : onKeyDown}
         {...props}
       >
         {content}
@@ -185,7 +226,17 @@ ButtonBase.displayName = 'ButtonBase';
  * with an overlay at its exact size.
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ tooltip, tooltipSide, title, 'aria-label': ariaLabel, ...props }, ref) => {
+  (
+    {
+      tooltip,
+      tooltipSide,
+      title,
+      disabledReason,
+      'aria-label': ariaLabel,
+      ...props
+    },
+    ref,
+  ) => {
     // `title` shows a tooltip for any button, and ALSO names icon-only buttons
     // (they have no visible text). Text buttons keep their accessible name from
     // their children — `title` must NOT override it there — so the name only
@@ -194,9 +245,19 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const accessibleName =
       ariaLabel ??
       (props.size === 'icon' || props.size === 'icon-sm' ? title : undefined);
-    const tip = tooltip ?? title;
+    // While disabled, a `disabledReason` explains why and takes over the visible
+    // tip. It needs the button kept focusable/hoverable (soft-disable), which
+    // can't work through a Radix `Slot`, so it's suppressed under `asChild`.
+    const showDisabledReason =
+      Boolean(props.disabled) && disabledReason != null && !props.asChild;
+    const tip = showDisabledReason ? disabledReason : (tooltip ?? title);
     const base = (
-      <ButtonBase {...props} aria-label={accessibleName} ref={ref} />
+      <ButtonBase
+        {...props}
+        aria-label={accessibleName}
+        softDisabled={showDisabledReason}
+        ref={ref}
+      />
     );
     // The tooltip Trigger must wrap the REAL button (`ButtonBase` forwards its
     // ref + props), never the `SkeletonBox` span — a plain span drops the

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 
 import { cn } from '../../lib/cn';
 import { SkeletonBox } from '../feedback/skeleton';
+import { hasDisabledReason } from '../overlays/disabled-reason';
 import { TooltipContent } from '../overlays/tooltip';
 
 export const buttonVariants = cva(
@@ -256,7 +257,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     // tip. It needs the button kept focusable/hoverable (soft-disable), which
     // can't work through a Radix `Slot`, so it's suppressed under `asChild`.
     const showDisabledReason =
-      Boolean(props.disabled) && disabledReason != null && !props.asChild;
+      Boolean(props.disabled) &&
+      hasDisabledReason(disabledReason) &&
+      !props.asChild;
     const tip = showDisabledReason ? disabledReason : (tooltip ?? title);
     const base = (
       <ButtonBase

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -145,6 +145,7 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
       disabledReason: _disabledReason,
       onClick,
       onKeyDown,
+      type,
       children,
       ...props
     },
@@ -208,6 +209,12 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
         disabled={soft ? undefined : isDisabled || undefined}
         aria-busy={isLoading || undefined}
         aria-disabled={isDisabled || undefined}
+        // A soft-disabled button keeps emitting events to surface its tooltip,
+        // so inside a <form> it would otherwise act as an implicit submit
+        // button. Activation is already blocked by `blockActivation`, but
+        // defaulting `type` to "button" is robust defense-in-depth; an explicit
+        // caller `type` always wins.
+        type={soft ? (type ?? 'button') : type}
         onClick={soft ? blockActivation : onClick}
         onKeyDown={soft ? blockActivation : onKeyDown}
         {...props}

--- a/packages/ui/src/components/primitives/icon-button.test.tsx
+++ b/packages/ui/src/components/primitives/icon-button.test.tsx
@@ -113,6 +113,66 @@ describe('IconButton', () => {
       const tooltip = await screen.findByRole('tooltip');
       expect(tooltip).toHaveTextContent('You can only delete your own rows');
     });
+
+    it('keeps native disabled when no reason is given', () => {
+      render(<IconButton icon={Trash2} aria-label="Delete" disabled />);
+      // Native `disabled` (inert, out of the tab order); no soft-disable.
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('keeps native disabled when the reason is empty/whitespace', () => {
+      render(
+        <IconButton
+          icon={Trash2}
+          aria-label="Delete"
+          disabled
+          disabledReason="   "
+        />,
+      );
+      // A blank reason explains nothing, so the control must fall back to a
+      // native disable rather than become inert-but-focusable with no tooltip.
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('blocks activation on click, Space, and Enter while soft-disabled', async () => {
+      const handleClick = vi.fn();
+      const { user } = render(
+        <IconButton
+          icon={Trash2}
+          aria-label="Delete"
+          disabled
+          disabledReason="You can only delete your own rows"
+          onClick={handleClick}
+        />,
+      );
+      const button = screen.getByRole('button');
+      await user.click(button);
+      button.focus();
+      await user.keyboard(' ');
+      await user.keyboard('{Enter}');
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('describes the focused soft-disabled icon button via aria-describedby', async () => {
+      const { user } = render(
+        <IconButton
+          icon={Trash2}
+          aria-label="Delete"
+          disabled
+          disabledReason="You can only delete your own rows"
+        />,
+      );
+      await user.tab();
+      const button = screen.getByRole('button');
+      const describedBy = button.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      const description = describedBy
+        ? document.getElementById(describedBy)
+        : null;
+      expect(description).toHaveTextContent(
+        'You can only delete your own rows',
+      );
+    });
   });
 
   describe('accessibility', () => {

--- a/packages/ui/src/components/primitives/icon-button.test.tsx
+++ b/packages/ui/src/components/primitives/icon-button.test.tsx
@@ -95,6 +95,26 @@ describe('IconButton', () => {
     });
   });
 
+  describe('disabledReason', () => {
+    it('soft-disables and surfaces the reason on focus', async () => {
+      const { user } = render(
+        <IconButton
+          icon={Trash2}
+          aria-label="Delete"
+          disabled
+          disabledReason="You can only delete your own rows"
+        />,
+      );
+      const button = screen.getByRole('button');
+      // Kept focusable so the reason reaches keyboard users.
+      expect(button).not.toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      await user.tab();
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('You can only delete your own rows');
+    });
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,7 +21,7 @@ export {
 export { Input, type InputProps } from './components/forms/input';
 export { Textarea, type TextareaProps } from './components/forms/textarea';
 export { Label } from './components/forms/label';
-export { Checkbox } from './components/forms/checkbox';
+export { Checkbox, type CheckboxProps } from './components/forms/checkbox';
 export { Slider, type SliderProps } from './components/forms/slider';
 export { Field, type FieldProps } from './components/forms/field';
 

--- a/services/platform/app/components/ui/wizard/wizard-footer.tsx
+++ b/services/platform/app/components/ui/wizard/wizard-footer.tsx
@@ -13,6 +13,13 @@ export interface WizardFooterProps {
   finishLabel: string;
   /** Required only when any step is optional (renders the Skip action). */
   skipLabel?: string;
+  /**
+   * Why the Next button is disabled while the active step is invalid, surfaced
+   * as a hover/focus tooltip on the (soft-disabled) button so users know what's
+   * left to do (#1949). Not shown while a step transition is submitting — the
+   * button's loading spinner already explains that state.
+   */
+  nextDisabledReason?: string;
   className?: string;
   /**
    * Full-width, vertically-stacked layout: the primary Next/Finish button spans
@@ -33,6 +40,7 @@ export function WizardFooter({
   nextLabel,
   finishLabel,
   skipLabel,
+  nextDisabledReason,
   className,
   stacked,
 }: WizardFooterProps) {
@@ -49,8 +57,13 @@ export function WizardFooter({
   } = useWizard();
 
   const submitting = status === 'submitting';
-  const nextDisabled = !activeStep || !isStepValid(activeStep.id) || submitting;
+  const stepInvalid = !activeStep || !isStepValid(activeStep.id);
+  const nextDisabled = stepInvalid || submitting;
   const showSkip = Boolean(activeStep?.optional && skipLabel);
+  // Only explain the "step incomplete" case — while submitting, the spinner
+  // (isLoading) already conveys why the button is inert.
+  const primaryDisabledReason =
+    stepInvalid && !submitting ? nextDisabledReason : undefined;
 
   // The active step may override the primary label/emphasis (e.g. "Skip for
   // now" vs "Connect"); otherwise fall back to the standard Next/Finish label.
@@ -70,6 +83,7 @@ export function WizardFooter({
           variant={primaryVariant}
           onClick={goNext}
           disabled={nextDisabled}
+          disabledReason={primaryDisabledReason}
           isLoading={submitting}
         >
           {primaryLabel}
@@ -107,6 +121,7 @@ export function WizardFooter({
           variant={primaryVariant}
           onClick={goNext}
           disabled={nextDisabled}
+          disabledReason={primaryDisabledReason}
           isLoading={submitting}
         >
           {primaryLabel}

--- a/services/platform/app/components/ui/wizard/wizard.test.tsx
+++ b/services/platform/app/components/ui/wizard/wizard.test.tsx
@@ -77,7 +77,11 @@ describe('Wizard navigation', () => {
 });
 
 describe('Wizard validation gating', () => {
-  function GatedHarness() {
+  function GatedHarness({
+    nextDisabledReason,
+  }: {
+    nextDisabledReason?: string;
+  }) {
     const [value, setValue] = useState('');
     const steps: WizardStepMeta[] = [
       { id: 'name', label: 'Name' },
@@ -96,7 +100,12 @@ describe('Wizard validation gating', () => {
         <WizardStep id="done">
           <p>Done content</p>
         </WizardStep>
-        <WizardFooter backLabel="Back" nextLabel="Next" finishLabel="Finish" />
+        <WizardFooter
+          backLabel="Back"
+          nextLabel="Next"
+          finishLabel="Finish"
+          nextDisabledReason={nextDisabledReason}
+        />
       </Wizard>
     );
   }
@@ -105,6 +114,23 @@ describe('Wizard validation gating', () => {
     const { user } = render(<GatedHarness />);
     const next = screen.getByRole('button', { name: 'Next' });
     expect(next).toBeDisabled();
+    await user.type(screen.getByRole('textbox'), 'Acme');
+    expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+
+  it('explains the disabled Next button via a tooltip when given a reason', async () => {
+    const { user } = render(
+      <GatedHarness nextDisabledReason="Complete this step to continue" />,
+    );
+    const next = screen.getByRole('button', { name: 'Next' });
+    // Soft-disabled so the reason can reach pointer and keyboard users: still
+    // inert (aria-disabled) but in the tab order rather than natively disabled.
+    expect(next).not.toBeDisabled();
+    expect(next).toHaveAttribute('aria-disabled', 'true');
+    next.focus();
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Complete this step to continue');
+    // Once the step is valid the reason no longer applies and Next enables.
     await user.type(screen.getByRole('textbox'), 'Acme');
     expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
   });

--- a/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
+++ b/services/platform/app/features/organization/components/onboarding/onboarding-wizard.tsx
@@ -220,6 +220,7 @@ export function OnboardingWizard({
             nextLabel={tCommon('actions.next')}
             finishLabel={t('finish.goToDashboard')}
             skipLabel={tCommon('actions.skip')}
+            nextDisabledReason={tCommon('actions.completeStepToContinue')}
           />
         </Wizard>
       </main>

--- a/services/platform/messages/de-CH.json
+++ b/services/platform/messages/de-CH.json
@@ -65,7 +65,8 @@
   },
   "common": {
     "actions": {
-      "close": "Schliessen"
+      "close": "Schliessen",
+      "completeStepToContinue": "Schliesse diesen Schritt ab, um fortzufahren"
     },
     "aria": {
       "close": "Schliessen",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1927,6 +1927,7 @@
       "back": "Zurück",
       "next": "Weiter",
       "skip": "Überspringen",
+      "completeStepToContinue": "Schließe diesen Schritt ab, um fortzufahren",
       "loading": "Lädt...",
       "done": "Fertig",
       "duplicate": "Duplizieren",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1927,6 +1927,7 @@
       "back": "Back",
       "next": "Next",
       "skip": "Skip",
+      "completeStepToContinue": "Complete this step to continue",
       "loading": "Loading...",
       "done": "Done",
       "duplicate": "Duplicate",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1928,6 +1928,7 @@
       "back": "Retour",
       "next": "Suivant",
       "skip": "Passer",
+      "completeStepToContinue": "Terminez cette étape pour continuer",
       "loading": "Chargement...",
       "done": "Terminé",
       "duplicate": "Dupliquer",


### PR DESCRIPTION
## What & why

Resolves #1949. Disabled buttons/controls gave no reason for being disabled. A natively-`disabled` button emits no pointer events and leaves the tab order, so a tooltip could never reach it on hover *or* focus.

## Change

Adds a shared `disabledReason` affordance to the `@tale/ui` `Button` primitive (inherited for free by `IconButton`, which composes `Button`). When a button is `disabled` **and** carries a `disabledReason`:

- it is kept focusable and switched from the native `disabled` attribute to `aria-disabled` (still rendered visually disabled via new `aria-disabled:*` variants, and inert to click / Enter / Space);
- the reason is shown through the existing shared Tooltip on **hover and focus**, and Radix wires `aria-describedby` so screen-reader users hear it too.

`disabledReason` is ignored while the button is enabled (callers can pass it unconditionally) and suppressed under `asChild` (the button is then a Radix `Slot`). Existing `disabled` behaviour is unchanged when no reason is supplied.

## Acceptance criteria

- [x] Every disabled button/control can surface a reason on hover/focus via one shared prop.
- [x] Works for keyboard users (focusable, `aria-disabled`, `aria-describedby` via Tooltip).

## Verification

- `bun run --filter @tale/ui test` — full unit suite green, incl. 6 new `Button` cases + 1 `IconButton` case and an axe audit (`checkAccessibility`) on the soft-disabled markup.
- `bun run --filter @tale/ui typecheck` and `lint` (oxlint, type-aware) — clean.
- Added a `DisabledWithReason` Storybook story (Storybook a11y project runs in CI; its browser couldn't be downloaded in the local sandbox).

## Notes / Definition of Done

- No user-facing strings added — the reason text is caller-provided — so i18n / docs are **N/A**.
- Not a new primitive (a prop on an existing one); story added, a11y covered, `Skeletonize` already wraps the button.