### PR TITLE
fix: dark-mode destructive contrast, empty-table hover, notification dot

### DIFF
--- a/packages/ui/src/components/navigation/bottom-tab-bar.tsx
+++ b/packages/ui/src/components/navigation/bottom-tab-bar.tsx
@@ -115,7 +115,7 @@ function BottomTabBarButton({ item }: BottomTabBarButtonProps) {
           <>
             <span
               aria-hidden="true"
-              className="bg-destructive text-destructive-foreground absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold"
+              className="text-destructive-foreground absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] leading-none font-semibold"
             >
               {item.badge}
             </span>

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -26,7 +26,7 @@ export const buttonVariants = cva(
         primary:
           'bg-accent-base text-accent-fg shadow-[0_1px_1.75px_rgba(3,7,18,0.4),0_0_0_1px_rgba(3,7,18,1)] hover:opacity-95 ring-1 ring-inset ring-white/20 [background-image:linear-gradient(to_bottom,rgba(255,255,255,0.16),rgba(255,255,255,0))]',
         destructive:
-          'bg-destructive text-destructive-foreground -outline-offset-1 outline-destructive shadow-sm hover:bg-destructive/90',
+          'bg-red-600 text-destructive-foreground -outline-offset-1 outline-red-600 shadow-sm hover:bg-red-700',
         success:
           'bg-success text-success-foreground -outline-offset-1 outline-success shadow-sm hover:bg-success/90',
         secondary:

--- a/services/platform/app/features/chat/components/chat-history-sidebar.tsx
+++ b/services/platform/app/features/chat/components/chat-history-sidebar.tsx
@@ -1137,7 +1137,7 @@ function ChatRow({ chat }: { chat: ChatItem }) {
               (it sits left of the actions overlay) until the chat is opened. */}
           {hasNewResponse && (
             <span
-              className="bg-destructive text-destructive-foreground pointer-events-none relative z-10 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold"
+              className="text-destructive-foreground pointer-events-none relative z-10 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] leading-none font-semibold"
               aria-label={t('newResponse')}
             >
               1

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -53,7 +53,7 @@ export function NotificationBell({
         {unreadCount > 0 && (
           <span
             aria-hidden
-            className="bg-destructive text-destructive-foreground absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold"
+            className="text-destructive-foreground absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-semibold"
           >
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>

--- a/services/platform/app/features/notifications/components/notification-row.tsx
+++ b/services/platform/app/features/notifications/components/notification-row.tsx
@@ -72,7 +72,7 @@ export function NotificationRow({
         aria-hidden
         className={cn(
           'mt-1.5 size-2 shrink-0 rounded-full',
-          read ? 'bg-transparent' : 'bg-sky-500',
+          read ? 'bg-transparent' : 'bg-blue-500',
         )}
       />
       <div className="min-w-0 flex-1">

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -617,7 +617,7 @@ export function BudgetEditor({ organizationId }: BudgetEditorProps) {
                     </TableRow>
                   ))
                 ) : (
-                  <TableRow className="hover:bg-transparent">
+                  <TableRow data-no-hover>
                     <TableCell colSpan={COLUMN_COUNT} className="p-0">
                       <RulesTableEmptyState
                         icon={Wallet}

--- a/services/platform/app/features/settings/governance/components/default-model-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/default-model-editor.tsx
@@ -673,7 +673,7 @@ export function DefaultModelEditor({
                   </TableRow>
                 ))
               ) : (
-                <TableRow className="hover:bg-transparent">
+                <TableRow data-no-hover>
                   <TableCell colSpan={5} className="p-0">
                     <RulesTableEmptyState
                       icon={Database}

--- a/services/platform/app/features/settings/governance/components/feature-flags-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/feature-flags-editor.tsx
@@ -586,7 +586,7 @@ export function FeatureFlagsEditor({
                   </TableRow>
                 ))
               ) : (
-                <TableRow className="hover:bg-transparent">
+                <TableRow data-no-hover>
                   <TableCell colSpan={COLUMN_COUNT} className="p-0">
                     <RulesTableEmptyState
                       icon={SlidersHorizontal}

--- a/services/platform/app/features/settings/governance/components/model-access-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/model-access-editor.tsx
@@ -714,7 +714,7 @@ export function ModelAccessEditor({ organizationId }: ModelAccessEditorProps) {
                       </TableRow>
                     ))
                   ) : (
-                    <TableRow className="hover:bg-transparent">
+                    <TableRow data-no-hover>
                       <TableCell colSpan={4} className="p-0">
                         <RulesTableEmptyState
                           icon={ShieldCheck}


### PR DESCRIPTION
## Summary

Three small, related UX/accessibility fixes for the platform, each as its own atomic commit.

- **WCAG AA on destructive fills (dark mode).** The `--destructive` token does double duty as error-*text* colour and as the *fill* behind white text on destructive buttons/badges. In dark mode it's lightened toward red-400 to stay legible as text, which drops white-on-fill contrast to **~2.75:1** (AA needs 4.5:1); light mode was borderline at **~3.7:1**. Pointed the four white-text-on-red fills at a fixed `red-600`/`red-700` — the shared destructive button variant (covers *Delete all chats* and every destructive button), the notification bell badge, the mobile tab-bar badge, and the chat-history "new response" badge. `red-600` clears AA against white in both themes. Error *text* keeps the token untouched (red-on-neutral is ~7:1).
- **Empty table rows no longer respond to hover.** Four governance editors suppressed the shared `TableBody` hover with a per-row `hover:bg-transparent`, which loses the CSS specificity fight against the `tbody` selector and highlighted anyway. Switched them to `data-no-hover`. Hover signals "this row is actionable" — an empty placeholder has nothing to act on. Real data rows keep hovering normally.
- **Notification unread dot → blue.** `sky-500` (#0ea5e9) reads as teal/cyan; switched to `blue-500` (#3b82f6) — the unambiguous unread-blue cue, which also clears the 3:1 non-text contrast bar in both themes.

## Test plan

- [ ] Dark mode: destructive buttons (*Delete all chats*), notification bell badge, mobile tab-bar badge, and chat "new response" badge are legible (white text on red, ≥4.5:1).
- [ ] Light mode: same destructive surfaces still look correct, not overly bold.
- [ ] Governance editors (Policies & Limits / budget, default-model, feature-flags, model-access): empty-state rows show no hover highlight; populated rows still highlight on hover.
- [ ] Notifications popover: unread dot is blue, not teal.