### PR TITLE
fix: add destructive-confirm step to self-service passkey removal (#2081)

### DIFF
--- a/services/platform/app/features/settings/account/components/passkey-section.test.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.test.tsx
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen, waitFor, within } from '@/tests/utils/render';
+
+import { PasskeySection } from './passkey-section';
+
+// Shared across the hoisted `vi.mock` factories and the assertions below.
+// `deletePasskey` is the credential-destroying call the confirm gate protects;
+// spying on it proves it fires ONLY after the dialog is accepted.
+const { PASSKEY, PASSKEYS_RESULT, STATUS_RESULT, deletePasskey } = vi.hoisted(
+  () => {
+    const passkey = { id: 'pk-1', name: 'MacBook Touch ID' };
+    return {
+      PASSKEY: passkey,
+      // Stable identities so re-renders never see a fresh object.
+      PASSKEYS_RESULT: { data: [passkey], isLoading: false },
+      STATUS_RESULT: { data: { authenticated: true, hasCredential: true } },
+      deletePasskey: vi.fn(),
+    };
+  },
+);
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// Local-credential gate: a non-SSO user who owns at least one passkey.
+vi.mock('@/app/hooks/use-convex-query', () => ({
+  useConvexQuery: () => STATUS_RESULT,
+}));
+
+// Stub the passkey-list read (so the row renders deterministically) and the
+// query-client invalidation seam (there is no QueryClientProvider in a
+// component test), mirroring the settings providers-list test.
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQuery: () => PASSKEYS_RESULT,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    passkey: {
+      listUserPasskeys: vi
+        .fn()
+        .mockResolvedValue({ data: [PASSKEY], error: null }),
+      deletePasskey,
+    },
+  },
+}));
+
+// The register dialog is an unrelated subtree; stub it so the test stays
+// scoped to the revoke-confirm flow.
+vi.mock('./passkey-register-dialog', () => ({
+  PasskeyRegisterDialog: () => null,
+}));
+
+describe('PasskeySection', () => {
+  beforeEach(() => {
+    deletePasskey.mockReset();
+    deletePasskey.mockResolvedValue({ error: null });
+  });
+
+  it('renders a Remove control for each registered passkey', () => {
+    render(<PasskeySection />);
+
+    expect(screen.getByText('MacBook Touch ID')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it('opens a destructive confirmation instead of deleting on the first click', async () => {
+    const { user } = render(<PasskeySection />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    // The confirm dialog is open and names the credential, but nothing has been
+    // revoked yet — a single mis-click is no longer destructive.
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByRole('heading', { name: 'Remove this passkey?' }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText(/MacBook Touch ID/)).toBeInTheDocument();
+    expect(deletePasskey).not.toHaveBeenCalled();
+  });
+
+  it('revokes the passkey only after the confirmation is accepted', async () => {
+    const { user } = render(<PasskeySection />);
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(deletePasskey).toHaveBeenCalledWith({ id: 'pk-1' });
+    });
+    // The dialog closes once the credential is removed.
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not revoke the passkey when the confirmation is cancelled', async () => {
+    const { user } = render(<PasskeySection />);
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deletePasskey).not.toHaveBeenCalled();
+  });
+
+  describe('accessibility', () => {
+    it('passes an axe audit in the default state', async () => {
+      const { container } = render(<PasskeySection />);
+
+      await checkAccessibility(container);
+    });
+
+    it('passes an axe audit with the confirm dialog open', async () => {
+      const { user } = render(<PasskeySection />);
+
+      await user.click(screen.getByRole('button', { name: 'Remove' }));
+      await screen.findByRole('dialog');
+
+      await checkAccessibility(screen.getByRole('dialog'));
+    });
+  });
+});

--- a/services/platform/app/features/settings/account/components/passkey-section.tsx
+++ b/services/platform/app/features/settings/account/components/passkey-section.tsx
@@ -6,6 +6,7 @@ import { Text } from '@tale/ui/text';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { useConvexQuery } from '@/app/hooks/use-convex-query';
 import { useToast } from '@/app/hooks/use-toast';
@@ -43,6 +44,12 @@ export function PasskeySection() {
   const { data: status } = useConvexQuery(api.two_factor.queries.getStatus, {});
 
   const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
+  // Passkey pending destructive confirmation; `null` keeps the dialog closed.
+  const [confirmTarget, setConfirmTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [revoking, setRevoking] = useState(false);
 
   const { data: passkeys, isLoading } = useQuery({
     queryKey: PASSKEYS_QUERY_KEY,
@@ -62,9 +69,13 @@ export function PasskeySection() {
     void queryClient.invalidateQueries({ queryKey: PASSKEYS_QUERY_KEY });
   }
 
-  async function revoke(id: string) {
+  async function handleRevoke() {
+    if (!confirmTarget) return;
+    setRevoking(true);
     try {
-      const result = await authClient.passkey.deletePasskey({ id });
+      const result = await authClient.passkey.deletePasskey({
+        id: confirmTarget.id,
+      });
       if (result?.error) {
         toast({
           title: t('passkeys.errors.revokeFailed'),
@@ -73,12 +84,15 @@ export function PasskeySection() {
         return;
       }
       toast({ title: t('passkeys.revoked'), variant: 'success' });
+      setConfirmTarget(null);
       invalidate();
     } catch {
       toast({
         title: t('passkeys.errors.revokeFailed'),
         variant: 'destructive',
       });
+    } finally {
+      setRevoking(false);
     }
   }
 
@@ -95,23 +109,27 @@ export function PasskeySection() {
     >
       {!isLoading && passkeys && passkeys.length > 0 && (
         <Stack gap={2}>
-          {passkeys.map((pk) => (
-            <HStack
-              key={pk.id}
-              justify="between"
-              align="center"
-              className="rounded-md border px-3 py-2"
-            >
-              <VStack gap={0} className="min-w-0">
-                <Text className="truncate text-sm font-medium">
-                  {pk.name?.trim() || t('passkeys.unnamed')}
-                </Text>
-              </VStack>
-              <Button variant="ghost" onClick={() => revoke(pk.id)}>
-                {t('passkeys.revokeButton')}
-              </Button>
-            </HStack>
-          ))}
+          {passkeys.map((pk) => {
+            const name = pk.name?.trim() || t('passkeys.unnamed');
+            return (
+              <HStack
+                key={pk.id}
+                justify="between"
+                align="center"
+                className="rounded-md border px-3 py-2"
+              >
+                <VStack gap={0} className="min-w-0">
+                  <Text className="truncate text-sm font-medium">{name}</Text>
+                </VStack>
+                <Button
+                  variant="ghost"
+                  onClick={() => setConfirmTarget({ id: pk.id, name })}
+                >
+                  {t('passkeys.revokeButton')}
+                </Button>
+              </HStack>
+            );
+          })}
         </Stack>
       )}
 
@@ -128,6 +146,21 @@ export function PasskeySection() {
           toast({ title: t('passkeys.registered'), variant: 'success' });
           invalidate();
         }}
+      />
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setConfirmTarget(null);
+        }}
+        title={t('passkeys.confirmTitle')}
+        description={t('passkeys.confirmDescription', {
+          name: confirmTarget?.name ?? '',
+        })}
+        confirmText={t('passkeys.revokeButton')}
+        variant="destructive"
+        isLoading={revoking}
+        onConfirm={handleRevoke}
       />
     </SettingsSection>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6946,6 +6946,8 @@
       "unnamed": "Passkey",
       "registered": "Passkey registriert",
       "revoked": "Passkey entfernt",
+      "confirmTitle": "Diesen Passkey entfernen?",
+      "confirmDescription": "Dies entfernt den Passkey \"{name}\" dauerhaft. Du kannst dich damit nicht mehr anmelden und musst ihn erneut registrieren.",
       "namePromptDescription": "Gib diesem Passkey einen Namen, damit du ihn später wiedererkennst (z. B. \"MacBook Touch ID\").",
       "nameLabel": "Passkey-Name",
       "namePlaceholder": "MacBook Touch ID",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7208,6 +7208,8 @@
       "unnamed": "Passkey",
       "registered": "Passkey registered",
       "revoked": "Passkey removed",
+      "confirmTitle": "Remove this passkey?",
+      "confirmDescription": "This permanently removes the passkey \"{name}\". You can no longer sign in with it and will have to register it again.",
       "namePromptDescription": "Give this passkey a name so you can recognize it later (e.g. \"MacBook Touch ID\").",
       "nameLabel": "Passkey name",
       "namePlaceholder": "MacBook Touch ID",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6947,6 +6947,8 @@
       "unnamed": "Passkey",
       "registered": "Passkey enregistré",
       "revoked": "Passkey supprimé",
+      "confirmTitle": "Supprimer ce passkey ?",
+      "confirmDescription": "Cela supprime définitivement le passkey \"{name}\". Tu ne pourras plus l'utiliser pour te connecter et devras l'enregistrer à nouveau.",
       "namePromptDescription": "Donne un nom à ce passkey pour le reconnaître plus tard (p. ex. \"Touch ID du MacBook\").",
       "nameLabel": "Nom du passkey",
       "namePlaceholder": "Touch ID du MacBook",


### PR DESCRIPTION
Closes #2081

## Problem
The self-service Passkeys section (`passkey-section.tsx`) wired `revoke(pk.id)` straight into the **Remove** button's `onClick`, immediately calling `authClient.passkey.deletePasskey({ id })` with no confirmation. A single mis-click permanently and irreversibly removed a registered phishing-resistant credential — inconsistent with the admin-side revoke (gated behind a destructive `ConfirmDialog`) and the sibling 2FA flows.

## Fix
- Added a `confirmTarget` state + destructive `ConfirmDialog`, mirroring `PasskeyAdminControl`. The **Remove** button now opens the dialog; the actual `deletePasskey` call only fires from `onConfirm`.
- Added a `revoking` loading state so the confirm button shows progress and the dialog can't be dismissed mid-delete.
- Added self-service i18n strings `twoFactor.passkeys.confirmTitle` / `confirmDescription` to `en`, `de`, and `fr` (de-CH inherits, consistent with the existing admin block).

## Verification
- `tsc --noEmit` — passes
- `oxlint --type-aware` on the changed file — 0 warnings, 0 errors
- All three locale JSON files validated