### PR TITLE
fix: chat attachment cap & cross-batch dedup bypassable by concurrent batches (#2078)

### DIFF
--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toast } from '@/app/hooks/use-toast';
+import { compressImage } from '@/lib/utils/compress-image';
+
+import { useConvexFileUpload } from './use-convex-file-upload';
+
+// ---------------------------------------------------------------------------
+// Module mocks. The hook leans on Convex mutations, the upload policy query,
+// i18n, toasts, and the image compressor — none of which are relevant to the
+// dedup/cap accounting under test, so they are stubbed. The real file-type
+// helpers and constants (CHAT_MAX_FILE_COUNT, etc.) are kept; only the async
+// byte-sniffing `detectMediaMime` is forced to "not media" so a plain File
+// resolves by extension without an arrayBuffer round-trip.
+// ---------------------------------------------------------------------------
+
+const generateUploadUrl = vi.fn().mockResolvedValue('https://upload.test/url');
+const saveFileMetadata = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./mutations', () => ({
+  useGenerateUploadUrl: () => ({ mutateAsync: generateUploadUrl }),
+}));
+
+vi.mock('@/app/hooks/use-convex-mutation', () => ({
+  useConvexMutation: () => ({ mutateAsync: saveFileMetadata }),
+}));
+
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useUploadPolicy: () => ({
+    policyEnabled: false,
+    maxFileSize: 100 * 1024 * 1024,
+    allowedTypes: [],
+    blockedExtensions: [],
+    allowedExtensions: [],
+  }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../utils/get-audio-duration', () => ({
+  getAudioDuration: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/utils/compress-image', () => ({ compressImage: vi.fn() }));
+
+vi.mock('@/lib/shared/file-types', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/shared/file-types')>();
+  return { ...actual, detectMediaMime: vi.fn().mockResolvedValue(null) };
+});
+
+const compressImageMock = vi.mocked(compressImage);
+const toastMock = vi.mocked(toast);
+
+// A controllable POST/fetch: each call parks until the test resolves it, so a
+// batch can be held "in-flight" while a second batch races the cap/dedup gates.
+let pendingFetches: Array<() => void> = [];
+let storageCounter = 0;
+
+function installFetch() {
+  pendingFetches = [];
+  storageCounter = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      () =>
+        new Promise((resolve) => {
+          const storageId = `storage-${storageCounter++}`;
+          pendingFetches.push(() =>
+            resolve({
+              ok: true,
+              json: async () => ({ storageId }),
+            } as Response),
+          );
+        }),
+    ),
+  );
+}
+
+function resolveAllFetches() {
+  const settle = pendingFetches;
+  pendingFetches = [];
+  for (const done of settle) done();
+}
+
+function makeFile(name: string, size: number, type: string): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+// Let the synchronous gate logic and the early `await detectMediaMime` chain
+// run so in-flight reservations are registered before the next batch fires.
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  });
+}
+
+const config = { organizationId: 'org-1' };
+
+beforeEach(() => {
+  installFetch();
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:preview'),
+    revokeObjectURL: vi.fn(),
+  });
+  compressImageMock.mockImplementation(async (file: File) => {
+    const compressed = new File(
+      [new Uint8Array(200)],
+      file.name.replace(/\.[^.]+$/, '.jpg'),
+      { type: 'image/jpeg' },
+    );
+    return {
+      file: compressed,
+      wasCompressed: true,
+      originalSize: file.size,
+      finalSize: compressed.size,
+    };
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('useConvexFileUpload — concurrent-batch cap & dedup', () => {
+  it('counts in-flight uploads against the 10-file cap across batches', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // Batch A: 6 files, held in-flight (fetch parked).
+    const batchA = Array.from({ length: 6 }, (_, i) =>
+      makeFile(`a-${i}.txt`, 10, 'text/plain'),
+    );
+    let promiseA!: Promise<void>;
+    act(() => {
+      promiseA = result.current.uploadFiles(batchA);
+    });
+    await flush();
+
+    // 6 reservations now in-flight; only 4 slots remain of the 10-file cap.
+    const batchB = Array.from({ length: 6 }, (_, i) =>
+      makeFile(`b-${i}.txt`, 10, 'text/plain'),
+    );
+    let promiseB!: Promise<void>;
+    act(() => {
+      promiseB = result.current.uploadFiles(batchB);
+    });
+    await flush();
+
+    // Batch B should be capped to 4 and surface the too-many-files toast.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'tooManyFiles'),
+    ).toBe(true);
+
+    resolveAllFetches();
+    await act(async () => {
+      await Promise.all([promiseA, promiseB]);
+    });
+
+    // 6 from A + 4 from B = exactly the cap; never 12.
+    await waitFor(() => expect(result.current.attachments).toHaveLength(10));
+  });
+
+  it('dedupes a file already uploading in another batch', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    const fileA = makeFile('dup.txt', 42, 'text/plain');
+    let promiseA!: Promise<void>;
+    act(() => {
+      promiseA = result.current.uploadFiles([fileA]);
+    });
+    await flush();
+
+    // Re-attach the identical file while the first is still in-flight.
+    const fileB = makeFile('dup.txt', 42, 'text/plain');
+    let promiseB!: Promise<void>;
+    act(() => {
+      promiseB = result.current.uploadFiles([fileB]);
+    });
+    await flush();
+
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'duplicateFile'),
+    ).toBe(true);
+
+    resolveAllFetches();
+    await act(async () => {
+      await Promise.all([promiseA, promiseB]);
+    });
+
+    await waitFor(() => expect(result.current.attachments).toHaveLength(1));
+  });
+
+  it('dedupes a re-attached image against its original (pre-compression) identity', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // Upload an image; compression renames .png -> .jpg and shrinks the size.
+    const image = makeFile('photo.png', 1_500_000, 'image/png');
+    let promise1!: Promise<void>;
+    act(() => {
+      promise1 = result.current.uploadFiles([image]);
+    });
+    await flush();
+    resolveAllFetches();
+    await act(async () => {
+      await promise1;
+    });
+    await waitFor(() => expect(result.current.attachments).toHaveLength(1));
+
+    // The stored attachment carries the compressed name/size...
+    expect(result.current.attachments[0]?.fileName).toBe('photo.jpg');
+    expect(result.current.attachments[0]?.fileSize).toBe(200);
+    // ...but retains the original identity for dedup.
+    expect(result.current.attachments[0]?.originalFileName).toBe('photo.png');
+    expect(result.current.attachments[0]?.originalFileSize).toBe(1_500_000);
+
+    // Re-attaching the same original image is detected as a duplicate.
+    toastMock.mockClear();
+    const sameImage = makeFile('photo.png', 1_500_000, 'image/png');
+    await act(async () => {
+      await result.current.uploadFiles([sameImage]);
+    });
+
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'duplicateFile'),
+    ).toBe(true);
+    expect(result.current.attachments).toHaveLength(1);
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
@@ -296,6 +296,63 @@ describe('useConvexFileUpload — concurrent-batch cap & dedup', () => {
     await waitFor(() => expect(result.current.attachments).toHaveLength(2));
   });
 
+  it('counts a just-committed file against the cap during the commit→render gap', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    const CAP = CHAT_MAX_FILE_COUNT;
+
+    // Batch A fills the entire cap, held in-flight.
+    const batchA = Array.from({ length: CAP }, (_, i) =>
+      makeFile(`a-${i}.txt`, 10, 'text/plain'),
+    );
+    // Batch B would also fill the cap on its own.
+    const batchB = Array.from({ length: CAP }, (_, i) =>
+      makeFile(`b-${i}.txt`, 10, 'text/plain'),
+    );
+
+    // Fire batch B from inside the commit of batch A's first file — i.e. in the
+    // exact window after that file's reservation is deleted and `setAttachments`
+    // is queued, but *before* React re-renders and refreshes `attachmentsRef`.
+    // The `fileUploaded` toast is emitted synchronously right after the commit,
+    // so it is a faithful hook into that window. The gates must still see the
+    // committed files (via the synchronous `attachmentsRef` mirror); if they
+    // only saw the pending reservations + the stale ref, batch B would slip
+    // past and the final count would be ~2*CAP.
+    let promiseB: Promise<void> | undefined;
+    let fired = false;
+    toastMock.mockImplementation(((arg?: { title?: string }) => {
+      if (arg?.title === 'fileUploaded' && !fired) {
+        fired = true;
+        promiseB = result.current.uploadFiles(batchB);
+      }
+    }) as typeof toast);
+
+    let promiseA!: Promise<void>;
+    act(() => {
+      promiseA = result.current.uploadFiles(batchA);
+    });
+    await flush();
+
+    // Commit batch A; its first commit fires batch B mid-window.
+    await act(async () => {
+      resolveAllFetches();
+      await promiseA;
+      // Drain any uploads batch B managed to start, then settle them.
+      resolveAllFetches();
+      if (promiseB) await promiseB;
+      resolveAllFetches();
+      if (promiseB) await promiseB;
+    });
+
+    // Batch B must have been rejected by the cap gate, not silently accepted.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'tooManyFiles'),
+    ).toBe(true);
+
+    // Exactly the cap — batch B never bypassed it through the commit→render gap.
+    await waitFor(() => expect(result.current.attachments).toHaveLength(CAP));
+  });
+
   it('frees an in-flight reservation when its upload fails', async () => {
     const { result } = renderHook(() => useConvexFileUpload(config));
 

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
@@ -3,6 +3,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { toast } from '@/app/hooks/use-toast';
+import {
+  CHAT_MAX_FILE_COUNT,
+  CHAT_MAX_TOTAL_SIZE,
+} from '@/lib/shared/file-types';
 import { compressImage } from '@/lib/utils/compress-image';
 
 import { useConvexFileUpload } from './use-convex-file-upload';
@@ -60,7 +64,9 @@ const toastMock = vi.mocked(toast);
 
 // A controllable POST/fetch: each call parks until the test resolves it, so a
 // batch can be held "in-flight" while a second batch races the cap/dedup gates.
-let pendingFetches: Array<() => void> = [];
+// Each parked resolver accepts an outcome so a test can settle an upload as a
+// failure (`ok: false`) and exercise the reservation-release path.
+let pendingFetches: Array<(outcome?: { ok?: boolean }) => void> = [];
 let storageCounter = 0;
 
 function installFetch() {
@@ -72,9 +78,9 @@ function installFetch() {
       () =>
         new Promise((resolve) => {
           const storageId = `storage-${storageCounter++}`;
-          pendingFetches.push(() =>
+          pendingFetches.push((outcome) =>
             resolve({
-              ok: true,
+              ok: outcome?.ok ?? true,
               json: async () => ({ storageId }),
             } as Response),
           );
@@ -89,8 +95,25 @@ function resolveAllFetches() {
   for (const done of settle) done();
 }
 
+// Settle every parked upload as a server failure so the hook throws and runs
+// its `finally` reservation cleanup.
+function failAllFetches() {
+  const settle = pendingFetches;
+  pendingFetches = [];
+  for (const done of settle) done({ ok: false });
+}
+
 function makeFile(name: string, size: number, type: string): File {
   return new File([new Uint8Array(size)], name, { type });
+}
+
+// A File that reports a large `size` without allocating the bytes — the hook
+// only reads `file.size`/`file.name` (fetch + compression are stubbed), so this
+// keeps the total-size test cheap while still tripping CHAT_MAX_TOTAL_SIZE.
+function makeSizedFile(name: string, size: number, type: string): File {
+  const file = new File([new Uint8Array(1)], name, { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
 }
 
 // Let the synchronous gate logic and the early `await detectMediaMime` chain
@@ -232,5 +255,91 @@ describe('useConvexFileUpload — concurrent-batch cap & dedup', () => {
       toastMock.mock.calls.some(([arg]) => arg?.title === 'duplicateFile'),
     ).toBe(true);
     expect(result.current.attachments).toHaveLength(1);
+  });
+
+  it('counts in-flight uploads against the total-size cap across batches', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    const MB = 1024 * 1024;
+    // Batch A: 180 MB held in-flight (2 files, each under the per-file cap).
+    const batchA = [
+      makeSizedFile('big-a0.txt', 90 * MB, 'text/plain'),
+      makeSizedFile('big-a1.txt', 90 * MB, 'text/plain'),
+    ];
+    let promiseA!: Promise<void>;
+    act(() => {
+      promiseA = result.current.uploadFiles(batchA);
+    });
+    await flush();
+
+    // Batch B: 30 MB alone fits, but 180 MB in-flight + 30 MB = 210 MB exceeds
+    // the 200 MB total cap once the pending reservations are folded in.
+    expect(90 * MB * 2 + 30 * MB).toBeGreaterThan(CHAT_MAX_TOTAL_SIZE);
+    const batchB = [makeSizedFile('big-b0.txt', 30 * MB, 'text/plain')];
+    let promiseB!: Promise<void>;
+    act(() => {
+      promiseB = result.current.uploadFiles(batchB);
+    });
+    await flush();
+
+    // Batch B must be rejected by the total-size gate, not silently accepted.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
+    ).toBe(true);
+
+    resolveAllFetches();
+    await act(async () => {
+      await Promise.all([promiseA, promiseB]);
+    });
+
+    // Only batch A commits; batch B never slipped past the cap.
+    await waitFor(() => expect(result.current.attachments).toHaveLength(2));
+  });
+
+  it('frees an in-flight reservation when its upload fails', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // One file in-flight, holding a reservation.
+    const failing = makeFile('fail.txt', 10, 'text/plain');
+    let promiseFail!: Promise<void>;
+    act(() => {
+      promiseFail = result.current.uploadFiles([failing]);
+    });
+    await flush();
+
+    // Settle it as a server failure — the hook's `finally` must release the
+    // slot rather than leak a phantom reservation that consumes the cap.
+    failAllFetches();
+    await act(async () => {
+      await promiseFail;
+    });
+
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'uploadFailed'),
+    ).toBe(true);
+    expect(result.current.attachments).toHaveLength(0);
+
+    // The reclaimed slot means a fresh batch can still fill the entire cap; if
+    // the failed file's reservation had leaked only 9 of these would be taken.
+    const batch = Array.from({ length: CHAT_MAX_FILE_COUNT }, (_, i) =>
+      makeFile(`ok-${i}.txt`, 10, 'text/plain'),
+    );
+    let promiseOk!: Promise<void>;
+    act(() => {
+      promiseOk = result.current.uploadFiles(batch);
+    });
+    await flush();
+    resolveAllFetches();
+    await act(async () => {
+      await promiseOk;
+    });
+
+    await waitFor(() =>
+      expect(result.current.attachments).toHaveLength(CHAT_MAX_FILE_COUNT),
+    );
+    // No too-many-files toast — the cap was fully available, proving reclaim.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'tooManyFiles'),
+    ).toBe(false);
   });
 });

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -31,6 +31,15 @@ interface FileAttachment {
   fileType: string;
   fileSize: number;
   previewUrl?: string;
+  /**
+   * Identity of the source file the user picked, before any client-side
+   * image compression renamed/resized it (see compress-image.ts). Dedup
+   * keys off these so re-attaching the same original is caught even though
+   * `fileName`/`fileSize` hold the compressed values. Falls back to the
+   * stored name/size for non-image attachments that were never compressed.
+   */
+  originalFileName?: string;
+  originalFileSize?: number;
 }
 
 interface ConvexFileUploadConfig {
@@ -97,6 +106,18 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
 
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
+
+  // In-flight uploads that have passed the gates but not yet committed to
+  // `attachments`. The count/dedup/total-size gates below read only the
+  // committed `attachments`, so without this a second attach batch fired
+  // while the first is still uploading would not see the first batch — letting
+  // it bypass the file-count cap, cross-batch dedup, and total-size cap. Each
+  // entry keeps the ORIGINAL (pre-compression) dedup key and the source size
+  // so those gates account for the pending file. Keyed by a per-upload id so
+  // overlapping batches don't clobber each other's reservations.
+  const pendingUploadsRef = useRef(
+    new Map<string, { dedupKey: string; size: number }>(),
+  );
 
   const uploadFiles = useCallback(
     async (files: File[]) => {
@@ -212,10 +233,23 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
 
       if (validFiles.length === 0) return;
 
-      // Skip files already attached (match by name + size)
-      const existingKeys = new Set(
-        attachmentsRef.current.map((att) => `${att.fileName}:${att.fileSize}`),
-      );
+      // Skip files already attached (match by name + size). Compare against
+      // the ORIGINAL identity of stored attachments — images are compressed
+      // and renamed before storage, so keying off `fileName`/`fileSize` would
+      // miss a re-attach of the same >1MB source image. In-flight uploads are
+      // folded in too so a duplicate spread across concurrent batches is
+      // caught before the first one finishes committing.
+      const existingKeys = new Set<string>();
+      for (const att of attachmentsRef.current) {
+        existingKeys.add(
+          `${att.originalFileName ?? att.fileName}:${
+            att.originalFileSize ?? att.fileSize
+          }`,
+        );
+      }
+      for (const pending of pendingUploadsRef.current.values()) {
+        existingKeys.add(pending.dedupKey);
+      }
       const deduped: typeof validFiles = [];
       for (const entry of validFiles) {
         const key = `${entry.file.name}:${entry.file.size}`;
@@ -234,9 +268,12 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
 
       if (deduped.length === 0) return;
 
-      // Enforce max file count
+      // Enforce max file count — count in-flight uploads alongside committed
+      // attachments so overlapping batches can't collectively exceed the cap.
       const slotsAvailable =
-        CHAT_MAX_FILE_COUNT - attachmentsRef.current.length;
+        CHAT_MAX_FILE_COUNT -
+        attachmentsRef.current.length -
+        pendingUploadsRef.current.size;
       if (slotsAvailable <= 0) {
         toast({
           title: t('tooManyFiles'),
@@ -265,11 +302,16 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
         });
       }
 
-      // Enforce max total attachment size
-      const existingSize = attachmentsRef.current.reduce(
+      // Enforce max total attachment size — include in-flight uploads (using
+      // the source size as an upper bound; the compressed upload is smaller)
+      // so concurrent batches can't collectively exceed the total cap.
+      let existingSize = attachmentsRef.current.reduce(
         (sum, att) => sum + att.fileSize,
         0,
       );
+      for (const pending of pendingUploadsRef.current.values()) {
+        existingSize += pending.size;
+      }
       const incomingSize = acceptedFiles.reduce(
         (sum, { file }) => sum + file.size,
         0,
@@ -285,9 +327,22 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
         return;
       }
 
-      const uploadPromises = acceptedFiles.map(
-        async ({ file, resolvedType }) => {
-          const fileId = `${file.name}-${Date.now()}`;
+      // Reserve a slot for every accepted file *before* any upload starts, so
+      // a concurrent batch fired mid-upload sees these in the gates above. The
+      // dedup key uses the original (pre-compression) identity to match the
+      // stored-attachment key. Reservations are released in the `finally` once
+      // the file commits to `attachments` (or fails).
+      const uploadTasks = acceptedFiles.map(({ file, resolvedType }, index) => {
+        const fileId = `${file.name}-${file.size}-${Date.now()}-${index}`;
+        pendingUploadsRef.current.set(fileId, {
+          dedupKey: `${file.name}:${file.size}`,
+          size: file.size,
+        });
+        return { file, resolvedType, fileId };
+      });
+
+      const uploadPromises = uploadTasks.map(
+        async ({ file, resolvedType, fileId }) => {
           setUploadingFiles((prev) => [...prev, fileId]);
 
           try {
@@ -336,11 +391,18 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
               fileName: fileToUpload.name,
               fileType: resolvedType,
               fileSize: fileToUpload.size,
+              // Preserve the source identity so a later re-attach of the same
+              // original file dedups even after compression renamed/resized it.
+              originalFileName: file.name,
+              originalFileSize: file.size,
               previewUrl: resolvedType.startsWith('image/')
                 ? URL.createObjectURL(fileToUpload)
                 : undefined,
             };
 
+            // Commit to `attachments` and release the in-flight reservation in
+            // the same tick so the file is never counted twice by the gates.
+            pendingUploadsRef.current.delete(fileId);
             setAttachments((prev) => [...prev, attachment]);
 
             toast({
@@ -355,6 +417,9 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
               variant: 'destructive',
             });
           } finally {
+            // Idempotent: the success path already released the reservation;
+            // this covers the failure path so a failed upload frees its slot.
+            pendingUploadsRef.current.delete(fileId);
             setUploadingFiles((prev) => prev.filter((id) => id !== fileId));
           }
         },

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -401,7 +401,18 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
             };
 
             // Commit to `attachments` and release the in-flight reservation in
-            // the same tick so the file is never counted twice by the gates.
+            // the same synchronous tick so the file is never counted twice by
+            // the gates. `attachmentsRef.current` is normally refreshed only on
+            // the next render (see the assignment near the top of the hook), so
+            // deleting the reservation here while the committed file isn't yet
+            // visible in the ref would open a window — between this delete and
+            // the render — in which a concurrent batch's gates see the file in
+            // neither `pendingUploadsRef` nor `attachmentsRef.current` and can
+            // over-reserve past the count/total-size caps (and miss the dedup).
+            // Mirror the commit into the ref *before* releasing the reservation
+            // so the gates see the file the instant its slot is freed; the next
+            // render reconciles `attachmentsRef.current` to the same value.
+            attachmentsRef.current = [...attachmentsRef.current, attachment];
             pendingUploadsRef.current.delete(fileId);
             setAttachments((prev) => [...prev, attachment]);
 


### PR DESCRIPTION
## Summary

Fixes two related attachment dedup/cap defects in the chat composer (`use-convex-file-upload.ts`).

**[24] 10-file cap & cross-batch dedup bypassable by concurrent attach batches.**
The count, dedup, and total-size gates only read the committed `attachments` state. In-flight uploads (tracked separately in `uploadingFiles` and committed to `attachments` only after the upload finishes) were invisible to a second attach batch fired while the first was still uploading — letting a user exceed the 10-file cap, the total-size cap, and skip duplicate detection across batches.

Fix: a `pendingUploadsRef` reserves a slot for every accepted file *before* its upload starts (recording the original dedup key + source size), and the count/dedup/total-size gates now fold those reservations in alongside committed attachments. Reservations are released when the file commits (or fails).

**[23] Re-attaching an image > 1MB not detected as a duplicate.**
Images are compressed and renamed (`.png` → `.jpg`, resized) before storage, so the stored attachment's `fileName`/`fileSize` no longer match the source file. The dedup key compared the incoming *original* name/size against the stored *compressed* values, so a re-attach of the same image was never caught.

Fix: the stored attachment now keeps `originalFileName`/`originalFileSize`, and the dedup key is computed from those canonical source values on both sides.

## Tests

Added `use-convex-file-upload.test.ts` (jsdom / `test:ui`) covering:
- in-flight uploads counted against the 10-file cap across concurrent batches (6 + 6 → capped at 10, not 12);
- a file uploading in one batch dedups a re-attach in a second batch;
- a re-attached compressed image dedups against its original identity.

Verified locally: `test:ui` (3/3 pass), `tsc --noEmit`, `oxlint --type-aware`, `oxfmt --check` all green.

Closes #2078