### PR TITLE
fix(platform): require name in customer edit dialog for vendor parity

### DIFF
--- a/services/platform/app/features/customers/components/customer-edit-dialog.test.tsx
+++ b/services/platform/app/features/customers/components/customer-edit-dialog.test.tsx
@@ -54,36 +54,32 @@ describe('CustomerEditDialog', () => {
     expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
   });
 
-  it('submits when customer has no name', async () => {
+  it('blocks submission when the name is cleared', async () => {
     const onOpenChange = vi.fn();
     const { user } = render(
       <CustomerEditDialog
-        customer={makeCustomer({ name: undefined })}
+        customer={makeCustomer({ name: 'John' })}
         isOpen={true}
         onOpenChange={onOpenChange}
       />,
     );
 
-    const emailInput = screen.getByDisplayValue('test@example.com');
-    await user.clear(emailInput);
-    await user.type(emailInput, 'new@example.com');
+    const nameInput = screen.getByDisplayValue('John');
+    await user.clear(nameInput);
 
     const submitButton = screen.getByRole('button', { name: /save/i });
     await user.click(submitButton);
 
+    // Required-name validation must block the no-op update entirely:
+    // no mutation fires, no misleading success toast, and the dialog
+    // stays open so the user can correct the empty name.
     await waitFor(() => {
-      expect(mockMutateAsync).toHaveBeenCalledWith({
-        customerId: 'customer-1',
-        name: undefined,
-        email: 'new@example.com',
-        locale: 'en',
-        status: 'active',
-      });
+      expect(mockMutateAsync).not.toHaveBeenCalled();
     });
-
-    await waitFor(() => {
-      expect(onOpenChange).toHaveBeenCalledWith(false);
-    });
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'success' }),
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
   it('submits with name when customer has a name', async () => {

--- a/services/platform/app/features/customers/components/customer-edit-dialog.tsx
+++ b/services/platform/app/features/customers/components/customer-edit-dialog.tsx
@@ -52,7 +52,13 @@ export function CustomerEditDialog({
   const formSchema = useMemo(
     () =>
       z.object({
-        name: z.string().trim(),
+        name: z
+          .string()
+          .trim()
+          .min(
+            1,
+            tCommon('validation.required', { field: tCustomers('name') }),
+          ),
         email: z.string().email(tCommon('validation.email')),
         locale: z
           .string()
@@ -99,10 +105,9 @@ export function CustomerEditDialog({
 
   const onSubmit = async (data: CustomerFormData) => {
     try {
-      const trimmedName = data.name.trim();
       await updateCustomer.mutateAsync({
         customerId: customer._id,
-        name: trimmedName || undefined,
+        name: data.name.trim(),
         email: data.email.trim(),
         locale: data.locale,
         status: data.status,
@@ -146,6 +151,7 @@ export function CustomerEditDialog({
         {...register('name')}
         disabled={isSubmitting}
         errorMessage={errors.name?.message}
+        required
       />
 
       <Input


### PR DESCRIPTION
## Summary

Clearing a customer's name in the edit dialog was a silent no-op that still showed "Customer updated successfully". The schema only had `z.string().trim()` (no `min(1)`) and `onSubmit` coalesced the empty name to `undefined`, which the backend's `Object.fromEntries(... value !== undefined)` filter then dropped — so nothing changed but the success toast still fired. The sibling **Vendor** edit dialog already required its name; this brings the Customer dialog to parity.

## Changes
- `customer-edit-dialog.tsx`: name schema is now `z.string().trim().min(1, validation.required)`, the name `Input` is marked `required`, and the `name: trimmedName || undefined` coalesce is replaced with `name: data.name.trim()` — matching `vendor-edit-dialog.tsx`.
- `customer-edit-dialog.test.tsx`: replaced the now-invalid "submits when customer has no name" test with one asserting that clearing the name blocks the mutation, suppresses the success toast, and keeps the dialog open.

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on changed files — 0 warnings/errors
- `vitest` (ui project) for the dialog test — 5/5 pass

Closes #2060