### PR TITLE
feat(platform): skip KB indexing for external-agent attachment uploads

### DIFF
--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -196,6 +196,22 @@ export function ChatInterface({
     }
   }, [insertedPrompt, setInsertedPrompt, setInputValue]);
 
+  // Agent availability — disable input when no agents exist
+  const { agents } = useChatAgents(organizationId);
+  const hasNoAgents = agents !== undefined && agents.length === 0;
+
+  // Image-generation agent derivations for EditingBanner.
+  const activeAgentMeta = useMemo(
+    () => agents?.find((a) => a.name === effectiveAgent?.name),
+    [agents, effectiveAgent?.name],
+  );
+  const isImageGenAgent =
+    activeAgentMeta?.primaryBehavior === 'image-generation';
+  // External-agent (sandbox session) threads support queue mode: the composer
+  // stays usable while a turn runs and sends enqueue for the running agent.
+  const isExternalAgentThread =
+    activeAgentMeta?.primaryBehavior === 'external-agent';
+
   const {
     attachments,
     setAttachments,
@@ -204,7 +220,13 @@ export function ChatInterface({
     removeAttachment,
     retryAttachmentTranscription,
     clearAttachments,
-  } = useConvexFileUpload({ organizationId, threadId });
+  } = useConvexFileUpload({
+    organizationId,
+    threadId,
+    // External agents read attachments straight from the sandbox, not the
+    // KB — skip RAG indexing so those uploads don't show "Index failed".
+    disableIndexing: isExternalAgentThread,
+  });
 
   const { isIndexing, statusMap: indexingStatuses } =
     useFileIndexingStatus(attachments);
@@ -300,21 +322,6 @@ export function ChatInterface({
     [savedMessageMap, deletePrompt],
   );
 
-  // Agent availability — disable input when no agents exist
-  const { agents } = useChatAgents(organizationId);
-  const hasNoAgents = agents !== undefined && agents.length === 0;
-
-  // Image-generation agent derivations for EditingBanner.
-  const activeAgentMeta = useMemo(
-    () => agents?.find((a) => a.name === effectiveAgent?.name),
-    [agents, effectiveAgent?.name],
-  );
-  const isImageGenAgent =
-    activeAgentMeta?.primaryBehavior === 'image-generation';
-  // External-agent (sandbox session) threads support queue mode: the composer
-  // stays usable while a turn runs and sends enqueue for the running agent.
-  const isExternalAgentThread =
-    activeAgentMeta?.primaryBehavior === 'external-agent';
   const threadImages = useThreadImages(isImageGenAgent ? messages : undefined);
   const { providers: providersForEdit } = useListProviders(organizationId);
   const activeModelRef = effectiveAgent?.name

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -49,6 +49,14 @@ interface ConvexFileUploadConfig {
    * path keeps them readable to the agent in the same org.
    */
   threadId?: string;
+  /**
+   * Suppress automatic knowledge-base (RAG) indexing for files uploaded
+   * through this composer. Set when the active conversation targets an
+   * external agent (sandbox sessions like Claude Code): those agents read
+   * attachments straight from the sandbox, so indexing them into the KB is
+   * wasted work that only surfaces a spurious "Index failed" badge.
+   */
+  disableIndexing?: boolean;
   maxFileSize?: number;
   allowedTypes?: string[];
 }
@@ -320,6 +328,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
               ...(config.threadId !== undefined && {
                 threadId: config.threadId,
               }),
+              ...(config.disableIndexing && { skipRagIndexing: true }),
             });
 
             const attachment: FileAttachment = {
@@ -358,6 +367,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
       saveFileMetadata,
       config.organizationId,
       config.threadId,
+      config.disableIndexing,
       mergedConfig,
       policyLimits,
       t,

--- a/services/platform/convex/file_metadata/mutations.test.ts
+++ b/services/platform/convex/file_metadata/mutations.test.ts
@@ -133,6 +133,29 @@ describe('saveFileMetadata (public)', () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
+  it('skips RAG indexing when skipRagIndexing is set (external agent)', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    // An indexable PDF that would normally queue RAG — the external-agent
+    // composer opts out so the file is staged to the sandbox, not the KB.
+    await handler(ctx, { ...baseArgs, skipRagIndexing: true });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      'fileMetadata',
+      expect.objectContaining({
+        ragStatus: undefined,
+        ragQueuedAt: undefined,
+      }),
+    );
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalledWith(
+      0,
+      'mock',
+      expect.objectContaining({ storageId: 'storage_1' }),
+    );
+  });
+
   it('patches existing file metadata by storageId', async () => {
     mockGetAuthUser.mockResolvedValue(AUTH_USER);
     const existing = {

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -31,6 +31,17 @@ export const saveFileMetadata = mutation({
      * spoofing across orgs.
      */
     threadId: v.optional(v.string()),
+    /**
+     * Suppress automatic RAG indexing for this upload. The composer sets
+     * this when the active conversation targets an external agent (sandbox
+     * sessions like Claude Code): those agents receive attachments by
+     * file-staging into the sandbox (see external_agent/attachment_files),
+     * not via the knowledge base, so indexing them is wasted work that only
+     * produces a spurious "Index failed" badge. Worst case a client lies and
+     * skips indexing its own file — the file stays usable inline; nothing
+     * cross-tenant is exposed, so this stays a client-supplied hint.
+     */
+    skipRagIndexing: v.optional(v.boolean()),
   },
   async handler(ctx, args) {
     const authUser = await getAuthUserIdentity(ctx);
@@ -83,7 +94,9 @@ export const saveFileMetadata = mutation({
     // failed" badge. Non-indexable files keep ragStatus undefined — the
     // audio pattern — and stay usable inline in chat.
     const shouldIndex =
-      !isAudio && isRagIndexableFile(args.fileName, args.contentType);
+      !args.skipRagIndexing &&
+      !isAudio &&
+      isRagIndexableFile(args.fileName, args.contentType);
 
     const now = Date.now();
 


### PR DESCRIPTION
## Problem

When a user uploads a file while an **external agent** (sandbox session like Claude Code) is selected in the composer, the file is auto-indexed into the knowledge base (RAG). But external agents receive attachments by **file-staging into the sandbox** (#2119), not via the KB — so this indexing is wasted work that only surfaces a spurious **"Index failed"** badge in the composer.

## Change

Thread a `skipRagIndexing` signal from the composer down to the upload mutation:

- **`convex/file_metadata/mutations.ts`** — `saveFileMetadata` gains an optional `skipRagIndexing` arg, folded into the `shouldIndex` gate. Suppresses both the `ragStatus: 'queued'` write and the scheduled `uploadFileToRag` action. The re-upload retry path reuses `shouldIndex`, so it's covered automatically.
- **`use-convex-file-upload.ts`** — new `disableIndexing` config flag, passed through as `skipRagIndexing`.
- **`chat-interface.tsx`** — passes `disableIndexing: isExternalAgentThread` (the composer already derives `primaryBehavior === 'external-agent'`). The agent-derivation block moved above the upload hook so the signal is available at call time.

### Why a client hint, not a server-side thread lookup
A fresh chat uploads attachments **before the thread (and its `agentSlug`) exists** — the server has no signal there. The composer always knows the selected agent, so a client flag covers both fresh and existing threads. Worst case a client skips indexing its own file: the file stays usable inline, and nothing cross-tenant is exposed — so this stays a client-supplied hint.

## Verification
- `mutations.test.ts` — 14 passed, incl. a new "skips RAG indexing when skipRagIndexing is set (external agent)" case
- `tsc --noEmit` — clean (full project, exit 0)
