### PR TITLE
fix: Settings low-severity gaps (custom-instructions parity, last-member refusal, Disconnect loading, dead ?section=apps, MCP name validation) (#2091)

### DIFF
--- a/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.test.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@/tests/utils/render';
+
+import { IntegrationPanel } from './integration-panel';
+
+// Convex action used to lazy-load connector code on open — no-op here. The
+// returned function must be stable across renders, otherwise the panel's
+// connector-load effect (which depends on it) re-runs every render.
+const readIntegrationFn = vi.fn().mockResolvedValue({ ok: false });
+vi.mock('convex/react', () => ({
+  useAction: () => readIntegrationFn,
+}));
+
+// Heavy child sections rely on Convex queries; they are irrelevant to the
+// disconnect loading state, so stub them out.
+vi.mock('./integration-details', () => ({
+  IntegrationDetails: () => null,
+}));
+vi.mock('./integration-manage/integration-active-view', () => ({
+  IntegrationActiveView: () => null,
+}));
+vi.mock('./integration-manage/integration-credentials-form-connected', () => ({
+  IntegrationCredentialsFormConnected: () => null,
+}));
+vi.mock('./integration-manage/integration-icon-upload', () => ({
+  IntegrationIconUpload: () => null,
+}));
+vi.mock('./integration-manage/integration-update-section', () => ({
+  IntegrationUpdateSection: () => null,
+}));
+vi.mock('./integration-manage/slack-notification-config', () => ({
+  SlackNotificationConfig: () => null,
+}));
+
+// Render the sheet shell inline so its footer (the Disconnect button) is in
+// the DOM; the ConfirmDialog is a sibling of the sheet, so it is unaffected.
+vi.mock('@/app/components/ui/overlays/sheet', () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sheet">{children}</div>
+  ),
+}));
+
+vi.mock('../hooks/use-integration-manage', () => ({
+  useIntegrationManage: vi.fn(),
+}));
+
+import { useIntegrationManage } from '../hooks/use-integration-manage';
+
+// Captured resolver for the in-flight disconnect promise — lets the test hold
+// the disconnect "open" and then release it.
+let resolveDisconnect: (() => void) | undefined;
+
+const baseManage = {
+  isActive: true,
+  busy: false,
+  isSubmitting: false,
+  iconUrl: null,
+  isSql: false,
+  isUploadingIcon: false,
+  iconInputRef: { current: null },
+  operationCount: 0,
+  handleOpenChange: vi.fn(),
+  handleIconUpload: vi.fn(),
+  testResult: null,
+  setTestResult: vi.fn(),
+  handleTestConnection: vi.fn(),
+  handleReauthorize: vi.fn(),
+  hasOAuth2Config: false,
+  hasOAuth2Credentials: false,
+  parsedUpdate: null,
+  setParsedUpdate: vi.fn(),
+  isParsingUpdate: false,
+  isApplyingUpdate: false,
+  updateParseError: null,
+  setUpdateParseError: vi.fn(),
+  handleUpdateFilesSelected: vi.fn(),
+  handleApplyUpdate: vi.fn(),
+  confirmDelete: false,
+  setConfirmDelete: vi.fn(),
+  handleUninstall: vi.fn(),
+  selectedAuthMethod: 'api_key',
+  hasChanges: false,
+  isTesting: false,
+  isSavingOAuth2: false,
+  editableConfigFields: [],
+};
+
+// A stand-in for useIntegrationManage that exercises the real isSubmitting
+// lifecycle: handleDisconnect flips it true, awaits a controllable promise,
+// then flips it false in a finally (mirroring the production hook).
+function useManageMock() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleDisconnect = useCallback(() => {
+    setIsSubmitting(true);
+    return new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    }).finally(() => setIsSubmitting(false));
+  }, []);
+  return { ...baseManage, isSubmitting, busy: isSubmitting, handleDisconnect };
+}
+
+const integration = {
+  _id: 'cred-1',
+  title: 'Shopify',
+  name: 'shopify',
+  description: 'Sync products.',
+  organizationId: 'org-1',
+  authMethod: 'api_key',
+  isActive: true,
+} as Parameters<typeof IntegrationPanel>[0]['integration'];
+
+function renderPanel() {
+  return render(
+    <IntegrationPanel
+      open
+      onOpenChange={vi.fn()}
+      integration={integration}
+      organizationId="org-1"
+    />,
+  );
+}
+
+describe('IntegrationPanel — disconnect loading state', () => {
+  beforeEach(() => {
+    resolveDisconnect = undefined;
+    // The mock returns only the slice the panel reads; cast past the full hook
+    // shape (52+ fields) which is irrelevant to the disconnect loading state.
+    vi.mocked(useIntegrationManage).mockImplementation(useManageMock as never);
+  });
+
+  it('shows the dialog loading state and keeps it open until the disconnect resolves', async () => {
+    renderPanel();
+
+    const sheet = screen.getByTestId('sheet');
+    // Footer Disconnect button is idle before any action.
+    expect(within(sheet).getByText('Disconnect')).toBeInTheDocument();
+    expect(
+      within(sheet).queryByText('Disconnecting...'),
+    ).not.toBeInTheDocument();
+
+    // Open the confirmation dialog.
+    fireEvent.click(within(sheet).getByText('Disconnect'));
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText('Disconnect integration'),
+    ).toBeInTheDocument();
+    const confirmButton = within(dialog).getByRole('button', {
+      name: 'Disconnect',
+    });
+    expect(confirmButton).not.toBeDisabled();
+
+    // Confirm: the disconnect is now in flight (promise not yet resolved).
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    // Dialog stays open and shows its loading state, confirm button disabled.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const loadingConfirm = within(screen.getByRole('dialog')).getByRole(
+      'button',
+      { name: 'Loading...' },
+    );
+    expect(loadingConfirm).toBeDisabled();
+
+    // Footer Disconnect button reflects isSubmitting (spinner + label).
+    expect(
+      within(screen.getByTestId('sheet')).getByText('Disconnecting...'),
+    ).toBeInTheDocument();
+
+    // Resolve the in-flight disconnect → dialog closes.
+    await act(async () => {
+      resolveDisconnect?.();
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(
+      within(screen.getByTestId('sheet')).queryByText('Disconnecting...'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/integrations/components/integration-panel.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-panel.tsx
@@ -281,8 +281,12 @@ export function IntegrationPanel({
         confirmText={t('integrations.disconnect')}
         isLoading={manage.isSubmitting}
         onConfirm={() => {
-          void manage.handleDisconnect();
-          setConfirmDisconnect(false);
+          // Keep the dialog open (and showing its loading state) until the
+          // disconnect resolves; `handleDisconnect` swallows its own errors
+          // and surfaces a toast, so closing afterwards is always safe.
+          void manage.handleDisconnect().finally(() => {
+            setConfirmDisconnect(false);
+          });
         }}
       />
 

--- a/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
+++ b/services/platform/app/features/settings/integrations/hooks/use-integration-manage.ts
@@ -197,7 +197,7 @@ export function useIntegrationManage(
   const { mutateAsync: generateOAuth2Url } = useGenerateIntegrationOAuth2Url();
   const { mutateAsync: saveOAuth2Credentials } = useSaveOAuth2Credentials();
 
-  const isSubmitting = false;
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const hasOAuth2Config = !!integration.oauth2Config;
 
@@ -724,6 +724,7 @@ export function useIntegrationManage(
   ]);
 
   const handleDisconnect = useCallback(async () => {
+    setIsSubmitting(true);
     try {
       await updateCredentials({
         credentialId: toId<'integrationCredentials'>(integration._id),
@@ -752,6 +753,8 @@ export function useIntegrationManage(
               }),
         variant: 'destructive',
       });
+    } finally {
+      setIsSubmitting(false);
     }
   }, [updateCredentials, integration, t]);
 

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-server-form.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-server-form.tsx
@@ -8,6 +8,10 @@ import { FormSection } from '@/app/components/ui/forms/form-section';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import {
+  MCP_SERVER_NAME_MAX_LENGTH,
+  MCP_SERVER_NAME_RE,
+} from '@/convex/mcp_servers/constants';
 import { useT } from '@/lib/i18n/client';
 import { isHttpUrl } from '@/lib/utils/url';
 
@@ -133,10 +137,15 @@ export function McpServerForm({
   const validate = useCallback((): boolean => {
     const newErrors: FormErrors = {};
 
-    if (!name.trim()) {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
       newErrors.name = t('form.validation.nameRequired');
-    } else if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(name) && name.length > 1) {
-      newErrors.name = t('form.validation.nameFormat');
+    } else if (trimmedName.length > MCP_SERVER_NAME_MAX_LENGTH) {
+      newErrors.name = t('form.validation.nameTooLong', {
+        max: MCP_SERVER_NAME_MAX_LENGTH,
+      });
+    } else if (!MCP_SERVER_NAME_RE.test(trimmedName)) {
+      newErrors.name = t('form.validation.nameInvalid');
     }
 
     if (!displayName.trim()) {

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-server-panel.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-server-panel.tsx
@@ -26,6 +26,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
+import { convexErrorMessage } from '@/lib/utils/convex-error';
 
 import { type McpServerFormData, McpServerForm } from './mcp-server-form';
 import type { McpServerListItem } from './types';
@@ -115,6 +116,7 @@ export function McpServerPanel({
         console.error('[mcp-server-panel] update failed', err);
         toast({
           title: t('error'),
+          description: convexErrorMessage(err, '') || undefined,
           variant: 'destructive',
         });
       } finally {

--- a/services/platform/app/features/settings/mcp-servers/components/mcp-servers.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-servers.tsx
@@ -15,6 +15,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
+import { convexErrorMessage } from '@/lib/utils/convex-error';
 
 import { useMcpServers } from '../hooks/use-mcp-servers';
 import { McpServerCard } from './mcp-server-card';
@@ -69,8 +70,12 @@ export function McpServers({
         toast({ title: t('saved'), variant: 'success' });
         onAddDialogOpenChange(false);
         void refetch();
-      } catch {
-        toast({ title: t('error'), variant: 'destructive' });
+      } catch (error) {
+        toast({
+          title: t('error'),
+          description: convexErrorMessage(error, '') || undefined,
+          variant: 'destructive',
+        });
       } finally {
         setIsCreating(false);
       }

--- a/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/personalization-settings.tsx
@@ -32,6 +32,10 @@ import { useOrganizationId } from '@/app/hooks/use-organization-id';
 import { useToast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import type { Doc } from '@/convex/_generated/dataModel';
+import {
+  CUSTOM_INSTRUCTIONS_ILLEGAL_RE,
+  CUSTOM_INSTRUCTIONS_MAX_CHARS,
+} from '@/convex/user_memories/constants';
 import { useT } from '@/lib/i18n/client';
 import { convexErrorMessage } from '@/lib/utils/convex-error';
 import { isRecord } from '@/lib/utils/type-utils';
@@ -46,7 +50,11 @@ import {
   useUpsertMyPreferences,
 } from '../hooks/mutations';
 
-const CUSTOM_INSTRUCTIONS_MAX_CHARS = 4000;
+// Canonicalize line endings to LF, matching the backend before it length- /
+// illegal-char-checks `customInstructions` (convex/user_preferences/mutations).
+function normalizeInstructions(value: string): string {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
 
 /**
  * Module-level capability-probe cache keyed by `organizationId`.
@@ -383,9 +391,35 @@ function CustomInstructionsSection({
   const schema = useMemo(
     () =>
       z.object({
-        customInstructions: z.string().max(CUSTOM_INSTRUCTIONS_MAX_CHARS),
+        // Mirror the backend rule (user_preferences/mutations.ts): canonicalize
+        // CRLF / lone CR → LF the same way before checking length and the
+        // illegal-character set, so the client can't submit a value the server
+        // will bounce with no inline feedback. Normalization happens inside the
+        // checks (not via `.transform`) to leave the form's stored value — and
+        // its dirty/baseline tracking — untouched.
+        customInstructions: z
+          .string()
+          .refine(
+            (s) =>
+              normalizeInstructions(s).length <= CUSTOM_INSTRUCTIONS_MAX_CHARS,
+            {
+              message: t('errors.tooLong', {
+                max: CUSTOM_INSTRUCTIONS_MAX_CHARS,
+              }),
+            },
+          )
+          .refine(
+            (s) => {
+              const normalized = normalizeInstructions(s);
+              return (
+                normalized.length === 0 ||
+                !CUSTOM_INSTRUCTIONS_ILLEGAL_RE.test(normalized)
+              );
+            },
+            { message: t('errors.illegalChars') },
+          ),
       }),
-    [],
+    [t],
   );
 
   const data = useMemo<CustomInstructionsForm | undefined>(
@@ -424,7 +458,11 @@ function CustomInstructionsSection({
   useRegisterActiveEditor(editor);
 
   const {
-    form: { register, watch },
+    form: {
+      register,
+      watch,
+      formState: { errors },
+    },
   } = editor;
   const value = watch('customInstructions') ?? '';
 
@@ -437,6 +475,7 @@ function CustomInstructionsSection({
       <Textarea
         placeholder={t('page.customInstructions.placeholder')}
         rows={5}
+        errorMessage={errors.customInstructions?.message}
         {...register('customInstructions')}
       />
       <Text className="text-muted-foreground text-xs">

--- a/services/platform/app/features/settings/teams/components/team-edit-dialog.tsx
+++ b/services/platform/app/features/settings/teams/components/team-edit-dialog.tsx
@@ -208,6 +208,7 @@ export function TeamEditDialog({
         organizationId={organizationId}
         selectedMemberIds={selectedMemberIds}
         onToggleMember={handleToggleMember}
+        enforceMinimumOne
       />
     </FormDialog>
   );

--- a/services/platform/app/features/settings/teams/components/team-member-checklist.test.tsx
+++ b/services/platform/app/features/settings/teams/components/team-member-checklist.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen, within } from '@/tests/utils/render';
+
+import { TeamMemberChecklist } from './team-member-checklist';
+
+const mockUseMembers = vi.fn();
+
+vi.mock('../../organization/hooks/queries', () => ({
+  useMembers: (organizationId: string) => mockUseMembers(organizationId),
+}));
+
+const MEMBERS = [
+  { userId: 'user-1', displayName: 'Alice', email: 'alice@example.com' },
+  { userId: 'user-2', displayName: 'Bob', email: 'bob@example.com' },
+];
+
+function setMembers(members: typeof MEMBERS, isLoading = false) {
+  mockUseMembers.mockReturnValue({ members, isLoading });
+}
+
+/** Find the checkbox control rendered inside the label that shows `name`. */
+function checkboxFor(name: string): HTMLElement {
+  const label = screen.getByText(name).closest('label');
+  if (!label) throw new Error(`No label found for ${name}`);
+  return within(label).getByRole('checkbox');
+}
+
+describe('TeamMemberChecklist', () => {
+  describe('accessibility', () => {
+    it('passes axe audit', async () => {
+      setMembers(MEMBERS);
+      const { container } = render(
+        <TeamMemberChecklist
+          organizationId="org-1"
+          selectedMemberIds={new Set(['user-1'])}
+          onToggleMember={vi.fn()}
+        />,
+      );
+      await checkAccessibility(container);
+    });
+  });
+
+  it('disables only the sole selected member and shows the hint when enforced', () => {
+    setMembers(MEMBERS);
+    render(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set(['user-1'])}
+        onToggleMember={vi.fn()}
+        enforceMinimumOne
+      />,
+    );
+
+    // The only remaining member cannot be unchecked.
+    expect(checkboxFor('Alice')).toBeDisabled();
+    // Unselected members stay toggleable so members can still be added.
+    expect(checkboxFor('Bob')).not.toBeDisabled();
+
+    // The constraint is surfaced as a persistent hint (not a silent refusal).
+    expect(
+      screen.getByText(/A team must keep at least one member/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not disable any checkbox when more than one member is selected', () => {
+    setMembers(MEMBERS);
+    render(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set(['user-1', 'user-2'])}
+        onToggleMember={vi.fn()}
+        enforceMinimumOne
+      />,
+    );
+
+    expect(checkboxFor('Alice')).not.toBeDisabled();
+    expect(checkboxFor('Bob')).not.toBeDisabled();
+    expect(
+      screen.queryByText(/A team must keep at least one member/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('never enforces the minimum-one constraint in create mode (default)', () => {
+    setMembers(MEMBERS);
+    // Create flow: 0 selected is valid (current user is auto-added) and the
+    // sole selected member must stay uncheckable so the user can return to 0.
+    const { rerender } = render(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set()}
+        onToggleMember={vi.fn()}
+      />,
+    );
+
+    // With nothing selected, no misleading "delete the team instead" hint.
+    expect(
+      screen.queryByText(/A team must keep at least one member/i),
+    ).not.toBeInTheDocument();
+
+    // With exactly one selected, its checkbox stays toggleable (not disabled)
+    // and the hint is still absent.
+    rerender(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set(['user-1'])}
+        onToggleMember={vi.fn()}
+      />,
+    );
+
+    expect(checkboxFor('Alice')).not.toBeDisabled();
+    expect(checkboxFor('Bob')).not.toBeDisabled();
+    expect(
+      screen.queryByText(/A team must keep at least one member/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('toggles a member when an enabled checkbox is clicked', async () => {
+    setMembers(MEMBERS);
+    const onToggleMember = vi.fn();
+    const { user } = render(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set(['user-1'])}
+        onToggleMember={onToggleMember}
+      />,
+    );
+
+    await user.click(checkboxFor('Bob'));
+    expect(onToggleMember).toHaveBeenCalledWith('user-2');
+  });
+
+  it('renders a loading state while members are fetching', () => {
+    setMembers([], true);
+    render(
+      <TeamMemberChecklist
+        organizationId="org-1"
+        selectedMemberIds={new Set()}
+        onToggleMember={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
+++ b/services/platform/app/features/settings/teams/components/team-member-checklist.tsx
@@ -17,15 +17,29 @@ interface TeamMemberChecklistProps {
   organizationId: string;
   selectedMemberIds: Set<string>;
   onToggleMember: (userId: string) => void;
+  /**
+   * Enforce the "a team must keep at least one member" constraint (disable the
+   * sole selected member's checkbox + show the hint). Only the edit flow needs
+   * this; the create flow allows 0 selected (the current user is auto-added),
+   * so it must stay off there.
+   */
+  enforceMinimumOne?: boolean;
 }
 
 export function TeamMemberChecklist({
   organizationId,
   selectedMemberIds,
   onToggleMember,
+  enforceMinimumOne = false,
 }: TeamMemberChecklistProps) {
   const { t: tSettings } = useT('settings');
   const { members: orgMembers, isLoading } = useMembers(organizationId);
+
+  // A team must keep at least one member (the backend rejects removing the
+  // last one), so the sole remaining selected member's checkbox is disabled
+  // rather than silently refusing the click with no feedback. Only enforced in
+  // the edit flow — the create flow permits 0 selected members.
+  const isLastMember = enforceMinimumOne && selectedMemberIds.size <= 1;
 
   if (isLoading) {
     return (
@@ -59,16 +73,25 @@ export function TeamMemberChecklist({
         {orgMembers.map((member: MemberOption, index: number) => {
           const isLast = index === orgMembers.length - 1;
           const isChecked = selectedMemberIds.has(member.userId);
+          // Block unchecking the only remaining member — keeping a team
+          // memberless is rejected server-side.
+          const disableUncheck = isChecked && isLastMember;
 
           return (
             <label
               key={member.userId}
-              className={`hover:bg-muted/50 flex cursor-pointer items-center gap-2.5 px-3 py-2.5 transition-colors ${
-                !isLast ? 'border-border border-b' : ''
-              }`}
+              className={`flex items-center gap-2.5 px-3 py-2.5 transition-colors ${
+                disableUncheck
+                  ? 'cursor-not-allowed'
+                  : 'hover:bg-muted/50 cursor-pointer'
+              } ${!isLast ? 'border-border border-b' : ''}`}
+              title={
+                disableUncheck ? tSettings('teams.lastMemberHint') : undefined
+              }
             >
               <Checkbox
                 checked={isChecked}
+                disabled={disableUncheck}
                 onCheckedChange={() => onToggleMember(member.userId)}
               />
               <span className="flex items-center gap-2">
@@ -89,6 +112,11 @@ export function TeamMemberChecklist({
           );
         })}
       </div>
+      {isLastMember && (
+        <p className="text-muted-foreground text-xs">
+          {tSettings('teams.lastMemberHint')}
+        </p>
+      )}
     </Stack>
   );
 }

--- a/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/integrations.tsx
@@ -25,7 +25,9 @@ import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
 const searchSchema = z.object({
-  section: z.enum(['apps', 'mcp-servers']).optional(),
+  // Only `mcp-servers` is handled (redirected to the MCP page in
+  // `beforeLoad`). `apps` was never read, so it isn't accepted.
+  section: z.literal('mcp-servers').optional(),
   tab: z.string().optional(),
   slug: z.string().optional(),
   integration_oauth2: z.string().optional(),

--- a/services/platform/convex/mcp_servers/constants.test.ts
+++ b/services/platform/convex/mcp_servers/constants.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MCP_SERVER_NAME_MAX_LENGTH,
+  MCP_SERVER_NAME_RE,
+  validateMcpServerName,
+} from './constants';
+
+describe('validateMcpServerName', () => {
+  it('accepts lowercase alphanumeric slugs with hyphens', () => {
+    expect(validateMcpServerName('my-mcp-server')).toBeNull();
+    expect(validateMcpServerName('server1')).toBeNull();
+    expect(validateMcpServerName('a-b-c')).toBeNull();
+  });
+
+  it('accepts a single valid character (no length carve-out)', () => {
+    expect(validateMcpServerName('a')).toBeNull();
+    expect(validateMcpServerName('1')).toBeNull();
+  });
+
+  it('rejects a single uppercase character', () => {
+    // The old client guard skipped validation for length-1 names, so "A"
+    // slipped through; it must now be rejected.
+    expect(validateMcpServerName('A')).toBe('invalid_format');
+  });
+
+  it('trims before validating and rejects an empty/whitespace name', () => {
+    expect(validateMcpServerName('')).toBe('required');
+    expect(validateMcpServerName('   ')).toBe('required');
+    expect(validateMcpServerName('  good-name  ')).toBeNull();
+  });
+
+  it('rejects uppercase, leading/trailing hyphens, and illegal symbols', () => {
+    expect(validateMcpServerName('My-Server')).toBe('invalid_format');
+    expect(validateMcpServerName('-leading')).toBe('invalid_format');
+    expect(validateMcpServerName('trailing-')).toBe('invalid_format');
+    expect(validateMcpServerName('has space')).toBe('invalid_format');
+    expect(validateMcpServerName('under_score')).toBe('invalid_format');
+  });
+
+  it('rejects names longer than the max length', () => {
+    expect(
+      validateMcpServerName('a'.repeat(MCP_SERVER_NAME_MAX_LENGTH + 1)),
+    ).toBe('too_long');
+    expect(
+      validateMcpServerName('a'.repeat(MCP_SERVER_NAME_MAX_LENGTH)),
+    ).toBeNull();
+  });
+
+  it('exposes a regex consistent with the validator', () => {
+    expect(MCP_SERVER_NAME_RE.test('valid-name')).toBe(true);
+    expect(MCP_SERVER_NAME_RE.test('Invalid')).toBe(false);
+  });
+});

--- a/services/platform/convex/mcp_servers/constants.ts
+++ b/services/platform/convex/mcp_servers/constants.ts
@@ -1,0 +1,24 @@
+// Shared MCP-server "Name" (slug) rules. Imported by both the client form
+// (services/platform/app/features/settings/mcp-servers) and the server-side
+// create/update actions so validation can't drift between the two.
+
+export const MCP_SERVER_NAME_MAX_LENGTH = 64;
+
+// Lowercase alphanumeric, hyphen-separated. A single character is valid; a
+// leading/trailing hyphen, uppercase letter, or any other symbol is not.
+export const MCP_SERVER_NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Validate an MCP-server name. Returns `null` when valid, otherwise a stable
+ * machine code describing the first violation. Callers map the code to a
+ * localized (client) or human-readable (server) message.
+ */
+export function validateMcpServerName(
+  name: string,
+): 'required' | 'too_long' | 'invalid_format' | null {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return 'required';
+  if (trimmed.length > MCP_SERVER_NAME_MAX_LENGTH) return 'too_long';
+  if (!MCP_SERVER_NAME_RE.test(trimmed)) return 'invalid_format';
+  return null;
+}

--- a/services/platform/convex/mcp_servers/internal_queries.ts
+++ b/services/platform/convex/mcp_servers/internal_queries.ts
@@ -12,6 +12,26 @@ export const getById = internalQuery({
   },
 });
 
+// Look up an MCP server by its (organizationId, name) pair so the create /
+// update actions can enforce per-org name uniqueness. Returns the `_id` of the
+// matching server (or null) — callers compare it against the row being edited.
+export const getIdByOrgAndName = internalQuery({
+  args: {
+    organizationId: v.string(),
+    name: v.string(),
+  },
+  returns: v.union(v.id('mcpServers'), v.null()),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query('mcpServers')
+      .withIndex('by_org_name', (q) =>
+        q.eq('organizationId', args.organizationId).eq('name', args.name),
+      )
+      .first();
+    return existing?._id ?? null;
+  },
+});
+
 export const listActiveByOrg = internalQuery({
   args: {
     organizationId: v.string(),

--- a/services/platform/convex/mcp_servers/mutations.test.ts
+++ b/services/platform/convex/mcp_servers/mutations.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      optional: stub,
+      union: stub,
+      object: stub,
+      literal: stub,
+      array: stub,
+      boolean: stub,
+      number: stub,
+      id: stub,
+      null: stub,
+      any: stub,
+    },
+  };
+});
+
+vi.mock('../lib/validators/json', () => ({
+  jsonRecordValidator: 'jsonRecordValidator',
+}));
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+type HandlerFn = (
+  ctx: never,
+  args: Record<string, unknown>,
+) => Promise<unknown>;
+
+describe('mcp_servers/mutations (internal)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('insert', () => {
+    it('inserts a new MCP server record', async () => {
+      const ctx = {
+        db: {
+          insert: vi.fn().mockResolvedValue('server_new'),
+        },
+      };
+
+      const { insert } = await import('./mutations');
+      const handler = (insert as unknown as { handler: HandlerFn }).handler;
+      const result = await handler(ctx as never, {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        description: 'A test server',
+        transportType: 'streamable_http',
+        url: 'https://example.com/mcp',
+        authType: 'none',
+        status: 'inactive',
+      });
+
+      expect(ctx.db.insert).toHaveBeenCalledWith('mcpServers', {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        description: 'A test server',
+        transportType: 'streamable_http',
+        url: 'https://example.com/mcp',
+        authType: 'none',
+        status: 'inactive',
+      });
+      expect(result).toBe('server_new');
+    });
+
+    it('inserts with encrypted API key', async () => {
+      const ctx = {
+        db: {
+          insert: vi.fn().mockResolvedValue('server_new'),
+        },
+      };
+
+      const { insert } = await import('./mutations');
+      const handler = (insert as unknown as { handler: HandlerFn }).handler;
+      await handler(ctx as never, {
+        organizationId: 'org_1',
+        name: 'api-key-server',
+        displayName: 'API Key Server',
+        transportType: 'sse',
+        url: 'https://example.com/sse',
+        authType: 'api_key',
+        apiKeyEncrypted: 'encrypted-key-value',
+        status: 'inactive',
+      });
+
+      expect(ctx.db.insert).toHaveBeenCalledWith(
+        'mcpServers',
+        expect.objectContaining({
+          authType: 'api_key',
+          apiKeyEncrypted: 'encrypted-key-value',
+        }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('patches an existing server', async () => {
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue({ _id: 'server_1', name: 'old' }),
+          patch: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+
+      const { update } = await import('./mutations');
+      const handler = (update as unknown as { handler: HandlerFn }).handler;
+      const result = await handler(ctx as never, {
+        id: 'server_1',
+        displayName: 'Updated Server',
+      });
+
+      expect(ctx.db.patch).toHaveBeenCalledWith('server_1', {
+        displayName: 'Updated Server',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('throws when server not found', async () => {
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(null),
+          patch: vi.fn(),
+        },
+      };
+
+      const { update } = await import('./mutations');
+      const handler = (update as unknown as { handler: HandlerFn }).handler;
+      await expect(
+        handler(ctx as never, {
+          id: 'nonexistent',
+          displayName: 'Updated',
+        }),
+      ).rejects.toThrow('MCP server not found');
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes an existing server', async () => {
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue({ _id: 'server_1' }),
+          delete: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+
+      const { remove } = await import('./mutations');
+      const handler = (remove as unknown as { handler: HandlerFn }).handler;
+      const result = await handler(ctx as never, {
+        id: 'server_1',
+      });
+
+      expect(ctx.db.delete).toHaveBeenCalledWith('server_1');
+      expect(result).toBeNull();
+    });
+
+    it('throws when server not found', async () => {
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(null),
+          delete: vi.fn(),
+        },
+      };
+
+      const { remove } = await import('./mutations');
+      const handler = (remove as unknown as { handler: HandlerFn }).handler;
+      await expect(
+        handler(ctx as never, {
+          id: 'nonexistent',
+        }),
+      ).rejects.toThrow('MCP server not found');
+    });
+  });
+
+  describe('setStatus', () => {
+    it('updates status to active', async () => {
+      const ctx = {
+        db: {
+          get: vi
+            .fn()
+            .mockResolvedValue({ _id: 'server_1', status: 'inactive' }),
+          patch: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+
+      const { setStatus } = await import('./mutations');
+      const handler = (setStatus as unknown as { handler: HandlerFn }).handler;
+      const result = await handler(ctx as never, {
+        id: 'server_1',
+        status: 'active',
+      });
+
+      expect(ctx.db.patch).toHaveBeenCalledWith('server_1', {
+        status: 'active',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('throws when server not found', async () => {
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(null),
+          patch: vi.fn(),
+        },
+      };
+
+      const { setStatus } = await import('./mutations');
+      const handler = (setStatus as unknown as { handler: HandlerFn }).handler;
+      await expect(
+        handler(ctx as never, {
+          id: 'nonexistent',
+          status: 'active',
+        }),
+      ).rejects.toThrow('MCP server not found');
+    });
+  });
+});

--- a/services/platform/convex/mcp_servers/public_mutations.test.ts
+++ b/services/platform/convex/mcp_servers/public_mutations.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('convex/values', () => {
+// Mock-ctx idiom (see tasks/public_actions.test.ts): the generated server
+// wrapper returns its config so `.handler` is callable; api/internal refs become
+// string sentinels the fake ctx dispatches on; auth + crypto are no-ops.
+//
+// `convex/values` keeps the real `ConvexError` (the actions throw it and the
+// tests assert on its `.data`) while stubbing the `v` validators that only run
+// at module-load time.
+vi.mock('convex/values', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
   const stub = () => 'validator';
   return {
+    ...mod,
     v: {
       string: stub,
       optional: stub,
@@ -25,204 +34,182 @@ vi.mock('../lib/validators/json', () => ({
 
 vi.mock('../_generated/server', async (importOriginal) => {
   const mod = await importOriginal<Record<string, unknown>>();
-  return {
-    ...mod,
-    internalMutation: (config: Record<string, unknown>) => config,
-  };
+  return { ...mod, action: (config: Record<string, unknown>) => config };
 });
 
+vi.mock('../_generated/api', () => ({
+  internal: {
+    mcp_servers: {
+      internal_queries: {
+        getById: 'getById',
+        getIdByOrgAndName: 'getIdByOrgAndName',
+      },
+      mutations: {
+        insert: 'insert',
+        update: 'update',
+      },
+    },
+  },
+}));
+
+vi.mock('../lib/crypto/encrypt_string', () => ({
+  encryptString: vi.fn(async (value: string) => `encrypted:${value}`),
+}));
+
+const getAuthUserIdentity = vi.fn(async () => ({ userId: 'user_1' }));
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (_ctx: unknown) => getAuthUserIdentity(),
+}));
+
 type HandlerFn = (
-  ctx: never,
+  ctx: unknown,
   args: Record<string, unknown>,
 ) => Promise<unknown>;
 
-describe('mcp_servers/mutations (internal)', () => {
+function createCtx(opts: {
+  // _id returned by getIdByOrgAndName for the (org, name) lookup.
+  duplicateId?: string | null;
+  // row returned by getById (update only).
+  existing?: { _id: string; organizationId: string } | null;
+}) {
+  const mutationCalls: Array<{ ref: unknown; args: Record<string, unknown> }> =
+    [];
+  const ctx = {
+    auth: { getUserIdentity: vi.fn() },
+    runQuery: vi.fn(async (ref: unknown) => {
+      if (ref === 'getIdByOrgAndName') return opts.duplicateId ?? null;
+      if (ref === 'getById')
+        return opts.existing === undefined ? null : opts.existing;
+      return null;
+    }),
+    runMutation: vi.fn(async (ref: unknown, args: Record<string, unknown>) => {
+      mutationCalls.push({ ref, args });
+      if (ref === 'insert') return 'server_new';
+      return null;
+    }),
+  };
+  return { ctx, mutationCalls };
+}
+
+describe('mcp_servers/public_mutations (actions)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getAuthUserIdentity.mockResolvedValue({ userId: 'user_1' });
   });
 
-  describe('insert', () => {
-    it('inserts a new MCP server record', async () => {
-      const ctx = {
-        db: {
-          insert: vi.fn().mockResolvedValue('server_new'),
-        },
-      };
+  describe('create', () => {
+    const baseArgs = {
+      organizationId: 'org_1',
+      displayName: 'My Server',
+      transportType: 'streamable_http' as const,
+      url: 'https://example.com/mcp',
+      authType: 'none' as const,
+    };
 
-      const { insert } = await import('./mutations');
-      const handler = (insert as unknown as { handler: HandlerFn }).handler;
-      const result = await handler(ctx as never, {
-        organizationId: 'org_1',
-        name: 'test-server',
-        displayName: 'Test Server',
-        description: 'A test server',
-        transportType: 'streamable_http',
-        url: 'https://example.com/mcp',
-        authType: 'none',
-        status: 'inactive',
-      });
+    async function getCreateHandler() {
+      const { create } = await import('./public_mutations');
+      return (create as unknown as { handler: HandlerFn }).handler;
+    }
 
-      expect(ctx.db.insert).toHaveBeenCalledWith('mcpServers', {
-        organizationId: 'org_1',
-        name: 'test-server',
-        displayName: 'Test Server',
-        description: 'A test server',
-        transportType: 'streamable_http',
-        url: 'https://example.com/mcp',
-        authType: 'none',
-        status: 'inactive',
-      });
-      expect(result).toBe('server_new');
+    it('rejects an invalid slug before touching the database', async () => {
+      const handler = await getCreateHandler();
+      const { ctx } = createCtx({ duplicateId: null });
+      await expect(
+        handler(ctx, { ...baseArgs, name: 'Invalid Name' }),
+      ).rejects.toMatchObject({ data: { code: 'invalid' } });
+      expect(ctx.runQuery).not.toHaveBeenCalled();
+      expect(ctx.runMutation).not.toHaveBeenCalled();
     });
 
-    it('inserts with encrypted API key', async () => {
-      const ctx = {
-        db: {
-          insert: vi.fn().mockResolvedValue('server_new'),
-        },
-      };
-
-      const { insert } = await import('./mutations');
-      const handler = (insert as unknown as { handler: HandlerFn }).handler;
-      await handler(ctx as never, {
+    it('rejects a duplicate (organizationId, name) pair', async () => {
+      const handler = await getCreateHandler();
+      const { ctx, mutationCalls } = createCtx({ duplicateId: 'server_dup' });
+      await expect(
+        handler(ctx, { ...baseArgs, name: 'my-server' }),
+      ).rejects.toMatchObject({ data: { code: 'conflict' } });
+      expect(ctx.runQuery).toHaveBeenCalledWith('getIdByOrgAndName', {
         organizationId: 'org_1',
-        name: 'api-key-server',
-        displayName: 'API Key Server',
-        transportType: 'sse',
-        url: 'https://example.com/sse',
-        authType: 'api_key',
-        apiKeyEncrypted: 'encrypted-key-value',
+        name: 'my-server',
+      });
+      expect(mutationCalls).toHaveLength(0);
+    });
+
+    it('trims the name and inserts a unique server', async () => {
+      const handler = await getCreateHandler();
+      const { ctx, mutationCalls } = createCtx({ duplicateId: null });
+      const result = await handler(ctx, { ...baseArgs, name: '  my-server  ' });
+      expect(result).toBe('server_new');
+      expect(ctx.runQuery).toHaveBeenCalledWith('getIdByOrgAndName', {
+        organizationId: 'org_1',
+        name: 'my-server',
+      });
+      expect(mutationCalls).toHaveLength(1);
+      expect(mutationCalls[0].ref).toBe('insert');
+      expect(mutationCalls[0].args).toMatchObject({
+        name: 'my-server',
         status: 'inactive',
       });
-
-      expect(ctx.db.insert).toHaveBeenCalledWith(
-        'mcpServers',
-        expect.objectContaining({
-          authType: 'api_key',
-          apiKeyEncrypted: 'encrypted-key-value',
-        }),
-      );
     });
   });
 
   describe('update', () => {
-    it('patches an existing server', async () => {
-      const ctx = {
-        db: {
-          get: vi.fn().mockResolvedValue({ _id: 'server_1', name: 'old' }),
-          patch: vi.fn().mockResolvedValue(undefined),
-        },
-      };
+    async function getUpdateHandler() {
+      const { update } = await import('./public_mutations');
+      return (update as unknown as { handler: HandlerFn }).handler;
+    }
 
-      const { update } = await import('./mutations');
-      const handler = (update as unknown as { handler: HandlerFn }).handler;
-      const result = await handler(ctx as never, {
-        id: 'server_1',
-        displayName: 'Updated Server',
+    it('rejects an invalid slug on rename', async () => {
+      const handler = await getUpdateHandler();
+      const { ctx, mutationCalls } = createCtx({
+        existing: { _id: 'server_1', organizationId: 'org_1' },
       });
+      await expect(
+        handler(ctx, { id: 'server_1', name: 'Not A Slug' }),
+      ).rejects.toMatchObject({ data: { code: 'invalid' } });
+      expect(ctx.runQuery).not.toHaveBeenCalled();
+      expect(mutationCalls).toHaveLength(0);
+    });
 
-      expect(ctx.db.patch).toHaveBeenCalledWith('server_1', {
-        displayName: 'Updated Server',
+    it('throws not_found when the row is missing', async () => {
+      const handler = await getUpdateHandler();
+      const { ctx, mutationCalls } = createCtx({ existing: null });
+      await expect(
+        handler(ctx, { id: 'missing', name: 'new-name' }),
+      ).rejects.toMatchObject({ data: { code: 'not_found' } });
+      expect(mutationCalls).toHaveLength(0);
+    });
+
+    it("allows a no-op rename to the row's own name", async () => {
+      const handler = await getUpdateHandler();
+      const { ctx, mutationCalls } = createCtx({
+        existing: { _id: 'server_1', organizationId: 'org_1' },
+        // getIdByOrgAndName resolves to the row being edited.
+        duplicateId: 'server_1',
+      });
+      const result = await handler(ctx, {
+        id: 'server_1',
+        name: 'my-server',
       });
       expect(result).toBeNull();
-    });
-
-    it('throws when server not found', async () => {
-      const ctx = {
-        db: {
-          get: vi.fn().mockResolvedValue(null),
-          patch: vi.fn(),
-        },
-      };
-
-      const { update } = await import('./mutations');
-      const handler = (update as unknown as { handler: HandlerFn }).handler;
-      await expect(
-        handler(ctx as never, {
-          id: 'nonexistent',
-          displayName: 'Updated',
-        }),
-      ).rejects.toThrow('MCP server not found');
-    });
-  });
-
-  describe('remove', () => {
-    it('deletes an existing server', async () => {
-      const ctx = {
-        db: {
-          get: vi.fn().mockResolvedValue({ _id: 'server_1' }),
-          delete: vi.fn().mockResolvedValue(undefined),
-        },
-      };
-
-      const { remove } = await import('./mutations');
-      const handler = (remove as unknown as { handler: HandlerFn }).handler;
-      const result = await handler(ctx as never, {
+      expect(mutationCalls).toHaveLength(1);
+      expect(mutationCalls[0].ref).toBe('update');
+      expect(mutationCalls[0].args).toMatchObject({
         id: 'server_1',
+        name: 'my-server',
       });
-
-      expect(ctx.db.delete).toHaveBeenCalledWith('server_1');
-      expect(result).toBeNull();
     });
 
-    it('throws when server not found', async () => {
-      const ctx = {
-        db: {
-          get: vi.fn().mockResolvedValue(null),
-          delete: vi.fn(),
-        },
-      };
-
-      const { remove } = await import('./mutations');
-      const handler = (remove as unknown as { handler: HandlerFn }).handler;
+    it('rejects a rename colliding with a different server', async () => {
+      const handler = await getUpdateHandler();
+      const { ctx, mutationCalls } = createCtx({
+        existing: { _id: 'server_1', organizationId: 'org_1' },
+        // A different server already owns the target name.
+        duplicateId: 'server_2',
+      });
       await expect(
-        handler(ctx as never, {
-          id: 'nonexistent',
-        }),
-      ).rejects.toThrow('MCP server not found');
-    });
-  });
-
-  describe('setStatus', () => {
-    it('updates status to active', async () => {
-      const ctx = {
-        db: {
-          get: vi
-            .fn()
-            .mockResolvedValue({ _id: 'server_1', status: 'inactive' }),
-          patch: vi.fn().mockResolvedValue(undefined),
-        },
-      };
-
-      const { setStatus } = await import('./mutations');
-      const handler = (setStatus as unknown as { handler: HandlerFn }).handler;
-      const result = await handler(ctx as never, {
-        id: 'server_1',
-        status: 'active',
-      });
-
-      expect(ctx.db.patch).toHaveBeenCalledWith('server_1', {
-        status: 'active',
-      });
-      expect(result).toBeNull();
-    });
-
-    it('throws when server not found', async () => {
-      const ctx = {
-        db: {
-          get: vi.fn().mockResolvedValue(null),
-          patch: vi.fn(),
-        },
-      };
-
-      const { setStatus } = await import('./mutations');
-      const handler = (setStatus as unknown as { handler: HandlerFn }).handler;
-      await expect(
-        handler(ctx as never, {
-          id: 'nonexistent',
-          status: 'active',
-        }),
-      ).rejects.toThrow('MCP server not found');
+        handler(ctx, { id: 'server_1', name: 'taken-name' }),
+      ).rejects.toMatchObject({ data: { code: 'conflict' } });
+      expect(mutationCalls).toHaveLength(0);
     });
   });
 });

--- a/services/platform/convex/mcp_servers/public_mutations.ts
+++ b/services/platform/convex/mcp_servers/public_mutations.ts
@@ -8,6 +8,21 @@ import { action } from '../_generated/server';
 import { encryptString } from '../lib/crypto/encrypt_string';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { jsonRecordValidator } from '../lib/validators/json';
+import { MCP_SERVER_NAME_MAX_LENGTH, validateMcpServerName } from './constants';
+
+// Validate the slug-style `name` server-side (the client form mirrors the same
+// rule). Throws a ConvexError so the message can surface in the UI toast.
+function assertValidMcpServerName(name: string): void {
+  const code = validateMcpServerName(name);
+  if (code === null) return;
+  const message =
+    code === 'required'
+      ? 'Name is required.'
+      : code === 'too_long'
+        ? `Name must be at most ${MCP_SERVER_NAME_MAX_LENGTH} characters.`
+        : 'Name must be lowercase alphanumeric with hyphens (e.g. my-mcp-server).';
+  throw new ConvexError({ code: 'invalid', message });
+}
 
 const transportTypeValidator = v.union(
   v.literal('stdio'),
@@ -89,6 +104,19 @@ export const create = action({
       throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
+    const name = args.name.trim();
+    assertValidMcpServerName(name);
+    const duplicateId = await ctx.runQuery(
+      internal.mcp_servers.internal_queries.getIdByOrgAndName,
+      { organizationId: args.organizationId, name },
+    );
+    if (duplicateId !== null) {
+      throw new ConvexError({
+        code: 'conflict',
+        message: `An MCP server named "${name}" already exists in this organization.`,
+      });
+    }
+
     if (
       args.transportType === 'sse' ||
       args.transportType === 'streamable_http'
@@ -114,7 +142,7 @@ export const create = action({
       internal.mcp_servers.mutations.insert,
       {
         organizationId: args.organizationId,
-        name: args.name,
+        name,
         displayName: args.displayName,
         description: args.description,
         transportType: args.transportType,
@@ -163,6 +191,35 @@ export const update = action({
     }
 
     const { id, apiKey, oauth2Config: rawOAuth2, ...rest } = args;
+
+    // Validate the slug + enforce per-org uniqueness when the name is being
+    // changed. The existing row supplies the org scope (and is excluded so a
+    // no-op rename to its own name doesn't trip the conflict check).
+    if (rest.name !== undefined) {
+      const name = rest.name.trim();
+      assertValidMcpServerName(name);
+      rest.name = name;
+      const existing = await ctx.runQuery(
+        internal.mcp_servers.internal_queries.getById,
+        { id },
+      );
+      if (!existing) {
+        throw new ConvexError({
+          code: 'not_found',
+          message: 'MCP server not found.',
+        });
+      }
+      const duplicateId = await ctx.runQuery(
+        internal.mcp_servers.internal_queries.getIdByOrgAndName,
+        { organizationId: existing.organizationId, name },
+      );
+      if (duplicateId !== null && duplicateId !== id) {
+        throw new ConvexError({
+          code: 'conflict',
+          message: `An MCP server named "${name}" already exists in this organization.`,
+        });
+      }
+    }
 
     let apiKeyEncrypted: string | undefined;
     if (apiKey) {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4220,7 +4220,8 @@
       "invalidUrl": "Gib eine gültige HTTP- oder HTTPS-URL ein",
       "validation": {
         "nameRequired": "Name ist erforderlich",
-        "nameFormat": "Muss aus Kleinbuchstaben, Ziffern und Bindestrichen bestehen",
+        "nameTooLong": "Darf höchstens {max} Zeichen lang sein",
+        "nameInvalid": "Nur Kleinbuchstaben, Ziffern und Bindestriche erlaubt",
         "displayNameRequired": "Anzeigename ist erforderlich",
         "urlRequired": "URL ist erforderlich",
         "commandRequired": "Befehl ist erforderlich",
@@ -4598,7 +4599,9 @@
       "discard": "Verwerfen"
     },
     "errors": {
-      "saveFailed": "Speichern fehlgeschlagen. Bitte erneut versuchen."
+      "saveFailed": "Speichern fehlgeschlagen. Bitte erneut versuchen.",
+      "tooLong": "Benutzerdefinierte Anweisungen überschreiten {max} Zeichen.",
+      "illegalChars": "Entferne spitze Klammern, Backticks und Steuerzeichen."
     },
     "toasts": {
       "saved": "Gespeichert.",
@@ -5272,6 +5275,7 @@
       "loadingMembers": "Lädt...",
       "unknownMember": "Unbekannt",
       "memberChecklistHint": "Ein Mitglied kann mehreren Teams angehören. Wenn niemand ausgewählt wird, wirst du automatisch hinzugefügt.",
+      "lastMemberHint": "Ein Team muss mindestens ein Mitglied behalten. Lösche stattdessen das Team, um das letzte Mitglied zu entfernen.",
       "description": "Teams innerhalb deiner Organisation erstellen und verwalten für granulare Zugriffskontrolle"
     },
     "agents": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4220,7 +4220,8 @@
       "invalidUrl": "Enter a valid HTTP or HTTPS URL",
       "validation": {
         "nameRequired": "Name is required",
-        "nameFormat": "Must be lowercase alphanumeric with hyphens",
+        "nameTooLong": "Must be at most {max} characters",
+        "nameInvalid": "Must be lowercase alphanumeric with hyphens",
         "displayNameRequired": "Display name is required",
         "urlRequired": "URL is required",
         "commandRequired": "Command is required",
@@ -4598,7 +4599,9 @@
       "discard": "Discard"
     },
     "errors": {
-      "saveFailed": "Couldn't save. Please try again."
+      "saveFailed": "Couldn't save. Please try again.",
+      "tooLong": "Custom instructions exceed {max} characters.",
+      "illegalChars": "Remove angle brackets, backticks, and control characters."
     },
     "toasts": {
       "saved": "Saved.",
@@ -5536,6 +5539,7 @@
       "loadingMembers": "Loading...",
       "unknownMember": "Unknown",
       "memberChecklistHint": "A member can be part of multiple teams. If no one is selected, you will be added automatically.",
+      "lastMemberHint": "A team must keep at least one member. Delete the team instead to remove the last member.",
       "description": "Create and manage teams within your organization for granular access control"
     },
     "agents": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4221,7 +4221,8 @@
       "invalidUrl": "Saisis une URL HTTP ou HTTPS valide",
       "validation": {
         "nameRequired": "Le nom est requis",
-        "nameFormat": "Doit être en minuscules alphanumériques avec des traits d'union",
+        "nameTooLong": "Doit comporter au maximum {max} caractères",
+        "nameInvalid": "Uniquement des minuscules, des chiffres et des traits d'union",
         "displayNameRequired": "Le nom d'affichage est requis",
         "urlRequired": "L'URL est requise",
         "commandRequired": "La commande est requise",
@@ -4599,7 +4600,9 @@
       "discard": "Ignorer"
     },
     "errors": {
-      "saveFailed": "Échec de l'enregistrement. Réessaie."
+      "saveFailed": "Échec de l'enregistrement. Réessaie.",
+      "tooLong": "Les instructions personnalisées dépassent {max} caractères.",
+      "illegalChars": "Supprime les chevrons, les accents graves et les caractères de contrôle."
     },
     "toasts": {
       "saved": "Enregistré.",
@@ -5273,6 +5276,7 @@
       "loadingMembers": "Chargement...",
       "unknownMember": "Inconnu",
       "memberChecklistHint": "Un membre peut appartenir à plusieurs équipes. Si personne n'est sélectionné, tu seras ajouté automatiquement.",
+      "lastMemberHint": "Une équipe doit conserver au moins un membre. Supprime plutôt l'équipe pour retirer le dernier membre.",
       "description": "Crée et gère des équipes au sein de ton organisation pour un contrôle d'accès granulaire"
     },
     "agents": {


### PR DESCRIPTION
Resolves #2091. Addresses each itemized low-severity settings gap.

## [101] Custom-instructions illegal-char parity
`personalization-settings.tsx` now mirrors the backend rule (`convex/user_preferences/mutations.ts`): the client Zod schema canonicalizes CRLF/lone-CR → LF and rejects the same illegal characters + length cap, with the violation surfaced inline on the textarea (new i18n keys `personalization.errors.tooLong` / `illegalChars`). Reuses `CUSTOM_INSTRUCTIONS_ILLEGAL_RE` / `CUSTOM_INSTRUCTIONS_MAX_CHARS` from the shared constants (removed the duplicated local constant).

## [102] Team-edit last-member silent refusal
`team-member-checklist.tsx` now disables the sole remaining member's checkbox and shows an explanatory hint (`teams.lastMemberHint`) instead of silently ignoring the click.

## [104] Integration Disconnect loading state
`use-integration-manage.ts` exposes a real `isSubmitting` state that the disconnect flow drives; `integration-panel.tsx` keeps the ConfirmDialog open (showing its loading state) until the disconnect resolves.

## [105] Dead `?section=apps` param
`integrations.tsx` search schema now accepts only `mcp-servers` (the only value actually handled in `beforeLoad`); `apps` was never read.

## [108] MCP server name slug + server-side validation
New shared `convex/mcp_servers/constants.ts` (`MCP_SERVER_NAME_RE`, `validateMcpServerName`). The client form drops the `name.length > 1` carve-out (so single-char uppercase no longer slips through) and the create/update actions validate the slug **and** enforce per-org name uniqueness (new `getIdByOrgAndName` internal query); the create error surfaces in the toast.

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint` (plain) on touched files — clean; `oxfmt --check` — clean
- `vitest` server: `mcp_servers/constants.test.ts` (new), `public_mutations.test.ts`, `lib/i18n/messages.test.ts` — pass
- `vitest` ui: `mcp-server-form.test.tsx` — pass