### PR TITLE
chore(platform): forward host env into docker:dev container

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "setup:clean": "bun services/platform/scripts/setup-clean.ts",
     "docker:build": "bunx turbo run docker:build",
     "docker:up": "docker compose up -d",
-    "docker:dev": "docker network inspect tale-sandbox-net >/dev/null 2>&1 || docker network create --internal --ipv6=false --driver=bridge tale-sandbox-net; docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml up --build -d",
+    "docker:dev": "docker network inspect tale-sandbox-net >/dev/null 2>&1 || docker network create --internal --ipv6=false --driver=bridge tale-sandbox-net; bun scripts/docker-dev-env-override.ts | docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml -f - up --build -d",
     "docker:dev:down": "docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml down",
     "docker:dev:logs": "docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml logs -f",
     "docker:down": "docker compose down",

--- a/scripts/docker-dev-env-override.ts
+++ b/scripts/docker-dev-env-override.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+/*
+  Emit an in-memory compose override that forwards the host's env vars into the
+  platform container — printed to stdout and piped into `docker compose -f -`
+  by `docker:dev`. Values flow through the pipe into the container's env at
+  create time and never touch disk: no .env file to write, gitignore, or leak.
+
+  Why this exists: compose can interpolate `${VAR}` but cannot glob env-var
+  *names*, so there is no declarative way to forward "whatever the developer
+  exported" (e.g. a TALE_PROVIDER_KEY_* under any suffix, or a non-prefixed key
+  some integration reads). Generating the `environment:` block here closes that
+  gap — export a var and it reaches the container on the next `docker:dev` with
+  no compose edit.
+
+  Forwards EVERYTHING in process.env except RUNTIME_DENYLIST: a handful of
+  OS/shell vars that must reflect the *container's* reality, not the host's.
+  Overriding PATH/HOME/NODE_PATH/etc. with host values (which point at host
+  paths absent inside the image) breaks command and module resolution and the
+  container fails to boot — that is a correctness floor, not a scoping
+  preference. Everything else (provider keys, app config, integration secrets)
+  is passed straight through.
+
+  Only the platform container is targeted: its entrypoint runs
+  sync-convex-env-from-dotenv.ts, which pushes any forwarded
+  `TALE_PROVIDER_KEY_*` from process.env into the Convex deployment (where
+  secret_resolver.ts reads them).
+
+  Keys and values are emitted via JSON.stringify — valid YAML flow scalars that
+  escape quotes/backslashes/newlines, so unusual names or values survive intact.
+*/
+
+// OS/shell/runtime vars whose value is meaningful only inside the process that
+// owns it. Forwarding the host's copy would shadow the container's own and
+// break execution (PATH/NODE_PATH → command & module lookup; HOME/NPM_CONFIG_*
+// → tool caches & global bins; HOSTNAME/PWD/SHELL/TERM/etc. → process identity).
+const RUNTIME_DENYLIST = new Set([
+  'PATH',
+  'HOME',
+  'HOSTNAME',
+  'PWD',
+  'OLDPWD',
+  'SHLVL',
+  'SHELL',
+  'TERM',
+  'USER',
+  'LOGNAME',
+  '_',
+  'NODE_PATH',
+  'NPM_CONFIG_PREFIX',
+  'NPM_CONFIG_UPDATE_NOTIFIER',
+  'NoDefaultCurrentDirectoryInExePath',
+]);
+
+const entries: string[] = [];
+for (const [key, value] of Object.entries(process.env)) {
+  if (value === undefined) continue;
+  if (RUNTIME_DENYLIST.has(key)) continue;
+  entries.push(`      ${JSON.stringify(key)}: ${JSON.stringify(value)}`);
+}
+
+// An override with no forwarded vars is still valid: emit an empty mapping so
+// the YAML parses and compose merges a no-op.
+const environment = entries.length > 0 ? entries.join('\n') : '      {}';
+
+process.stdout.write(
+  `services:\n` + `  platform:\n` + `    environment:\n` + `${environment}\n`,
+);


### PR DESCRIPTION
## Problem

When running `bun docker:dev`, env vars exported in the developer's shell (e.g. `TALE_PROVIDER_KEY_OPENROUTER`) never reached the `platform` container. The service only reads `.env` via `env_file` and has no passthrough for the host shell environment.

Concretely: with the key only in the shell, onboarding provisioned **zero** providers, the chat composer had no usable model, and the Send button stayed disabled — with no obvious error pointing at the missing env var.

## Why compose alone can't fix it

Compose can interpolate `${VAR}` but **cannot glob env-var names**, so there's no declarative way to say "forward whatever `TALE_PROVIDER_KEY_*` (or anything else) the developer exported." A static `environment:` list would require editing compose for every new key.

## Change

`docker:dev` now generates a `services.platform.environment` override from `process.env` and pipes it to compose via `-f -` (stdin):

```
bun scripts/docker-dev-env-override.ts | docker compose ... -f - up --build -d
```

- **No file on disk** — the values flow through a pipe into the container's env at create time; nothing to write, gitignore, or leak.
- **Forwards everything except `RUNTIME_DENYLIST`** — a small set of OS/shell vars (`PATH`, `HOME`, `HOSTNAME`, `NODE_PATH`, `NPM_CONFIG_*`, etc.) whose host values would shadow the container's own and break command/module resolution. This is a correctness floor, not scoping.
- Keys/values are emitted via `JSON.stringify` (valid YAML flow scalars), so unusual names/values survive intact.

The platform entrypoint already syncs container env into the Convex deployment (`convex env set`), so any forwarded `TALE_PROVIDER_KEY_*` now **auto-provisions providers** with no onboarding key entry and no per-key compose edits.

## Verification

- `docker compose ... -f - config` resolves with the override merged onto `platform`.
- Recreated the platform container via the new path: it boots **healthy** (denylist protects its runtime), `TALE_PROVIDER_KEY_OPENROUTER` is present in the container, and the OpenRouter provider auto-provisions (**49 models**).
- End-to-end: sent a chat message and received a streamed model reply.

## Note / follow-up

Because this forwards *everything* (minus the runtime denylist), a host var that collides with a stack config key (e.g. a stray `CONVEX_URL` / `NODE_ENV`) would override the container's intended value. The known dev-config keys with intentional defaults live in `x-dev-secrets`; happy to also exclude those if we want host noise to never shadow them.
