### PR TITLE
feat(platform): app details page + assorted UI polish fixes

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/components/ui/data-table/column-builders.tsx
+++ b/services/platform/app/components/ui/data-table/column-builders.tsx
@@ -349,6 +349,6 @@ export function createSelectColumn<TData>(): ColumnDef<TData> {
         />
       </div>
     ),
-    meta: { skeleton: { type: 'action' } },
+    meta: { skeleton: { type: 'checkbox' } },
   };
 }

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -88,6 +88,7 @@ interface ColumnMeta {
       | 'avatar-text'
       | 'icon-text'
       | 'action'
+      | 'checkbox'
       | 'switch';
   };
   align?: 'left' | 'center' | 'right';
@@ -726,7 +727,10 @@ export function DataTable<TData, TValue = unknown>({
               // `h-12` mirrors the real data rows below — without it the
               // skeleton collapses to its content height (~32px) and reads as a
               // dense, tight list that doesn't match the roomier loaded table.
-              <TableRow key={`skeleton-${rowIndex}`} className="min-h-12">
+              // Must be `h-12`, not `min-h-12`: CSS ignores `min-height` on a
+              // table row (`display: table-row`), whereas `height` is treated as
+              // a *minimum* there, so taller cells still grow the row past it.
+              <TableRow key={`skeleton-${rowIndex}`} className="h-12">
                 {enableExpanding && <TableCell className="w-[3rem]" />}
                 {columns.map((col, colIndex) => {
                   const textWidth = (salt: number, min: number, span: number) =>
@@ -747,6 +751,17 @@ export function DataTable<TData, TValue = unknown>({
                           <div className="h-8 w-8 rounded-md" />
                         </SkeletonBox>
                       </HStack>
+                    );
+                  } else if (skeletonType === 'checkbox') {
+                    // Mirrors the real 16px checkbox (`size-4`) — NOT the 32px
+                    // `action` button shape. In the pinned 40px select column an
+                    // `h-8 w-8` block leaves only ~4px each side and reads as
+                    // edge-to-edge; a `size-4` square keeps the ~12px gutter the
+                    // loaded checkbox has.
+                    cellContent = (
+                      <SkeletonBox>
+                        <div className="size-4 rounded" />
+                      </SkeletonBox>
                     );
                   } else if (skeletonType === 'badge') {
                     cellContent = (

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -122,8 +122,14 @@ export interface SearchableSelectProps {
   modal?: boolean;
 }
 
+// Radix Popover — unlike Radix Select — does NOT auto-size its content to the
+// trigger. Bind the min-width to `--radix-popover-trigger-width` so a full-width
+// field trigger (e.g. the install wizard's project picker) gets a full-width
+// dropdown instead of a 14.5rem one centered under it. `max()` keeps the 14.5rem
+// floor so compact toolbar triggers (agent/model pickers) still open a usable
+// width; content can grow it wider than either bound.
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+  'z-50 min-w-[max(14.5rem,var(--radix-popover-trigger-width))] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
 
 function defaultFilterFn(option: SearchableSelectOption, query: string) {
   const lower = query.toLowerCase();

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -16,11 +16,12 @@
  *  A non-blocking readiness checklist (missing integration credentials / agent
  *  setup / broken install) rides above the views/hub; the shell stays usable. */
 import { Alert } from '@tale/ui/alert';
+import { Badge } from '@tale/ui/badge';
 import { Button } from '@tale/ui/button';
 import { Card } from '@tale/ui/card';
 import { EmptyState } from '@tale/ui/empty-state';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
-import { Grid, HStack, VStack } from '@tale/ui/layout';
+import { Grid, HStack, Row, VStack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Tabs } from '@tale/ui/tabs';
 import { Text } from '@tale/ui/text';
@@ -29,6 +30,7 @@ import { LayoutGrid, Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
+import { startCase } from '@/lib/utils/string';
 
 import { useAppAgentReadiness } from '../hooks/use-app-agent-readiness';
 import { resolvePackLabels } from '../hooks/use-app-pack-labels';
@@ -497,6 +499,148 @@ function AddToThisProject({
   );
 }
 
+/**
+ * Org route, app NOT installed — a real pre-install details page: the full
+ * (un-clamped) description plus what the app brings (its pages / workflows /
+ * agents) and what it needs (integrations connected during setup), with Install
+ * as the CTA. Replaces the bare "install it first" prompt so you can judge an
+ * app before committing to it. The wizard (project pick / required integrations)
+ * lives inside, matching the one-click-vs-wizard split on the hub.
+ */
+function AppDetails({
+  organizationId,
+  appSlug,
+  app,
+  labels,
+}: {
+  organizationId: string;
+  appSlug: string;
+  app: AppSummary;
+  labels: Record<string, string>;
+}) {
+  const { t } = useT('apps');
+  const { install, isPending } = useAppInstallActions(organizationId);
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const needsWizard =
+    app.scope === 'project' || app.requiredIntegrations.length > 0;
+
+  // Pages by their resolved (pack-label or literal) titles; untitled views drop
+  // out — a blank chip says nothing about what the page is.
+  const pageTitles = app.views
+    .map((v) => resolvePackLabel(v.title, labels))
+    .filter((title): title is string => Boolean(title));
+
+  // The app's composition, as labelled chip groups. Slugs are humanized for
+  // display (we have no friendlier name pre-install); empty groups are dropped.
+  const includes = [
+    { key: 'views', label: t('details.pages'), items: pageTitles },
+    {
+      key: 'workflows',
+      label: t('details.workflows'),
+      items: app.workflows.map(startCase),
+    },
+    {
+      key: 'agents',
+      label: t('details.agents'),
+      items: app.agents.map(startCase),
+    },
+  ].filter((section) => section.items.length > 0);
+
+  return (
+    <VStack gap={6}>
+      <HStack className="items-start justify-between gap-3">
+        <HStack gap={3} className="min-w-0 items-start">
+          <Row
+            gap={0}
+            justify="center"
+            className="bg-muted text-muted-foreground size-10 shrink-0 rounded-lg"
+          >
+            <LayoutGrid className="size-5" />
+          </Row>
+          <VStack gap={1} className="min-w-0">
+            <Text as="span" className="text-xl font-semibold">
+              {app.name}
+            </Text>
+            <div>
+              <Badge variant="slate">
+                {t(
+                  app.scope === 'project'
+                    ? 'details.scopeProject'
+                    : 'details.scopeOrg',
+                )}
+              </Badge>
+            </div>
+          </VStack>
+        </HStack>
+        <Button
+          disabled={isPending}
+          onClick={() =>
+            needsWizard ? setWizardOpen(true) : void install(appSlug)
+          }
+        >
+          {t('install.install')}
+        </Button>
+      </HStack>
+
+      <Text variant="muted">
+        {app.description || t('install.notInstalledDescription')}
+      </Text>
+
+      {includes.length > 0 && (
+        <Card>
+          <VStack gap={4}>
+            <Text className="font-medium">{t('details.includesTitle')}</Text>
+            {includes.map((section) => (
+              <VStack key={section.key} gap={2}>
+                <Text variant="muted" className="text-sm">
+                  {section.label}
+                </Text>
+                <HStack gap={2} className="flex-wrap">
+                  {section.items.map((item, i) => (
+                    <Badge key={`${section.key}-${i}`} variant="outline">
+                      {item}
+                    </Badge>
+                  ))}
+                </HStack>
+              </VStack>
+            ))}
+          </VStack>
+        </Card>
+      )}
+
+      {app.requiredIntegrations.length > 0 && (
+        <Card>
+          <VStack gap={3}>
+            <Text className="font-medium">{t('details.requiresTitle')}</Text>
+            <HStack gap={2} className="flex-wrap">
+              {app.requiredIntegrations.map((slug) => (
+                <Badge key={slug} variant="outline">
+                  {startCase(slug)}
+                </Badge>
+              ))}
+            </HStack>
+            <Text variant="muted" className="text-sm">
+              {t('details.requiresHint')}
+            </Text>
+          </VStack>
+        </Card>
+      )}
+
+      {needsWizard && (
+        <AppInstallWizard
+          open={wizardOpen}
+          onOpenChange={setWizardOpen}
+          organizationId={organizationId}
+          appSlug={appSlug}
+          appName={app.name}
+          scope={app.scope}
+          requiredIntegrations={app.requiredIntegrations}
+        />
+      )}
+    </VStack>
+  );
+}
+
 export function AppPage({
   organizationId,
   appSlug,
@@ -509,11 +653,9 @@ export function AppPage({
 }) {
   const { t } = useT('apps');
   const { locale } = useLocale();
-  const [wizardOpen, setWizardOpen] = useState(false);
   const { apps, isLoading } = useApps(organizationId);
   const { bySlug, isLoading: stateLoading } =
     useAppInstallStates(organizationId);
-  const { install, isPending } = useAppInstallActions(organizationId);
 
   const app = apps.find((a) => a.slug === appSlug);
   const state = bySlug.get(appSlug);
@@ -567,39 +709,17 @@ export function AppPage({
     );
   }
 
-  // ORG route, not installed — Install prompt (wizard picks the first project
-  // for a project-scoped app / walks required integrations).
+  // ORG route, not installed — a pre-install details page (full description +
+  // what it includes / needs) with Install as the CTA. The wizard (project pick
+  // for a project-scoped app / required integrations) lives inside it.
   if (!state) {
-    const needsWizard = isProjectScoped || app.requiredIntegrations.length > 0;
     return (
-      <>
-        <EmptyState
-          icon={LayoutGrid}
-          title={t('install.notInstalledTitle', { defaultValue: app.name })}
-          description={t('install.notInstalledDescription')}
-          action={
-            <Button
-              disabled={isPending}
-              onClick={() =>
-                needsWizard ? setWizardOpen(true) : void install(appSlug)
-              }
-            >
-              {t('install.install')}
-            </Button>
-          }
-        />
-        {needsWizard && (
-          <AppInstallWizard
-            open={wizardOpen}
-            onOpenChange={setWizardOpen}
-            organizationId={organizationId}
-            appSlug={appSlug}
-            appName={app.name}
-            scope={app.scope}
-            requiredIntegrations={app.requiredIntegrations}
-          />
-        )}
-      </>
+      <AppDetails
+        organizationId={organizationId}
+        appSlug={appSlug}
+        app={app}
+        labels={labels}
+      />
     );
   }
 

--- a/services/platform/app/features/notifications/components/notification-row.tsx
+++ b/services/platform/app/features/notifications/components/notification-row.tsx
@@ -121,7 +121,12 @@ export function NotificationRow({
           />
         )}
       </div>
-      {children}
+      {children && (
+        // Actions render OUTSIDE the interactive body (no nested buttons), so
+        // re-create the body's content inset and add the missing bottom gutter:
+        // pl-9 (36px) = body px-4 (16) + unread dot size-2 (8) + gap-3 (12).
+        <div className="pr-4 pb-3 pl-9">{children}</div>
+      )}
     </li>
   );
 }

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -13,13 +13,22 @@
       "title": "Noch nichts anzuzeigen",
       "description": "Für dieses Pack sind keine Seiten konfiguriert."
     },
+    "details": {
+      "scopeOrg": "Organisations-App",
+      "scopeProject": "Projekt-App",
+      "includesTitle": "Enthalten",
+      "pages": "Seiten",
+      "workflows": "Workflows",
+      "agents": "Agenten",
+      "requiresTitle": "Was du brauchst",
+      "requiresHint": "Diese verbindest du bei der Einrichtung."
+    },
     "install": {
       "install": "Installieren",
       "installed": "Installiert",
       "reinstall": "Neu installieren",
       "setup": "Einrichtung abschließen",
       "uninstall": "Deinstallieren",
-      "notInstalledTitle": "Noch nicht installiert",
       "notInstalledDescription": "Installiere diese App, um ihre Agenten und Workflows zu deiner Organisation hinzuzufügen.",
       "chooseProjectDescription": "Diese App läuft innerhalb eines Projekts. Wähle, wo ihre Aufgaben und Seiten leben.",
       "projectLabel": "Projekt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -13,13 +13,22 @@
       "title": "Nothing to show yet",
       "description": "This pack has no pages configured."
     },
+    "details": {
+      "scopeOrg": "Organization app",
+      "scopeProject": "Project app",
+      "includesTitle": "What's included",
+      "pages": "Pages",
+      "workflows": "Workflows",
+      "agents": "Agents",
+      "requiresTitle": "What you'll need",
+      "requiresHint": "You'll connect these during setup."
+    },
     "install": {
       "install": "Install",
       "installed": "Installed",
       "reinstall": "Reinstall",
       "setup": "Finish setup",
       "uninstall": "Uninstall",
-      "notInstalledTitle": "Not installed yet",
       "notInstalledDescription": "Install this app to add its agents and workflows to your organization.",
       "chooseProjectDescription": "This app runs inside a project. Choose where its tasks and pages live.",
       "projectLabel": "Project",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -13,13 +13,22 @@
       "title": "Rien à afficher",
       "description": "Aucune page n'est configurée pour ce pack."
     },
+    "details": {
+      "scopeOrg": "Application d'organisation",
+      "scopeProject": "Application de projet",
+      "includesTitle": "Ce qui est inclus",
+      "pages": "Pages",
+      "workflows": "Workflows",
+      "agents": "Agents",
+      "requiresTitle": "Ce dont vous aurez besoin",
+      "requiresHint": "Vous les connecterez lors de la configuration."
+    },
     "install": {
       "install": "Installer",
       "installed": "Installé",
       "reinstall": "Réinstaller",
       "setup": "Terminer la configuration",
       "uninstall": "Désinstaller",
-      "notInstalledTitle": "Pas encore installé",
       "notInstalledDescription": "Installez cette application pour ajouter ses agents et workflows à votre organisation.",
       "chooseProjectDescription": "Cette application fonctionne au sein d'un projet. Choisissez où vivront ses tâches et ses pages.",
       "projectLabel": "Projet",


### PR DESCRIPTION
## What & why

Four independent UI fixes/improvements, split out from the canvas-viewer PR. Each is its own atomic commit.

1. **`feat`: pre-install app details page** — replaces the bare "install it first" `EmptyState` (org route, uninstalled app) with a real details page: full description, what the app brings (pages / workflows / agents as chip groups), what it needs (required integrations), Install CTA, with the wizard inside. Removes the now-orphaned `apps.install.notInstalledTitle` key (the old EmptyState was its only user).
2. **`fix`: data-table checkbox skeleton + row height** — adds a `checkbox` skeleton type (16px `size-4`, mirrors the real checkbox in the pinned 40px select column rather than the edge-to-edge 32px `action` shape); skeleton rows use `h-12` instead of `min-h-12` (CSS ignores `min-height` on `display: table-row`, so rows were collapsing).
3. **`fix`: searchable-select dropdown width** — binds the Popover min-width to `--radix-popover-trigger-width` via `max(14.5rem, …)`, so a full-width trigger (the install wizard's project picker) opens a full-width dropdown while compact toolbar pickers keep the floor.
4. **`fix`: notification row action inset** — wraps row actions in `pl-9 pr-4 pb-3` so they line up with the body text and regain the missing bottom gutter.

## Verification

- ✅ `typecheck` + `lint` green against latest `main`
- ✅ `lint:sast` (Opengrep) — 0 findings in changed files
- ✅ i18n `parity` + `usage` enforce green (incl. the orphaned-key removal — the `usage` check caught it)
- ✅ `test:ui` (data-table + searchable-select) green — 8 files / 79 tests
- ⚠️ Authenticated in-browser walkthrough **not run locally** (no dev credential); relying on CI e2e + reviewer check

## Definition of Done

- [x] **Translations — all base locales** — en/de/fr: added `apps.details.*`, removed orphaned `apps.install.notInstalledTitle`. de-CH falls back to de.
- [x] **Accessibility** — Install is a `button`; chips/scope are `Badge`s; the data-table & searchable-select changes are presentational (no a11y semantics change).
- [x] **Tests** — typecheck + `test:ui` green. No new e2e spec for the details page (presentational enhancement of the existing install flow; CI e2e + existing specs cover installation).
- [x] **Docs** — N/A (internal UI polish; the documented install steps are unchanged).
- [x] **Migrations** — N/A (no data-model change).
- [x] **Storybook** — N/A (app components under `services/platform`, not `packages/ui` primitives).
- [x] **Instructions** — N/A (no documented path/command/pattern changed).
