### PR TITLE
fix: surface one-click app install/reinstall failures with a toast (#2067)

### DIFF
--- a/services/platform/app/features/apps/components/app-page.tsx
+++ b/services/platform/app/features/apps/components/app-page.tsx
@@ -32,6 +32,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '@/lib/i18n/client';
 import { startCase } from '@/lib/utils/string';
 
+import { notifyOnInstallFailure } from '../hooks/install-failure-toast';
 import { useAppAgentReadiness } from '../hooks/use-app-agent-readiness';
 import { useAppConfig } from '../hooks/use-app-config';
 import { resolvePackLabels } from '../hooks/use-app-pack-labels';
@@ -95,7 +96,12 @@ function ReadinessChecklist({
             <Button
               size="sm"
               disabled={isPending}
-              onClick={() => void reinstall(appSlug)}
+              onClick={() =>
+                notifyOnInstallFailure(
+                  reinstall(appSlug),
+                  t('install.reinstallFailed'),
+                )
+              }
             >
               {t('install.reinstall')}
             </Button>
@@ -530,7 +536,12 @@ function AddToThisProject({
       action={
         <Button
           disabled={isPending}
-          onClick={() => void install(appSlug, projectId)}
+          onClick={() =>
+            notifyOnInstallFailure(
+              install(appSlug, projectId),
+              t('install.installFailed'),
+            )
+          }
         >
           {t('membership.addToThisProject')}
         </Button>
@@ -615,7 +626,12 @@ function AppDetails({
         <Button
           disabled={isPending}
           onClick={() =>
-            needsWizard ? setWizardOpen(true) : void install(appSlug)
+            needsWizard
+              ? setWizardOpen(true)
+              : notifyOnInstallFailure(
+                  install(appSlug),
+                  t('install.installFailed'),
+                )
           }
         >
           {t('install.install')}

--- a/services/platform/app/features/apps/components/apps-grid.tsx
+++ b/services/platform/app/features/apps/components/apps-grid.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
 
+import { notifyOnInstallFailure } from '../hooks/install-failure-toast';
 import { type AppSummary, useApps } from '../hooks/use-apps';
 import {
   type AppInstallState,
@@ -120,7 +121,10 @@ export function AppsGrid({ organizationId }: { organizationId: string }) {
                     app.scope === 'project' ||
                     app.requiredIntegrations.length > 0
                       ? setWizardApp(app)
-                      : void install(app.slug)
+                      : notifyOnInstallFailure(
+                          install(app.slug),
+                          t('install.installFailed'),
+                        )
                   }
                 >
                   {t('install.install')}

--- a/services/platform/app/features/apps/hooks/install-failure-toast.test.ts
+++ b/services/platform/app/features/apps/hooks/install-failure-toast.test.ts
@@ -30,7 +30,7 @@ describe('notifyOnInstallFailure', () => {
   });
 
   it('omits the description when the rejection is not an Error', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     notifyOnInstallFailure(
       Promise.reject('boom'),
@@ -44,6 +44,7 @@ describe('notifyOnInstallFailure', () => {
       description: undefined,
       variant: 'destructive',
     });
+    expect(errorSpy).toHaveBeenCalledWith('boom');
   });
 
   it('does not toast when the action resolves', async () => {

--- a/services/platform/app/features/apps/hooks/install-failure-toast.test.ts
+++ b/services/platform/app/features/apps/hooks/install-failure-toast.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { toastSpy } = vi.hoisted(() => ({ toastSpy: vi.fn() }));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: toastSpy }));
+
+import { notifyOnInstallFailure } from './install-failure-toast';
+
+describe('notifyOnInstallFailure', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('shows a destructive toast and logs when the action rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new Error('App "x" not found in the catalog');
+
+    notifyOnInstallFailure(Promise.reject(err), 'Couldn’t install the app');
+    // Let the rejected promise settle through the attached `.catch`.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(toastSpy).toHaveBeenCalledWith({
+      title: 'Couldn’t install the app',
+      description: 'App "x" not found in the catalog',
+      variant: 'destructive',
+    });
+    expect(errorSpy).toHaveBeenCalledWith(err);
+  });
+
+  it('omits the description when the rejection is not an Error', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    notifyOnInstallFailure(
+      Promise.reject('boom'),
+      'Couldn’t reinstall the app',
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(toastSpy).toHaveBeenCalledWith({
+      title: 'Couldn’t reinstall the app',
+      description: undefined,
+      variant: 'destructive',
+    });
+  });
+
+  it('does not toast when the action resolves', async () => {
+    notifyOnInstallFailure(Promise.resolve('ok'), 'Couldn’t install the app');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(toastSpy).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/app/features/apps/hooks/install-failure-toast.ts
+++ b/services/platform/app/features/apps/hooks/install-failure-toast.ts
@@ -1,0 +1,31 @@
+'use client';
+
+/**
+ * Surface a rejected fire-and-forget install/reinstall as a destructive toast
+ * (+ console.error) instead of letting it vanish as an unhandled promise
+ * rejection.
+ *
+ * The one-click Install / "Add to this project" / readiness Reinstall handlers
+ * call these actions without awaiting them, so without this they'd swallow
+ * failures silently. The install wizard (`doInstall`) and the ⋯ lifecycle menu
+ * (`AppLifecycleActions`) already do their own try/catch + toast, so they don't
+ * use this helper.
+ *
+ * `failureTitle` is passed pre-resolved (the caller runs `t(...)`) so the i18n
+ * key stays statically visible to the message-usage check.
+ */
+import { toast } from '@/app/hooks/use-toast';
+
+export function notifyOnInstallFailure(
+  action: Promise<unknown>,
+  failureTitle: string,
+): void {
+  void action.catch((err: unknown) => {
+    console.error(err);
+    toast({
+      title: failureTitle,
+      description: err instanceof Error ? err.message : undefined,
+      variant: 'destructive',
+    });
+  });
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -26,6 +26,7 @@
     "install": {
       "install": "Installieren",
       "installed": "Installiert",
+      "installFailed": "App konnte nicht installiert werden",
       "reinstall": "Neu installieren",
       "setup": "Einrichtung abschließen",
       "uninstall": "Deinstallieren",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -26,6 +26,7 @@
     "install": {
       "install": "Install",
       "installed": "Installed",
+      "installFailed": "Couldn't install the app",
       "reinstall": "Reinstall",
       "setup": "Finish setup",
       "uninstall": "Uninstall",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -26,6 +26,7 @@
     "install": {
       "install": "Installer",
       "installed": "Installé",
+      "installFailed": "Impossible d'installer l'application",
       "reinstall": "Réinstaller",
       "setup": "Terminer la configuration",
       "uninstall": "Désinstaller",


### PR DESCRIPTION
Closes #2067

## Problem

The one-click app install / reinstall handlers fired `void install(...)` / `void reinstall(...)` with no `.catch`. Because `useConvexAction` is a bare `useMutation` with no `onError` and the QueryClient defines no global mutation error handler, a rejected install promise was discarded as an unhandled rejection — **no error toast, no UI state change, no console log**. This contradicts the install wizard (`doInstall`) and the ⋯ lifecycle menu, which both surface a destructive toast on failure, and it violates the repo ban on swallowing errors.

Affected one-click surfaces:
- Apps hub card **Install** button (`apps-grid.tsx`)
- Org app page **Install** CTA (`AppDetails`)
- Project **Add to this project** prompt (`AddToThisProject`)
- Org app page readiness **Reinstall** button (`ReadinessChecklist`)

## Fix

Added a small `notifyOnInstallFailure(action, failureTitle)` helper (`features/apps/hooks/install-failure-toast.ts`) that attaches a `.catch` to the fire-and-forget promise, logs via `console.error`, and shows a destructive toast (title + `err.message` description) — mirroring the wizard's `doInstall`. All four one-click handlers now route through it.

The failure title is resolved by the caller (`t('install.installFailed')` / `t('install.reinstallFailed')`) so the i18n keys stay statically visible to the message-usage check. Added the missing `install.installFailed` key to `en`, `de`, and `fr` (`de-CH` is a partial override that falls back to `de`); `install.reinstallFailed` already existed.

The background integrity re-check (`void verify(...)`) is intentionally left silent — surfacing a toast for a passive on-open check would be noisy and is out of scope.

## Verification
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings, 0 errors
- i18n `messages.test.ts` (parity + usage in enforce mode) — 23/23 passing