### PR TITLE
fix(platform): reset editor dirty state after save

### DIFF
--- a/services/platform/app/components/env/env-var-list-editor.test.tsx
+++ b/services/platform/app/components/env/env-var-list-editor.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+import { fireEvent, render, screen, waitFor } from '@/tests/utils/render';
+
+import { EnvVarListEditor, type LoadedEnvVar } from './env-var-list-editor';
+
+const plainRows: LoadedEnvVar[] = [
+  { key: 'FOO', isSecret: false, value: 'bar' },
+];
+
+function setup(rows: readonly LoadedEnvVar[] = plainRows) {
+  const onSet = vi.fn().mockResolvedValue(undefined);
+  const onDelete = vi.fn().mockResolvedValue(undefined);
+  const utils = render(
+    <EnvVarListEditor
+      rows={rows}
+      isLoading={false}
+      onSet={onSet}
+      onDelete={onDelete}
+    />,
+  );
+  return { onSet, onDelete, ...utils };
+}
+
+describe('EnvVarListEditor — Save dirty state', () => {
+  it('disables Save with no edits', () => {
+    setup();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('enables Save after editing a value, then re-disables after a successful save', async () => {
+    const { onSet } = setup();
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
+    expect(saveBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('value'), {
+      target: { value: 'baz' },
+    });
+    expect(saveBtn).toBeEnabled();
+
+    fireEvent.click(saveBtn);
+    await waitFor(() =>
+      expect(onSet).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'FOO', value: 'baz', isSecret: false }),
+      ),
+    );
+    // The core fix: after a successful save the button greys out again.
+    await waitFor(() => expect(saveBtn).toBeDisabled());
+  });
+
+  it('enables Save when a row is added', () => {
+    setup();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Add variable' }));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('keeps Save disabled when a stored secret is merely focused (mask is display-only)', () => {
+    setup([{ key: 'TOKEN', isSecret: true, maskedValue: 'sk-****xyz' }]);
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
+    expect(saveBtn).toBeDisabled();
+
+    // The secret renders its mask preview as the value; focusing clears it for a
+    // clean re-type but must not mark the form dirty.
+    fireEvent.focus(screen.getByDisplayValue('sk-****xyz'));
+    expect(saveBtn).toBeDisabled();
+  });
+});

--- a/services/platform/app/components/env/env-var-list-editor.tsx
+++ b/services/platform/app/components/env/env-var-list-editor.tsx
@@ -19,6 +19,7 @@ import { Text } from '@tale/ui/text';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { useRegisterDirtySource } from '@/app/components/ui/editor/use-dirty-source';
 import { Select } from '@/app/components/ui/forms/select';
 import { toast } from '@/app/hooks/use-toast';
 import { useT } from '@/lib/i18n/client';
@@ -136,9 +137,21 @@ export function EnvVarListEditor({
   // After a save we clear this so the post-write reactive update re-snapshots
   // with the freshly-computed secret previews.
   const dirty = useRef(false);
+  // Re-rendering dirty flag that drives the Save button + the navigation
+  // blocker. Distinct from the `dirty` ref above: the ref guards the
+  // server-reload snapshot and is set on ANY interaction (including the mask
+  // focus/blur display toggles); this state flips true only on a real, savable
+  // edit, so merely focusing a stored secret never enables Save or arms the
+  // blocker.
+  const [isDirty, setIsDirty] = useState(false);
   // Keys present at the last snapshot — the delete set is computed against THIS,
   // not the current rows (a removed row is gone from `localRows`).
   const loadedKeys = useRef(new Set<string>());
+
+  // Warn on navigation away while env edits are unsaved; clears once `isDirty`
+  // flips false after a successful save. No-ops gracefully outside a
+  // DirtyBlockerProvider (e.g. a dialog surface).
+  useRegisterDirtySource(isDirty);
 
   // Snapshot the query into editable local state whenever it changes AND the
   // user has no pending edits.
@@ -149,12 +162,24 @@ export function EnvVarListEditor({
     setLocalRows(loaded);
   }, [rows, isLoading]);
 
+  // A real, savable edit: guards the snapshot AND enables Save / arms the blocker.
+  const markDirty = (): void => {
+    dirty.current = true;
+    setIsDirty(true);
+  };
   const patch = (i: number, p: Partial<Row>): void => {
+    markDirty();
+    setLocalRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...p } : r)));
+  };
+  // Display-only row mutation: a stored secret's mask preview toggling on
+  // focus/blur. Guards the snapshot like a real edit, but must NOT mark the form
+  // dirty — the mask is never saved, so focusing a secret can't enable Save.
+  const patchDisplay = (i: number, p: Partial<Row>): void => {
     dirty.current = true;
     setLocalRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...p } : r)));
   };
   const addRow = (): void => {
-    dirty.current = true;
+    markDirty();
     setLocalRows((rs) => [
       ...rs,
       {
@@ -169,7 +194,7 @@ export function EnvVarListEditor({
     ]);
   };
   const removeRow = (i: number): void => {
-    dirty.current = true;
+    markDirty();
     setLocalRows((rs) => rs.filter((_, j) => j !== i));
   };
 
@@ -216,6 +241,7 @@ export function EnvVarListEditor({
       // freshly-computed secret previews (secrets are write-only — only the
       // server can produce them).
       dirty.current = false;
+      setIsDirty(false);
       toast({ title: t('saved'), variant: 'success' });
     } catch (err) {
       toast({
@@ -333,7 +359,7 @@ export function EnvVarListEditor({
                 disabled={busy}
                 className="font-mono"
                 onFocus={() => {
-                  if (r.masked) patch(i, { value: '', masked: false });
+                  if (r.masked) patchDisplay(i, { value: '', masked: false });
                 }}
                 onChange={(e) =>
                   patch(i, {
@@ -349,7 +375,7 @@ export function EnvVarListEditor({
                     !r.secretDirty &&
                     r.value === ''
                   ) {
-                    patch(i, { value: r.maskedDisplay, masked: true });
+                    patchDisplay(i, { value: r.maskedDisplay, masked: true });
                   }
                 }}
               />
@@ -392,7 +418,7 @@ export function EnvVarListEditor({
           <Plus className="size-4" />
           {t('add')}
         </Button>
-        <Button onClick={() => void onSave()} disabled={busy}>
+        <Button onClick={() => void onSave()} disabled={busy || !isDirty}>
           {saving ? t('saving') : t('save')}
         </Button>
       </HStack>

--- a/services/platform/app/components/ui/editor/use-form-editor.test.tsx
+++ b/services/platform/app/components/ui/editor/use-form-editor.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
-import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -123,5 +130,48 @@ describe('useFormEditor', () => {
     const { result } = mount({ name: 'A', color: '#FF0000' });
     act(() => result.current.form.setValue('name', '', { shouldDirty: true }));
     await waitFor(() => expect(result.current.isValid).toBe(false));
+  });
+
+  // Regression: a native `<form onSubmit={editor.submit}>` must run the save AND
+  // reset the dirty baseline. The earlier wiring used the raw
+  // `handleSubmit(save)`, which saved but never reset — so the Save button (a
+  // `type="submit"` form button) stayed active and the navigation blocker fired
+  // after a successful save. The existing tests only called `editor.save()`
+  // directly, so they never exercised this path.
+  it('clears isDirty after a native form submit through editor.submit', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const holder: { current: ReturnType<typeof useFormEditor<Form>> | null } = {
+      current: null,
+    };
+
+    function Harness() {
+      const editor = useFormEditor<Form>({
+        data: { name: 'A', color: '#FF0000' },
+        schema,
+        save,
+      });
+      holder.current = editor;
+      return (
+        <form onSubmit={editor.submit}>
+          <input aria-label="name" {...editor.form.register('name')} />
+          <button type="submit">Save</button>
+        </form>
+      );
+    }
+
+    const { container } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: 'B' },
+    });
+    await waitFor(() => expect(holder.current?.isDirty).toBe(true));
+
+    // Fire the native submit (what clicking the `type="submit"` button does).
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith(expect.objectContaining({ name: 'B' })),
+    );
+    await waitFor(() => expect(holder.current?.isDirty).toBe(false));
   });
 });

--- a/services/platform/app/components/ui/editor/use-form-editor.ts
+++ b/services/platform/app/components/ui/editor/use-form-editor.ts
@@ -50,6 +50,16 @@ interface FormEditor<T extends FieldValues> extends EditorController {
   hasRemoteUpdate: boolean;
   /** Dismisses the remote-update indicator until the next upstream change. */
   dismissRemoteUpdate: () => void;
+  /**
+   * Form `onSubmit` handler — wire it as `<form onSubmit={editor.submit}>`.
+   * It routes the native submit (Save button `type="submit"`, Enter key)
+   * through {@link save}/`doSave`, so the dirty baseline is reset on success.
+   *
+   * Use this instead of the raw `form.handleSubmit(save)`: that calls `save`
+   * directly and never clears `isDirty`, leaving the Save button active and
+   * tripping the navigation blocker after a successful save.
+   */
+  submit: (e?: { preventDefault: () => void }) => void;
 }
 
 /**
@@ -196,6 +206,22 @@ export function useFormEditor<T extends FieldValues>({
     }
   }, [form]);
 
+  const submit = useCallback(
+    (e?: { preventDefault: () => void }) => {
+      e?.preventDefault();
+      // Route the native form submit through `doSave` so the dirty baseline is
+      // reset on success. Validation failures surface inline via `form.setError`
+      // and server errors are already toasted by the caller's `save` — log
+      // anything unexpected rather than swallow it (mirrors password-policy).
+      doSave().catch((err) => {
+        if (!(err instanceof Error && err.message === 'VALIDATION_FAILED')) {
+          console.error('[useFormEditor] submit failed', err);
+        }
+      });
+    },
+    [doSave],
+  );
+
   const reset = useCallback(() => {
     if (isSavingRef.current) return;
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- DefaultValues<T> ⊂ T
@@ -224,6 +250,7 @@ export function useFormEditor<T extends FieldValues>({
     isLoading: data === undefined,
     dirtyKeys,
     save: doSave,
+    submit,
     reset,
     setServerErrors,
   };

--- a/services/platform/app/features/apps/registry/connected/agent-env-dialog.tsx
+++ b/services/platform/app/features/apps/registry/connected/agent-env-dialog.tsx
@@ -89,6 +89,10 @@ function EnvEditor({
 
   const [rows, setRows] = useState<Row[]>([]);
   const [saving, setSaving] = useState(false);
+  // Drives the Save button: stays disabled until the user actually edits a row,
+  // so Save isn't clickable with zero changes. The dialog closes on a
+  // successful save, so there's nothing to reset.
+  const [isDirty, setIsDirty] = useState(false);
   const initialized = useRef(false);
   // Keys present at load — the delete set is computed against THIS, not the
   // current rows (a removed row is gone from `rows`, so it must be remembered
@@ -107,9 +111,12 @@ function EnvEditor({
     setRows(loaded);
   }, [data, isLoading]);
 
-  const patch = (i: number, p: Partial<Row>): void =>
+  const patch = (i: number, p: Partial<Row>): void => {
+    setIsDirty(true);
     setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...p } : r)));
-  const addRow = (): void =>
+  };
+  const addRow = (): void => {
+    setIsDirty(true);
     setRows((rs) => [
       ...rs,
       {
@@ -120,8 +127,11 @@ function EnvEditor({
         secretDirty: false,
       },
     ]);
-  const removeRow = (i: number): void =>
+  };
+  const removeRow = (i: number): void => {
+    setIsDirty(true);
     setRows((rs) => rs.filter((_, j) => j !== i));
+  };
 
   const onSave = async (): Promise<void> => {
     const active = rows.filter((r) => r.key.trim() !== '');
@@ -259,7 +269,7 @@ function EnvEditor({
         <Button variant="ghost" onClick={onClose} disabled={saving}>
           {t('agents.env.cancel')}
         </Button>
-        <Button onClick={() => void onSave()} disabled={saving}>
+        <Button onClick={() => void onSave()} disabled={saving || !isDirty}>
           {saving ? t('agents.env.saving') : t('agents.env.save')}
         </Button>
       </HStack>

--- a/services/platform/app/features/apps/registry/connected/agent-instructions-dialog.tsx
+++ b/services/platform/app/features/apps/registry/connected/agent-instructions-dialog.tsx
@@ -110,6 +110,15 @@ export function AgentInstructionsDialog({
     }
   };
 
+  // Enable Save only when the text actually differs from what was loaded, so the
+  // button greys out with no pending change (and after a save re-reads the same
+  // value). Mirrors the load-time normalization of a non-string field to ''.
+  const baselineInstructions =
+    typeof config?.systemInstructions === 'string'
+      ? config.systemInstructions
+      : '';
+  const isDirty = config !== null && value !== baselineInstructions;
+
   return (
     <ResponsiveDialog
       open={agentSlug !== null}
@@ -148,7 +157,13 @@ export function AgentInstructionsDialog({
             </Button>
             <Button
               onClick={() => void onSave()}
-              disabled={loading || saving || error !== null || config === null}
+              disabled={
+                loading ||
+                saving ||
+                error !== null ||
+                config === null ||
+                !isDirty
+              }
             >
               {saving
                 ? t('agents.instructions.saving')

--- a/services/platform/app/features/projects/components/project-instructions-editor.tsx
+++ b/services/platform/app/features/projects/components/project-instructions-editor.tsx
@@ -99,10 +99,7 @@ export function ProjectInstructionsEditor({
         description={t('instructions.placeholder')}
       />
 
-      <form
-        id={FORM_ID}
-        onSubmit={editor.form.handleSubmit((values) => save(values))}
-      >
+      <form id={FORM_ID} onSubmit={editor.submit}>
         <fieldset disabled={!canEdit || editor.isLoading} className="contents">
           <FormSection>
             {(() => {

--- a/services/platform/app/features/projects/components/project-overview.tsx
+++ b/services/platform/app/features/projects/components/project-overview.tsx
@@ -138,7 +138,6 @@ export function ProjectOverview({
   const {
     form: {
       register,
-      handleSubmit,
       formState: { errors },
     },
   } = editor;
@@ -224,10 +223,7 @@ export function ProjectOverview({
           description={t('overview.identityDescription')}
           gap={4}
         >
-          <form
-            id={PROJECT_OVERVIEW_FORM_ID}
-            onSubmit={handleSubmit((values) => save(values))}
-          >
+          <form id={PROJECT_OVERVIEW_FORM_ID} onSubmit={editor.submit}>
             <fieldset
               disabled={editor.isLoading || editor.isSaving}
               className="contents"

--- a/services/platform/app/features/settings/branding/components/branding-form.tsx
+++ b/services/platform/app/features/settings/branding/components/branding-form.tsx
@@ -152,7 +152,7 @@ export function BrandingForm({
   useRegisterActiveEditor(editor);
 
   const {
-    form: { handleSubmit, watch, setValue, getValues, control },
+    form: { watch, setValue, getValues, control },
   } = editor;
 
   const watchedValues = watch();
@@ -260,7 +260,7 @@ export function BrandingForm({
   return (
     <Form
       id="branding-form"
-      onSubmit={handleSubmit((values) => save(values))}
+      onSubmit={editor.submit}
       className="w-full max-w-sm shrink-0 space-y-0 self-start"
     >
       <Stack gap={0} justify="between" className="h-full">

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.tsx
@@ -583,7 +583,7 @@ export function EnterpriseSsoForm({ organizationId, config }: Props) {
   );
 
   return (
-    <form id={FORM_ID} onSubmit={editor.form.handleSubmit(save)}>
+    <form id={FORM_ID} onSubmit={editor.submit}>
       <fieldset disabled={!canEdit || editor.isLoading} className="contents">
         <Stack gap={5}>
           {connected && (

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.tsx
@@ -187,7 +187,6 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
 
   const {
     register,
-    handleSubmit,
     formState: { errors },
   } = editor.form;
   const canEdit = !cannotManage;
@@ -207,7 +206,7 @@ export function LoginPolicyEditor({ organizationId }: LoginPolicyEditorProps) {
           />
         }
       >
-        <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+        <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset
             disabled={!canEdit || editor.isLoading}
             className="contents"

--- a/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/password-policy-editor.tsx
@@ -146,7 +146,6 @@ export function PasswordPolicyEditor({
 
   const {
     register,
-    handleSubmit,
     watch,
     setValue,
     formState: { errors },
@@ -180,7 +179,7 @@ export function PasswordPolicyEditor({
         title={t('passwordPolicy.title')}
         description={t('passwordPolicy.description')}
       >
-        <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+        <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset
             disabled={!canEdit || editor.isLoading}
             className="contents"

--- a/services/platform/app/features/settings/governance/components/sandbox-quota-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/sandbox-quota-editor.tsx
@@ -119,7 +119,6 @@ export function SandboxQuotaEditor({
 
   const {
     register,
-    handleSubmit,
     formState: { errors },
   } = editor.form;
 
@@ -129,7 +128,7 @@ export function SandboxQuotaEditor({
         title={t('sandboxQuota.title')}
         description={t('sandboxQuota.description')}
       >
-        <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+        <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset
             disabled={!canEdit || editor.isLoading}
             className="contents"

--- a/services/platform/app/features/settings/governance/components/session-idle-timeout-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/session-idle-timeout-editor.tsx
@@ -140,7 +140,6 @@ export function SessionIdleTimeoutEditor({
 
   const {
     register,
-    handleSubmit,
     formState: { errors },
   } = editor.form;
   const canEdit = !cannotManage;
@@ -160,7 +159,7 @@ export function SessionIdleTimeoutEditor({
           />
         }
       >
-        <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+        <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset
             disabled={!canEdit || editor.isLoading}
             className="contents"

--- a/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/system-prompt-editor.tsx
@@ -113,7 +113,6 @@ export function SystemPromptEditor({
 
   const {
     register,
-    handleSubmit,
     watch,
     formState: { errors },
   } = editor.form;
@@ -126,7 +125,7 @@ export function SystemPromptEditor({
         title={t('systemPrompt.title')}
         description={t('systemPrompt.description')}
       >
-        <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+        <form id={FORM_ID} onSubmit={editor.submit}>
           <fieldset disabled={editor.isLoading} className="contents">
             <Stack gap={6} className="max-w-2xl">
               <FormSection

--- a/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/upload-policy-editor.tsx
@@ -203,7 +203,6 @@ export function UploadPolicyEditor({
   const {
     getValues,
     register,
-    handleSubmit,
     formState: { errors },
   } = editor.form;
   const canManage = !cannotManage;
@@ -247,7 +246,7 @@ export function UploadPolicyEditor({
         }
       >
         {enabled && (
-          <form id={FORM_ID} onSubmit={handleSubmit(save)}>
+          <form id={FORM_ID} onSubmit={editor.submit}>
             <fieldset
               disabled={!canManage || editor.isLoading}
               className="contents"

--- a/services/platform/app/features/settings/integrations/components/integration-manage/slack-notification-config.tsx
+++ b/services/platform/app/features/settings/integrations/components/integration-manage/slack-notification-config.tsx
@@ -17,6 +17,7 @@ import {
   NOTIFICATION_EVENT_META,
 } from '@/convex/notifications/event_catalog_meta';
 import { useT } from '@/lib/i18n/client';
+import { structuralEqual } from '@/lib/utils/structural-equal';
 
 import { useUpdateCredentials } from '../../hooks/mutations';
 import type { Integration } from '../../hooks/use-integration-manage';
@@ -61,6 +62,19 @@ export function SlackNotificationConfig({
   const [channelsText, setChannelsText] = useState(initialChannels.join(', '));
   const [notifyEvents, setNotifyEvents] = useState(initialEvents);
   const [saving, setSaving] = useState(false);
+
+  // Save stays disabled until something actually changes, so it greys out with
+  // no pending edit (and after a save, once the refetched `connectionConfig`
+  // re-derives the baselines to match). Compared against the live
+  // `connectionConfig`-derived `initial*` values above.
+  const currentChannels = channelsText
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const isDirty =
+    agentSlug !== initialAgentSlug ||
+    !structuralEqual(currentChannels, initialChannels) ||
+    !structuralEqual(notifyEvents, initialEvents);
 
   const agentOptions = useMemo(() => {
     // `agents` is undefined while loading; only treat an empty list as
@@ -168,7 +182,7 @@ export function SlackNotificationConfig({
         </Stack>
 
         <HStack justify="end">
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={handleSave} disabled={saving || !isDirty}>
             {saving
               ? t('integrations.slackNotify.saving')
               : t('integrations.slackNotify.save')}

--- a/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.test.tsx
@@ -39,7 +39,6 @@ function Harness() {
       memberContext={null}
       canDelete={false}
       isCurrentOrganization
-      onSave={save}
     />
   );
 }
@@ -65,7 +64,6 @@ function LoadHarness({ orgName }: { orgName: string }) {
       memberContext={null}
       canDelete={false}
       isCurrentOrganization
-      onSave={save}
     />
   );
 }

--- a/services/platform/app/features/settings/organization/components/organization-settings.tsx
+++ b/services/platform/app/features/settings/organization/components/organization-settings.tsx
@@ -89,7 +89,6 @@ export function OrganizationSettingsView({
   memberContext,
   canDelete,
   isCurrentOrganization,
-  onSave,
 }: {
   controller: OrganizationController;
   organization: Organization;
@@ -99,13 +98,12 @@ export function OrganizationSettingsView({
   canDelete: boolean;
   /** Whether this is the org the user is currently viewing (drives post-delete nav). */
   isCurrentOrganization: boolean;
-  onSave: (values: OrganizationFormData) => Promise<void>;
 }) {
   const { t: tSettings } = useT('settings');
   const { t: tGlobal } = useT('global');
 
   const { form, isLoading, isSaving } = controller;
-  const { handleSubmit, register, control } = form;
+  const { register, control } = form;
 
   const localeOptions = useMemo(
     () =>
@@ -127,10 +125,7 @@ export function OrganizationSettingsView({
         title={tSettings('organization.detailsTitle')}
         description={tSettings('organization.detailsDescription')}
       >
-        <Form
-          id="organization-form"
-          onSubmit={handleSubmit((values) => onSave(values))}
-        >
+        <Form id="organization-form" onSubmit={controller.submit}>
           <fieldset disabled={isLoading} className="divide-border divide-y">
             <SettingsRow
               className="py-5"
@@ -387,7 +382,6 @@ export function OrganizationSettings({
         // The settings route is always scoped to the org the user is currently
         // in (`/dashboard/$id/...`), so deleting it must route them elsewhere.
         isCurrentOrganization
-        onSave={save}
       />
     </Skeletonize>
   );

--- a/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
+++ b/services/platform/app/routes/dashboard/$id/automations/$amId/configuration.tsx
@@ -164,7 +164,6 @@ function ConfigurationPage() {
   const {
     form: {
       register,
-      handleSubmit,
       formState: { errors },
       control,
     },
@@ -179,10 +178,7 @@ function ConfigurationPage() {
   return (
     <Skeletonize loading={isLoading}>
       <ContentArea variant="narrow" gap={4}>
-        <form
-          id={CONFIGURATION_FORM_ID}
-          onSubmit={handleSubmit((values) => save(values))}
-        >
+        <form id={CONFIGURATION_FORM_ID} onSubmit={editor.submit}>
           <fieldset
             disabled={isLoading || editor.isLoading || editor.isSaving}
             className="contents"


### PR DESCRIPTION
## Problem

Clicking **Save** on several editors left the button "active" (dark/clickable) afterwards, and navigating away wrongly warned "you have unsaved changes." Reported on the agent **Environment** tab, then on **governance** configs (e.g. *Sandbox concurrency limits*). Investigation found **two root causes**.

## Root cause 1 — the Save button bypasses the dirty-reset (central)

`useFormEditor` resets the dirty baseline (`form.reset(values, { keepDirty: false })`) **only inside `doSave`**. `EditorActions` renders Save as `<button type="submit" form={formId}>`, but the form editors wired `<form onSubmit={handleSubmit(save)}>` — the **raw** RHF save. So clicking Save fired the native form submit and called `save` directly, **never resetting the baseline** → `isDirty` stayed `true` → Save never greyed out and the navigation blocker fired.

The tell: `⌘S` went through `controller.save()` (doSave → reset) and worked; only the button-click/Enter path was broken. `account-form` was clean only because its `save` manually called `form.reset()`; the others had none. The unit suite only ever called `editor.save()` directly, so CI never caught it.

**Fix:** add a reset-aware `editor.submit` to `useFormEditor` and route the 12 affected form editors' `onSubmit` through it (6 governance + branding, org-settings, project-overview, project-instructions, enterprise-sso, automations config). `account-form` / `personalization` were already correct and left untouched.

## Root cause 2 — ad-hoc Save buttons that ignore dirtiness

`EnvVarListEditor` (agent/workflow/step env), the apps-registry agent env/instructions dialogs, and the Slack notification settings disabled Save only **while saving**. They now gate Save on a real change comparison; `EnvVarListEditor` also registers a dirty source so the navigation blocker warns on unsaved env edits and clears after save (a `patchDisplay` split keeps "focusing a masked secret" from counting as dirty).

## Verification

- `oxlint --type-aware` — 0 errors (17 files)
- `tsc --noEmit` — clean
- Vitest — 72 tests pass, incl. a **new regression test** that drives a real `<form onSubmit={editor.submit}>` and asserts dirty clears after a native submit (verified it **fails** on the old `handleSubmit(save)` wiring), plus new `EnvVarListEditor` dirty tests
- In-browser check against the dev stack was blocked by its self-signed TLS cert (Playwright rejects it); the deterministic native-submit test substitutes for it

UI-only — no schema/migration, no new user-facing strings.