### PR TITLE
fix(platform): add accessible name to notifications popover dialog (#2096)

### DIFF
--- a/services/platform/app/features/notifications/components/notification-bell.test.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, waitFor } from '@/tests/utils/render';
+
+import { NotificationBell } from './notification-bell';
+
+// The bell's own count hooks — keep them quiet so the component renders without
+// a live backend. Values are irrelevant to the dialog-naming assertion.
+vi.mock('../hooks/queries', () => ({
+  useNotificationsUnreadCount: () => ({ data: 0 }),
+}));
+vi.mock('@/app/features/inbox/hooks/queries', () => ({
+  useUnreadNotificationCount: () => 0,
+}));
+
+// The popover body pulls in the full notifications data layer; stub it so the
+// test stays focused on the popover container's accessible name.
+vi.mock('./notification-list-panel', () => ({
+  NotificationListPanel: () => <div data-testid="notification-list-panel" />,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NotificationBell', () => {
+  // Regression test for #2096: Radix renders the popover content as
+  // role="dialog"; it must carry an accessible name so screen readers announce
+  // it as the "Notifications" dialog rather than an unnamed one (WCAG 4.1.2).
+  // Mirrors the [role="dialog"].toHaveAccessibleName(...) pattern in
+  // automation-create-dialog.test.tsx.
+  it('gives the notifications popover dialog an accessible name', async () => {
+    const { user } = render(<NotificationBell organizationId="org-1" />);
+
+    // No dialog until the popover is opened.
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Notifications' }));
+
+    // The Radix popover renders in a portal (document.body), not inside the
+    // render container.
+    await waitFor(() =>
+      expect(document.querySelector('[role="dialog"]')).toHaveAccessibleName(
+        'Notifications',
+      ),
+    );
+  });
+});

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -105,6 +105,10 @@ export function NotificationBell({
           align="end"
           side="right"
           sideOffset={8}
+          // Radix renders the popover content as `role="dialog"`; give it an
+          // accessible name so screen readers announce it as the
+          // "Notifications" dialog rather than an unnamed one (WCAG 4.1.2).
+          aria-label={tNav('notifications')}
           className={cn(
             POPOVER_CONTENT_CLASSES,
             'bg-card w-96 max-w-[calc(100vw-2rem)] p-0',


### PR DESCRIPTION
Closes #2096

## Problem
The notifications bell popover renders as `role="dialog"` (via Radix `Popover.Content`) with no `aria-label`/`aria-labelledby`, so screen readers announce an unnamed dialog (WCAG 4.1.2).

## Fix
Add `aria-label={tNav('notifications')}` to the `PopoverPrimitive.Content` in `notification-bell.tsx`, giving the dialog the localized accessible name "Notifications" — consistent with the named "Create project" dialog.

## Verification
- `bunx oxlint --type-aware` on the changed file — clean
- `bunx tsc --noEmit` — passes