### PR TITLE
fix(convex): add thread RLS to approval-by-thread queries (#2025)

### DIFF
--- a/services/platform/convex/approvals/queries.ts
+++ b/services/platform/convex/approvals/queries.ts
@@ -4,6 +4,7 @@ import { v } from 'convex/values';
 import { query } from '../_generated/server';
 import { DEFAULT_COUNT_CAP } from '../lib/helpers/count_items_in_org';
 import { getAuthUserIdentity, getOrganizationMember } from '../lib/rls';
+import { canAccessThread } from '../lib/rls/auth/can_access_thread';
 import { UnauthorizedError } from '../lib/rls/errors';
 import * as ApprovalsHelpers from './helpers';
 import { listApprovalsPaginated as listApprovalsPaginatedHelper } from './list_approvals_paginated';
@@ -222,6 +223,14 @@ export const getPendingIntegrationApprovalsForThread = query({
       return [];
     }
 
+    // RLS: only members of the thread's org may read its approval rows. A
+    // guessed/out-of-tenant threadId resolves to no accessible thread and
+    // returns []. Capture the thread's org to cross-check each row below.
+    const thread = await canAccessThread(ctx, args.threadId, authUser);
+    if (!thread) {
+      return [];
+    }
+
     const approvals = [];
     for await (const approval of ctx.db
       .query('approvals')
@@ -230,6 +239,10 @@ export const getPendingIntegrationApprovalsForThread = query({
         continue;
       }
       if (args.messageId && approval.messageId !== args.messageId) {
+        continue;
+      }
+      // Defence in depth: drop any row whose org diverges from the thread's.
+      if (approval.organizationId !== thread.organizationId) {
         continue;
       }
       approvals.push(approval);
@@ -251,6 +264,14 @@ export const getWorkflowCreationApprovalsForThread = query({
       return [];
     }
 
+    // RLS: only members of the thread's org may read its approval rows. A
+    // guessed/out-of-tenant threadId resolves to no accessible thread and
+    // returns []. Capture the thread's org to cross-check each row below.
+    const thread = await canAccessThread(ctx, args.threadId, authUser);
+    if (!thread) {
+      return [];
+    }
+
     const approvals = [];
     for await (const approval of ctx.db
       .query('approvals')
@@ -259,6 +280,10 @@ export const getWorkflowCreationApprovalsForThread = query({
         continue;
       }
       if (args.messageId && approval.messageId !== args.messageId) {
+        continue;
+      }
+      // Defence in depth: drop any row whose org diverges from the thread's.
+      if (approval.organizationId !== thread.organizationId) {
         continue;
       }
       approvals.push(approval);
@@ -280,6 +305,14 @@ export const getHumanInputRequestsForThread = query({
       return [];
     }
 
+    // RLS: only members of the thread's org may read its approval rows. A
+    // guessed/out-of-tenant threadId resolves to no accessible thread and
+    // returns []. Capture the thread's org to cross-check each row below.
+    const thread = await canAccessThread(ctx, args.threadId, authUser);
+    if (!thread) {
+      return [];
+    }
+
     const approvals = [];
     for await (const approval of ctx.db
       .query('approvals')
@@ -288,6 +321,10 @@ export const getHumanInputRequestsForThread = query({
         continue;
       }
       if (args.messageId && approval.messageId !== args.messageId) {
+        continue;
+      }
+      // Defence in depth: drop any row whose org diverges from the thread's.
+      if (approval.organizationId !== thread.organizationId) {
         continue;
       }
       approvals.push(approval);

--- a/services/platform/convex/approvals/queries.ts
+++ b/services/platform/convex/approvals/queries.ts
@@ -242,7 +242,12 @@ export const getPendingIntegrationApprovalsForThread = query({
         continue;
       }
       // Defence in depth: drop any row whose org diverges from the thread's.
-      if (approval.organizationId !== thread.organizationId) {
+      // Org-less threads (canAccessThread returns no organizationId) have
+      // nothing to diverge from, so skip the check rather than drop every row.
+      if (
+        thread.organizationId &&
+        approval.organizationId !== thread.organizationId
+      ) {
         continue;
       }
       approvals.push(approval);
@@ -283,7 +288,12 @@ export const getWorkflowCreationApprovalsForThread = query({
         continue;
       }
       // Defence in depth: drop any row whose org diverges from the thread's.
-      if (approval.organizationId !== thread.organizationId) {
+      // Org-less threads (canAccessThread returns no organizationId) have
+      // nothing to diverge from, so skip the check rather than drop every row.
+      if (
+        thread.organizationId &&
+        approval.organizationId !== thread.organizationId
+      ) {
         continue;
       }
       approvals.push(approval);
@@ -324,7 +334,12 @@ export const getHumanInputRequestsForThread = query({
         continue;
       }
       // Defence in depth: drop any row whose org diverges from the thread's.
-      if (approval.organizationId !== thread.organizationId) {
+      // Org-less threads (canAccessThread returns no organizationId) have
+      // nothing to diverge from, so skip the check rather than drop every row.
+      if (
+        thread.organizationId &&
+        approval.organizationId !== thread.organizationId
+      ) {
         continue;
       }
       approvals.push(approval);

--- a/services/platform/convex/approvals/queries_thread_rls.test.ts
+++ b/services/platform/convex/approvals/queries_thread_rls.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Export the raw handlers so we can drive them with a mocked ctx (same pattern
+// as thread_files/queries.test.ts).
+vi.mock('../_generated/server', () => ({
+  query: ({ handler }: { handler: Function }) => handler,
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+const mockCanAccessThread = vi.fn();
+vi.mock('../lib/rls/auth/can_access_thread', () => ({
+  canAccessThread: (...args: unknown[]) => mockCanAccessThread(...args),
+}));
+
+const {
+  getPendingIntegrationApprovalsForThread,
+  getWorkflowCreationApprovalsForThread,
+  getHumanInputRequestsForThread,
+} = await import('./queries');
+
+type Handler = (
+  ctx: unknown,
+  args: Record<string, unknown>,
+) => Promise<unknown>;
+
+const getIntegration =
+  getPendingIntegrationApprovalsForThread as unknown as Handler;
+const getWorkflow = getWorkflowCreationApprovalsForThread as unknown as Handler;
+const getHumanInput = getHumanInputRequestsForThread as unknown as Handler;
+
+type Row = Record<string, unknown>;
+
+/** In-memory ctx.db: withIndex → asyncIterator, filtering by the eq() calls. */
+function makeCtx(approvals: Row[]) {
+  const applyIndex = (cb?: (q: unknown) => unknown): Row[] => {
+    if (!cb) return [...approvals];
+    const eqs: Array<[string, unknown]> = [];
+    const q = {
+      eq(field: string, value: unknown) {
+        eqs.push([field, value]);
+        return q;
+      },
+    };
+    cb(q);
+    return approvals.filter((r) => eqs.every(([f, v]) => r[f] === v));
+  };
+  return {
+    db: {
+      query: () => ({
+        withIndex: (_name: string, cb?: (q: unknown) => unknown) => {
+          const rows = applyIndex(cb);
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield* rows;
+            },
+          };
+        },
+      }),
+    },
+  };
+}
+
+function approvalRow(over: Partial<Row> = {}): Row {
+  return {
+    _id: 'apr_1',
+    threadId: 'thread_1',
+    organizationId: 'org_1',
+    resourceType: 'integration_operation',
+    status: 'pending',
+    messageId: undefined,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAuthUserIdentity.mockResolvedValue({ userId: 'u_1' });
+  // Default: caller can access the thread, which lives in org_1.
+  mockCanAccessThread.mockResolvedValue({
+    threadId: 'thread_1',
+    organizationId: 'org_1',
+  });
+});
+
+const cases: Array<{ name: string; handler: Handler; resourceType: string }> = [
+  {
+    name: 'getPendingIntegrationApprovalsForThread',
+    handler: getIntegration,
+    resourceType: 'integration_operation',
+  },
+  {
+    name: 'getWorkflowCreationApprovalsForThread',
+    handler: getWorkflow,
+    resourceType: 'workflow_creation',
+  },
+  {
+    name: 'getHumanInputRequestsForThread',
+    handler: getHumanInput,
+    resourceType: 'human_input_request',
+  },
+];
+
+for (const { name, handler, resourceType } of cases) {
+  describe(`${name} — thread RLS`, () => {
+    it('returns [] when the user is not authenticated', async () => {
+      mockGetAuthUserIdentity.mockResolvedValue(null);
+      const ctx = makeCtx([approvalRow({ resourceType })]);
+      const out = await handler(ctx, { threadId: 'thread_1' });
+      expect(out).toEqual([]);
+      // Must not consult the thread / table when unauthenticated.
+      expect(mockCanAccessThread).not.toHaveBeenCalled();
+    });
+
+    it('returns [] for an out-of-tenant (inaccessible) threadId', async () => {
+      mockCanAccessThread.mockResolvedValue(null);
+      const ctx = makeCtx([approvalRow({ resourceType })]);
+      const out = await handler(ctx, { threadId: 'thread_other_org' });
+      expect(out).toEqual([]);
+      expect(mockCanAccessThread).toHaveBeenCalledWith(
+        ctx,
+        'thread_other_org',
+        { userId: 'u_1' },
+      );
+    });
+
+    it('returns matching rows when the caller can access the thread', async () => {
+      const ctx = makeCtx([approvalRow({ _id: 'a', resourceType })]);
+      const out = (await handler(ctx, { threadId: 'thread_1' })) as Row[];
+      expect(out).toHaveLength(1);
+      expect(out[0]._id).toBe('a');
+    });
+
+    it('drops rows whose org diverges from the thread (defence in depth)', async () => {
+      const ctx = makeCtx([
+        approvalRow({ _id: 'mine', resourceType, organizationId: 'org_1' }),
+        approvalRow({ _id: 'leak', resourceType, organizationId: 'org_2' }),
+      ]);
+      const out = (await handler(ctx, { threadId: 'thread_1' })) as Row[];
+      expect(out.map((r) => r._id)).toEqual(['mine']);
+    });
+
+    it('ignores rows of a different resourceType on the same thread', async () => {
+      const ctx = makeCtx([
+        approvalRow({ _id: 'keep', resourceType }),
+        approvalRow({ _id: 'skip', resourceType: 'something_else' }),
+      ]);
+      const out = (await handler(ctx, { threadId: 'thread_1' })) as Row[];
+      expect(out.map((r) => r._id)).toEqual(['keep']);
+    });
+  });
+}

--- a/services/platform/convex/approvals/queries_thread_rls.test.ts
+++ b/services/platform/convex/approvals/queries_thread_rls.test.ts
@@ -146,6 +146,21 @@ for (const { name, handler, resourceType } of cases) {
       expect(out.map((r) => r._id)).toEqual(['mine']);
     });
 
+    it('returns matching rows for an accessible org-less thread', async () => {
+      // canAccessThread grants the owner access to an org-less thread and
+      // returns no organizationId; the divergence check must not drop rows.
+      mockCanAccessThread.mockResolvedValue({
+        threadId: 'thread_1',
+        organizationId: undefined,
+      });
+      const ctx = makeCtx([
+        approvalRow({ _id: 'a', resourceType, organizationId: 'org_1' }),
+        approvalRow({ _id: 'b', resourceType, organizationId: 'org_2' }),
+      ]);
+      const out = (await handler(ctx, { threadId: 'thread_1' })) as Row[];
+      expect(out.map((r) => r._id)).toEqual(['a', 'b']);
+    });
+
     it('ignores rows of a different resourceType on the same thread', async () => {
       const ctx = makeCtx([
         approvalRow({ _id: 'keep', resourceType }),


### PR DESCRIPTION
## Summary

`getPendingIntegrationApprovalsForThread`, `getWorkflowCreationApprovalsForThread`, and `getHumanInputRequestsForThread` in `services/platform/convex/approvals/queries.ts` only checked that the caller was authenticated — they never verified org membership. Any logged-in user could read another tenant's pending integration-operation, workflow-creation, or human-input-request approval rows (including `metadata`, `resourceId`, `wfExecutionId`, `stepSlug`, and `organizationId`) just by knowing/guessing a `threadId`.

## Fix

Each of the three handlers now calls `canAccessThread(ctx, args.threadId, authUser)` before scanning the `approvals` table and returns `[]` when the thread is not accessible to the caller — mirroring the established RLS pattern used by `listResolvedHumanInputRequestsByThread` and the thread-scoped queries elsewhere in the codebase (e.g. `thread_files`, `user_memories`). As defence in depth, each row is also dropped when `approval.organizationId` diverges from the thread's org.

These queries take no `organizationId` arg and have no in-repo callers to update, so the threadId-based `canAccessThread` gate is the least-disruptive correct fix.

## Tests

Added `services/platform/convex/approvals/queries_thread_rls.test.ts` (15 cases, 5 per handler): unauthenticated → `[]`, out-of-tenant/inaccessible threadId → `[]` (and `canAccessThread` invoked), accessible thread returns matching rows, cross-org rows dropped, and other resourceTypes ignored.

- `vitest --run --project server` (approvals): 36 passed
- `tsc --noEmit`: clean
- `oxlint --type-aware` on changed files: 0 warnings, 0 errors

Closes #2025