### PR TITLE
refactor(proxy): default the dev host to localhost instead of tale.local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,10 @@
 #     HOST=example.com
 #     SITE_URL=https://example.com:8443
 #   Development:
-#     HOST=tale.local
-#     SITE_URL=https://tale.local
-HOST=tale.local
-SITE_URL=https://tale.local
+#     HOST=localhost
+#     SITE_URL=https://localhost
+HOST=localhost
+SITE_URL=https://localhost
 # Optional: Base path for subpath deployments behind a reverse proxy
 # Example: BASE_PATH=/app for accessing via https://example.com/app/
 # Leave empty or unset for root deployments

--- a/.env.test
+++ b/.env.test
@@ -5,8 +5,8 @@
 # DO NOT use these values in production.
 
 # Domain (required by all services)
-HOST=tale.local
-SITE_URL=https://tale.local
+HOST=localhost
+SITE_URL=https://localhost
 
 # TLS
 TLS_MODE=selfsigned

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -37,8 +37,8 @@
 # Each value is `${VAR:-default}`: an env var or .env entry overrides it.
 # -----------------------------------------------------------------------------
 x-dev-secrets: &dev-secrets
-  HOST: ${HOST:-tale.local}
-  SITE_URL: ${SITE_URL:-https://tale.local}
+  HOST: ${HOST:-localhost}
+  SITE_URL: ${SITE_URL:-https://localhost}
   TLS_MODE: ${TLS_MODE:-selfsigned}
   DB_PASSWORD: ${DB_PASSWORD:-tale_dev_password}
   KNOWLEDGE_DB_NAME: ${KNOWLEDGE_DB_NAME:-tale_knowledge}

--- a/compose.yml
+++ b/compose.yml
@@ -246,7 +246,7 @@ services:
       # Independent convex data volume. Once Phase 2 migration completes, this
       # contains everything platform-data previously held under /app/data/.
       - convex-data:/app/data
-      # Caddy self-signed CA (for Rust backend → tale.local outbound HTTPS).
+      # Caddy self-signed CA (so the Rust backend trusts outbound HTTPS to the proxy).
       - caddy-data:/caddy-data:ro
 
     env_file:
@@ -309,7 +309,7 @@ services:
       args:
         VERSION: ${VERSION:-dev}
 
-    # No port mapping needed - accessed via proxy at https://tale.local (or your domain)
+    # No port mapping needed - accessed via proxy at https://localhost (or your domain)
     # internally via http://platform:3000
 
     # Volume mounts — Phase 2 split:
@@ -395,7 +395,7 @@ services:
   #
   # For local development:
   #   - Run: docker compose up
-  #   - Access: https://tale.local (self-signed cert, browser warning expected)
+  #   - Access: https://localhost (self-signed cert, browser warning expected)
   #   - To trust certs: docker exec tale-proxy caddy trust
   #
   # For production with HTTPS:
@@ -475,13 +475,15 @@ services:
     # Networks
     networks:
       internal:
-        # Hairpin NAT resolution via network alias
-        # This allows containers to resolve HOST to the proxy container
-        # via Docker's internal DNS, solving the hairpin NAT issue.
-        # Use app.localhost (or another real hostname) instead of localhost
-        # because localhost is always in /etc/hosts and can't be overridden.
+        # Network alias so a container resolving the *public* HOST lands on the
+        # proxy via Docker's internal DNS (hairpin NAT). For the default
+        # `localhost` this alias is inert — every container's /etc/hosts pins
+        # `localhost` to 127.0.0.1, which shadows Docker DNS — and that is fine:
+        # the platform makes no server-side calls to its own public URL (no SSR;
+        # internal traffic uses Docker service names / the internal Convex URL).
+        # The alias still does real work when HOST is a custom domain.
         aliases:
-          - ${HOST:-tale.local}
+          - ${HOST:-localhost}
 
   # ============================================================================
   # Tale Sandbox Egress (tinyproxy) — HTTPS forward proxy

--- a/docs/de/self-hosted/configuration/authentication.md
+++ b/docs/de/self-hosted/configuration/authentication.md
@@ -15,8 +15,8 @@ Greif danach auf kleinen Instanzen und Air-gapped-Deployments, wo das Hinzufüge
 
 ```bash
 # .env — keine Flags für lokales Passwort nötig
-HOST=tale.local
-SITE_URL=https://tale.local
+HOST=localhost
+SITE_URL=https://localhost
 BETTER_AUTH_SECRET=...
 ```
 

--- a/docs/de/self-hosted/configuration/environment-reference.md
+++ b/docs/de/self-hosted/configuration/environment-reference.md
@@ -19,11 +19,11 @@ Die `.env.example`-Datei bringt Inline-Kommentare mit, die jede Variable im Kont
 
 ## Domain-Identität (Pflicht beim ersten Boot)
 
-| Name        | Default              | Beschreibung                                                                                                                   |
-| ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `HOST`      | `tale.local`         | **Pflicht.** Hostname ohne Protokoll. Wird für Docker-Networking und ausgehende Mails verwendet.                               |
-| `SITE_URL`  | `https://tale.local` | **Pflicht.** Vollständige kanonische URL inklusive Schema und Port. Auth-Callbacks und externe Links nutzen das.               |
-| `BASE_PATH` | unset                | **Optional.** Pfad-Präfix für Subpath-Deployments hinter einem Reverse-Proxy (z. B. `/app`). Bei Root-Deployment unset lassen. |
+| Name        | Default             | Beschreibung                                                                                                                   |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `HOST`      | `localhost`         | **Pflicht.** Hostname ohne Protokoll. Wird für Docker-Networking und ausgehende Mails verwendet.                               |
+| `SITE_URL`  | `https://localhost` | **Pflicht.** Vollständige kanonische URL inklusive Schema und Port. Auth-Callbacks und externe Links nutzen das.               |
+| `BASE_PATH` | unset               | **Optional.** Pfad-Präfix für Subpath-Deployments hinter einem Reverse-Proxy (z. B. `/app`). Bei Root-Deployment unset lassen. |
 
 Die `SITE_URL` muss exakt mit dem übereinstimmen, was der Benutzer im Browser eingibt. Ein nachgestellter Slash, ein fehlender Port oder `http` statt `https` brechen den Auth-Callback und produzieren Sign-in-Schleifen.
 

--- a/docs/de/self-hosted/install/cli-install.md
+++ b/docs/de/self-hosted/install/cli-install.md
@@ -100,7 +100,7 @@ Befehle beenden mit `0` bei Erfolg, `2` bei einem Nutzungsfehler, `3` bei einer 
 
 - `-d, --detach` — im Hintergrund laufen statt Logs zu streamen.
 - `-p, --port <port>` — auszugebender HTTPS-Port (Standard `443`).
-- `--host <hostname>` — Host-Alias für den Proxy (Standard `tale.local`).
+- `--host <hostname>` — Host-Alias für den Proxy (Standard `localhost`).
 - `-y, --yes` — nicht-interaktiv: Abfragen automatisch akzeptieren (z. B. Docker installieren oder starten).
 
 `tale deploy` — Blue-Green-Deployment ohne Ausfallzeit der aktuellen CLI-Version. Beim ersten Deploy fragt es nach deiner Produktiv-Domain und der Let's-Encrypt-E-Mail (oder übergib `--host`).

--- a/docs/en/self-hosted/configuration/authentication.md
+++ b/docs/en/self-hosted/configuration/authentication.md
@@ -15,8 +15,8 @@ Reach for it on small instances and air-gapped deployments where adding an IdP i
 
 ```bash
 # .env — no flags needed for local password
-HOST=tale.local
-SITE_URL=https://tale.local
+HOST=localhost
+SITE_URL=https://localhost
 BETTER_AUTH_SECRET=...
 ```
 

--- a/docs/en/self-hosted/configuration/environment-reference.md
+++ b/docs/en/self-hosted/configuration/environment-reference.md
@@ -19,11 +19,11 @@ The `.env.example` file ships with inline comments that explain each variable in
 
 ## Domain identity (required at first boot)
 
-| Name        | Default              | Description                                                                                                               |
-| ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `HOST`      | `tale.local`         | **Required.** Hostname without protocol. Used for Docker networking and outbound email.                                   |
-| `SITE_URL`  | `https://tale.local` | **Required.** Full canonical URL including scheme and any non-standard port. Auth callbacks and external links use this.  |
-| `BASE_PATH` | unset                | **Optional.** Path prefix for subpath deployments behind a reverse proxy (e.g. `/app`). Leave unset for root deployments. |
+| Name        | Default             | Description                                                                                                               |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `HOST`      | `localhost`         | **Required.** Hostname without protocol. Used for Docker networking and outbound email.                                   |
+| `SITE_URL`  | `https://localhost` | **Required.** Full canonical URL including scheme and any non-standard port. Auth callbacks and external links use this.  |
+| `BASE_PATH` | unset               | **Optional.** Path prefix for subpath deployments behind a reverse proxy (e.g. `/app`). Leave unset for root deployments. |
 
 The `SITE_URL` must match what the user types in the browser exactly. A trailing slash, a missing port, or `http` instead of `https` will break the auth callback and produce sign-in loops.
 

--- a/docs/en/self-hosted/install/cli-install.md
+++ b/docs/en/self-hosted/install/cli-install.md
@@ -100,7 +100,7 @@ Commands exit `0` on success, `2` on a usage error, `3` on an unmet precondition
 
 - `-d, --detach` — run in the background instead of streaming logs.
 - `-p, --port <port>` — HTTPS port to expose (default `443`).
-- `--host <hostname>` — host alias for the proxy (default `tale.local`).
+- `--host <hostname>` — host alias for the proxy (default `localhost`).
 - `-y, --yes` — non-interactive: auto-accept prompts (e.g. installing or starting Docker).
 
 `tale deploy` — blue-green, zero-downtime deploy of the current CLI version. On the first deploy it prompts for your production domain and Let's Encrypt email (or pass `--host`).

--- a/docs/fr/self-hosted/configuration/authentication.md
+++ b/docs/fr/self-hosted/configuration/authentication.md
@@ -15,8 +15,8 @@ Choisis-le sur les petites instances et les déploiements auto-hébergés air-ga
 
 ```bash
 # .env — pas de flag nécessaire pour le mot de passe local
-HOST=tale.local
-SITE_URL=https://tale.local
+HOST=localhost
+SITE_URL=https://localhost
 BETTER_AUTH_SECRET=...
 ```
 

--- a/docs/fr/self-hosted/configuration/environment-reference.md
+++ b/docs/fr/self-hosted/configuration/environment-reference.md
@@ -19,11 +19,11 @@ Le fichier `.env.example` ship des commentaires inline qui expliquent chaque var
 
 ## Identité de domaine (obligatoire au premier boot)
 
-| Nom         | Défaut               | Description                                                                                                                               |
-| ----------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `HOST`      | `tale.local`         | **Obligatoire.** Nom d'hôte sans protocole. Utilisé pour le réseau Docker et le mail sortant.                                             |
-| `SITE_URL`  | `https://tale.local` | **Obligatoire.** URL canonique complète incluant le schéma et tout port non standard. Les callbacks d'auth l'utilisent.                   |
-| `BASE_PATH` | non défini           | **Optionnel.** Préfixe de chemin pour les déploiements en sous-chemin derrière un reverse proxy (ex. `/app`). Laisse vide pour la racine. |
+| Nom         | Défaut              | Description                                                                                                                               |
+| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `HOST`      | `localhost`         | **Obligatoire.** Nom d'hôte sans protocole. Utilisé pour le réseau Docker et le mail sortant.                                             |
+| `SITE_URL`  | `https://localhost` | **Obligatoire.** URL canonique complète incluant le schéma et tout port non standard. Les callbacks d'auth l'utilisent.                   |
+| `BASE_PATH` | non défini          | **Optionnel.** Préfixe de chemin pour les déploiements en sous-chemin derrière un reverse proxy (ex. `/app`). Laisse vide pour la racine. |
 
 Le `SITE_URL` doit correspondre exactement à ce que l'utilisateur tape dans le navigateur. Un slash en queue, un port manquant ou `http` au lieu de `https` cassent le callback d'auth et produisent des boucles de sign-in.
 

--- a/docs/fr/self-hosted/install/cli-install.md
+++ b/docs/fr/self-hosted/install/cli-install.md
@@ -100,7 +100,7 @@ Les commandes se terminent avec `0` en cas de succès, `2` pour une erreur d'uti
 
 - `-d, --detach` — s'exécuter en arrière-plan au lieu de diffuser les logs.
 - `-p, --port <port>` — port HTTPS à exposer (par défaut `443`).
-- `--host <hostname>` — alias d'hôte pour le proxy (par défaut `tale.local`).
+- `--host <hostname>` — alias d'hôte pour le proxy (par défaut `localhost`).
 - `-y, --yes` — non-interactif : accepter automatiquement les invites (p. ex. installer ou démarrer Docker).
 
 `tale deploy` — déploiement blue-green sans interruption de la version actuelle du CLI. Au premier déploiement, il demande votre domaine de production et l'e-mail Let's Encrypt (ou passez `--host`).

--- a/services/convex/docker-entrypoint.sh
+++ b/services/convex/docker-entrypoint.sh
@@ -18,7 +18,7 @@ FORCE_SEED="${FORCE_SEED:-false}"
 # ----------------------------------------------------------------------------
 # Responsibilities (see plan: "Convex as a database"):
 #   1. Privilege drop (root → uid 1001 app)
-#   2. CA cert trust (for Rust backend → tale.local outbound HTTPS)
+#   2. CA cert trust (for Rust backend → proxy outbound HTTPS, self-signed)
 #   3. Builtin JSON seed (version-marker gated, idempotent)
 #   4. Start convex-local-backend
 #   5. Start Convex Dashboard (Next.js standalone) with basePath injection
@@ -184,8 +184,11 @@ if [ "${TLS_MODE:-selfsigned}" != "letsencrypt" ] && \
 
   log_info "Waiting for Caddy CA certificate at ${CA_CERT_PATH}..."
   while [ ! -f "${CA_CERT_PATH}" ] && [ "$waited" -lt "$CA_WAIT_TIMEOUT" ]; do
-    # Trigger certificate generation by making an insecure request to Caddy
-    curl -sk "https://${HOST:-tale.local}/health" >/dev/null 2>&1 || true
+    # Trigger certificate generation by making an insecure request to Caddy.
+    # Reach the proxy by its Docker service name, not ${HOST}: with the default
+    # HOST=localhost, `https://localhost` resolves to this container's own
+    # loopback (never the proxy), so the warmup would hit nothing.
+    curl -sk "https://proxy/health" >/dev/null 2>&1 || true
     sleep "$CA_WAIT_INTERVAL"
     waited=$((waited + CA_WAIT_INTERVAL))
   done

--- a/services/platform/convex/agent_tools/files/helpers/analyze_image.ts
+++ b/services/platform/convex/agent_tools/files/helpers/analyze_image.ts
@@ -3,7 +3,7 @@
  * Extracts detailed content from images (text, data, etc.)
  *
  * NOTE: We use binary data instead of the SDK's getFile() approach because:
- * - getFile() returns URLs like https://tale.local/... which are internal URLs
+ * - getFile() returns URLs like https://localhost/... which are internal URLs
  * - External vision APIs (OpenRouter, etc.) cannot access these internal URLs
  * - Binary data embeds the image directly, bypassing URL accessibility issues
  *

--- a/services/platform/env.sh
+++ b/services/platform/env.sh
@@ -11,7 +11,7 @@ env_normalize_common() {
   export HOSTNAME="${HOSTNAME:-0.0.0.0}"
 
   # Domain configuration
-  # HOST is the hostname without protocol (e.g., "tale.local", "demo.tale.dev")
+  # HOST is the hostname without protocol (e.g., "localhost", "demo.tale.dev")
   # SITE_URL is the full canonical URL with protocol (required)
   local host="${HOST:-localhost}"
 

--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -12,7 +12,7 @@
 #
 # Users always access via HTTPS regardless of TLS mode.
 #
-# Development: https://tale.local (TLS_MODE=selfsigned)
+# Development: https://localhost (TLS_MODE=selfsigned)
 # Production:  https://yourdomain.com (TLS_MODE=letsencrypt)
 #
 # Blue-Green Deployment:
@@ -22,7 +22,7 @@
 
 # Global options
 {
-	default_sni {$HOST:tale.local}
+	default_sni {$HOST:localhost}
 }
 
 # Health check endpoint (internal only, not exposed externally)
@@ -36,7 +36,7 @@
 # The Caddy entrypoint substitutes the TLS placeholder line below and the
 # {$DOCS_ORIGIN} placeholder on the next line.
 # ============================================================================
-{$DOCS_ORIGIN:https://docs.tale.local} {
+{$DOCS_ORIGIN:https://docs.localhost} {
 	# TLS_PLACEHOLDER
 
 	log {
@@ -72,7 +72,7 @@
 	}
 }
 
-{$SITE_ORIGIN:https://tale.local} {
+{$SITE_ORIGIN:https://localhost} {
 	# TLS Configuration - This line is replaced by entrypoint based on TLS_MODE
 	# DO NOT MODIFY - entrypoint will replace this placeholder
 	# TLS_PLACEHOLDER

--- a/services/proxy/Dockerfile
+++ b/services/proxy/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.version="${VERSION}" \
 
 # Set environment variables with sensible defaults
 ENV TALE_VERSION=${VERSION} \
-    HOST=tale.local \
+    HOST=localhost \
     TLS_MODE=selfsigned
 
 # Copy Caddyfile

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -28,7 +28,7 @@ Routes (defined in `Caddyfile`):
 
 - `TLS_MODE` — `selfsigned` (default, Caddy internal CA) or `letsencrypt`
 - `TLS_EMAIL` — Let's Encrypt notifications (recommended when using `letsencrypt`)
-- `SITE_ORIGIN` — e.g. `https://tale.local`
+- `SITE_ORIGIN` — e.g. `https://localhost`
 - `BASE_PATH` — for subpath deployments
 
 ## Development

--- a/services/proxy/docker-entrypoint.sh
+++ b/services/proxy/docker-entrypoint.sh
@@ -13,7 +13,7 @@ set -e
 # ============================================================================
 # Domain Configuration
 # ============================================================================
-HOST="${HOST:-tale.local}"
+HOST="${HOST:-localhost}"
 
 # SITE_URL is required
 if [ -z "${SITE_URL:-}" ]; then
@@ -75,7 +75,7 @@ case "${TLS_MODE:-selfsigned}" in
         # ACME with email for notifications
         TLS_CONFIG="tls ${TLS_EMAIL}"
       else
-        TLS_EMAIL_DEFAULT="tls@${HOST:-tale.local}"
+        TLS_EMAIL_DEFAULT="tls@${HOST:-localhost}"
         echo "  Email: ${TLS_EMAIL_DEFAULT} (default, set TLS_EMAIL to override)"
         TLS_CONFIG="tls ${TLS_EMAIL_DEFAULT}"
       fi

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -105,7 +105,7 @@ deploy` to roll the containers.
 | `-s, --services <list>` | Specific services to update (comma-separated)                 |
 | `--dry-run`             | Preview deployment without making changes                     |
 | `--skip-backup`         | Skip the automatic pre-deploy volume snapshot (logged loudly) |
-| `--host <hostname>`     | Host alias for proxy (default: `tale.local` or `$HOST`)       |
+| `--host <hostname>`     | Host alias for proxy (default: `localhost` or `$HOST`)        |
 
 ### `tale update`
 
@@ -209,7 +209,7 @@ Config lives at `~/.tale-daemon/config.json` (chmod 600). Set
 | `BACKUP_KEEP_COUNT`    | Snapshots kept regardless of age                        | `5`                         |
 | `BACKUP_KEEP_DAYS`     | Days a snapshot is kept regardless of count             | `14`                        |
 | `PROJECT_NAME`         | Docker project name                                     | `tale`                      |
-| `HOST`                 | Host alias for proxy                                    | `tale.local`                |
+| `HOST`                 | Host alias for proxy                                    | `localhost`                 |
 | `TALE_DAEMON_API_KEY`  | `tale daemon` API key (keeps it out of the config file) | _(unset)_                   |
 | `TALE_DAEMON_HOME`     | Override the `tale daemon` config directory             | `~/.tale-daemon`            |
 

--- a/tools/cli/src/commands/dev/index.ts
+++ b/tools/cli/src/commands/dev/index.ts
@@ -9,7 +9,7 @@ export function createDevCommand(): Command {
     .description('Run Tale locally with your project files (live-reloaded)')
     .option('-d, --detach', 'run in background')
     .option('-p, --port <port>', 'HTTPS port to expose', '443')
-    .option('--host <hostname>', 'host alias for proxy', 'tale.local')
+    .option('--host <hostname>', 'host alias for proxy', 'localhost')
     .addOption(
       new Option(
         '-y, --yes',

--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -208,7 +208,7 @@ export async function runDev(options: DevOptions): Promise<void> {
 
   const version = pkg.version.includes('-dev') ? 'latest' : pkg.version;
   const port = options.port ?? 443;
-  const hostAlias = options.host ?? 'tale.local';
+  const hostAlias = options.host ?? 'localhost';
   const portSuffix = port === 443 ? '' : `:${port}`;
   const url = `${env.SITE_URL.replace(/:443$/, '')}${portSuffix}`;
 

--- a/tools/cli/src/lib/actions/restore.test.ts
+++ b/tools/cli/src/lib/actions/restore.test.ts
@@ -58,7 +58,7 @@ mock.module('../../utils/logger', () => ({
 
 const env: DeploymentEnv = {
   GHCR_REGISTRY: 'ghcr.io/tale-project/tale',
-  SITE_URL: 'https://tale.local',
+  SITE_URL: 'https://localhost',
   HEALTH_CHECK_TIMEOUT: 1,
   DRAIN_TIMEOUT: 0,
   DEPLOY_DIR: '/tmp/tale-restore-test',

--- a/tools/cli/src/lib/actions/rollback.test.ts
+++ b/tools/cli/src/lib/actions/rollback.test.ts
@@ -92,7 +92,7 @@ mock.module('../../utils/logger', () => ({
 }));
 const env: DeploymentEnv = {
   GHCR_REGISTRY: 'ghcr.io/tale-project/tale',
-  SITE_URL: 'https://tale.local',
+  SITE_URL: 'https://localhost',
   HEALTH_CHECK_TIMEOUT: 1,
   DRAIN_TIMEOUT: 0,
   DEPLOY_DIR: '/tmp/tale-rollback-test',

--- a/tools/cli/src/lib/actions/run-deploy.ts
+++ b/tools/cli/src/lib/actions/run-deploy.ts
@@ -119,7 +119,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<void> {
     services = serviceList.filter(isValidService);
   }
 
-  const hostAlias = options.host ?? process.env.HOST ?? 'tale.local';
+  const hostAlias = options.host ?? process.env.HOST ?? 'localhost';
   await deploy({
     version,
     // --override-all implies --stop so the stop-gated tier rolls and the

--- a/tools/cli/src/lib/compose/services/create-proxy-service.ts
+++ b/tools/cli/src/lib/compose/services/create-proxy-service.ts
@@ -31,6 +31,10 @@ export function createProxyService(
     logging: DEFAULT_LOGGING,
     networks: {
       internal: {
+        // Hairpin-NAT alias: lets a container resolve the public HOST to the
+        // proxy. Inert for the default `localhost` (shadowed by /etc/hosts),
+        // which is fine — nothing calls the public URL server-side (no SSR).
+        // Does real work when HOST is a custom domain. Mirrors compose.yml.
         aliases: [hostAlias],
       },
     },


### PR DESCRIPTION
## What

Unify the development/default hostname from `tale.local` (and `docs.tale.local`) to **`localhost`** (and `docs.localhost`) across the stack:

- **Env defaults:** `.env.example`, `.env.test`, `compose.dev.yml` (`x-dev-secrets`)
- **Proxy:** `Caddyfile` (`default_sni`, `SITE_ORIGIN`, `DOCS_ORIGIN`), `Dockerfile`, `docker-entrypoint.sh` (`HOST` + `TLS_EMAIL` defaults), `README.md`
- **CLI:** `--host` / `HOST` defaults in `dev.ts`, `run-deploy.ts`, `commands/dev/index.ts`, plus `tools/cli/README.md` and test fixtures
- **Docs (en/de/fr):** `environment-reference.md`, `authentication.md`, `cli-install.md`
- **Comments:** `compose.yml`, `services/platform/env.sh`, `analyze_image.ts`

## Why

`localhost` resolves natively, so the manual `/etc/hosts` entry that `tale.local` required is no longer needed — local setup is one step shorter.

## The hairpin-NAT consideration

Bare `localhost` is pinned to `127.0.0.1` in every container's `/etc/hosts`, which shadows the Docker network alias — so the container→proxy hairpin alias is **intentionally inert** for the `localhost` default. That's fine: nothing relies on it at runtime (no SSR; internal traffic uses Docker service names / the internal Convex URL). I verified every `SITE_URL` consumer only builds browser-facing URL strings — none fetch the proxy server-side. The alias still does real work when `HOST` is a custom domain.

The one container→proxy call — the convex CA-warmup `curl` — is repointed from `https://${HOST}/health` (which would hit the convex container's own loopback under `localhost`) to the internal **`proxy`** service name, so it still triggers self-signed cert generation.

## Verification

- CLI: `tsc --noEmit` clean, `oxlint` clean, affected unit tests pass (restore / rollback / ensure-env — 34 pass)
- No `tale.local` references remain in the tree
- Markdown tables re-aligned (the shorter `localhost` needed re-padding)

Note: `tools/cli/src/generated/embedded-files.ts` is a gitignored build artifact (regenerated by `bun run build`), so it's not part of this diff.