### PR TITLE
fix: treat missing retention config as empty state on governance load (#1997)

### DIFF
--- a/services/platform/convex/governance/retention_actions.ts
+++ b/services/platform/convex/governance/retention_actions.ts
@@ -116,10 +116,14 @@ export const getRetentionBoundsAction = action({
     const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
     const orgConfig = await loadOrgRetentionConfig(ctx, orgSlug);
     if (!orgConfig) {
-      throw new ConvexError({
-        code: 'RETENTION_CONFIG_MISSING',
-        message: `Retention config not yet installed. Copy builtin-configs/governance/retention.json to $TALE_CONFIG_DIR/${orgSlug}/governance/retention.json then reload.`,
-      });
+      // A not-yet-installed retention config is an expected empty state on
+      // normal page loads (e.g. a fresh org), not an error. Return empty
+      // bounds so the editor falls back to schema-level defaults instead of
+      // logging a RETENTION_CONFIG_MISSING ConvexError on every load.
+      return {
+        bounds: [],
+        retentionDisabled: isRetentionDisabled(),
+      };
     }
 
     let bounds;

--- a/services/platform/convex/governance/retention_bounds_proposal.ts
+++ b/services/platform/convex/governance/retention_bounds_proposal.ts
@@ -303,7 +303,26 @@ export const getPendingBoundsProposal = action({
     });
 
     const orgSlug = await resolveOrgSlug(ctx, args.organizationId);
-    const proposedBounds = await computeEffectiveAppliedBounds(ctx, orgSlug);
+    // A not-yet-installed retention config is an expected empty state on
+    // normal page loads (e.g. a fresh org), not an error: there is no
+    // proposal to surface until the operator installs the config. Return
+    // null (banner stays silent) instead of throwing a
+    // RETENTION_CONFIG_MISSING ConvexError on every load. The write paths
+    // (apply/reject/seed) still throw — you cannot act on bounds that the
+    // operator has not installed yet.
+    let proposedBounds: AppliedBoundsByCategory;
+    try {
+      proposedBounds = await computeEffectiveAppliedBounds(ctx, orgSlug);
+    } catch (err) {
+      if (
+        err instanceof ConvexError &&
+        isRecord(err.data) &&
+        err.data.code === 'RETENTION_CONFIG_MISSING'
+      ) {
+        return null;
+      }
+      throw err;
+    }
     const proposedHash = await hashAppliedBounds(proposedBounds);
 
     const applied: {

--- a/services/platform/convex/governance/retention_config_missing.test.ts
+++ b/services/platform/convex/governance/retention_config_missing.test.ts
@@ -1,0 +1,172 @@
+import { ConvexError } from 'convex/values';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for #1997: opening Governance "Policies & Limits"
+// on a fresh org (no retention.json installed yet) used to log three
+// `ConvexError(RETENTION_CONFIG_MISSING)` because the read-only actions
+// threw instead of returning an "empty state". These tests pin the
+// graceful behaviour: the READ paths return null / empty bounds, while
+// the WRITE path still throws (you cannot save against bounds the
+// operator has not installed).
+
+// String sentinels so the mock ctx can route each `run*` call by ref.
+vi.mock('../_generated/api', () => ({
+  internal: {
+    governance: {
+      internal_queries: {
+        verifyOrgMember: 'verifyOrgMember',
+        verifyOrgAdmin: 'verifyOrgAdmin',
+        getAppliedBounds: 'getAppliedBounds',
+        getRetentionPolicyForOrg: 'getRetentionPolicyForOrg',
+      },
+    },
+    lib: {
+      config_store: {
+        actions: { readConfigArea: 'readConfigArea' },
+      },
+    },
+  },
+}));
+
+const mockResolveOrgSlug = vi.fn(async (..._args: unknown[]) => 'acme');
+vi.mock('../organizations/resolve_org_slug', () => ({
+  resolveOrgSlug: (...args: unknown[]) => mockResolveOrgSlug(...args),
+}));
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    action: (config: Record<string, unknown>) => config,
+    internalAction: (config: Record<string, unknown>) => config,
+  };
+});
+
+// vi.mock above replaces the Convex function builders with identity
+// functions so the runtime shape is `{ args, returns, handler }`.
+//
+// oxlint-disable-next-line typescript/no-explicit-any -- third-party gap (see AGENTS.md)
+type Handler = { handler: (...args: unknown[]) => Promise<any> };
+
+async function loadActions(): Promise<Record<string, Handler>> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- see above
+  return (await import('./retention_actions')) as unknown as Record<
+    string,
+    Handler
+  >;
+}
+
+async function loadProposal(): Promise<Record<string, Handler>> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- see above
+  return (await import('./retention_bounds_proposal')) as unknown as Record<
+    string,
+    Handler
+  >;
+}
+
+interface RunCall {
+  ref: string;
+  args: unknown;
+}
+
+interface MockOptions {
+  /** Value `readConfigArea` resolves to (null = config not installed). */
+  configArea?: unknown;
+  /** Identity returned by `ctx.auth.getUserIdentity`. */
+  identity?: { subject: string; email?: string; name?: string } | null;
+  /** Value the `verifyOrgAdmin` query resolves to (write paths). */
+  member?: unknown;
+}
+
+function createMockCtx(opts: MockOptions = {}) {
+  const runQueries: RunCall[] = [];
+  const runActions: RunCall[] = [];
+  const ctx = {
+    auth: {
+      getUserIdentity: vi.fn(async () =>
+        opts.identity === undefined
+          ? { subject: 'user_1', email: 'a@example.com', name: 'A' }
+          : opts.identity,
+      ),
+    },
+    runQuery: vi.fn(async (ref: string, args: unknown) => {
+      runQueries.push({ ref, args });
+      if (ref === 'verifyOrgMember') return { role: 'member' };
+      if (ref === 'verifyOrgAdmin') return opts.member ?? { role: 'admin' };
+      if (ref === 'getAppliedBounds') return null;
+      if (ref === 'getRetentionPolicyForOrg') return null;
+      throw new Error(`unexpected runQuery ref: ${ref}`);
+    }),
+    runAction: vi.fn(async (ref: string, args: unknown) => {
+      runActions.push({ ref, args });
+      if (ref === 'readConfigArea') return opts.configArea ?? null;
+      throw new Error(`unexpected runAction ref: ${ref}`);
+    }),
+  };
+  return { ctx, runQueries, runActions };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.TALE_RETENTION_DISABLED;
+});
+
+describe('getRetentionBoundsAction with missing config', () => {
+  it('returns empty bounds instead of throwing RETENTION_CONFIG_MISSING', async () => {
+    const m = await loadActions();
+    const { ctx } = createMockCtx({ configArea: null });
+    const result = await m.getRetentionBoundsAction.handler(ctx, {
+      organizationId: 'org_A',
+    });
+    expect(result).toEqual({ bounds: [], retentionDisabled: false });
+  });
+
+  it('still reports retentionDisabled from the env flag', async () => {
+    process.env.TALE_RETENTION_DISABLED = 'true';
+    const m = await loadActions();
+    const { ctx } = createMockCtx({ configArea: null });
+    const result = await m.getRetentionBoundsAction.handler(ctx, {
+      organizationId: 'org_A',
+    });
+    expect(result).toEqual({ bounds: [], retentionDisabled: true });
+  });
+});
+
+describe('getPendingBoundsProposal with missing config', () => {
+  it('returns null instead of throwing RETENTION_CONFIG_MISSING', async () => {
+    const m = await loadProposal();
+    const { ctx, runQueries } = createMockCtx({ configArea: null });
+    const result = await m.getPendingBoundsProposal.handler(ctx, {
+      organizationId: 'org_A',
+    });
+    expect(result).toBeNull();
+    // Bails out before reading applied bounds — nothing to propose.
+    expect(runQueries.some((c) => c.ref === 'getAppliedBounds')).toBe(false);
+  });
+});
+
+describe('upsertRetentionPolicyAction with missing config', () => {
+  it('still throws RETENTION_CONFIG_MISSING (write path unchanged)', async () => {
+    const m = await loadActions();
+    const { ctx } = createMockCtx({ configArea: null });
+    await expect(
+      m.upsertRetentionPolicyAction.handler(ctx, {
+        organizationId: 'org_A',
+        config: { documentsRetentionDays: 90 },
+      }),
+    ).rejects.toMatchObject({
+      data: { code: 'RETENTION_CONFIG_MISSING' },
+    });
+  });
+
+  it('the rejection is a ConvexError', async () => {
+    const m = await loadActions();
+    const { ctx } = createMockCtx({ configArea: null });
+    await expect(
+      m.upsertRetentionPolicyAction.handler(ctx, {
+        organizationId: 'org_A',
+        config: { documentsRetentionDays: 90 },
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+});


### PR DESCRIPTION
## Summary

Opening Governance **Policies & Limits** on a fresh org (no `retention.json` installed yet) logged `ConvexError(RETENTION_CONFIG_MISSING)` on every normal page load. The read-only retention actions threw on a not-yet-configured retention setting instead of treating it as an expected empty state.

This makes the **read** paths return a graceful empty state, while the **write** path still throws (you cannot save against bounds the operator has not installed):

- `getRetentionBoundsAction` (read, drives `useRetentionBounds`) now returns `{ bounds: [], retentionDisabled }` when the org has no retention config. The editor already falls back to schema-level defaults for categories without a bound row, so rendering is unaffected — just console-clean.
- `getPendingBoundsProposal` (read, drives the proposal banner) now returns `null` when the config is missing — there is nothing to propose until the operator installs the config. It bails out before reading applied bounds.
- `upsertRetentionPolicyAction`, `applyBoundsProposal`, `rejectBoundsProposal`, and `seedInitialBoundsInternal` are unchanged — write/apply paths still surface `RETENTION_CONFIG_MISSING`.

## Tests

Added `convex/governance/retention_config_missing.test.ts` pinning the behaviour:
- read paths return empty/null without throwing (and don't query applied bounds),
- `retentionDisabled` still reflects the env flag,
- the write path still throws a `ConvexError(RETENTION_CONFIG_MISSING)`.

Verified locally: `vitest --project server` (retention suites, 66+5 passing), `oxlint --type-aware`, and `tsc --noEmit` all green.

Closes #1997