### PR TITLE
fix: adaptive-header a11y — single h1, breadcrumb nav, heading order (#1994)

### DIFF
--- a/packages/ui/src/components/feedback/empty-state.test.tsx
+++ b/packages/ui/src/components/feedback/empty-state.test.tsx
@@ -13,16 +13,16 @@ describe('EmptyState', () => {
       expect(screen.getByRole('heading')).toHaveTextContent('No results found');
     });
 
-    it('renders the title as an h2 by default (no h1->h3 skip under a page heading)', () => {
-      render(<EmptyState title="No documents yet" />);
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        'No documents yet',
+    it('renders the title as an h3 by default (sits under a section h2)', () => {
+      render(<EmptyState title="No teams yet" />);
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+        'No teams yet',
       );
     });
 
-    it('honors an explicit headingLevel', () => {
-      render(<EmptyState title="No documents yet" headingLevel={3} />);
-      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+    it('honors an explicit headingLevel (e.g. h2 directly under a page h1)', () => {
+      render(<EmptyState title="No documents yet" headingLevel={2} />);
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
         'No documents yet',
       );
     });

--- a/packages/ui/src/components/feedback/empty-state.test.tsx
+++ b/packages/ui/src/components/feedback/empty-state.test.tsx
@@ -13,6 +13,20 @@ describe('EmptyState', () => {
       expect(screen.getByRole('heading')).toHaveTextContent('No results found');
     });
 
+    it('renders the title as an h2 by default (no h1->h3 skip under a page heading)', () => {
+      render(<EmptyState title="No documents yet" />);
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'No documents yet',
+      );
+    });
+
+    it('honors an explicit headingLevel', () => {
+      render(<EmptyState title="No documents yet" headingLevel={3} />);
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+        'No documents yet',
+      );
+    });
+
     it('renders description when provided', () => {
       render(
         <EmptyState

--- a/packages/ui/src/components/feedback/empty-state.tsx
+++ b/packages/ui/src/components/feedback/empty-state.tsx
@@ -13,6 +13,13 @@ interface EmptyStateProps {
   description?: ReactNode;
   action?: ReactNode;
   className?: string;
+  /**
+   * Heading level for the title (1-6). Defaults to `2` so an empty state that
+   * sits directly under a page `h1` (the common case — e.g. a list view's
+   * empty body) does not skip from `h1` to `h3`. Pass an explicit level when
+   * the empty state nests under a deeper section heading.
+   */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 export function EmptyState({
@@ -21,6 +28,7 @@ export function EmptyState({
   description,
   action,
   className,
+  headingLevel = 2,
 }: EmptyStateProps) {
   return (
     <div
@@ -32,7 +40,7 @@ export function EmptyState({
       {Icon && (
         <Icon className="text-muted-foreground mb-4 size-5" aria-hidden />
       )}
-      <Heading level={3} size="sm">
+      <Heading level={headingLevel} size="sm">
         {title}
       </Heading>
       {description && (

--- a/packages/ui/src/components/feedback/empty-state.tsx
+++ b/packages/ui/src/components/feedback/empty-state.tsx
@@ -14,10 +14,11 @@ interface EmptyStateProps {
   action?: ReactNode;
   className?: string;
   /**
-   * Heading level for the title (1-6). Defaults to `2` so an empty state that
-   * sits directly under a page `h1` (the common case — e.g. a list view's
-   * empty body) does not skip from `h1` to `h3`. Pass an explicit level when
-   * the empty state nests under a deeper section heading.
+   * Heading level for the title (1-6). Defaults to `3` — most empty states sit
+   * inside a section (under an `h2`) or a dialog, where `h3` keeps the heading
+   * order non-skipping. Pass an explicit level for other contexts: an empty
+   * state rendered directly under a page `h1` (with no intervening section
+   * heading) should use `2` so the outline doesn't skip `h1`→`h3`.
    */
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
@@ -28,7 +29,7 @@ export function EmptyState({
   description,
   action,
   className,
-  headingLevel = 2,
+  headingLevel = 3,
 }: EmptyStateProps) {
   return (
     <div

--- a/services/platform/app/components/layout/adaptive-header.test.tsx
+++ b/services/platform/app/components/layout/adaptive-header.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { render, screen } from '@/tests/utils/render';
 
 import {
   AdaptiveHeaderProvider,
@@ -30,6 +30,25 @@ describe('AdaptiveHeader', () => {
         </AdaptiveHeaderProvider>,
       );
       await checkAccessibility(container);
+    });
+
+    // The title is rendered twice — once by the desktop root, once mirrored
+    // into the mobile slot — so the inactive copy must be hidden from the
+    // accessibility tree (`aria-hidden`) to avoid a duplicate `h1`. `getByRole`
+    // ignores `aria-hidden` subtrees, so exactly one heading must remain.
+    it('exposes only one h1 even though the title is mirrored into the slot', () => {
+      render(
+        <AdaptiveHeaderProvider>
+          <AdaptiveHeaderRoot>
+            <AdaptiveHeaderTitle>Page Title</AdaptiveHeaderTitle>
+          </AdaptiveHeaderRoot>
+          <AdaptiveHeaderSlot />
+        </AdaptiveHeaderProvider>,
+      );
+      expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Page Title',
+      );
     });
   });
 });

--- a/services/platform/app/components/layout/adaptive-header.tsx
+++ b/services/platform/app/components/layout/adaptive-header.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useIsMobile } from '@/app/hooks/use-is-mobile';
 import { cn } from '@/lib/utils/cn';
 
 // =============================================================================
@@ -75,11 +76,21 @@ interface AdaptiveHeaderSlotProps {
 
 export function AdaptiveHeaderSlot({ className }: AdaptiveHeaderSlotProps) {
   const content = useAdaptiveHeaderContent();
+  const isMobile = useIsMobile();
 
   if (!content) return null;
 
   return (
-    <div className={cn('flex items-center flex-1 min-w-0', className)}>
+    // The slot is the *mobile* mirror of the header content (which the desktop
+    // `AdaptiveHeaderRoot` also renders). Both copies carry the page-title
+    // `h1`, so the inactive copy must be removed from the accessibility tree —
+    // otherwise AT sees a duplicate heading. CSS `display:none` already hides
+    // it visually; `aria-hidden` makes the intent explicit and keeps exactly
+    // one copy exposed even where the responsive stylesheet isn't applied.
+    <div
+      aria-hidden={!isMobile || undefined}
+      className={cn('flex items-center flex-1 min-w-0', className)}
+    >
       {content}
     </div>
   );
@@ -112,6 +123,7 @@ export function AdaptiveHeaderRoot({
   standalone = true,
 }: AdaptiveHeaderRootProps) {
   const { setHeaderContent } = useAdaptiveHeader();
+  const isMobile = useIsMobile();
 
   // Register children with context for mobile rendering
   useEffect(() => {
@@ -122,6 +134,12 @@ export function AdaptiveHeaderRoot({
   return (
     <HStack
       gap={0}
+      // The root is the *desktop* copy — always `hidden` below `md` (the mobile
+      // mirror renders through `AdaptiveHeaderSlot`). Its page-title `h1` would
+      // otherwise duplicate the slot's, so mark it `aria-hidden` on mobile to
+      // keep exactly one heading in the accessibility tree even if the
+      // responsive `display:none` isn't applied.
+      aria-hidden={isMobile || undefined}
       className={cn(
         // Fixed height (not min-h): action clusters (e.g. the settings
         // Save/Discard buttons) would otherwise grow the strip by a pixel

--- a/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
+++ b/services/platform/app/components/ui/data-table/data-table-empty-state.tsx
@@ -8,6 +8,13 @@ export interface DataTableEmptyStateProps {
   title: string;
   /** Description text or rich content */
   description?: ReactNode;
+  /**
+   * Heading level for the empty-state title. Defaults (via `EmptyState`) to
+   * `3`, which is correct for the common case of a table inside a settings
+   * section (under an `h2`). A table rendered directly under a page `h1` with
+   * no intervening section heading should pass `2` to avoid an `h1`→`h3` skip.
+   */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 /**
@@ -24,6 +31,14 @@ export function DataTableEmptyState({
   icon,
   title,
   description,
+  headingLevel,
 }: DataTableEmptyStateProps) {
-  return <EmptyState icon={icon} title={title} description={description} />;
+  return (
+    <EmptyState
+      icon={icon}
+      title={title}
+      description={description}
+      headingLevel={headingLevel}
+    />
+  );
 }

--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -920,6 +920,7 @@ export function DataTable<TData, TValue = unknown>({
                     icon={emptyState?.icon}
                     title={emptyState?.title ?? ''}
                     description={emptyState?.description}
+                    headingLevel={emptyState?.headingLevel}
                   />
                 </div>
               </TableCell>
@@ -932,6 +933,7 @@ export function DataTable<TData, TValue = unknown>({
                   <DataTableEmptyState
                     title={t('search.noResults')}
                     description={t('search.tryAdjusting')}
+                    headingLevel={emptyState?.headingLevel}
                   />
                 </div>
               </TableCell>

--- a/services/platform/app/features/chat/components/chat-messages.tsx
+++ b/services/platform/app/features/chat/components/chat-messages.tsx
@@ -1020,9 +1020,13 @@ export const ChatMessages = memo(function ChatMessages({
       labelId={messageHistoryLabelId}
       header={
         <>
-          <h2 id={messageHistoryLabelId} className="sr-only">
+          {/* Accessible name for the `role="log"` region. A plain `<span>`
+              (not a heading) so it doesn't inject an out-of-order `h2` ahead of
+              the page `h1` (e.g. the empty-state welcome heading) — the log is
+              already named for AT via `aria-labelledby`. */}
+          <span id={messageHistoryLabelId} className="sr-only">
             {t('aria.messageHistory')}
-          </h2>
+          </span>
           {loadMoreHeader}
           <div className="h-6" aria-hidden="true" />
         </>
@@ -1058,9 +1062,12 @@ export const ChatMessages = memo(function ChatMessages({
       aria-live="polite"
       aria-labelledby={messageHistoryLabelId}
     >
-      <h2 id={messageHistoryLabelId} className="sr-only">
+      {/* Accessible name for the `role="log"` region — a plain `<span>`, not a
+          heading, so it stays out of the page heading outline (see the
+          virtualized branch above). */}
+      <span id={messageHistoryLabelId} className="sr-only">
         {t('aria.messageHistory')}
-      </h2>
+      </span>
       <Stack gap={3} className="pt-6">
         {loadMoreHeader}
 

--- a/services/platform/app/features/documents/components/documents-table.tsx
+++ b/services/platform/app/features/documents/components/documents-table.tsx
@@ -391,6 +391,10 @@ export function DocumentsTable({
           icon: FileText,
           title: tDocuments('emptyState.title'),
           description: tDocuments('emptyState.description'),
+          // The documents table sits directly under the page `h1` ("Knowledge")
+          // with no intervening section heading, so the empty-state title is an
+          // `h2` — otherwise the heading outline skips `h1`→`h3`.
+          headingLevel: 2,
         }}
         {...list.tableProps}
       />

--- a/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/$agentId.tsx
@@ -108,51 +108,75 @@ function AgentDetailLayout() {
   // `AgentConfigProvider` and therefore cannot mount until the config loads.
   const breadcrumb = (
     <AdaptiveHeaderRoot standalone={false} className="gap-2">
-      <Heading level={1} size="base" truncate>
-        <Link
-          to="/dashboard/$id/agents"
-          params={{ id: organizationId }}
-          className={cn(
-            'hidden md:inline text-foreground rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
-            resolvedDisplayName && 'text-muted-foreground cursor-pointer',
-          )}
-        >
-          {t('agents.title')}&nbsp;&nbsp;
-        </Link>
-        {folderSegments.map((segment, i) => {
-          const path = folderSegments.slice(0, i + 1).join('/');
-          return (
+      {/* Semantic breadcrumb: a `nav > ol` of crumbs. The parent "Agents" link
+          (and any folder links) are plain links; only the leaf carries
+          `aria-current="page"`, and the leaf is also the page's single `h1`.
+          `activeOptions={{ exact: true }}` stops TanStack's `<Link>` from
+          auto-tagging the parent crumb with `aria-current="page"` just because
+          this detail route is nested under `/agents`. */}
+      <nav
+        aria-label={tCommon('aria.breadcrumb')}
+        className="flex min-w-0 items-center"
+      >
+        <ol className="flex min-w-0 items-center">
+          <li className="hidden items-center md:flex">
             <Link
-              key={path}
-              to="/dashboard/$id/agents/all"
+              to="/dashboard/$id/agents"
               params={{ id: organizationId }}
-              search={{ folder: path }}
-              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring hidden cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset md:inline"
-            >
-              /&nbsp;&nbsp;{segment}&nbsp;&nbsp;
-            </Link>
-          );
-        })}
-        <span className="text-foreground">
-          <span className="hidden md:inline">/&nbsp;&nbsp;</span>
-          {/* `contents` so the Skeletonize wrapper adds no block box — its
-              default <div> is block-level and would drop the agent name onto a
-              second line inside this inline breadcrumb. With `contents` the
-              name flows inline and the truncating <Heading> keeps it to one
-              line. */}
-          <Skeletonize
-            loading={isLoading}
-            label={t('agents.title')}
-            className="contents"
-          >
-            <SkeletonBox>
-              {resolvedDisplayName || (
-                <span className="inline-block h-4 w-32 align-middle" />
+              activeOptions={{ exact: true }}
+              className={cn(
+                'text-foreground focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+                resolvedDisplayName &&
+                  'text-muted-foreground hover:text-foreground cursor-pointer',
               )}
-            </SkeletonBox>
-          </Skeletonize>
-        </span>
-      </Heading>
+            >
+              {t('agents.title')}
+            </Link>
+          </li>
+          {folderSegments.map((segment, i) => {
+            const path = folderSegments.slice(0, i + 1).join('/');
+            return (
+              <li key={path} className="hidden items-center md:flex">
+                <span className="text-muted-foreground mx-2" aria-hidden="true">
+                  /
+                </span>
+                <Link
+                  to="/dashboard/$id/agents/all"
+                  params={{ id: organizationId }}
+                  search={{ folder: path }}
+                  className="text-muted-foreground hover:text-foreground focus-visible:ring-ring cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
+                >
+                  {segment}
+                </Link>
+              </li>
+            );
+          })}
+          <li className="flex min-w-0 items-center">
+            <span
+              className="text-muted-foreground mx-2 hidden md:inline"
+              aria-hidden="true"
+            >
+              /
+            </span>
+            {/* The leaf is the page title — a single `h1` — and the current
+                breadcrumb item. `contents` keeps the Skeletonize wrapper from
+                adding a block box so the truncating heading stays one line. */}
+            <Heading level={1} size="base" truncate aria-current="page">
+              <Skeletonize
+                loading={isLoading}
+                label={t('agents.title')}
+                className="contents"
+              >
+                <SkeletonBox>
+                  {resolvedDisplayName || (
+                    <span className="inline-block h-4 w-32 align-middle" />
+                  )}
+                </SkeletonBox>
+              </Skeletonize>
+            </Heading>
+          </li>
+        </ol>
+      </nav>
     </AdaptiveHeaderRoot>
   );
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1986,6 +1986,7 @@
       "completed": "Abgeschlossen",
       "back": "Zurück",
       "backTo": "Zurück zu {page}",
+      "breadcrumb": "Brotkrumennavigation",
       "automationsNavigation": "Automatisierungen-Navigation",
       "agentsNavigation": "Agents-Navigation",
       "knowledgeNavigation": "Wissen-Navigation",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1986,6 +1986,7 @@
       "completed": "Completed",
       "back": "Back",
       "backTo": "Back to {page}",
+      "breadcrumb": "Breadcrumb",
       "automationsNavigation": "Automations navigation",
       "agentsNavigation": "Agents navigation",
       "knowledgeNavigation": "Knowledge navigation",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1987,6 +1987,7 @@
       "completed": "Terminé",
       "back": "Retour",
       "backTo": "Retour à {page}",
+      "breadcrumb": "Fil d'Ariane",
       "automationsNavigation": "Navigation des automatisations",
       "agentsNavigation": "Navigation des agents",
       "knowledgeNavigation": "Navigation de la base de connaissances",


### PR DESCRIPTION
## Summary

Fixes the adaptive-header accessibility issues reported in #1994 (keyboard/AT sweep):

1. **Duplicate `h1`** — the page title is rendered twice (desktop `AdaptiveHeaderRoot` + the mobile `AdaptiveHeaderSlot` mirror). The breakpoint-inactive copy is now `aria-hidden` (driven by `useIsMobile`), so exactly one `h1` stays in the accessibility tree even where the responsive `display:none` isn't applied.
2. **Heading order**
   - Chat: the `role="log"` message-history label was an `sr-only` `h2` that preceded the page `h1` (e.g. the welcome heading). It's now a plain `sr-only` `<span>` still referenced via `aria-labelledby`, so it leaves the heading outline.
   - `EmptyState` now renders its title as an `h2` by default (was `h3`), so a list empty state directly under a page `h1` no longer skips `h1`→`h3`. The level is overridable via a new `headingLevel` prop.
3. **Breadcrumb** — the agent detail trail was a single `h1` of links, with the parent "Agents" crumb auto-tagged `aria-current="page"` by TanStack's `<Link>`. It's now a semantic `nav[aria-label] > ol`; the parent link uses `activeOptions={{ exact: true }}` to drop the stale `aria-current`, and only the leaf (the page's single `h1`) carries `aria-current="page"`.

## Tests
- `packages/ui` `empty-state`: default `h2` + `headingLevel` override.
- `platform` `adaptive-header`: only one `h1` exposed when the title is mirrored into the slot.
- Existing chat / data-table / conversations empty-state suites pass unchanged.
- `tsc --noEmit` green for both `@tale/platform` and `@tale/ui`; oxlint clean.

Closes #1994