### PR TITLE
fix(platform): show sign-in toast on 2FA TOTP login, not enrollment copy (#2083)

### DIFF
--- a/services/platform/app/routes/_auth/2fa.tsx
+++ b/services/platform/app/routes/_auth/2fa.tsx
@@ -90,8 +90,9 @@ function TwoFactorVerifyPage() {
           position: 'top-center',
         });
       } else {
+        // TOTP success during sign-in: confirm the sign-in, not enrollment.
         toast({
-          title: t('enrollment.enabled'),
+          title: t('verify.success'),
           variant: 'success',
           position: 'top-center',
         });

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6989,6 +6989,7 @@
       "submitButton": "Prüfen",
       "invalid": "Ungültiger oder abgelaufener Code. Bitte erneut versuchen.",
       "tooManyAttempts": "Zu viele Fehlversuche. Bitte später erneut versuchen.",
+      "success": "Angemeldet",
       "backupCodeSuccess": "Backup-Code verwendet. Erwäge, die Backup-Codes in den Einstellungen neu zu erzeugen.",
       "usePasskeyButton": "Stattdessen einen Passkey verwenden",
       "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen oder abgebrochen. Versuche es erneut oder verwende einen Code."

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7251,6 +7251,7 @@
       "submitButton": "Verify",
       "invalid": "Invalid or expired code. Please try again.",
       "tooManyAttempts": "Too many failed attempts. Try again later.",
+      "success": "Signed in successfully",
       "backupCodeSuccess": "Backup code used. Consider regenerating your backup codes in Settings.",
       "usePasskeyButton": "Use a passkey instead",
       "passkeyFailed": "Passkey sign-in failed or was cancelled. Try again or use a code."

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6990,6 +6990,7 @@
       "submitButton": "Vérifier",
       "invalid": "Code invalide ou expiré. Merci de réessayer.",
       "tooManyAttempts": "Trop de tentatives échouées. Merci de réessayer plus tard.",
+      "success": "Connecté avec succès",
       "backupCodeSuccess": "Code de secours utilisé. Pense à régénérer tes codes de secours dans les Paramètres.",
       "usePasskeyButton": "Utiliser un passkey à la place",
       "passkeyFailed": "Connexion par passkey échouée ou annulée. Réessaie ou utilise un code."


### PR DESCRIPTION
## Summary

Fixes #2083.

During 2FA sign-in, the TOTP success branch of `services/platform/app/routes/_auth/2fa.tsx` reused `twoFactor.enrollment.enabled` ("Two-factor authentication enabled"), telling a *returning* user they had just **enabled** 2FA instead of confirming the sign-in.

## Changes

- Added a new `twoFactor.verify.success` message key to `en.json`, `de.json`, and `fr.json` ("Signed in successfully" / "Angemeldet" / "Connecté avec succès"), matching the password path's `login.toast.success` wording.
- The TOTP success branch now shows `t('verify.success')` instead of `t('enrollment.enabled')`.
- The backup-code branch is unchanged (it already had its own correct copy).
- `de-CH.json` is a sparse override that falls back to `de`, so no change was needed there.

## Verification

- `oxlint --type-aware` on the changed route: 0 warnings, 0 errors.
- All four locale JSON files validated as parseable.
- The `t` function is a generic `TFunction`, so the new key is type-safe by construction.