### PR TITLE
feat(platform): open prompt library directly when composer is empty

### DIFF
--- a/services/platform/app/features/chat/components/save-prompt-menu.tsx
+++ b/services/platform/app/features/chat/components/save-prompt-menu.tsx
@@ -21,6 +21,25 @@ export function SavePromptMenu({
 }: SavePromptMenuProps) {
   const { t: tChat } = useT('chat');
 
+  // With an empty composer there's nothing to save as a draft, so the only
+  // useful action is the prompt library. Skip the menu and open it directly.
+  if (!canSavePromptDraft) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label={tChat('promptLibrary')}
+        tooltip={tChat('promptLibrary')}
+        tooltipSide="top"
+        disabled={disabled}
+        onClick={onOpenPromptLibrary}
+        className="focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset"
+      >
+        <Bookmark className="size-4" aria-hidden="true" />
+      </Button>
+    );
+  }
+
   const items: DropdownMenuGroup[] = [
     [
       {
@@ -28,7 +47,6 @@ export function SavePromptMenu({
         label: tChat('savePromptDraft'),
         icon: Bookmark,
         onClick: onSavePromptDraft,
-        disabled: !canSavePromptDraft,
       },
       {
         type: 'item',


### PR DESCRIPTION
## What

When the composer is empty, the save-prompt bookmark button now opens the **Prompt library** dialog directly instead of first showing a dropdown.

## Why

With an empty composer there is nothing to save as a draft, so "Save prompt draft" is always disabled and the dropdown's only usable item is "Prompt library". That made opening the library a needless two-click affair. Now:

- **Empty composer** → bookmark opens the Prompt library dialog directly (one click).
- **Composer has text** → unchanged: the bookmark opens the dropdown with **Save prompt draft** (enabled) + **Prompt library**.

## Changes

- `services/platform/app/features/chat/components/save-prompt-menu.tsx`: early-return a plain icon button (label/tooltip "Prompt library", `onClick` opens the library) when `!canSavePromptDraft`; keep the dropdown otherwise. Dropped the now-dead `disabled: !canSavePromptDraft` on the save-draft item.

## Verification

Ran the full Docker dev stack and tested both states in the browser:

- Empty input → single click opens the Prompt library dialog, no intermediate menu.
- Typed text → button switches to the "Save options" dropdown; both items present, Save prompt draft enabled.

No console errors (only unrelated font/changelog warnings).