### PR TITLE
fix: close governance logs and notifications inbox low-severity gaps (#2092)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/features/inbox/hooks/queries.ts
+++ b/services/platform/app/features/inbox/hooks/queries.ts
@@ -1,15 +1,21 @@
+import { useCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { api } from '@/convex/_generated/api';
 
-export function useMyNotifications(
-  organizationId: string,
-  options?: { unreadOnly?: boolean },
-) {
-  const { data, isLoading } = useConvexQuery(
+/**
+ * Paginated personal-notification stream (review requests, escalations, task
+ * pings). Cursor-based so the inbox panel can "Load more" past the first page
+ * instead of stopping at a fixed cap. The Unread/All filter is applied
+ * client-side (see `NotificationListPanel`), so it is intentionally NOT a query
+ * argument — toggling it must not change the query key (which would reset
+ * pagination and re-flash the skeleton).
+ */
+export function useMyNotificationsList(organizationId: string) {
+  return useCachedPaginatedQuery(
     api.collab.notifications.listMyNotifications,
-    { organizationId, unreadOnly: options?.unreadOnly },
+    { organizationId },
+    { initialNumItems: 25 },
   );
-  return { notifications: data ?? [], isLoading };
 }
 
 export function useUnreadNotificationCount(organizationId: string) {

--- a/services/platform/app/features/notifications/components/notification-list-panel.test.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { NotificationListPanel } from './notification-list-panel';
+
+// [119] The personal inbox stream is now cursor-paginated like the org stream,
+// and the panel drives a single "Load more" affordance off BOTH streams: it is
+// enabled while either has another page, and a click advances every stream that
+// still has more. These tests pin that combined wiring.
+//
+// We stub both streams' query hooks so each test can fix the two `status`
+// values independently, and the two `loadMore` spies let us assert exactly
+// which streams a click advances. Empty result arrays keep the focus on the
+// load-more control (which renders below the list regardless of row count) and
+// avoid pulling in row/render-target plumbing.
+
+const orgLoadMore = vi.fn();
+const myLoadMore = vi.fn();
+
+// Mutated per test before render to drive the two streams' pagination states.
+const streamState = {
+  org: 'Exhausted' as
+    | 'LoadingFirstPage'
+    | 'CanLoadMore'
+    | 'LoadingMore'
+    | 'Exhausted',
+  my: 'Exhausted' as
+    | 'LoadingFirstPage'
+    | 'CanLoadMore'
+    | 'LoadingMore'
+    | 'Exhausted',
+};
+
+// Org stream hooks (`../hooks/queries`, `../hooks/mutations`).
+vi.mock('@/app/features/notifications/hooks/queries', () => ({
+  useNotificationsList: () => ({
+    results: [],
+    status: streamState.org,
+    loadMore: orgLoadMore,
+  }),
+  useNotificationsUnreadCount: () => ({ data: 0 }),
+}));
+vi.mock('@/app/features/notifications/hooks/mutations', () => ({
+  useMarkNotificationRead: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useMarkAllNotificationsRead: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+// Personal stream hooks (`@/app/features/inbox/hooks/*`).
+vi.mock('@/app/features/inbox/hooks/queries', () => ({
+  useMyNotificationsList: () => ({
+    results: [],
+    status: streamState.my,
+    loadMore: myLoadMore,
+  }),
+  useUnreadNotificationCount: () => 0,
+}));
+vi.mock('@/app/features/inbox/hooks/mutations', () => ({
+  useMarkNotificationRead: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useMarkAllNotificationsRead: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+function renderPanel() {
+  return render(<NotificationListPanel organizationId="org-1" />);
+}
+
+describe('NotificationListPanel — combined load-more', () => {
+  beforeEach(() => {
+    orgLoadMore.mockClear();
+    myLoadMore.mockClear();
+    streamState.org = 'Exhausted';
+    streamState.my = 'Exhausted';
+  });
+
+  it('hides "Load more" when both streams are exhausted', () => {
+    renderPanel();
+    expect(
+      screen.queryByRole('button', { name: 'Load more' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('advances both streams when both can load more', async () => {
+    streamState.org = 'CanLoadMore';
+    streamState.my = 'CanLoadMore';
+    const { user } = renderPanel();
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(orgLoadMore).toHaveBeenCalledTimes(1);
+    expect(myLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Load more" when only the personal stream has more, and advances only it', async () => {
+    streamState.org = 'Exhausted';
+    streamState.my = 'CanLoadMore';
+    const { user } = renderPanel();
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(myLoadMore).toHaveBeenCalledTimes(1);
+    expect(orgLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('shows "Load more" when only the org stream has more, and advances only it', async () => {
+    streamState.org = 'CanLoadMore';
+    streamState.my = 'Exhausted';
+    const { user } = renderPanel();
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(orgLoadMore).toHaveBeenCalledTimes(1);
+    expect(myLoadMore).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/notifications/components/notification-list-panel.tsx
+++ b/services/platform/app/features/notifications/components/notification-list-panel.tsx
@@ -10,7 +10,7 @@ import {
   useMarkNotificationRead as useMarkMyNotificationRead,
 } from '@/app/features/inbox/hooks/mutations';
 import {
-  useMyNotifications,
+  useMyNotificationsList,
   useUnreadNotificationCount,
 } from '@/app/features/inbox/hooks/queries';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -84,8 +84,13 @@ export function NotificationListPanel({
 
   // The PERSONAL stream (review requests, escalations, task pings) renders
   // interleaved with the org stream — one panel for everything, with inline
-  // review actions and task deep links.
-  const { notifications: myNotifications } = useMyNotifications(organizationId);
+  // review actions and task deep links. It is paginated like the org stream so
+  // "Load more" walks both, rather than capping the personal inbox.
+  const {
+    results: myNotifications,
+    status: myStatus,
+    loadMore: loadMoreMy,
+  } = useMyNotificationsList(organizationId);
   const myUnread = useUnreadNotificationCount(organizationId);
   const markMyRead = useMarkMyNotificationRead();
   const markAllMyRead = useMarkAllMyNotificationsRead();
@@ -175,8 +180,15 @@ export function NotificationListPanel({
     [myNotifications, hiddenIds, filter],
   );
   const unreadCount = (unread ?? 0) + myUnread;
-  const canLoadMore = status === 'CanLoadMore';
-  const isLoadingMore = status === 'LoadingMore';
+  // Drive one "Load more" affordance off BOTH streams: it's enabled while
+  // either has another page, shows progress while either is fetching, and a
+  // click advances every stream that still has more.
+  const canLoadMore = status === 'CanLoadMore' || myStatus === 'CanLoadMore';
+  const isLoadingMore = status === 'LoadingMore' || myStatus === 'LoadingMore';
+  const handleLoadMore = useCallback(() => {
+    if (status === 'CanLoadMore') loadMore(LOAD_MORE_NUM_ITEMS);
+    if (myStatus === 'CanLoadMore') loadMoreMy(LOAD_MORE_NUM_ITEMS);
+  }, [status, loadMore, myStatus, loadMoreMy]);
 
   return (
     <div className={cn('flex h-[24rem] flex-col', className)}>
@@ -229,7 +241,7 @@ export function NotificationListPanel({
       </div>
       <div className="flex-1 overflow-y-auto">
         {items.length === 0 && myItems.length === 0 ? (
-          status === 'LoadingFirstPage' ? (
+          status === 'LoadingFirstPage' || myStatus === 'LoadingFirstPage' ? (
             // Short-lived async load — a centered spinner + label reads
             // cleaner than a fake-content skeleton when items typically
             // arrive in under a second.
@@ -335,7 +347,7 @@ export function NotificationListPanel({
               variant="ghost"
               className="w-full"
               disabled={!canLoadMore}
-              onClick={() => loadMore(LOAD_MORE_NUM_ITEMS)}
+              onClick={handleLoadMore}
             >
               {isLoadingMore ? t('loading') : t('loadMore')}
             </Button>

--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
@@ -66,10 +67,23 @@ vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'org-1',
 }));
 
-function renderPage() {
-  return render(
-    <AuditLogsPage organizationId="org-1" onCategoryChange={vi.fn()} />,
+// The active tab now round-trips through the URL (the route owns it), so the
+// component is controlled. Mirror that here with a tiny stateful harness so
+// clicking a trigger flips the selection the same way the route would.
+function ControlledAuditLogsPage() {
+  const [tab, setTab] = useState('audit');
+  return (
+    <AuditLogsPage
+      organizationId="org-1"
+      tab={tab}
+      onTabChange={setTab}
+      onCategoryChange={vi.fn()}
+    />
   );
+}
+
+function renderPage() {
+  return render(<ControlledAuditLogsPage />);
 }
 
 describe('AuditLogsPage', () => {

--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.test.tsx
@@ -120,6 +120,38 @@ describe('AuditLogsPage', () => {
     expect(activityTab).toHaveAttribute('aria-selected', 'false');
   });
 
+  it('shows the category filter only on the Audit and Errors tabs', async () => {
+    // [114] The category `DataTableFilters` feeds only the audit + error
+    // queries, so the page renders it solely on those two tabs — on "Sign-in
+    // blocks" and "Activity logs" it was a no-op and is now omitted entirely.
+    // The shared toolbar's filter trigger is the `FilterButton`, accessible by
+    // its "Filter" label, so its presence/absence tracks the fix exactly.
+    const { user } = renderPage();
+
+    // Default "Audit logs" tab — filter present.
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+
+    // "Sign-in blocks" tab — filter hidden (was a no-op).
+    await user.click(screen.getByRole('tab', { name: 'Sign-in blocks' }));
+    expect(
+      screen.queryByRole('button', { name: 'Filter' }),
+    ).not.toBeInTheDocument();
+
+    // "Activity logs" tab — filter hidden (was a no-op).
+    await user.click(screen.getByRole('tab', { name: 'Activity logs' }));
+    expect(
+      screen.queryByRole('button', { name: 'Filter' }),
+    ).not.toBeInTheDocument();
+
+    // "Error logs" tab — filter present (category really filters it).
+    await user.click(screen.getByRole('tab', { name: 'Error logs' }));
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+
+    // Back to "Audit logs" — filter present again.
+    await user.click(screen.getByRole('tab', { name: 'Audit logs' }));
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+  });
+
   it('passes an axe audit of the tab strip and active audit table', async () => {
     renderPage();
     // Audit the migrated subject — the tablist + the active tab panel holding

--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
@@ -27,12 +27,17 @@ interface AuditLogsPageProps {
   organizationId: string;
   category?: string;
   onCategoryChange: (category: string | undefined) => void;
+  /** Active tab key, sourced from the URL so reload/deep-link/Back restore it. */
+  tab?: string;
+  onTabChange: (tab: string) => void;
 }
 
 export function AuditLogsPage({
   organizationId,
   category,
   onCategoryChange,
+  tab,
+  onTabChange,
 }: AuditLogsPageProps) {
   const { t } = useT('settings');
   const { t: tAccess } = useT('accessDenied');
@@ -42,6 +47,13 @@ export function AuditLogsPage({
   const memberContext = useCurrentMemberContext(organizationId);
   const memberRole = memberContext.data?.role;
   const isAdminUser = memberRole === 'admin' || memberRole === 'owner';
+
+  // Tabs are driven controlled off the URL `tab` key (default "audit"). The
+  // category filter only feeds the audit + errors queries, so it's a no-op on
+  // the "Block counters" and "Activity logs" tabs — render it only where it
+  // actually filters something.
+  const activeTab = tab ?? 'audit';
+  const showCategoryFilter = activeTab === 'audit' || activeTab === 'errors';
 
   const paginatedResult = useListAuditLogsPaginated({
     organizationId,
@@ -145,14 +157,17 @@ export function AuditLogsPage({
         className="min-h-0 flex-1"
       >
         <Tabs
-          defaultValue="audit"
+          value={activeTab}
+          onValueChange={onTabChange}
           className="flex min-h-0 flex-1 flex-col"
           actions={
             <Row gap={2}>
-              <DataTableFilters
-                filters={auditFilterConfigs}
-                onClearAll={handleClearFilters}
-              />
+              {showCategoryFilter && (
+                <DataTableFilters
+                  filters={auditFilterConfigs}
+                  onClearAll={handleClearFilters}
+                />
+              )}
               {isAdminUser && (
                 <>
                   <Button

--- a/services/platform/app/routes/dashboard/$id/settings/governance/logs.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/logs.tsx
@@ -10,6 +10,20 @@ const searchSchema = z.object({
   tab: z.enum(['audit', 'blocks', 'activity', 'errors']).optional(),
 });
 
+type LogsTab = NonNullable<z.infer<typeof searchSchema>['tab']>;
+
+// Type guard (not a cast) so narrowing the `string` from Radix's
+// `onValueChange` to the tab enum stays type-safe — the type-aware lint
+// rejects a `value as LogsTab` assertion here.
+function isLogsTab(value: string): value is LogsTab {
+  return (
+    value === 'audit' ||
+    value === 'blocks' ||
+    value === 'activity' ||
+    value === 'errors'
+  );
+}
+
 export const Route = createFileRoute('/dashboard/$id/settings/governance/logs')(
   {
     head: () => ({ meta: seo('logs') }),
@@ -45,7 +59,7 @@ function LogsRoute() {
         params: { id: organizationId },
         search: {
           category,
-          tab: next === 'audit' ? undefined : (next as typeof tab),
+          tab: next === 'audit' || !isLogsTab(next) ? undefined : next,
         },
       });
     },

--- a/services/platform/app/routes/dashboard/$id/settings/governance/logs.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/logs.tsx
@@ -7,6 +7,7 @@ import { seo } from '@/lib/utils/seo';
 
 const searchSchema = z.object({
   category: z.string().optional(),
+  tab: z.enum(['audit', 'blocks', 'activity', 'errors']).optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/settings/governance/logs')(
@@ -19,18 +20,36 @@ export const Route = createFileRoute('/dashboard/$id/settings/governance/logs')(
 
 function LogsRoute() {
   const { id: organizationId } = Route.useParams();
-  const { category } = Route.useSearch();
+  const { category, tab } = Route.useSearch();
   const navigate = useNavigate();
 
+  // Both `category` and `tab` round-trip through the URL; each handler carries
+  // the other's current value forward so changing one never drops the other.
+  // The default tab (`audit`) is omitted from the URL so the canonical entry
+  // path stays clean, mirroring how an empty `category` is left off.
   const handleCategoryChange = useCallback(
     (next: string | undefined) => {
       void navigate({
         to: '/dashboard/$id/settings/governance/logs',
         params: { id: organizationId },
-        search: next ? { category: next } : {},
+        search: { category: next || undefined, tab },
       });
     },
-    [navigate, organizationId],
+    [navigate, organizationId, tab],
+  );
+
+  const handleTabChange = useCallback(
+    (next: string) => {
+      void navigate({
+        to: '/dashboard/$id/settings/governance/logs',
+        params: { id: organizationId },
+        search: {
+          category,
+          tab: next === 'audit' ? undefined : (next as typeof tab),
+        },
+      });
+    },
+    [navigate, organizationId, category],
   );
 
   return (
@@ -38,6 +57,8 @@ function LogsRoute() {
       organizationId={organizationId}
       category={category}
       onCategoryChange={handleCategoryChange}
+      tab={tab}
+      onTabChange={handleTabChange}
     />
   );
 }

--- a/services/platform/convex/collab/notifications.ts
+++ b/services/platform/convex/collab/notifications.ts
@@ -55,7 +55,6 @@ const notificationRowValidator = v.object({
 export const listMyNotifications = query({
   args: {
     organizationId: v.string(),
-    unreadOnly: v.optional(v.boolean()),
     paginationOpts: paginationOptsValidator,
   },
   returns: v.object({
@@ -68,24 +67,13 @@ export const listMyNotifications = query({
     // Cursor-based pagination (mirrors `notifications.queries.list`) so the
     // personal inbox is no longer capped — the panel's "Load more" can walk
     // past the first page instead of stopping at a hard 100-row ceiling.
-    const result = args.unreadOnly
-      ? await ctx.db
-          .query('userNotifications')
-          .withIndex('by_user_org_read', (q) =>
-            q
-              .eq('userId', userId)
-              .eq('organizationId', args.organizationId)
-              .eq('read', false),
-          )
-          .order('desc')
-          .paginate(args.paginationOpts)
-      : await ctx.db
-          .query('userNotifications')
-          .withIndex('by_user_org_created', (q) =>
-            q.eq('userId', userId).eq('organizationId', args.organizationId),
-          )
-          .order('desc')
-          .paginate(args.paginationOpts);
+    const result = await ctx.db
+      .query('userNotifications')
+      .withIndex('by_user_org_created', (q) =>
+        q.eq('userId', userId).eq('organizationId', args.organizationId),
+      )
+      .order('desc')
+      .paginate(args.paginationOpts);
 
     return {
       page: result.page,

--- a/services/platform/convex/collab/notifications.ts
+++ b/services/platform/convex/collab/notifications.ts
@@ -2,6 +2,7 @@
  * Per-user content notification inbox: list, unread count, mark read.
  */
 
+import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
 import { mutation, query, type QueryCtx } from '../_generated/server';
@@ -55,29 +56,42 @@ export const listMyNotifications = query({
   args: {
     organizationId: v.string(),
     unreadOnly: v.optional(v.boolean()),
+    paginationOpts: paginationOptsValidator,
   },
-  returns: v.array(notificationRowValidator),
+  returns: v.object({
+    page: v.array(notificationRowValidator),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
   handler: async (ctx, args) => {
     const userId = await resolveUserId(ctx, args.organizationId);
-    if (args.unreadOnly) {
-      return await ctx.db
-        .query('userNotifications')
-        .withIndex('by_user_org_read', (q) =>
-          q
-            .eq('userId', userId)
-            .eq('organizationId', args.organizationId)
-            .eq('read', false),
-        )
-        .order('desc')
-        .take(INBOX_PAGE_CAP);
-    }
-    return await ctx.db
-      .query('userNotifications')
-      .withIndex('by_user_org_created', (q) =>
-        q.eq('userId', userId).eq('organizationId', args.organizationId),
-      )
-      .order('desc')
-      .take(INBOX_PAGE_CAP);
+    // Cursor-based pagination (mirrors `notifications.queries.list`) so the
+    // personal inbox is no longer capped — the panel's "Load more" can walk
+    // past the first page instead of stopping at a hard 100-row ceiling.
+    const result = args.unreadOnly
+      ? await ctx.db
+          .query('userNotifications')
+          .withIndex('by_user_org_read', (q) =>
+            q
+              .eq('userId', userId)
+              .eq('organizationId', args.organizationId)
+              .eq('read', false),
+          )
+          .order('desc')
+          .paginate(args.paginationOpts)
+      : await ctx.db
+          .query('userNotifications')
+          .withIndex('by_user_org_created', (q) =>
+            q.eq('userId', userId).eq('organizationId', args.organizationId),
+          )
+          .order('desc')
+          .paginate(args.paginationOpts);
+
+    return {
+      page: result.page,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
   },
 });
 


### PR DESCRIPTION
Resolves #2092 — three low-severity polish gaps in **Governance → Logs** and the **notifications inbox**.

### [114] Category filter no-op on 2 tabs
The shared `DataTableFilters` block lived in the `Tabs` `actions` slot and rendered on all four tabs, but `category` only feeds the audit + errors queries — it was a silent no-op on **Block counters** and **Activity logs**. The filter is now rendered only on the `audit`/`errors` tabs (`showCategoryFilter`), so it no longer appears where it does nothing.

### [115] Active tab not in URL
`Tabs` used `defaultValue="audit"` (component-local state), so reload / deep-link / Back always reset to *Audit logs*. The route's `validateSearch` now accepts an optional `tab` enum and drives `Tabs` in controlled mode (`value` + `onValueChange`), mirroring the existing `category` round-trip. The default `audit` tab is omitted from the URL to keep the canonical path clean, and each handler carries the other search param forward so changing the tab never drops the category (and vice versa).

### [119] Personal notifications capped at 100 with no Load-more
`listMyNotifications` used `.take(100)` with no pagination, and the panel's *Load more* only advanced the org stream — so the personal inbox was hard-capped at 100 rows. The query is now cursor-paginated (mirroring `notifications.queries.list`), the inbox hook uses `useCachedPaginatedQuery`, and the panel drives a single *Load more* off **both** streams (enabled while either has more, advancing every stream that still has a page).

### Verification
- `tsc --noEmit` — clean
- `oxlint` on changed files — 0 warnings / 0 errors
- `vitest run audit-logs-page.test.tsx` — updated for controlled tabs, 3/3 pass