### PR TITLE
fix(platform): coerce automations metrics period search param (#2024)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/automations/metrics.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/automations/metrics.search.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchSchema } from './metrics';
+
+// Regression coverage for #2024: a shared/bookmarked
+// `/automations/metrics?period=90` URL is parsed by the router as the JSON
+// number 90, which must not crash the route via SearchParamError.
+describe('automations metrics searchSchema', () => {
+  it('coerces numeric period values to the string enum', () => {
+    expect(searchSchema.parse({ period: 90 }).period).toBe('90');
+    expect(searchSchema.parse({ period: 30 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 7 }).period).toBe('7');
+  });
+
+  it('accepts string period values', () => {
+    expect(searchSchema.parse({ period: '90' }).period).toBe('90');
+  });
+
+  it('falls back to the default window for out-of-range values', () => {
+    expect(searchSchema.parse({ period: 999 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 'nonsense' }).period).toBe('30');
+  });
+
+  it('leaves an omitted period undefined', () => {
+    expect(searchSchema.parse({}).period).toBeUndefined();
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/automations/metrics.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/metrics.tsx
@@ -11,8 +11,16 @@ import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
 import { useT } from '@/lib/i18n/client';
 import { seo } from '@/lib/utils/seo';
 
-const searchSchema = z.object({
-  period: z.enum(['7', '30', '90']).optional(),
+export const searchSchema = z.object({
+  // The router parses a bare `?period=90` as the JSON number 90, which fails a
+  // plain string enum and crashes the page (issue #2024). Coerce to a string
+  // first, then fall back to the default window for any out-of-range value so a
+  // shared/bookmarked URL never renders the error boundary.
+  period: z.coerce
+    .string()
+    .pipe(z.enum(['7', '30', '90']))
+    .catch('30')
+    .optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/automations/metrics')({


### PR DESCRIPTION
## Summary

A shared or bookmarked `/automations/metrics?period=90` (or `?period=30`/`?period=7`) URL crashed the page with a full-page error boundary. TanStack Router parses the bare `90` as the JSON number `90`, which fails the string `z.enum(['7','30','90'])` and throws `SearchParamError`.

This coerces the value to a string, validates it against the enum, and falls back to the default 30-day window for any out-of-range value — so a shared/bookmarked URL loads correctly and an invalid period degrades gracefully instead of crashing.

Same root cause and fix pattern as #1987 (agents metrics page), which remains a separate open issue.

## Changes
- `services/platform/app/routes/dashboard/$id/automations/metrics.tsx`: `period` schema is now `z.coerce.string().pipe(z.enum(['7','30','90'])).catch('30').optional()`.
- Added `metrics.search.test.ts` regression coverage: numeric coercion, string passthrough, out-of-range fallback, and omitted-param cases.

## Verification
- `bunx vitest --run --project server` on the new test — 4 passed.
- `bunx tsc --noEmit` — clean.
- `bunx oxlint --type-aware` on changed files — 0 warnings, 0 errors.

Closes #2024