### PR TITLE
fix(platform): validate budget rules in editor so dead rules can't be saved (#2061)

### DIFF
--- a/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
@@ -148,6 +148,52 @@ describe('BudgetEditor', () => {
     });
   });
 
+  // Issue #2061: the editor must not persist a "silently dead" rule — a
+  // user/team/role scope with no target, or a rule with no positive limit.
+  describe('rule dialog validation (#2061)', () => {
+    it('blocks saving a rule with no limit set and shows an inline error', async () => {
+      setLoaded([]);
+      const { user } = render(<BudgetEditor organizationId="org-1" />);
+
+      await user.click(screen.getByRole('button', { name: /add rule/i }));
+      // The Add dialog is open (default scope, no limits → invalid).
+      expect(
+        await screen.findByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      // The limit-required error surfaces and the dialog stays open (no save).
+      expect(
+        await screen.findByText(/set at least one limit/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+      // No rule was committed — the table still shows the empty state.
+      expect(
+        screen.getByText(/no budget rules configured/i),
+      ).toBeInTheDocument();
+    });
+
+    it('saves a default-scope rule once a positive limit is provided', async () => {
+      setLoaded([]);
+      const { user } = render(<BudgetEditor organizationId="org-1" />);
+
+      await user.click(screen.getByRole('button', { name: /add rule/i }));
+      const tokenInput = await screen.findByLabelText(/max tokens/i);
+      await user.type(tokenInput, '1000000');
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      // Dialog closed (saved) and the new rule row is shown.
+      expect(
+        screen.queryByRole('button', { name: /confirm/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+  });
+
   describe('structural parity (skeleton matches content)', () => {
     it('renders the same column count in both states', () => {
       setLoaded([

--- a/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
@@ -192,6 +192,79 @@ describe('BudgetEditor', () => {
       ).not.toBeInTheDocument();
       expect(screen.getByText('default')).toBeInTheDocument();
     });
+
+    // The headline case of #2061: a user/team/role scope with no target is a
+    // permanently dead rule (the enforcer requires a `scopeId` match). Editing a
+    // pre-seeded role rule that has a limit but no target exercises the
+    // target-required guard without driving the Radix scope <Select>.
+    it('blocks saving a scoped (role) rule with no target and shows an inline error', async () => {
+      setLoaded([{ scope: 'role', period: 'monthly', maxTokens: 1_000_000 }]);
+      const { user } = render(<BudgetEditor organizationId="org-1" />);
+
+      await user.click(screen.getByRole('button', { name: /edit rule/i }));
+      expect(
+        await screen.findByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      // The target-required error surfaces and the dialog stays open (no save).
+      expect(
+        await screen.findByText(/select a target for this scope/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('saves a scoped (role) rule once a target and limit are present', async () => {
+      setLoaded([
+        {
+          scope: 'role',
+          scopeId: 'admin',
+          period: 'monthly',
+          maxTokens: 1_000_000,
+        },
+      ]);
+      const { user } = render(<BudgetEditor organizationId="org-1" />);
+
+      await user.click(screen.getByRole('button', { name: /edit rule/i }));
+      expect(
+        await screen.findByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      // No target/limit error — the dialog closes (saved).
+      expect(
+        screen.queryByRole('button', { name: /confirm/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // A per-field `0` is not "no limit": the enforcer reads it as the strictest
+    // cap and blocks every request. Typing `0` must be rejected, not saved.
+    it('rejects a limit field set to zero (a "block-everything" rule)', async () => {
+      setLoaded([]);
+      const { user } = render(<BudgetEditor organizationId="org-1" />);
+
+      await user.click(screen.getByRole('button', { name: /add rule/i }));
+      const tokenInput = await screen.findByLabelText(/max tokens/i);
+      await user.type(tokenInput, '0');
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      // The per-field "must be greater than zero" error surfaces, the dialog
+      // stays open, and nothing is committed.
+      expect(
+        await screen.findByText(/must be greater than zero/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /confirm/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/no budget rules configured/i),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('structural parity (skeleton matches content)', () => {

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -81,8 +81,11 @@ function scopeNeedsTarget(scope: BudgetRule['scope']): boolean {
   return scope === 'user' || scope === 'team' || scope === 'role';
 }
 
-/** A rule only enforces if at least one positive limit is set. With every
- *  limit unset (or zero) the enforcer resolves no cap and the rule is dead. */
+/** A rule only enforces meaningfully if at least one *positive* limit is set.
+ *  With every limit unset the enforcer resolves no cap and the rule is dead.
+ *  A limit of `0` is worse than unset: the enforcer treats it as the strictest
+ *  cap (`projectedCost >= 0` etc. is always true) and blocks every request — so
+ *  a set-but-non-positive limit is rejected per-field in `validateBudgetRule`. */
 function hasUsableLimit(rule: BudgetRule): boolean {
   return (
     (rule.maxTokens != null && rule.maxTokens > 0) ||
@@ -113,13 +116,18 @@ function validateBudgetRule(rule: BudgetRule, t: TFunction): BudgetRuleErrors {
     errors.scopeId = t('budgets.targetRequired');
   }
 
-  if (rule.maxTokens != null && rule.maxTokens < 0) {
+  // A *set* limit must be positive. `0` (typed directly — `"0"` is truthy so it
+  // survives the `onChange` guard — or a sub-cent cost that rounds down to `0`
+  // cents) is not "no limit": the enforcer reads it as the strictest possible
+  // cap and blocks every request. Reject `<= 0` to mirror `hasUsableLimit`'s
+  // `> 0` premise so a per-field zero can't slip past as a usable limit.
+  if (rule.maxTokens != null && rule.maxTokens <= 0) {
     errors.maxTokens = t('budgets.invalidTokenLimit');
   }
-  if (rule.maxCostCents != null && rule.maxCostCents < 0) {
+  if (rule.maxCostCents != null && rule.maxCostCents <= 0) {
     errors.maxCostCents = t('budgets.invalidCostLimit');
   }
-  if (rule.maxRequests != null && rule.maxRequests < 0) {
+  if (rule.maxRequests != null && rule.maxRequests <= 0) {
     errors.maxRequests = t('budgets.invalidMaxRequests');
   }
   if (

--- a/services/platform/app/features/settings/governance/components/budget-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.tsx
@@ -14,7 +14,8 @@ import {
   TableRow,
 } from '@tale/ui/table';
 import { Text } from '@tale/ui/text';
-import { Pencil, Plus, Trash2, Wallet } from 'lucide-react';
+import type { TFunction } from 'i18next';
+import { Pencil, Plus, Trash2, Wallet, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -73,6 +74,68 @@ function emptyRule(): BudgetRule {
   };
 }
 
+/** Scopes that target a specific subject — they only enforce when their
+ *  `scopeId` matches a user/team/role at runtime (see `budget_enforcement.ts`).
+ *  Saving one with an empty `scopeId` produces a permanently dead rule. */
+function scopeNeedsTarget(scope: BudgetRule['scope']): boolean {
+  return scope === 'user' || scope === 'team' || scope === 'role';
+}
+
+/** A rule only enforces if at least one positive limit is set. With every
+ *  limit unset (or zero) the enforcer resolves no cap and the rule is dead. */
+function hasUsableLimit(rule: BudgetRule): boolean {
+  return (
+    (rule.maxTokens != null && rule.maxTokens > 0) ||
+    (rule.maxCostCents != null && rule.maxCostCents > 0) ||
+    (rule.maxRequests != null && rule.maxRequests > 0)
+  );
+}
+
+interface BudgetRuleErrors {
+  scopeId?: string;
+  maxTokens?: string;
+  maxCostCents?: string;
+  maxRequests?: string;
+  warningThresholdPercent?: string;
+  /** Cross-field: no positive limit set on the rule. */
+  limits?: string;
+}
+
+/**
+ * Client-side validation mirroring the constraints the enforcer relies on.
+ * Prevents the editor from persisting a "silently dead" rule (issue #2061):
+ * a user/team/role scope with no target, or a rule with no positive limit.
+ */
+function validateBudgetRule(rule: BudgetRule, t: TFunction): BudgetRuleErrors {
+  const errors: BudgetRuleErrors = {};
+
+  if (scopeNeedsTarget(rule.scope) && !rule.scopeId) {
+    errors.scopeId = t('budgets.targetRequired');
+  }
+
+  if (rule.maxTokens != null && rule.maxTokens < 0) {
+    errors.maxTokens = t('budgets.invalidTokenLimit');
+  }
+  if (rule.maxCostCents != null && rule.maxCostCents < 0) {
+    errors.maxCostCents = t('budgets.invalidCostLimit');
+  }
+  if (rule.maxRequests != null && rule.maxRequests < 0) {
+    errors.maxRequests = t('budgets.invalidMaxRequests');
+  }
+  if (
+    rule.warningThresholdPercent != null &&
+    (rule.warningThresholdPercent < 0 || rule.warningThresholdPercent > 100)
+  ) {
+    errors.warningThresholdPercent = t('budgets.invalidWarningThreshold');
+  }
+
+  if (!hasUsableLimit(rule)) {
+    errors.limits = t('budgets.limitRequired');
+  }
+
+  return errors;
+}
+
 function parseBudgetConfig(policy: unknown): BudgetConfig {
   const config = isRecord(policy) ? policy : {};
   const result = budgetConfigSchema.safeParse(config);
@@ -80,6 +143,23 @@ function parseBudgetConfig(policy: unknown): BudgetConfig {
     return result.data;
   }
   return { enabled: false, rules: [] };
+}
+
+/** Inline form-level error, styled to match the `Input` component's own error
+ *  row (destructive text + leading icon, announced via `role="alert"`). Used
+ *  for the cross-field messages (target / at-least-one-limit) that don't belong
+ *  to a single `Input`. */
+function FieldError({ message }: { message: string }) {
+  return (
+    <p
+      role="alert"
+      aria-live="polite"
+      className="text-destructive flex items-center gap-1.5 text-sm"
+    >
+      <XCircle className="size-4" aria-hidden="true" />
+      {message}
+    </p>
+  );
 }
 
 interface RuleDialogProps {
@@ -105,14 +185,34 @@ function RuleDialog({
 }: RuleDialogProps) {
   const { t } = useT('governance');
   const [draft, setDraft] = useState(initialRule);
+  // Reveal a field's error only once the user has touched it (or has attempted
+  // to submit) so a freshly-opened dialog isn't pre-filled with red. Keyed by
+  // field name; `limits` is the cross-field "at least one limit" group.
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   useEffect(() => {
     if (open) {
       setDraft(initialRule);
+      setTouched({});
+      setSubmitAttempted(false);
     }
   }, [open, initialRule]);
 
   const updateDraft = useCallback((patch: Partial<BudgetRule>) => {
+    setTouched((prev) => {
+      const next = { ...prev };
+      for (const key of Object.keys(patch)) next[key] = true;
+      // Editing any limit field flags the cross-field "at least one limit" group.
+      if (
+        'maxTokens' in patch ||
+        'maxCostCents' in patch ||
+        'maxRequests' in patch
+      ) {
+        next.limits = true;
+      }
+      return next;
+    });
     setDraft((prev) => {
       const updated = { ...prev, ...patch };
       if (patch.scope === 'default' || patch.scope === 'org') {
@@ -122,14 +222,30 @@ function RuleDialog({
     });
   }, []);
 
+  const errors = useMemo(() => validateBudgetRule(draft, t), [draft, t]);
+
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
+      // Guard: never persist a dead rule. Reveal every error and bail.
+      if (Object.keys(validateBudgetRule(draft, t)).length > 0) {
+        setSubmitAttempted(true);
+        return;
+      }
       onSave(draft);
       onOpenChange(false);
     },
-    [draft, onSave, onOpenChange],
+    [draft, t, onSave, onOpenChange],
   );
+
+  // A field's error is shown after it's been touched or a submit was attempted.
+  // The target error also surfaces as soon as a target-requiring scope is
+  // chosen, so the requirement is visible the moment it becomes relevant.
+  const showTargetError =
+    !!errors.scopeId && (submitAttempted || touched.scope || touched.scopeId);
+  const showLimitError = !!errors.limits && (submitAttempted || touched.limits);
+  const fieldError = (key: keyof BudgetRuleErrors) =>
+    submitAttempted || touched[key] ? errors[key] : undefined;
 
   return (
     <FormDialog
@@ -160,6 +276,7 @@ function RuleDialog({
               value={draft.scopeId ?? ''}
               onValueChange={(value) => updateDraft({ scopeId: value })}
               disabled={cannotManage}
+              error={showTargetError}
             />
           )}
 
@@ -175,6 +292,7 @@ function RuleDialog({
                 searchPlaceholder={t('budgets.searchUsers')}
                 emptyText={t('budgets.noUsersFound')}
                 aria-label={t('budgets.selectUserAriaLabel')}
+                error={showTargetError}
               />
             </div>
           )}
@@ -191,6 +309,7 @@ function RuleDialog({
                 searchPlaceholder={t('budgets.searchTeams')}
                 emptyText={t('budgets.noTeamsFound')}
                 aria-label={t('budgets.selectTeamAriaLabel')}
+                error={showTargetError}
               />
             </div>
           )}
@@ -208,6 +327,10 @@ function RuleDialog({
           />
         </Row>
 
+        {showTargetError && errors.scopeId && (
+          <FieldError message={errors.scopeId} />
+        )}
+
         <Stack gap={3}>
           <div>
             <Input
@@ -224,6 +347,7 @@ function RuleDialog({
               disabled={cannotManage}
               placeholder="e.g. 1000000"
               min={0}
+              errorMessage={fieldError('maxTokens')}
             />
             <Text className="text-muted-foreground mt-1 text-xs">
               {t('budgets.tokenLimitHelp')}
@@ -246,6 +370,7 @@ function RuleDialog({
               placeholder="e.g. 50.00"
               min={0}
               step={0.01}
+              errorMessage={fieldError('maxCostCents')}
             />
             <Text className="text-muted-foreground mt-1 text-xs">
               {t('budgets.costLimitHelp')}
@@ -267,11 +392,16 @@ function RuleDialog({
               disabled={cannotManage}
               placeholder="e.g. 500"
               min={0}
+              errorMessage={fieldError('maxRequests')}
             />
             <Text className="text-muted-foreground mt-1 text-xs">
               {t('budgets.maxRequestsHelp')}
             </Text>
           </div>
+
+          {showLimitError && errors.limits && (
+            <FieldError message={errors.limits} />
+          )}
 
           <div>
             <Input
@@ -289,6 +419,7 @@ function RuleDialog({
               placeholder="e.g. 80"
               min={0}
               max={100}
+              errorMessage={fieldError('warningThresholdPercent')}
             />
             <Text className="text-muted-foreground mt-1 text-xs">
               {t('budgets.warningThresholdHelp')}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2759,7 +2759,13 @@
       "searchTeams": "Teams suchen...",
       "noTeamsFound": "Keine Teams gefunden",
       "selectTeamAriaLabel": "Team auswählen",
-      "saved": "Budgetregeln wurden aktualisiert"
+      "saved": "Budgetregeln wurden aktualisiert",
+      "targetRequired": "Wählen Sie ein Ziel für diesen Geltungsbereich, sonst greift die Regel nie.",
+      "limitRequired": "Legen Sie mindestens ein Limit (Tokens, Kosten oder Anfragen) fest, damit die Regel greifen kann.",
+      "invalidTokenLimit": "Das Token-Limit muss null oder größer sein.",
+      "invalidCostLimit": "Das Kostenlimit muss null oder größer sein.",
+      "invalidMaxRequests": "Das Anfragenlimit muss null oder größer sein.",
+      "invalidWarningThreshold": "Der Warnschwellenwert muss zwischen 0 und 100 liegen."
     },
     "defaultModels": {
       "title": "Standardmodelle",

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2762,9 +2762,9 @@
       "saved": "Budgetregeln wurden aktualisiert",
       "targetRequired": "Wählen Sie ein Ziel für diesen Geltungsbereich, sonst greift die Regel nie.",
       "limitRequired": "Legen Sie mindestens ein Limit (Tokens, Kosten oder Anfragen) fest, damit die Regel greifen kann.",
-      "invalidTokenLimit": "Das Token-Limit muss null oder größer sein.",
-      "invalidCostLimit": "Das Kostenlimit muss null oder größer sein.",
-      "invalidMaxRequests": "Das Anfragenlimit muss null oder größer sein.",
+      "invalidTokenLimit": "Das Token-Limit muss größer als null sein.",
+      "invalidCostLimit": "Das Kostenlimit muss größer als null sein.",
+      "invalidMaxRequests": "Das Anfragenlimit muss größer als null sein.",
       "invalidWarningThreshold": "Der Warnschwellenwert muss zwischen 0 und 100 liegen."
     },
     "defaultModels": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2759,7 +2759,13 @@
       "searchTeams": "Search teams...",
       "noTeamsFound": "No teams found",
       "selectTeamAriaLabel": "Select team",
-      "saved": "Budget rules have been updated"
+      "saved": "Budget rules have been updated",
+      "targetRequired": "Select a target for this scope, or the rule will never apply.",
+      "limitRequired": "Set at least one limit (tokens, cost, or requests) so the rule can enforce.",
+      "invalidTokenLimit": "Token limit must be zero or greater.",
+      "invalidCostLimit": "Cost limit must be zero or greater.",
+      "invalidMaxRequests": "Request limit must be zero or greater.",
+      "invalidWarningThreshold": "Warning threshold must be between 0 and 100."
     },
     "defaultModels": {
       "title": "Default Models",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2762,9 +2762,9 @@
       "saved": "Budget rules have been updated",
       "targetRequired": "Select a target for this scope, or the rule will never apply.",
       "limitRequired": "Set at least one limit (tokens, cost, or requests) so the rule can enforce.",
-      "invalidTokenLimit": "Token limit must be zero or greater.",
-      "invalidCostLimit": "Cost limit must be zero or greater.",
-      "invalidMaxRequests": "Request limit must be zero or greater.",
+      "invalidTokenLimit": "Token limit must be greater than zero.",
+      "invalidCostLimit": "Cost limit must be greater than zero.",
+      "invalidMaxRequests": "Request limit must be greater than zero.",
       "invalidWarningThreshold": "Warning threshold must be between 0 and 100."
     },
     "defaultModels": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2763,9 +2763,9 @@
       "saved": "Les règles de budget ont été mises à jour",
       "targetRequired": "Sélectionnez une cible pour cette portée, sinon la règle ne s'appliquera jamais.",
       "limitRequired": "Définissez au moins une limite (jetons, coût ou requêtes) pour que la règle puisse s'appliquer.",
-      "invalidTokenLimit": "La limite de jetons doit être supérieure ou égale à zéro.",
-      "invalidCostLimit": "La limite de coût doit être supérieure ou égale à zéro.",
-      "invalidMaxRequests": "La limite de requêtes doit être supérieure ou égale à zéro.",
+      "invalidTokenLimit": "La limite de jetons doit être supérieure à zéro.",
+      "invalidCostLimit": "La limite de coût doit être supérieure à zéro.",
+      "invalidMaxRequests": "La limite de requêtes doit être supérieure à zéro.",
       "invalidWarningThreshold": "Le seuil d'alerte doit être compris entre 0 et 100."
     },
     "defaultModels": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2760,7 +2760,13 @@
       "searchTeams": "Rechercher des équipes...",
       "noTeamsFound": "Aucune équipe trouvée",
       "selectTeamAriaLabel": "Sélectionner une équipe",
-      "saved": "Les règles de budget ont été mises à jour"
+      "saved": "Les règles de budget ont été mises à jour",
+      "targetRequired": "Sélectionnez une cible pour cette portée, sinon la règle ne s'appliquera jamais.",
+      "limitRequired": "Définissez au moins une limite (jetons, coût ou requêtes) pour que la règle puisse s'appliquer.",
+      "invalidTokenLimit": "La limite de jetons doit être supérieure ou égale à zéro.",
+      "invalidCostLimit": "La limite de coût doit être supérieure ou égale à zéro.",
+      "invalidMaxRequests": "La limite de requêtes doit être supérieure ou égale à zéro.",
+      "invalidWarningThreshold": "Le seuil d'alerte doit être compris entre 0 et 100."
     },
     "defaultModels": {
       "title": "Modèles par défaut",


### PR DESCRIPTION
## Summary

The budget rule editor (Settings → Governance → Budgets) could persist **silently dead rules** that never enforce:
- a `user`/`team`/`role` scope saved with **no target** (`scopeId`) — the enforcer requires a `scopeId` match, so it never applies;
- a rule with **no positive limit** (all of `maxTokens`/`maxCostCents`/`maxRequests` unset/zero) — the enforcer resolves no cap.

The dialog also lacked the inline field-validation parity of the other bounded governance editors (e.g. password policy).

## Changes
- Add `validateBudgetRule()` in `budget-editor.tsx` mirroring the constraints the enforcer relies on.
- Block save in the rule dialog when invalid and surface inline errors:
  - **target required** for user/team/role scopes,
  - **at least one limit required**,
  - per-field bounds (non-negative limits, warning threshold 0–100), wired via `errorMessage` on each numeric `Input` and `error` on the target selectors.
- Errors reveal on touch / submit attempt so a freshly-opened dialog isn't pre-filled with red.
- Add i18n keys (en/de/fr) and unit tests covering the dead-rule guard and the valid-save path.

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` (changed files) — 0 warnings, 0 errors
- `bunx vitest --config vitest.ui.config.ts budget-editor.test.tsx` — 11 passed

Closes #2061