### PR TITLE
feat: chat file-panel UX polish + sandbox LaTeX toolchain

### DIFF
--- a/services/platform/app/features/chat/components/chat-panel/chat-panel-context.tsx
+++ b/services/platform/app/features/chat/components/chat-panel/chat-panel-context.tsx
@@ -29,10 +29,18 @@ interface ChatPanelContextType {
   activeTab: ChatPaneId | null;
   /** Maximized (full pane + tabs) vs minimized (the shared strip). */
   isMaximized: boolean;
+  /**
+   * Whether the maximized pane is expanded to a full-viewport overlay (desktop
+   * only — mobile is already full-width). Lets a cramped docked panel grow to
+   * the whole window for reading documents / the live browser, then snap back.
+   */
+  isFullscreen: boolean;
   /** Open a pane maximized and make it the active tab. */
   openPane: (id: ChatPaneId) => void;
   /** Collapse to the strip without losing content (never a dead-end). */
   minimize: () => void;
+  /** Toggle the full-viewport overlay on the maximized pane (desktop only). */
+  toggleFullscreen: () => void;
   /** Clear shell state — used on new-chat / thread switch. */
   reset: () => void;
 }
@@ -85,6 +93,7 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
   );
   const [activeTab, setActiveTab] = useState<ChatPaneId | null>(null);
   const [isMaximized, setIsMaximized] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const registerPane = useCallback((descriptor: ChatPaneDescriptor) => {
     setRegistry((prev) => {
@@ -117,11 +126,18 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
     setIsMaximized(true);
   }, []);
 
-  const minimize = useCallback(() => setIsMaximized(false), []);
+  // Collapsing to the strip also leaves fullscreen, so re-opening starts docked.
+  const minimize = useCallback(() => {
+    setIsMaximized(false);
+    setIsFullscreen(false);
+  }, []);
+
+  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), []);
 
   const reset = useCallback(() => {
     setActiveTab(null);
     setIsMaximized(false);
+    setIsFullscreen(false);
   }, []);
 
   // Reset shell state on every thread switch (mirrors the per-thread reset in
@@ -132,6 +148,7 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
     if (prevThreadIdRef.current !== threadId) {
       setActiveTab(null);
       setIsMaximized(false);
+      setIsFullscreen(false);
       prevThreadIdRef.current = threadId;
     }
   }, [threadId]);
@@ -144,6 +161,7 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
     if (visiblePanes.length === 0) {
       if (activeTab !== null) setActiveTab(null);
       if (isMaximized) setIsMaximized(false);
+      if (isFullscreen) setIsFullscreen(false);
       return;
     }
     const stillVisible =
@@ -151,7 +169,7 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
     if (!stillVisible) {
       setActiveTab(visiblePanes[0].id);
     }
-  }, [visiblePanes, activeTab, isMaximized]);
+  }, [visiblePanes, activeTab, isMaximized, isFullscreen]);
 
   const value = useMemo<ChatPanelContextType>(
     () => ({
@@ -160,8 +178,10 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
       visiblePanes,
       activeTab,
       isMaximized,
+      isFullscreen,
       openPane,
       minimize,
+      toggleFullscreen,
       reset,
     }),
     [
@@ -170,8 +190,10 @@ export function ChatPanelProvider({ children }: ChatPanelProviderProps) {
       visiblePanes,
       activeTab,
       isMaximized,
+      isFullscreen,
       openPane,
       minimize,
+      toggleFullscreen,
       reset,
     ],
   );

--- a/services/platform/app/features/chat/components/chat-panel/chat-panel.tsx
+++ b/services/platform/app/features/chat/components/chat-panel/chat-panel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Button } from '@tale/ui/button';
-import { PanelRightClose } from 'lucide-react';
-import { useRef, type KeyboardEvent } from 'react';
+import { Maximize2, Minimize2, PanelRightClose } from 'lucide-react';
+import { useEffect, useRef, type KeyboardEvent } from 'react';
 
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
 import { useIsMobile } from '@/app/hooks/use-is-mobile';
@@ -39,8 +39,15 @@ const bodyId = (id: ChatPaneId) => `chat-panel-body-${id}`;
 export function ChatPanel() {
   const { t } = useT('chat');
   const isMobile = useIsMobile();
-  const { visiblePanes, activeTab, isMaximized, openPane, minimize } =
-    useChatPanel();
+  const {
+    visiblePanes,
+    activeTab,
+    isMaximized,
+    isFullscreen,
+    openPane,
+    minimize,
+    toggleFullscreen,
+  } = useChatPanel();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const { width, minWidth, maxWidth, handleMouseDown, handleKeyDown } =
@@ -49,6 +56,20 @@ export function ChatPanel() {
       maxWidth: MAX_WIDTH,
       initialWidth: DEFAULT_WIDTH,
     });
+
+  // Desktop fullscreen expands to the same full-viewport overlay mobile always
+  // uses (mobile has no docked state to grow from, so its toggle is hidden).
+  const isOverlay = isMobile || isFullscreen;
+
+  // Escape leaves the desktop fullscreen overlay (back to the docked pane).
+  useEffect(() => {
+    if (!isFullscreen) return undefined;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') toggleFullscreen();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isFullscreen, toggleFullscreen]);
 
   if (visiblePanes.length === 0) return null;
 
@@ -98,19 +119,23 @@ export function ChatPanel() {
     <div
       className={cn(
         'border-border bg-background relative flex h-full shrink-0 flex-col border-l',
-        // On mobile the panel is a full-screen fixed overlay above the chat so
-        // the tabs + body are usable on a narrow viewport; on desktop it's a
-        // fixed-width docked column in the flex row that the user can resize.
+        // The panel is a full-screen fixed overlay above the chat when it has no
+        // docked column to live in — always on mobile (narrow viewport), and on
+        // desktop when the user toggles fullscreen to read a cramped document.
         // Fixed positioning (not a Radix Dialog) keeps every body mounted, so
-        // the Live Browser's RFB socket survives minimize/maximize on mobile.
-        isMobile && 'fixed inset-0 z-40 w-full border-l-0',
+        // the Live Browser's RFB socket survives minimize/maximize/fullscreen.
+        // z-50 matches the app's top-layer tier so the overlay also covers the
+        // `sticky z-50` composer; it renders after the chat column in the DOM,
+        // and Radix-portaled tooltips/dialogs (also z-50, but later in the body)
+        // still sit above it.
+        isOverlay && 'fixed inset-0 z-50 w-full border-l-0',
       )}
-      style={isMobile ? undefined : { width }}
+      style={isOverlay ? undefined : { width }}
       role="complementary"
       aria-label={t('chatPanel.ariaLabel', { defaultValue: 'Chat panel' })}
     >
-      {/* Drag-to-resize handle — desktop only (mobile is full-width). */}
-      {!isMobile && (
+      {/* Drag-to-resize handle — only when docked (overlay is full-width). */}
+      {!isOverlay && (
         <div
           ref={panelRef}
           role="separator"
@@ -170,6 +195,44 @@ export function ChatPanel() {
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {activeHeaderActions}
+          {/* Fullscreen toggle — desktop only; mobile is already full-screen. */}
+          {!isMobile && (
+            <Tooltip
+              content={
+                isFullscreen
+                  ? t('chatPanel.exitFullscreen', {
+                      defaultValue: 'Exit full screen',
+                    })
+                  : t('chatPanel.fullscreen', {
+                      defaultValue: 'Expand to full screen',
+                    })
+              }
+              side="bottom"
+            >
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={toggleFullscreen}
+                aria-pressed={isFullscreen}
+                aria-label={
+                  isFullscreen
+                    ? t('chatPanel.exitFullscreen', {
+                        defaultValue: 'Exit full screen',
+                      })
+                    : t('chatPanel.fullscreen', {
+                        defaultValue: 'Expand to full screen',
+                      })
+                }
+              >
+                {isFullscreen ? (
+                  <Minimize2 className="size-3.5" />
+                ) : (
+                  <Maximize2 className="size-3.5" />
+                )}
+              </Button>
+            </Tooltip>
+          )}
           <Tooltip
             content={t('chatPanel.minimize', {
               defaultValue: 'Minimize chat panel',

--- a/services/platform/app/features/workspace/components/workspace-files-pane.tsx
+++ b/services/platform/app/features/workspace/components/workspace-files-pane.tsx
@@ -933,6 +933,16 @@ function WorkspaceFilesBody({
 
   const handleSelectFile = useCallback((p: string) => setSelectedPath(p), []);
 
+  // An explicit Refresh re-probes a stopped session without remounting the body
+  // (a remount would collapse the tree's expanded folders and drop the open
+  // file — the very thing the user wants to keep). Flipping back to "running"
+  // re-mounts the tree, whose first load reports the real state and flips this
+  // back to stopped if the session is still down. When already running this is a
+  // no-op, and the tree refreshes its expanded dirs in place off `refreshNonce`.
+  useEffect(() => {
+    setSessionRunning(true);
+  }, [refreshNonce]);
+
   if (!sessionRunning) {
     return <SessionStoppedState />;
   }
@@ -1065,14 +1075,16 @@ function WorkspaceFilesPaneComponent({ available }: WorkspaceFilesPaneProps) {
       hasContent: true,
       headerActions,
       body: (
-        // Key by threadId + refreshNonce so the body remounts — resetting
-        // `selectedPath` and `sessionRunning` to their fresh defaults — both on
-        // a thread switch (else the previous thread's file shows) and on an
-        // explicit Refresh. The Refresh remount is what lets a STOPPED session
-        // recover: once `sessionRunning` is false the tree unmounts and can no
-        // longer report itself running, so only a remount re-checks it.
+        // Key by threadId alone so the body remounts on a thread switch —
+        // resetting `selectedPath` and `sessionRunning` to fresh defaults so the
+        // previous thread's file/state never bleeds in. Deliberately NOT keyed
+        // by `refreshNonce`: Refresh must preserve the open file and the tree's
+        // expanded folders. The tree re-fetches its expanded dirs in place off
+        // the `refreshNonce` prop, and a STOPPED session is re-probed by the
+        // effect in the body (which re-mounts the tree to re-check) — no remount
+        // of the whole body, so nothing collapses.
         <WorkspaceFilesBody
-          key={`${threadId}:${refreshNonce}`}
+          key={threadId}
           threadId={threadId}
           showHidden={showHidden}
           refreshNonce={refreshNonce}

--- a/services/platform/app/features/workspace/hooks/canvas-preferences.tsx
+++ b/services/platform/app/features/workspace/hooks/canvas-preferences.tsx
@@ -16,7 +16,13 @@ interface CanvasPreferences {
    *  every file, so flipping it on holds as you browse the rest of the files. */
   wrap: boolean;
   toggleWrap: () => void;
-  /** The Source/Preview choice, remembered per file path. */
+  /**
+   * The Source/Preview choice. A file the user has explicitly toggled keeps its
+   * own choice; any file they haven't touched defaults to the LAST mode they
+   * picked anywhere (then to `fallback` before any pick). So choosing Preview on
+   * one doc carries to the next doc you open — like `wrap` — while still letting
+   * individual files override.
+   */
   getViewMode: (path: string, fallback: ViewMode) => ViewMode;
   setViewMode: (path: string, mode: ViewMode) => void;
 }
@@ -24,17 +30,20 @@ interface CanvasPreferences {
 function useCanvasPreferencesState(): CanvasPreferences {
   const [wrap, setWrap] = useState(false);
   const [modeByPath, setModeByPath] = useState<Record<string, ViewMode>>({});
+  // The last Source/Preview pick, used as the sticky default for files that
+  // don't have their own explicit choice yet.
+  const [lastMode, setLastMode] = useState<ViewMode | null>(null);
 
   const toggleWrap = useCallback(() => setWrap((w) => !w), []);
   const getViewMode = useCallback(
-    (path: string, fallback: ViewMode) => modeByPath[path] ?? fallback,
-    [modeByPath],
+    (path: string, fallback: ViewMode) =>
+      modeByPath[path] ?? lastMode ?? fallback,
+    [modeByPath, lastMode],
   );
-  const setViewMode = useCallback(
-    (path: string, mode: ViewMode) =>
-      setModeByPath((prev) => ({ ...prev, [path]: mode })),
-    [],
-  );
+  const setViewMode = useCallback((path: string, mode: ViewMode) => {
+    setModeByPath((prev) => ({ ...prev, [path]: mode }));
+    setLastMode(mode);
+  }, []);
 
   return useMemo(
     () => ({ wrap, toggleWrap, getViewMode, setViewMode }),

--- a/services/platform/app/features/workspace/viewers/canvas-viewer-frame.tsx
+++ b/services/platform/app/features/workspace/viewers/canvas-viewer-frame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, type ReactNode } from 'react';
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 
@@ -13,14 +13,29 @@ interface CanvasViewerFrameProps {
   children: ReactNode;
 }
 
+// The card sits `bottom-3` (12px) above the frame's bottom edge; reserve a gap
+// of one more `gap-3` (12px) between the card's top and the last line so they
+// never touch. The content gutter = measured card height + these two insets.
+const CARD_BOTTOM_INSET = 12;
+const CARD_TOP_GAP = 12;
+// Seed the gutter for the first paint (≈ a one-row card) so content doesn't
+// briefly render under where the card will land before the measurement lands.
+const INITIAL_CARD_HEIGHT = 44;
+
 /**
  * Shared shell for every canvas file viewer: the content pane plus the floating,
  * bottom-right action card. Hoisted out of `renderable-file-viewer.tsx` so the
  * code/markdown/html/svg/mermaid/image viewers all present one identical control
  * surface — previously the code viewer used a full-width top strip while the
  * renderable viewer used this card. Viewers pass their own buttons as `actions`;
- * the frame owns the position, the `pb-14` gutter that keeps the last line of
+ * the frame owns the position, the bottom gutter that keeps the last line of
  * content clear of the card, and the size label.
+ *
+ * The card is capped to the viewer width and wraps, so on a narrow (docked)
+ * viewer the buttons stack to a second row instead of overflowing the column and
+ * being clipped. Because that makes the card height variable, the content gutter
+ * is measured from the live card height (a fixed pad would be too short for a
+ * wrapped card and tuck the final line behind the toolbar).
  */
 function CanvasViewerFrameComponent({
   sizeLabel,
@@ -28,14 +43,33 @@ function CanvasViewerFrameComponent({
   children,
 }: CanvasViewerFrameProps) {
   const { t } = useT('chat');
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [cardHeight, setCardHeight] = useState(INITIAL_CARD_HEIGHT);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return undefined;
+    const measure = () => setCardHeight(el.offsetHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="relative flex h-full min-h-0 flex-col">
-      {/* `pb-14` reserves a gutter the height of the floating card so the last
-          line of content can scroll clear of it instead of hiding behind it. */}
-      <div className="min-h-0 flex-1 overflow-hidden pb-14">{children}</div>
+      {/* Bottom gutter the height of the floating card so the last line of
+          content can scroll clear of it instead of hiding behind it. */}
+      <div
+        className="min-h-0 flex-1 overflow-hidden"
+        style={{ paddingBottom: cardHeight + CARD_BOTTOM_INSET + CARD_TOP_GAP }}
+      >
+        {children}
+      </div>
 
       <div
-        className="border-border bg-background/95 absolute right-3 bottom-3 z-10 flex items-center gap-1 rounded-lg border p-1 shadow-md backdrop-blur"
+        ref={cardRef}
+        className="border-border bg-background/95 absolute right-3 bottom-3 z-10 flex max-w-[calc(100%-1.5rem)] flex-wrap items-center justify-end gap-1 rounded-lg border p-1 shadow-md backdrop-blur"
         role="group"
         aria-label={t('canvas.fileActionsAriaLabel', {
           defaultValue: 'File actions',

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1778,7 +1778,9 @@
       "stripAria": "Chat-Bereich",
       "ariaLabel": "Chat-Bereich",
       "minimize": "Chat-Bereich minimieren",
-      "resizeAria": "Chat-Bereich vergrößern"
+      "resizeAria": "Chat-Bereich vergrößern",
+      "fullscreen": "Auf Vollbild erweitern",
+      "exitFullscreen": "Vollbild beenden"
     }
   },
   "common": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1778,7 +1778,9 @@
       "stripAria": "Chat panel",
       "ariaLabel": "Chat panel",
       "minimize": "Minimize chat panel",
-      "resizeAria": "Resize chat panel"
+      "resizeAria": "Resize chat panel",
+      "fullscreen": "Expand to full screen",
+      "exitFullscreen": "Exit full screen"
     }
   },
   "common": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1779,7 +1779,9 @@
       "stripAria": "Panneau de discussion",
       "ariaLabel": "Panneau de discussion",
       "minimize": "Réduire le panneau de discussion",
-      "resizeAria": "Redimensionner le panneau de discussion"
+      "resizeAria": "Redimensionner le panneau de discussion",
+      "fullscreen": "Passer en plein écran",
+      "exitFullscreen": "Quitter le plein écran"
     }
   },
   "common": {

--- a/services/platform/tests/integration/container-image-test.ts
+++ b/services/platform/tests/integration/container-image-test.ts
@@ -45,10 +45,13 @@ const SIZE_BUDGETS: Record<string, number> = {
   convex: 2500,
   sandbox: 320,
   'sandbox-egress': 80,
-  // Grew past the prior 2100 budget with native docker/compose-in-session
-  // (runtime tiers, #1881) on top of the playwright/chromium toolchain. ~10%
-  // headroom over the current optimized size.
-  'sandbox-runtime': 2800,
+  // Carries a heavy toolchain by design, on top of the playwright/chromium base
+  // and native docker/compose-in-session (runtime tiers, #1881):
+  //   - document conversion: libreoffice + poppler + pandoc (~570 MB)
+  //   - LaTeX/XeTeX for pandoc publication-grade PDF: texlive-xetex +
+  //     latex-recommended + fonts-recommended + lang-chinese + lmodern (~660 MB)
+  // The amd64 image is ~4.0 GB as a result; ~10% headroom over that.
+  'sandbox-runtime': 4400,
 };
 
 const SERVICES = [

--- a/services/sandbox-runtime/Dockerfile
+++ b/services/sandbox-runtime/Dockerfile
@@ -102,6 +102,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       pandoc \
     && rm -rf /var/lib/apt/lists/*
 
+# --- LaTeX (XeTeX) for publication-grade PDF -------------------------------
+# Gives `pandoc -o out.pdf --pdf-engine=xelatex` a real TeX engine, so PDFs get
+# a genuine `--toc`, page numbers, running headers/footers, a title page and
+# full font/margin control — instead of the brittle render-then-stitch route
+# (LibreOffice/fitz) the agent otherwise falls back to. A separate layer from
+# the Office/PDF block above: it's a large, self-contained concern that caches
+# independently. Kept to the XeTeX subset pandoc's default template needs, NOT
+# the multi-GB full `texlive` meta-package:
+#   texlive-xetex             — the `xelatex` engine (Unicode/OpenType native).
+#   texlive-latex-recommended — the core package set the default template loads.
+#   texlive-fonts-recommended — Latin Modern / TeX Gyre fonts that template uses.
+#   texlive-lang-chinese      — xeCJK / ctex so the Chinese workspace docs
+#       (e.g. *-zh-CN.md) typeset instead of dropping to tofu. The CJK *fonts*
+#       (Noto CJK) are already baked above for the live browser, so this adds
+#       only the macro packages; it also pulls texlive-latex-extra, handy for
+#       richer templates (fancyhdr, mdframed, …).
+#   lmodern                   — Latin Modern `lmodern.sty`. Pandoc's default
+#       LaTeX template does `\usepackage{lmodern}`, but it's only a *Recommends*
+#       of texlive-latex-recommended, so `--no-install-recommends` drops it and
+#       every `pandoc --pdf-engine=xelatex` then dies with "lmodern.sty not
+#       found". Pull it explicitly (the one Recommends we actually need).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      texlive-xetex \
+      texlive-latex-recommended \
+      texlive-fonts-recommended \
+      texlive-lang-chinese \
+      lmodern \
+    && rm -rf /var/lib/apt/lists/*
+
 # uv — fast Python package installer/resolver. See https://github.com/astral-sh/uv
 COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
 


### PR DESCRIPTION
External-agent chat file-panel UX improvements, plus a LaTeX toolchain in the sandbox image so pandoc can produce publication-grade PDFs. Each change is its own commit.

## Changes

### `feat(platform)` — fullscreen toggle for the chat side panel
The docked right-side panel was too narrow for reading documents. Added an expand/collapse control in the panel header that grows it to a full-viewport overlay (reusing the existing mobile overlay path), with **Escape** to exit. The overlay is `z-50` so it covers the `sticky z-50` composer instead of letting it bleed through at the bottom.

### `fix(platform)` — canvas file-action toolbar no longer clips in the docked panel
The floating Source/Preview/Copy/Download card was wider than the narrow docked viewer column, so its left edge was clipped (and the last content line could tuck behind it). The card is now capped to the viewer width and **wraps** to a second row when needed; the content gutter is sized from the card's **measured height** (the old fixed `pb-14` cleared by only ~2px).

### `fix(platform)` — refresh preserves expanded folders + open file
Clicking **Refresh** collapsed the workspace file tree back to root and dropped the open file, because the body was keyed by `refreshNonce` (forcing a remount). It's now keyed by `threadId` alone — the tree already re-fetches its expanded dirs in place off `refreshNonce`, and a stopped session is re-probed via an effect rather than a full remount.

### `feat(platform)` — sticky Source/Preview across files
The view mode was remembered per file path, so each newly-opened doc reverted to the `source` default. It now tracks the last-picked mode as the sticky default for untouched files (mirroring the shared `wrap` toggle), while files you explicitly toggle still keep their own choice.

### `feat(sandbox)` — LaTeX/XeTeX toolchain for pandoc PDF output
Added `texlive-xetex texlive-latex-recommended texlive-fonts-recommended texlive-lang-chinese lmodern` to the sandbox-runtime image so `pandoc --pdf-engine=xelatex --toc` yields real TOC / page numbers / headers-footers / title page instead of the render-and-stitch fallback.
- `lmodern` is pulled explicitly: pandoc's default template needs `lmodern.sty`, but it's only a *Recommends* that `--no-install-recommends` drops.
- `texlive-lang-chinese` provides xeCJK so the Chinese workspace docs typeset (Noto CJK fonts were already baked for the live browser). Chinese output requires `-V CJKmainfont="Noto Sans CJK SC"`.
- Image size 4.46 → 5.39 GB (~880 MB).

## Verification
- **Frontend** (Playwright against the dev app, geometry/hit-testing, not just screenshots): fullscreen overlay covers the composer and Escape restores the docked pane; toolbar stays inside the viewer column (wraps to 2 rows) and the last line clears it; refresh keeps `vatplus/source` expanded and the open file selected; a never-opened doc inherits the last-picked Preview mode.
- **Sandbox** (e2e in the rebuilt image as session role uid 10001): `xelatex` present; `pandoc → xelatex` PDF for English (with `--toc`) and Chinese (CJK text extractable via `pdftotext`) — 3/3 pass.
- `tsc --noEmit` and `oxlint --type-aware` clean on all touched files.