### PR TITLE
fix(platform): show backup-code description on 2FA verify page (#2084)

### DIFF
--- a/services/platform/app/routes/_auth/2fa.tsx
+++ b/services/platform/app/routes/_auth/2fa.tsx
@@ -138,7 +138,7 @@ function TwoFactorVerifyPage() {
     <AuthFormLayout title={t('verify.title')}>
       <Stack gap={6}>
         <Text variant="muted" className="text-center text-sm">
-          {useBackup ? t('verify.description') : t('verify.description')}
+          {useBackup ? t('verify.backupDescription') : t('verify.description')}
         </Text>
 
         <Form onSubmit={handleSubmit} autoComplete="off">

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6982,6 +6982,7 @@
     "verify": {
       "title": "Identität bestätigen",
       "description": "Gib den 6-stelligen Code aus deiner Authenticator-App ein.",
+      "backupDescription": "Gib einen deiner Backup-Codes ein.",
       "codeLabel": "Authentifizierungscode",
       "useBackupCodeToggle": "Stattdessen einen Backup-Code verwenden",
       "useAuthenticatorToggle": "Stattdessen die Authenticator-App verwenden",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7244,6 +7244,7 @@
     "verify": {
       "title": "Verify your identity",
       "description": "Enter the 6-digit code from your authenticator app.",
+      "backupDescription": "Enter one of your backup codes.",
       "codeLabel": "Authentication code",
       "useBackupCodeToggle": "Use a backup code instead",
       "useAuthenticatorToggle": "Use the authenticator app instead",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6983,6 +6983,7 @@
     "verify": {
       "title": "Vérifier ton identité",
       "description": "Saisis le code à 6 chiffres de ton application d'authentification.",
+      "backupDescription": "Saisis l'un de tes codes de secours.",
       "codeLabel": "Code d'authentification",
       "useBackupCodeToggle": "Utiliser un code de secours à la place",
       "useAuthenticatorToggle": "Utiliser l'application d'authentification à la place",


### PR DESCRIPTION
## Summary

Fixes #2084.

On the 2FA verify page (`services/platform/app/routes/_auth/2fa.tsx`), the instruction text used a dead no-op ternary where both branches resolved to `t('verify.description')`, so backup-code mode still showed "Enter the 6-digit code from your authenticator app." No `twoFactor.verify.backupDescription` key existed in any locale.

## Changes

- Wire line 141 to `useBackup ? t('verify.backupDescription') : t('verify.description')`.
- Add `twoFactor.verify.backupDescription` to `en.json`, `de.json`, and `fr.json`. `de-CH` is a sparse override locale and falls back to `de`; the German string contains no ß, so no `de-CH` override is needed.

## Verification

- `bunx vitest --run lib/i18n/messages.test.ts` — 23 passed (parity + usage enforce mode clean).
- `bunx tsc --noEmit` — clean.
- `bunx oxlint --type-aware app/routes/_auth/2fa.tsx` — 0 warnings, 0 errors.