### PR TITLE
fix(platform): guard trusted-headers authenticate endpoint against open redirect (#2037)

### DIFF
--- a/services/platform/convex/trusted_headers_auth/authenticate_handler.test.ts
+++ b/services/platform/convex/trusted_headers_auth/authenticate_handler.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ActionCtx } from '../_generated/server';
+import { trustedHeadersAuthenticateHandler } from './authenticate_handler';
+
+// The handler signs a cookie and asks Better Auth for a JWT cookie; neither is
+// relevant to the redirect-target hardening under test, so stub both.
+vi.mock('../enterprise_sso/sign_cookie_value', () => ({
+  signCookieValue: vi.fn().mockResolvedValue('signed-token'),
+}));
+
+vi.mock('../auth', () => ({
+  createAuth: vi.fn(() => ({
+    handler: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+  })),
+}));
+
+function createCtx(): ActionCtx {
+  return {
+    runMutation: vi.fn().mockResolvedValue({
+      sessionToken: 'session-token',
+      userId: 'user_1',
+      organizationId: 'org_1',
+      shouldClearOldSession: false,
+      trustedHeadersChanged: false,
+    }),
+  } as unknown as ActionCtx;
+}
+
+function authRequest(redirect: string | null): Request {
+  const url = new URL(
+    'https://app.example.com/api/trusted-headers/authenticate',
+  );
+  if (redirect !== null) {
+    url.searchParams.set('redirect', redirect);
+  }
+  return new Request(url.toString(), {
+    headers: { 'Remote-Email': 'user@example.com' },
+  });
+}
+
+describe('trustedHeadersAuthenticateHandler — open-redirect hardening (#2037)', () => {
+  beforeEach(() => {
+    process.env.TRUSTED_HEADERS_ENABLED = 'true';
+    process.env.BETTER_AUTH_SECRET = 'test-secret';
+    delete process.env.BASE_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.TRUSTED_HEADERS_ENABLED;
+    delete process.env.BETTER_AUTH_SECRET;
+    vi.clearAllMocks();
+  });
+
+  // Each entry is a user-controlled `redirect` value that must NOT survive into
+  // the navigation sinks; the handler must fall back to the dashboard.
+  const hostileRedirects = [
+    'https://evil.com',
+    'http://evil.com/phish',
+    '//evil.com',
+    '/\\evil.com',
+    'javascript:alert(1)',
+    'dashboard',
+  ];
+
+  it.each(hostileRedirects)(
+    'neutralises hostile redirect %s and falls back to the dashboard',
+    async (redirect) => {
+      const res = await trustedHeadersAuthenticateHandler(
+        createCtx(),
+        authRequest(redirect),
+      );
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      // The malicious host/scheme must never reach either navigation sink.
+      expect(html).not.toContain('evil.com');
+      expect(html).not.toContain('javascript:');
+      // Both sinks point at the safe default instead.
+      expect(html).toContain('0;url=/dashboard');
+      expect(html).toContain("window.location.href = '/dashboard'");
+    },
+  );
+
+  it('preserves a safe same-origin redirect path', async () => {
+    const res = await trustedHeadersAuthenticateHandler(
+      createCtx(),
+      authRequest('/log-in/team-a?tab=members'),
+    );
+    const html = await res.text();
+
+    expect(html).toContain('0;url=/log-in/team-a?tab=members');
+    expect(html).toContain(
+      "window.location.href = '/log-in/team-a?tab=members'",
+    );
+  });
+
+  it('falls back to the dashboard when no redirect is supplied', async () => {
+    const res = await trustedHeadersAuthenticateHandler(
+      createCtx(),
+      authRequest(null),
+    );
+    const html = await res.text();
+
+    expect(html).toContain('0;url=/dashboard');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2037 — open redirect on the trusted-headers authenticate endpoint.

The runtime fix for this issue already landed on `main` as part of #2118: a shared `sanitizeInternalRedirect` / `isSafeInternalPath` helper (`lib/shared/utils/safe-redirect.ts`) is now applied at **both** navigation sinks that the issue called out:

- `convex/trusted_headers_auth/authenticate_handler.ts` — the `redirect` query param is passed through `sanitizeInternalRedirect(..., `${basePath}/dashboard`)` before being reflected into the `<meta http-equiv="refresh">` and `window.location.href` sinks.
- `app/routes/_auth/log-in.tsx` — the login page forwards only a validated same-origin path as `?redirect=` (defence in depth).

`isSafeInternalPath` requires a single leading `/`, rejects protocol-relative (`//evil.com`) and backslash (`/\evil.com`) host-smuggling, rejects absolute/`scheme:` URLs, and re-resolves against a fixed origin as a belt-and-braces check. Anything unsafe falls back to `${basePath}/dashboard`.

What was still missing was a regression test pinned to the **actual vulnerable endpoint** (the existing tests only cover the helper in isolation). This PR adds that:

- `convex/trusted_headers_auth/authenticate_handler.test.ts` drives `trustedHeadersAuthenticateHandler` end-to-end with hostile `redirect` values (`https://evil.com`, `http://evil.com/phish`, `//evil.com`, `/\evil.com`, `javascript:alert(1)`, bare `dashboard`) and asserts the malicious host/scheme never reaches either navigation sink and that both fall back to `/dashboard`. It also asserts a safe same-origin path (`/log-in/team-a?tab=members`) is preserved and that a missing param falls back to the dashboard.

This formally links and closes the issue, and locks in the fix so a future refactor of the handler can't silently reintroduce the open redirect.

## Tests

- `bunx vitest --run --project server convex/trusted_headers_auth/authenticate_handler.test.ts` → 8 passing.
- `bunx vitest --run --project server lib/shared/utils/safe-redirect.test.ts` → 5 passing.
- `bunx oxlint --type-aware` clean on the new file.