### PR TITLE
fix(platform): coerce project metrics period search param (#2033)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/metrics.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/metrics.search.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchSchema } from './metrics';
+
+// Regression coverage for #2033: a shared/bookmarked
+// `/projects/$projectId/metrics?period=90` URL is parsed by the router as the
+// JSON number 90, which must not crash the route via SearchParamError.
+describe('project metrics searchSchema', () => {
+  it('coerces numeric period values to the string enum', () => {
+    expect(searchSchema.parse({ period: 90 }).period).toBe('90');
+    expect(searchSchema.parse({ period: 30 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 7 }).period).toBe('7');
+  });
+
+  it('accepts string period values', () => {
+    expect(searchSchema.parse({ period: '90' }).period).toBe('90');
+  });
+
+  it('falls back to the default window for out-of-range values', () => {
+    expect(searchSchema.parse({ period: 999 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 'nonsense' }).period).toBe('30');
+  });
+
+  it('leaves an omitted period undefined', () => {
+    expect(searchSchema.parse({}).period).toBeUndefined();
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId/metrics.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId/metrics.tsx
@@ -9,8 +9,16 @@ import {
 } from '@/app/features/tasks/components/project-metrics-page';
 import { seo } from '@/lib/utils/seo';
 
-const searchSchema = z.object({
-  period: z.enum(['7', '30', '90']).optional(),
+export const searchSchema = z.object({
+  // The router parses a bare `?period=90` as the JSON number 90, which fails a
+  // plain string enum and crashes the page (issue #2033). Coerce to a string
+  // first, then fall back to the default window for any out-of-range value so a
+  // shared/bookmarked URL never renders the error boundary.
+  period: z.coerce
+    .string()
+    .pipe(z.enum(['7', '30', '90']))
+    .catch('30')
+    .optional(),
 });
 
 export const Route = createFileRoute(


### PR DESCRIPTION
## Summary

A shared or bookmarked `/dashboard/{org}/projects/{projectId}/metrics?period=90` URL was parsed by TanStack Router's default `parseSearch` (which runs `JSON.parse`) as the JSON **number** `90`. The route's `z.enum(['7','30','90'])` expects strings, so it threw a `SearchParamError` and the page fell to the error boundary.

This applies the same fix already shipped for the agents metrics page (#1987) and automations metrics page (#2024): coerce the value to a string, validate it against the enum, and fall back to the default 30-day window for any out-of-range value so a shared/bookmarked URL never crashes.

## Changes
- `metrics.tsx`: `period` now uses `z.coerce.string().pipe(z.enum(['7','30','90'])).catch('30').optional()`. The schema is exported for testing.
- `metrics.search.test.ts`: regression coverage mirroring #2024 — numeric coercion, string pass-through, out-of-range fallback, omitted-undefined.

## Verification
- `vitest --project server` on the new test: 4 passed
- `tsc --noEmit`: clean
- `oxlint --type-aware` on changed files: 0 warnings, 0 errors

Closes #2033