### PR TITLE
fix: guard owner role and duplicate membership in createMember/addMember (#2035)

### DIFF
--- a/services/platform/convex/members/mutations.test.ts
+++ b/services/platform/convex/members/mutations.test.ts
@@ -555,6 +555,42 @@ describe('addMember handler', () => {
     );
   });
 
+  it('rejects assigning the owner role', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // caller is admin
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_caller', role: 'admin' }],
+    });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...defaultArgs, role: 'owner' }),
+    ).rejects.toThrow('The owner role cannot be assigned manually');
+  });
+
+  it('rejects adding a user who is already a member', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // caller is admin
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_caller', role: 'admin' }],
+    });
+    // target user lookup
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'user_target', email: 'target@example.com' }],
+    });
+    // existing-membership lookup returns a row
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_existing', role: 'member' }],
+    });
+    const handler = await getHandler();
+
+    await expect(handler(ctx, defaultArgs)).rejects.toThrow(
+      'User is already a member of this organization',
+    );
+  });
+
   it('allows owner to add members', async () => {
     mockGetAuthUser.mockResolvedValue(AUTH_USER);
     const ctx = createMockCtx();
@@ -566,6 +602,8 @@ describe('addMember handler', () => {
     ctx.runQuery.mockResolvedValueOnce({
       page: [{ _id: 'user_target', email: 'target@example.com' }],
     });
+    // existing-membership lookup — none, so the add proceeds
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
     // create
     ctx.runMutation.mockResolvedValueOnce({ _id: 'm_new' });
     const handler = await getHandler();

--- a/services/platform/convex/members/mutations.ts
+++ b/services/platform/convex/members/mutations.ts
@@ -69,6 +69,14 @@ export const addMember = mutation({
       throw new Error('Only admins can add members');
     }
 
+    // The owner role can only be assigned through the owner-gated
+    // transferOwnership flow — reject it here so a non-owner admin cannot
+    // self-escalate by passing role: 'owner' (mirrors updateMemberRole).
+    const role = (args.role ?? 'member').toLowerCase();
+    if (role === 'owner') {
+      throw new Error('The owner role cannot be assigned manually');
+    }
+
     const targetUser = findOneUser(
       await ctx.runQuery(components.betterAuth.adapter.findMany, {
         model: 'user',
@@ -77,7 +85,28 @@ export const addMember = mutation({
       }),
     );
 
-    const role = (args.role ?? 'member').toLowerCase();
+    // Reject re-adding a user who already has a membership in this org, mirroring
+    // createMember's existing-user branch. Without this, an admin could mint a
+    // second membership row for an existing member (including themselves),
+    // producing a duplicate mirror row regardless of role.
+    const existingMember = findOneMember(
+      await ctx.runQuery(components.betterAuth.adapter.findMany, {
+        model: 'member',
+        paginationOpts: { cursor: null, numItems: 1 },
+        where: [
+          {
+            field: 'organizationId',
+            value: args.organizationId,
+            operator: 'eq',
+          },
+          { field: 'userId', value: args.userId, operator: 'eq' },
+        ],
+      }),
+    );
+    if (existingMember) {
+      throw new Error('User is already a member of this organization');
+    }
+
     const createdAt = Date.now();
     const created = await ctx.runMutation(
       components.betterAuth.adapter.create,

--- a/services/platform/convex/users/create_member.test.ts
+++ b/services/platform/convex/users/create_member.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../_generated/api', () => ({
+  components: {
+    betterAuth: {
+      adapter: {
+        findMany: 'betterAuth:adapter:findMany',
+        create: 'betterAuth:adapter:create',
+      },
+    },
+  },
+}));
+
+const mockGetAuthUserIdentity = vi.fn();
+vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+}));
+
+vi.mock('../auth', () => ({
+  createAuth: vi.fn(),
+}));
+
+vi.mock('../members/mirror_sync', () => ({
+  upsertMemberMirror: vi.fn(),
+}));
+
+vi.mock('./password_metadata', () => ({
+  recordPasswordChange: vi.fn(),
+}));
+
+function createMockCtx() {
+  return {
+    runQuery: vi.fn(),
+    runMutation: vi.fn(),
+  };
+}
+
+const AUTH_USER = {
+  userId: 'user_caller',
+  email: 'admin@example.com',
+  name: 'Admin',
+};
+
+describe('createMember', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function getCreateMember() {
+    const mod = await import('./create_member');
+    return mod.createMember;
+  }
+
+  const baseArgs = {
+    organizationId: 'org_1',
+    email: 'new@example.com',
+    password: 'sup3r-secret-pw',
+  };
+
+  it('throws when unauthenticated', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(null);
+    const ctx = createMockCtx();
+    const createMember = await getCreateMember();
+
+    await expect(createMember(ctx as never, baseArgs)).rejects.toThrow(
+      'Unauthenticated',
+    );
+  });
+
+  it('throws when caller is not an admin', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // caller membership lookup — plain member
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_caller', role: 'member' }],
+    });
+    const createMember = await getCreateMember();
+
+    await expect(createMember(ctx as never, baseArgs)).rejects.toThrow(
+      'Only admins can create members',
+    );
+  });
+
+  it('rejects assigning the owner role even for an admin caller', async () => {
+    mockGetAuthUserIdentity.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // caller membership lookup — admin (passes isAdmin, but must not mint owner)
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_caller', role: 'admin' }],
+    });
+    const createMember = await getCreateMember();
+
+    await expect(
+      createMember(ctx as never, { ...baseArgs, role: 'owner' }),
+    ).rejects.toThrow('The owner role cannot be assigned manually');
+
+    // The guard must fire before any account/membership is written.
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/convex/users/create_member.ts
+++ b/services/platform/convex/users/create_member.ts
@@ -72,6 +72,14 @@ export async function createMember(
     throw new Error('Only admins can create members');
   }
 
+  // The owner role can only be assigned through the owner-gated
+  // transferOwnership flow — never via createMember. Mirror updateMemberRole's
+  // rejection so a non-owner admin cannot self-escalate by passing
+  // role: 'owner' (see members/mutations.ts updateMemberRole).
+  if ((args.role ?? '').toLowerCase() === 'owner') {
+    throw new Error('The owner role cannot be assigned manually');
+  }
+
   const email = args.email.toLowerCase().trim();
 
   // Check if user already exists by querying Better Auth directly


### PR DESCRIPTION
## Summary

Closes #2035.

The public Convex mutations `api.users.mutations.createMember` and `api.members.mutations.addMember` accepted `role: 'owner'` and gated only on `isAdmin(callerRole)` — which is true for `admin` as well as `owner`. This let a non-owner admin self-escalate to `owner`, bypassing the owner-only `transferOwnership` invariant. `addMember` additionally never checked for an existing membership, so an admin could mint a second (owner) membership row for any `userId`, including their own.

## Changes

- **`users/create_member.ts`** — reject `role.toLowerCase() === 'owner'` right after the admin check, before any account/membership is written. Mirrors `updateMemberRole`'s existing guard ("The owner role cannot be assigned manually").
- **`members/mutations.ts` (`addMember`)** — reject `role === 'owner'` with the same message, and reject adding a `userId` that already has a membership in the org ("User is already a member of this organization"), mirroring `createMember`'s existing-user branch. This prevents duplicate/second membership rows regardless of role.
- Owner remains reachable only through the owner-gated `transferOwnership` flow.

## Tests

- `members/mutations.test.ts` — new cases: `addMember` rejects the owner role, and rejects adding an already-member user; updated the happy-path test for the new existing-membership lookup.
- `users/create_member.test.ts` (new) — `createMember` rejects the owner role for an admin caller and writes nothing; plus unauthenticated / non-admin guards.

## Verification

- `vitest --run --project server` (members + users mutation tests) — green (26 tests)
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings / 0 errors