### PR TITLE
fix(sandbox): stop deploy flip leaving session-create on the draining colour

### DIFF
--- a/services/platform/convex/node_only/sandbox/helpers/session_client.test.ts
+++ b/services/platform/convex/node_only/sandbox/helpers/session_client.test.ts
@@ -4,9 +4,39 @@
 
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { drainSessionExecResilient } from './session_client';
+import { drainSessionExecResilient, sessionCreate } from './session_client';
 
 const enc = new TextEncoder();
+
+/** A spawner 503 "draining" body — the bare `sandbox` alias is mid-flip. */
+function drainingResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'draining',
+      message: 'spawner is draining; create on the active colour',
+    }),
+    { status: 503, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+/** A successful create body, tagged with the colour the spawner answered on. */
+function createdResponse(sessionId: string, color: string): Response {
+  const session = {
+    sessionId,
+    organizationId: 'org-1',
+    profile: 'agent',
+    state: 'ready',
+    backend: 'docker',
+    createdAtMs: 1,
+    lastActivityAtMs: 1,
+    expiresAtMs: 2,
+    idleTimeoutMs: 1,
+  };
+  return new Response(JSON.stringify({ session }), {
+    status: 200,
+    headers: { 'content-type': 'application/json', 'x-sandbox-color': color },
+  });
+}
 
 /** Build a Response whose body is an SSE stream of the given raw blocks. */
 function sseResponse(blocks: string[]): Response {
@@ -103,4 +133,50 @@ describe('drainSessionExecResilient', () => {
     // Longer timeout: the give-up path deliberately sleeps the full linear
     // backoff (0.5+1+1.5+2+2.5s ≈ 7.5s) across the 5 retries.
   }, 15_000);
+});
+
+describe('sessionCreate drain-retry', () => {
+  test('retries past a 503 draining and creates on the active colour', async () => {
+    let n = 0;
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      n += 1;
+      // First attempt lands on the draining old colour mid-flip; the re-POST
+      // re-resolves the `sandbox` alias onto the active (green) colour.
+      return n === 1 ? drainingResponse() : createdResponse('ses-x', 'green');
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    const result = await sessionCreate({
+      sessionId: 'ses-x',
+      organizationId: 'org-1',
+      profile: 'agent',
+    });
+
+    expect(n).toBe(2);
+    expect(result.session.sessionId).toBe('ses-x');
+    expect(result.spawnerColor).toBe('green');
+  });
+
+  test('gives up after the max drain retries', async () => {
+    let n = 0;
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      n += 1;
+      return drainingResponse();
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    await expect(
+      sessionCreate({
+        sessionId: 'ses-y',
+        organizationId: 'org-1',
+        profile: 'agent',
+      }),
+    ).rejects.toThrow(/draining/);
+    // 1 initial + CREATE_DRAIN_RETRY_MAX (5) retries; the 6th attempt has
+    // attempt === MAX, so it falls through to the generic 503 failure.
+    expect(n).toBe(6);
+    // The give-up path sleeps 5 × 400ms ≈ 2s across the retries.
+  }, 10_000);
 });

--- a/services/platform/convex/node_only/sandbox/helpers/session_client.ts
+++ b/services/platform/convex/node_only/sandbox/helpers/session_client.ts
@@ -179,6 +179,14 @@ export interface SessionInfo {
 }
 
 const CREATE_TIMEOUT_MS = 200_000; // create polls runnerd readiness (≤180s)
+// Blue-green drain-retry for session create. A 503 "draining" means the bare
+// `sandbox` alias briefly resolves to the OLD colour mid-flip (the deploy moves
+// it to the new colour and revokes it from the lingering old one — see
+// flip-sandbox.ts's releaseSandboxAlias). Re-POST so it re-resolves onto the
+// now-active colour, mirroring spawner_client's one-shot drain-retry. Bounded so
+// a genuinely down tier still fails fast instead of looping.
+const CREATE_DRAIN_RETRY_MAX = 5;
+const CREATE_DRAIN_RETRY_DELAY_MS = 400;
 // Grace added to the caller's exec timeoutMs for the SSE fetch, so the stream
 // outlives the sandbox-side exec deadline and delivers the terminal result
 // instead of aborting first (the old code hardcoded 60s here too).
@@ -214,25 +222,42 @@ export async function sessionCreate(
 ): Promise<SessionCreateResult> {
   const path = '/v1/sessions';
   const bodyJson = JSON.stringify(body);
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, bodyJson),
-    body: bodyJson,
-    signal: AbortSignal.timeout(CREATE_TIMEOUT_MS),
-  });
-  if (res.status === 409) throw new SessionDuplicateError(body.sessionId);
-  if (res.status === 429) throw new SpawnerBusyError(parseRetryAfterMs(res));
-  if (!res.ok) {
-    throw new Error(
-      `sandbox session create failed (${res.status}): ${await safeText(res)}`,
-    );
+  // Re-sign per attempt: each retry needs a fresh timestamp (clock-skew window)
+  // and a fresh nonce (spawner replay cache) — see signedHeaders.
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(`${getSpawnerUrl()}${path}`, {
+      method: 'POST',
+      headers: signedHeaders('POST', path, bodyJson),
+      body: bodyJson,
+      signal: AbortSignal.timeout(CREATE_TIMEOUT_MS),
+    });
+    if (res.status === 409) throw new SessionDuplicateError(body.sessionId);
+    if (res.status === 429) throw new SpawnerBusyError(parseRetryAfterMs(res));
+    // 503 "draining": the targeted colour is mid-flip. Re-POST so the bare
+    // `sandbox` alias re-resolves onto the now-active colour. A non-draining
+    // 503 (or exhausted retries) falls through to the generic failure below.
+    if (res.status === 503 && attempt < CREATE_DRAIN_RETRY_MAX) {
+      const peek = await safeText(res);
+      if (peek.includes('draining')) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, CREATE_DRAIN_RETRY_DELAY_MS),
+        );
+        continue;
+      }
+      throw new Error(`sandbox session create failed (503): ${peek}`);
+    }
+    if (!res.ok) {
+      throw new Error(
+        `sandbox session create failed (${res.status}): ${await safeText(res)}`,
+      );
+    }
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    const parsed = (await res.json()) as { session: SessionInfo };
+    return {
+      session: parsed.session,
+      spawnerColor: res.headers.get('x-sandbox-color'),
+    };
   }
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const parsed = (await res.json()) as { session: SessionInfo };
-  return {
-    session: parsed.session,
-    spawnerColor: res.headers.get('x-sandbox-color'),
-  };
 }
 
 /** DELETE /v1/sessions/:id — idempotent teardown. */

--- a/tools/cli/src/lib/actions/flip-sandbox.test.ts
+++ b/tools/cli/src/lib/actions/flip-sandbox.test.ts
@@ -124,6 +124,52 @@ describe('flipSandboxTier teardown vs linger', () => {
     expect(warned.some((l) => l.includes('lingering'))).toBe(true);
   });
 
+  test('revokes the bare `sandbox` alias from a lingering old colour', async () => {
+    arrangeDocker({ drainStatusJson: '{"inFlight":0,"sessions":2}' });
+
+    await flipSandboxTier({
+      config,
+      deployDir: '/tmp/tale-flip-test',
+      currentColor: 'blue',
+      nextColor: 'green',
+      dryRun: false,
+      streamLogs: false,
+      healthTimeout: 1,
+    });
+
+    const connectCallFor = (container: string): string[] | undefined =>
+      dockerMock.mock.calls
+        .map((c) => c.map(String))
+        .find(
+          (a) =>
+            a[0] === 'network' &&
+            a[1] === 'connect' &&
+            a[a.length - 1] === container,
+        );
+
+    // The lingering (draining) old colour is reconnected with ONLY its colour
+    // alias — never the bare `sandbox` — so new creates can't round-robin onto
+    // it. (`sandbox-blue` is a distinct string from the bare `sandbox`.)
+    const oldConnect = connectCallFor('tale-sandbox-blue');
+    expect(oldConnect).toBeDefined();
+    expect(oldConnect).toContain('sandbox-blue');
+    expect(oldConnect).not.toContain('sandbox');
+
+    // No per-alias edit in docker, so the revoke disconnects first.
+    const oldDisconnected = dockerMock.mock.calls
+      .map((c) => c.map(String))
+      .some(
+        (a) =>
+          a[0] === 'network' &&
+          a[1] === 'disconnect' &&
+          a[a.length - 1] === 'tale-sandbox-blue',
+      );
+    expect(oldDisconnected).toBe(true);
+
+    // The new (active) colour still carries the bare `sandbox` alias.
+    expect(connectCallFor('tale-sandbox-green')).toContain('sandbox');
+  });
+
   test('lingers (does not tear down) when the session count stays unknown', async () => {
     // Drain POST succeeds (default mock) but every drain-status read is
     // unparseable → the final status is unknown. Tearing down here could kill

--- a/tools/cli/src/lib/actions/flip-sandbox.ts
+++ b/tools/cli/src/lib/actions/flip-sandbox.ts
@@ -47,7 +47,12 @@ interface FlipSandboxOptions {
  *   5. If the old colour has NO live sessions, tear it down (spawner + egress +
  *      its session containers). If it DOES, LINGER it: leave the spawner +
  *      egress + session containers running on the still-resolvable
- *      `sandbox-<old>` alias so a long agent turn survives the deploy. The old
+ *      `sandbox-<old>` alias so a long agent turn survives the deploy, AND
+ *      revoke its bare `sandbox` alias (it acquired one when IT was active) so
+ *      `sandbox` resolves to EXACTLY the new colour. Without the revoke both
+ *      colours answer to `sandbox`, Docker's embedded DNS round-robins NEW
+ *      session-creates across both, and the ones hitting the draining old colour
+ *      fail with 503 "spawner is draining; create on the active colour". The old
  *      spawner keeps serving exec/cancel/attach for its sessions while 503ing
  *      NEW work; Convex routes session ops to `sandbox-<spawnerColor>` (the
  *      colour recorded on the session row at create).
@@ -130,6 +135,11 @@ export async function flipSandboxTier(opts: FlipSandboxOptions): Promise<void> {
       logger.warn(
         `sandbox ${currentColor} has ${outcome.status.sessions} live session(s) — lingering on sandbox-${currentColor} until they end or its max-linger TTL; not tearing it down. A subsequent flip back to ${currentColor} reclaims it.`,
       );
+      await releaseSandboxAlias(
+        internalNet,
+        `${pid}-sandbox-${currentColor}`,
+        currentColor,
+      );
     } else if (outcome.status === null) {
       // Drain was acknowledged but its session count stayed UNKNOWN to the
       // deadline (status endpoint unreachable / malformed). Treat unknown as
@@ -137,6 +147,11 @@ export async function flipSandboxTier(opts: FlipSandboxOptions): Promise<void> {
       // live agent turn. The spawner's own max-linger reap is the backstop.
       logger.warn(
         `sandbox ${currentColor} drained but its session count is unknown — lingering on sandbox-${currentColor} rather than risk tearing down live sessions. Its max-linger TTL (or the next flip back) reclaims it.`,
+      );
+      await releaseSandboxAlias(
+        internalNet,
+        `${pid}-sandbox-${currentColor}`,
+        currentColor,
       );
     } else {
       await teardownColor(pid, currentColor);
@@ -181,6 +196,55 @@ async function moveSandboxAlias(
   if (!con.success) {
     throw new Error(
       `Failed to move the \`sandbox\` alias to ${container}: ${con.stderr.trim()}`,
+    );
+  }
+}
+
+/**
+ * Revoke the bare `sandbox` alias from a LINGERING old colour while keeping its
+ * colour-suffixed `sandbox-<color>` alias. The old colour acquired `sandbox`
+ * when IT was active (its own prior flip); if it keeps it, both colours answer
+ * to `sandbox`, Docker's embedded DNS round-robins NEW session-creates across
+ * both, and the ones hitting the now-draining old colour fail with 503 "spawner
+ * is draining; create on the active colour" — persistently, because the
+ * platform's fetch keep-alive pool pins to the old colour's IP.
+ *
+ * Docker has no per-alias edit, so we disconnect + reconnect with only the
+ * colour alias. The resulting internal-network IP change is deliberately
+ * harmless here and in fact helps: it severs the platform's pinned keep-alive
+ * socket to the draining colour (forcing a fresh DNS resolve onto the active
+ * colour) and the lingering session's own stream, which the resilient exec
+ * drain re-attaches via the retained `sandbox-<color>`. Safe to run because the
+ * caller invokes it only AFTER the one-shot drain reached inFlight === 0, so no
+ * in-flight one-shot is cut. Best-effort: a gone/unattached container is a no-op.
+ */
+async function releaseSandboxAlias(
+  network: string,
+  container: string,
+  color: DeploymentColor,
+): Promise<void> {
+  const dis = await docker('network', 'disconnect', network, container);
+  if (!dis.success) {
+    // Already gone / not attached — nothing is holding the `sandbox` alias.
+    logger.debug(
+      `release \`sandbox\` alias: ${container} not disconnected (continuing): ${dis.stderr.trim()}`,
+    );
+    return;
+  }
+  const con = await docker(
+    'network',
+    'connect',
+    '--alias',
+    `sandbox-${color}`,
+    network,
+    container,
+  );
+  if (!con.success) {
+    // Reconnect failed after a successful disconnect: the old colour is now off
+    // the internal network, so its lingering sessions are unreachable until the
+    // spawner's max-linger reap or the next flip back reclaims it. Surface it.
+    logger.warn(
+      `Failed to re-attach ${container} with its \`sandbox-${color}\` alias — its lingering sessions may be unreachable until the next flip: ${con.stderr.trim()}`,
     );
   }
 }


### PR DESCRIPTION
## Problem

On a `tale deploy`-managed instance, sandbox **session creates** fail with:

```
sandbox session create failed (503): {"error":"draining","message":"spawner is draining; create on the active colour"}
```

and it **reproduces on every re-run** — it is not a transient flip-window race.

## Root cause

The blue-green flip (`flipSandboxTier`) moves the bare `sandbox` network alias onto the new colour but, when the old colour **lingers** (it still has live agent sessions), never revokes the alias from the old one. The old colour kept `sandbox` from when it was active, so Docker's embedded DNS resolved `sandbox` to **both** colours and round-robined new session-creates onto the now-draining old spawner. The platform's `fetch` keep-alive pool then pinned to the old colour's IP, making it fail **persistently**.

Compounding it: `sessionCreate` POSTed the bare `sandbox` alias once and threw on a 503 `draining`, unlike the one-shot `spawnerExecute` path which already retries through a flip.

## Fix

1. **`fix(cli)` — structural cure.** When lingering, revoke the bare `sandbox` alias from the old colour (keep only `sandbox-<old>` for colour-routed session ops), so `sandbox` resolves to **exactly** the active colour. Done after the one-shot drain reaches `inFlight === 0`, so no in-flight one-shot is cut; the disconnect's IP change deliberately severs the platform's pinned keep-alive socket (forcing a fresh resolve onto the active colour) and the lingering session re-attaches via the resilient exec drain.
2. **`fix(convex)` — defence in depth.** Give `sessionCreate` the same bounded drain-retry (5 × 400ms, re-signed per attempt) that `spawnerExecute` already has, so a create racing the brief flip window re-resolves onto the active colour instead of hard-failing.

## Verification

- `tsc --noEmit` clean (CLI + platform); `oxlint`/`--type-aware` 0 warnings on changed files; opengrep 0 findings.
- Unit tests 8/8: `flip-sandbox.test.ts` asserts the lingering old colour is reconnected **without** the bare `sandbox` alias; `session_client.test.ts` asserts `sessionCreate` retries past a draining 503 onto the active colour and gives up after the bound.

## Deploy note

CLI behaviour change — takes effect only after the target instance runs `tale upgrade` then `tale deploy`. No schema migration (sandbox tier change). To unblock an already-stuck instance now: `docker network disconnect <pid>_internal <pid>-sandbox-<draining-color>` then restart the convex container.