### PR TITLE
fix: rehydrate agent execution-timeout input from config on restore (#2065)

### DIFF
--- a/services/platform/app/features/agents/components/agent-navigation.tsx
+++ b/services/platform/app/features/agents/components/agent-navigation.tsx
@@ -57,6 +57,9 @@ const AGENT_TAB_DIRTY_KEYS = {
     'roleRestriction',
     'composerMode',
     'i18n',
+    // The execution-timeout input is rendered on the General tab, so its
+    // diff key belongs here for the per-tab unsaved-changes indicator.
+    'timeoutMs',
   ],
   instructions: [
     'systemInstructions',
@@ -66,7 +69,6 @@ const AGENT_TAB_DIRTY_KEYS = {
     'nativeWebTools',
     'structuredResponsesEnabled',
     'maxSteps',
-    'timeoutMs',
     'outputReserve',
     'personalizationMode',
   ],

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/general-tab-timeout.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/general-tab-timeout.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// Regression coverage for #2065: the execution-timeout input used to be a
+// one-shot `useState` mirror of `config.timeoutMs` that latched the first value
+// forever. A History/Restore (`overrideConfig`) advanced the config but the
+// input kept showing the stale value, and a later blur of the unedited field
+// re-marked the form dirty and clobbered the restored value. The field now
+// derives its display from `config.timeoutMs` directly.
+
+const { mockUseParams } = vi.hoisted(() => ({
+  mockUseParams: () => ({ id: 'org-1', agentId: 'agent-1' }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    useParams: mockUseParams,
+    ...config,
+  }),
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <a href="/">{children}</a>
+  ),
+}));
+
+vi.mock('@/app/features/agents/hooks/mutations', () => ({
+  useUpdateAgentBindings: () => ({ mutateAsync: vi.fn() }),
+  useUpdateAgentSharing: () => ({ mutateAsync: vi.fn() }),
+  useTranslateAgentFields: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/app/features/agents/hooks/queries', () => ({
+  useAgentBinding: () => ({ data: null }),
+}));
+
+vi.mock('@/app/features/organization/hooks/queries', () => ({
+  useOrganization: () => ({ data: null }),
+}));
+
+vi.mock('@/app/hooks/use-team-filter', () => ({
+  useTeamFilter: () => ({ teams: [] }),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import {
+  AgentConfigProvider,
+  useAgentConfig,
+} from '@/app/features/agents/hooks/use-agent-config-context';
+
+import { Route } from './index';
+
+// The router-mock above replaces `createFileRoute` so `Route` is the plain
+// config object (component included); the real Route type doesn't expose it.
+const GeneralTab = (Route as unknown as { component: () => React.ReactElement })
+  .component;
+
+// Captures the live config context so the test can drive `overrideConfig`
+// (the restore path) and assert `isDirty` the way the Save bar does.
+let ctx: ReturnType<typeof useAgentConfig> | null = null;
+function CaptureConfig() {
+  ctx = useAgentConfig();
+  return null;
+}
+function getCtx() {
+  if (!ctx) throw new Error('config context was not captured');
+  return ctx;
+}
+
+function renderGeneralTab(timeoutMs: number) {
+  ctx = null;
+  return render(
+    <AgentConfigProvider
+      agentName="agent-1"
+      initialConfig={{ supportedModels: [], timeoutMs }}
+    >
+      <CaptureConfig />
+      <GeneralTab />
+    </AgentConfigProvider>,
+  );
+}
+
+const timeoutInput = () => screen.getByRole<HTMLInputElement>('spinbutton');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GeneralTab execution-timeout input (#2065)', () => {
+  it('rehydrates from config when a restore overrides timeoutMs', () => {
+    renderGeneralTab(7 * 60_000);
+    expect(timeoutInput().value).toBe('7');
+
+    // Simulate History/Restore: overrideConfig advances both working copy and
+    // baseline to the snapshot value.
+    act(() =>
+      getCtx().overrideConfig({ supportedModels: [], timeoutMs: 12 * 60_000 }),
+    );
+
+    expect(timeoutInput().value).toBe('12');
+    expect(getCtx().isDirty).toBe(false);
+  });
+
+  it('does not re-mark dirty or revert when an unedited field is blurred', () => {
+    renderGeneralTab(7 * 60_000);
+
+    act(() =>
+      getCtx().overrideConfig({ supportedModels: [], timeoutMs: 12 * 60_000 }),
+    );
+    expect(getCtx().isDirty).toBe(false);
+
+    // Focus + blur without typing — the classic stale-mirror revert trigger.
+    fireEvent.focus(timeoutInput());
+    fireEvent.blur(timeoutInput());
+
+    expect(getCtx().isDirty).toBe(false);
+    expect(timeoutInput().value).toBe('12');
+    expect(getCtx().config.timeoutMs).toBe(12 * 60_000);
+  });
+
+  it('commits an edited value into config and marks dirty', () => {
+    renderGeneralTab(7 * 60_000);
+
+    fireEvent.change(timeoutInput(), { target: { value: '15' } });
+
+    expect(timeoutInput().value).toBe('15');
+    expect(getCtx().config.timeoutMs).toBe(15 * 60_000);
+    expect(getCtx().isDirty).toBe(true);
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId/index.tsx
@@ -2,7 +2,7 @@ import { PageSection } from '@tale/ui/page-section';
 import { SectionHeader } from '@tale/ui/section-header';
 import { createFileRoute } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -171,19 +171,17 @@ function GeneralTab() {
     t,
   ]);
 
-  const [timeoutMinutes, setTimeoutMinutes] = useState(DEFAULT_TIMEOUT_MINUTES);
-  const [timeoutInitialized, setTimeoutInitialized] = useState(false);
-
-  useEffect(() => {
-    if (!timeoutInitialized) {
-      setTimeoutMinutes(
-        config.timeoutMs
-          ? Math.round(config.timeoutMs / 60_000)
-          : DEFAULT_TIMEOUT_MINUTES,
-      );
-      setTimeoutInitialized(true);
-    }
-  }, [config.timeoutMs, timeoutInitialized]);
+  // Displayed minutes are DERIVED from `config.timeoutMs` (the source of
+  // truth) so a restore / any `overrideConfig` rehydrates the input — no
+  // one-shot useState mirror that latches the first value forever. While the
+  // user is actively typing we hold the raw text in `timeoutDraft`; it is
+  // `null` whenever the field is not being edited, so the input falls back to
+  // `config`. Clearing the draft on blur re-syncs the display to `config`.
+  const configTimeoutMinutes = config.timeoutMs
+    ? Math.round(config.timeoutMs / 60_000)
+    : DEFAULT_TIMEOUT_MINUTES;
+  const [timeoutDraft, setTimeoutDraft] = useState<string | null>(null);
+  const timeoutValue = timeoutDraft ?? String(configTimeoutMinutes);
 
   const teamOptions = useMemo(() => {
     const items = [{ value: NO_TEAM_VALUE, label: t('agents.form.teamNone') }];
@@ -258,11 +256,44 @@ function GeneralTab() {
     [updateConfig],
   );
 
+  // Commit a clamped minutes value into `config`, but only when it actually
+  // differs from what `config` already holds — so blurring a field the user
+  // never edited can never re-mark the form dirty or clobber a restored value.
+  const commitTimeout = useCallback(
+    (minutes: number) => {
+      const clamped = Math.max(1, Math.min(25, Math.round(minutes)));
+      const nextMs = clamped * 60_000;
+      if (nextMs !== config.timeoutMs) {
+        updateConfig({ timeoutMs: nextMs });
+      }
+    },
+    [config.timeoutMs, updateConfig],
+  );
+
+  const handleTimeoutChange = useCallback(
+    (raw: string) => {
+      setTimeoutDraft(raw);
+      // Only push valid numeric input through to `config`; an empty/partial
+      // entry stays in the draft until blur so typing isn't fought.
+      if (raw !== '') {
+        const parsed = Number(raw);
+        if (Number.isFinite(parsed)) commitTimeout(parsed);
+      }
+    },
+    [commitTimeout],
+  );
+
   const handleTimeoutBlur = useCallback(() => {
-    const clamped = Math.max(1, Math.min(25, timeoutMinutes));
-    setTimeoutMinutes(clamped);
-    updateConfig({ timeoutMs: clamped * 60_000 });
-  }, [timeoutMinutes, updateConfig]);
+    // Re-sync the display to `config` once editing ends.
+    if (timeoutDraft === null) return;
+    const parsed = Number(timeoutDraft);
+    commitTimeout(
+      timeoutDraft !== '' && Number.isFinite(parsed)
+        ? parsed
+        : DEFAULT_TIMEOUT_MINUTES,
+    );
+    setTimeoutDraft(null);
+  }, [timeoutDraft, commitTimeout]);
 
   // Agent type (primaryBehavior) — Internal (chat, runs the platform tool loop)
   // vs External agent (Claude Code / OpenCode in a sandbox) vs Image generation.
@@ -482,12 +513,8 @@ function GeneralTab() {
             type="number"
             label={t('agents.general.timeoutMinutes')}
             description={t('agents.general.timeoutMinutesHelp')}
-            value={timeoutMinutes}
-            onChange={(e) =>
-              setTimeoutMinutes(
-                Number(e.target.value) || DEFAULT_TIMEOUT_MINUTES,
-              )
-            }
+            value={timeoutValue}
+            onChange={(e) => handleTimeoutChange(e.target.value)}
             onBlur={handleTimeoutBlur}
             min={1}
             max={25}


### PR DESCRIPTION
Closes #2065

## Problem
The Agent General-tab **Execution timeout (minutes)** input mirrored `config.timeoutMs` into component-local `useState` exactly once, via a `useEffect` gated by `if (!timeoutInitialized)`. After that latch:

- A History/Restore (or any `overrideConfig` path) advanced the shared config but **did not** update the displayed value — the input kept showing the stale value.
- Blurring the (unedited) field wrote the stale local value back through `updateConfig({ timeoutMs })`, re-marking the form dirty and clobbering the restored value on the next Save.

This is the useState-mirror-of-server-state anti-pattern the repo bans; every other General-tab field reads/writes `config` directly.

## Fix
- `app/routes/dashboard/$id/agents/$agentId/index.tsx`: drop the `timeoutMinutes`/`timeoutInitialized` state and the seeding `useEffect`. The displayed minutes are now **derived** from `config.timeoutMs` (the source of truth), with a small local `timeoutDraft` buffer that holds raw text **only while the user is actively typing** (`null` otherwise, so the input rehydrates on restore/override). Blur clears the draft to re-sync to `config`.
- `commitTimeout` only writes when the clamped value actually differs from `config.timeoutMs`, so blurring an unedited field can never re-mark dirty or revert a restored value.
- `app/features/agents/components/agent-navigation.tsx`: move `timeoutMs` from the `instructions` per-tab diff-key list to `general` (the secondary inconsistency noted in the issue) — the input is rendered on the General tab, so its unsaved-changes indicator now lands on the correct tab.

## Tests
- New `general-tab-timeout.test.tsx` covering: rehydration when a restore overrides `timeoutMs`, no re-dirty/no-revert on blur of an unedited field, and committing an edited value.
- `bunx tsc --noEmit` (platform): clean
- `bunx oxlint --type-aware` on changed files: clean
- `vitest` (ui): new test + `agent-navigation.test.tsx` pass