### PR TITLE
fix(platform): surface PROJECT_HAS_BOUND_APPS error on project delete (#2068)

### DIFF
--- a/services/platform/app/features/projects/components/project-delete-dialog.test.tsx
+++ b/services/platform/app/features/projects/components/project-delete-dialog.test.tsx
@@ -1,0 +1,95 @@
+import { ConvexError } from 'convex/values';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { ProjectDeleteDialog } from './project-delete-dialog';
+
+// Regression cover for #2068: the delete dialog's catch block mapped only
+// PROJECT_CONFIRM_PHRASE_MISMATCH / PROJECT_LEGAL_HOLD / RATE_LIMITED, so a
+// PROJECT_HAS_BOUND_APPS error (thrown when appProjectBindings still reference
+// the project) fell through to the generic "Couldn't delete project" toast and
+// the bound app names returned in error.data.apps were discarded. The dialog
+// now maps the code to the actionable i18n message and lists the app names.
+
+const mockDeleteProject = vi.fn();
+const mockNavigate = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('../hooks/mutations', () => ({
+  useDeleteProject: () => ({ mutateAsync: mockDeleteProject }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+  useToast: () => ({ toast: mockToast }),
+}));
+
+function renderDialog() {
+  return render(
+    <ProjectDeleteDialog
+      open={true}
+      onOpenChange={vi.fn()}
+      organizationId="org-1"
+      projectId={'project-1' as never}
+      projectName="Q2 Sales"
+    />,
+  );
+}
+
+describe('ProjectDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces the actionable message with bound app names on PROJECT_HAS_BOUND_APPS', async () => {
+    mockDeleteProject.mockRejectedValueOnce(
+      new ConvexError({
+        code: 'PROJECT_HAS_BOUND_APPS',
+        apps: ['Invoices', 'CRM'],
+      }),
+    );
+
+    const { user } = renderDialog();
+
+    // Detach mode (default): the confirm phrase isn't required, so the delete
+    // button is enabled. It shares the "Delete project" label with the title.
+    const buttons = screen.getAllByRole('button', { name: 'Delete project' });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title:
+          'Uninstall the apps using this project first, then delete it: Invoices, CRM.',
+        variant: 'destructive',
+      }),
+    );
+    // The generic fallback must NOT be used on this path.
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Couldn't delete project" }),
+    );
+  });
+
+  it('falls back to the generic actionable message when no app names are returned', async () => {
+    mockDeleteProject.mockRejectedValueOnce(
+      new ConvexError({ code: 'PROJECT_HAS_BOUND_APPS' }),
+    );
+
+    const { user } = renderDialog();
+
+    const buttons = screen.getAllByRole('button', { name: 'Delete project' });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Uninstall the apps using this project first, then delete it.',
+        variant: 'destructive',
+      }),
+    );
+  });
+});

--- a/services/platform/app/features/projects/components/project-delete-dialog.test.tsx
+++ b/services/platform/app/features/projects/components/project-delete-dialog.test.tsx
@@ -42,6 +42,13 @@ function renderDialog() {
   );
 }
 
+// Detach mode (default): the confirm phrase isn't required, so the confirm
+// button is enabled. The dialog title is a heading, so the only element with
+// the button role and the "Delete project" name is the confirm button.
+function getDeleteButton() {
+  return screen.getByRole('button', { name: 'Delete project' });
+}
+
 describe('ProjectDeleteDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -57,10 +64,7 @@ describe('ProjectDeleteDialog', () => {
 
     const { user } = renderDialog();
 
-    // Detach mode (default): the confirm phrase isn't required, so the delete
-    // button is enabled. It shares the "Delete project" label with the title.
-    const buttons = screen.getAllByRole('button', { name: 'Delete project' });
-    await user.click(buttons[buttons.length - 1]);
+    await user.click(getDeleteButton());
 
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -82,8 +86,27 @@ describe('ProjectDeleteDialog', () => {
 
     const { user } = renderDialog();
 
-    const buttons = screen.getAllByRole('button', { name: 'Delete project' });
-    await user.click(buttons[buttons.length - 1]);
+    await user.click(getDeleteButton());
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Uninstall the apps using this project first, then delete it.',
+        variant: 'destructive',
+      }),
+    );
+  });
+
+  it('falls back to the generic actionable message when apps is malformed', async () => {
+    // The runtime guard narrows error.data.apps to string[]; a non-array (or a
+    // non-string element) must not reach the named variant — it falls back to
+    // the generic message rather than rendering "[object Object]" or "123".
+    mockDeleteProject.mockRejectedValueOnce(
+      new ConvexError({ code: 'PROJECT_HAS_BOUND_APPS', apps: [123] }),
+    );
+
+    const { user } = renderDialog();
+
+    await user.click(getDeleteButton());
 
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/services/platform/app/features/projects/components/project-delete-dialog.tsx
+++ b/services/platform/app/features/projects/components/project-delete-dialog.tsx
@@ -90,6 +90,25 @@ export function ProjectDeleteDialog({
           });
           return;
         }
+        if (code === 'PROJECT_HAS_BOUND_APPS') {
+          // The backend names the bound app(s) in error.data.apps so the
+          // operator knows exactly what to uninstall first; surface them when
+          // present, otherwise fall back to the generic actionable message.
+          const rawApps: unknown = error.data?.apps;
+          const apps = Array.isArray(rawApps)
+            ? rawApps.filter((app): app is string => typeof app === 'string')
+            : [];
+          toast({
+            title:
+              apps.length > 0
+                ? t('errors.PROJECT_HAS_BOUND_APPS_NAMED', {
+                    apps: apps.join(', '),
+                  })
+                : t('errors.PROJECT_HAS_BOUND_APPS'),
+            variant: 'destructive',
+          });
+          return;
+        }
         if (code === 'PROJECT_LEGAL_HOLD') {
           toast({
             title: t('errors.PROJECT_LEGAL_HOLD'),

--- a/services/platform/convex/projects/error_codes.test.ts
+++ b/services/platform/convex/projects/error_codes.test.ts
@@ -125,6 +125,12 @@ describe('projects error-code ↔ i18n key consistency', () => {
       // at the regex match position, and intentionally lives outside the
       // PROJECT_/DOCUMENT_/THREAD_ namespaces so the regex skips it.
       'RATE_LIMITED',
+      // UI-only formatting variant of the server-thrown PROJECT_HAS_BOUND_APPS
+      // code: same condition, but with an `{apps}` placeholder so the delete
+      // dialog can list the bound app names the backend returns in
+      // `error.data.apps`. There is no separate server throw — the thrown code
+      // stays PROJECT_HAS_BOUND_APPS; the UI picks the named vs. generic message.
+      'PROJECT_HAS_BOUND_APPS_NAMED',
     ]);
 
     const orphans: string[] = [];

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7517,6 +7517,7 @@
       "PROJECT_FORBIDDEN": "Du hast keinen Zugriff auf dieses Projekt.",
       "PROJECT_NOT_FOUND": "Wir konnten dieses Projekt nicht finden. Es wurde möglicherweise gelöscht.",
       "PROJECT_HAS_BOUND_APPS": "Deinstalliere zuerst die Apps, die dieses Projekt nutzen, dann lösche es.",
+      "PROJECT_HAS_BOUND_APPS_NAMED": "Deinstalliere zuerst die Apps, die dieses Projekt nutzen, dann lösche es: {apps}.",
       "PROJECT_MISMATCH": "Dieser Chat liegt in einem anderen Projekt. Wechsle den Kontext, um fortzufahren.",
       "PROJECT_AGENT_NOT_ALLOWED": "{agentName} ist in diesem Projekt nicht verfügbar. Wähle einen anderen Agenten.",
       "PROJECT_MODEL_NOT_ALLOWED": "{modelName} ist in diesem Projekt nicht verfügbar. Wähle ein anderes Modell.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5146,6 +5146,7 @@
       "PROJECT_FORBIDDEN": "You don't have access to this project.",
       "PROJECT_NOT_FOUND": "We couldn't find that project. It may have been deleted.",
       "PROJECT_HAS_BOUND_APPS": "Uninstall the apps using this project first, then delete it.",
+      "PROJECT_HAS_BOUND_APPS_NAMED": "Uninstall the apps using this project first, then delete it: {apps}.",
       "PROJECT_MISMATCH": "This chat is in a different project. Switch context to continue.",
       "PROJECT_AGENT_NOT_ALLOWED": "{agentName} isn't available in this project. Pick another agent.",
       "PROJECT_MODEL_NOT_ALLOWED": "{modelName} isn't available in this project. Pick another model.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7518,6 +7518,7 @@
       "PROJECT_FORBIDDEN": "Tu n'as pas accès à ce projet.",
       "PROJECT_NOT_FOUND": "Impossible de trouver ce projet. Il a peut-être été supprimé.",
       "PROJECT_HAS_BOUND_APPS": "Désinstallez d'abord les applications qui utilisent ce projet, puis supprimez-le.",
+      "PROJECT_HAS_BOUND_APPS_NAMED": "Désinstallez d'abord les applications qui utilisent ce projet, puis supprimez-le : {apps}.",
       "PROJECT_MISMATCH": "Ce chat se trouve dans un autre projet. Change de contexte pour continuer.",
       "PROJECT_AGENT_NOT_ALLOWED": "{agentName} n'est pas disponible dans ce projet. Choisis un autre agent.",
       "PROJECT_MODEL_NOT_ALLOWED": "{modelName} n'est pas disponible dans ce projet. Choisis un autre modèle.",


### PR DESCRIPTION
## Summary

Deleting a project that still has apps bound to it (`appProjectBindings`) made the backend throw `ConvexError({ code: 'PROJECT_HAS_BOUND_APPS', apps: [...] })`, but the delete dialog's `catch` only mapped `PROJECT_CONFIRM_PHRASE_MISMATCH`, `PROJECT_LEGAL_HOLD`, and `RATE_LIMITED`. The `PROJECT_HAS_BOUND_APPS` code fell through to the generic `settings.deleteError` toast ("Couldn't delete project"), and the bound app names returned in `error.data.apps` were discarded — so the user was never told what to do.

## Changes

- `project-delete-dialog.tsx`: add a `PROJECT_HAS_BOUND_APPS` branch in the catch. It surfaces the existing actionable i18n message `projects.errors.PROJECT_HAS_BOUND_APPS` ("Uninstall the apps using this project first, then delete it."), and when the backend returns app names it lists them via a new `PROJECT_HAS_BOUND_APPS_NAMED` string.
- `messages/{en,de,fr}.json`: add `projects.errors.PROJECT_HAS_BOUND_APPS_NAMED` with an `{apps}` placeholder (de-CH is a sparse overlay and intentionally omits it).
- `project-delete-dialog.test.tsx`: new component tests covering both the named-apps and generic fallback paths.

## Verification

- `vitest --config vitest.ui.config.ts project-delete-dialog.test.tsx` — 2 passed
- `vitest --project server lib/i18n/messages.test.ts` — 23 passed (i18n parity enforced)
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — clean

Closes #2068