### PR TITLE
fix(platform): clear conversations search filter when box emptied after ?search= seed (#1992)

### DIFF
--- a/services/platform/app/features/conversations/components/conversations.test.tsx
+++ b/services/platform/app/features/conversations/components/conversations.test.tsx
@@ -1,0 +1,116 @@
+import type { UsePaginatedQueryResult } from 'convex/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConversationItem } from '@/convex/conversations/types';
+import { render, screen } from '@/tests/utils/render';
+
+import { Conversations } from './conversations';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for #1992: a lane opened via `?search=` seeds the filter
+// from the URL param, but clearing the search box must actually clear the
+// filter (state is the source of truth — it must NOT fall back to the stale URL
+// param on every render).
+// ---------------------------------------------------------------------------
+
+// `useNavigate` is called to keep the URL in sync with the search state; in the
+// jsdom test there is no router, so a no-op navigate is enough.
+const navigateSpy = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateSpy,
+}));
+
+// The bulk-actions hook reaches for convex mutations; stub it out so the list
+// renders without a backend (mirrors customers-table.test.tsx).
+vi.mock('../hooks/use-bulk-actions', () => ({
+  useBulkActions: () => ({
+    isBulkProcessing: false,
+    bulkSendDialog: { isOpen: false, isSending: false },
+    openBulkSendDialog: vi.fn(),
+    closeBulkSendDialog: vi.fn(),
+    handleSendMessages: vi.fn(),
+    handleBulkResolve: vi.fn(),
+    handleBulkReopen: vi.fn(),
+    handleBulkSpam: vi.fn(),
+    handleBulkArchive: vi.fn(),
+    handleBulkUnarchive: vi.fn(),
+  }),
+}));
+
+// The reading pane pulls in convex queries/mutations; it is irrelevant to the
+// list-filtering behaviour under test, so stub it to a marker.
+vi.mock('./conversation-panel', () => ({
+  ConversationPanel: () => <div data-testid="conversation-panel" />,
+}));
+
+function makeConversation(id: string, title: string): ConversationItem {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal fixture; the list row only reads id/title/unread_count for this test
+  return {
+    _id: id,
+    id,
+    title,
+    description: '',
+    subject: '',
+    status: 'open',
+    unread_count: 0,
+    last_message_at: '2026-01-01T00:00:00.000Z',
+    messages: [],
+  } as unknown as ConversationItem;
+}
+
+function makePaginatedResult(
+  results: ConversationItem[],
+): UsePaginatedQueryResult<ConversationItem> {
+  return {
+    results,
+    status: 'Exhausted',
+    isLoading: false,
+    loadMore: vi.fn(),
+  } as unknown as UsePaginatedQueryResult<ConversationItem>;
+}
+
+const searchBox = () => screen.getByPlaceholderText('Search conversations');
+
+/** Whether a conversation list row exists (rows are buttons labelled by title). */
+function hasConversationRow(title: string): boolean {
+  return screen.queryByRole('button', { name: title }) !== null;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Conversations', () => {
+  it('clears the filter when the search box is emptied after a ?search= seed', async () => {
+    const conversations = [
+      makeConversation('c1', 'Refund please'),
+      makeConversation('c2', 'Order shipped'),
+    ];
+
+    const { user } = render(
+      <Conversations
+        status="open"
+        organizationId="test-org-id"
+        // Seeded from the `?search=Refund` URL param.
+        search="Refund"
+        paginatedResult={makePaginatedResult(conversations)}
+        conversationCount={conversations.length}
+        totalConversationCount={conversations.length}
+      />,
+    );
+
+    // The seeded filter is applied: only the matching row is visible.
+    expect(searchBox()).toHaveValue('Refund');
+    expect(hasConversationRow('Refund please')).toBe(true);
+    expect(hasConversationRow('Order shipped')).toBe(false);
+
+    // Clearing the box must remove the filter and bring every row back — it
+    // must NOT fall back to the stale `search` prop (the #1992 bug). The input
+    // is readonly until focused (anti-autofill), so click to focus it first.
+    await user.click(searchBox());
+    await user.clear(searchBox());
+    expect(searchBox()).toHaveValue('');
+    expect(hasConversationRow('Refund please')).toBe(true);
+    expect(hasConversationRow('Order shipped')).toBe(true);
+  });
+});

--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -4,6 +4,7 @@ import { Button } from '@tale/ui/button';
 import { DropdownMenu, type DropdownMenuItem } from '@tale/ui/dropdown-menu';
 import { Row } from '@tale/ui/layout';
 import { LoadingOverlay } from '@tale/ui/loading-overlay';
+import { useNavigate } from '@tanstack/react-router';
 import type { UsePaginatedQueryResult } from 'convex/react';
 import {
   ArchiveIcon,
@@ -84,13 +85,35 @@ export function Conversations({
   conversationCount,
   totalConversationCount,
 }: ConversationsProps) {
+  const navigate = useNavigate();
+
   const [selectedConversationId, setSelectedConversationId] = useState<
     string | null
   >(null);
 
+  // `searchQuery` is the single source of truth for the filter. It is seeded
+  // once from the `?search=` URL param; thereafter the URL is kept in sync from
+  // state (not the other way around) so that clearing the box actually clears
+  // the filter instead of falling back to the stale URL param on every render.
   const [searchQuery, setSearchQuery] = useState(initialSearch || '');
   const [readFilter, setReadFilter] = useState<'all' | 'read' | 'unread'>(
     'all',
+  );
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchQuery(value);
+      void navigate({
+        to: '/dashboard/$id/conversations/$status',
+        params: { id: organizationId, status: status ?? 'open' },
+        search: (prev) => ({
+          ...prev,
+          search: value.length > 0 ? value : undefined,
+        }),
+        replace: true,
+      });
+    },
+    [navigate, organizationId, status],
   );
 
   const { t: tChat } = useT('chat');
@@ -110,9 +133,8 @@ export function Conversations({
   const filteredConversations = useMemo(() => {
     let results = paginatedResult.results;
 
-    const searchTerm = searchQuery || initialSearch;
-    if (searchTerm) {
-      results = filterByTextSearch(results, searchTerm, [
+    if (searchQuery) {
+      results = filterByTextSearch(results, searchQuery, [
         'title',
         'description',
         'subject',
@@ -127,7 +149,7 @@ export function Conversations({
     }
 
     return results;
-  }, [paginatedResult.results, searchQuery, initialSearch, readFilter]);
+  }, [paginatedResult.results, searchQuery, readFilter]);
 
   const {
     selectionState,
@@ -358,7 +380,7 @@ export function Conversations({
             <SearchInput
               placeholder={tChat('searchConversations')}
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(e) => handleSearchChange(e.target.value)}
               wrapperClassName="flex-1"
               className="bg-transparent pr-3 text-sm shadow-none"
               disabled={controlsDisabled}


### PR DESCRIPTION
## Summary

Fixes #1992.

When a conversations lane was opened via a `?search=` URL param, clearing the search box did nothing — the list stayed filtered.

**Root cause.** In `services/platform/app/features/conversations/components/conversations.tsx`, `searchQuery` was seeded from the `initialSearch` prop, but the applied term was `const searchTerm = searchQuery || initialSearch;`. Once the user emptied the box, `'' || initialSearch` fell back to the stale URL param on every render, so the filter stuck.

## Fix

- `searchQuery` is now the single source of truth for the filter (seeded once from the URL param). The applied filter uses `searchQuery` alone — no OR-fallback to `initialSearch`.
- The `?search=` URL param is now kept in sync **from** state via `useNavigate` (mirrors the existing pattern in `customers-table.tsx`), using `replace: true` so typing doesn't spam history. Clearing the box drops the param.

## Tests

- Added `conversations.test.tsx`: seeds the filter from `search="Refund"`, asserts only the matching row shows, then clears the box and asserts every row reappears (fails against the old `|| initialSearch` code).
- `bunx tsc --noEmit` — green
- `bunx oxlint --type-aware` on changed files — green
- `bunx vitest --run --config vitest.ui.config.ts` for the new test — green

Closes #1992