### PR TITLE
fix(platform): Enterprise SSO + SCIM end-to-end hardening (Microsoft Entra) (#2116)

### DIFF
--- a/services/platform/convex/conversations/create_conversation_with_message.test.ts
+++ b/services/platform/convex/conversations/create_conversation_with_message.test.ts
@@ -1,0 +1,56 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import { createConversationWithMessage } from './create_conversation_with_message';
+import type { CreateConversationWithMessageArgs } from './create_conversation_with_message';
+
+vi.mock('../audit_logs/helpers', () => ({
+  logSuccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./create_conversation', () => ({
+  createConversation: vi.fn().mockResolvedValue({
+    success: true,
+    conversationId: 'created_conversation' as Id<'conversations'>,
+  }),
+}));
+
+const ORG_ID = 'org_1';
+
+function makeArgs(): CreateConversationWithMessageArgs {
+  return {
+    organizationId: ORG_ID,
+    initialMessage: {
+      sender: 'sender@example.com',
+      content: 'hello',
+      isCustomer: true,
+    },
+  } as CreateConversationWithMessageArgs;
+}
+
+describe('createConversationWithMessage — client-facing failures use ConvexError (#2049)', () => {
+  it('throws a coded ConvexError when the created conversation cannot be retrieved', async () => {
+    // The conversation is created but the immediate read-back returns null,
+    // exercising the post-create retrieval invariant.
+    const ctx = {
+      db: {
+        get: vi.fn().mockResolvedValue(null),
+        insert: vi
+          .fn()
+          .mockResolvedValue('message_id' as Id<'conversationMessages'>),
+        patch: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as MutationCtx;
+
+    await expect(
+      createConversationWithMessage(ctx, makeArgs()),
+    ).rejects.toBeInstanceOf(ConvexError);
+    await expect(
+      createConversationWithMessage(ctx, makeArgs()),
+    ).rejects.toMatchObject({
+      data: { code: 'conversation_not_found' },
+    });
+  });
+});

--- a/services/platform/convex/conversations/create_conversation_with_message.ts
+++ b/services/platform/convex/conversations/create_conversation_with_message.ts
@@ -5,6 +5,8 @@
  * Useful for email workflows and other scenarios where a conversation always starts with a message.
  */
 
+import { ConvexError } from 'convex/values';
+
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import * as AuditLogHelpers from '../audit_logs/helpers';
@@ -57,7 +59,10 @@ export async function createConversationWithMessage(
   // Get the conversation to access its channel
   const conversation = await ctx.db.get(conversationId);
   if (!conversation) {
-    throw new Error('Failed to retrieve created conversation');
+    throw new ConvexError({
+      code: 'conversation_not_found',
+      message: 'Failed to retrieve created conversation',
+    });
   }
 
   // Determine message direction and delivery state

--- a/services/platform/convex/conversations/update_conversations.test.ts
+++ b/services/platform/convex/conversations/update_conversations.test.ts
@@ -1,0 +1,74 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../_generated/server';
+import type { UpdateConversationsArgs } from './types';
+import { updateConversations } from './update_conversations';
+
+vi.mock('../audit_logs/helpers', () => ({
+  logSuccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+const ORG_ID = 'org_1';
+
+function makeConversation(id: string, organizationId = ORG_ID) {
+  return {
+    _id: id,
+    organizationId,
+    status: 'open',
+    priority: 'normal',
+    metadata: {},
+  };
+}
+
+function createMockCtx(conversations: Array<Record<string, unknown>>) {
+  const ctx = {
+    db: {
+      get: vi.fn((id: string) =>
+        Promise.resolve(conversations.find((c) => c._id === id) ?? null),
+      ),
+      patch: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as MutationCtx;
+  return ctx;
+}
+
+describe('updateConversations — client-facing failures use ConvexError (#2049)', () => {
+  it('throws a coded ConvexError when neither id nor org is provided', async () => {
+    const ctx = createMockCtx([]);
+    const args = { updates: {} } as UpdateConversationsArgs;
+
+    await expect(updateConversations(ctx, args)).rejects.toBeInstanceOf(
+      ConvexError,
+    );
+    await expect(updateConversations(ctx, args)).rejects.toMatchObject({
+      data: { code: 'conversation_target_required' },
+    });
+  });
+
+  it('throws a coded ConvexError when the conversation does not exist', async () => {
+    const ctx = createMockCtx([]);
+    const args = {
+      conversationId: 'missing' as Id<'conversations'>,
+      updates: {},
+    } as UpdateConversationsArgs;
+
+    await expect(updateConversations(ctx, args)).rejects.toMatchObject({
+      data: { code: 'conversation_not_found' },
+    });
+  });
+
+  it('hides cross-tenant targets behind a not-found ConvexError', async () => {
+    const ctx = createMockCtx([makeConversation('c_1', 'org_other')]);
+    const args = {
+      conversationId: 'c_1' as Id<'conversations'>,
+      organizationId: ORG_ID,
+      updates: {},
+    } as UpdateConversationsArgs;
+
+    await expect(updateConversations(ctx, args)).rejects.toMatchObject({
+      data: { code: 'conversation_not_found' },
+    });
+  });
+});

--- a/services/platform/convex/conversations/update_conversations.test.ts
+++ b/services/platform/convex/conversations/update_conversations.test.ts
@@ -54,6 +54,9 @@ describe('updateConversations — client-facing failures use ConvexError (#2049)
       updates: {},
     } as UpdateConversationsArgs;
 
+    await expect(updateConversations(ctx, args)).rejects.toBeInstanceOf(
+      ConvexError,
+    );
     await expect(updateConversations(ctx, args)).rejects.toMatchObject({
       data: { code: 'conversation_not_found' },
     });
@@ -67,6 +70,9 @@ describe('updateConversations — client-facing failures use ConvexError (#2049)
       updates: {},
     } as UpdateConversationsArgs;
 
+    await expect(updateConversations(ctx, args)).rejects.toBeInstanceOf(
+      ConvexError,
+    );
     await expect(updateConversations(ctx, args)).rejects.toMatchObject({
       data: { code: 'conversation_not_found' },
     });

--- a/services/platform/convex/conversations/update_conversations.ts
+++ b/services/platform/convex/conversations/update_conversations.ts
@@ -64,7 +64,10 @@ export async function updateConversations(
     }
     // Cross-tenant write guard: when the caller's org is known (the agent
     // conversation_write tool always passes it), the target conversation must
-    // belong to it — mirrors addMessageToConversation. Closes the IDOR.
+    // belong to it. Unlike addMessageToConversation (which reports a
+    // distinguishable `conversation_org_mismatch`), this deliberately reuses
+    // `conversation_not_found` so a cross-tenant probe cannot confirm the
+    // record exists in another organization. Closes the IDOR.
     if (
       args.organizationId &&
       conversation.organizationId !== args.organizationId

--- a/services/platform/convex/conversations/update_conversations.ts
+++ b/services/platform/convex/conversations/update_conversations.ts
@@ -2,6 +2,7 @@
  * Update conversations with flexible filtering and updates (business logic)
  */
 
+import { ConvexError } from 'convex/values';
 import { set, merge } from 'lodash';
 
 import { isRecord } from '../../lib/utils/type-utils';
@@ -42,9 +43,11 @@ export async function updateConversations(
 ): Promise<UpdateConversationsResult> {
   // Validate: must provide either conversationId or organizationId
   if (!args.conversationId && !args.organizationId) {
-    throw new Error(
-      'Must provide either conversationId or organizationId for safety',
-    );
+    throw new ConvexError({
+      code: 'conversation_target_required',
+      message:
+        'Must provide either conversationId or organizationId for safety',
+    });
   }
 
   // Find conversations to update
@@ -54,7 +57,10 @@ export async function updateConversations(
     // Update by ID (most common case)
     const conversation = await ctx.db.get(args.conversationId);
     if (!conversation) {
-      throw new Error(`Conversation not found: ${args.conversationId}`);
+      throw new ConvexError({
+        code: 'conversation_not_found',
+        message: 'Conversation not found',
+      });
     }
     // Cross-tenant write guard: when the caller's org is known (the agent
     // conversation_write tool always passes it), the target conversation must
@@ -63,7 +69,10 @@ export async function updateConversations(
       args.organizationId &&
       conversation.organizationId !== args.organizationId
     ) {
-      throw new Error(`Conversation not found: ${args.conversationId}`);
+      throw new ConvexError({
+        code: 'conversation_not_found',
+        message: 'Conversation not found',
+      });
     }
     conversationsToUpdate = [conversation];
   } else if (args.organizationId) {


### PR DESCRIPTION
## Summary

Resolves the consolidated **Enterprise SSO + SCIM end-to-end hardening** epic #2116.

The bulk of the epic's defects were already addressed on `main` by #2118 (open-redirect validation, multi-org email-domain SSO routing, protocol-switch secret validation, controlled SSO form fields, role-mapping editor, SCIM Group PATCH composition, 2FA/banner/password-gate polish, and the `ConvexError` sweep across users/SSO-config/SCIM/task-metrics/tasks/conversations). I verified each enumerated site in the sub-issues (#2036, #2037, #2082, #2057, #2095, #2049, #2085, #1921) against the current code and confirmed they are in place.

This PR closes the remaining gap in the **#2049 [84]** sweep — the `convex/conversations/*` mutations that still threw a raw `Error` for client-facing failures, so Convex redacted them to a generic "Server Error" with no machine-readable `code`:

- `update_conversations.ts` — `conversation_target_required` (missing id/org) and `conversation_not_found` (missing target + cross-tenant guard), matching the codes already used by the sibling conversation mutations.
- `create_conversation_with_message.ts` — `conversation_not_found` for the post-create retrieval invariant.

Background `internal_actions.ts` (integration send/download failures) is intentionally left on raw `Error`: those are server-side `internalAction` failures, not client-facing mutation results, and fall outside the issue's enumerated mutation sites.

## Tests

- Added co-located `update_conversations.test.ts` asserting each failure path throws a `ConvexError` carrying the correct `data.code`.
- `bunx vitest --run --project server convex/conversations/` → 4 files, 23 tests passing.
- `oxlint --type-aware` clean on changed files.

Closes #2116