### PR TITLE
fix: export-chat "Deselect all" no-op and dead download-disabled state (#2080)

### DIFF
--- a/services/platform/app/features/chat/components/export-chat-dialog.test.tsx
+++ b/services/platform/app/features/chat/components/export-chat-dialog.test.tsx
@@ -116,4 +116,66 @@ describe('ExportChatDialog', () => {
       mockMessages.length,
     );
   });
+
+  it('clears all checkboxes and disables downloads when Deselect all is clicked', async () => {
+    const { user } = render(
+      <ExportChatDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        threadId="thread-1"
+        organizationId="org-1"
+      />,
+    );
+
+    // Starts with everything selected.
+    expect(
+      screen.getByText(
+        `${mockMessages.length} of ${mockMessages.length} messages selected`,
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Deselect all' }));
+
+    // Selection genuinely reaches zero and stays there.
+    expect(
+      screen.getByText(`0 of ${mockMessages.length} messages selected`),
+    ).toBeInTheDocument();
+    // The toggle flips to "Select all"; no checkbox remains checked.
+    expect(
+      screen.getByRole('button', { name: 'Select all' }),
+    ).toBeInTheDocument();
+    for (const checkbox of screen.getAllByRole('checkbox')) {
+      expect(checkbox).not.toBeChecked();
+    }
+    // Both download buttons disable while nothing is selected.
+    expect(
+      screen.getByRole('button', { name: 'Download Markdown' }),
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+  });
+
+  it('reaches zero when messages are deselected one by one', async () => {
+    const { user } = render(
+      <ExportChatDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        threadId="thread-1"
+        organizationId="org-1"
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    for (const checkbox of checkboxes) {
+      await user.click(checkbox);
+    }
+
+    // Removing the final message empties the selection instead of re-selecting.
+    expect(
+      screen.getByText(`0 of ${mockMessages.length} messages selected`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Download Markdown' }),
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+  });
 });

--- a/services/platform/app/features/chat/components/export-chat-dialog.tsx
+++ b/services/platform/app/features/chat/components/export-chat-dialog.tsx
@@ -165,49 +165,51 @@ function ExportChatDialogContent({
     [data?.messages],
   );
 
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  // Selection is either the `'all'` sentinel (the default before the user
+  // touches anything — every message selected, including ones that load later)
+  // or an explicit Set. An explicit empty Set genuinely means "nothing
+  // selected", so deselecting down to zero stays at zero.
+  const [selection, setSelection] = useState<'all' | Set<string>>('all');
 
-  // Sync selection with messages once loaded (default all selected)
   const allIds = useMemo(() => new Set(messages.map((m) => m._id)), [messages]);
   const effectiveSelected = useMemo(() => {
-    if (selectedIds.size === 0 && messages.length > 0) {
+    if (selection === 'all') {
       return allIds;
     }
     // Remove stale IDs that no longer exist
     const valid = new Set<string>();
-    for (const id of selectedIds) {
+    for (const id of selection) {
       if (allIds.has(id)) valid.add(id);
     }
     return valid;
-  }, [selectedIds, allIds, messages.length]);
+  }, [selection, allIds]);
 
-  const allSelected = effectiveSelected.size === messages.length;
+  const allSelected =
+    messages.length > 0 && effectiveSelected.size === messages.length;
   const noneSelected = effectiveSelected.size === 0;
 
   const handleToggleAll = useCallback(() => {
     if (allSelected) {
-      setSelectedIds(new Set());
+      setSelection(new Set());
     } else {
-      setSelectedIds(new Set(messages.map((m) => m._id)));
+      setSelection('all');
     }
-  }, [allSelected, messages]);
+  }, [allSelected]);
 
   const handleToggleMessage = useCallback(
     (id: string) => {
-      setSelectedIds((prev) => {
-        const base =
-          prev.size === 0 && messages.length > 0
-            ? new Set(messages.map((m) => m._id))
-            : new Set(prev);
-        if (base.has(id)) {
-          base.delete(id);
+      setSelection((prev) => {
+        const base = prev === 'all' ? allIds : prev;
+        const next = new Set(base);
+        if (next.has(id)) {
+          next.delete(id);
         } else {
-          base.add(id);
+          next.add(id);
         }
-        return base;
+        return next;
       });
     },
-    [messages],
+    [allIds],
   );
 
   const youLabel = t('export.you');


### PR DESCRIPTION
## Summary

Fixes #2080.

The export-chat dialog used an **empty `Set` as a sentinel meaning "default = all selected"**. As a result:
- **Deselect all** was a no-op — `setSelectedIds(new Set())` instantly re-resolved to `allIds` on the next render.
- Deselecting messages one-by-one never reached zero — removing the last id emptied the set, re-triggering the sentinel.
- `noneSelected` was therefore always `false`, making the `disabled={noneSelected}` guards on both download buttons dead code.

## Fix

Replaced the overloaded empty-set sentinel with an explicit discriminated selection model: `selection` is either the `'all'` sentinel (default, selects every message including ones that load later) or an explicit `Set<string>`. An explicit **empty** set now genuinely means "nothing selected", so:
- **Deselect all** sets `selection = new Set()` → counter reads `0 of N`, toggle flips to **Select all**, both download buttons disable.
- Deselecting the final message empties the set instead of re-selecting everything.

## Tests

Added two regression tests in `export-chat-dialog.test.tsx`:
- Clicking **Deselect all** → `0 of N`, no checkboxes checked, both downloads disabled.
- Deselecting messages one-by-one reaches zero (final message no longer re-selects all).

All 5 UI tests pass; `tsc --noEmit` and `oxlint --type-aware` are clean on the changed files.