### PR TITLE
fix(convex): stop researcher flicker, stream delegation sub-threads, gate on approval

### DIFF
--- a/services/platform/convex/agent_tools/delegation/run_delegate_step.test.ts
+++ b/services/platform/convex/agent_tools/delegation/run_delegate_step.test.ts
@@ -28,3 +28,43 @@ describe('applyDelegationStrip (double-delegation guard)', () => {
     expect(applyDelegationStrip(base, undefined)).toBe(base);
   });
 });
+
+describe('applyDelegationStrip (human-input gate strip)', () => {
+  const withGate: SerializableAgentConfig = {
+    name: 'researcher',
+    instructions: 'research the sub-task',
+    maxSteps: 40,
+    convexToolNames: ['update_todos', 'request_human_input', 'web'],
+  };
+
+  it('removes request_human_input from a delegated run, even without stripping', () => {
+    const out = applyDelegationStrip(withGate, undefined);
+    expect(out.convexToolNames).toEqual(['update_todos', 'web']);
+    // Re-delegation is NOT disabled when only the gate is stripped.
+    expect(out.delegationDisabled).toBeUndefined();
+  });
+
+  it('strips both the gate and re-delegation when stripping', () => {
+    const out = applyDelegationStrip(withGate, true);
+    expect(out.convexToolNames).toEqual(['update_todos', 'web']);
+    expect(out.delegationDisabled).toBe(true);
+  });
+
+  it('never mutates the input config', () => {
+    applyDelegationStrip(withGate, true);
+    expect(withGate.convexToolNames).toEqual([
+      'update_todos',
+      'request_human_input',
+      'web',
+    ]);
+  });
+
+  it('leaves a delegate without the gate untouched (same reference)', () => {
+    const noGate: SerializableAgentConfig = {
+      name: 'coder',
+      instructions: 'write code',
+      convexToolNames: ['web'],
+    };
+    expect(applyDelegationStrip(noGate, undefined)).toBe(noGate);
+  });
+});

--- a/services/platform/convex/agent_tools/delegation/run_delegate_step.ts
+++ b/services/platform/convex/agent_tools/delegation/run_delegate_step.ts
@@ -21,18 +21,46 @@ import {
 import type { DelegateAgentMeta } from './create_delegation_tool';
 
 /**
- * The double-delegation guard: when an orchestrated leaf delegate runs, strip
- * its delegation entirely so it can't re-delegate (the router owns
- * decomposition). Returns the config UNCHANGED when not stripping, and never
- * mutates the input. Uses the explicit `delegationDisabled` flag — delegates
- * are derived from the org chart at tool-build time, so only this flag
- * reliably disables delegation.
+ * Prepare a delegate's config for a delegated run.
+ *
+ * Two strips happen here:
+ *
+ * 1. **Human-input gate (always).** A delegated sub-agent runs
+ *    non-interactively: there is no flow to resume a delegate after a
+ *    `request_human_input` gate. The approval re-homes to the PARENT thread
+ *    (`request_human_input_tool.ts` → `getApprovalThreadId`) and
+ *    `submitHumanInputResponse` resumes the PARENT agent, never the delegate
+ *    (`human_input/mutations.ts`). So a delegate's gate only strands a pending
+ *    approval that locks the composer while the parent answers anyway. Drop
+ *    `request_human_input` from `convexToolNames` on every delegated run —
+ *    which also clears its `stopWhen` halt (generate_response.ts). The gate
+ *    still works when the same agent (e.g. the Researcher) runs as the PRIMARY
+ *    agent, which does not go through here.
+ *
+ * 2. **Re-delegation (the double-delegation guard, gated on `strip`).** When an
+ *    orchestrated leaf delegate runs, disable its delegation so it can't
+ *    re-delegate (the router owns decomposition). Uses the explicit
+ *    `delegationDisabled` flag — delegates are derived from the org chart at
+ *    tool-build time, so only this flag reliably disables delegation.
+ *
+ * Returns the config UNCHANGED (same reference) when neither strip applies, and
+ * never mutates the input.
  */
 export function applyDelegationStrip(
   config: SerializableAgentConfig,
   strip: boolean | undefined,
 ): SerializableAgentConfig {
-  return strip ? { ...config, delegationDisabled: true } : config;
+  const hasGate = config.convexToolNames?.includes('request_human_input');
+  if (!hasGate && !strip) return config;
+
+  const next: SerializableAgentConfig = { ...config };
+  if (hasGate) {
+    next.convexToolNames = config.convexToolNames?.filter(
+      (toolName) => toolName !== 'request_human_input',
+    );
+  }
+  if (strip) next.delegationDisabled = true;
+  return next;
 }
 
 export interface RunDelegateStepArgs {

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -2704,4 +2704,8 @@ function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export { needsToolResultRetry, shouldRetryGeneration } from './retry_policy';
+export {
+  endedOnHumanInputGate,
+  needsToolResultRetry,
+  shouldRetryGeneration,
+} from './retry_policy';

--- a/services/platform/convex/lib/agent_response/generate_response.ts
+++ b/services/platform/convex/lib/agent_response/generate_response.ts
@@ -22,7 +22,7 @@ import {
   type MessageDoc,
 } from '@convex-dev/agent';
 import type { StreamMessage } from '@convex-dev/agent/validators';
-import type { ModelMessage } from 'ai';
+import { hasToolCall, type ModelMessage, stepCountIs } from 'ai';
 
 import {
   classifyChatErrorCode,
@@ -204,6 +204,19 @@ export async function generateAgentResponse(
     prewarm,
     pinnedFileIds,
   } = args;
+
+  // Hard-stop the agent loop the moment `request_human_input` is called. That
+  // tool only surfaces an approval card and tells the model to stop and wait —
+  // but "stop" was a prompt-only contract the model could (and did) ignore,
+  // most visibly the researcher barrelling past its plan-confirmation card
+  // straight into web searches. `hasToolCall` turns the gate into a real stop.
+  // Scoped to agents that actually expose the tool so no other agent's loop
+  // behaviour changes. Setting `stopWhen` makes the SDK ignore the config's
+  // `maxSteps`, so the step cap is re-applied here via `stepCountIs` (mirroring
+  // the default in create_agent_config.ts).
+  const humanInputStopWhen = convexToolNames?.includes('request_human_input')
+    ? [stepCountIs(args.maxSteps ?? 40), hasToolCall('request_human_input')]
+    : undefined;
 
   const debugLog = createDebugLog(
     `DEBUG_${agentType.toUpperCase()}_AGENT`,
@@ -1259,6 +1272,7 @@ export async function generateAgentResponse(
             system: systemPrompt,
             prompt: promptToSend,
             abortSignal: abortController.signal,
+            ...(humanInputStopWhen ? { stopWhen: humanInputStopWhen } : {}),
             ...(outputTransform !== null && {
               experimental_transform: outputTransform,
             }),
@@ -1478,6 +1492,7 @@ export async function generateAgentResponse(
               system: systemPrompt,
               prompt: promptToSend,
               abortSignal: abortController.signal,
+              ...(humanInputStopWhen ? { stopWhen: humanInputStopWhen } : {}),
               ...(promptMessageId ? { promptMessageId } : {}),
               ...(effectiveTemperature != null && {
                 temperature: effectiveTemperature,

--- a/services/platform/convex/lib/agent_response/retry_policy.ts
+++ b/services/platform/convex/lib/agent_response/retry_policy.ts
@@ -57,6 +57,38 @@ export function needsToolResultRetry(
 }
 
 /**
+ * The interactive approval-gate tool. When the agent loop is halted because the
+ * model called this (see the `stopWhen: hasToolCall('request_human_input')` in
+ * generate_response.ts), the stop is INTENTIONAL — an approval card is now shown
+ * and the turn must wait for the user's response in a future turn.
+ */
+const HUMAN_INPUT_GATE_TOOL = 'request_human_input';
+
+/**
+ * True when the generation's LAST step ended by calling `request_human_input`.
+ *
+ * That is the deliberate approval-gate halt and MUST be treated as terminal: the
+ * AI SDK reports `finishReason: 'tool-calls'` for it (or `'stop'` with no
+ * trailing text), which the retry logic below would otherwise read as an
+ * incomplete response and auto-continue — barrelling straight past the gate the
+ * stop exists to enforce (researcher plan-confirmation, disambiguation cards…).
+ *
+ * Scoped to the LAST step: when `stopWhen` fires, the gate call is always the
+ * final step. A gate call in an earlier step (the model kept going on its own)
+ * is not a gate halt and stays retryable.
+ */
+export function endedOnHumanInputGate(steps: unknown[] | undefined): boolean {
+  if (!steps || steps.length === 0) return false;
+  type StepLike = { toolCalls?: Array<{ toolName: string }> };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- dynamic data from AI SDK
+  const typedSteps = steps as StepLike[];
+  const lastStep = typedSteps[typedSteps.length - 1];
+  return (lastStep?.toolCalls ?? []).some(
+    (call) => call.toolName === HUMAN_INPUT_GATE_TOOL,
+  );
+}
+
+/**
  * Finish reasons that indicate a completed or non-retryable state.
  * - "stop": normal LLM completion
  * - "cancelled": user explicitly cancelled the generation
@@ -89,6 +121,14 @@ export function shouldRetryGeneration(
   alreadyRetried: boolean,
 ): { retry: boolean; reason: string } {
   if (alreadyRetried) return { retry: false, reason: 'already-retried' };
+
+  // The approval gate (`request_human_input`) halts the loop on purpose — the
+  // turn must wait for the user, not auto-continue. Treat it as terminal no
+  // matter the finishReason ('tool-calls' when stopWhen fires, or 'stop' with
+  // empty trailing text), so the continue path never resumes past the gate.
+  if (endedOnHumanInputGate(steps)) {
+    return { retry: false, reason: 'awaiting-human-input' };
+  }
 
   if (finishReason && NON_RETRYABLE_FINISH_REASONS.has(finishReason)) {
     if (finishReason === 'stop' && needsToolResultRetry(text, steps)) {

--- a/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
+++ b/services/platform/convex/lib/agent_response/should_retry_generation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 // These are pure functions — no mocks needed
 import {
+  endedOnHumanInputGate,
   shouldRetryGeneration,
   needsToolResultRetry,
 } from './generate_response';
@@ -157,6 +158,46 @@ describe('shouldRetryGeneration', () => {
     });
   });
 
+  describe('human-input approval gate is terminal', () => {
+    // Regression: `stopWhen: hasToolCall('request_human_input')` halts the loop
+    // with finishReason 'tool-calls'; without this branch the continue/retry
+    // path resumed past the gate and ran the whole task anyway (the researcher
+    // barrelling past its plan-confirmation card).
+    it('does not retry when the last step called request_human_input (tool-calls)', () => {
+      const steps = [
+        makeStep({ toolCalls: [{ toolName: 'update_todos' }] }),
+        makeStep({ toolCalls: [{ toolName: 'request_human_input' }] }),
+      ];
+      const result = shouldRetryGeneration('tool-calls', '', steps, false);
+      expect(result).toEqual({ retry: false, reason: 'awaiting-human-input' });
+    });
+
+    it('does not retry on the "stop" + empty-text gate halt either', () => {
+      const steps = [
+        makeStep({
+          toolCalls: [{ toolName: 'request_human_input' }],
+          text: '',
+        }),
+      ];
+      const result = shouldRetryGeneration('stop', '', steps, false);
+      expect(result).toEqual({ retry: false, reason: 'awaiting-human-input' });
+    });
+
+    it('still retries when request_human_input is only an EARLIER step', () => {
+      // The model called the gate, then kept going on its own — that is NOT a
+      // stopWhen halt, so the incomplete trailing tool call stays retryable.
+      const steps = [
+        makeStep({ toolCalls: [{ toolName: 'request_human_input' }] }),
+        makeStep({ toolCalls: [{ toolName: 'web' }] }),
+      ];
+      const result = shouldRetryGeneration('tool-calls', '', steps, false);
+      expect(result).toEqual({
+        retry: true,
+        reason: 'finish-reason-tool-calls',
+      });
+    });
+  });
+
   describe('already-retried guard', () => {
     it('returns false when already retried, even for retryable finishReason', () => {
       const result = shouldRetryGeneration('length', 'Partial...', [], true);
@@ -191,6 +232,35 @@ describe('needsToolResultRetry', () => {
     expect(needsToolResultRetry('Response', [makeStep({ text: 'Hi' })])).toBe(
       false,
     );
+  });
+});
+
+describe('endedOnHumanInputGate', () => {
+  it('returns false for no steps', () => {
+    expect(endedOnHumanInputGate([])).toBe(false);
+    expect(endedOnHumanInputGate(undefined)).toBe(false);
+  });
+
+  it('returns true when the last step called request_human_input', () => {
+    const steps = [
+      makeStep({ toolCalls: [{ toolName: 'update_todos' }] }),
+      makeStep({ toolCalls: [{ toolName: 'request_human_input' }] }),
+    ];
+    expect(endedOnHumanInputGate(steps)).toBe(true);
+  });
+
+  it('returns false when the gate call is not the last step', () => {
+    const steps = [
+      makeStep({ toolCalls: [{ toolName: 'request_human_input' }] }),
+      makeStep({ toolCalls: [{ toolName: 'web' }] }),
+    ];
+    expect(endedOnHumanInputGate(steps)).toBe(false);
+  });
+
+  it('returns false for an ordinary tool call', () => {
+    expect(
+      endedOnHumanInputGate([makeStep({ toolCalls: [{ toolName: 'web' }] })]),
+    ).toBe(false);
   });
 
   it('returns true when last step has tool calls (preamble-only)', () => {

--- a/services/platform/convex/lib/rls/auth/can_access_thread.test.ts
+++ b/services/platform/convex/lib/rls/auth/can_access_thread.test.ts
@@ -7,10 +7,15 @@ vi.mock('../../../_generated/api', () => ({
         findMany: 'betterAuth:adapter:findMany',
       },
     },
+    agent: {
+      threads: {
+        getThread: 'agent:threads:getThread',
+      },
+    },
   },
 }));
 
-const { canAccessThread, assertThreadAccess } =
+const { canAccessThread, assertThreadAccess, canAccessThreadOrSubThread } =
   await import('./can_access_thread');
 
 const authUser = { userId: 'user_1', email: 'larry@tale.dev' };
@@ -469,5 +474,175 @@ describe('assertThreadAccess', () => {
     await expect(
       assertThreadAccess(ctx as never, 't_1', authUser),
     ).rejects.toMatchObject({ data: { code: 'forbidden' } });
+  });
+});
+
+/**
+ * Mock ctx for the sub-thread tests: `threadMetadata` is keyed by threadId (so
+ * a sub-thread can resolve to `null` while its parent resolves to a real row),
+ * and `agent.threads.getThread` is served from `summariesByThreadId`.
+ */
+function createSubThreadMockCtx(opts: {
+  metadataByThreadId: Record<string, MockMetadata>;
+  summariesByThreadId?: Record<string, string | undefined>;
+  members?: BetterAuthMember[];
+}) {
+  return {
+    db: {
+      query: vi.fn().mockImplementation((table: string) => ({
+        withIndex: vi
+          .fn()
+          .mockImplementation(
+            (_index: string, builder?: (q: unknown) => unknown) => {
+              let capturedThreadId: string | undefined;
+              if (builder) {
+                const q = {
+                  eq: (field: string, value: string) => {
+                    if (field === 'threadId') capturedThreadId = value;
+                    return q;
+                  },
+                };
+                builder(q);
+              }
+              return {
+                first: vi
+                  .fn()
+                  .mockResolvedValue(
+                    table === 'memberMirror'
+                      ? null
+                      : capturedThreadId
+                        ? (opts.metadataByThreadId[capturedThreadId] ?? null)
+                        : null,
+                  ),
+              };
+            },
+          ),
+      })),
+    },
+    runQuery: vi
+      .fn()
+      .mockImplementation(
+        (
+          ref: string,
+          args:
+            | { threadId: string }
+            | { where: { field: string; value: string }[] },
+        ) => {
+          if (ref === 'agent:threads:getThread') {
+            const threadId = (args as { threadId: string }).threadId;
+            const summary = opts.summariesByThreadId?.[threadId];
+            return Promise.resolve(summary !== undefined ? { summary } : null);
+          }
+          // isOrgMember → Better Auth `member` findMany
+          const where = (args as { where: { field: string; value: string }[] })
+            .where;
+          const orgIdFilter = where.find((w) => w.field === 'organizationId');
+          const userIdFilter = where.find((w) => w.field === 'userId');
+          const page = (opts.members ?? []).filter(
+            (m) =>
+              (orgIdFilter === undefined ||
+                m.organizationId === orgIdFilter.value) &&
+              (userIdFilter === undefined || m.userId === userIdFilter.value),
+          );
+          return Promise.resolve({ page, isDone: true, continueCursor: '' });
+        },
+      ),
+    auth: {},
+  };
+}
+
+describe('canAccessThreadOrSubThread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const parentMeta: MockMetadata = {
+    _id: 'tm_parent',
+    threadId: 't_parent',
+    userId: 'user_1',
+    organizationId: 'org_1',
+  };
+  const ownerMembers: BetterAuthMember[] = [
+    { _id: 'm_1', organizationId: 'org_1', userId: 'user_1', role: 'admin' },
+  ];
+
+  it('grants access to a sub-thread whose parent the user can access', async () => {
+    // The sub-thread has NO threadMetadata row of its own (the Agent SDK
+    // component creates it without one) — access is inherited from the parent.
+    const ctx = createSubThreadMockCtx({
+      metadataByThreadId: { t_parent: parentMeta },
+      summariesByThreadId: {
+        t_sub: JSON.stringify({
+          subAgentType: 'researcher',
+          parentThreadId: 't_parent',
+        }),
+      },
+      members: ownerMembers,
+    });
+
+    const result = await canAccessThreadOrSubThread(
+      ctx as never,
+      't_sub',
+      authUser,
+    );
+
+    expect(result).toEqual(parentMeta);
+  });
+
+  it('denies a sub-thread whose parent the user cannot access', async () => {
+    const ctx = createSubThreadMockCtx({
+      // Parent exists but the user is not a member of its org.
+      metadataByThreadId: {
+        t_parent: { ...parentMeta, userId: 'user_other' },
+      },
+      summariesByThreadId: {
+        t_sub: JSON.stringify({ parentThreadId: 't_parent' }),
+      },
+      members: [],
+    });
+
+    const result = await canAccessThreadOrSubThread(
+      ctx as never,
+      't_sub',
+      authUser,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('denies a thread that has neither metadata nor a parent summary', async () => {
+    const ctx = createSubThreadMockCtx({
+      metadataByThreadId: {},
+      summariesByThreadId: { t_orphan: undefined },
+      members: ownerMembers,
+    });
+
+    const result = await canAccessThreadOrSubThread(
+      ctx as never,
+      't_orphan',
+      authUser,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('walks nested delegation up to an accessible ancestor', async () => {
+    // sub2 → sub1 → parent(owned). Both intermediate sub-threads lack metadata.
+    const ctx = createSubThreadMockCtx({
+      metadataByThreadId: { t_parent: parentMeta },
+      summariesByThreadId: {
+        t_sub2: JSON.stringify({ parentThreadId: 't_sub1' }),
+        t_sub1: JSON.stringify({ parentThreadId: 't_parent' }),
+      },
+      members: ownerMembers,
+    });
+
+    const result = await canAccessThreadOrSubThread(
+      ctx as never,
+      't_sub2',
+      authUser,
+    );
+
+    expect(result).toEqual(parentMeta);
   });
 });

--- a/services/platform/convex/lib/rls/auth/can_access_thread.ts
+++ b/services/platform/convex/lib/rls/auth/can_access_thread.ts
@@ -1,5 +1,7 @@
 import { ConvexError } from 'convex/values';
 
+import { isRecord } from '../../../../lib/utils/type-utils';
+import { components } from '../../../_generated/api';
 import type { Doc } from '../../../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../../../_generated/server';
 import type { AuthenticatedUser } from '../types';
@@ -99,6 +101,85 @@ export async function canAccessThread(
   }
 
   return null;
+}
+
+/**
+ * Max parent hops walked when authorizing a delegated sub-thread. Delegation is
+ * one level in practice (chat thread → sub-agent thread); the small bound just
+ * defends against an unexpected cycle or deep nesting walking forever.
+ */
+const MAX_SUB_THREAD_PARENT_HOPS = 4;
+
+/**
+ * Like {@link canAccessThread}, but also authorizes delegated sub-threads.
+ *
+ * Sub-agent threads (e.g. the researcher's per-delegation thread) are created
+ * through the Agent SDK component and have NO `threadMetadata` row of their own
+ * (see `get_or_create_sub_thread.ts`), so `canAccessThread` always denies them.
+ * The chat UI nevertheless subscribes to a sub-thread's live stream to render
+ * the nested delegation timeline — without this, that subscription returns the
+ * forbidden fallback on every tick.
+ *
+ * A sub-thread is visible to whoever can see the PARENT thread it was spawned
+ * from. We read the component thread's `summary.parentThreadId` and authorize
+ * against the parent (returning the PARENT's metadata, which callers use only
+ * as a truthy access gate). Bounded by {@link MAX_SUB_THREAD_PARENT_HOPS}.
+ *
+ * Use this ONLY on read paths that legitimately stream sub-threads (the
+ * streaming-messages query). Keep ordinary thread access on `canAccessThread`.
+ */
+export async function canAccessThreadOrSubThread(
+  ctx: QueryCtx | MutationCtx,
+  threadId: string,
+  authUser: AuthenticatedUser,
+  expectedOrgId?: string,
+): Promise<ThreadMetadata | null> {
+  const direct = await canAccessThread(ctx, threadId, authUser, expectedOrgId);
+  if (direct) return direct;
+
+  let currentThreadId = threadId;
+  for (let hop = 0; hop < MAX_SUB_THREAD_PARENT_HOPS; hop++) {
+    const parentThreadId = await readSubThreadParentId(ctx, currentThreadId);
+    if (!parentThreadId) return null;
+
+    const parentAccess = await canAccessThread(
+      ctx,
+      parentThreadId,
+      authUser,
+      expectedOrgId,
+    );
+    if (parentAccess) return parentAccess;
+
+    // Parent itself may be another sub-thread (nested delegation) — keep
+    // walking up until we hit a thread with metadata the user can access.
+    currentThreadId = parentThreadId;
+  }
+  return null;
+}
+
+/** Read a delegated sub-thread's `parentThreadId` from its component-thread
+ *  summary. Returns `undefined` when the thread is missing, has no summary, or
+ *  the summary isn't a sub-thread record. */
+async function readSubThreadParentId(
+  ctx: QueryCtx | MutationCtx,
+  threadId: string,
+): Promise<string | undefined> {
+  const thread = await ctx.runQuery(components.agent.threads.getThread, {
+    threadId,
+  });
+  if (!thread?.summary) return undefined;
+  try {
+    const summary: unknown = JSON.parse(thread.summary);
+    if (isRecord(summary) && typeof summary.parentThreadId === 'string') {
+      return summary.parentThreadId;
+    }
+  } catch (err) {
+    console.warn(
+      `[canAccessThreadOrSubThread] unparseable summary for thread ${threadId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+  return undefined;
 }
 
 /**

--- a/services/platform/convex/thread_todos/queries.test.ts
+++ b/services/platform/convex/thread_todos/queries.test.ts
@@ -141,6 +141,39 @@ describe('thread_todos.get — delegate sub-thread fallback', () => {
     expect(mockGetDelegateSubThreadIds).not.toHaveBeenCalled();
   });
 
+  it('skips an EMPTY parent row and surfaces the delegate sub-thread plan', async () => {
+    // Regression: once the parent agent runs its own web/integration calls, a
+    // `threadTodos` row materializes on the parent purely to track
+    // `integrationCallCount` — with `todos: []`. It must NOT shadow the
+    // researcher delegate's real plan (the bug that made the plan pane flash
+    // then vanish mid-run).
+    mockGetDelegateSubThreadIds.mockResolvedValue(['sub']);
+    const ctx = makeCtx({
+      threadMetadata: [metaRow()],
+      threadTodos: [
+        todosRow({ threadId: 'parent', todos: [], integrationCallCount: 21 }),
+        todosRow({ threadId: 'sub', updatedAt: 7 }),
+      ],
+    });
+    const out = (await getTodos(ctx, { threadId: 'parent' })) as {
+      threadId: string;
+      todos: unknown[];
+    } | null;
+    expect(out?.threadId).toBe('sub');
+    expect(out?.todos).toHaveLength(1);
+  });
+
+  it('returns null when the only row (parent) has an empty todos array', async () => {
+    // An empty row is not a plan — with no delegate plan either, show nothing
+    // rather than an empty pane.
+    const ctx = makeCtx({
+      threadMetadata: [metaRow()],
+      threadTodos: [todosRow({ threadId: 'parent', todos: [] })],
+    });
+    const out = await getTodos(ctx, { threadId: 'parent' });
+    expect(out).toBeNull();
+  });
+
   it('returns null when neither parent nor any sub-thread has todos', async () => {
     mockGetDelegateSubThreadIds.mockResolvedValue(['sub']);
     const ctx = makeCtx({ threadMetadata: [metaRow()], threadTodos: [] });

--- a/services/platform/convex/thread_todos/queries.ts
+++ b/services/platform/convex/thread_todos/queries.ts
@@ -71,15 +71,28 @@ export const get = query({
     // per-item fork linkage, so we surface the nearest one in the lineage
     // rather than trying to slice it. The `by_org_thread` org filter is the
     // access gate for sub-threads (which carry no `threadMetadata`).
+    //
+    // A "hit" requires a row with ACTUAL todos. A thread that only made
+    // integration calls still owns a `threadTodos` row (it tracks
+    // `integrationCallCount`) with an EMPTY `todos` array — that empty row must
+    // NOT count as a plan, or it shadows a delegate sub-thread's real plan:
+    // once the parent agent runs its own web/integration calls, an empty parent
+    // row appears and the research-plan pane blinks out mid-run.
     const chain = await getBranchAncestorThreadIds(ctx, args.threadId);
     let record: Awaited<ReturnType<typeof readTodos>> = null;
     for (const hop of chain) {
-      record = await readTodos(hop.threadId);
-      if (record) break;
+      const own = await readTodos(hop.threadId);
+      if (own && own.todos.length > 0) {
+        record = own;
+        break;
+      }
       const subThreadIds = await getDelegateSubThreadIds(ctx, hop.threadId);
       for (const subThreadId of subThreadIds) {
-        record = await readTodos(subThreadId);
-        if (record) break;
+        const sub = await readTodos(subThreadId);
+        if (sub && sub.todos.length > 0) {
+          record = sub;
+          break;
+        }
       }
       if (record) break;
     }

--- a/services/platform/convex/threads/get_thread_messages_streaming.test.ts
+++ b/services/platform/convex/threads/get_thread_messages_streaming.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The module pulls in `components` from the generated API and the agent SDK at
+// import time; stub them so we can import the pure `emptyStreamsResult` helper
+// without a full Convex test harness.
+vi.mock('../_generated/api', () => ({ components: { agent: {} } }));
+vi.mock('../_generated/server', () => ({}));
+
+const { emptyStreamsResult } = await import('./get_thread_messages_streaming');
+
+describe('emptyStreamsResult', () => {
+  it('returns undefined when the client did not request streams', () => {
+    // No `streamArgs` → the agent client treats `streams: undefined` as "no
+    // streaming", which is exactly what the non-streaming fallback wants.
+    expect(emptyStreamsResult(undefined)).toBeUndefined();
+  });
+
+  it('returns an empty list payload for a list request', () => {
+    // Must match the shape the client reads (`streams.messages`). Returning a
+    // bespoke sentinel here is what crashed `useDeltaStreams` (.messages was
+    // undefined → `.filter` of undefined).
+    expect(emptyStreamsResult({ kind: 'list' })).toEqual({
+      kind: 'list',
+      messages: [],
+    });
+  });
+
+  it('returns an empty deltas payload for a deltas request', () => {
+    expect(emptyStreamsResult({ kind: 'deltas', cursors: [] })).toEqual({
+      kind: 'deltas',
+      deltas: [],
+    });
+  });
+});

--- a/services/platform/convex/threads/get_thread_messages_streaming.ts
+++ b/services/platform/convex/threads/get_thread_messages_streaming.ts
@@ -24,6 +24,28 @@ import type {
   StreamingMessagesResult,
 } from './types';
 
+/**
+ * Empty `streams` payload shaped to match the client's `streamArgs.kind`.
+ *
+ * The `@convex-dev/agent` client hook (`useDeltaStreams`) reads
+ * `result.streams.messages` for a `list` request — with NO shape guard — so any
+ * payload missing that field makes it call `.filter` on `undefined` and crash
+ * the chat subtree. Callers that short-circuit before `syncStreams` (the
+ * auth/access fallbacks in `getThreadMessagesStreaming`'s query wrapper) MUST
+ * return this instead of a bespoke sentinel: those fallbacks fire on a live
+ * subscription — e.g. a WebSocket token refresh mid-stream momentarily nulls
+ * the identity — so a malformed payload turns into a crash/recover flicker loop
+ * for the duration of a long run.
+ */
+export function emptyStreamsResult(
+  streamArgs: GetThreadMessagesStreamingArgs['streamArgs'],
+): StreamingMessagesResult['streams'] {
+  if (!streamArgs) return undefined;
+  return streamArgs.kind === 'list'
+    ? { kind: 'list', messages: [] }
+    : { kind: 'deltas', deltas: [] };
+}
+
 export async function getThreadMessagesStreaming(
   ctx: QueryCtx,
   args: GetThreadMessagesStreamingArgs,

--- a/services/platform/convex/threads/queries.ts
+++ b/services/platform/convex/threads/queries.ts
@@ -5,11 +5,17 @@ import { v } from 'convex/values';
 import { components } from '../_generated/api';
 import { query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls';
-import { canAccessThread } from '../lib/rls/auth/can_access_thread';
+import {
+  canAccessThread,
+  canAccessThreadOrSubThread,
+} from '../lib/rls/auth/can_access_thread';
 import { autoRouteReasonValidator } from '../streaming/validators';
 import { isGenerationFresh } from './generation_liveness';
 import { getThreadMessages as getThreadMessagesHelper } from './get_thread_messages';
-import { getThreadMessagesStreaming as getThreadMessagesStreamingHelper } from './get_thread_messages_streaming';
+import {
+  emptyStreamsResult,
+  getThreadMessagesStreaming as getThreadMessagesStreamingHelper,
+} from './get_thread_messages_streaming';
 import { listArchivedThreads as listArchivedThreadsHelper } from './list_archived_threads';
 import {
   isHiddenFromChatHistory,
@@ -144,17 +150,24 @@ export const getThreadMessagesStreaming = query({
         page: [],
         isDone: true,
         continueCursor: '',
-        streams: { value: null },
+        streams: emptyStreamsResult(args.streamArgs),
       };
     }
 
-    const metadata = await canAccessThread(ctx, args.threadId, authUser);
+    // `OrSubThread`: the chat UI streams a delegated sub-agent's thread to
+    // render its live nested timeline, and sub-threads have no threadMetadata
+    // row — authorize them via their parent thread (see helper docs).
+    const metadata = await canAccessThreadOrSubThread(
+      ctx,
+      args.threadId,
+      authUser,
+    );
     if (!metadata) {
       return {
         page: [],
         isDone: true,
         continueCursor: '',
-        streams: { value: null },
+        streams: emptyStreamsResult(args.streamArgs),
       };
     }
 


### PR DESCRIPTION
## Summary

Three related bugs that surface when the **researcher** agent runs a research plan (reported from `demo.tale.dev`, reproduced locally by creating a todo plan and starting research):

### 1. Crash / flicker loop (console `TypeError: …reading 'filter'`)
`getThreadMessagesStreaming`'s unauthenticated / no-access fallbacks returned `streams: { value: null }` — a shape the `@convex-dev/agent` client can't read. `useDeltaStreams` does `streamList.streams.messages.filter(...)`, so `.messages` being `undefined` threw *"Cannot read properties of undefined (reading 'filter')"*, crash-looping the chat-input error boundary (the blank↔visible flicker).

**Fix:** return a payload matching the requested `streamArgs.kind` via a new `emptyStreamsResult` helper (`{ kind: 'list', messages: [] }` / `{ kind: 'deltas', deltas: [] }` / `undefined`).

### 2. Deterministic root cause of the flicker — sub-threads aren't accessible
The chat UI streams a delegate's **sub-thread** to render the nested delegation timeline (`message-segments.tsx` → `useThreadMessages(subThreadId)`). But delegated sub-threads are created through the Agent SDK component with **no `threadMetadata` row** (`get_or_create_sub_thread.ts`), so `canAccessThread` denied them on every tick → fallback fired deterministically (network-independent, hence reproducible locally).

**Fix:** add `canAccessThreadOrSubThread`, which authorizes a sub-thread via the parent thread it was spawned from (bounded walk up `summary.parentThreadId`), used **only** on the streaming read path so ordinary RLS is untouched. This restores the live timeline instead of merely not crashing.

### 3. Approval gate bypassed — researcher starts before the user confirms
`request_human_input` only *tells* the model to stop; the chat agent loop had no `stopWhen`, so with `maxSteps: 40` the researcher barrelled past its "确认研究计划 / Proceed?" card straight into web searches.

**Fix:** add `stopWhen: [stepCountIs(maxSteps), hasToolCall('request_human_input')]` at the `streamText`/`generateText` call sites, scoped to agents that actually expose the tool, making the gate a hard stop. (Setting `stopWhen` makes the SDK ignore the config's `maxSteps`, so the step cap is folded back in via `stepCountIs`.)

## Blast radius
- (1) is a pure defensive correctness fix on the streaming query return shape.
- (2) adds a new helper used only by the streaming query; hot RLS paths still call `canAccessThread`.
- (3) only changes loop behaviour for agents that expose `request_human_input` (researcher and any future agent that asks for input).

## Tests
- `can_access_thread.test.ts`: sub-thread parent-resolution access — grant via owned parent, deny via inaccessible parent, deny orphan (no metadata + no parent), nested delegation walks to an accessible ancestor.
- `get_thread_messages_streaming.test.ts`: `emptyStreamsResult` shape for list / deltas / undefined.
- Full `tsc --noEmit` clean; `oxlint --type-aware` clean on changed files.

## Verification notes
Not yet manually verified against a running researcher run end-to-end — recommend a quick `/verify` (start a deep-research plan, confirm: no flicker, the nested timeline renders live, and research does NOT begin until the plan-confirmation card is answered).