### PR TITLE
fix: add download/preview affordance to project files tab (#2070)

### DIFF
--- a/services/platform/app/features/projects/components/project-files-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-files-tab.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { render, screen, waitFor, within } from '@/tests/utils/render';
+
+import { ProjectFilesTab } from './project-files-tab';
+
+// Regression coverage for issue #2070: the Files tab exposed no way to
+// download/open/preview an attached file. The fix wires the existing
+// DocumentPreviewDialog into each row (a clickable title + an explicit preview
+// IconButton) whenever the row carries a storage `fileId`. The preview dialog
+// itself self-fetches via Convex, so it's stubbed here to a deterministic
+// surface; what's asserted at the component tier is the same observable
+// behaviour a user drives: a previewable row exposes the affordance and
+// activating it opens the dialog for the right document, while a row without a
+// stored file shows no affordance.
+
+type DocFixture = {
+  _id: Id<'documents'>;
+  _creationTime: number;
+  title?: string;
+  fileId?: Id<'_storage'>;
+  mimeType?: string;
+  extension?: string;
+  indexed?: boolean;
+  ragStatus: 'queued' | 'running' | 'completed' | 'failed' | null;
+  createdBy?: string;
+};
+
+let documentsFixture: DocFixture[] = [];
+let projectFixture: { canEdit: boolean } | null = { canEdit: true };
+
+vi.mock('../hooks/queries', () => ({
+  useProject: () => ({ project: projectFixture, isLoading: false }),
+  useProjectDocuments: () => ({
+    documents: documentsFixture,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useAttachDocumentToProject: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({ documentId: 'doc-x' }),
+  }),
+  useDetachDocumentFromProject: () => ({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/app/hooks/use-convex-mutation', () => ({
+  useConvexMutation: () => ({ mutateAsync: vi.fn().mockResolvedValue({}) }),
+}));
+
+vi.mock('@/app/hooks/use-convex-action', () => ({
+  useConvexAction: () => ({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: vi.fn(),
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// The real preview dialog self-fetches the document/URL through Convex; stub it
+// to a deterministic surface that records the document it was asked to open.
+vi.mock('@/app/features/documents/components/document-preview-dialog', () => ({
+  DocumentPreviewDialog: ({
+    open,
+    documentId,
+    fileName,
+  }: {
+    open: boolean;
+    documentId?: string;
+    fileName?: string;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Preview">
+        <span data-testid="preview-doc-id">{documentId}</span>
+        <span data-testid="preview-file-name">{fileName}</span>
+      </div>
+    ) : null,
+}));
+
+const PROJECT_ID = 'proj-1' as Id<'projects'>;
+
+function renderTab() {
+  return render(
+    <ProjectFilesTab organizationId="org-1" projectId={PROJECT_ID} />,
+  );
+}
+
+function makeDoc(overrides: Partial<DocFixture> = {}): DocFixture {
+  return {
+    _id: 'doc-1' as Id<'documents'>,
+    _creationTime: 0,
+    title: 'Report.pdf',
+    fileId: 'storage-1' as Id<'_storage'>,
+    mimeType: 'application/pdf',
+    ragStatus: 'completed',
+    ...overrides,
+  };
+}
+
+describe('ProjectFilesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    documentsFixture = [];
+    projectFixture = { canEdit: true };
+  });
+
+  it('exposes a preview affordance on a row that has a stored file', () => {
+    documentsFixture = [makeDoc()];
+    renderTab();
+
+    // The title is a button (opens the preview) and there's an explicit
+    // "Preview file" control.
+    expect(
+      screen.getByRole('button', { name: 'Report.pdf' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Preview file' }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the preview dialog for the row when the preview button is clicked', async () => {
+    documentsFixture = [makeDoc()];
+    const { user } = renderTab();
+
+    expect(screen.queryByRole('dialog', { name: 'Preview' })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Preview file' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Preview' });
+    expect(within(dialog).getByTestId('preview-doc-id')).toHaveTextContent(
+      'doc-1',
+    );
+    expect(within(dialog).getByTestId('preview-file-name')).toHaveTextContent(
+      'Report.pdf',
+    );
+  });
+
+  it('opens the preview when the file title is clicked', async () => {
+    documentsFixture = [makeDoc()];
+    const { user } = renderTab();
+
+    await user.click(screen.getByRole('button', { name: 'Report.pdf' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: 'Preview' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows no preview affordance for a row without a stored file', async () => {
+    documentsFixture = [makeDoc({ fileId: undefined, title: 'Pending.pdf' })];
+    renderTab();
+
+    // The title renders as plain text, not a button, and no preview control.
+    expect(screen.getByText('Pending.pdf')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pending.pdf' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Preview file' })).toBeNull();
+  });
+});

--- a/services/platform/app/features/projects/components/project-files-tab.tsx
+++ b/services/platform/app/features/projects/components/project-files-tab.tsx
@@ -2,17 +2,19 @@
 
 import { Button } from '@tale/ui/button';
 import { EmptyPlaceholder } from '@tale/ui/empty-placeholder';
+import { IconButton } from '@tale/ui/icon-button';
 import { HStack, Stack } from '@tale/ui/layout';
 import { StickySectionHeader } from '@tale/ui/sticky-section-header';
 import { Text } from '@tale/ui/text';
 import { ConvexError } from 'convex/values';
-import { FileText, RotateCcw, Upload } from 'lucide-react';
+import { Eye, FileText, RotateCcw, Upload } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
 import { FileUpload } from '@/app/components/ui/forms/file-upload';
 import { FormSection } from '@/app/components/ui/forms/form-section';
+import { DocumentPreviewDialog } from '@/app/features/documents/components/document-preview-dialog';
 import { useConvexAction } from '@/app/hooks/use-convex-action';
 import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
 import { toast } from '@/app/hooks/use-toast';
@@ -60,6 +62,10 @@ export function ProjectFilesTab({
   const [retryingIds, setRetryingIds] = useState(new Set<string>());
   const [confirmDetachId, setConfirmDetachId] =
     useState<Id<'documents'> | null>(null);
+  const [previewDoc, setPreviewDoc] = useState<{
+    id: Id<'documents'>;
+    title: string;
+  } | null>(null);
 
   const uploadOne = useCallback(
     async (file: File): Promise<void> => {
@@ -251,6 +257,14 @@ export function ProjectFilesTab({
             {documents.map((doc) => {
               const isRetrying = retryingIds.has(String(doc._id));
               const failed = doc.ragStatus === 'failed';
+              const displayTitle =
+                doc.title ?? doc.extension ?? t('files.unknownTitle');
+              // A file can only be opened/downloaded once its bytes have been
+              // stored, so gate the preview affordance on the storage id that
+              // `listProjectDocuments` returns per row.
+              const canPreview = doc.fileId != null;
+              const openPreview = () =>
+                setPreviewDoc({ id: doc._id, title: displayTitle });
               return (
                 <HStack
                   key={doc._id}
@@ -263,13 +277,33 @@ export function ProjectFilesTab({
                     aria-hidden="true"
                   />
                   <Stack gap={0} className="min-w-0 flex-1">
-                    <Text as="span" variant="body" truncate>
-                      {doc.title ?? doc.extension ?? t('files.unknownTitle')}
-                    </Text>
+                    {canPreview ? (
+                      <button
+                        type="button"
+                        onClick={openPreview}
+                        className="min-w-0 cursor-pointer text-left hover:underline"
+                      >
+                        <Text as="span" variant="body" truncate>
+                          {displayTitle}
+                        </Text>
+                      </button>
+                    ) : (
+                      <Text as="span" variant="body" truncate>
+                        {displayTitle}
+                      </Text>
+                    )}
                     <Text as="span" variant="caption">
                       {statusLabel(doc.ragStatus)}
                     </Text>
                   </Stack>
+                  {canPreview ? (
+                    <IconButton
+                      icon={Eye}
+                      variant="ghost"
+                      aria-label={t('files.previewAction')}
+                      onClick={openPreview}
+                    />
+                  ) : null}
                   {failed && canEdit ? (
                     <Button
                       variant="ghost"
@@ -326,6 +360,15 @@ export function ProjectFilesTab({
           </FileUpload.Root>
         ) : null}
       </FormSection>
+
+      <DocumentPreviewDialog
+        open={previewDoc !== null}
+        onOpenChange={(open) => {
+          if (!open) setPreviewDoc(null);
+        }}
+        documentId={previewDoc?.id}
+        fileName={previewDoc?.title}
+      />
 
       <ConfirmDialog
         open={confirmDetachId !== null}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7333,6 +7333,7 @@
       "ragStatusCompleted": "Indexiert",
       "ragStatusFailed": "Fehlgeschlagen",
       "detachAction": "Aus Projekt entfernen",
+      "previewAction": "Datei anzeigen",
       "detachSuccess": "Dokument aus Projekt entfernt",
       "detachError": "Dokument konnte nicht entfernt werden",
       "attachSuccess": "Dokument zum Projekt hinzugefügt",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4969,6 +4969,7 @@
       "ragStatusCompleted": "Indexed",
       "ragStatusFailed": "Failed",
       "detachAction": "Remove from project",
+      "previewAction": "Preview file",
       "detachSuccess": "Document removed from project",
       "detachError": "Couldn't remove document",
       "attachSuccess": "Document added to project",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7334,6 +7334,7 @@
       "ragStatusCompleted": "Indexé",
       "ragStatusFailed": "Échec",
       "detachAction": "Retirer du projet",
+      "previewAction": "Aperçu du fichier",
       "detachSuccess": "Document retiré du projet",
       "detachError": "Impossible de retirer le document",
       "attachSuccess": "Document ajouté au projet",


### PR DESCRIPTION
## Summary

The Projects → Files tab rendered each attached file as plain text with no way to download, open, or preview it — so files attached to a project could not be retrieved from the UI (issue #2070).

This wires the existing `DocumentPreviewDialog` (preview + working download) into each file row, reusing the `fileId` already returned by `listProjectDocuments`:

- The file **title is now a clickable button** that opens the preview dialog.
- An explicit **"Preview file" icon button** (`Eye`) is added per row.
- Both affordances are gated on the row having a stored `fileId`, so rows whose bytes aren't stored yet stay non-interactive.
- The dialog provides the existing download flow (download button) and inline preview.

The change is additive and low-risk: no backend/query changes, just the component plus i18n keys (`projects.files.previewAction`) in `en`/`de`/`fr`.

## Testing

- Added `project-files-tab.test.tsx` covering: preview affordance present on a stored row, dialog opens via the preview button and via the title (with the correct document id/name), and absent on a row without a stored file.
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on changed files — clean
- `vitest` UI project — 4/4 pass

Closes #2070