### PR TITLE
fix(platform): stop docker:dev override leaking host-relative network vars

### DIFF
--- a/scripts/docker-dev-env-override.ts
+++ b/scripts/docker-dev-env-override.ts
@@ -49,6 +49,28 @@ const RUNTIME_DENYLIST = new Set([
   'NPM_CONFIG_PREFIX',
   'NPM_CONFIG_UPDATE_NOTIFIER',
   'NoDefaultCurrentDirectoryInExePath',
+  // Host-relative networking vars: their value is meaningful only on the host,
+  // never inside the container, so forwarding them breaks container-internal
+  // networking — the same correctness floor as PATH/HOME above.
+  //   * CONVEX_URL points the host `bun dev` loop at the host-run
+  //     convex-local-backend (127.0.0.1:3210); inside the container the convex
+  //     service is reached at the compose alias http://convex:3210 (the
+  //     entrypoint's own default). A forwarded host value makes 127.0.0.1
+  //     resolve to the platform container itself → Convex unreachable.
+  //   * HTTP(S)_PROXY/ALL_PROXY point at a host-local proxy (e.g. an xray/v2ray
+  //     listener on 127.0.0.1). undici (Node `fetch`, used by `convex env set`
+  //     and friends) honors them and routes to 127.0.0.1 *inside* the
+  //     container, where nothing listens → `TypeError: fetch failed`. The
+  //     platform makes zero proxied outbound, so it never needs them.
+  'CONVEX_URL',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
 ]);
 
 const entries: string[] = [];


### PR DESCRIPTION
## Problem

`bun run docker:dev` fails to boot the stack on a developer machine that uses a local HTTP proxy. Two distinct failures, one root cause.

`scripts/docker-dev-env-override.ts` forwards the host's `process.env` into the `platform` container so developer-exported vars (provider keys, app config) reach it without compose edits. It forwarded **everything** except a small OS/shell `RUNTIME_DENYLIST` (`PATH`/`HOME`/…), so **host-relative networking vars leaked in** and broke container-internal networking:

- **`CONVEX_URL=http://127.0.0.1:3210`** (the value the host `bun dev` loop uses to reach the host-run convex-local-backend) overrode the container's correct default `http://convex:3210`. Inside the container `127.0.0.1` is the platform container itself → Convex unreachable → entrypoint times out waiting on `/version`:
  ```
  ERROR Convex service /version failed to respond within 120s
  ```
- **`HTTP_PROXY`/`HTTPS_PROXY=http://127.0.0.1:10808`** (a host-local xray/v2ray listener) made undici (Node `fetch`, used by `convex env set`) route to a port nothing listens on *inside* the container → `TypeError: fetch failed` after 6 retries (~34s each). The WebSocket-based `convex env list` ignores the proxy and worked, which is what made this confusing:
  ```
  WARN  Failed to set BETTER_AUTH_SECRET (value length: 43)
  WARN  Failed to set DB_PASSWORD (value length: 23)
  ```

## Fix

Add `CONVEX_URL` and the `HTTP(S)_PROXY` / `ALL_PROXY` / `NO_PROXY` family (both cases) to `RUNTIME_DENYLIST`, alongside `PATH`/`HOME` — these are the same class of var: meaningful only on the host, never inside the container. The container falls back to its own correct defaults. The host keeps its proxy for builds and image pulls; the platform makes zero proxied outbound, so it never needs these.

## Verification

Reproduced on a machine with `HTTP_PROXY=HTTPS_PROXY=http://127.0.0.1:10808` exported. After the change, re-ran `bun run docker:dev`:

- Platform container env no longer contains the proxy vars; `CONVEX_URL=http://convex:3210`.
- Env-sync: **153 sets succeeded, 0 failures** (previously every set failed after ~34s).
- `✔ Deployed Convex functions to http://convex:3210` → `Platform ready` → all services `healthy`.

## Note

Host **desktop-session junk** vars (`SESSION_MANAGER`, `QT_ACCESSIBILITY`, …) are still forwarded and now successfully land in the Convex deployment env — cosmetic pollution, not breaking. Tightening the override to forward only useful vars is left as a separate follow-up.