### PR TITLE
fix: scope getByStorageIds to caller's org to close cross-tenant leak (#2027)

### DIFF
--- a/services/platform/app/features/automations/hooks/use-assistant-chat.ts
+++ b/services/platform/app/features/automations/hooks/use-assistant-chat.ts
@@ -77,13 +77,15 @@ export function useAssistantChat({
     removeAttachment,
     clearAttachments,
   } = useConvexFileUpload({ organizationId });
-  const { isIndexing, statusMap: indexingStatuses } =
-    useFileIndexingStatus(attachments);
+  const { isIndexing, statusMap: indexingStatuses } = useFileIndexingStatus(
+    attachments,
+    organizationId,
+  );
   const {
     isTranscribing,
     isQueryLoading: isTranscriptionQueryLoading,
     statusMap: transcriptionStatuses,
-  } = useFileTranscriptionStatus(attachments);
+  } = useFileTranscriptionStatus(attachments, organizationId);
   const [inputValue, setInputValue] = useState('');
   const [isPending, setIsPending] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);

--- a/services/platform/app/features/chat/components/chat-interface.tsx
+++ b/services/platform/app/features/chat/components/chat-interface.tsx
@@ -228,15 +228,17 @@ export function ChatInterface({
     disableIndexing: isExternalAgentThread,
   });
 
-  const { isIndexing, statusMap: indexingStatuses } =
-    useFileIndexingStatus(attachments);
+  const { isIndexing, statusMap: indexingStatuses } = useFileIndexingStatus(
+    attachments,
+    organizationId,
+  );
 
   const {
     isTranscribing,
     isQueryLoading: isTranscriptionQueryLoading,
     statusMap: transcriptionStatuses,
     hasFailedAudioJobs,
-  } = useFileTranscriptionStatus(attachments);
+  } = useFileTranscriptionStatus(attachments, organizationId);
 
   const {
     jobs: videoLinkJobs,

--- a/services/platform/app/features/chat/components/message-bubble.tsx
+++ b/services/platform/app/features/chat/components/message-bubble.tsx
@@ -888,6 +888,7 @@ function MessageBubbleComponent({
                 <FileAttachmentDisplay
                   key={attachment.fileId}
                   attachment={attachment}
+                  organizationId={organizationId}
                   onImageClick={
                     galleryIdx >= 0 ? () => openGallery(galleryIdx) : undefined
                   }

--- a/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
+++ b/services/platform/app/features/chat/components/message-bubble/file-displays.tsx
@@ -173,9 +173,11 @@ export function FileTypeIcon({
 
 export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
   attachment,
+  organizationId,
   onImageClick,
 }: {
   attachment: FileAttachment;
+  organizationId?: string;
   onImageClick?: () => void;
 }) {
   const { t } = useT('chat');
@@ -191,7 +193,9 @@ export const FileAttachmentDisplay = memo(function FileAttachmentDisplay({
   // the existing plural query (skip when not media to avoid subscriptions).
   const audioMetadataList = useQuery(
     api.file_metadata.queries.getByStorageIds,
-    isMedia ? { storageIds: [attachment.fileId] } : 'skip',
+    isMedia && organizationId
+      ? { organizationId, storageIds: [attachment.fileId] }
+      : 'skip',
   );
   const audioMetadata = audioMetadataList?.[0];
   const canPreviewTranscript =

--- a/services/platform/app/features/chat/components/source-cards.tsx
+++ b/services/platform/app/features/chat/components/source-cards.tsx
@@ -102,7 +102,9 @@ function SourceCardsComponent({ citations, organizationId }: SourceCardsProps) {
   }, [sourceList]);
   const fileMetas = useQuery(
     api.file_metadata.queries.getByStorageIds,
-    uniqueRagFileIds.length > 0 ? { storageIds: uniqueRagFileIds } : 'skip',
+    organizationId && uniqueRagFileIds.length > 0
+      ? { organizationId, storageIds: uniqueRagFileIds }
+      : 'skip',
   );
   const metaByFileId = useMemo(() => {
     const map = new Map<

--- a/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
@@ -27,7 +27,10 @@ const POLL_INTERVAL_MS = 3_000;
  *   while any file is in queued/running state. Polling stops automatically
  *   when the user leaves the page or all files finish indexing.
  */
-export function useFileIndexingStatus(attachments: FileAttachment[]) {
+export function useFileIndexingStatus(
+  attachments: FileAttachment[],
+  organizationId: string,
+) {
   const fileIds = useMemo(
     () =>
       attachments
@@ -38,7 +41,9 @@ export function useFileIndexingStatus(attachments: FileAttachment[]) {
 
   const metadata = useQuery(
     api.file_metadata.queries.getByStorageIds,
-    fileIds.length > 0 ? { storageIds: fileIds } : 'skip',
+    organizationId && fileIds.length > 0
+      ? { organizationId, storageIds: fileIds }
+      : 'skip',
   );
 
   const statusMap = useMemo(() => {

--- a/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-transcription-status.ts
@@ -41,7 +41,10 @@ export interface FileTranscriptionInfo {
  * during the brief window before metadata first resolves (prevents a rapid
  * click from slipping past a not-yet-known `running` state).
  */
-export function useFileTranscriptionStatus(attachments: FileAttachment[]) {
+export function useFileTranscriptionStatus(
+  attachments: FileAttachment[],
+  organizationId: string,
+) {
   const audioFileIds = useMemo(
     () =>
       attachments
@@ -52,7 +55,9 @@ export function useFileTranscriptionStatus(attachments: FileAttachment[]) {
 
   const metadata = useQuery(
     api.file_metadata.queries.getByStorageIds,
-    audioFileIds.length > 0 ? { storageIds: audioFileIds } : 'skip',
+    organizationId && audioFileIds.length > 0
+      ? { organizationId, storageIds: audioFileIds }
+      : 'skip',
   );
 
   const isQueryLoading = audioFileIds.length > 0 && metadata === undefined;

--- a/services/platform/app/features/tasks/components/task-attachments.tsx
+++ b/services/platform/app/features/tasks/components/task-attachments.tsx
@@ -26,6 +26,7 @@ export function TaskAttachments({
   uploadingFiles,
   canEdit,
   disabled,
+  organizationId,
   onUpload,
   onRemove,
 }: {
@@ -33,6 +34,7 @@ export function TaskAttachments({
   uploadingFiles: string[];
   canEdit: boolean;
   disabled?: boolean;
+  organizationId: string;
   onUpload: (files: File[]) => void;
   onRemove: (fileId: Id<'_storage'>) => void;
 }) {
@@ -52,7 +54,10 @@ export function TaskAttachments({
         <Row gap={2} wrap align="start">
           {attachments.map((attachment) => (
             <div key={attachment.fileId} className="group relative">
-              <FileAttachmentDisplay attachment={attachment} />
+              <FileAttachmentDisplay
+                attachment={attachment}
+                organizationId={organizationId}
+              />
               {canEdit && (
                 <button
                   type="button"

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -326,6 +326,7 @@ function CreateTaskBody({
             uploadingFiles={uploadingFiles}
             canEdit
             disabled={submitting}
+            organizationId={organizationId}
             onUpload={(files) => void uploadFiles(files)}
             onRemove={removeAttachment}
           />
@@ -566,6 +567,7 @@ function EditTaskBody({
             attachments={task.attachments ?? []}
             uploadingFiles={uploadingFiles}
             canEdit={canEdit}
+            organizationId={task.organizationId}
             onUpload={onUploadAttachments}
             onRemove={onRemoveAttachment}
           />

--- a/services/platform/convex/file_metadata/queries.test.ts
+++ b/services/platform/convex/file_metadata/queries.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      id: stub,
+      object: stub,
+      union: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+    },
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    query: (config: Record<string, unknown>) => config,
+  };
+});
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+/**
+ * Mock ctx whose `by_storageId` lookup resolves each storageId to a row from
+ * `rowsByStorageId` (or null when absent). Each `.map` iteration builds a fresh
+ * query → withIndex → first chain, so we capture the eq'd storageId per chain.
+ */
+function createMockCtx(rowsByStorageId: Record<string, unknown>) {
+  const ctx = {
+    db: {
+      query: vi.fn(() => {
+        let captured: string | undefined;
+        const builder = {
+          withIndex: vi.fn((_index: string, cb: (q: unknown) => unknown) => {
+            const q = {
+              eq: (_field: string, value: string) => {
+                captured = value;
+                return q;
+              },
+            };
+            cb(q);
+            return builder;
+          }),
+          first: vi.fn(async () =>
+            captured ? (rowsByStorageId[captured] ?? null) : null,
+          ),
+        };
+        return builder;
+      }),
+    },
+  };
+  return ctx;
+}
+
+async function getHandler() {
+  const { getByStorageIds } = await import('./queries');
+  return (getByStorageIds as unknown as { handler: Function }).handler;
+}
+
+const AUTH_USER = {
+  userId: 'user_1',
+  email: 'test@example.com',
+  name: 'Test User',
+};
+
+const ownRow = {
+  organizationId: 'org_A',
+  storageId: 'storage_own',
+  fileName: 'own.pdf',
+  contentType: 'application/pdf',
+  size: 10,
+  transcript: 'mine',
+  _creationTime: 1,
+};
+
+const foreignRow = {
+  organizationId: 'org_B',
+  storageId: 'storage_foreign',
+  fileName: 'secret.mp3',
+  contentType: 'audio/mpeg',
+  size: 20,
+  transcript: 'cross-tenant secret transcript',
+  _creationTime: 2,
+};
+
+describe('getByStorageIds (public) — RLS', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOrganizationMember.mockResolvedValue({ _id: 'member_1' });
+  });
+
+  it('returns [] for unauthenticated callers', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(null);
+    const ctx = createMockCtx({});
+    const handler = await getHandler();
+
+    const result = await handler(ctx, {
+      organizationId: 'org_A',
+      storageIds: ['storage_own'],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockGetOrganizationMember).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when the caller is not a member of the org', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    mockGetOrganizationMember.mockRejectedValue(new Error('Not a member'));
+    const ctx = createMockCtx({ storage_own: ownRow });
+    const handler = await getHandler();
+
+    const result = await handler(ctx, {
+      organizationId: 'org_A',
+      storageIds: ['storage_own'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('filters out rows belonging to a different organization', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx({ storage_foreign: foreignRow });
+    const handler = await getHandler();
+
+    // Caller is a member of org_A but asks for a storageId owned by org_B.
+    const result = await handler(ctx, {
+      organizationId: 'org_A',
+      storageIds: ['storage_foreign'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns metadata for in-tenant storage ids', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx({
+      storage_own: ownRow,
+      storage_foreign: foreignRow,
+    });
+    const handler = await getHandler();
+
+    const result = await handler(ctx, {
+      organizationId: 'org_A',
+      storageIds: ['storage_own', 'storage_foreign'],
+    });
+
+    // Only the org_A row comes back; the org_B row is filtered.
+    expect(result).toHaveLength(1);
+    expect(result[0].storageId).toBe('storage_own');
+    expect(result[0].transcript).toBe('mine');
+  });
+});

--- a/services/platform/convex/file_metadata/queries.ts
+++ b/services/platform/convex/file_metadata/queries.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 
 export const getUserStorageUsage = query({
   args: {
@@ -65,6 +66,7 @@ export const getByDocumentId = query({
 
 export const getByStorageIds = query({
   args: {
+    organizationId: v.string(),
     storageIds: v.array(v.id('_storage')),
   },
   returns: v.array(
@@ -116,6 +118,25 @@ export const getByStorageIds = query({
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) return [];
 
+    // RLS: only members of the named org may read its file metadata. Without
+    // this, any authenticated user could pass a foreign storageId and pull
+    // back another tenant's fileName/transcript/RAG state (issue #2027). The
+    // soft-fail to `[]` matches the reactive-subscription contract used across
+    // these queries (a non-member must not throw and white-screen the chip).
+    try {
+      await getOrganizationMember(ctx, args.organizationId, {
+        userId: authUser.userId,
+        email: authUser.email,
+        name: authUser.name,
+      });
+    } catch (error) {
+      console.warn(
+        '[fileMetadata.queries.getByStorageIds] org membership lookup failed:',
+        error instanceof Error ? error.message : error,
+      );
+      return [];
+    }
+
     const results = await Promise.all(
       args.storageIds.slice(0, 20).map(async (storageId) => {
         const meta = await ctx.db
@@ -123,6 +144,11 @@ export const getByStorageIds = query({
           .withIndex('by_storageId', (q) => q.eq('storageId', storageId))
           .first();
         if (!meta) return null;
+        // Per-row tenant scope: the storageId index is global, so a row whose
+        // organizationId differs from the verified caller's org is filtered
+        // out even though the membership check above passed for a *different*
+        // org the caller does belong to.
+        if (meta.organizationId !== args.organizationId) return null;
         return {
           storageId: meta.storageId,
           documentId: meta.documentId,


### PR DESCRIPTION
## Summary

`fileMetadata.queries.getByStorageIds` confirmed login via `getAuthUserIdentity` but then performed an unguarded `by_storageId` index lookup with **no organization scoping**. Any authenticated user could pass a foreign `_storage` id and read another tenant's `fileName`, `contentType`, `transcript`, and RAG/processing metadata — cross-tenant data exposure (issue #2027).

## Fix

- Add a required `organizationId` argument to `getByStorageIds` (mirrors `getByDocumentId`).
- Verify the caller is a member of that org via `getOrganizationMember`, soft-failing to `[]` on non-membership to preserve the reactive-subscription contract (a non-member must not throw and break the chip UI).
- Filter every returned row by `meta.organizationId === args.organizationId`, so a foreign-tenant row is dropped even when the caller is a member of *some* org.
- Thread `organizationId` through all four call sites (`source-cards`, `file-displays`/`FileAttachmentDisplay`, `use-file-indexing-status`, `use-file-transcription-status`) and their parents (`chat-interface`, `use-assistant-chat`, `message-bubble`, `task-attachments` → `task-modal`); each `useQuery` skips until an org id is present.

## Tests

Added `convex/file_metadata/queries.test.ts` covering: unauthenticated → `[]`, non-member → `[]`, foreign-org row filtered out, in-tenant rows returned.

Verified locally: `tsc --noEmit`, `oxlint --type-aware`, server vitest (file_metadata suite + new test), and `migrations:check` all green.

Closes #2027