### PR TITLE
feat(platform): issue-desk auto-close + per-install repo config

### DIFF
--- a/builtin-configs/apps/issue-desk/app.json
+++ b/builtin-configs/apps/issue-desk/app.json
@@ -4,14 +4,14 @@
   "icon": "ticket",
   "scope": "project",
   "messageNamespace": "issueDesk",
-  "workflows": ["issue-desk/desk-process"],
+  "workflows": ["issue-desk/desk-process", "issue-desk/reconcile"],
   "agents": ["desk-implementer", "desk-reviewer"],
   "roles": {
     "implementer": "issue-desk/desk-implementer",
     "reviewer": "issue-desk/desk-reviewer"
   },
   "capabilities": {
-    "workflows": ["issue-desk/desk-process"],
+    "workflows": ["issue-desk/desk-process", "issue-desk/reconcile"],
     "roles": ["issue-desk/desk-implementer", "issue-desk/desk-reviewer"],
     "functions": [
       { "path": "tasks/queries:listTasksByProject", "mode": "query" },

--- a/builtin-configs/apps/issue-desk/app.json
+++ b/builtin-configs/apps/issue-desk/app.json
@@ -41,6 +41,14 @@
     ]
   },
   "requires": {
-    "integrations": ["github"]
+    "integrations": ["github"],
+    "config": [
+      {
+        "key": "owner",
+        "type": "string",
+        "labelKey": "issueDesk.config.owner"
+      },
+      { "key": "repo", "type": "string", "labelKey": "issueDesk.config.repo" }
+    ]
   }
 }

--- a/builtin-configs/apps/issue-desk/app.json
+++ b/builtin-configs/apps/issue-desk/app.json
@@ -44,11 +44,15 @@
     "integrations": ["github"],
     "config": [
       {
-        "key": "owner",
+        "key": "repository",
         "type": "string",
-        "labelKey": "issueDesk.config.owner"
-      },
-      { "key": "repo", "type": "string", "labelKey": "issueDesk.config.repo" }
+        "labelKey": "issueDesk.config.repository",
+        "placeholderKey": "issueDesk.config.repositoryPlaceholder",
+        "derive": {
+          "pattern": "^(?:https?://github\\.com/)?([^/\\s]+)/([^/\\s#]+?)(?:\\.git)?/?$",
+          "into": ["owner", "repo"]
+        }
+      }
     ]
   }
 }

--- a/builtin-configs/apps/issue-desk/messages/de.json
+++ b/builtin-configs/apps/issue-desk/messages/de.json
@@ -17,5 +17,7 @@
   "issueDesk.col.number": "Nummer",
   "issueDesk.col.title": "Titel",
   "issueDesk.col.state": "Status",
-  "issueDesk.col.status": "Status"
+  "issueDesk.col.status": "Status",
+  "issueDesk.config.owner": "GitHub-Eigentümer (Benutzer oder Organisation)",
+  "issueDesk.config.repo": "GitHub-Repository"
 }

--- a/builtin-configs/apps/issue-desk/messages/de.json
+++ b/builtin-configs/apps/issue-desk/messages/de.json
@@ -18,6 +18,6 @@
   "issueDesk.col.title": "Titel",
   "issueDesk.col.state": "Status",
   "issueDesk.col.status": "Status",
-  "issueDesk.config.owner": "GitHub-Eigentümer (Benutzer oder Organisation)",
-  "issueDesk.config.repo": "GitHub-Repository"
+  "issueDesk.config.repository": "GitHub-Repository",
+  "issueDesk.config.repositoryPlaceholder": "owner/repo oder https://github.com/owner/repo"
 }

--- a/builtin-configs/apps/issue-desk/messages/en.json
+++ b/builtin-configs/apps/issue-desk/messages/en.json
@@ -18,6 +18,6 @@
   "issueDesk.col.title": "Title",
   "issueDesk.col.state": "State",
   "issueDesk.col.status": "Status",
-  "issueDesk.config.owner": "GitHub owner (user or org)",
-  "issueDesk.config.repo": "GitHub repository"
+  "issueDesk.config.repository": "GitHub repository",
+  "issueDesk.config.repositoryPlaceholder": "owner/repo or https://github.com/owner/repo"
 }

--- a/builtin-configs/apps/issue-desk/messages/en.json
+++ b/builtin-configs/apps/issue-desk/messages/en.json
@@ -17,5 +17,7 @@
   "issueDesk.col.number": "Number",
   "issueDesk.col.title": "Title",
   "issueDesk.col.state": "State",
-  "issueDesk.col.status": "Status"
+  "issueDesk.col.status": "Status",
+  "issueDesk.config.owner": "GitHub owner (user or org)",
+  "issueDesk.config.repo": "GitHub repository"
 }

--- a/builtin-configs/apps/issue-desk/messages/fr.json
+++ b/builtin-configs/apps/issue-desk/messages/fr.json
@@ -17,5 +17,7 @@
   "issueDesk.col.number": "Numéro",
   "issueDesk.col.title": "Titre",
   "issueDesk.col.state": "État",
-  "issueDesk.col.status": "Statut"
+  "issueDesk.col.status": "Statut",
+  "issueDesk.config.owner": "Propriétaire GitHub (utilisateur ou organisation)",
+  "issueDesk.config.repo": "Dépôt GitHub"
 }

--- a/builtin-configs/apps/issue-desk/messages/fr.json
+++ b/builtin-configs/apps/issue-desk/messages/fr.json
@@ -18,6 +18,6 @@
   "issueDesk.col.title": "Titre",
   "issueDesk.col.state": "État",
   "issueDesk.col.status": "Statut",
-  "issueDesk.config.owner": "Propriétaire GitHub (utilisateur ou organisation)",
-  "issueDesk.config.repo": "Dépôt GitHub"
+  "issueDesk.config.repository": "Dépôt GitHub",
+  "issueDesk.config.repositoryPlaceholder": "owner/repo ou https://github.com/owner/repo"
 }

--- a/builtin-configs/apps/issue-desk/views/desk.json
+++ b/builtin-configs/apps/issue-desk/views/desk.json
@@ -19,8 +19,8 @@
                 "path": "integrations/public_actions:listGitHubIssues",
                 "args": {
                   "organizationId": "$orgId",
-                  "owner": "tale-project",
-                  "repo": "tale",
+                  "owner": "$config:owner",
+                  "repo": "$config:repo",
                   "state": "open"
                 }
               },
@@ -41,7 +41,7 @@
                   }
                 },
                 "refField": "externalId",
-                "rowKeyTemplate": "tale-project/tale#{number}"
+                "rowKeyTemplate": "{owner}/{repo}#{number}"
               },
               "actions": [
                 {
@@ -54,7 +54,7 @@
                     "organizationId": "$orgId",
                     "projectId": "$projectId",
                     "externalSystem": "github",
-                    "externalId": "$tpl:tale-project/tale#{number}",
+                    "externalId": "$tpl:{owner}/{repo}#{number}",
                     "title": "$selected.title",
                     "externalUrl": "$selected.html_url",
                     "description": "$label:issueDesk.taskTemplate",

--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
@@ -1,0 +1,170 @@
+{
+  "name": "Reconcile task state from GitHub",
+  "description": "Scheduled, UPDATE-ONLY reconcile of the issue-desk board against GitHub. Each run lists the repository's issues and, for every issue that ALREADY has a task on this board (matched by the stable external ref \"owner/repo#number\"), syncs its open/closed lifecycle: a closed issue moves its task to done, a reopened issue pulls a terminal task back to backlog. It NEVER creates a task — the desk's manual 'create task from issue' intake owns creation — so the board is never flooded. This is what closes the loop when a desk pull request is merged OUT OF BAND (GitHub UI, CI auto-merge, a teammate): the implementer's PR carries 'Closes #<issue>', so merging it closes the issue, and this reconcile then moves the parked 'in review' task to done. Runs org-scoped with no projectId (the update path keys off each found task's own project), via the generic task workflow action and the github connector — no GitHub-specific or issue-desk-specific backend code.",
+  "i18n": {
+    "en": {
+      "name": "Reconcile task state from GitHub",
+      "description": "Closes a board task when its GitHub issue closes (e.g. the desk's PR merged) and reopens it if the issue reopens. Update-only — never creates tasks."
+    },
+    "de": {
+      "name": "Aufgabenstatus aus GitHub abgleichen",
+      "description": "Schließt eine Board-Aufgabe, wenn ihr GitHub-Issue geschlossen wird (z. B. nach dem Merge des Desk-PRs), und öffnet sie bei einem erneut geöffneten Issue wieder. Nur Aktualisierung — legt nie neue Aufgaben an."
+    },
+    "fr": {
+      "name": "Réconcilier l'état des tâches depuis GitHub",
+      "description": "Termine une tâche du tableau lorsque son ticket GitHub est fermé (par ex. après le merge de la PR du desk) et la rouvre si le ticket est rouvert. Mise à jour uniquement — ne crée jamais de tâche."
+    }
+  },
+  "version": "1.0.0",
+  "metadata": {
+    "pack": "issue-desk"
+  },
+  "config": {
+    "timeout": 600000,
+    "retryPolicy": {
+      "maxRetries": 2,
+      "backoffMs": 2000
+    },
+    "variables": {
+      "workflowId": "issue_desk_reconcile"
+    }
+  },
+  "triggers": {
+    "schedules": [
+      {
+        "cron": "*/15 * * * *",
+        "timezone": "UTC",
+        "variables": {
+          "owner": "tale-project",
+          "repo": "tale",
+          "state": "all"
+        }
+      }
+    ]
+  },
+  "requires": {
+    "integrations": [
+      {
+        "name": "github",
+        "operations": ["list_issues"]
+      }
+    ]
+  },
+  "steps": [
+    {
+      "stepSlug": "start",
+      "name": "start",
+      "stepType": "start",
+      "config": {
+        "inputSchema": {
+          "properties": {
+            "owner": {
+              "description": "GitHub repository owner (user or organization login), e.g. \"tale-project\".",
+              "type": "string"
+            },
+            "repo": {
+              "description": "GitHub repository name, e.g. \"tale\".",
+              "type": "string"
+            },
+            "state": {
+              "description": "Which issues to list: \"all\" (default) reconciles both closes and reopens; \"closed\" only closes.",
+              "type": "string"
+            }
+          },
+          "required": ["owner", "repo"]
+        }
+      },
+      "nextSteps": {
+        "success": "list_issues"
+      }
+    },
+    {
+      "stepSlug": "list_issues",
+      "name": "List GitHub Issues",
+      "stepType": "action",
+      "config": {
+        "type": "integration",
+        "parameters": {
+          "name": "github",
+          "operation": "list_issues",
+          "params": {
+            "owner": "{{input.owner}}",
+            "repo": "{{input.repo}}",
+            "state": "{{input.state || 'all'}}",
+            "per_page": 100
+          }
+        }
+      },
+      "nextSteps": {
+        "success": "check_has_issues"
+      }
+    },
+    {
+      "stepSlug": "check_has_issues",
+      "name": "Skip Loop If No Issues",
+      "stepType": "condition",
+      "config": {
+        "expression": "(steps.list_issues.output.data.result.data | length) > 0",
+        "description": "The loop step throws on an empty items array (not covered by continueOnError), so route the empty case straight to done."
+      },
+      "nextSteps": {
+        "true": "loop_issues",
+        "false": "done"
+      }
+    },
+    {
+      "stepSlug": "loop_issues",
+      "name": "Loop Through Issues",
+      "stepType": "loop",
+      "config": {
+        "continueOnError": true,
+        "itemVariable": "issue",
+        "items": "{{steps.list_issues.output.data.result.data}}"
+      },
+      "nextSteps": {
+        "loop": "skip_pull_requests",
+        "done": "done"
+      }
+    },
+    {
+      "stepSlug": "skip_pull_requests",
+      "name": "Skip Pull Requests",
+      "stepType": "condition",
+      "config": {
+        "expression": "!loop.item.pull_request",
+        "description": "GitHub's issues endpoint returns pull requests too; PR objects carry a `pull_request` field that plain issues lack. Only real issues map to tasks; PRs route straight back to the loop."
+      },
+      "nextSteps": {
+        "true": "reconcile_task",
+        "false": "loop_issues"
+      }
+    },
+    {
+      "stepSlug": "reconcile_task",
+      "name": "Reconcile Task From Issue",
+      "stepType": "action",
+      "config": {
+        "type": "task",
+        "parameters": {
+          "operation": "upsert_external",
+          "createIfMissing": false,
+          "externalSystem": "github",
+          "externalId": "{{input.owner + '/' + input.repo + '#' + loop.item.number}}",
+          "externalUrl": "{{loop.item.html_url}}",
+          "title": "{{loop.item.title}}",
+          "externalState": "{{loop.item.state}}"
+        }
+      },
+      "nextSteps": {
+        "success": "loop_issues"
+      }
+    },
+    {
+      "stepSlug": "done",
+      "name": "Done",
+      "stepType": "output",
+      "config": {},
+      "nextSteps": {}
+    }
+  ]
+}

--- a/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
+++ b/builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json
@@ -35,8 +35,6 @@
         "cron": "*/15 * * * *",
         "timezone": "UTC",
         "variables": {
-          "owner": "tale-project",
-          "repo": "tale",
           "state": "all"
         }
       }

--- a/services/platform/app/features/apps/components/app-config-drawer.tsx
+++ b/services/platform/app/features/apps/components/app-config-drawer.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+/**
+ * Side panel for an installed app's per-install config — opened from the app's
+ * ⋯ menu ("Configuration"). Hosts the `AppConfigForm`; saving closes the panel.
+ * The form is keyed on `open` so each fresh open remounts it against the current
+ * stored values (no reactive update can clobber an in-progress edit).
+ */
+import { VStack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+
+import { Sheet } from '@/app/components/ui/overlays/sheet';
+import { useT } from '@/lib/i18n/client';
+
+import type { AppConfigField } from '../hooks/use-apps';
+import { AppConfigForm } from './app-config-form';
+
+export function AppConfigDrawer({
+  open,
+  onOpenChange,
+  organizationId,
+  appSlug,
+  fields,
+  config,
+  resolveLabel,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  appSlug: string;
+  fields: AppConfigField[];
+  config: Record<string, unknown>;
+  resolveLabel: (labelKey: string) => string;
+}) {
+  const { t } = useT('apps');
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('config.title')}
+      description={t('config.description')}
+      size="md"
+    >
+      {open && (
+        <VStack gap={5} className="h-full overflow-y-auto p-6">
+          <VStack gap={1}>
+            <Text className="text-lg font-semibold">{t('config.title')}</Text>
+            <Text variant="muted" className="text-sm">
+              {t('config.description')}
+            </Text>
+          </VStack>
+          <AppConfigForm
+            organizationId={organizationId}
+            appSlug={appSlug}
+            fields={fields}
+            config={config}
+            resolveLabel={resolveLabel}
+            onSaved={() => onOpenChange(false)}
+          />
+        </VStack>
+      )}
+    </Sheet>
+  );
+}

--- a/services/platform/app/features/apps/components/app-config-form.tsx
+++ b/services/platform/app/features/apps/components/app-config-form.tsx
@@ -2,11 +2,18 @@
 
 /**
  * Per-install config editor for an app — renders one input per declared
- * `requires.config` key (e.g. a GitHub owner/repo), prefilled from the stored
+ * `requires.config` key (e.g. a GitHub repository), prefilled from the stored
  * values, and saves via `setAppConfig`. This is what lets a repo-agnostic app be
  * pointed at the operator's OWN target instead of a hardcoded one; the saved
  * values feed the app's views (via the `$config:` binding token) and its
  * scheduled workflows (synced into their variables by the mutation).
+ *
+ * A field may declare a `derive` rule (one input → many stored keys, e.g. a
+ * single "owner/repo or URL" that splits into `owner` + `repo`). The split runs
+ * here via the shared `deriveConfigValues` before the save: the stored map holds
+ * the raw input (read back into this form) plus the derived keys (bound by the
+ * views). The derivation is non-secret first-party manifest data and the values
+ * are the operator's own config, so doing it client-side crosses no boundary.
  */
 import { Button } from '@tale/ui/button';
 import { Card } from '@tale/ui/card';
@@ -14,16 +21,31 @@ import { Checkbox } from '@tale/ui/checkbox';
 import { Input } from '@tale/ui/input';
 import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
+import { deriveConfigValues } from '@/lib/shared/platform/derive_config';
 
 import { useSetAppConfig } from '../hooks/use-app-config';
 import type { AppConfigField } from '../hooks/use-apps';
 
 function asString(v: unknown): string {
   return typeof v === 'string' || typeof v === 'number' ? String(v) : '';
+}
+
+/** Build the editor's local state from the stored config (each field's own key
+ *  holds the raw value the user typed; derived sub-keys aren't edited here). */
+function initValues(
+  fields: AppConfigField[],
+  config: Record<string, unknown>,
+): Record<string, string | boolean> {
+  const init: Record<string, string | boolean> = {};
+  for (const f of fields) {
+    init[f.key] =
+      f.type === 'boolean' ? config[f.key] === true : asString(config[f.key]);
+  }
+  return init;
 }
 
 export function AppConfigForm({
@@ -37,35 +59,41 @@ export function AppConfigForm({
   appSlug: string;
   fields: AppConfigField[];
   config: Record<string, unknown>;
-  /** Resolve a field's `labelKey` against the app's pack catalog. */
+  /** Resolve a field's `labelKey`/`placeholderKey` against the app's pack catalog. */
   resolveLabel: (labelKey: string) => string;
 }) {
   const { t } = useT('apps');
   const setConfig = useSetAppConfig();
-  const [values, setValues] = useState<Record<string, string | boolean>>(() => {
-    const init: Record<string, string | boolean> = {};
-    for (const f of fields) {
-      init[f.key] =
-        f.type === 'boolean' ? config[f.key] === true : asString(config[f.key]);
-    }
-    return init;
-  });
+  const [values, setValues] = useState<Record<string, string | boolean>>(() =>
+    initValues(fields, config),
+  );
+  /** Field keys whose entered value failed its `derive` rule, shown inline. */
+  const [invalid, setInvalid] = useState<string[]>([]);
+
+  // `config` is reactive and arrives after the first paint (and updates after a
+  // save). Re-seed local state when the stored values change so the inputs show
+  // what's persisted — a plain `useState` initializer runs once and would leave
+  // the form blank on a value that loaded late. Keyed on the stored values, not
+  // identity, so an unrelated re-render doesn't clobber an in-progress edit.
+  const configSignature = JSON.stringify(
+    fields.map((f) => config[f.key] ?? null),
+  );
+  useEffect(() => {
+    setValues(initValues(fields, config));
+    setInvalid([]);
+    // configSignature captures the relevant stored values; fields is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configSignature]);
 
   if (fields.length === 0) return null;
 
   const onSave = async (): Promise<void> => {
-    const out: Record<string, string | number | boolean> = {};
-    for (const f of fields) {
-      const v = values[f.key];
-      if (f.type === 'number') {
-        const n = Number(v);
-        out[f.key] = Number.isFinite(n) ? n : 0;
-      } else if (f.type === 'boolean') {
-        out[f.key] = v === true;
-      } else {
-        out[f.key] = typeof v === 'string' ? v.trim() : '';
-      }
+    const { values: out, invalid: bad } = deriveConfigValues(fields, values);
+    if (bad.length > 0) {
+      setInvalid(bad);
+      return; // refuse to persist a value a view binding can't use
     }
+    setInvalid([]);
     try {
       await setConfig.mutateAsync({ organizationId, appSlug, config: out });
       toast({ title: t('config.saved') });
@@ -104,11 +132,24 @@ export function AppConfigForm({
                 <Input
                   type={f.type === 'number' ? 'number' : 'text'}
                   value={asString(values[f.key])}
+                  placeholder={
+                    f.placeholderKey
+                      ? resolveLabel(f.placeholderKey)
+                      : undefined
+                  }
                   disabled={setConfig.isPending}
+                  aria-invalid={invalid.includes(f.key) || undefined}
                   onChange={(e) =>
                     setValues((s) => ({ ...s, [f.key]: e.target.value }))
                   }
                 />
+              )}
+              {invalid.includes(f.key) && (
+                <Text variant="error" className="text-sm">
+                  {t('config.invalidValue', {
+                    label: resolveLabel(f.labelKey),
+                  })}
+                </Text>
               )}
             </VStack>
           ))}

--- a/services/platform/app/features/apps/components/app-config-form.tsx
+++ b/services/platform/app/features/apps/components/app-config-form.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+/**
+ * Per-install config editor for an app — renders one input per declared
+ * `requires.config` key (e.g. a GitHub owner/repo), prefilled from the stored
+ * values, and saves via `setAppConfig`. This is what lets a repo-agnostic app be
+ * pointed at the operator's OWN target instead of a hardcoded one; the saved
+ * values feed the app's views (via the `$config:` binding token) and its
+ * scheduled workflows (synced into their variables by the mutation).
+ */
+import { Button } from '@tale/ui/button';
+import { Card } from '@tale/ui/card';
+import { Checkbox } from '@tale/ui/checkbox';
+import { Input } from '@tale/ui/input';
+import { HStack, VStack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import { useState } from 'react';
+
+import { toast } from '@/app/hooks/use-toast';
+import { useT } from '@/lib/i18n/client';
+
+import { useSetAppConfig } from '../hooks/use-app-config';
+import type { AppConfigField } from '../hooks/use-apps';
+
+function asString(v: unknown): string {
+  return typeof v === 'string' || typeof v === 'number' ? String(v) : '';
+}
+
+export function AppConfigForm({
+  organizationId,
+  appSlug,
+  fields,
+  config,
+  resolveLabel,
+}: {
+  organizationId: string;
+  appSlug: string;
+  fields: AppConfigField[];
+  config: Record<string, unknown>;
+  /** Resolve a field's `labelKey` against the app's pack catalog. */
+  resolveLabel: (labelKey: string) => string;
+}) {
+  const { t } = useT('apps');
+  const setConfig = useSetAppConfig();
+  const [values, setValues] = useState<Record<string, string | boolean>>(() => {
+    const init: Record<string, string | boolean> = {};
+    for (const f of fields) {
+      init[f.key] =
+        f.type === 'boolean' ? config[f.key] === true : asString(config[f.key]);
+    }
+    return init;
+  });
+
+  if (fields.length === 0) return null;
+
+  const onSave = async (): Promise<void> => {
+    const out: Record<string, string | number | boolean> = {};
+    for (const f of fields) {
+      const v = values[f.key];
+      if (f.type === 'number') {
+        const n = Number(v);
+        out[f.key] = Number.isFinite(n) ? n : 0;
+      } else if (f.type === 'boolean') {
+        out[f.key] = v === true;
+      } else {
+        out[f.key] = typeof v === 'string' ? v.trim() : '';
+      }
+    }
+    try {
+      await setConfig.mutateAsync({ organizationId, appSlug, config: out });
+      toast({ title: t('config.saved') });
+    } catch (err) {
+      toast({
+        title: t('config.saveError'),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <VStack gap={4}>
+        <VStack gap={1}>
+          <Text className="font-medium">{t('config.title')}</Text>
+          <Text variant="muted" className="text-sm">
+            {t('config.description')}
+          </Text>
+        </VStack>
+        <VStack gap={3}>
+          {fields.map((f) => (
+            <VStack key={f.key} gap={1}>
+              <Text as="label" className="text-sm font-medium">
+                {resolveLabel(f.labelKey)}
+              </Text>
+              {f.type === 'boolean' ? (
+                <Checkbox
+                  checked={values[f.key] === true}
+                  disabled={setConfig.isPending}
+                  onCheckedChange={(c) =>
+                    setValues((s) => ({ ...s, [f.key]: c === true }))
+                  }
+                />
+              ) : (
+                <Input
+                  type={f.type === 'number' ? 'number' : 'text'}
+                  value={asString(values[f.key])}
+                  disabled={setConfig.isPending}
+                  onChange={(e) =>
+                    setValues((s) => ({ ...s, [f.key]: e.target.value }))
+                  }
+                />
+              )}
+            </VStack>
+          ))}
+        </VStack>
+        <HStack className="justify-end">
+          <Button onClick={() => void onSave()} disabled={setConfig.isPending}>
+            {setConfig.isPending ? t('config.saving') : t('config.save')}
+          </Button>
+        </HStack>
+      </VStack>
+    </Card>
+  );
+}

--- a/services/platform/app/features/apps/components/app-config-form.tsx
+++ b/services/platform/app/features/apps/components/app-config-form.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 /**
- * Per-install config editor for an app — renders one input per declared
- * `requires.config` key (e.g. a GitHub repository), prefilled from the stored
- * values, and saves via `setAppConfig`. This is what lets a repo-agnostic app be
- * pointed at the operator's OWN target instead of a hardcoded one; the saved
- * values feed the app's views (via the `$config:` binding token) and its
- * scheduled workflows (synced into their variables by the mutation).
+ * Per-install config editor for an app — one input per declared `requires.config`
+ * key (e.g. a GitHub repository), prefilled from the stored values, saved via
+ * `setAppConfig`. This is what lets a repo-agnostic app be pointed at the
+ * operator's OWN target instead of a hardcoded one; the saved values feed the
+ * app's views (via the `$config:` binding token) and its scheduled workflows.
+ *
+ * Rendered inside the config side panel (`AppConfigDrawer`) — it is just the
+ * form body (fields + Save); the panel owns the heading and chrome.
  *
  * A field may declare a `derive` rule (one input → many stored keys, e.g. a
  * single "owner/repo or URL" that splits into `owner` + `repo`). The split runs
@@ -16,9 +18,7 @@
  * are the operator's own config, so doing it client-side crosses no boundary.
  */
 import { Button } from '@tale/ui/button';
-import { Card } from '@tale/ui/card';
 import { Checkbox } from '@tale/ui/checkbox';
-import { CollapsibleDetails } from '@tale/ui/collapsible-details';
 import { Input } from '@tale/ui/input';
 import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
@@ -55,6 +55,7 @@ export function AppConfigForm({
   fields,
   config,
   resolveLabel,
+  onSaved,
 }: {
   organizationId: string;
   appSlug: string;
@@ -62,6 +63,8 @@ export function AppConfigForm({
   config: Record<string, unknown>;
   /** Resolve a field's `labelKey`/`placeholderKey` against the app's pack catalog. */
   resolveLabel: (labelKey: string) => string;
+  /** Called after a successful save (e.g. to close the side panel). */
+  onSaved?: () => void;
 }) {
   const { t } = useT('apps');
   const setConfig = useSetAppConfig();
@@ -71,11 +74,11 @@ export function AppConfigForm({
   /** Field keys whose entered value failed its `derive` rule, shown inline. */
   const [invalid, setInvalid] = useState<string[]>([]);
 
-  // `config` is reactive and arrives after the first paint (and updates after a
-  // save). Re-seed local state when the stored values change so the inputs show
-  // what's persisted — a plain `useState` initializer runs once and would leave
-  // the form blank on a value that loaded late. Keyed on the stored values, not
-  // identity, so an unrelated re-render doesn't clobber an in-progress edit.
+  // `config` is reactive and may arrive after the first paint. Re-seed local
+  // state when the stored values change so the inputs show what's persisted — a
+  // plain `useState` initializer runs once and would leave the form blank on a
+  // value that loaded late. Keyed on the stored values, not identity, so an
+  // unrelated re-render doesn't clobber an in-progress edit.
   const configSignature = JSON.stringify(
     fields.map((f) => config[f.key] ?? null),
   );
@@ -103,6 +106,7 @@ export function AppConfigForm({
     try {
       await setConfig.mutateAsync({ organizationId, appSlug, config: out });
       toast({ title: t('config.saved') });
+      onSaved?.();
     } catch (err) {
       toast({
         title: t('config.saveError'),
@@ -111,22 +115,8 @@ export function AppConfigForm({
     }
   };
 
-  // Once every field has a stored value the app is pointed somewhere and the
-  // editor is just noise above the views — collapse it behind a summary the user
-  // can expand to change. While unconfigured it stays open + prominent so the
-  // setup step is obvious.
-  const isConfigured = fields.every((f) =>
-    f.type === 'boolean' ? true : asString(config[f.key]).trim() !== '',
-  );
-  // A compact echo of the configured values for the collapsed summary line.
-  const summary = fields
-    .filter((f) => f.type !== 'boolean')
-    .map((f) => asString(config[f.key]).trim())
-    .filter(Boolean)
-    .join(' · ');
-
-  const body = (
-    <>
+  return (
+    <VStack gap={4}>
       <VStack gap={3}>
         {fields.map((f) => (
           <VStack key={f.key} gap={1}>
@@ -171,48 +161,6 @@ export function AppConfigForm({
           {setConfig.isPending ? t('config.saving') : t('config.save')}
         </Button>
       </HStack>
-    </>
-  );
-
-  return (
-    <Card>
-      {isConfigured ? (
-        <CollapsibleDetails
-          summary={
-            <>
-              <Text as="span" className="shrink-0 font-medium">
-                {t('config.title')}
-              </Text>
-              {summary && (
-                <Text
-                  as="span"
-                  variant="muted"
-                  className="min-w-0 truncate text-sm font-normal"
-                >
-                  {summary}
-                </Text>
-              )}
-            </>
-          }
-        >
-          <VStack gap={4} className="mt-3">
-            <Text variant="muted" className="text-sm">
-              {t('config.description')}
-            </Text>
-            {body}
-          </VStack>
-        </CollapsibleDetails>
-      ) : (
-        <VStack gap={4}>
-          <VStack gap={1}>
-            <Text className="font-medium">{t('config.title')}</Text>
-            <Text variant="muted" className="text-sm">
-              {t('config.description')}
-            </Text>
-          </VStack>
-          {body}
-        </VStack>
-      )}
-    </Card>
+    </VStack>
   );
 }

--- a/services/platform/app/features/apps/components/app-config-form.tsx
+++ b/services/platform/app/features/apps/components/app-config-form.tsx
@@ -18,6 +18,7 @@
 import { Button } from '@tale/ui/button';
 import { Card } from '@tale/ui/card';
 import { Checkbox } from '@tale/ui/checkbox';
+import { CollapsibleDetails } from '@tale/ui/collapsible-details';
 import { Input } from '@tale/ui/input';
 import { HStack, VStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
@@ -87,6 +88,11 @@ export function AppConfigForm({
 
   if (fields.length === 0) return null;
 
+  // "Dirty" only when an input differs from what's stored — keep Save disabled
+  // otherwise so it never invites a no-op write of the already-saved values.
+  const baseline = initValues(fields, config);
+  const dirty = fields.some((f) => values[f.key] !== baseline[f.key]);
+
   const onSave = async (): Promise<void> => {
     const { values: out, invalid: bad } = deriveConfigValues(fields, values);
     if (bad.length > 0) {
@@ -105,61 +111,108 @@ export function AppConfigForm({
     }
   };
 
+  // Once every field has a stored value the app is pointed somewhere and the
+  // editor is just noise above the views — collapse it behind a summary the user
+  // can expand to change. While unconfigured it stays open + prominent so the
+  // setup step is obvious.
+  const isConfigured = fields.every((f) =>
+    f.type === 'boolean' ? true : asString(config[f.key]).trim() !== '',
+  );
+  // A compact echo of the configured values for the collapsed summary line.
+  const summary = fields
+    .filter((f) => f.type !== 'boolean')
+    .map((f) => asString(config[f.key]).trim())
+    .filter(Boolean)
+    .join(' · ');
+
+  const body = (
+    <>
+      <VStack gap={3}>
+        {fields.map((f) => (
+          <VStack key={f.key} gap={1}>
+            <Text as="label" className="text-sm font-medium">
+              {resolveLabel(f.labelKey)}
+            </Text>
+            {f.type === 'boolean' ? (
+              <Checkbox
+                checked={values[f.key] === true}
+                disabled={setConfig.isPending}
+                onCheckedChange={(c) =>
+                  setValues((s) => ({ ...s, [f.key]: c === true }))
+                }
+              />
+            ) : (
+              <Input
+                type={f.type === 'number' ? 'number' : 'text'}
+                value={asString(values[f.key])}
+                placeholder={
+                  f.placeholderKey ? resolveLabel(f.placeholderKey) : undefined
+                }
+                disabled={setConfig.isPending}
+                aria-invalid={invalid.includes(f.key) || undefined}
+                onChange={(e) =>
+                  setValues((s) => ({ ...s, [f.key]: e.target.value }))
+                }
+              />
+            )}
+            {invalid.includes(f.key) && (
+              <Text variant="error" className="text-sm">
+                {t('config.invalidValue', { label: resolveLabel(f.labelKey) })}
+              </Text>
+            )}
+          </VStack>
+        ))}
+      </VStack>
+      <HStack className="justify-end">
+        <Button
+          onClick={() => void onSave()}
+          disabled={setConfig.isPending || !dirty}
+        >
+          {setConfig.isPending ? t('config.saving') : t('config.save')}
+        </Button>
+      </HStack>
+    </>
+  );
+
   return (
     <Card>
-      <VStack gap={4}>
-        <VStack gap={1}>
-          <Text className="font-medium">{t('config.title')}</Text>
-          <Text variant="muted" className="text-sm">
-            {t('config.description')}
-          </Text>
-        </VStack>
-        <VStack gap={3}>
-          {fields.map((f) => (
-            <VStack key={f.key} gap={1}>
-              <Text as="label" className="text-sm font-medium">
-                {resolveLabel(f.labelKey)}
+      {isConfigured ? (
+        <CollapsibleDetails
+          summary={
+            <>
+              <Text as="span" className="shrink-0 font-medium">
+                {t('config.title')}
               </Text>
-              {f.type === 'boolean' ? (
-                <Checkbox
-                  checked={values[f.key] === true}
-                  disabled={setConfig.isPending}
-                  onCheckedChange={(c) =>
-                    setValues((s) => ({ ...s, [f.key]: c === true }))
-                  }
-                />
-              ) : (
-                <Input
-                  type={f.type === 'number' ? 'number' : 'text'}
-                  value={asString(values[f.key])}
-                  placeholder={
-                    f.placeholderKey
-                      ? resolveLabel(f.placeholderKey)
-                      : undefined
-                  }
-                  disabled={setConfig.isPending}
-                  aria-invalid={invalid.includes(f.key) || undefined}
-                  onChange={(e) =>
-                    setValues((s) => ({ ...s, [f.key]: e.target.value }))
-                  }
-                />
-              )}
-              {invalid.includes(f.key) && (
-                <Text variant="error" className="text-sm">
-                  {t('config.invalidValue', {
-                    label: resolveLabel(f.labelKey),
-                  })}
+              {summary && (
+                <Text
+                  as="span"
+                  variant="muted"
+                  className="min-w-0 truncate text-sm font-normal"
+                >
+                  {summary}
                 </Text>
               )}
-            </VStack>
-          ))}
+            </>
+          }
+        >
+          <VStack gap={4} className="mt-3">
+            <Text variant="muted" className="text-sm">
+              {t('config.description')}
+            </Text>
+            {body}
+          </VStack>
+        </CollapsibleDetails>
+      ) : (
+        <VStack gap={4}>
+          <VStack gap={1}>
+            <Text className="font-medium">{t('config.title')}</Text>
+            <Text variant="muted" className="text-sm">
+              {t('config.description')}
+            </Text>
+          </VStack>
+          {body}
         </VStack>
-        <HStack className="justify-end">
-          <Button onClick={() => void onSave()} disabled={setConfig.isPending}>
-            {setConfig.isPending ? t('config.saving') : t('config.save')}
-          </Button>
-        </HStack>
-      </VStack>
+      )}
     </Card>
   );
 }

--- a/services/platform/app/features/apps/components/app-lifecycle-actions.tsx
+++ b/services/platform/app/features/apps/components/app-lifecycle-actions.tsx
@@ -11,7 +11,7 @@
  *    (`APP_HAS_BOUND_PROJECTS`); we surface that as a clear toast, and when the
  *    bound-project count is known we block it up front with a hint. */
 import { ConvexError } from 'convex/values';
-import { FolderMinus, RotateCw, Trash2 } from 'lucide-react';
+import { FolderMinus, RotateCw, SlidersHorizontal, Trash2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -44,6 +44,9 @@ interface AppLifecycleActionsProps {
   /** Extra classes for the ⋯ trigger (e.g. card overlay positioning). */
   triggerClassName?: string;
   onChanged?: () => void;
+  /** When set, adds a "Configuration" item that opens the app's config panel.
+   *  Omitted for apps that declare no `requires.config`. */
+  onConfigure?: () => void;
 }
 
 export function AppLifecycleActions({
@@ -55,6 +58,7 @@ export function AppLifecycleActions({
   boundProjectCount,
   triggerClassName,
   onChanged,
+  onConfigure,
 }: AppLifecycleActionsProps) {
   const { t } = useT('apps');
   const { reinstall, uninstall, removeFromProject } =
@@ -138,7 +142,19 @@ export function AppLifecycleActions({
 
   const blockedByBindings = (boundProjectCount ?? 0) > 0;
 
-  const actions =
+  // "Configuration" leads the menu (when the app declares config); a separator
+  // sets it apart from the lifecycle (reinstall/remove/uninstall) group below.
+  const configAction = onConfigure
+    ? [
+        {
+          key: 'configure',
+          label: t('config.title'),
+          icon: SlidersHorizontal,
+          onClick: onConfigure,
+        },
+      ]
+    : [];
+  const lifecycleActions =
     context === 'project'
       ? [
           {
@@ -146,6 +162,7 @@ export function AppLifecycleActions({
             label: t('install.removeFromProject'),
             icon: FolderMinus,
             destructive: true,
+            separator: configAction.length > 0,
             onClick: () => dialogs.open.removeFromProject(),
           },
         ]
@@ -154,6 +171,7 @@ export function AppLifecycleActions({
             key: 'reinstall',
             label: t('install.reinstall'),
             icon: RotateCw,
+            separator: configAction.length > 0,
             onClick: () => dialogs.open.reinstall(),
           },
           {
@@ -175,6 +193,7 @@ export function AppLifecycleActions({
             },
           },
         ];
+  const actions = [...configAction, ...lifecycleActions];
 
   return (
     <>

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -33,6 +33,7 @@ import { useT } from '@/lib/i18n/client';
 import { startCase } from '@/lib/utils/string';
 
 import { useAppAgentReadiness } from '../hooks/use-app-agent-readiness';
+import { useAppConfig } from '../hooks/use-app-config';
 import { resolvePackLabels } from '../hooks/use-app-pack-labels';
 import {
   type AppSummary,
@@ -48,6 +49,7 @@ import {
 import { AppView } from '../registry/app-view';
 import { AppRuntimeProvider, resolvePackLabel } from '../runtime/app-runtime';
 import { ResourceDetailProvider } from '../runtime/resource-detail';
+import { AppConfigForm } from './app-config-form';
 import { AppLifecycleActions } from './app-lifecycle-actions';
 import { AppInstallWizard } from './install-wizard/app-install-wizard';
 
@@ -288,6 +290,7 @@ function InstalledAppBody({
   lifecycleContext: 'org' | 'project';
 }) {
   const { t } = useT('apps');
+  const { config } = useAppConfig(organizationId, appSlug);
   const lifecycle = (
     <AppLifecycleActions
       appSlug={appSlug}
@@ -305,6 +308,7 @@ function InstalledAppBody({
         appSlug,
         allowlist: app.functions,
         labels,
+        config,
       }}
     >
       <ResourceDetailProvider>
@@ -317,6 +321,15 @@ function InstalledAppBody({
             blockedIntegrations={blockedIntegrations}
             projectId={projectId}
           />
+          {app.requiredConfig.length > 0 && (
+            <AppConfigForm
+              organizationId={organizationId}
+              appSlug={appSlug}
+              fields={app.requiredConfig}
+              config={config}
+              resolveLabel={(labelKey) => labels[labelKey] ?? labelKey}
+            />
+          )}
           {app.views.length === 0 ? (
             <VStack gap={4}>
               <HStack className="justify-end">{lifecycle}</HStack>

--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -49,7 +49,7 @@ import {
 import { AppView } from '../registry/app-view';
 import { AppRuntimeProvider, resolvePackLabel } from '../runtime/app-runtime';
 import { ResourceDetailProvider } from '../runtime/resource-detail';
-import { AppConfigForm } from './app-config-form';
+import { AppConfigDrawer } from './app-config-drawer';
 import { AppLifecycleActions } from './app-lifecycle-actions';
 import { AppInstallWizard } from './install-wizard/app-install-wizard';
 
@@ -291,6 +291,15 @@ function InstalledAppBody({
 }) {
   const { t } = useT('apps');
   const { config } = useAppConfig(organizationId, appSlug);
+  const [configOpen, setConfigOpen] = useState(false);
+  const hasConfig = app.requiredConfig.length > 0;
+  // "Configured" = every declared field has a stored value. While false, a
+  // prompt nudges setup; while true, config lives only in the ⋯ menu → panel.
+  const isConfigured = app.requiredConfig.every((f) => {
+    if (f.type === 'boolean') return true;
+    const v = config[f.key];
+    return (typeof v === 'string' || typeof v === 'number') && String(v) !== '';
+  });
   const lifecycle = (
     <AppLifecycleActions
       appSlug={appSlug}
@@ -298,6 +307,7 @@ function InstalledAppBody({
       organizationId={organizationId}
       context={lifecycleContext}
       projectId={projectId}
+      onConfigure={hasConfig ? () => setConfigOpen(true) : undefined}
     />
   );
   return (
@@ -321,8 +331,25 @@ function InstalledAppBody({
             blockedIntegrations={blockedIntegrations}
             projectId={projectId}
           />
-          {app.requiredConfig.length > 0 && (
-            <AppConfigForm
+          {hasConfig && !isConfigured && (
+            <Card>
+              <HStack className="items-center justify-between gap-3">
+                <VStack gap={1} className="min-w-0">
+                  <Text className="font-medium">{t('config.setupTitle')}</Text>
+                  <Text variant="muted" className="text-sm">
+                    {t('config.setupPrompt')}
+                  </Text>
+                </VStack>
+                <Button onClick={() => setConfigOpen(true)}>
+                  {t('config.configure')}
+                </Button>
+              </HStack>
+            </Card>
+          )}
+          {hasConfig && (
+            <AppConfigDrawer
+              open={configOpen}
+              onOpenChange={setConfigOpen}
               organizationId={organizationId}
               appSlug={appSlug}
               fields={app.requiredConfig}

--- a/services/platform/app/features/apps/hooks/use-app-config.ts
+++ b/services/platform/app/features/apps/hooks/use-app-config.ts
@@ -1,0 +1,25 @@
+import { useConvexMutation } from '@/app/hooks/use-convex-mutation';
+import { useConvexQuery } from '@/app/hooks/use-convex-query';
+import { api } from '@/convex/_generated/api';
+
+/**
+ * An installed app's per-install config values (`requires.config` keys → values,
+ * e.g. github owner/repo). Reactive; `{}` until configured. Read by the app
+ * runtime so views resolve `$config:<key>`; edited via the app's config form.
+ */
+export function useAppConfig(
+  organizationId: string,
+  appSlug: string,
+): { config: Record<string, unknown>; isLoading: boolean } {
+  const q = useConvexQuery(api.apps.config.getAppConfig, {
+    organizationId,
+    appSlug,
+  });
+  const data: Record<string, unknown> = q.data ?? {};
+  return { config: data, isLoading: q.isLoading };
+}
+
+/** Mutation to set an installed app's per-install config. */
+export function useSetAppConfig() {
+  return useConvexMutation(api.apps.config.setAppConfig);
+}

--- a/services/platform/app/features/apps/hooks/use-apps.ts
+++ b/services/platform/app/features/apps/hooks/use-apps.ts
@@ -3,6 +3,14 @@ import { api } from '@/convex/_generated/api';
 import type { FunctionBinding } from '@/lib/shared/platform/function_bindings';
 import type { AppScope } from '@/lib/shared/schemas/apps';
 
+/** One declared per-install config key from an app manifest's `requires.config`
+ *  (e.g. `{ key: 'owner', type: 'string', labelKey: 'issueDesk.config.owner' }`). */
+export interface AppConfigField {
+  key: string;
+  type: 'string' | 'number' | 'boolean';
+  labelKey: string;
+}
+
 /** A navigable area of a view — its content is single-column Puck Data, or a
  *  `columns` array of Puck Data documents laid out side by side. */
 export interface AppTabDoc {
@@ -42,6 +50,12 @@ export interface AppSummary {
    * the hub decide, before install, whether to route through the connect wizard.
    */
   requiredIntegrations: string[];
+  /**
+   * Per-install config keys the app declares (`requires.config`) — e.g. a GitHub
+   * `owner`/`repo`. Drives the app's config form; the values are stored on the
+   * install row and read by views via the `$config:` binding token.
+   */
+  requiredConfig: AppConfigField[];
   views: AppViewDoc[];
   /**
    * The app's own pack-authored label catalogs (`messages/<locale>.json`),

--- a/services/platform/app/features/apps/hooks/use-apps.ts
+++ b/services/platform/app/features/apps/hooks/use-apps.ts
@@ -4,11 +4,17 @@ import type { FunctionBinding } from '@/lib/shared/platform/function_bindings';
 import type { AppScope } from '@/lib/shared/schemas/apps';
 
 /** One declared per-install config key from an app manifest's `requires.config`
- *  (e.g. `{ key: 'owner', type: 'string', labelKey: 'issueDesk.config.owner' }`). */
+ *  (e.g. `{ key: 'repository', type: 'string', labelKey: 'issueDesk.config.repository' }`). */
 export interface AppConfigField {
   key: string;
   type: 'string' | 'number' | 'boolean';
   labelKey: string;
+  /** Optional input placeholder (pack-label key) — a format hint. */
+  placeholderKey?: string;
+  /** Optional one-input → many-keys derivation: the entered string is split by
+   *  `pattern` into the `into` keys (e.g. `owner`/`repo`) on save. The field's
+   *  own key keeps the raw input for read-back; the views bind the split keys. */
+  derive?: { pattern: string; into: string[] };
 }
 
 /** A navigable area of a view — its content is single-column Puck Data, or a

--- a/services/platform/app/features/apps/hooks/use-bound-action-query.ts
+++ b/services/platform/app/features/apps/hooks/use-bound-action-query.ts
@@ -40,7 +40,8 @@ export function useBoundActionQuery(
   path: string,
   args: unknown,
 ): BoundActionQueryResult {
-  const { organizationId, projectId, allowlist, labels } = useAppRuntime();
+  const { organizationId, projectId, allowlist, labels, config } =
+    useAppRuntime();
   const { isAuthenticated } = useConvexAuth();
   const allowed =
     isValidFunctionPath(path) && isFunctionAllowed(path, allowlist, 'action');
@@ -48,14 +49,29 @@ export function useBoundActionQuery(
   // Hooks run unconditionally; `enabled` (not the ref) gates the actual call.
   const action = useAction(makeFunctionReference<'action'>(path));
   const argsKey = JSON.stringify(args ?? {});
+  // Resolved args embed config values (e.g. owner/repo), so a config change must
+  // bust the cache — fold it into the key.
+  const configKey = JSON.stringify(config ?? {});
 
   const query = useQuery({
     // projectId folded in alongside organizationId so two projects never share a
     // cache entry even though the unresolved args carry the same sentinels.
-    queryKey: ['bound-action-query', path, organizationId, projectId, argsKey],
+    queryKey: [
+      'bound-action-query',
+      path,
+      organizationId,
+      projectId,
+      argsKey,
+      configKey,
+    ],
     queryFn: () =>
       action(
-        resolveBindingArgs(args ?? {}, { organizationId, projectId, labels }),
+        resolveBindingArgs(args ?? {}, {
+          organizationId,
+          projectId,
+          labels,
+          config,
+        }),
       ),
     staleTime: Infinity,
     // ConvexError is deterministic (validation / auth / expected-state) — don't

--- a/services/platform/app/features/apps/hooks/use-bound-action-query.ts
+++ b/services/platform/app/features/apps/hooks/use-bound-action-query.ts
@@ -16,9 +16,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAction, useConvexAuth } from 'convex/react';
 import { makeFunctionReference } from 'convex/server';
+import { useMemo } from 'react';
 
 import { isStructuredConvexError } from '@/app/hooks/use-action-query';
 import {
+  bindingArgsResolved,
   isFunctionAllowed,
   isValidFunctionPath,
   resolveBindingArgs,
@@ -34,6 +36,9 @@ export interface BoundActionQueryResult {
   refetch: () => void;
   /** The path was not in the app's allowlist (or malformed) — nothing was called. */
   blocked: boolean;
+  /** A `$config:` (or other) binding the args reference is still unset, so no
+   *  call fired — the app needs configuration before this list can load. */
+  needsConfig: boolean;
 }
 
 export function useBoundActionQuery(
@@ -53,6 +58,23 @@ export function useBoundActionQuery(
   // bust the cache — fold it into the key.
   const configKey = JSON.stringify(config ?? {});
 
+  // Resolve once for both the gate and the call. An unset `$config:` reference
+  // resolves to `undefined`; gate on a fully-bound result so an unconfigured app
+  // shows an empty state instead of firing a request that fails arg validation.
+  const resolved = useMemo(
+    () =>
+      resolveBindingArgs(args ?? {}, {
+        organizationId,
+        projectId,
+        labels,
+        config,
+      }),
+    // argsKey/configKey stand in for the structurally-compared args + config.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [argsKey, configKey, organizationId, projectId, labels],
+  );
+  const ready = bindingArgsResolved(resolved);
+
   const query = useQuery({
     // projectId folded in alongside organizationId so two projects never share a
     // cache entry even though the unresolved args carry the same sentinels.
@@ -64,29 +86,22 @@ export function useBoundActionQuery(
       argsKey,
       configKey,
     ],
-    queryFn: () =>
-      action(
-        resolveBindingArgs(args ?? {}, {
-          organizationId,
-          projectId,
-          labels,
-          config,
-        }),
-      ),
+    queryFn: () => action(resolved),
     staleTime: Infinity,
     // ConvexError is deterministic (validation / auth / expected-state) — don't
     // burn ~7s of retry backoff before the UI sees it. Network errors still retry.
     retry: (failureCount, err) =>
       !isStructuredConvexError(err) && failureCount < 3,
-    enabled: allowed && isAuthenticated,
+    enabled: allowed && isAuthenticated && ready,
   });
 
   return {
     data: query.data,
-    isLoading: allowed ? query.isLoading : false,
+    isLoading: allowed && ready ? query.isLoading : false,
     isFetching: query.isFetching,
     error: query.error,
     refetch: () => void query.refetch(),
     blocked: !allowed,
+    needsConfig: allowed && !ready,
   };
 }

--- a/services/platform/app/features/apps/hooks/use-bound-action.ts
+++ b/services/platform/app/features/apps/hooks/use-bound-action.ts
@@ -31,7 +31,7 @@ export interface BoundAction {
 }
 
 export function useBoundAction(path: string, mode: FunctionMode): BoundAction {
-  const { organizationId, projectId, appSlug, allowlist, labels } =
+  const { organizationId, projectId, appSlug, allowlist, labels, config } =
     useAppRuntime();
   const allowed =
     isValidFunctionPath(path) && isFunctionAllowed(path, allowlist, mode);
@@ -49,6 +49,7 @@ export function useBoundAction(path: string, mode: FunctionMode): BoundAction {
         projectId,
         selected,
         labels,
+        config,
       });
       // Phase-1 audit marker (server-side gate + persisted audit is Phase 3).
       console.info('[app-binding]', { appSlug, organizationId, path, mode });
@@ -64,6 +65,7 @@ export function useBoundAction(path: string, mode: FunctionMode): BoundAction {
       projectId,
       appSlug,
       labels,
+      config,
       mutation,
       action,
     ],

--- a/services/platform/app/features/apps/hooks/use-bound-query.ts
+++ b/services/platform/app/features/apps/hooks/use-bound-query.ts
@@ -27,7 +27,8 @@ export interface BoundQueryResult {
 }
 
 export function useBoundQuery(path: string, args: unknown): BoundQueryResult {
-  const { organizationId, projectId, allowlist, labels } = useAppRuntime();
+  const { organizationId, projectId, allowlist, labels, config } =
+    useAppRuntime();
   const allowed =
     isValidFunctionPath(path) && isFunctionAllowed(path, allowlist, 'query');
 
@@ -36,6 +37,7 @@ export function useBoundQuery(path: string, args: unknown): BoundQueryResult {
     organizationId,
     projectId,
     labels,
+    config,
   });
   // Hooks run unconditionally; `'skip'` means no subscription when disallowed.
   const q = useConvexQuery(ref, allowed ? resolvedArgs : 'skip');

--- a/services/platform/app/features/apps/registry/connected/external-list.tsx
+++ b/services/platform/app/features/apps/registry/connected/external-list.tsx
@@ -194,6 +194,11 @@ export function ExternalList({
         <Text variant="error">
           {t('binding.blocked', { path: source.path })}
         </Text>
+      ) : query.needsConfig ? (
+        // A `$config:` the source binds is still unset — the app hasn't been
+        // pointed at a target yet. Prompt to configure rather than firing a
+        // request that would fail arg validation.
+        <Text variant="muted">{t('list.needsConfig')}</Text>
       ) : query.isLoading && rows.length === 0 ? (
         <SkeletonText lines={3} />
       ) : query.error ? (

--- a/services/platform/app/features/apps/registry/connected/external-list.tsx
+++ b/services/platform/app/features/apps/registry/connected/external-list.tsx
@@ -35,6 +35,7 @@ import { isRecord } from '@/lib/utils/type-utils';
 
 import { useBoundActionQuery } from '../../hooks/use-bound-action-query';
 import { useBoundQuery } from '../../hooks/use-bound-query';
+import { useAppRuntime } from '../../runtime/app-runtime';
 import {
   resolveColumnLabels,
   usePackLabelString,
@@ -132,6 +133,7 @@ export function ExternalList({
 }: ExternalListProps) {
   const { t } = useT('apps');
   const labelOf = usePackLabelString();
+  const { config } = useAppRuntime();
 
   const [page, setPage] = useState(1);
   const paginated = perPage !== undefined;
@@ -172,8 +174,9 @@ export function ExternalList({
       pickRefRows(refQuery.data),
       excludeBy.refField,
       excludeBy.rowKeyTemplate,
+      config,
     );
-  }, [rows, rowWhen, excludeBy, refQuery.data]);
+  }, [rows, rowWhen, excludeBy, refQuery.data, config]);
 
   const refresh = (
     <Button

--- a/services/platform/app/features/apps/runtime/action-effects.tsx
+++ b/services/platform/app/features/apps/runtime/action-effects.tsx
@@ -48,6 +48,8 @@ export interface EffectContext {
   selected?: Record<string, unknown>;
   result?: Record<string, unknown>;
   labels?: Record<string, string>;
+  /** The app's per-install config values (`$config:`/template `{key}`). */
+  config?: Record<string, unknown>;
 }
 
 /** A fully resolved, ready-to-apply effect (or null when it can't/shouldn't run). */
@@ -112,7 +114,7 @@ export function useActionEffect(): (
 ) => void {
   const navigate = useNavigate();
   const { open } = useResourceDetail();
-  const { organizationId, projectId, labels } = useAppRuntime();
+  const { organizationId, projectId, labels, config } = useAppRuntime();
 
   return useCallback(
     (effect, result, selected) => {
@@ -122,6 +124,7 @@ export function useActionEffect(): (
         selected,
         result: isRecord(result) ? result : undefined,
         labels,
+        config,
       });
       if (!resolved) return;
       if (resolved.kind === 'openDetail') {
@@ -140,6 +143,6 @@ export function useActionEffect(): (
         void go({ to: resolved.to, params: resolved.params });
       }
     },
-    [navigate, open, organizationId, projectId, labels],
+    [navigate, open, organizationId, projectId, labels, config],
   );
 }

--- a/services/platform/app/features/apps/runtime/app-runtime.tsx
+++ b/services/platform/app/features/apps/runtime/app-runtime.tsx
@@ -27,6 +27,13 @@ export interface AppRuntime {
    * Connected blocks resolve `ui.labelKey` against this via `usePackLabel`.
    */
   labels: Record<string, string>;
+  /**
+   * The app's per-install config values (`requires.config` keys → values, e.g. a
+   * configured github `owner`/`repo`). Connected blocks resolve `$config:<key>`
+   * and `{key}` templates against this, so a view targets the operator's own repo
+   * with no hardcoded literal. Empty until configured.
+   */
+  config: Record<string, unknown>;
 }
 
 const AppRuntimeContext = createContext<AppRuntime | null>(null);

--- a/services/platform/app/features/operator/components/render-kinds/status-panel.test.tsx
+++ b/services/platform/app/features/operator/components/render-kinds/status-panel.test.tsx
@@ -41,6 +41,7 @@ describe('StatusPanel', () => {
           appSlug: 'issue-desk',
           allowlist: [],
           labels: { 'issueDesk.verdictReady': 'Ready to merge' },
+          config: {},
         }}
       >
         <StatusPanel

--- a/services/platform/app/routes/dashboard/$id/apps/$appSlug/runs/$executionId.tsx
+++ b/services/platform/app/routes/dashboard/$id/apps/$appSlug/runs/$executionId.tsx
@@ -33,7 +33,7 @@ function AppRunDetail() {
   const { labels } = useAppPackLabels(organizationId, appSlug);
   return (
     <AppRuntimeProvider
-      value={{ organizationId, appSlug, allowlist: [], labels }}
+      value={{ organizationId, appSlug, allowlist: [], labels, config: {} }}
     >
       <VStack gap={4}>
         <Link

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/apps/$appSlug/runs/$executionId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/apps/$appSlug/runs/$executionId.tsx
@@ -35,7 +35,14 @@ function ProjectAppRunDetail() {
   const { labels } = useAppPackLabels(organizationId, appSlug);
   return (
     <AppRuntimeProvider
-      value={{ organizationId, projectId, appSlug, allowlist: [], labels }}
+      value={{
+        organizationId,
+        projectId,
+        appSlug,
+        allowlist: [],
+        labels,
+        config: {},
+      }}
     >
       <VStack gap={4}>
         <Link

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -221,6 +221,7 @@ import type * as approvals_queries from "../approvals/queries.js";
 import type * as approvals_types from "../approvals/types.js";
 import type * as approvals_validators from "../approvals/validators.js";
 import type * as apps_agent_readiness from "../apps/agent_readiness.js";
+import type * as apps_config from "../apps/config.js";
 import type * as apps_file_actions from "../apps/file_actions.js";
 import type * as apps_file_utils from "../apps/file_utils.js";
 import type * as apps_install_actions from "../apps/install_actions.js";
@@ -1812,6 +1813,7 @@ declare const fullApi: ApiFromModules<{
   "approvals/types": typeof approvals_types;
   "approvals/validators": typeof approvals_validators;
   "apps/agent_readiness": typeof apps_agent_readiness;
+  "apps/config": typeof apps_config;
   "apps/file_actions": typeof apps_file_actions;
   "apps/file_utils": typeof apps_file_utils;
   "apps/install_actions": typeof apps_install_actions;

--- a/services/platform/convex/apps/config.test.ts
+++ b/services/platform/convex/apps/config.test.ts
@@ -1,0 +1,125 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root (this file is at
+// convex/apps/), mirroring tasks/internal_mutations.test.ts.
+const TEST_DIR_FROM_CONVEX_ROOT = 'apps';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_cfg';
+const USER = 'user_cfg';
+type T = TestConvex<typeof schema>;
+
+// Seed the local member mirror so the org-membership gate resolves on its hot
+// path and never falls back to the (test-unavailable) Better Auth component.
+async function seedMember(t: T): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      memberId: 'm1',
+      userId: USER,
+      organizationId: ORG,
+      role: 'owner',
+      createdAt: 0,
+    });
+  });
+}
+
+describe('apps/config', () => {
+  it('stores config and syncs it into the app workflow schedule variables', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('appInstallations', {
+        organizationId: ORG,
+        appSlug: 'issue-desk',
+        installedAt: 0,
+        installedBy: USER,
+        status: 'active',
+        requiredIntegrations: ['github'],
+        resources: [
+          {
+            domain: 'workflows',
+            path: 'issue-desk/reconcile.json',
+            contentHash: 'h',
+          },
+        ],
+      });
+    });
+    // The schedule the installer created — only static defaults, no repo yet.
+    const schedId: Id<'wfSchedules'> = await t.run(async (ctx) =>
+      ctx.db.insert('wfSchedules', {
+        organizationId: ORG,
+        workflowSlug: 'issue-desk/reconcile',
+        cronExpression: '*/15 * * * *',
+        timezone: 'UTC',
+        isActive: true,
+        variables: { state: 'all' },
+        createdAt: 0,
+        createdBy: 'system',
+      }),
+    );
+
+    const asUser = t.withIdentity({ subject: USER });
+    await asUser.mutation(api.apps.config.setAppConfig, {
+      organizationId: ORG,
+      appSlug: 'issue-desk',
+      config: { owner: 'acme', repo: 'widgets' },
+    });
+
+    // Stored on the install row + read back by getAppConfig.
+    const cfg = await asUser.query(api.apps.config.getAppConfig, {
+      organizationId: ORG,
+      appSlug: 'issue-desk',
+    });
+    expect(cfg).toEqual({ owner: 'acme', repo: 'widgets' });
+
+    // Merged into the schedule variables — state kept, owner/repo injected — so
+    // the org-level reconcile schedule now targets the configured repo.
+    const sched = await t.run(async (ctx) => ctx.db.get(schedId));
+    expect(sched?.variables).toEqual({
+      state: 'all',
+      owner: 'acme',
+      repo: 'widgets',
+    });
+  });
+
+  it('returns an empty object before the app is configured', async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('appInstallations', {
+        organizationId: ORG,
+        appSlug: 'issue-desk',
+        installedAt: 0,
+        installedBy: USER,
+        status: 'active',
+        requiredIntegrations: [],
+        resources: [],
+      });
+    });
+    const cfg = await t
+      .withIdentity({ subject: USER })
+      .query(api.apps.config.getAppConfig, {
+        organizationId: ORG,
+        appSlug: 'issue-desk',
+      });
+    expect(cfg).toEqual({});
+  });
+});

--- a/services/platform/convex/apps/config.ts
+++ b/services/platform/convex/apps/config.ts
@@ -1,0 +1,101 @@
+import { v } from 'convex/values';
+
+import { mutation, query } from '../_generated/server';
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
+import { jsonRecordValidator } from '../lib/validators/json';
+
+/**
+ * Per-install config for an app — the values an operator supplied for the app's
+ * declared `requires.config` keys (e.g. a GitHub `owner`/`repo`). Org+app scoped
+ * (one target per org install). Read by the app's views through the `$config:`
+ * binding token so a repo-agnostic app points at the operator's OWN repo with no
+ * hardcoded target. Empty object until configured.
+ */
+export const getAppConfig = query({
+  args: { organizationId: v.string(), appSlug: v.string() },
+  returns: jsonRecordValidator,
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) return {};
+    await getOrganizationMember(ctx, args.organizationId, authUser);
+    const row = await ctx.db
+      .query('appInstallations')
+      .withIndex('by_org_slug', (q) =>
+        q.eq('organizationId', args.organizationId).eq('appSlug', args.appSlug),
+      )
+      .first();
+    return row?.config ?? {};
+  },
+});
+
+/**
+ * Set an installed app's per-install config (the `requires.config` values, e.g.
+ * github owner/repo). Stores them on the org install row AND syncs them into the
+ * `variables` of every schedule the app's workflows declared — so a scheduled
+ * workflow (e.g. the issue-desk reconcile) targets the configured repo instead of
+ * a hardcoded default. The app's workflow slugs come from the install resource
+ * ledger, so no manifest/FS read is needed.
+ *
+ * First-party authors (see function_bindings security posture): values are
+ * shape-checked to scalars here; the install wizard validates keys/types against
+ * the manifest's `requires.config`.
+ */
+export const setAppConfig = mutation({
+  args: {
+    organizationId: v.string(),
+    appSlug: v.string(),
+    config: jsonRecordValidator,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const authUser = await getAuthUserIdentity(ctx);
+    if (!authUser) throw new Error('Not authenticated');
+    await getOrganizationMember(ctx, args.organizationId, authUser);
+
+    // Config values are scalars (string/number/boolean) — reject structured
+    // values that the form can't produce and the `$config:` token can't render.
+    for (const [key, value] of Object.entries(args.config)) {
+      const t = typeof value;
+      if (t !== 'string' && t !== 'number' && t !== 'boolean') {
+        throw new Error(
+          `Config value for "${key}" must be a string, number, or boolean`,
+        );
+      }
+    }
+
+    const row = await ctx.db
+      .query('appInstallations')
+      .withIndex('by_org_slug', (q) =>
+        q.eq('organizationId', args.organizationId).eq('appSlug', args.appSlug),
+      )
+      .first();
+    if (!row) {
+      throw new Error(
+        `App "${args.appSlug}" is not installed in this organization`,
+      );
+    }
+    await ctx.db.patch(row._id, { config: args.config });
+
+    // Push the values into the app's scheduled-workflow variables. The schedule
+    // is created at install with only the workflow's static defaults; merging
+    // config in (config wins) is what lets the org-level reconcile schedule
+    // target the configured repo.
+    const workflowSlugs = row.resources
+      .filter((r) => r.domain === 'workflows')
+      .map((r) => r.path.replace(/\.json$/, ''));
+    for (const workflowSlug of workflowSlugs) {
+      for await (const sched of ctx.db
+        .query('wfSchedules')
+        .withIndex('by_workflowSlug', (q) =>
+          q.eq('workflowSlug', workflowSlug),
+        )) {
+        if (sched.organizationId !== args.organizationId) continue;
+        await ctx.db.patch(sched._id, {
+          variables: { ...sched.variables, ...args.config },
+        });
+      }
+    }
+    return null;
+  },
+});

--- a/services/platform/convex/apps/file_actions.ts
+++ b/services/platform/convex/apps/file_actions.ts
@@ -168,6 +168,10 @@ export const listApps = action({
         // already-parsed manifest; the same list is denormalized onto the
         // install record (`appInstallations.requiredIntegrations`).
         requiredIntegrations: manifest.requires?.integrations ?? [],
+        // Declared per-install config keys (e.g. github owner/repo). Drives the
+        // app's config form; values are stored on the install row + read by
+        // views via `$config:`.
+        requiredConfig: manifest.requires?.config ?? [],
         views,
         ...(Object.keys(messages).length > 0 && { messages }),
       });

--- a/services/platform/convex/apps/schema.ts
+++ b/services/platform/convex/apps/schema.ts
@@ -1,6 +1,8 @@
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+import { jsonRecordValidator } from '../lib/validators/json';
+
 /**
  * One row per installed app per org — the ORG-LEVEL resource ledger. An app is
  * installed by COPYING its bundle's resources (agents/workflows/integration-defs)
@@ -54,6 +56,16 @@ export const appInstallationsTable = defineTable({
       contentHash: v.string(),
     }),
   ),
+  /**
+   * Per-install configuration values the user supplied for the app's declared
+   * `requires.config` keys (e.g. a GitHub `owner`/`repo`), keyed by config key.
+   * Org+app scoped (one repo per org install). Read by views via the `$config:`
+   * binding token and synced into the app's scheduled-workflow `variables` by
+   * `setAppConfig`, so an app ships repo-agnostic and the operator points it at
+   * their own repo at install — no hardcoded targets. Preserved across reinstall
+   * (the resource-ledger refresh never touches it). Absent until configured.
+   */
+  config: v.optional(jsonRecordValidator),
 })
   .index('by_org', ['organizationId'])
   .index('by_org_slug', ['organizationId', 'appSlug']);

--- a/services/platform/convex/tasks/internal_mutations.test.ts
+++ b/services/platform/convex/tasks/internal_mutations.test.ts
@@ -59,12 +59,38 @@ function upsert(
   );
 }
 
-async function taskProjectId(t: T, taskId: string): Promise<string> {
+async function taskProjectId(t: T, taskId: string | null): Promise<string> {
+  if (!taskId) throw new Error('expected a taskId');
   return await t.run(async (ctx) => {
     const task = await ctx.db.get(taskId as Id<'tasks'>);
     if (!task) throw new Error('task not found');
     return String(task.projectId);
   });
+}
+
+async function taskStatus(t: T, taskId: string | null): Promise<string> {
+  if (!taskId) throw new Error('expected a taskId');
+  return await t.run(async (ctx) => {
+    const task = await ctx.db.get(taskId as Id<'tasks'>);
+    if (!task) throw new Error('task not found');
+    return task.status;
+  });
+}
+
+// The update-only reconcile call: org-scope, NO projectId, never creates.
+function reconcile(t: T, externalId: string, externalState: 'open' | 'closed') {
+  return t.mutation(
+    internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+    {
+      organizationId: ORG,
+      actorId: 'workflow',
+      externalSystem: 'github',
+      externalId,
+      title: `Issue ${externalId}`,
+      externalState,
+      createIfMissing: false,
+    },
+  );
 }
 
 describe('agentUpsertTaskByExternalRef — dedup scope', () => {
@@ -111,5 +137,37 @@ describe('agentUpsertTaskByExternalRef — dedup scope', () => {
     expect(b.taskId).toBe(a.taskId);
     // The task stays in the project that first materialized it (projectId is not re-homed).
     expect(await taskProjectId(t, b.taskId)).toBe(String(projectA));
+  });
+});
+
+describe('agentUpsertTaskByExternalRef — createIfMissing (update-only reconcile)', () => {
+  it('no-ops when the issue has no task on the board (and needs no projectId)', async () => {
+    const t = convexTest(schema, modules);
+
+    const res = await reconcile(t, 'owner/repo#999', 'closed');
+
+    expect(res).toEqual({ taskId: null, created: false });
+    const count = await t.run(
+      async (ctx) => (await ctx.db.query('tasks').collect()).length,
+    );
+    expect(count).toBe(0); // never materialized a task for an untracked issue
+  });
+
+  it('closes an existing task when its issue closed — org-scoped, without a projectId', async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+
+    // The desk created the task earlier (open).
+    const created = await upsert(t, projectA, 'owner/repo#1851');
+    expect(created.created).toBe(true);
+    expect(created.taskId).not.toBeNull();
+
+    // A PR merged out of band closed the issue; reconcile finds the task by
+    // org+externalId (no projectId) and moves it to done.
+    const res = await reconcile(t, 'owner/repo#1851', 'closed');
+
+    expect(res.created).toBe(false);
+    expect(res.taskId).toBe(created.taskId);
+    expect(await taskStatus(t, created.taskId)).toBe('done');
   });
 });

--- a/services/platform/convex/tasks/internal_mutations.ts
+++ b/services/platform/convex/tasks/internal_mutations.ts
@@ -291,7 +291,11 @@ export const agentUpsertTaskByExternalRef = internalMutation({
   args: {
     organizationId: v.string(),
     actorId: v.string(),
-    projectId: v.id('projects'),
+    /** Destination project for a CREATE. Required when a task may be created
+     *  (the default) and for `dedupeScope:'project'` lookups; omittable for an
+     *  org-scope, `createIfMissing:false` reconcile that only updates existing
+     *  tasks (the update path keys off the found task's own project). */
+    projectId: v.optional(v.id('projects')),
     externalSystem: v.string(),
     externalId: v.string(),
     title: v.string(),
@@ -318,43 +322,55 @@ export const agentUpsertTaskByExternalRef = internalMutation({
      *  `'project'` keys on the project (one task per issue per project);
      *  `'org'` (default) keys on the org (one task per issue per org). */
     dedupeScope: v.optional(v.union(v.literal('org'), v.literal('project'))),
+    /** What to do when the external ref matches no existing task:
+     *  - `true` (default): create one (needs `projectId`) — the intake sync.
+     *  - `false`: no-op (`taskId: null`) — an UPDATE-ONLY reconcile that only
+     *    closes/reopens tasks already on the board, never materializing a task
+     *    for every issue, and so can run org-scoped without a `projectId`. */
+    createIfMissing: v.optional(v.boolean()),
   },
   handler: async (
     ctx,
     args,
-  ): Promise<{ taskId: Id<'tasks'>; created: boolean }> => {
-    const project = await loadProjectInOrg(
-      ctx,
-      args.projectId,
-      args.organizationId,
-    );
+  ): Promise<{ taskId: Id<'tasks'> | null; created: boolean }> => {
     const title = trimTitle(args.title);
     const description = args.description?.trim() || undefined;
     const now = Date.now();
+    const createIfMissing = args.createIfMissing ?? true;
 
     // Dedup within the chosen scope: project-scoped apps look up by project so the
     // same issue in another project is treated as absent (→ a new task); the
-    // default org scope keeps the one-task-per-issue-per-org sync behavior.
-    const existing =
-      args.dedupeScope === 'project'
-        ? await ctx.db
-            .query('tasks')
-            .withIndex('by_project_external', (q) =>
-              q
-                .eq('projectId', args.projectId)
-                .eq('externalSystem', args.externalSystem)
-                .eq('externalId', args.externalId),
-            )
-            .first()
-        : await ctx.db
-            .query('tasks')
-            .withIndex('by_org_external', (q) =>
-              q
-                .eq('organizationId', args.organizationId)
-                .eq('externalSystem', args.externalSystem)
-                .eq('externalId', args.externalId),
-            )
-            .first();
+    // default org scope keeps the one-task-per-issue-per-org sync behavior. The
+    // project lookup needs an explicit projectId; the org lookup does not — which
+    // is what lets an update-only reconcile run without one.
+    let existing: Doc<'tasks'> | null;
+    if (args.dedupeScope === 'project') {
+      const projectId = args.projectId;
+      if (!projectId) {
+        throw new Error(
+          "agentUpsertTaskByExternalRef: dedupeScope 'project' requires a projectId",
+        );
+      }
+      existing = await ctx.db
+        .query('tasks')
+        .withIndex('by_project_external', (q) =>
+          q
+            .eq('projectId', projectId)
+            .eq('externalSystem', args.externalSystem)
+            .eq('externalId', args.externalId),
+        )
+        .first();
+    } else {
+      existing = await ctx.db
+        .query('tasks')
+        .withIndex('by_org_external', (q) =>
+          q
+            .eq('organizationId', args.organizationId)
+            .eq('externalSystem', args.externalSystem)
+            .eq('externalId', args.externalId),
+        )
+        .first();
+    }
 
     if (existing) {
       // Preserve a non-empty existing description when asked (re-sync), so a
@@ -422,9 +438,22 @@ export const agentUpsertTaskByExternalRef = internalMutation({
       return { taskId: existing._id, created: false };
     }
 
+    // No existing task. An update-only reconcile stops here (it never floods the
+    // board with a task per issue); the intake sync falls through to create.
+    if (!createIfMissing) {
+      return { taskId: null, created: false };
+    }
+    const projectId = args.projectId;
+    if (!projectId) {
+      throw new Error(
+        'agentUpsertTaskByExternalRef: creating a task requires a projectId',
+      );
+    }
+    const project = await loadProjectInOrg(ctx, projectId, args.organizationId);
+
     const status: Doc<'tasks'>['status'] =
       args.externalState === 'closed' ? 'done' : SYNC_OPEN_STATUS;
-    const rank = await computeEndRank(ctx, args.projectId, status);
+    const rank = await computeEndRank(ctx, projectId, status);
     const number = await nextTaskNumber(ctx, project);
     // A create launched by an installed app's workflow is OWNED by that app:
     // attribute it to the app (createdByType:'app', createdBy:<appSlug>) so the
@@ -439,7 +468,7 @@ export const agentUpsertTaskByExternalRef = internalMutation({
       : null;
     const taskId = await ctx.db.insert('tasks', {
       organizationId: args.organizationId,
-      projectId: args.projectId,
+      projectId,
       title,
       description,
       status,
@@ -480,7 +509,7 @@ export const agentUpsertTaskByExternalRef = internalMutation({
       resourceId: String(taskId),
       resourceName: title,
       metadata: {
-        projectId: String(args.projectId),
+        projectId: String(projectId),
         externalSystem: args.externalSystem,
         externalId: args.externalId,
       },

--- a/services/platform/convex/tasks/public_actions.ts
+++ b/services/platform/convex/tasks/public_actions.ts
@@ -139,20 +139,27 @@ export const createTaskFromExternalIssue = action({
         dedupeScope: args.projectId ? 'project' : 'org',
       },
     );
+    // Creation is unconditional here (a projectId is always resolved above and
+    // createIfMissing defaults true), so a null id is unreachable — guard it
+    // anyway since the upsert now returns null for update-only reconciles.
+    const taskId = result.taskId;
+    if (!taskId) {
+      throw new Error('Failed to create or find the task for this issue');
+    }
 
     let executionId: string | null | undefined;
     if (args.runWorkflowSlug && result.created) {
       // The workflow reads the full task doc (input.task.{_id,title,externalUrl,
       // description,...}); fetch it rather than re-deriving the shape here.
       const loaded = await ctx.runQuery(api.tasks.queries.getTask, {
-        taskId: result.taskId,
+        taskId,
       });
       if (!loaded?.task) {
         // Just-created task isn't readable back (e.g. raced delete): don't start
         // a run doomed to fail on a null input.task — surface no run instead.
         console.error(
           '[create-task] created task not readable; skipping workflow start',
-          result.taskId,
+          taskId,
         );
         executionId = null;
       } else {
@@ -164,7 +171,7 @@ export const createTaskFromExternalIssue = action({
       }
     }
 
-    return { taskId: result.taskId, created: result.created, executionId };
+    return { taskId, created: result.created, executionId };
   },
 });
 

--- a/services/platform/convex/workflow_engine/action_defs/task/task_action.ts
+++ b/services/platform/convex/workflow_engine/action_defs/task/task_action.ts
@@ -94,7 +94,7 @@ type TaskActionParams =
     }
   | {
       operation: 'upsert_external';
-      projectId: string;
+      projectId?: string;
       externalSystem: string;
       externalId: string;
       title: string;
@@ -103,6 +103,8 @@ type TaskActionParams =
       labels?: string[];
       priority?: 'p0' | 'p1' | 'p2' | 'p3';
       externalState?: 'open' | 'closed';
+      dedupeScope?: 'org' | 'project';
+      createIfMissing?: boolean;
     };
 
 export const taskAction: ActionDefinition<TaskActionParams> = {
@@ -175,7 +177,9 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
     }),
     v.object({
       operation: v.literal('upsert_external'),
-      projectId: v.id('projects'),
+      // Optional: an org-scope, update-only reconcile (createIfMissing:false)
+      // needs no project — only the create path does.
+      projectId: v.optional(v.id('projects')),
       externalSystem: v.string(),
       externalId: v.string(),
       title: v.string(),
@@ -186,6 +190,10 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
       externalState: v.optional(
         v.union(v.literal('open'), v.literal('closed')),
       ),
+      dedupeScope: v.optional(v.union(v.literal('org'), v.literal('project'))),
+      // false → only update tasks already on the board (close/reopen), never
+      // create one per issue. Default (create) keeps the intake-sync behavior.
+      createIfMissing: v.optional(v.boolean()),
     }),
   ),
   async execute(ctx, params, variables) {
@@ -394,7 +402,9 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
           {
             organizationId,
             actorId: WORKFLOW_ACTOR_ID,
-            projectId: toId<'projects'>(params.projectId),
+            projectId: params.projectId
+              ? toId<'projects'>(params.projectId)
+              : undefined,
             externalSystem: params.externalSystem,
             externalId: params.externalId,
             title: params.title,
@@ -407,12 +417,18 @@ export const taskAction: ActionDefinition<TaskActionParams> = {
             labels: params.labels,
             priority: params.priority,
             externalState: params.externalState,
+            dedupeScope: params.dedupeScope,
+            createIfMissing: params.createIfMissing,
           },
         );
-        const task = await ctx.runQuery(
-          internal.tasks.internal_queries.getTaskByIdInternal,
-          { taskId: result.taskId, organizationId },
-        );
+        // An update-only reconcile (createIfMissing:false) no-ops when the issue
+        // has no task on the board — there's nothing to fetch or return.
+        const task = result.taskId
+          ? await ctx.runQuery(
+              internal.tasks.internal_queries.getTaskByIdInternal,
+              { taskId: result.taskId, organizationId },
+            )
+          : null;
         return { task, created: result.created };
       }
 

--- a/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
@@ -121,7 +121,9 @@ describe('issue-desk demo app (data) validates against the skeleton', () => {
     // the same template the materialize action uses to write it.
     expect(excludeBy?.query?.path).toBe('tasks/queries:listTasksByProject');
     expect(excludeBy?.refField).toBe('externalId');
-    expect(excludeBy?.rowKeyTemplate).toBe('tale-project/tale#{number}');
+    // Config-driven: owner/repo come from the per-install config, the row's
+    // `number` from the issue — the same template the materialize action writes.
+    expect(excludeBy?.rowKeyTemplate).toBe('{owner}/{repo}#{number}');
     // The cross-ref query is collected (so publish-time validation covers it)
     // and is in the allowlist.
     const paths = collectViewBindings(view).map((b) => b.path);

--- a/services/platform/lib/shared/platform/derive_config.test.ts
+++ b/services/platform/lib/shared/platform/derive_config.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { type DerivableConfigField, deriveConfigValues } from './derive_config';
+
+// The issue-desk rule: accept `owner/repo` or a full GitHub URL, split → owner+repo.
+const GITHUB_REPO: DerivableConfigField = {
+  key: 'repository',
+  type: 'string',
+  derive: {
+    pattern:
+      '^(?:https?://github\\.com/)?([^/\\s]+)/([^/\\s#]+?)(?:\\.git)?/?$',
+    into: ['owner', 'repo'],
+  },
+};
+
+describe('deriveConfigValues', () => {
+  it('splits a plain owner/repo slug', () => {
+    const { values, invalid } = deriveConfigValues([GITHUB_REPO], {
+      repository: 'tale-project/tale',
+    });
+    expect(invalid).toEqual([]);
+    expect(values).toEqual({
+      repository: 'tale-project/tale',
+      owner: 'tale-project',
+      repo: 'tale',
+    });
+  });
+
+  it('splits a full https GitHub URL', () => {
+    const { values } = deriveConfigValues([GITHUB_REPO], {
+      repository: 'https://github.com/tale-project/tale',
+    });
+    expect(values.owner).toBe('tale-project');
+    expect(values.repo).toBe('tale');
+  });
+
+  it('strips a trailing .git and slash', () => {
+    const { values } = deriveConfigValues([GITHUB_REPO], {
+      repository: 'https://github.com/acme/widgets.git/',
+    });
+    expect(values.owner).toBe('acme');
+    expect(values.repo).toBe('widgets');
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    const { values, invalid } = deriveConfigValues([GITHUB_REPO], {
+      repository: '  acme/widgets  ',
+    });
+    expect(invalid).toEqual([]);
+    expect(values.owner).toBe('acme');
+    expect(values.repo).toBe('widgets');
+    // raw is kept untrimmed-as-entered only after coerce trims? raw keeps input.
+    expect(values.repository).toBe('  acme/widgets  ');
+  });
+
+  it('flags a non-matching value as invalid and writes no sub-keys', () => {
+    const { values, invalid } = deriveConfigValues([GITHUB_REPO], {
+      repository: 'not a repo',
+    });
+    expect(invalid).toEqual(['repository']);
+    expect(values.repository).toBe('not a repo');
+    expect(values.owner).toBeUndefined();
+    expect(values.repo).toBeUndefined();
+  });
+
+  it('treats a cleared value as unconfigured (raw only, no sub-keys, not invalid)', () => {
+    const { values, invalid } = deriveConfigValues([GITHUB_REPO], {
+      repository: '',
+    });
+    expect(invalid).toEqual([]);
+    expect(values).toEqual({ repository: '' });
+  });
+
+  it('rejects an over-long input instead of running the regex on it', () => {
+    const { invalid } = deriveConfigValues([GITHUB_REPO], {
+      repository: 'a'.repeat(400) + '/b',
+    });
+    expect(invalid).toEqual(['repository']);
+  });
+
+  it('treats an un-compilable pattern as a non-match (never throws)', () => {
+    const bad: DerivableConfigField = {
+      key: 'x',
+      type: 'string',
+      derive: { pattern: '([', into: ['y'] },
+    };
+    const { invalid, values } = deriveConfigValues([bad], { x: 'anything' });
+    expect(invalid).toEqual(['x']);
+    expect(values.y).toBeUndefined();
+  });
+
+  it('passes plain (non-derive) fields through, coercing by type', () => {
+    const fields: DerivableConfigField[] = [
+      { key: 'name', type: 'string' },
+      { key: 'count', type: 'number' },
+      { key: 'on', type: 'boolean' },
+    ];
+    const { values, invalid } = deriveConfigValues(fields, {
+      name: 'hi',
+      count: '7' as unknown as string,
+      on: true,
+    });
+    expect(invalid).toEqual([]);
+    expect(values).toEqual({ name: 'hi', count: 7, on: true });
+  });
+});

--- a/services/platform/lib/shared/platform/derive_config.ts
+++ b/services/platform/lib/shared/platform/derive_config.ts
@@ -22,7 +22,7 @@ export interface DerivableConfigField {
   derive?: { pattern: string; into: string[] };
 }
 
-export interface DeriveConfigResult {
+interface DeriveConfigResult {
   /** The map to persist: each field's raw value PLUS every derived sub-key. */
   values: Record<string, string | number | boolean>;
   /** Field keys whose `derive` rule didn't match the entered value (non-empty

--- a/services/platform/lib/shared/platform/derive_config.ts
+++ b/services/platform/lib/shared/platform/derive_config.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-install app config derivation — the generic mechanism that lets an app
+ * collect ONE input but store several keys.
+ *
+ * An app's `requires.config` field may declare a `derive` rule (a regex +
+ * target keys). The config form renders one input for the field; on save this
+ * splits the entered string into the declared sub-keys, which is what the app's
+ * views and scheduled workflows actually bind (`$config:owner`, `{repo}`, …).
+ * The platform carries no domain knowledge — the regex and target keys live in
+ * the app manifest. Example: a single "owner/repo or GitHub URL" input deriving
+ * `owner` + `repo`.
+ *
+ * Pure + isomorphic: the form runs it before calling `setAppConfig`, so the
+ * stored map already holds both the raw input (for the form to read back) and
+ * the derived keys (for the bindings). No FS or manifest read needed server-side.
+ */
+
+/** The subset of an `AppConfigField` this module needs. */
+export interface DerivableConfigField {
+  key: string;
+  type: 'string' | 'number' | 'boolean';
+  derive?: { pattern: string; into: string[] };
+}
+
+export interface DeriveConfigResult {
+  /** The map to persist: each field's raw value PLUS every derived sub-key. */
+  values: Record<string, string | number | boolean>;
+  /** Field keys whose `derive` rule didn't match the entered value (non-empty
+   *  input that the form should flag and refuse to save). */
+  invalid: string[];
+}
+
+/**
+ * Config inputs are short identifiers / URLs; cap the length before running a
+ * manifest-supplied regex so a pathological pattern can't be fed a huge string
+ * (a cheap ReDoS guard — over-long input is treated as a non-match).
+ */
+const MAX_DERIVE_INPUT = 300;
+
+function coerce(
+  type: DerivableConfigField['type'],
+  value: unknown,
+): string | number | boolean {
+  if (type === 'boolean') return value === true;
+  if (type === 'number') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return typeof value === 'string' ? value : value == null ? '' : String(value);
+}
+
+/**
+ * Expand raw form values into the map to store. For a plain field the value is
+ * coerced and kept as-is. For a `derive` field the raw string is kept under the
+ * field's own key (so the form reads it back) AND split into the `into` keys:
+ *
+ *  - non-empty input that matches → the captured groups land under `into`;
+ *  - non-empty input that does NOT match → `key` reported in `invalid`, no
+ *    sub-keys written (the caller should refuse the save);
+ *  - empty/cleared input → only the (empty) raw is written, no sub-keys — so an
+ *    unconfigured app resolves `$config:<subKey>` to `undefined` and its views
+ *    can skip the call instead of sending a blank target.
+ */
+export function deriveConfigValues(
+  fields: DerivableConfigField[],
+  raw: Record<string, string | boolean>,
+): DeriveConfigResult {
+  const values: Record<string, string | number | boolean> = {};
+  const invalid: string[] = [];
+
+  for (const field of fields) {
+    const rawValue = raw[field.key];
+    values[field.key] = coerce(field.type, rawValue);
+
+    if (!field.derive) continue;
+
+    const text = typeof rawValue === 'string' ? rawValue.trim() : '';
+    if (text === '') continue; // cleared → leave sub-keys unset
+
+    const groups = matchDerive(field.derive, text);
+    if (!groups) {
+      invalid.push(field.key);
+      continue;
+    }
+    field.derive.into.forEach((subKey, i) => {
+      values[subKey] = groups[i];
+    });
+  }
+
+  return { values, invalid };
+}
+
+/**
+ * Run one derive rule. Returns the captured groups (one per `into` entry) or
+ * `null` if the input is too long, the pattern is invalid, it doesn't match, or
+ * it captures fewer groups than `into` needs.
+ */
+function matchDerive(
+  derive: { pattern: string; into: string[] },
+  text: string,
+): string[] | null {
+  if (text.length > MAX_DERIVE_INPUT) return null;
+  let re: RegExp;
+  try {
+    re = new RegExp(derive.pattern);
+  } catch (err) {
+    console.warn(`[deriveConfig] invalid pattern ${derive.pattern}:`, err);
+    return null;
+  }
+  const match = re.exec(text);
+  if (!match) return null;
+  const groups: string[] = [];
+  for (let i = 0; i < derive.into.length; i++) {
+    const g = match[i + 1];
+    if (g === undefined) return null;
+    groups.push(g);
+  }
+  return groups;
+}

--- a/services/platform/lib/shared/platform/exclude_by.test.ts
+++ b/services/platform/lib/shared/platform/exclude_by.test.ts
@@ -58,6 +58,20 @@ describe('excludeExisting', () => {
     expect(result).not.toBe(issues);
   });
 
+  it('builds the key from per-install config (owner/repo) merged with the row', () => {
+    // A repo-agnostic key: owner/repo come from the app's config, number from the
+    // row — so it matches the externalId the create path wrote from the same config.
+    const scoped = '{owner}/{repo}#{number}';
+    const config = { owner: 'acme', repo: 'widgets' };
+    const refRows = [{ externalId: 'acme/widgets#2' }];
+    expect(
+      excludeExisting(issues, refRows, 'externalId', scoped, config),
+    ).toEqual([
+      { number: 1, title: 'a' },
+      { number: 3, title: 'c' },
+    ]);
+  });
+
   it('ignores reference rows with falsy keys (no accidental exclusion)', () => {
     const refRows = [{ externalId: undefined }, { externalId: '' }];
     expect(excludeExisting(issues, refRows, 'externalId', tmpl)).toEqual(

--- a/services/platform/lib/shared/platform/exclude_by.ts
+++ b/services/platform/lib/shared/platform/exclude_by.ts
@@ -38,19 +38,27 @@ export function buildExclusionSet(
 }
 
 /**
- * Return `rows` minus any whose `rowKeyTemplate` (interpolated over the row)
- * matches a key present in `refRows[refField]`. Empty `refRows` ⇒ `rows`
- * unchanged.
+ * Return `rows` minus any whose `rowKeyTemplate` matches a key present in
+ * `refRows[refField]`. The template is interpolated over the row MERGED WITH
+ * `templateScope` (the app's per-install config, e.g. a configured `owner`/
+ * `repo`); row fields win a name clash. This lets the join key embed both
+ * configured values and per-row fields (e.g. `"{owner}/{repo}#{number}"`) so it
+ * still matches the externalId the create path wrote from the same config. Empty
+ * `refRows` ⇒ `rows` unchanged.
  */
 export function excludeExisting<T extends Record<string, unknown>>(
   rows: readonly T[],
   refRows: readonly unknown[],
   refField: string,
   rowKeyTemplate: string,
+  templateScope?: Record<string, unknown>,
 ): T[] {
   const set = buildExclusionSet(refRows, refField);
   if (set.size === 0) return [...rows];
   return rows.filter(
-    (row) => !set.has(interpolateTemplate(rowKeyTemplate, row)),
+    (row) =>
+      !set.has(
+        interpolateTemplate(rowKeyTemplate, { ...templateScope, ...row }),
+      ),
   );
 }

--- a/services/platform/lib/shared/platform/function_bindings.test.ts
+++ b/services/platform/lib/shared/platform/function_bindings.test.ts
@@ -102,6 +102,26 @@ describe('resolveBindingArgs', () => {
     // Unknown fields stay verbatim (fail-visible).
     expect(resolveBindingArgs('$tpl:{missing}', tctx)).toBe('{missing}');
   });
+  it('substitutes $config:<key> from the per-install config', () => {
+    const cctx = {
+      organizationId: 'org_1',
+      config: { owner: 'acme', repo: 'widgets' },
+    };
+    expect(resolveBindingArgs('$config:owner', cctx)).toBe('acme');
+    expect(resolveBindingArgs('$config:repo', cctx)).toBe('widgets');
+    // Unset key → undefined (a visible miss, not a literal).
+    expect(resolveBindingArgs('$config:missing', cctx)).toBeUndefined();
+  });
+  it('$tpl: mixes config and row fields so one key can target the configured repo', () => {
+    const ctx = {
+      organizationId: 'org_1',
+      config: { owner: 'acme', repo: 'widgets' },
+      selected: { number: 42 },
+    };
+    expect(resolveBindingArgs('$tpl:{owner}/{repo}#{number}', ctx)).toBe(
+      'acme/widgets#42',
+    );
+  });
   it('resolves $label: via the pack catalog, then interpolates the row', () => {
     const lctx = {
       organizationId: 'org_1',

--- a/services/platform/lib/shared/platform/function_bindings.test.ts
+++ b/services/platform/lib/shared/platform/function_bindings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type FunctionBinding,
+  bindingArgsResolved,
   collectViewBindings,
   isFunctionAllowed,
   isValidFunctionPath,
@@ -247,5 +248,33 @@ describe('collectViewBindings + validateViewBindings', () => {
     const errors = validateViewBindings(offending, allowlist);
     expect(errors.length).toBe(1);
     expect(errors[0]).toContain('secret/x:peek');
+  });
+});
+
+describe('bindingArgsResolved', () => {
+  it('is true when every value is bound (no undefined)', () => {
+    const resolved = resolveBindingArgs(
+      { organizationId: '$orgId', owner: '$config:owner', state: 'open' },
+      { organizationId: 'org_1', config: { owner: 'acme' } },
+    );
+    expect(bindingArgsResolved(resolved)).toBe(true);
+  });
+
+  it('is false when a $config: reference is unset (resolves to undefined)', () => {
+    const resolved = resolveBindingArgs(
+      { organizationId: '$orgId', owner: '$config:owner' },
+      { organizationId: 'org_1', config: {} },
+    );
+    expect(bindingArgsResolved(resolved)).toBe(false);
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    expect(bindingArgsResolved({ a: { b: [1, 'x', true] } })).toBe(true);
+    expect(bindingArgsResolved({ a: { b: [1, undefined] } })).toBe(false);
+    expect(bindingArgsResolved([{ ok: 'y' }, { ok: undefined }])).toBe(false);
+  });
+
+  it('treats null as bound (only undefined gates the call)', () => {
+    expect(bindingArgsResolved({ a: null })).toBe(true);
   });
 });

--- a/services/platform/lib/shared/platform/function_bindings.ts
+++ b/services/platform/lib/shared/platform/function_bindings.ts
@@ -158,11 +158,17 @@ export function validateViewBindings(
  *  - `$selected` / `$selected.<key>` → the selected row, or one of its fields;
  *  - `$result` / `$result.<key>` → the just-resolved action result (used by
  *    `onSuccess` effects to read e.g. a created id).
- * Prefix templates (interpolated over the selected row, `{field}` syntax):
- *  - `$tpl:…{field}…` → the suffix as an `interpolateTemplate` over the row, so
- *    an arg can embed row fields (e.g. `"$tpl:{owner}/{repo}#{number}"`);
+ *  - `$config:<key>` → the app's per-install config value for `key` (from
+ *    `ctx.config`, e.g. a configured github `owner`/`repo`); undefined if unset.
+ *    This is what keeps an app repo-agnostic — the operator's target is data, not
+ *    a hardcoded literal.
+ * Prefix templates (interpolated over the row MERGED WITH config, `{field}`
+ * syntax; row fields win a name clash):
+ *  - `$tpl:…{field}…` → the suffix as an `interpolateTemplate` over
+ *    `{...config, ...selected}`, so one arg can mix config + row fields (e.g.
+ *    `"$tpl:{owner}/{repo}#{number}"` — owner/repo from config, number from the row);
  *  - `$label:<key>` → the pack label `key` (from `ctx.labels`, else the key
- *    itself) interpolated over the row — a localized, row-templated string.
+ *    itself) interpolated over the same merged context — a localized string.
  */
 export function resolveBindingArgs(
   args: unknown,
@@ -173,8 +179,13 @@ export function resolveBindingArgs(
     selected?: Record<string, unknown>;
     result?: Record<string, unknown>;
     labels?: Record<string, string>;
+    /** The app's per-install config values (`$config:`/template `{key}`). */
+    config?: Record<string, unknown>;
   },
 ): unknown {
+  // Templates can reference both per-install config and the selected row; row
+  // fields win a name clash (they're the more specific, per-item value).
+  const templateScope = { ...ctx.config, ...ctx.selected };
   if (typeof args === 'string') {
     if (args === '$orgId') return ctx.organizationId;
     // Undefined when the app isn't project-scoped: fall through so the literal
@@ -191,15 +202,15 @@ export function resolveBindingArgs(
     if (args.startsWith('$result.') && ctx.result) {
       return ctx.result[args.slice('$result.'.length)];
     }
+    if (args.startsWith('$config:')) {
+      return ctx.config?.[args.slice('$config:'.length)];
+    }
     if (args.startsWith('$tpl:')) {
-      return interpolateTemplate(
-        args.slice('$tpl:'.length),
-        ctx.selected ?? {},
-      );
+      return interpolateTemplate(args.slice('$tpl:'.length), templateScope);
     }
     if (args.startsWith('$label:')) {
       const key = args.slice('$label:'.length);
-      return interpolateTemplate(ctx.labels?.[key] ?? key, ctx.selected ?? {});
+      return interpolateTemplate(ctx.labels?.[key] ?? key, templateScope);
     }
     return args;
   }

--- a/services/platform/lib/shared/platform/function_bindings.ts
+++ b/services/platform/lib/shared/platform/function_bindings.ts
@@ -226,3 +226,23 @@ export function resolveBindingArgs(
   }
   return args;
 }
+
+/**
+ * Whether a resolved args tree is fully bound — i.e. holds no `undefined`. A
+ * `$config:<key>` (or `$selected.`/`$result.`) reference whose value is absent
+ * resolves to `undefined`; a literal/`$orgId`/`$projectId` never does. So an
+ * `undefined` anywhere means a binding the live context couldn't satisfy yet —
+ * typically an app whose `requires.config` hasn't been filled in. Callers gate
+ * the actual call on this so an unconfigured view shows an empty state instead
+ * of firing a malformed request (e.g. `listGitHubIssues` missing `owner`).
+ */
+export function bindingArgsResolved(resolved: unknown): boolean {
+  if (resolved === undefined) return false;
+  if (Array.isArray(resolved)) return resolved.every(bindingArgsResolved);
+  if (resolved !== null && typeof resolved === 'object') {
+    return Object.values(resolved as Record<string, unknown>).every(
+      bindingArgsResolved,
+    );
+  }
+  return true;
+}

--- a/services/platform/lib/shared/schemas/apps.ts
+++ b/services/platform/lib/shared/schemas/apps.ts
@@ -55,6 +55,26 @@ export const appManifestSchema = z
               key: z.string(),
               type: z.enum(['string', 'number', 'boolean']),
               labelKey: z.string(),
+              /** Optional input placeholder (pack-label key) — a format hint,
+               *  e.g. "owner/repo or https://github.com/owner/repo". */
+              placeholderKey: z.string().optional(),
+              /**
+               * Optional derivation: collect this field as ONE input, then split
+               * the entered string into several stored keys via a regex. `pattern`
+               * is matched against the value and its capture groups are stored
+               * under `into` (group 1 → into[0], …). Lets a repo-agnostic app ask
+               * for a single "owner/repo or URL" instead of two fields, while the
+               * views/workflows keep binding the split keys (`$config:owner` etc.).
+               * The platform stays domain-agnostic — the rule lives here, not in
+               * code. Authored by first parties; inputs are length-capped to bound
+               * regex cost (see `deriveConfigValues`).
+               */
+              derive: z
+                .object({
+                  pattern: z.string(),
+                  into: z.array(z.string()).min(1),
+                })
+                .optional(),
             }),
           )
           .optional(),

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -62,6 +62,14 @@
       "agentNeedsSetup": "{agent} muss noch eingerichtet werden.",
       "setupButton": "Einrichten"
     },
+    "config": {
+      "title": "Konfiguration",
+      "description": "Richte diese App auf deine eigenen Ressourcen aus. Diese Werte steuern ihre Seiten und geplanten Abläufe.",
+      "save": "Speichern",
+      "saving": "Wird gespeichert…",
+      "saved": "Konfiguration gespeichert",
+      "saveError": "Konfiguration konnte nicht gespeichert werden"
+    },
     "installWizard": {
       "title": "{name} einrichten",
       "progress": "{label} · Schritt {current} von {total}",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -69,7 +69,10 @@
       "saving": "Wird gespeichert…",
       "saved": "Konfiguration gespeichert",
       "saveError": "Konfiguration konnte nicht gespeichert werden",
-      "invalidValue": "{label}: Prüfe das Format und versuche es erneut."
+      "invalidValue": "{label}: Prüfe das Format und versuche es erneut.",
+      "configure": "Konfigurieren",
+      "setupTitle": "Konfiguration erforderlich",
+      "setupPrompt": "Richte diese App auf deine Ressourcen aus, um sie zu nutzen."
     },
     "installWizard": {
       "title": "{name} einrichten",
@@ -117,7 +120,7 @@
       "refresh": "Aktualisieren",
       "error": "Daten konnten nicht geladen werden: {error}",
       "notConnected": "Diese Integration ist noch nicht verbunden. Verbinde sie, um Daten zu laden.",
-      "needsConfig": "Konfiguriere diese App oben, um Daten zu laden.",
+      "needsConfig": "Konfiguriere diese App, um Daten zu laden.",
       "prev": "Zurück",
       "next": "Weiter",
       "page": "Seite {page}",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -68,7 +68,8 @@
       "save": "Speichern",
       "saving": "Wird gespeichert…",
       "saved": "Konfiguration gespeichert",
-      "saveError": "Konfiguration konnte nicht gespeichert werden"
+      "saveError": "Konfiguration konnte nicht gespeichert werden",
+      "invalidValue": "{label}: Prüfe das Format und versuche es erneut."
     },
     "installWizard": {
       "title": "{name} einrichten",
@@ -116,6 +117,7 @@
       "refresh": "Aktualisieren",
       "error": "Daten konnten nicht geladen werden: {error}",
       "notConnected": "Diese Integration ist noch nicht verbunden. Verbinde sie, um Daten zu laden.",
+      "needsConfig": "Konfiguriere diese App oben, um Daten zu laden.",
       "prev": "Zurück",
       "next": "Weiter",
       "page": "Seite {page}",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -69,7 +69,10 @@
       "saving": "Saving…",
       "saved": "Configuration saved",
       "saveError": "Couldn't save configuration",
-      "invalidValue": "{label}: check the format and try again."
+      "invalidValue": "{label}: check the format and try again.",
+      "configure": "Configure",
+      "setupTitle": "Configuration needed",
+      "setupPrompt": "Point this app at your resources to start using it."
     },
     "installWizard": {
       "title": "Set up {name}",
@@ -117,7 +120,7 @@
       "refresh": "Refresh",
       "error": "Couldn't load data: {error}",
       "notConnected": "This integration isn't connected yet. Connect it to load data.",
-      "needsConfig": "Configure this app above to load data.",
+      "needsConfig": "Configure this app to load data.",
       "prev": "Previous",
       "next": "Next",
       "page": "Page {page}",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -68,7 +68,8 @@
       "save": "Save",
       "saving": "Saving…",
       "saved": "Configuration saved",
-      "saveError": "Couldn't save configuration"
+      "saveError": "Couldn't save configuration",
+      "invalidValue": "{label}: check the format and try again."
     },
     "installWizard": {
       "title": "Set up {name}",
@@ -116,6 +117,7 @@
       "refresh": "Refresh",
       "error": "Couldn't load data: {error}",
       "notConnected": "This integration isn't connected yet. Connect it to load data.",
+      "needsConfig": "Configure this app above to load data.",
       "prev": "Previous",
       "next": "Next",
       "page": "Page {page}",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -62,6 +62,14 @@
       "agentNeedsSetup": "{agent} needs setup to run.",
       "setupButton": "Set up"
     },
+    "config": {
+      "title": "Configuration",
+      "description": "Point this app at your own resources. These values drive its pages and scheduled work.",
+      "save": "Save",
+      "saving": "Saving…",
+      "saved": "Configuration saved",
+      "saveError": "Couldn't save configuration"
+    },
     "installWizard": {
       "title": "Set up {name}",
       "progress": "{label} · step {current} of {total}",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -69,7 +69,10 @@
       "saving": "Enregistrement…",
       "saved": "Configuration enregistrée",
       "saveError": "Impossible d'enregistrer la configuration",
-      "invalidValue": "{label} : vérifiez le format et réessayez."
+      "invalidValue": "{label} : vérifiez le format et réessayez.",
+      "configure": "Configurer",
+      "setupTitle": "Configuration requise",
+      "setupPrompt": "Pointez cette application vers vos ressources pour commencer à l'utiliser."
     },
     "installWizard": {
       "title": "Configurer {name}",
@@ -117,7 +120,7 @@
       "refresh": "Actualiser",
       "error": "Impossible de charger les données : {error}",
       "notConnected": "Cette intégration n'est pas encore connectée. Connecte-la pour charger les données.",
-      "needsConfig": "Configurez cette application ci-dessus pour charger les données.",
+      "needsConfig": "Configurez cette application pour charger les données.",
       "prev": "Précédent",
       "next": "Suivant",
       "page": "Page {page}",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -68,7 +68,8 @@
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "saved": "Configuration enregistrée",
-      "saveError": "Impossible d'enregistrer la configuration"
+      "saveError": "Impossible d'enregistrer la configuration",
+      "invalidValue": "{label} : vérifiez le format et réessayez."
     },
     "installWizard": {
       "title": "Configurer {name}",
@@ -116,6 +117,7 @@
       "refresh": "Actualiser",
       "error": "Impossible de charger les données : {error}",
       "notConnected": "Cette intégration n'est pas encore connectée. Connecte-la pour charger les données.",
+      "needsConfig": "Configurez cette application ci-dessus pour charger les données.",
       "prev": "Précédent",
       "next": "Suivant",
       "page": "Page {page}",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -62,6 +62,14 @@
       "agentNeedsSetup": "{agent} doit être configuré pour fonctionner.",
       "setupButton": "Configurer"
     },
+    "config": {
+      "title": "Configuration",
+      "description": "Pointez cette application vers vos propres ressources. Ces valeurs alimentent ses pages et ses tâches planifiées.",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "saved": "Configuration enregistrée",
+      "saveError": "Impossible d'enregistrer la configuration"
+    },
     "installWizard": {
       "title": "Configurer {name}",
       "progress": "{label} · étape {current} sur {total}",


### PR DESCRIPTION
Makes the **Issue resolution desk** finish its own work and stop being hardcoded to one repo — two related fixes, each as app data + a small generic platform primitive (no per-vertical backend code).

## 1. Auto-close tasks when their PR is merged out of band

A desk task parks at `in_review` when its PR opens and the workflow ends; only the manual **Merge** button advanced it to `done`. A PR merged any other way (GitHub UI, CI automerge, a teammate) stranded the task at `in_review` forever — the screenshots of a desk full of stuck rows.

- **`builtin-configs/apps/issue-desk/workflows/issue-desk/reconcile.json`** — an org-level **scheduled** workflow (`triggers.schedules`, `*/15`) that lists the repo's issues and reconciles tasks already on the board via the generic `task.upsert_external` action. The implementer's PR carries `Closes #N`, so merging closes the issue and this moves the parked task to `done`. Wired into the app's `workflows` + `capabilities`.
- **`agentUpsertTaskByExternalRef`** gains optional `projectId` + `createIfMissing` (default `true`). `createIfMissing:false` = **update-only**: close/reopen tasks already present, never materialize one per issue — and so runs org-scoped with **no `projectId`** (the org lookup keys off `externalId`; only create needs a project). Plumbed through the `task` workflow action.

No platform cron: apps get periodic work by declaring `triggers.schedules`, which the existing installer materializes into `wfSchedules` — fired by the one generic `scanAndTrigger` cron.

## 2. Per-install repo config (the app was hardcoded to `tale-project/tale`)

The manifest schema had a **dormant** `requires.config`, but nothing collected/stored/read it — so the desk's view hardcoded github `owner`/`repo` `"tale-project/tale"` (4 spots) and only *we* could use it. Completed the pipeline generically (any app benefits):

- **Storage** — optional `config` on the `appInstallations` row (org+app scoped, preserved across reinstall). Additive optional field → **no migration**.
- **`apps/config.ts`** — `getAppConfig` + `setAppConfig` (org-gated). `setAppConfig` also **syncs the values into the `variables`** of every schedule the app's workflows declared, so the reconcile schedule targets the configured repo with no static default.
- **View binding** — a `$config:<key>` token, and `$tpl:`/`excludeBy` templates now interpolate over the per-install config merged with the row. Threaded via `AppRuntime.config` to every connected block + the `ExternalList` join.
- **UI** — a config form (one input per `requires.config` key) on the app page.

`issue-desk` now declares `owner`/`repo` as config; its view + reconcile schedule read them instead of the hardcoded literal, so any org points the desk at its own repo. i18n for the form + field labels in en/de/fr.

## Verification
- Typecheck + lint clean; **159 server + 31 client tests** pass (new: resolver `$config`/`$tpl` merge, `excludeExisting` config scope, `createIfMissing` update-only close-without-projectId, `setAppConfig` store + schedule-sync via convex-test).
- `migrations:check` clean (no migration); app/view/workflow JSON validate against their Zod schemas.
- Live: the update-only upsert no-ops correctly on the running backend.

## Known limitation
Config is per-`(org, app)` — one repo per org install (multi-project bindings share it); per-project repos are a follow-up. Browser QA of the form + view loading against a configured repo is still pending.