### PR TITLE
fix(platform): use compressed image sizes in chat total-attachment-size check (#2031)

### DIFF
--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useUploadPolicy } from '@/app/features/settings/governance/hooks/queries';
 import { toast } from '@/app/hooks/use-toast';
-import { CHAT_MAX_FILE_COUNT } from '@/lib/shared/file-types';
+import { CHAT_MAX_FILE_COUNT, detectMediaMime } from '@/lib/shared/file-types';
+import { compressImage } from '@/lib/utils/compress-image';
 
 import { useConvexFileUpload } from './use-convex-file-upload';
 
@@ -62,12 +63,20 @@ vi.mock('@/lib/shared/file-types', async (importOriginal) => {
 
 const toastMock = vi.mocked(toast);
 const useUploadPolicyMock = vi.mocked(useUploadPolicy);
+const detectMediaMimeMock = vi.mocked(detectMediaMime);
+const compressImageMock = vi.mocked(compressImage);
 
 const MB = 1024 * 1024;
 
 // Override `size` so the test doesn't allocate the simulated byte count.
 function makeAudioFile(name: string, size: number): File {
   const file = new File([new Uint8Array(0)], name, { type: 'audio/mpeg' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+function makeImageFile(name: string, size: number): File {
+  const file = new File([new Uint8Array(0)], name, { type: 'image/png' });
   Object.defineProperty(file, 'size', { value: size });
   return file;
 }
@@ -428,5 +437,85 @@ describe('useConvexFileUpload — slot-overflow vs total-size ordering (#2029)',
     expect(
       toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the total-attachment-size check (#2031): the check
+// summed raw `file.size` for incoming images but compressed sizes for already-
+// attached ones, over-counting image batches and falsely rejecting them.
+// Compression now runs before the size check, so both sides use the stored
+// (post-compression) size. `detectMediaMime` is forced to an image type and
+// `compressImage` is stubbed to shrink each image to ~1 MB.
+// ---------------------------------------------------------------------------
+describe('useConvexFileUpload — total-size check uses compressed sizes (#2031)', () => {
+  beforeEach(() => {
+    detectMediaMimeMock.mockResolvedValue('image/png');
+    // Each image compresses down to 1 MB regardless of its raw size.
+    compressImageMock.mockImplementation(async (file: File) => {
+      const compressed = makeImageFile(file.name, 1 * MB);
+      return {
+        file: compressed,
+        wasCompressed: true,
+        originalSize: file.size,
+        finalSize: 1 * MB,
+      };
+    });
+  });
+
+  afterEach(() => {
+    // Restore the file-level default so other suites keep sniffing audio.
+    detectMediaMimeMock.mockResolvedValue('audio/mpeg');
+  });
+
+  it('accepts an image batch whose raw size exceeds the 200MB cap but compresses under it', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    // 3 × 80MB = 240MB raw (> 200MB cap) but 3 × 1MB = 3MB compressed.
+    await act(async () => {
+      await result.current.uploadFiles([
+        makeImageFile('a.png', 80 * MB),
+        makeImageFile('b.png', 80 * MB),
+        makeImageFile('c.png', 80 * MB),
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.attachments).toHaveLength(3));
+    // No "total size exceeded" rejection should have fired.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
+    ).toBe(false);
+    // Stored sizes are the compressed sizes.
+    for (const att of result.current.attachments) {
+      expect(att.fileSize).toBe(1 * MB);
+    }
+  });
+
+  it('still rejects when even the compressed total exceeds the 200MB cap', async () => {
+    // Compress to 90MB each: 3 × 90MB = 270MB compressed (> 200MB cap).
+    compressImageMock.mockImplementation(async (file: File) => {
+      const compressed = makeImageFile(file.name, 90 * MB);
+      return {
+        file: compressed,
+        wasCompressed: true,
+        originalSize: file.size,
+        finalSize: 90 * MB,
+      };
+    });
+
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    await act(async () => {
+      await result.current.uploadFiles([
+        makeImageFile('a.png', 95 * MB),
+        makeImageFile('b.png', 95 * MB),
+        makeImageFile('c.png', 95 * MB),
+      ]);
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'totalSizeExceeded'),
+    ).toBe(true);
   });
 });

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -313,6 +313,55 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
           ? deduped.slice(0, slotsAvailable)
           : deduped;
 
+      // Reserve a slot for every accepted file *before* any await yields, so a
+      // concurrent batch fired while compression or upload is in flight sees
+      // these in the gates above. The dedup key uses the original
+      // (pre-compression) identity to match the stored-attachment key (#2026).
+      const reservedTasks = acceptedFiles.map(
+        ({ file, resolvedType }, index) => {
+          const fileId = `${file.name}-${file.size}-${Date.now()}-${index}`;
+          pendingUploadsRef.current.set(fileId, {
+            dedupKey: `${file.name}:${file.size}`,
+            size: file.size,
+          });
+          return { file, resolvedType, fileId };
+        },
+      );
+
+      const releaseReservations = () => {
+        for (const { fileId } of reservedTasks) {
+          pendingUploadsRef.current.delete(fileId);
+        }
+      };
+
+      // Compress images up front, before the total-size check, so every size
+      // calculation works from the same (post-compression) basis. Previously
+      // compression ran inside the upload promise — AFTER this check — so
+      // `incomingSize` summed raw `file.size` while `existingSize` summed
+      // already-compressed sizes, over-counting image batches and falsely
+      // rejecting them. See #2031.
+      const preparedFiles = await Promise.all(
+        reservedTasks.map(async ({ file, resolvedType, fileId }) => {
+          if (resolvedType.startsWith('image/')) {
+            try {
+              const compressionResult = await compressImage(file);
+              return {
+                file,
+                fileToUpload: compressionResult.file,
+                resolvedType,
+                fileId,
+              };
+            } catch (error) {
+              // Fall back to the original file so a single compression failure
+              // doesn't sink the whole batch; the per-file/total caps still apply.
+              console.warn('[uploadFiles] image compression failed:', error);
+              return { file, fileToUpload: file, resolvedType, fileId };
+            }
+          }
+          return { file, fileToUpload: file, resolvedType, fileId };
+        }),
+      );
+
       // Enforce max total attachment size *before* announcing the slot trim.
       // The total-size check returns early without uploading anything, so if
       // it runs after the slot-overflow toast the user sees two contradictory
@@ -321,15 +370,20 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
       // "total size exceeded" that rejects the whole batch — net zero uploads.
       // Running it first means the slot-overflow toast only fires once we know
       // the trimmed batch will actually be uploaded. (#2029)
+      const reservedIds = new Set(reservedTasks.map(({ fileId }) => fileId));
       let existingSize = attachmentsRef.current.reduce(
         (sum, att) => sum + att.fileSize,
         0,
       );
-      for (const pending of pendingUploadsRef.current.values()) {
-        existingSize += pending.size;
+      for (const [id, pending] of pendingUploadsRef.current.entries()) {
+        // Other in-flight batches only — this batch's slots are summed below
+        // from post-compression sizes so we don't double-count reservations.
+        if (!reservedIds.has(id)) {
+          existingSize += pending.size;
+        }
       }
-      const incomingSize = acceptedFiles.reduce(
-        (sum, { file }) => sum + file.size,
+      const incomingSize = preparedFiles.reduce(
+        (sum, { fileToUpload }) => sum + fileToUpload.size,
         0,
       );
       if (existingSize + incomingSize > CHAT_MAX_TOTAL_SIZE) {
@@ -340,6 +394,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
           }),
           variant: 'destructive',
         });
+        releaseReservations();
         return;
       }
 
@@ -354,32 +409,12 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
         });
       }
 
-      // Reserve a slot for every accepted file *before* any upload starts, so
-      // a concurrent batch fired mid-upload sees these in the gates above. The
-      // dedup key uses the original (pre-compression) identity to match the
-      // stored-attachment key. Reservations are released in the `finally` once
-      // the file commits to `attachments` (or fails).
-      const uploadTasks = acceptedFiles.map(({ file, resolvedType }, index) => {
-        const fileId = `${file.name}-${file.size}-${Date.now()}-${index}`;
-        pendingUploadsRef.current.set(fileId, {
-          dedupKey: `${file.name}:${file.size}`,
-          size: file.size,
-        });
-        return { file, resolvedType, fileId };
-      });
-
-      const uploadPromises = uploadTasks.map(
-        async ({ file, resolvedType, fileId }) => {
+      const uploadPromises = preparedFiles.map(
+        async ({ file, fileToUpload, resolvedType, fileId }) => {
           setUploadingFiles((prev) => [...prev, fileId]);
 
           try {
-            let fileToUpload = file;
-
-            if (resolvedType.startsWith('image/')) {
-              const compressionResult = await compressImage(file);
-              fileToUpload = compressionResult.file;
-            }
-
+            // Images were already compressed before the total-size check above.
             const uploadUrl = await generateUploadUrl({});
 
             const result = await fetch(uploadUrl, {


### PR DESCRIPTION
## Summary

The chat composer's total-attachment-size check mixed two different size bases: `existingSize` summed the **compressed** sizes of already-attached files (stored after `compressImage` runs), while `incomingSize` summed the **raw** `file.size` of incoming images — because compression ran *inside* the upload promise, *after* the check had already decided. This systematically over-counted image-heavy batches and produced false `totalSizeExceeded` rejections (e.g. 240 MB raw images that compress to a few MB).

## Fix

Move image compression to run **before** the total-size check, so both `existingSize` and `incomingSize` use the same post-compression basis (the sizes that are actually stored/uploaded). The upload promise now reuses the already-compressed file instead of compressing again. A compression failure falls back to the original file so one bad image doesn't sink the whole batch.

## Tests

Added regression coverage in `use-convex-file-upload.cap.test.ts`:
- accepts an image batch that exceeds the 200 MB cap raw but compresses under it
- still rejects when even the compressed total exceeds the cap

Verified with `vitest --project client` (4 passed), `oxlint --type-aware` (0 errors), and `tsc --noEmit` (clean).

Closes #2031