### PR TITLE
fix: set document title on apps dashboard route (#2093)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/routes/dashboard/$id/apps.tsx
+++ b/services/platform/app/routes/dashboard/$id/apps.tsx
@@ -16,8 +16,12 @@ import { PageLayout } from '@/app/components/layout/page-layout';
 import { useApps } from '@/app/features/apps/hooks/use-apps';
 import { useT } from '@/lib/i18n/client';
 import { cn } from '@/lib/utils/cn';
+import { seo } from '@/lib/utils/seo';
 
 export const Route = createFileRoute('/dashboard/$id/apps')({
+  head: () => ({
+    meta: seo('apps'),
+  }),
   component: AppsLayout,
 });
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4136,6 +4136,10 @@
       "title": "Projekte",
       "description": "Geteilte Arbeitsbereiche für Dateien, Anweisungen und Chats."
     },
+    "apps": {
+      "title": "Apps",
+      "description": "Installierte Pakete und die Apps, die sie deiner Organisation hinzufügen."
+    },
     "websites": {
       "title": "Websites",
       "description": "Websites für die Wissensextraktion verwalten."

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4136,6 +4136,10 @@
       "title": "Projects",
       "description": "Shared workspaces for files, instructions, and chats."
     },
+    "apps": {
+      "title": "Apps",
+      "description": "Installed packs and the apps they add to your organization."
+    },
     "websites": {
       "title": "Websites",
       "description": "Manage websites for knowledge extraction."

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4139,7 +4139,7 @@
     },
     "apps": {
       "title": "Applications",
-      "description": "Modules installés et les applications qu'ils ajoutent à votre organisation."
+      "description": "Modules installés et les applications qu'ils ajoutent à ton organisation."
     },
     "websites": {
       "title": "Sites web",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4137,6 +4137,10 @@
       "title": "Projets",
       "description": "Espaces de travail partagés pour fichiers, instructions et discussions."
     },
+    "apps": {
+      "title": "Applications",
+      "description": "Modules installés et les applications qu'ils ajoutent à votre organisation."
+    },
     "websites": {
       "title": "Sites web",
       "description": "Gère les sites web pour l'extraction de connaissances."


### PR DESCRIPTION
## Summary

The `/dashboard/$id/apps` route had no `head:` option, so its document `<title>` fell back to the generic marketing default ("The Orchestration Layer for AI Agents - {Org}") instead of a page-specific title like the sibling dashboard routes (Chat, Projects, Agents).

## Changes
- Added `head: () => ({ meta: seo('apps') })` to the Apps route, matching the established pattern used by sibling dashboard routes.
- Added the `metadata.apps` entry (title + description) to the `en`, `de`, and `fr` message bundles so `seo('apps')` resolves a localized title.

Fixes #2093

## Verification
- `tsc --noEmit` passes (the `seo('apps')` key is type-checked against the metadata namespace).
- `oxlint` passes on the changed route.