### PR TITLE
fix(proxy): stop routing platform favicon + manifest to Convex dashboard

### DIFF
--- a/services/proxy/Caddyfile
+++ b/services/proxy/Caddyfile
@@ -118,9 +118,13 @@
 	}
 
 	# HTTP: Convex Dashboard static assets at root paths (logo, icons)
-	# Dashboard HTML references these at root but they're served under /convex-dashboard/
+	# Dashboard HTML references these at root but they're served under /convex-dashboard/.
+	# Only list assets the platform does NOT own at root. `/favicon.ico` and
+	# `/manifest.webmanifest` are served by the platform itself (dist/favicon.ico and
+	# the PWA manifest index.html references), so routing them here hijacked the
+	# platform's tab icon + PWA manifest with the Convex dashboard's (regression #1912).
 	@convexDashboardAssets {
-		path /convex-logo-only.svg /convex-light.svg /convex-dark.svg /favicon.ico /apple-touch-icon.png /manifest.webmanifest
+		path /convex-logo-only.svg /convex-light.svg /convex-dark.svg /apple-touch-icon.png
 	}
 	handle @convexDashboardAssets {
 		uri replace / /convex-dashboard/ 1


### PR DESCRIPTION
## Problem

In a deployed stack (`tale deploy`), the platform's browser-tab icon was the **Convex swirl** instead of the Tale favicon. Local `bun dev` (`localhost:3000`) was fine.

## Root cause

The favicon is served through **Caddy**, not the app directly. The `@convexDashboardAssets` matcher in `services/proxy/Caddyfile` was rewriting `/favicon.ico` (and `/manifest.webmanifest`) to the Convex dashboard backend (`convex:6791`):

```caddy
@convexDashboardAssets {
    path /convex-logo-only.svg /convex-light.svg /convex-dark.svg /favicon.ico /apple-touch-icon.png /manifest.webmanifest
}
handle @convexDashboardAssets { uri replace / /convex-dashboard/ 1; reverse_proxy convex:6791 }
```

So the platform's `index.html` request for `/favicon.ico` was answered with the Convex dashboard's favicon. The same applied to `/manifest.webmanifest`, silently swapping the platform's PWA install manifest for Convex's.

Both are **platform-owned root assets** (`dist/favicon.ico`, and the PWA manifest `index.html` references). They were added to this Convex-only matcher by mistake in #1912 (an unrelated PDF/masking/canvas change).

**Why dev was unaffected:** `localhost:3000` hits Vite directly with no Caddy in front, so `public/favicon.ico` is served correctly. The bug only surfaced through the proxy.

## Fix

Drop `/favicon.ico` and `/manifest.webmanifest` from the matcher so the platform serves its own. Kept the Convex-only logo SVGs and `/apple-touch-icon.png` (platform points apple-touch at an explicit `/assets/...` link, so no collision) so the Convex dashboard chrome still renders.

## Trade-off

The Convex dashboard tab (under `/convex-dashboard/`) now shows the Tale favicon instead of Convex's — cosmetic, and arguably nicer for an operator tool.

## Verification

- `localhost:3000` (Vite) was already correct — unchanged.
- After deploy, the platform tab serves `dist/favicon.ico` and the PWA manifest from the platform. Requires a proxy redeploy (`tale deploy`) and a hard refresh (favicons cache aggressively).