### PR TITLE
fix(platform): run total-size check before slot-overflow toast (#2029)

### DIFF
--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
@@ -346,3 +346,87 @@ describe('useConvexFileUpload — in-flight slot cap (#2026)', () => {
     await waitFor(() => expect(result.current.attachments).toHaveLength(1));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression coverage for #2029: when a batch overflows the slot cap AND the
+// trimmed batch would still push the running total past CHAT_MAX_TOTAL_SIZE,
+// the total-size check must run *before* the slot-overflow toast. Otherwise
+// the user sees a misleading "N files were not added" toast (implying the
+// trimmed batch was accepted) immediately followed by a blanket total-size
+// rejection — two contradictory toasts and zero uploads.
+// ---------------------------------------------------------------------------
+describe('useConvexFileUpload — slot-overflow vs total-size ordering (#2029)', () => {
+  it('shows only the total-size toast (not the slot-overflow toast) and uploads nothing when the trimmed batch still exceeds the total cap', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // Pre-fill 8 of the 10 slots with 21MB files → 168MB used, 2 slots left.
+    await act(async () => {
+      await result.current.uploadFiles(
+        Array.from({ length: 8 }, (_, i) =>
+          makeAudioFile(`existing-${i}.mp3`, 21 * MB),
+        ),
+      );
+    });
+    await waitFor(() => expect(result.current.attachments).toHaveLength(8));
+    toastMock.mockClear();
+    saveFileMetadata.mockClear();
+
+    // Add 5 more 21MB files: the slot cap trims the batch to 2 (2 slots left),
+    // but 168MB + 42MB = 210MB > 200MB total cap, so the whole batch is
+    // rejected by the total-size check.
+    await act(async () => {
+      await result.current.uploadFiles(
+        Array.from({ length: 5 }, (_, i) =>
+          makeAudioFile(`incoming-${i}.mp3`, 21 * MB),
+        ),
+      );
+    });
+
+    // Nothing new was uploaded.
+    expect(result.current.attachments).toHaveLength(8);
+    expect(saveFileMetadata).not.toHaveBeenCalled();
+
+    // The total-size toast fired...
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
+    ).toBe(true);
+    // ...and the misleading slot-overflow toast did NOT.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'tooManyFiles'),
+    ).toBe(false);
+  });
+
+  it('still shows the slot-overflow toast when the trimmed batch fits under the total cap', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // Pre-fill 8 of the 10 slots with small 1MB files → 8MB used, 2 slots left.
+    await act(async () => {
+      await result.current.uploadFiles(
+        Array.from({ length: 8 }, (_, i) =>
+          makeAudioFile(`existing-${i}.mp3`, 1 * MB),
+        ),
+      );
+    });
+    await waitFor(() => expect(result.current.attachments).toHaveLength(8));
+    toastMock.mockClear();
+    saveFileMetadata.mockClear();
+
+    // Add 5 more small files: slot cap trims to 2, total stays well under
+    // 200MB, so the 2 accepted files upload and the slot-overflow toast fires.
+    await act(async () => {
+      await result.current.uploadFiles(
+        Array.from({ length: 5 }, (_, i) =>
+          makeAudioFile(`incoming-${i}.mp3`, 1 * MB),
+        ),
+      );
+    });
+
+    await waitFor(() => expect(result.current.attachments).toHaveLength(10));
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'tooManyFiles'),
+    ).toBe(true);
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
+    ).toBe(false);
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -313,20 +313,14 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
           ? deduped.slice(0, slotsAvailable)
           : deduped;
 
-      if (acceptedFiles.length < deduped.length) {
-        toast({
-          title: t('tooManyFiles'),
-          description: t('tooManyFilesDescription', {
-            max: CHAT_MAX_FILE_COUNT,
-            rejected: deduped.length - acceptedFiles.length,
-          }),
-          variant: 'destructive',
-        });
-      }
-
-      // Enforce max total attachment size — include in-flight uploads (using
-      // the source size as an upper bound; the compressed upload is smaller)
-      // so concurrent batches can't collectively exceed the total cap.
+      // Enforce max total attachment size *before* announcing the slot trim.
+      // The total-size check returns early without uploading anything, so if
+      // it runs after the slot-overflow toast the user sees two contradictory
+      // toasts in quick succession: first "N files were not added" (implying
+      // the trimmed batch was accepted and is uploading), then a blanket
+      // "total size exceeded" that rejects the whole batch — net zero uploads.
+      // Running it first means the slot-overflow toast only fires once we know
+      // the trimmed batch will actually be uploaded. (#2029)
       let existingSize = attachmentsRef.current.reduce(
         (sum, att) => sum + att.fileSize,
         0,
@@ -347,6 +341,17 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
           variant: 'destructive',
         });
         return;
+      }
+
+      if (acceptedFiles.length < deduped.length) {
+        toast({
+          title: t('tooManyFiles'),
+          description: t('tooManyFilesDescription', {
+            max: CHAT_MAX_FILE_COUNT,
+            rejected: deduped.length - acceptedFiles.length,
+          }),
+          variant: 'destructive',
+        });
       }
 
       // Reserve a slot for every accepted file *before* any upload starts, so


### PR DESCRIPTION
## Summary

Fixes the misleading double-toast in the chat composer described in #2029.

When a batch of files overflowed both the **slot cap** (10 files/message) and the **total-size cap** (200 MB), the slot-overflow toast ("N files were not added…") fired *before* the total-size check. The user was led to believe the trimmed batch had been accepted, only for the total-size check to then reject the whole batch and return early — two contradictory toasts and **zero uploads**.

## Change

In `use-convex-file-upload.ts`, the **total-size check now runs before** the slot-overflow toast. The slot-overflow toast only fires once we know the trimmed batch will actually be uploaded:

- If the trimmed batch still exceeds the total cap → only the `totalSizeExceeded` toast fires, nothing uploads.
- If the trimmed batch fits under the total cap → the `tooManyFiles` slot-overflow toast fires and the accepted files upload, exactly as before.

No behavioral change to which files upload; only the ordering/emission of the toasts.

## Tests

Added two regression tests to `use-convex-file-upload.cap.test.ts`:
1. Slot overflow + total-size overflow → only the total-size toast fires, no uploads.
2. Slot overflow but within total cap → slot-overflow toast still fires, accepted files upload.

All 4 tests in the file pass; lint clean on the changed files.

Closes #2029