### PR TITLE
fix: stop getOrgWorkflowMetrics scan at prior-window boundary (#2077)

### DIFF
--- a/services/platform/convex/workflows/executions/get_org_workflow_metrics.test.ts
+++ b/services/platform/convex/workflows/executions/get_org_workflow_metrics.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { QueryCtx } from '../../_generated/server';
+import { getOrgWorkflowMetrics } from './get_org_workflow_metrics';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+type Row = {
+  _id: string;
+  organizationId: string;
+  status: 'completed' | 'failed' | 'running';
+  startedAt: number;
+  completedAt?: number;
+  wfDefinitionId?: string;
+  workflowSlug?: string;
+};
+
+/**
+ * Builds a mock `ctx` whose `wfExecutions` query is an async iterable over the
+ * provided rows. Mirrors the real `by_org` desc walk: rows are yielded in the
+ * order given, and the test supplies them newest-first (decreasing startedAt).
+ * `iterated` counts how many rows the consumer actually pulled, so we can
+ * assert the loop stops early instead of draining lifetime history.
+ */
+function createCtx(rows: Row[]) {
+  const counter = { iterated: 0 };
+
+  const builder = {
+    withIndex: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    async *[Symbol.asyncIterator]() {
+      for (const row of rows) {
+        counter.iterated += 1;
+        yield row;
+      }
+    },
+  };
+
+  const ctx = {
+    db: {
+      query: vi.fn().mockReturnValue(builder),
+    },
+  };
+
+  return { ctx: ctx as unknown as QueryCtx, builder, counter };
+}
+
+function makeRow(
+  partial: Partial<Row> & { startedAt: number; status: Row['status'] },
+): Row {
+  return {
+    _id: `exec_${partial.startedAt}`,
+    organizationId: 'org_1',
+    ...partial,
+  };
+}
+
+describe('getOrgWorkflowMetrics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('queries the by_org index in descending order', async () => {
+    const { ctx, builder } = createCtx([]);
+
+    await getOrgWorkflowMetrics(ctx, {
+      organizationId: 'org_1',
+      periodDays: 7,
+    });
+
+    expect(builder.withIndex).toHaveBeenCalledWith(
+      'by_org',
+      expect.any(Function),
+    );
+    expect(builder.order).toHaveBeenCalledWith('desc');
+  });
+
+  it('counts in-window and prior-window rows into the right buckets', async () => {
+    // periodDays = 7 → window = last 7 days, prior window = the 7 days before.
+    const inWindow = NOW - 2 * DAY_MS;
+    const priorWindow = NOW - 9 * DAY_MS;
+    const rows = [
+      makeRow({
+        startedAt: inWindow,
+        status: 'completed',
+        completedAt: inWindow + 5000,
+      }),
+      makeRow({ startedAt: inWindow - DAY_MS, status: 'failed' }),
+      makeRow({
+        startedAt: priorWindow,
+        status: 'completed',
+        completedAt: priorWindow + 1000,
+      }),
+    ];
+    const { ctx } = createCtx(rows);
+
+    const result = await getOrgWorkflowMetrics(ctx, {
+      organizationId: 'org_1',
+      periodDays: 7,
+    });
+
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.completed).toBe(1);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.capped).toBe(false);
+    expect(result.previousSummary.total).toBe(1);
+    expect(result.previousSummary.completed).toBe(1);
+  });
+
+  it('stops scanning once it passes the prior window and does not cap on historical volume', async () => {
+    const inWindow = NOW - DAY_MS;
+    const priorWindow = NOW - 9 * DAY_MS;
+    const rows: Row[] = [
+      makeRow({
+        startedAt: inWindow,
+        status: 'completed',
+        completedAt: inWindow + 1000,
+      }),
+      makeRow({
+        startedAt: priorWindow,
+        status: 'completed',
+        completedAt: priorWindow + 1000,
+      }),
+    ];
+    // A large amount of old history that sits before both windows. The desc
+    // walk should break before touching any of it.
+    for (let i = 0; i < 6000; i++) {
+      rows.push(
+        makeRow({ startedAt: NOW - (30 + i) * DAY_MS, status: 'completed' }),
+      );
+    }
+
+    const { ctx, counter } = createCtx(rows);
+
+    const result = await getOrgWorkflowMetrics(ctx, {
+      organizationId: 'org_1',
+      periodDays: 7,
+    });
+
+    // Only in-window + prior-window rows are counted; capped stays false even
+    // though lifetime history exceeds MAX_SCAN.
+    expect(result.summary.total).toBe(1);
+    expect(result.previousSummary.total).toBe(1);
+    expect(result.summary.capped).toBe(false);
+    // The loop should break at the first out-of-scope row, not drain history.
+    expect(counter.iterated).toBeLessThanOrEqual(3);
+  });
+
+  it('caps only when in-scope rows exceed MAX_SCAN', async () => {
+    const rows: Row[] = [];
+    // 5001 rows all inside the current window → genuinely truncated.
+    for (let i = 0; i < 5001; i++) {
+      rows.push(
+        makeRow({
+          startedAt: NOW - (i % 6) * DAY_MS - 1000,
+          status: 'completed',
+        }),
+      );
+    }
+
+    const { ctx } = createCtx(rows);
+
+    const result = await getOrgWorkflowMetrics(ctx, {
+      organizationId: 'org_1',
+      periodDays: 7,
+    });
+
+    expect(result.summary.capped).toBe(true);
+  });
+});

--- a/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
+++ b/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
@@ -125,8 +125,7 @@ export async function getOrgWorkflowMetrics(
     // remaining row is also out of scope, so we can stop. This bounds the scan
     // to in-window + prior-window rows and keeps `capped` meaning only
     // "in-scope data was truncated" (more than MAX_SCAN rows within the two
-    // windows) rather than firing on out-of-window historical volume. Same
-    // monotonic-desc assumption used by `listExecutions`.
+    // windows) rather than firing on out-of-window historical volume.
     if (e.startedAt < prevWindowStart) break;
     scanned++;
     if (scanned > MAX_SCAN) {

--- a/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
+++ b/services/platform/convex/workflows/executions/get_org_workflow_metrics.ts
@@ -119,12 +119,20 @@ export async function getOrgWorkflowMetrics(
     .query('wfExecutions')
     .withIndex('by_org', (q) => q.eq('organizationId', args.organizationId))
     .order('desc')) {
+    // The `by_org` index is walked newest-first and `startedAt` is set to
+    // `Date.now()` at insert, so it decreases monotonically along this walk.
+    // Once we reach a row older than the prior comparison window, every
+    // remaining row is also out of scope, so we can stop. This bounds the scan
+    // to in-window + prior-window rows and keeps `capped` meaning only
+    // "in-scope data was truncated" (more than MAX_SCAN rows within the two
+    // windows) rather than firing on out-of-window historical volume. Same
+    // monotonic-desc assumption used by `listExecutions`.
+    if (e.startedAt < prevWindowStart) break;
     scanned++;
     if (scanned > MAX_SCAN) {
       capped = true;
       break;
     }
-    if (e.startedAt < prevWindowStart) continue;
     if (e.startedAt < windowStart) {
       // Prior window — accumulate totals only.
       prevTotal++;


### PR DESCRIPTION
## Summary

`getOrgWorkflowMetrics` walks the `by_org` index newest-first to build the Automations metrics dashboard. Because `startedAt` is set to `Date.now()` at insert, it decreases monotonically along this desc walk. The previous loop only `continue`d rows older than `prevWindowStart` and never broke on the window boundary — so the *only* stop condition was `scanned > MAX_SCAN` (5000).

For an org with lots of lifetime history but few in-window runs (e.g. 6,000 lifetime / 200 in-window), this:
1. read thousands of irrelevant historical rows on every dashboard load (wasted read budget), and
2. set `capped = true`, surfacing the misleading "Showing the most recent 5,000 runs…" warning even though all in-window and prior-window data was fully counted.

## Fix

Add an early `break` once a row is older than `prevWindowStart`. Since the walk is monotonically decreasing, no relevant rows remain after that point. This:
- bounds the scan to in-window + prior-window rows, and
- makes `capped` mean only "in-scope data was truncated" (more than `MAX_SCAN` rows *within the two windows*), which is the correct semantics for the warning.

`scanned` is now incremented only for in-scope rows, so the cap reflects in-scope volume. This mirrors the monotonic-desc, newest-first assumption already used in `listExecutions`.

## Tests

Added `get_org_workflow_metrics.test.ts` covering:
- in-window vs prior-window bucketing,
- early break: 6,000 rows of out-of-window history are not scanned and `capped` stays `false`,
- `capped` becomes `true` only when in-scope rows exceed `MAX_SCAN`.

Verified: `vitest --project server` (4/4 pass), `tsc --noEmit`, and `oxlint --type-aware` all green.

Closes #2077