### PR TITLE
feat(platform): paginate the config-driven Collection block

### DIFF
--- a/builtin-configs/apps/issue-desk/app.json
+++ b/builtin-configs/apps/issue-desk/app.json
@@ -14,7 +14,7 @@
     "workflows": ["issue-desk/desk-process", "issue-desk/reconcile"],
     "roles": ["issue-desk/desk-implementer", "issue-desk/desk-reviewer"],
     "functions": [
-      { "path": "tasks/queries:listTasksByProject", "mode": "query" },
+      { "path": "tasks/queries:listTasksByProjectPaginated", "mode": "query" },
       {
         "path": "tasks/queries:listExternalKeysByProject",
         "mode": "query"

--- a/builtin-configs/apps/issue-desk/views/desk.json
+++ b/builtin-configs/apps/issue-desk/views/desk.json
@@ -91,11 +91,23 @@
                 "path": "tasks/queries:listTasksByProjectPaginated",
                 "args": {
                   "projectId": "$projectId",
-                  "externalSystem": "github",
-                  "excludeStatuses": ["done"]
+                  "externalSystem": "github"
                 }
               },
               "perPage": 50,
+              "filters": [
+                {
+                  "field": "status",
+                  "values": [
+                    "backlog",
+                    "todo",
+                    "in_progress",
+                    "in_review",
+                    "done",
+                    "cancelled"
+                  ]
+                }
+              ],
               "columns": ["title", "status"],
               "columnLabels": {
                 "title": "$label:issueDesk.col.title",

--- a/builtin-configs/apps/issue-desk/views/desk.json
+++ b/builtin-configs/apps/issue-desk/views/desk.json
@@ -88,12 +88,13 @@
               "id": "tasks",
               "title": "$label:issueDesk.tasksListTitle",
               "query": {
-                "path": "tasks/queries:listTasksByProject",
+                "path": "tasks/queries:listTasksByProjectPaginated",
                 "args": {
                   "projectId": "$projectId",
                   "externalSystem": "github"
                 }
               },
+              "perPage": 50,
               "columns": ["title", "status"],
               "columnLabels": {
                 "title": "$label:issueDesk.col.title",

--- a/builtin-configs/apps/issue-desk/views/desk.json
+++ b/builtin-configs/apps/issue-desk/views/desk.json
@@ -91,7 +91,8 @@
                 "path": "tasks/queries:listTasksByProjectPaginated",
                 "args": {
                   "projectId": "$projectId",
-                  "externalSystem": "github"
+                  "externalSystem": "github",
+                  "excludeStatuses": ["done"]
                 }
               },
               "perPage": 50,

--- a/services/platform/app/features/apps/hooks/use-bound-paginated-query.ts
+++ b/services/platform/app/features/apps/hooks/use-bound-paginated-query.ts
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * Generic, capability-gated CURSOR-PAGINATED reactive read — the paginating
+ * sibling of `useBoundQuery`. Same allowlist gate + `$orgId`/`$projectId`/
+ * `$config:` arg resolution, but routed through Convex `usePaginatedQuery` (via
+ * the cached wrapper) so a query-sourced list grows page-by-page behind a
+ * "Load more" button while staying a LIVE subscription — new/updated rows appear
+ * without a refetch (the decisive reason to paginate a query here rather than
+ * reuse the action-infinite hook, which would lose reactivity).
+ *
+ * The view authors only the data args (e.g. `{ projectId, externalSystem }`);
+ * `paginationOpts` is injected by `usePaginatedQuery`, so the resolved args must
+ * NOT carry it. An unset `$config:`/`$projectId` binding resolves to `undefined`;
+ * the hook gates on a fully-bound result and reports `needsConfig` instead of
+ * firing a malformed request — same posture as `useBoundActionInfiniteQuery`.
+ */
+import { makeFunctionReference } from 'convex/server';
+import { useMemo } from 'react';
+
+import { useCachedPaginatedQuery } from '@/app/hooks/use-cached-paginated-query';
+import type {
+  PaginatedQueryArgs,
+  PaginatedQueryReference,
+} from '@/app/hooks/use-convex-paginated-query';
+import {
+  bindingArgsResolved,
+  isFunctionAllowed,
+  isValidFunctionPath,
+  resolveBindingArgs,
+} from '@/lib/shared/platform/function_bindings';
+import { isRecord } from '@/lib/utils/type-utils';
+
+import { useAppRuntime } from '../runtime/app-runtime';
+
+export type BoundPaginatedStatus =
+  | 'LoadingFirstPage'
+  | 'CanLoadMore'
+  | 'LoadingMore'
+  | 'Exhausted';
+
+export interface BoundPaginatedQueryResult {
+  /** Accumulated rows across loaded pages (record-filtered). */
+  results: Record<string, unknown>[];
+  status: BoundPaginatedStatus;
+  isLoading: boolean;
+  /** Load the next `numItems` rows (Convex's own stable ref). */
+  loadMore: (numItems: number) => void;
+  /** The path was not in the app's allowlist (or malformed) — nothing was called. */
+  blocked: boolean;
+  /** A `$config:`/`$projectId` binding the args reference is still unset, so no
+   *  call fired — the app needs configuration before this list can load. */
+  needsConfig: boolean;
+}
+
+const DEFAULT_PER_PAGE = 50;
+
+export function useBoundPaginatedQuery(
+  path: string,
+  args: unknown,
+  options: { perPage?: number } = {},
+): BoundPaginatedQueryResult {
+  const { organizationId, projectId, allowlist, labels, config } =
+    useAppRuntime();
+  const allowed =
+    isValidFunctionPath(path) && isFunctionAllowed(path, allowlist, 'query');
+
+  const argsKey = JSON.stringify(args ?? {});
+  const configKey = JSON.stringify(config ?? {});
+  // Resolve the data args ONCE (for the gate + the subscription). An unset
+  // `$config:` reference resolves to `undefined`; gate on a fully-bound result.
+  const resolved = useMemo(
+    () =>
+      resolveBindingArgs(isRecord(args) ? args : {}, {
+        organizationId,
+        projectId,
+        labels,
+        config,
+      }),
+    // argsKey/configKey stand in for the structurally-compared args + config.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [argsKey, configKey, organizationId, projectId, labels],
+  );
+  const ready = bindingArgsResolved(resolved);
+
+  // A runtime-path query reference can't structurally satisfy the generic
+  // `PaginatedQueryReference` conditional (nor its `PaginatedQueryArgs`), so
+  // assert both — same precedent as `useBoundActionInfiniteQuery`'s
+  // `makeFunctionReference<'action'>` cast and `primeCachedPaginatedQuery`.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- runtime path ref can't satisfy the generic PaginatedQueryReference structurally
+  const ref = makeFunctionReference<'query'>(
+    path,
+  ) as unknown as PaginatedQueryReference;
+  const queryArgs =
+    allowed && ready
+      ? // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resolved data args (paginationOpts injected by the hook) match the query's non-pagination args
+        (resolved as PaginatedQueryArgs<PaginatedQueryReference>)
+      : 'skip';
+
+  const result = useCachedPaginatedQuery(ref, queryArgs, {
+    initialNumItems: options.perPage ?? DEFAULT_PER_PAGE,
+  });
+
+  return {
+    results: result.results.filter(isRecord),
+    status: result.status,
+    isLoading: allowed && ready ? result.isLoading : false,
+    loadMore: result.loadMore,
+    blocked: !allowed,
+    needsConfig: allowed && !ready,
+  };
+}

--- a/services/platform/app/features/apps/registry/connected/collection.test.tsx
+++ b/services/platform/app/features/apps/registry/connected/collection.test.tsx
@@ -1,11 +1,43 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
+import type { DropdownMenuGroup } from '@tale/ui/dropdown-menu';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { BoundPaginatedQueryResult } from '../../hooks/use-bound-paginated-query';
 import { Collection } from './collection';
+
+// Stand in for the Radix dropdown (portals/pointer-events are flaky in jsdom):
+// render the trigger plus one button per radio option that fires onValueChange,
+// so the filter merge can be driven directly.
+vi.mock('@tale/ui/dropdown-menu', () => ({
+  DropdownMenu: ({
+    trigger,
+    items,
+  }: {
+    trigger: ReactNode;
+    items: DropdownMenuGroup[];
+  }) => {
+    const radio = items.flat().find((i) => i.type === 'radio-group');
+    return (
+      <div>
+        {trigger}
+        {radio?.type === 'radio-group' &&
+          radio.options.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => radio.onValueChange(o.value)}
+            >
+              {`opt:${o.value}`}
+            </button>
+          ))}
+      </div>
+    );
+  },
+}));
 
 // i18n → echo `apps.<key>`, interpolating params, so assertions read clearly.
 vi.mock('@/lib/i18n/client', () => ({
@@ -34,10 +66,15 @@ vi.mock('./subject-capacity-chip', () => ({
 }));
 
 // The paginated data hook — drive it by hand per test. Keep the REAL DataTable
-// so the maxRows / no-truncation assertion is meaningful.
+// so the maxRows / no-truncation assertion is meaningful. Capture the args it
+// receives so the filter-merge can be asserted.
 let paginatedReturn: BoundPaginatedQueryResult;
+let lastPaginatedArgs: unknown;
 vi.mock('../../hooks/use-bound-paginated-query', () => ({
-  useBoundPaginatedQuery: () => paginatedReturn,
+  useBoundPaginatedQuery: (_path: string, args: unknown) => {
+    lastPaginatedArgs = args;
+    return paginatedReturn;
+  },
 }));
 
 // The single-shot hook — only used by the non-paginated regression test.
@@ -75,6 +112,7 @@ function taskRows(n: number) {
 
 afterEach(() => {
   loadMore.mockClear();
+  lastPaginatedArgs = undefined;
 });
 
 describe('Collection — paginated', () => {
@@ -169,5 +207,59 @@ describe('Collection — non-paginated (regression)', () => {
     expect(
       screen.queryByRole('button', { name: 'apps.list.loadMore' }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Collection — status filter (config-driven)', () => {
+  const STATUS_FILTER = [
+    { field: 'status', values: ['todo', 'in_progress', 'done'] },
+  ];
+
+  it('merges the selected value into the bound query args, and clears on All', async () => {
+    paginatedReturn = paginated({
+      results: taskRows(1),
+      status: 'CanLoadMore',
+    });
+
+    render(
+      <Collection
+        query={{ path: QUERY.path, args: { projectId: 'p1' } }}
+        columns={COLUMNS}
+        perPage={50}
+        filters={STATUS_FILTER}
+      />,
+    );
+
+    // No selection yet → args carry only the base projectId.
+    expect(lastPaginatedArgs).toEqual({ projectId: 'p1' });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'opt:in_progress' }),
+    );
+    expect(lastPaginatedArgs).toEqual({
+      projectId: 'p1',
+      status: 'in_progress',
+    });
+
+    // Selecting "All" removes the field again.
+    await userEvent.click(screen.getByRole('button', { name: 'opt:__all__' }));
+    expect(lastPaginatedArgs).toEqual({ projectId: 'p1' });
+  });
+
+  it('renders an All option (no status name hardcoded in the component)', () => {
+    paginatedReturn = paginated({ results: taskRows(1), status: 'Exhausted' });
+
+    render(
+      <Collection
+        query={QUERY}
+        columns={COLUMNS}
+        perPage={50}
+        filters={STATUS_FILTER}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'opt:__all__' }),
+    ).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/apps/registry/connected/collection.test.tsx
+++ b/services/platform/app/features/apps/registry/connected/collection.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { BoundPaginatedQueryResult } from '../../hooks/use-bound-paginated-query';
+import { Collection } from './collection';
+
+// i18n → echo `apps.<key>`, interpolating params, so assertions read clearly.
+vi.mock('@/lib/i18n/client', () => ({
+  useT: (ns: string) => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params
+        ? Object.entries(params).reduce(
+            (acc, [k, v]) => acc.replace(`{${k}}`, v),
+            `${ns}.${key}`,
+          )
+        : `${ns}.${key}`,
+  }),
+}));
+
+vi.mock('../../runtime/app-runtime', () => ({
+  usePackLabelString: () => (s?: string) => s ?? '',
+  resolveColumnLabels: (labels?: Record<string, string>) => labels ?? {},
+  useAppRuntime: () => ({}),
+}));
+
+// Subject expansion/accessory are domain components pulling in reactive deps;
+// never exercised here (no `subjectType`), so stub them to keep the import light.
+vi.mock('./subject-run', () => ({ SubjectRun: () => null }));
+vi.mock('./subject-capacity-chip', () => ({
+  SubjectCapacityChip: () => null,
+}));
+
+// The paginated data hook — drive it by hand per test. Keep the REAL DataTable
+// so the maxRows / no-truncation assertion is meaningful.
+let paginatedReturn: BoundPaginatedQueryResult;
+vi.mock('../../hooks/use-bound-paginated-query', () => ({
+  useBoundPaginatedQuery: () => paginatedReturn,
+}));
+
+// The single-shot hook — only used by the non-paginated regression test.
+let singleReturn: { data: unknown; isLoading: boolean; blocked: boolean };
+vi.mock('../../hooks/use-bound-query', () => ({
+  useBoundQuery: () => singleReturn,
+}));
+
+const loadMore = vi.fn();
+
+function paginated(
+  over: Partial<BoundPaginatedQueryResult>,
+): BoundPaginatedQueryResult {
+  return {
+    results: [],
+    status: 'CanLoadMore',
+    isLoading: false,
+    loadMore,
+    blocked: false,
+    needsConfig: false,
+    ...over,
+  };
+}
+
+const QUERY = { path: 'tasks/queries:listTasksByProjectPaginated', args: {} };
+const COLUMNS = ['title', 'status'];
+
+function taskRows(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    _id: `t_${i}`,
+    title: `Task ${i}`,
+    status: 'todo',
+  }));
+}
+
+afterEach(() => {
+  loadMore.mockClear();
+});
+
+describe('Collection — paginated', () => {
+  it('renders more than the default 50-row cap (no silent truncation)', () => {
+    paginatedReturn = paginated({
+      results: taskRows(60),
+      status: 'Exhausted',
+    });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    // 60 data rows + 1 header row — the old 50-cap would have shown 51.
+    expect(screen.getAllByRole('row')).toHaveLength(61);
+  });
+
+  it('shows "Load more" while more pages exist and loads the next page on click', async () => {
+    paginatedReturn = paginated({
+      results: taskRows(1),
+      status: 'CanLoadMore',
+    });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    const button = screen.getByRole('button', { name: 'apps.list.loadMore' });
+    await userEvent.click(button);
+    expect(loadMore).toHaveBeenCalledWith(50);
+  });
+
+  it('disables the button and shows the loading label while fetching more', () => {
+    paginatedReturn = paginated({
+      results: taskRows(1),
+      status: 'LoadingMore',
+    });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    expect(
+      screen.getByRole('button', { name: 'apps.list.loadingMore' }),
+    ).toBeDisabled();
+  });
+
+  it('shows the empty state (no button) when exhausted with no rows', () => {
+    paginatedReturn = paginated({ results: [], status: 'Exhausted' });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    expect(screen.getByText('apps.binding.empty')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'apps.list.loadMore' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a skeleton on first-page load (not a premature empty state)', () => {
+    paginatedReturn = paginated({ results: [], status: 'LoadingFirstPage' });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    expect(screen.queryByText('apps.binding.empty')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'apps.list.loadMore' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('surfaces the blocked state when the path is not allowlisted', () => {
+    paginatedReturn = paginated({ blocked: true });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    expect(screen.getByText('apps.binding.blocked')).toBeInTheDocument();
+  });
+
+  it('prompts to configure when a binding is unresolved', () => {
+    paginatedReturn = paginated({ needsConfig: true });
+
+    render(<Collection query={QUERY} columns={COLUMNS} perPage={50} />);
+
+    expect(screen.getByText('apps.list.needsConfig')).toBeInTheDocument();
+  });
+});
+
+describe('Collection — non-paginated (regression)', () => {
+  it('uses the single-shot path and shows no "Load more" when perPage is unset', () => {
+    singleReturn = {
+      data: { tasks: taskRows(1) },
+      isLoading: false,
+      blocked: false,
+    };
+
+    render(<Collection query={QUERY} columns={COLUMNS} />);
+
+    expect(screen.getByText('Task 0')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'apps.list.loadMore' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/apps/registry/connected/collection.tsx
+++ b/services/platform/app/features/apps/registry/connected/collection.tsx
@@ -7,10 +7,19 @@
  * so any list query can drive it. The reactive binding lives here (Puck only
  * composes the block). Row rendering is delegated to the shared `DataTable`.
  *
+ * Pagination is opt-in (set `perPage`): when on, the block reads through
+ * `useBoundPaginatedQuery` (Convex cursor pagination, still a LIVE subscription)
+ * and accumulates pages behind a "Load more" button; when off, it's a single
+ * reactive read — the original contract, unchanged. The two paths live in
+ * separate inner components so each calls exactly one data hook (no conditional
+ * hooks, no wasted subscription).
+ *
  * When `subjectType` is set, each row is expandable to show its workflow run
  * inline (`SubjectRun` → the reused execution view), so a domain list (tasks
  * now; others later) shows execution detail in-context — no separate run page.
  */
+import { Button } from '@tale/ui/button';
+import { HStack } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Text } from '@tale/ui/text';
 import { ListChecks } from 'lucide-react';
@@ -18,6 +27,7 @@ import { ListChecks } from 'lucide-react';
 import { useT } from '@/lib/i18n/client';
 import { isRecord } from '@/lib/utils/type-utils';
 
+import { useBoundPaginatedQuery } from '../../hooks/use-bound-paginated-query';
 import { useBoundQuery } from '../../hooks/use-bound-query';
 import {
   resolveColumnLabels,
@@ -42,6 +52,9 @@ export interface CollectionProps {
   subjectType?: string;
   /** Row field holding the subject id (default `_id`). */
   subjectIdField?: string;
+  /** Page size; when set, the block paginates (cursor) and accumulates pages
+   *  behind a "Load more" button. Omit for a single-shot reactive read. */
+  perPage?: number;
 }
 
 function pickArray(data: unknown): Record<string, unknown>[] {
@@ -62,7 +75,65 @@ function pickArray(data: unknown): Record<string, unknown>[] {
   return [];
 }
 
-export function Collection({
+/** The shared row table for both Collection paths: applies the optional
+ *  subject-row expansion + capacity-chip accessory and renders via `DataTable`.
+ *  `maxRows` is passed through (paginated lists pass `rows.length` so accumulated
+ *  pages aren't re-truncated; the single-shot list omits it → DataTable's default
+ *  cap). */
+function CollectionTable({
+  rows,
+  columns,
+  resolvedColumnLabels,
+  actions,
+  subjectType,
+  subjectIdField,
+  maxRows,
+}: {
+  rows: Record<string, unknown>[];
+  columns?: string[];
+  resolvedColumnLabels?: Record<string, string>;
+  actions?: BoundActionSpec[];
+  subjectType?: string;
+  subjectIdField: string;
+  maxRows?: number;
+}) {
+  return (
+    <DataTable
+      rows={rows}
+      columns={columns}
+      columnLabels={resolvedColumnLabels}
+      actions={actions}
+      maxRows={maxRows}
+      expansion={
+        subjectType
+          ? {
+              idField: subjectIdField,
+              render: (subjectId) => (
+                <SubjectRun subjectType={subjectType} subjectId={subjectId} />
+              ),
+            }
+          : undefined
+      }
+      rowAccessory={
+        subjectType
+          ? {
+              idField: subjectIdField,
+              render: (subjectId, statusBadge) => (
+                <SubjectCapacityChip
+                  subjectType={subjectType}
+                  subjectId={subjectId}
+                  fallback={statusBadge}
+                />
+              ),
+            }
+          : undefined
+      }
+    />
+  );
+}
+
+/** Single-shot reactive read — the original Collection behavior. */
+function CollectionSingle({
   title,
   query,
   columns,
@@ -87,40 +158,89 @@ export function Collection({
       ) : rows.length === 0 ? (
         <Text variant="muted">{t('binding.empty')}</Text>
       ) : (
-        <DataTable
+        <CollectionTable
           rows={rows}
           columns={columns}
-          columnLabels={resolveColumnLabels(columnLabels, labelOf)}
+          resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
           actions={actions}
-          expansion={
-            subjectType
-              ? {
-                  idField: subjectIdField,
-                  render: (subjectId) => (
-                    <SubjectRun
-                      subjectType={subjectType}
-                      subjectId={subjectId}
-                    />
-                  ),
-                }
-              : undefined
-          }
-          rowAccessory={
-            subjectType
-              ? {
-                  idField: subjectIdField,
-                  render: (subjectId, statusBadge) => (
-                    <SubjectCapacityChip
-                      subjectType={subjectType}
-                      subjectId={subjectId}
-                      fallback={statusBadge}
-                    />
-                  ),
-                }
-              : undefined
-          }
+          subjectType={subjectType}
+          subjectIdField={subjectIdField}
         />
       )}
     </Section>
+  );
+}
+
+/** Cursor-paginated read: accumulates pages behind a "Load more" button while
+ *  staying a live subscription. */
+function CollectionPaginated({
+  title,
+  query,
+  columns,
+  columnLabels,
+  actions,
+  subjectType,
+  subjectIdField = '_id',
+  perPage,
+}: CollectionProps) {
+  const { t } = useT('apps');
+  const labelOf = usePackLabelString();
+  const { results, status, loadMore, blocked, needsConfig } =
+    useBoundPaginatedQuery(query.path, query.args, { perPage });
+
+  return (
+    <Section title={labelOf(title)} icon={ListChecks}>
+      {blocked ? (
+        <Text variant="error">
+          {t('binding.blocked', { path: query.path })}
+        </Text>
+      ) : needsConfig ? (
+        // A `$config:`/`$projectId` binding the query references is still unset —
+        // prompt to configure rather than firing a request that would fail arg
+        // validation.
+        <Text variant="muted">{t('list.needsConfig')}</Text>
+      ) : status === 'LoadingFirstPage' ? (
+        <SkeletonText lines={3} />
+      ) : results.length === 0 ? (
+        <Text variant="muted">{t('binding.empty')}</Text>
+      ) : (
+        <>
+          <CollectionTable
+            rows={results}
+            columns={columns}
+            resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
+            actions={actions}
+            subjectType={subjectType}
+            subjectIdField={subjectIdField}
+            // Render the whole accumulated list — the default 50-row cap would
+            // silently swallow rows pulled in by "Load more".
+            maxRows={results.length}
+          />
+          {(status === 'CanLoadMore' || status === 'LoadingMore') && (
+            <HStack gap={3} className="items-center justify-center">
+              <Button
+                variant="ghost"
+                disabled={status === 'LoadingMore'}
+                onClick={() => loadMore(perPage ?? 50)}
+              >
+                {status === 'LoadingMore'
+                  ? t('list.loadingMore')
+                  : t('list.loadMore')}
+              </Button>
+            </HStack>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+
+export function Collection(props: CollectionProps) {
+  // `perPage` comes from view config and never changes at runtime, so picking the
+  // path here is stable — each inner component owns a consistent hook set.
+  return props.perPage !== undefined ? (
+    <CollectionPaginated {...props} />
+  ) : (
+    <CollectionSingle {...props} />
   );
 }

--- a/services/platform/app/features/apps/registry/connected/collection.tsx
+++ b/services/platform/app/features/apps/registry/connected/collection.tsx
@@ -14,17 +14,25 @@
  * separate inner components so each calls exactly one data hook (no conditional
  * hooks, no wasted subscription).
  *
+ * `filters` is opt-in too: each entry declares a `field` + its `values`, rendered
+ * as a single-select dropdown that merges the chosen value into the bound query's
+ * args (e.g. `status`). The field names + values live in view config (data), so
+ * the block hardcodes no domain vocabulary.
+ *
  * When `subjectType` is set, each row is expandable to show its workflow run
  * inline (`SubjectRun` → the reused execution view), so a domain list (tasks
  * now; others later) shows execution detail in-context — no separate run page.
  */
 import { Button } from '@tale/ui/button';
-import { HStack } from '@tale/ui/layout';
+import { DropdownMenu } from '@tale/ui/dropdown-menu';
+import { HStack, Row } from '@tale/ui/layout';
 import { SkeletonText } from '@tale/ui/skeleton';
 import { Text } from '@tale/ui/text';
-import { ListChecks } from 'lucide-react';
+import { ChevronDown, ListChecks } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
 
 import { useT } from '@/lib/i18n/client';
+import { cn } from '@/lib/utils/cn';
 import { isRecord } from '@/lib/utils/type-utils';
 
 import { useBoundPaginatedQuery } from '../../hooks/use-bound-paginated-query';
@@ -38,6 +46,14 @@ import { DataTable } from './data-table';
 import { Section } from './section';
 import { SubjectCapacityChip } from './subject-capacity-chip';
 import { SubjectRun } from './subject-run';
+
+/** One single-select filter: a query-arg/row `field` and its allowed `values`. */
+export interface CollectionFilterSpec {
+  field: string;
+  values: string[];
+  /** Optional `$label:` ref for the control's label (else the capitalized field). */
+  labelKey?: string;
+}
 
 export interface CollectionProps {
   title?: string;
@@ -55,7 +71,15 @@ export interface CollectionProps {
   /** Page size; when set, the block paginates (cursor) and accumulates pages
    *  behind a "Load more" button. Omit for a single-shot reactive read. */
   perPage?: number;
+  /** Single-select filters merged into the bound query's args (e.g. `status`). */
+  filters?: CollectionFilterSpec[];
 }
+
+/** Inner-component props: the (filter-merged) query + the rendered filter bar. */
+type InnerCollectionProps = CollectionProps & { filterBar?: ReactNode };
+
+/** Radio-group value standing for "no filter" (Radix items can't be empty). */
+const ALL_FILTER_VALUE = '__all__';
 
 function pickArray(data: unknown): Record<string, unknown>[] {
   if (Array.isArray(data)) return data.filter(isRecord);
@@ -73,6 +97,67 @@ function pickArray(data: unknown): Record<string, unknown>[] {
     }
   }
   return [];
+}
+
+/** The status/field filter row — a single-select dropdown per declared filter. */
+function CollectionFilterBar({
+  filters,
+  values,
+  onChange,
+}: {
+  filters: CollectionFilterSpec[];
+  values: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+}) {
+  const { t } = useT('apps');
+  const labelOf = usePackLabelString();
+  return (
+    <Row gap={2} wrap className="mb-3">
+      {filters.map((f) => {
+        const selected = values[f.field];
+        const label = f.labelKey ? labelOf(f.labelKey) : f.field;
+        return (
+          <DropdownMenu
+            key={f.field}
+            trigger={
+              <Button variant="secondary" size="sm">
+                <span
+                  className={cn(
+                    'text-muted-foreground',
+                    // Match DataTable's capitalize-the-raw-key fallback when the
+                    // view didn't author a localized label.
+                    !f.labelKey && 'capitalize',
+                  )}
+                >
+                  {label}:
+                </span>
+                <span className="ml-1">{selected ?? t('list.all')}</span>
+                <ChevronDown className="ml-1 size-4" aria-hidden />
+              </Button>
+            }
+            items={[
+              [
+                {
+                  type: 'radio-group',
+                  value: selected ?? ALL_FILTER_VALUE,
+                  onValueChange: (v) => {
+                    const next = { ...values };
+                    if (v === ALL_FILTER_VALUE) delete next[f.field];
+                    else next[f.field] = v;
+                    onChange(next);
+                  },
+                  options: [
+                    { value: ALL_FILTER_VALUE, label: t('list.all') },
+                    ...f.values.map((v) => ({ value: v, label: v })),
+                  ],
+                },
+              ],
+            ]}
+          />
+        );
+      })}
+    </Row>
+  );
 }
 
 /** The shared row table for both Collection paths: applies the optional
@@ -141,7 +226,8 @@ function CollectionSingle({
   actions,
   subjectType,
   subjectIdField = '_id',
-}: CollectionProps) {
+  filterBar,
+}: InnerCollectionProps) {
   const { t } = useT('apps');
   const labelOf = usePackLabelString();
   const { data, isLoading, blocked } = useBoundQuery(query.path, query.args);
@@ -153,19 +239,24 @@ function CollectionSingle({
         <Text variant="error">
           {t('binding.blocked', { path: query.path })}
         </Text>
-      ) : isLoading && rows.length === 0 ? (
-        <SkeletonText lines={3} />
-      ) : rows.length === 0 ? (
-        <Text variant="muted">{t('binding.empty')}</Text>
       ) : (
-        <CollectionTable
-          rows={rows}
-          columns={columns}
-          resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
-          actions={actions}
-          subjectType={subjectType}
-          subjectIdField={subjectIdField}
-        />
+        <>
+          {filterBar}
+          {isLoading && rows.length === 0 ? (
+            <SkeletonText lines={3} />
+          ) : rows.length === 0 ? (
+            <Text variant="muted">{t('binding.empty')}</Text>
+          ) : (
+            <CollectionTable
+              rows={rows}
+              columns={columns}
+              resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
+              actions={actions}
+              subjectType={subjectType}
+              subjectIdField={subjectIdField}
+            />
+          )}
+        </>
       )}
     </Section>
   );
@@ -182,7 +273,8 @@ function CollectionPaginated({
   subjectType,
   subjectIdField = '_id',
   perPage,
-}: CollectionProps) {
+  filterBar,
+}: InnerCollectionProps) {
   const { t } = useT('apps');
   const labelOf = usePackLabelString();
   const { results, status, loadMore, blocked, needsConfig } =
@@ -199,35 +291,43 @@ function CollectionPaginated({
         // prompt to configure rather than firing a request that would fail arg
         // validation.
         <Text variant="muted">{t('list.needsConfig')}</Text>
-      ) : status === 'LoadingFirstPage' ? (
-        <SkeletonText lines={3} />
-      ) : results.length === 0 ? (
-        <Text variant="muted">{t('binding.empty')}</Text>
       ) : (
         <>
-          <CollectionTable
-            rows={results}
-            columns={columns}
-            resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
-            actions={actions}
-            subjectType={subjectType}
-            subjectIdField={subjectIdField}
-            // Render the whole accumulated list — the default 50-row cap would
-            // silently swallow rows pulled in by "Load more".
-            maxRows={results.length}
-          />
-          {(status === 'CanLoadMore' || status === 'LoadingMore') && (
-            <HStack gap={3} className="items-center justify-center">
-              <Button
-                variant="ghost"
-                disabled={status === 'LoadingMore'}
-                onClick={() => loadMore(perPage ?? 50)}
-              >
-                {status === 'LoadingMore'
-                  ? t('list.loadingMore')
-                  : t('list.loadMore')}
-              </Button>
-            </HStack>
+          {filterBar}
+          {status === 'LoadingFirstPage' ? (
+            <SkeletonText lines={3} />
+          ) : results.length === 0 ? (
+            <Text variant="muted">{t('binding.empty')}</Text>
+          ) : (
+            <>
+              <CollectionTable
+                rows={results}
+                columns={columns}
+                resolvedColumnLabels={resolveColumnLabels(
+                  columnLabels,
+                  labelOf,
+                )}
+                actions={actions}
+                subjectType={subjectType}
+                subjectIdField={subjectIdField}
+                // Render the whole accumulated list — the default 50-row cap
+                // would silently swallow rows pulled in by "Load more".
+                maxRows={results.length}
+              />
+              {(status === 'CanLoadMore' || status === 'LoadingMore') && (
+                <HStack gap={3} className="items-center justify-center">
+                  <Button
+                    variant="ghost"
+                    disabled={status === 'LoadingMore'}
+                    onClick={() => loadMore(perPage ?? 50)}
+                  >
+                    {status === 'LoadingMore'
+                      ? t('list.loadingMore')
+                      : t('list.loadMore')}
+                  </Button>
+                </HStack>
+              )}
+            </>
           )}
         </>
       )}
@@ -236,11 +336,30 @@ function CollectionPaginated({
 }
 
 export function Collection(props: CollectionProps) {
-  // `perPage` comes from view config and never changes at runtime, so picking the
+  // Filter state lives once here and is merged into the bound query's args, so
+  // both inner paths get a filtered query + the same filter bar. `perPage` and
+  // `filters` come from view config and never change at runtime, so picking the
   // path here is stable — each inner component owns a consistent hook set.
+  const filters = props.filters ?? [];
+  const [filterValues, setFilterValues] = useState<Record<string, string>>({});
+
+  const baseArgs = isRecord(props.query.args) ? props.query.args : {};
+  const query =
+    filters.length > 0
+      ? { path: props.query.path, args: { ...baseArgs, ...filterValues } }
+      : props.query;
+  const filterBar =
+    filters.length > 0 ? (
+      <CollectionFilterBar
+        filters={filters}
+        values={filterValues}
+        onChange={setFilterValues}
+      />
+    ) : null;
+
   return props.perPage !== undefined ? (
-    <CollectionPaginated {...props} />
+    <CollectionPaginated {...props} query={query} filterBar={filterBar} />
   ) : (
-    <CollectionSingle {...props} />
+    <CollectionSingle {...props} query={query} filterBar={filterBar} />
   );
 }

--- a/services/platform/app/features/apps/registry/connected/collection.tsx
+++ b/services/platform/app/features/apps/registry/connected/collection.tsx
@@ -112,7 +112,7 @@ function CollectionFilterBar({
   const { t } = useT('apps');
   const labelOf = usePackLabelString();
   return (
-    <Row gap={2} wrap className="mb-3">
+    <Row gap={2} wrap>
       {filters.map((f) => {
         const selected = values[f.field];
         const label = f.labelKey ? labelOf(f.labelKey) : f.field;
@@ -234,29 +234,28 @@ function CollectionSingle({
   const rows = pickArray(data);
 
   return (
-    <Section title={labelOf(title)} icon={ListChecks}>
+    <Section
+      title={labelOf(title)}
+      icon={ListChecks}
+      action={blocked ? undefined : filterBar}
+    >
       {blocked ? (
         <Text variant="error">
           {t('binding.blocked', { path: query.path })}
         </Text>
+      ) : isLoading && rows.length === 0 ? (
+        <SkeletonText lines={3} />
+      ) : rows.length === 0 ? (
+        <Text variant="muted">{t('binding.empty')}</Text>
       ) : (
-        <>
-          {filterBar}
-          {isLoading && rows.length === 0 ? (
-            <SkeletonText lines={3} />
-          ) : rows.length === 0 ? (
-            <Text variant="muted">{t('binding.empty')}</Text>
-          ) : (
-            <CollectionTable
-              rows={rows}
-              columns={columns}
-              resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
-              actions={actions}
-              subjectType={subjectType}
-              subjectIdField={subjectIdField}
-            />
-          )}
-        </>
+        <CollectionTable
+          rows={rows}
+          columns={columns}
+          resolvedColumnLabels={resolveColumnLabels(columnLabels, labelOf)}
+          actions={actions}
+          subjectType={subjectType}
+          subjectIdField={subjectIdField}
+        />
       )}
     </Section>
   );
@@ -281,7 +280,11 @@ function CollectionPaginated({
     useBoundPaginatedQuery(query.path, query.args, { perPage });
 
   return (
-    <Section title={labelOf(title)} icon={ListChecks}>
+    <Section
+      title={labelOf(title)}
+      icon={ListChecks}
+      action={blocked || needsConfig ? undefined : filterBar}
+    >
       {blocked ? (
         <Text variant="error">
           {t('binding.blocked', { path: query.path })}
@@ -293,7 +296,6 @@ function CollectionPaginated({
         <Text variant="muted">{t('list.needsConfig')}</Text>
       ) : (
         <>
-          {filterBar}
           {status === 'LoadingFirstPage' ? (
             <SkeletonText lines={3} />
           ) : results.length === 0 ? (

--- a/services/platform/app/features/apps/registry/tale-config.tsx
+++ b/services/platform/app/features/apps/registry/tale-config.tsx
@@ -169,6 +169,7 @@ export const taleConfig: Config<TaleComponents> = {
         actions,
         subjectType,
         subjectIdField,
+        perPage,
       }) =>
         query ? (
           <Collection
@@ -179,6 +180,7 @@ export const taleConfig: Config<TaleComponents> = {
             actions={actions}
             subjectType={subjectType}
             subjectIdField={subjectIdField}
+            perPage={perPage}
           />
         ) : (
           <></>

--- a/services/platform/app/features/apps/registry/tale-config.tsx
+++ b/services/platform/app/features/apps/registry/tale-config.tsx
@@ -170,6 +170,7 @@ export const taleConfig: Config<TaleComponents> = {
         subjectType,
         subjectIdField,
         perPage,
+        filters,
       }) =>
         query ? (
           <Collection
@@ -181,6 +182,7 @@ export const taleConfig: Config<TaleComponents> = {
             subjectType={subjectType}
             subjectIdField={subjectIdField}
             perPage={perPage}
+            filters={filters}
           />
         ) : (
           <></>

--- a/services/platform/convex/_generated/api.d.ts
+++ b/services/platform/convex/_generated/api.d.ts
@@ -1173,6 +1173,7 @@ import type * as tasks_helpers from "../tasks/helpers.js";
 import type * as tasks_internal_mutations from "../tasks/internal_mutations.js";
 import type * as tasks_internal_queries from "../tasks/internal_queries.js";
 import type * as tasks_issue_ref from "../tasks/issue_ref.js";
+import type * as tasks_list_tasks_paginated from "../tasks/list_tasks_paginated.js";
 import type * as tasks_mentions from "../tasks/mentions.js";
 import type * as tasks_mutations from "../tasks/mutations.js";
 import type * as tasks_public_actions from "../tasks/public_actions.js";
@@ -2767,6 +2768,7 @@ declare const fullApi: ApiFromModules<{
   "tasks/internal_mutations": typeof tasks_internal_mutations;
   "tasks/internal_queries": typeof tasks_internal_queries;
   "tasks/issue_ref": typeof tasks_issue_ref;
+  "tasks/list_tasks_paginated": typeof tasks_list_tasks_paginated;
   "tasks/mentions": typeof tasks_mentions;
   "tasks/mutations": typeof tasks_mutations;
   "tasks/public_actions": typeof tasks_public_actions;

--- a/services/platform/convex/tasks/list_tasks_paginated.test.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.test.ts
@@ -83,7 +83,7 @@ describe('listTasksByProjectPaginated', () => {
     expect(builder.filter).toHaveBeenCalledTimes(1);
   });
 
-  it('filters by status when provided', async () => {
+  it('pins status into the index range, not a post-filter', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
@@ -93,24 +93,15 @@ describe('listTasksByProjectPaginated', () => {
       includeArchived: true,
     });
 
-    expect(builder.filter).toHaveBeenCalledTimes(1);
+    expect(builder.withIndex).toHaveBeenCalledWith(
+      'by_project_status_rank',
+      expect.any(Function),
+    );
+    // status is narrowed in the index range — no `.filter()` for it.
+    expect(builder.filter).not.toHaveBeenCalled();
   });
 
-  it('drops each excluded status with its own .filter() (hide done)', async () => {
-    const { ctx, builder } = createMockQueryBuilder();
-
-    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
-      paginationOpts: DEFAULT_PAGINATION_OPTS,
-      projectId: PROJECT_ID,
-      excludeStatuses: ['done', 'cancelled'],
-      includeArchived: true,
-    });
-
-    // One negative filter per excluded status — config-driven, nothing hardcoded.
-    expect(builder.filter).toHaveBeenCalledTimes(2);
-  });
-
-  it('stacks externalSystem + status + archived as three filters', async () => {
+  it('applies externalSystem + archived as filters (status stays in the index)', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 
     await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
@@ -121,7 +112,7 @@ describe('listTasksByProjectPaginated', () => {
       // includeArchived omitted ⇒ archived exclusion applies too.
     });
 
-    expect(builder.filter).toHaveBeenCalledTimes(3);
+    expect(builder.filter).toHaveBeenCalledTimes(2);
   });
 
   it('returns the pagination result unchanged', async () => {

--- a/services/platform/convex/tasks/list_tasks_paginated.test.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import { listTasksByProjectPaginated } from './list_tasks_paginated';
+
+function createMockQueryBuilder(
+  documents: Array<Record<string, unknown>> = [],
+) {
+  const paginateResult = {
+    page: documents,
+    isDone: true,
+    continueCursor: documents.length > 0 ? 'cursor_1' : '',
+  };
+
+  const builder = {
+    withIndex: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    filter: vi.fn().mockReturnThis(),
+    paginate: vi.fn().mockResolvedValue(paginateResult),
+  };
+
+  const ctx = {
+    db: {
+      query: vi.fn().mockReturnValue(builder),
+    },
+  };
+
+  return { ctx, builder, paginateResult };
+}
+
+const DEFAULT_PAGINATION_OPTS = { numItems: 20, cursor: null, id: 0 };
+const PROJECT_ID = 'project_1' as Id<'projects'>;
+
+describe('listTasksByProjectPaginated', () => {
+  it('walks by_project_status_rank in ascending (status, rank) order', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+      includeArchived: true,
+    });
+
+    expect(ctx.db.query).toHaveBeenCalledWith('tasks');
+    expect(builder.withIndex).toHaveBeenCalledWith(
+      'by_project_status_rank',
+      expect.any(Function),
+    );
+    expect(builder.order).toHaveBeenCalledWith('asc');
+    // includeArchived: true ⇒ no archived filter, and no other facets given.
+    expect(builder.filter).not.toHaveBeenCalled();
+    expect(builder.paginate).toHaveBeenCalledWith(DEFAULT_PAGINATION_OPTS);
+  });
+
+  it('excludes archived rows by default (a .filter())', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+    });
+
+    // The archived exclusion is the only facet here.
+    expect(builder.filter).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters by externalSystem when provided', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+      externalSystem: 'github',
+      includeArchived: true,
+    });
+
+    // Still the (status, rank) index — externalSystem is a post-filter.
+    expect(builder.withIndex).toHaveBeenCalledWith(
+      'by_project_status_rank',
+      expect.any(Function),
+    );
+    expect(builder.filter).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters by status when provided', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+      status: 'in_progress',
+      includeArchived: true,
+    });
+
+    expect(builder.filter).toHaveBeenCalledTimes(1);
+  });
+
+  it('stacks externalSystem + status + archived as three filters', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+      externalSystem: 'github',
+      status: 'in_progress',
+      // includeArchived omitted ⇒ archived exclusion applies too.
+    });
+
+    expect(builder.filter).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns the pagination result unchanged', async () => {
+    const docs = [
+      { _id: 't_1', title: 'A', status: 'todo' },
+      { _id: 't_2', title: 'B', status: 'in_progress' },
+    ];
+    const { ctx, paginateResult } = createMockQueryBuilder(docs);
+
+    const result = await listTasksByProjectPaginated(
+      ctx as unknown as QueryCtx,
+      {
+        paginationOpts: DEFAULT_PAGINATION_OPTS,
+        projectId: PROJECT_ID,
+        includeArchived: true,
+      },
+    );
+
+    expect(result).toBe(paginateResult);
+    expect(result.page).toHaveLength(2);
+  });
+
+  it('passes paginationOpts through to paginate (cursor + numItems)', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+    const opts = { numItems: 50, cursor: 'abc123', id: 3 };
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: opts,
+      projectId: PROJECT_ID,
+      includeArchived: true,
+    });
+
+    expect(builder.paginate).toHaveBeenCalledWith(opts);
+  });
+});

--- a/services/platform/convex/tasks/list_tasks_paginated.test.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.test.ts
@@ -96,6 +96,20 @@ describe('listTasksByProjectPaginated', () => {
     expect(builder.filter).toHaveBeenCalledTimes(1);
   });
 
+  it('drops each excluded status with its own .filter() (hide done)', async () => {
+    const { ctx, builder } = createMockQueryBuilder();
+
+    await listTasksByProjectPaginated(ctx as unknown as QueryCtx, {
+      paginationOpts: DEFAULT_PAGINATION_OPTS,
+      projectId: PROJECT_ID,
+      excludeStatuses: ['done', 'cancelled'],
+      includeArchived: true,
+    });
+
+    // One negative filter per excluded status — config-driven, nothing hardcoded.
+    expect(builder.filter).toHaveBeenCalledTimes(2);
+  });
+
   it('stacks externalSystem + status + archived as three filters', async () => {
     const { ctx, builder } = createMockQueryBuilder();
 

--- a/services/platform/convex/tasks/list_tasks_paginated.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.ts
@@ -1,0 +1,59 @@
+/**
+ * List a project's tasks via Convex native `.paginate()` for use with
+ * `usePaginatedQuery`.
+ *
+ * Walks `by_project_status_rank` so rows arrive in `(status, rank)` order — the
+ * same grouping the board renders — and that order is preserved ACROSS cursor
+ * pages (a single stream, one "Load more", grouping intact). The remaining
+ * facets (`externalSystem`, `status`, archived) are applied as `.filter()`; a
+ * filter can thin a page, which the paginated client handles transparently by
+ * loading the next slice while `status === 'CanLoadMore'`.
+ *
+ * Access control is the caller's job (the `query` wrapper runs
+ * `loadAccessibleProject`); this helper takes an already-authorized ctx so it
+ * stays unit-testable against a mock ctx — the same split as
+ * `list_customers_paginated`.
+ */
+
+import type { PaginationOptions, PaginationResult } from 'convex/server';
+
+import type { Doc, Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+
+export interface ListTasksByProjectPaginatedArgs {
+  paginationOpts: PaginationOptions;
+  projectId: Id<'projects'>;
+  /** Scope to tasks linked to an external system (e.g. 'github'). */
+  externalSystem?: string;
+  status?: string;
+  includeArchived?: boolean;
+}
+
+export async function listTasksByProjectPaginated(
+  ctx: QueryCtx,
+  args: ListTasksByProjectPaginatedArgs,
+): Promise<PaginationResult<Doc<'tasks'>>> {
+  let query = ctx.db
+    .query('tasks')
+    .withIndex('by_project_status_rank', (q) =>
+      q.eq('projectId', args.projectId),
+    )
+    // Ascending → (status, rank) order, matching the board's client-side sort.
+    .order('asc');
+
+  if (args.externalSystem !== undefined) {
+    const externalSystem = args.externalSystem;
+    query = query.filter((q) =>
+      q.eq(q.field('externalSystem'), externalSystem),
+    );
+  }
+  if (args.status !== undefined) {
+    const status = args.status;
+    query = query.filter((q) => q.eq(q.field('status'), status));
+  }
+  if (!args.includeArchived) {
+    query = query.filter((q) => q.eq(q.field('archivedAt'), undefined));
+  }
+
+  return await query.paginate(args.paginationOpts);
+}

--- a/services/platform/convex/tasks/list_tasks_paginated.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.ts
@@ -25,11 +25,9 @@ export interface ListTasksByProjectPaginatedArgs {
   projectId: Id<'projects'>;
   /** Scope to tasks linked to an external system (e.g. 'github'). */
   externalSystem?: string;
-  /** Keep only this status (a positive filter). */
-  status?: string;
-  /** Drop these statuses (a negative filter) — lets a view hide e.g. `done`
-   *  tasks via config, with no status names hardcoded in the component. */
-  excludeStatuses?: string[];
+  /** Keep only this status (drives the view's status filter). Pinned into the
+   *  index range so a filtered list stays dense — no post-filter page thinning. */
+  status?: Doc<'tasks'>['status'];
   includeArchived?: boolean;
 }
 
@@ -37,12 +35,17 @@ export async function listTasksByProjectPaginated(
   ctx: QueryCtx,
   args: ListTasksByProjectPaginatedArgs,
 ): Promise<PaginationResult<Doc<'tasks'>>> {
+  // Narrow the index to (projectId[, status]); ascending → (status, rank) order,
+  // matching the board's client-side sort. Pinning `status` keeps a status-
+  // filtered page dense instead of thinning it with a post-filter.
   let query = ctx.db
     .query('tasks')
-    .withIndex('by_project_status_rank', (q) =>
-      q.eq('projectId', args.projectId),
-    )
-    // Ascending → (status, rank) order, matching the board's client-side sort.
+    .withIndex('by_project_status_rank', (q) => {
+      const scoped = q.eq('projectId', args.projectId);
+      return args.status !== undefined
+        ? scoped.eq('status', args.status)
+        : scoped;
+    })
     .order('asc');
 
   if (args.externalSystem !== undefined) {
@@ -50,16 +53,6 @@ export async function listTasksByProjectPaginated(
     query = query.filter((q) =>
       q.eq(q.field('externalSystem'), externalSystem),
     );
-  }
-  if (args.status !== undefined) {
-    const status = args.status;
-    query = query.filter((q) => q.eq(q.field('status'), status));
-  }
-  // Negative status filter (e.g. hide `done`). `const` is per-iteration, so each
-  // closure captures its own value. Like the other facets it can thin a page —
-  // the paginated client just loads the next slice.
-  for (const excluded of args.excludeStatuses ?? []) {
-    query = query.filter((q) => q.neq(q.field('status'), excluded));
   }
   if (!args.includeArchived) {
     query = query.filter((q) => q.eq(q.field('archivedAt'), undefined));

--- a/services/platform/convex/tasks/list_tasks_paginated.ts
+++ b/services/platform/convex/tasks/list_tasks_paginated.ts
@@ -25,7 +25,11 @@ export interface ListTasksByProjectPaginatedArgs {
   projectId: Id<'projects'>;
   /** Scope to tasks linked to an external system (e.g. 'github'). */
   externalSystem?: string;
+  /** Keep only this status (a positive filter). */
   status?: string;
+  /** Drop these statuses (a negative filter) — lets a view hide e.g. `done`
+   *  tasks via config, with no status names hardcoded in the component. */
+  excludeStatuses?: string[];
   includeArchived?: boolean;
 }
 
@@ -50,6 +54,12 @@ export async function listTasksByProjectPaginated(
   if (args.status !== undefined) {
     const status = args.status;
     query = query.filter((q) => q.eq(q.field('status'), status));
+  }
+  // Negative status filter (e.g. hide `done`). `const` is per-iteration, so each
+  // closure captures its own value. Like the other facets it can thin a page —
+  // the paginated client just loads the next slice.
+  for (const excluded of args.excludeStatuses ?? []) {
+    query = query.filter((q) => q.neq(q.field('status'), excluded));
   }
   if (!args.includeArchived) {
     query = query.filter((q) => q.eq(q.field('archivedAt'), undefined));

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -200,7 +200,6 @@ export const listTasksByProjectPaginated = query({
     projectId: v.id('projects'),
     externalSystem: v.optional(v.string()),
     status: v.optional(taskStatusValidator),
-    excludeStatuses: v.optional(v.array(taskStatusValidator)),
     includeArchived: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -8,6 +8,7 @@
  * orders by `rank` client-side.
  */
 
+import { paginationOptsValidator } from 'convex/server';
 import { v } from 'convex/values';
 
 import { isRecord } from '../../lib/utils/type-utils';
@@ -23,6 +24,7 @@ import { UnauthorizedError } from '../lib/rls/errors';
 import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 import { canClaimTask, checkProjectAccess } from './access';
 import { readTaskDiscussionMessages } from './internal_queries';
+import { listTasksByProjectPaginated as listTasksByProjectPaginatedHelper } from './list_tasks_paginated';
 import {
   boardViewFiltersValidator,
   boardViewScopeValidator,
@@ -181,6 +183,28 @@ export const listTasksByProject = query({
     );
 
     return { tasks: rows, truncated };
+  },
+});
+
+/**
+ * Cursor-paginated sibling of {@link listTasksByProject} for the config-driven
+ * `Collection` block. Walks `by_project_status_rank` so rows arrive in
+ * `(status, rank)` order — the board grouping — preserved across pages, with the
+ * facets applied as `.filter()` (see `list_tasks_paginated`). Project-ACL gated
+ * exactly like the bounded list; `returns` is omitted (the paginated-query
+ * convention, mirroring `customers`/`products`).
+ */
+export const listTasksByProjectPaginated = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    projectId: v.id('projects'),
+    externalSystem: v.optional(v.string()),
+    status: v.optional(taskStatusValidator),
+    includeArchived: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    await loadAccessibleProject(ctx, args.projectId);
+    return await listTasksByProjectPaginatedHelper(ctx, args);
   },
 });
 

--- a/services/platform/convex/tasks/queries.ts
+++ b/services/platform/convex/tasks/queries.ts
@@ -200,6 +200,7 @@ export const listTasksByProjectPaginated = query({
     projectId: v.id('projects'),
     externalSystem: v.optional(v.string()),
     status: v.optional(taskStatusValidator),
+    excludeStatuses: v.optional(v.array(taskStatusValidator)),
     includeArchived: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
@@ -70,7 +70,7 @@ describe('issue-desk demo app (data) validates against the skeleton', () => {
       ]),
     );
     const fnPaths = manifest.capabilities?.functions?.map((f) => f.path) ?? [];
-    expect(fnPaths).toContain('tasks/queries:listTasksByProject');
+    expect(fnPaths).toContain('tasks/queries:listTasksByProjectPaginated');
     // App agents are listed via the app-scoped action; the global `listAgents`
     // would never return them.
     expect(fnPaths).toContain('agents/file_actions:listAppAgents');
@@ -159,6 +159,17 @@ describe('issue-desk demo app (data) validates against the skeleton', () => {
     const columns = collection?.props?.columns;
     expect(Array.isArray(columns)).toBe(true);
     expect(columns).not.toContain('externalId');
+  });
+
+  it('Tasks board paginates (cursor-paginated query + perPage), so the tail is reachable', () => {
+    const collection = blockOfType('Collection');
+    const query = collection?.props?.query as { path?: string } | undefined;
+    // The board binds the cursor-paginated query, not the bounded 2000-row scan.
+    expect(query?.path).toBe('tasks/queries:listTasksByProjectPaginated');
+    // `perPage` is what flips the block into its accumulate-with-"Load more"
+    // path; without it the list silently caps at the 50-row render limit.
+    expect(typeof collection?.props?.perPage).toBe('number');
+    expect(collection?.props?.perPage as number).toBeGreaterThan(0);
   });
 
   it('has no org-wide approvals ReviewQueue (it leaked unrelated approvals)', () => {

--- a/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
@@ -172,14 +172,18 @@ describe('issue-desk demo app (data) validates against the skeleton', () => {
     expect(collection?.props?.perPage as number).toBeGreaterThan(0);
   });
 
-  it('Tasks board hides done tasks via config (excludeStatuses), not hardcoded', () => {
+  it('Tasks board offers a config-driven status filter (no status hardcoded in code)', () => {
     const collection = blockOfType('Collection');
-    const args = (
-      collection?.props?.query as { args?: Record<string, unknown> }
-    )?.args;
-    // The exclusion lives in the view config (data), so the component stays
-    // generic — no status name is baked into the Collection block's code.
-    expect(args?.excludeStatuses).toEqual(['done']);
+    const filters = collection?.props?.filters as
+      | Array<{ field?: string; values?: string[] }>
+      | undefined;
+    // The filterable field + its values live in the view config (data), so the
+    // generic Collection block carries no status names.
+    const statusFilter = filters?.find((f) => f.field === 'status');
+    expect(statusFilter).toBeDefined();
+    expect(statusFilter?.values).toEqual(
+      expect.arrayContaining(['in_progress', 'done']),
+    );
   });
 
   it('has no org-wide approvals ReviewQueue (it leaked unrelated approvals)', () => {

--- a/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
+++ b/services/platform/convex/workflow_engine/helpers/validation/issue_desk_app.test.ts
@@ -172,6 +172,16 @@ describe('issue-desk demo app (data) validates against the skeleton', () => {
     expect(collection?.props?.perPage as number).toBeGreaterThan(0);
   });
 
+  it('Tasks board hides done tasks via config (excludeStatuses), not hardcoded', () => {
+    const collection = blockOfType('Collection');
+    const args = (
+      collection?.props?.query as { args?: Record<string, unknown> }
+    )?.args;
+    // The exclusion lives in the view config (data), so the component stays
+    // generic — no status name is baked into the Collection block's code.
+    expect(args?.excludeStatuses).toEqual(['done']);
+  });
+
   it('has no org-wide approvals ReviewQueue (it leaked unrelated approvals)', () => {
     expect(blockOfType('ReviewQueue')).toBeUndefined();
     const fnPaths = manifest.capabilities?.functions?.map((f) => f.path) ?? [];

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -126,7 +126,8 @@
       "created": "Erstellt",
       "start": "Starten",
       "markDone": "Als erledigt markieren",
-      "merge": "Pull Request mergen"
+      "merge": "Pull Request mergen",
+      "all": "Alle"
     },
     "agents": {
       "none": "Keine Agenten konfiguriert.",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -126,7 +126,8 @@
       "created": "Created",
       "start": "Start",
       "markDone": "Mark done",
-      "merge": "Merge pull request"
+      "merge": "Merge pull request",
+      "all": "All"
     },
     "agents": {
       "none": "No agents configured.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -126,7 +126,8 @@
       "created": "Créé",
       "start": "Démarrer",
       "markDone": "Marquer comme terminé",
-      "merge": "Merger la pull request"
+      "merge": "Merger la pull request",
+      "all": "Tous"
     },
     "agents": {
       "none": "Aucun agent configuré.",


### PR DESCRIPTION
## Problem

The **Issue resolution desk → Tasks** tab had no pagination at either layer. `tasks/queries:listTasksByProject` does a bounded scan up to `TASK_BOARD_CAP = 2000` and the generic `Collection` block fed the whole array to `DataTable`, which renders only `rows.slice(0, maxRows)` (`maxRows` default **50**). So once a project accumulated >50 tasks, **everything past #50 was fetched but never shown**.

## Solution

### 1. Cursor pagination for the generic `Collection` block (opt-in via `perPage`)

Mirrors its action-sourced sibling `ExternalList`. Status grouping is preserved across pages with a single cursor stream and a single "Load more" — **no per-status merge, no new index, no migration**.

- **`tasks/queries:listTasksByProjectPaginated`** (new `tasks/list_tasks_paginated.ts` helper + thin `query` wrapper) uses `paginationOptsValidator` + `.paginate()`, walking the **existing `by_project_status_rank` index** `.order('asc')` so rows arrive in `(status, rank)` order — the board grouping, preserved across pages. Project ACL (`loadAccessibleProject`) preserved; `returns` omitted per the `customers`/`products` convention.
- **`useBoundPaginatedQuery`** — capability-gated paginated sibling of `useBoundQuery`, wrapping `useCachedPaginatedQuery`. Gating copied from `useBoundActionInfiniteQuery`. Stays a **live reactive subscription**.
- **`Collection`** splits into `CollectionSingle` / `CollectionPaginated` inner components (no conditional hooks). The paginated path renders a "Load more" button and passes `maxRows={rows.length}`. With no `perPage`, behavior is **unchanged**.
- Puck registry threads `perPage`; `issue-desk` `desk.json` → paginated query + `perPage: 50`.

### 2. Config-driven status filter on the `Collection` block (opt-in via `filters`)

Lets the user filter the desk by status, instead of baking in a "hide done" rule. Each filter is declared in **view config** (`filters: [{ field, values }]`) and rendered as a single-select dropdown in the section header (right-aligned); the choice merges into the bound query's args — so the generic block **hardcodes no status vocabulary**.

- `Collection` renders a `DropdownMenu` radio-group per filter; selection merges `{ field: value }` into the query args, "All" clears it.
- `listTasksByProjectPaginated`: `status` now **narrows the index range** (`eq(projectId, status)`) so a filtered list stays dense (no post-filter page thinning).
- `issue-desk` `desk.json` declares a `status` filter over the six task statuses.
- New `apps.list.all` label (en/de/fr) for the "All" option. No other new labels — reuses `apps.list.loadMore` / `loadingMore` / `needsConfig`.

## Testing

- `tsc --noEmit` ✅ · `oxlint --type-aware` ✅ (0 findings)
- `convex/tasks/list_tasks_paginated.test.ts` — index dispatch, `.order('asc')`, status-in-index, filter stacking, cursor passthrough (server) ✅
- `connected/collection.test.tsx` — 60-row no-truncation, Load more + click, loading/empty/blocked/needsConfig, **non-paginated regression**, **status-filter merge + clear** (client) ✅
- `issue_desk_app.test.ts` — updated fnPath + "Tasks paginates" + "Tasks offers a status filter" assertions ✅
- 33 unit tests pass total.
- Verified end-to-end on the local dev stack: seeded ~80 mixed-status github tasks → desk renders grouped rows, "Load more" past 50, and the header status dropdown filters live.

## Notes

- `_generated/api.d.ts` regenerated to register the new `tasks/list_tasks_paginated` module (committed).
