### PR TITLE
feat(platform): add borderless read-only input variant (#1942)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/components/ui/forms/input.stories.tsx
+++ b/services/platform/app/components/ui/forms/input.stories.tsx
@@ -34,9 +34,9 @@ import { Input } from './input';
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'unstyled'],
+      options: ['default', 'unstyled', 'readOnly'],
       description:
-        'Visual variant: `default` (bordered field) or `unstyled` (no chrome, inherits surrounding styles)',
+        'Visual variant: `default` (bordered field), `unstyled` (no chrome, inherits surrounding styles), or `readOnly` (borderless, transparent, text-like display). A native `readOnly` input selects `readOnly` automatically.',
     },
     type: {
       control: 'select',
@@ -214,6 +214,40 @@ export const Disabled: Story = {
     label: 'Disabled field',
     disabled: true,
     defaultValue: 'Cannot edit this',
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    label: 'Read-only field',
+    readOnly: true,
+    defaultValue: 'Informational value',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Display-only value: borderless and transparent, but keeps the field footprint (`h-9` + padding) so there is no layout shift when toggling to an editable field. A native `readOnly` input picks this variant automatically.',
+      },
+    },
+  },
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Input label="Editable" defaultValue="You can change this" />
+      <Input label="Read-only" readOnly defaultValue="Informational value" />
+      <Input label="Disabled" disabled defaultValue="Temporarily unavailable" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Editable vs. read-only vs. disabled. All three measure 36px tall and share the same footprint — read-only drops the border/background so the value reads as text, disabled dims the bordered field to signal it is temporarily unavailable.',
+      },
+    },
   },
 };
 

--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -33,13 +33,54 @@ describe('Input', () => {
   });
 
   describe('variants', () => {
-    it.each(['default', 'unstyled'] as const)(
+    it.each(['default', 'unstyled', 'readOnly'] as const)(
       'renders %s variant',
       (variant) => {
         render(<Input variant={variant} placeholder="Test" />);
         expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
       },
     );
+  });
+
+  describe('read-only display variant', () => {
+    // Display-only values must read as text — borderless and transparent — yet
+    // keep the field footprint (same `h-9` + padding box as an editable input)
+    // so toggling editable ↔ read-only causes no layout shift (#1942).
+    it('auto-selects the borderless variant for a native readOnly input', () => {
+      render(<Input label="Plan" readOnly defaultValue="Enterprise" />);
+      const input = screen.getByLabelText('Plan', { exact: false });
+      expect(input).toHaveClass('bg-transparent');
+      expect(input).toHaveClass('h-9');
+      expect(input).toHaveClass('px-3');
+      // No visible ring/border chrome on the resting field.
+      expect(input.className).not.toContain('--color-border-input');
+    });
+
+    it('keeps the editable field footprint (h-9 + horizontal padding)', () => {
+      render(<Input label="Email" defaultValue="a@b.com" />);
+      const input = screen.getByLabelText('Email', { exact: false });
+      expect(input).toHaveClass('h-9');
+      expect(input).toHaveClass('px-3');
+    });
+
+    it('lets an explicit variant override the readOnly default', () => {
+      render(
+        <Input
+          label="Plan"
+          readOnly
+          variant="default"
+          defaultValue="Enterprise"
+        />,
+      );
+      const input = screen.getByLabelText('Plan', { exact: false });
+      expect(input.className).toContain('--color-border-input');
+    });
+
+    it('still forwards the readOnly attribute to the input', () => {
+      render(<Input label="Plan" readOnly defaultValue="Enterprise" />);
+      const input = screen.getByLabelText('Plan', { exact: false });
+      expect(input).toHaveAttribute('readonly');
+    });
   });
 
   describe('password input', () => {

--- a/services/platform/app/components/ui/forms/input.test.tsx
+++ b/services/platform/app/components/ui/forms/input.test.tsx
@@ -81,6 +81,29 @@ describe('Input', () => {
       const input = screen.getByLabelText('Plan', { exact: false });
       expect(input).toHaveAttribute('readonly');
     });
+
+    // The password/sensitive path is a separate render branch (it adds the eye
+    // toggle); the borderless variant must still resolve there so a read-only
+    // secret reads as text yet keeps the toggle.
+    it('applies the borderless variant on the password/toggle render path', () => {
+      render(
+        <Input
+          label="API key"
+          type="password"
+          readOnly
+          defaultValue="sk-secret"
+        />,
+      );
+      const input = screen.getByLabelText('API key', { exact: false });
+      expect(input).toHaveClass('bg-transparent');
+      expect(input).toHaveClass('h-9');
+      expect(input).toHaveAttribute('readonly');
+      expect(input.className).not.toContain('--color-border-input');
+      // The reveal toggle still renders alongside the read-only field.
+      expect(
+        screen.getByRole('button', { name: /show password/i }),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('password input', () => {

--- a/services/platform/app/components/ui/forms/input.tsx
+++ b/services/platform/app/components/ui/forms/input.tsx
@@ -29,6 +29,12 @@ const inputVariants = cva(
         default:
           'rounded-lg border border-transparent bg-input px-3 py-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-1 ring-[color:var(--color-border-input)] focus-visible:ring-primary',
         unstyled: 'bg-transparent border-0 ring-0 ring-offset-0',
+        // Borderless, text-like display for values the user cannot edit in
+        // context. Keeps the field's footprint (`h-9` from the base + the same
+        // `border`/`px`/`py` box as `default`) so toggling editable ↔ read-only
+        // causes no layout shift; just drops the visible ring + filled bg.
+        readOnly:
+          'rounded-lg border border-transparent bg-transparent px-3 py-2 ring-0 ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0',
       },
     },
     defaultVariants: {
@@ -88,6 +94,11 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
     const errorId = `${id}-error`;
     const descriptionId = `${id}-description`;
     const isPassword = type === 'password';
+    // A native `readOnly` input auto-selects the borderless display variant
+    // (transparent, no ring) unless the caller pins an explicit `variant`, so
+    // informational values render as text with no layout shift vs. editing.
+    const resolvedVariant =
+      variant ?? (props.readOnly ? 'readOnly' : undefined);
     const [show, setShow] = useState(false);
     const [showShake, setShowShake] = useState(false);
 
@@ -184,7 +195,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
               type={inputType}
               {...sensitiveAttrs}
               className={cn(
-                inputVariants({ variant }),
+                inputVariants({ variant: resolvedVariant }),
                 showInvalid &&
                   'border-destructive focus-visible:ring-destructive',
                 showShake && 'animate-shake',
@@ -254,7 +265,7 @@ const InputBase = forwardRef<HTMLInputElement, BaseProps>(
           type={inputType}
           {...sensitiveAttrs}
           className={cn(
-            inputVariants({ variant }),
+            inputVariants({ variant: resolvedVariant }),
             showInvalid && 'border-destructive focus-visible:ring-destructive',
             showShake && 'animate-shake',
             className,

--- a/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
+++ b/services/platform/app/features/settings/organization/components/member-edit-dialog.tsx
@@ -212,8 +212,8 @@ export function EditMemberDialog({
           label={t('form.email')}
           placeholder={t('form.emailPlaceholder')}
           {...register('email')}
-          className="bg-muted w-full"
-          disabled
+          className="w-full"
+          readOnly
           required
         />
         <Text variant="caption">{t('organization.emailCannotChange')}</Text>

--- a/services/platform/app/features/websites/components/website-edit-dialog.tsx
+++ b/services/platform/app/features/websites/components/website-edit-dialog.tsx
@@ -116,7 +116,7 @@ export function EditWebsiteDialog({
         id="domain"
         label={tWebsites('domain')}
         value={website.domain}
-        disabled
+        readOnly
       />
 
       <Select


### PR DESCRIPTION
Resolves #1942.

## What
- Add a `readOnly` visual variant to the platform `Input` (`services/platform/app/components/ui/forms/input.tsx`): transparent background, no border/ring, but the **same `h-9` height and `px-3 py-2` box** as the editable `default` variant — so toggling editable ↔ read-only causes **no layout shift**. A native `readOnly` input auto-selects this variant unless the caller pins an explicit `variant`.
- Replace the **display-only disabled** email field in the member edit dialog (value cannot change in context) with the read-only variant, dropping its bespoke `bg-muted` so it reads as text rather than a dimmed disabled control. `disabled` is kept only for *temporarily-unavailable* controls.

## Audit
All form primitives (`Input`, `Select` trigger, `@tale/ui` input) already measure **36px (`h-9`)** in every state — disabled included — so no height normalization was required.

## Acceptance criteria
- [x] All form controls measure 36px tall in every state.
- [x] Display-only values render borderless and text-like, with no layout shift vs. their editable state.
- [x] Storybook stories (`ReadOnly`, `States`) demonstrate editable vs. read-only vs. disabled.

## Verification
- `bun run vitest run app/components/ui/forms/input.test.tsx` → 36 passed (new read-only display variant tests included).
- `bun run typecheck` → green.
- `oxlint` on changed files → 0 warnings/errors.

No user-facing strings changed → docs/i18n N/A.