### PR TITLE
fix(platform): unwrap integration list envelope so issue desk shows issues

### DIFF
--- a/services/platform/convex/integrations/public_actions.ts
+++ b/services/platform/convex/integrations/public_actions.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 
 import { buildExclusionSet } from '../../lib/shared/platform/exclude_by';
 import { collectFilteredPage } from '../../lib/shared/platform/filtered_pagination';
-import { isRecord } from '../../lib/utils/type-utils';
+import { readIntegrationListPage } from '../../lib/shared/platform/integration_list_page';
 import { api, internal } from '../_generated/api';
 import { action } from '../_generated/server';
 import { requireOrgMembershipById } from '../lib/auth/require_org_membership';
@@ -138,11 +138,11 @@ export const listUntrackedGitHubIssues = action({
             skipApprovalCheck: true,
           },
         );
-        const pagination = isRecord(res) ? res.pagination : undefined;
-        return {
-          rows: isRecord(res) && Array.isArray(res.data) ? res.data : [],
-          hasNext: isRecord(pagination) && pagination.hasNextPage === true,
-        };
+        // `executeIntegration` returns an envelope whose connector payload (the
+        // issues array + upstream page hint) lives under `.result`, so unwrap it
+        // here rather than reading the top level (which always yielded an empty
+        // page and collapsed the desk to nothing).
+        return readIntegrationListPage(res);
       },
       excluded,
       rowKeyTemplate: args.rowKeyTemplate,

--- a/services/platform/lib/shared/platform/integration_list_page.test.ts
+++ b/services/platform/lib/shared/platform/integration_list_page.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { readIntegrationListPage } from './integration_list_page';
+
+/**
+ * The shape `executeIntegration` actually returns: the connector's payload
+ * (data + pagination) nested under `.result`, alongside envelope metadata.
+ * Reading the top level instead is the regression these tests guard against —
+ * it silently produced an empty page and made the issue desk show no issues.
+ */
+const envelope = (
+  data: unknown[],
+  hasNextPage: boolean,
+): Record<string, unknown> => ({
+  name: 'github',
+  operation: 'list_issues',
+  duration: 12,
+  version: 1,
+  result: {
+    success: true,
+    operation: 'list_issues',
+    count: data.length,
+    data,
+    pagination: { hasNextPage, nextPageInfo: hasNextPage ? '2' : null },
+    timestamp: 0,
+  },
+});
+
+describe('readIntegrationListPage', () => {
+  it('unwraps rows + hasNext from the nested `.result` envelope', () => {
+    const rows = [{ number: 2117 }, { number: 2116 }, { number: 2096 }];
+
+    expect(readIntegrationListPage(envelope(rows, true))).toEqual({
+      rows,
+      hasNext: true,
+    });
+  });
+
+  it('reports no next page when the envelope says so', () => {
+    expect(readIntegrationListPage(envelope([{ number: 1 }], false))).toEqual({
+      rows: [{ number: 1 }],
+      hasNext: false,
+    });
+  });
+
+  it('does NOT read the top level — a top-level data/pagination is ignored', () => {
+    // The bug shape: data/pagination at the top, nothing under `.result`.
+    // Such a result must NOT be mistaken for a flat payload, because the real
+    // envelope always carries a `.result` object.
+    const out = readIntegrationListPage({
+      name: 'github',
+      operation: 'list_issues',
+      result: { success: true, data: [], pagination: { hasNextPage: false } },
+      data: [{ number: 99 }],
+      pagination: { hasNextPage: true },
+    });
+    expect(out).toEqual({ rows: [], hasNext: false });
+  });
+
+  it('tolerates an already-flat payload (forward-compatible)', () => {
+    const out = readIntegrationListPage({
+      data: [{ number: 7 }],
+      pagination: { hasNextPage: true },
+    });
+    expect(out).toEqual({ rows: [{ number: 7 }], hasNext: true });
+  });
+
+  it('degrades to an empty, terminal page on a malformed result', () => {
+    expect(readIntegrationListPage(null)).toEqual({ rows: [], hasNext: false });
+    expect(readIntegrationListPage({ result: {} })).toEqual({
+      rows: [],
+      hasNext: false,
+    });
+  });
+});

--- a/services/platform/lib/shared/platform/integration_list_page.ts
+++ b/services/platform/lib/shared/platform/integration_list_page.ts
@@ -1,0 +1,26 @@
+/**
+ * Adapt an `executeIntegration` LIST result into the `{ rows, hasNext }` shape
+ * that `collectFilteredPage` consumes.
+ *
+ * `executeIntegration` wraps the connector's payload in an envelope —
+ * `{ name, operation, result: { data, pagination, ... }, ... }` — so the rows
+ * array and the upstream "is there a next page" hint live under `.result`, NOT
+ * at the top level. Reading `res.data` / `res.pagination` directly silently
+ * yields `undefined` (an empty page with no next page), which collapses a
+ * filtered list to nothing — the bug that made the issue desk show no issues.
+ *
+ * This unwraps `.result` first (mirroring the client's `parsePage`), and
+ * tolerates an already-flat shape so a future connector that returns
+ * `{ data, pagination }` directly still works.
+ */
+import { isRecord } from '../../utils/type-utils';
+import type { SourcePage } from './filtered_pagination';
+
+export function readIntegrationListPage(res: unknown): SourcePage {
+  const payload = isRecord(res) && isRecord(res.result) ? res.result : res;
+  const pagination = isRecord(payload) ? payload.pagination : undefined;
+  return {
+    rows: isRecord(payload) && Array.isArray(payload.data) ? payload.data : [],
+    hasNext: isRecord(pagination) && pagination.hasNextPage === true,
+  };
+}


### PR DESCRIPTION
## What

The issue desk rendered **no issues** even when untracked GitHub issues existed.

`executeIntegration` returns an *envelope* whose connector payload — the issues array plus the upstream "is there a next page" hint — lives under `.result`:

```
{ name, operation, result: { data, pagination, ... }, ... }
```

`listUntrackedGitHubIssues` read `res.data` / `res.pagination` from the **top level**, which always resolved to `undefined` → an empty page with no next page → the filtered list collapsed to nothing.

## Fix

Extract a shared `readIntegrationListPage` helper that:

- unwraps `.result` first (mirroring the client's `parsePage`),
- tolerates an already-flat `{ data, pagination }` payload for forward compatibility (a future connector that returns the payload directly still works),
- degrades to an empty, terminal page on a malformed/`null` result.

`listUntrackedGitHubIssues` now delegates to it instead of reading the top level.

## Tests

New `integration_list_page.test.ts` covers the nested envelope, the `hasNext` signal, the regression shape (top-level data must be ignored), the forward-compatible flat shape, and malformed input. All 5 pass.