### PR TITLE
fix: add missing i18n key apps.runs.backToApp (#2022)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -179,6 +179,7 @@
       "colStatus": "Status",
       "colStarted": "Gestartet",
       "watchLive": "Live ansehen",
+      "backToApp": "Zurück zur App",
       "queuedForCapacity": "Wartet auf Kapazität",
       "queuedForCapacityHint": "Wartet auf einen freien Sandbox-Platz. Startet automatisch, sobald Kapazität frei wird."
     },

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -179,6 +179,7 @@
       "colStatus": "Status",
       "colStarted": "Started",
       "watchLive": "Watch live",
+      "backToApp": "Back to app",
       "queuedForCapacity": "Queued for capacity",
       "queuedForCapacityHint": "Waiting for a free sandbox slot. Starts automatically once capacity frees up."
     },

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -179,6 +179,7 @@
       "colStatus": "Statut",
       "colStarted": "Démarré",
       "watchLive": "Voir en direct",
+      "backToApp": "Retour à l'application",
       "queuedForCapacity": "En attente de capacité",
       "queuedForCapacityHint": "En attente d'un emplacement de sandbox libre. Démarre automatiquement dès qu'une capacité se libère."
     },


### PR DESCRIPTION
## Summary

Adds the missing `apps.runs.backToApp` i18n key so the "Back to app" breadcrumb link on app execution detail pages is translatable instead of relying on the hard-coded `defaultValue: 'Back to app'`.

Both route files reference `t('runs.backToApp', { defaultValue: 'Back to app' })`:
- `services/platform/app/routes/dashboard/$id/apps/$appSlug/runs/$executionId.tsx`
- `services/platform/app/routes/dashboard/$id/projects/$projectId/apps/$appSlug/runs/$executionId.tsx`

## Changes

- `services/platform/messages/en.json` — add `apps.runs.backToApp: "Back to app"`
- `services/platform/messages/de.json` — add `apps.runs.backToApp: "Zurück zur App"`
- `services/platform/messages/fr.json` — add `apps.runs.backToApp: "Retour à l'application"`

(`de-CH.json` has no `apps.runs` block and falls back to `de`, so it is left unchanged.)

Closes #2022