### PR TITLE
fix(platform): count visible rows in automations list footer (#2094)

### DIFF
--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/desk-process.json
@@ -21,10 +21,7 @@
     "integrations": [
       {
         "name": "github",
-        "operations": [
-          "get_issue",
-          "create_pull_request"
-        ]
+        "operations": ["get_issue", "create_pull_request"]
       }
     ]
   },

--- a/services/platform/app/features/automations/components/automations-table.test.tsx
+++ b/services/platform/app/features/automations/components/automations-table.test.tsx
@@ -1,11 +1,34 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { describe, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
 import { render } from '@/tests/utils/render';
 
 import { AutomationsTable } from './automations-table';
+
+interface MockWorkflow {
+  slug: string;
+  name: string;
+  description?: string;
+  stepCount: number;
+  hash: string;
+  createdAtMs?: number;
+}
+
+const mockWorkflows: { current: MockWorkflow[] } = {
+  current: [
+    {
+      slug: 'my-workflow',
+      name: 'My Workflow',
+      description: 'A test workflow',
+      stepCount: 3,
+      hash: 'abc123',
+      createdAtMs: 1709856000000,
+    },
+  ],
+};
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
@@ -32,16 +55,7 @@ vi.mock('@/app/hooks/use-toast', () => ({
 
 vi.mock('../hooks/file-queries', () => ({
   useListWorkflows: () => ({
-    workflows: [
-      {
-        slug: 'my-workflow',
-        name: 'My Workflow',
-        description: 'A test workflow',
-        stepCount: 3,
-        hash: 'abc123',
-        createdAtMs: 1709856000000,
-      },
-    ],
+    workflows: mockWorkflows.current,
     isLoading: false,
     refetch: vi.fn(),
   }),
@@ -57,6 +71,19 @@ vi.mock('../hooks/file-mutations', () => ({
 }));
 
 describe('AutomationsTable', () => {
+  beforeEach(() => {
+    mockWorkflows.current = [
+      {
+        slug: 'my-workflow',
+        name: 'My Workflow',
+        description: 'A test workflow',
+        stepCount: 3,
+        hash: 'abc123',
+        createdAtMs: 1709856000000,
+      },
+    ];
+  });
+
   describe('accessibility', () => {
     it('passes axe audit', async () => {
       const { container } = render(
@@ -68,6 +95,39 @@ describe('AutomationsTable', () => {
           'empty-table-header': { enabled: false },
         },
       });
+    });
+  });
+
+  describe('count footer', () => {
+    // Regression for #2094: a folder collapses its child workflows into one
+    // row, so the footer must not count those hidden children against the
+    // visible folder rows ("Showing 1 of 15 automations").
+    it('counts visible rows, not grouped child workflows, in the folder view', () => {
+      mockWorkflows.current = Array.from({ length: 15 }, (_, i) => ({
+        slug: `projects/workflow-${i}`,
+        name: `Workflow ${i}`,
+        stepCount: 1,
+        hash: `hash-${i}`,
+      }));
+
+      render(<AutomationsTable organizationId="test-org-id" />);
+
+      // One folder row ("projects") stands in for all 15 child workflows.
+      expect(screen.getByText('Showing all 1 automations')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Showing 1 of 15 automations'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('reports all rows when nothing is grouped', () => {
+      mockWorkflows.current = [
+        { slug: 'alpha', name: 'Alpha', stepCount: 1, hash: 'a' },
+        { slug: 'beta', name: 'Beta', stepCount: 1, hash: 'b' },
+      ];
+
+      render(<AutomationsTable organizationId="test-org-id" />);
+
+      expect(screen.getByText('Showing all 2 automations')).toBeInTheDocument();
     });
   });
 });

--- a/services/platform/app/features/automations/components/automations-table.tsx
+++ b/services/platform/app/features/automations/components/automations-table.tsx
@@ -372,7 +372,19 @@ export function AutomationsTable({
           hasMore: false,
           onLoadMore: () => {},
           entityLabel: tAutomations('entityLabel'),
-          totalCount: validWorkflows?.length ?? 0,
+          // The footer reads "Showing {data.length} of {totalCount}", so both
+          // must count the same unit as the rows on screen. While searching the
+          // list is flat — every row is a workflow — so the denominator is the
+          // full workflow universe ("Showing 5 of 15 automations"). In the
+          // folder view rows are folders + direct workflows (a grouped folder
+          // hides its 15 children behind one row); there's no paged-away subset
+          // (hasMore is false), so the total is the visible row count and the
+          // footer reads "Showing all N automations" instead of mixing units
+          // ("Showing 1 of 15 automations" counted folder rows against child
+          // workflows).
+          totalCount: isSearching
+            ? (validWorkflows?.length ?? 0)
+            : tableItems.length,
         }}
         emptyState={
           searchQuery


### PR DESCRIPTION
Fixes #2094.

## Problem
On `/dashboard/{org}/automations`, when automations are grouped under a folder, the footer read **"Showing 1 of 15 automations"** — the numerator counted visible folder rows (`tableItems.length`) while the denominator counted every grouped child workflow (`validWorkflows.length`). Mixed units, so it implied 14 hidden rows.

## Fix
`automations-table.tsx` — make the footer numerator and denominator count the same unit:
- **Search view** (flat list, every row is a workflow): total stays the full workflow universe → "Showing 5 of 15 automations".
- **Folder view** (rows are folders + direct workflows; no paged-away subset since `hasMore: false`): total is the visible row count → "Showing all N automations".

## Tests
Added regression tests in `automations-table.test.tsx` covering the grouped-folder case (asserts the "Showing 1 of 15" string never appears) and the ungrouped case. All UI tests for the file pass; typecheck and lint clean.