### PR TITLE
fix(platform): localize MCP server form validation messages (#2063)

### DIFF
--- a/services/platform/app/features/settings/mcp-servers/components/mcp-server-form.tsx
+++ b/services/platform/app/features/settings/mcp-servers/components/mcp-server-form.tsx
@@ -133,40 +133,41 @@ export function McpServerForm({
     const newErrors: FormErrors = {};
 
     if (!name.trim()) {
-      newErrors.name = t('form.name') + ' is required';
+      newErrors.name = t('form.validation.nameRequired');
     } else if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(name) && name.length > 1) {
-      newErrors.name = 'Must be lowercase alphanumeric with hyphens';
+      newErrors.name = t('form.validation.nameFormat');
     }
 
     if (!displayName.trim()) {
-      newErrors.displayName = t('form.displayName') + ' is required';
+      newErrors.displayName = t('form.validation.displayNameRequired');
     }
 
     if (isHttpTransport && !url.trim()) {
-      newErrors.url = t('form.url') + ' is required';
+      newErrors.url = t('form.validation.urlRequired');
     }
 
     if (transportType === 'stdio' && !command.trim()) {
-      newErrors.command = t('form.command') + ' is required';
+      newErrors.command = t('form.validation.commandRequired');
     }
 
     if (authType === 'api_key' && !apiKey.trim() && !server) {
-      newErrors.apiKey = t('form.apiKey') + ' is required';
+      newErrors.apiKey = t('form.validation.apiKeyRequired');
     }
 
     if (authType === 'oauth2') {
       if (!tokenUrl.trim()) {
-        newErrors.tokenUrl = t('oauth2.tokenUrl') + ' is required';
+        newErrors.tokenUrl = t('form.validation.tokenUrlRequired');
       }
       if (!clientId.trim()) {
-        newErrors.clientId = t('oauth2.clientId') + ' is required';
+        newErrors.clientId = t('form.validation.clientIdRequired');
       }
       if (!clientSecret.trim() && !server) {
-        newErrors.clientSecret = t('oauth2.clientSecret') + ' is required';
+        newErrors.clientSecret = t('form.validation.clientSecretRequired');
       }
       if (grantType === 'authorization_code' && !authorizationUrl.trim()) {
-        newErrors.authorizationUrl =
-          t('oauth2.authorizationUrl') + ' is required';
+        newErrors.authorizationUrl = t(
+          'form.validation.authorizationUrlRequired',
+        );
       }
     }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4114,7 +4114,19 @@
       "saving": "Speichern...",
       "cancel": "Abbrechen",
       "connectionSection": "Verbindung",
-      "authSection": "Authentifizierung"
+      "authSection": "Authentifizierung",
+      "validation": {
+        "nameRequired": "Name ist erforderlich",
+        "nameFormat": "Muss aus Kleinbuchstaben, Ziffern und Bindestrichen bestehen",
+        "displayNameRequired": "Anzeigename ist erforderlich",
+        "urlRequired": "URL ist erforderlich",
+        "commandRequired": "Befehl ist erforderlich",
+        "apiKeyRequired": "API-Key ist erforderlich",
+        "tokenUrlRequired": "Token-URL ist erforderlich",
+        "clientIdRequired": "Client-ID ist erforderlich",
+        "clientSecretRequired": "Client-Geheimnis ist erforderlich",
+        "authorizationUrlRequired": "Autorisierungs-URL ist erforderlich"
+      }
     },
     "oauth2": {
       "tokenUrl": "Token-URL",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4114,7 +4114,19 @@
       "saving": "Saving...",
       "cancel": "Cancel",
       "connectionSection": "Connection",
-      "authSection": "Authentication"
+      "authSection": "Authentication",
+      "validation": {
+        "nameRequired": "Name is required",
+        "nameFormat": "Must be lowercase alphanumeric with hyphens",
+        "displayNameRequired": "Display name is required",
+        "urlRequired": "URL is required",
+        "commandRequired": "Command is required",
+        "apiKeyRequired": "API Key is required",
+        "tokenUrlRequired": "Token URL is required",
+        "clientIdRequired": "Client ID is required",
+        "clientSecretRequired": "Client secret is required",
+        "authorizationUrlRequired": "Authorization URL is required"
+      }
     },
     "oauth2": {
       "tokenUrl": "Token URL",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4115,7 +4115,19 @@
       "saving": "Enregistrement...",
       "cancel": "Annuler",
       "connectionSection": "Connexion",
-      "authSection": "Authentification"
+      "authSection": "Authentification",
+      "validation": {
+        "nameRequired": "Le nom est requis",
+        "nameFormat": "Doit être en minuscules alphanumériques avec des traits d'union",
+        "displayNameRequired": "Le nom d'affichage est requis",
+        "urlRequired": "L'URL est requise",
+        "commandRequired": "La commande est requise",
+        "apiKeyRequired": "La clé API est requise",
+        "tokenUrlRequired": "L'URL du jeton est requise",
+        "clientIdRequired": "L'ID client est requis",
+        "clientSecretRequired": "Le secret client est requis",
+        "authorizationUrlRequired": "L'URL d'autorisation est requise"
+      }
     },
     "oauth2": {
       "tokenUrl": "URL du jeton",


### PR DESCRIPTION
## Summary

The MCP server Add/Edit form built every validation message by concatenating a localized field label with a hardcoded English `' is required'` suffix, and the lowercase-name rule was a fully hardcoded English literal. In non-English locales this rendered mixed strings like `"Anzeigename is required"`, and these messages could not be translated because the `mcpServers` namespace had no validation keys.

This replaces the string-concatenation pattern with proper i18n keys, matching the approach already used by the API-key dialog (`apiKeys.form.nameRequired`).

## Changes

- Added a `mcpServers.form.validation` sub-namespace with full-sentence keys (`nameRequired`, `nameFormat`, `displayNameRequired`, `urlRequired`, `commandRequired`, `apiKeyRequired`, and the OAuth 2.0 `tokenUrlRequired` / `clientIdRequired` / `clientSecretRequired` / `authorizationUrlRequired`) to `en.json`, `de.json`, and `fr.json`.
- Replaced the label-plus-suffix concatenation in `mcp-server-form.tsx`'s `validate()` with `t('form.validation.*')` lookups — no grammar/word-order assumptions remain.
- `de-CH.json` is a regional override that already inherits the entire `mcpServers` namespace via i18next fallback, so it needs no new keys (consistent with the existing `apiKeys` keys, which it also inherits).

## Verification

- `bunx vitest --run lib/i18n/messages.test.ts` — 23 passed (parity + usage enforce key completeness across locales and that every key used in code exists).
- `bunx oxlint --type-aware` on the changed component — 0 warnings, 0 errors.

Closes #2063