### PR TITLE
fix: knowledge_entries mutations throw ConvexError instead of raw Error (#2000)

### DIFF
--- a/services/platform/convex/knowledge_entries/helpers.test.ts
+++ b/services/platform/convex/knowledge_entries/helpers.test.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { describe, expect, it, vi } from 'vitest';
 
 import { normalizeTopicKey } from './constants';
@@ -127,28 +128,46 @@ describe('validateTopicAndContent', () => {
     expect(result.content).toBe('Open 9-5');
   });
 
+  // #2000: validation rejects with structured ConvexError codes (not raw
+  // `Error`), so the client receives a readable code instead of an opaque
+  // "Server Error".
+  function codeOf(fn: () => unknown): string | undefined {
+    try {
+      fn();
+    } catch (err) {
+      if (!(err instanceof ConvexError)) return undefined;
+      const data: unknown = err.data;
+      if (typeof data !== 'object' || data === null || !('code' in data)) {
+        return undefined;
+      }
+      const candidate: unknown = (data as { code: unknown }).code;
+      return typeof candidate === 'string' ? candidate : undefined;
+    }
+    return undefined;
+  }
+
   it('rejects empty topic', () => {
-    expect(() => validateTopicAndContent('   ', 'content')).toThrow(
-      'Topic is required',
+    expect(codeOf(() => validateTopicAndContent('   ', 'content'))).toBe(
+      'KNOWLEDGE_ENTRY_TOPIC_REQUIRED',
     );
   });
 
   it('rejects topic over the cap', () => {
-    expect(() => validateTopicAndContent('x'.repeat(121), 'content')).toThrow(
-      '120',
-    );
+    expect(
+      codeOf(() => validateTopicAndContent('x'.repeat(121), 'content')),
+    ).toBe('KNOWLEDGE_ENTRY_TOPIC_TOO_LONG');
   });
 
   it('rejects empty content', () => {
-    expect(() => validateTopicAndContent('topic', '   ')).toThrow(
-      'Content is required',
+    expect(codeOf(() => validateTopicAndContent('topic', '   '))).toBe(
+      'KNOWLEDGE_ENTRY_CONTENT_REQUIRED',
     );
   });
 
   it('rejects content over the cap', () => {
-    expect(() => validateTopicAndContent('topic', 'x'.repeat(8001))).toThrow(
-      '8000',
-    );
+    expect(
+      codeOf(() => validateTopicAndContent('topic', 'x'.repeat(8001))),
+    ).toBe('KNOWLEDGE_ENTRY_CONTENT_TOO_LONG');
   });
 });
 

--- a/services/platform/convex/knowledge_entries/helpers.ts
+++ b/services/platform/convex/knowledge_entries/helpers.ts
@@ -5,6 +5,8 @@
  * bundle (or their tests' mock surface).
  */
 
+import { ConvexError } from 'convex/values';
+
 import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import {
@@ -43,13 +45,27 @@ export function validateTopicAndContent(
 ): { topic: string; topicKey: string; content: string } {
   const trimmedTopic = topic.trim();
   const trimmedContent = content.trim();
-  if (!trimmedTopic) throw new Error('Topic is required');
-  if (trimmedTopic.length > TOPIC_MAX_LENGTH) {
-    throw new Error(`Topic exceeds ${TOPIC_MAX_LENGTH} characters`);
+  // Structured ConvexError codes so the client surfaces a readable message
+  // instead of an opaque "Server Error" (raw `Error` messages are redacted by
+  // Convex in prod). Called from both public and internal mutations;
+  // ConvexError propagates correctly through both paths.
+  if (!trimmedTopic) {
+    throw new ConvexError({ code: 'KNOWLEDGE_ENTRY_TOPIC_REQUIRED' });
   }
-  if (!trimmedContent) throw new Error('Content is required');
+  if (trimmedTopic.length > TOPIC_MAX_LENGTH) {
+    throw new ConvexError({
+      code: 'KNOWLEDGE_ENTRY_TOPIC_TOO_LONG',
+      max: TOPIC_MAX_LENGTH,
+    });
+  }
+  if (!trimmedContent) {
+    throw new ConvexError({ code: 'KNOWLEDGE_ENTRY_CONTENT_REQUIRED' });
+  }
   if (trimmedContent.length > CONTENT_MAX_LENGTH) {
-    throw new Error(`Content exceeds ${CONTENT_MAX_LENGTH} characters`);
+    throw new ConvexError({
+      code: 'KNOWLEDGE_ENTRY_CONTENT_TOO_LONG',
+      max: CONTENT_MAX_LENGTH,
+    });
   }
   return {
     topic: trimmedTopic,

--- a/services/platform/convex/knowledge_entries/mutations.test.ts
+++ b/services/platform/convex/knowledge_entries/mutations.test.ts
@@ -29,7 +29,11 @@ vi.mock('../lib/rls/organization/get_organization_member', () => ({
 
 import { ConvexError } from 'convex/values';
 
-import { createKnowledgeEntry, updateKnowledgeEntry } from './mutations';
+import {
+  createKnowledgeEntry,
+  deleteKnowledgeEntry,
+  updateKnowledgeEntry,
+} from './mutations';
 
 type Handler = (ctx: unknown, args: unknown) => Promise<unknown>;
 
@@ -132,5 +136,125 @@ describe('knowledge entry duplicate guard (#2056)', () => {
 
     expect(code).toBe('KNOWLEDGE_ENTRY_DUPLICATE');
     expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+});
+
+// Regression for #2000: every public mutation must reject with a structured
+// ConvexError code rather than a raw `Error`, which Convex redacts to an opaque
+// "Server Error" in prod — losing the message the UI needs to render feedback.
+describe('knowledge entry structured errors (#2000)', () => {
+  function handlerOf(fn: unknown): Handler {
+    return (fn as { handler: Handler }).handler;
+  }
+
+  it('createKnowledgeEntry throws UNAUTHENTICATED when there is no auth user', async () => {
+    const ctx = createMockCtx(null);
+    ctx.auth.getUserIdentity = vi.fn().mockResolvedValue(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(createKnowledgeEntry)(ctx, {
+        organizationId: 'org_1',
+        topic: 'Refunds',
+        content: 'How refunds work.',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
+  it('createKnowledgeEntry throws KNOWLEDGE_ENTRY_TOPIC_REQUIRED for a blank topic', async () => {
+    const ctx = createMockCtx(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(createKnowledgeEntry)(ctx, {
+        organizationId: 'org_1',
+        topic: '   ',
+        content: 'How refunds work.',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('KNOWLEDGE_ENTRY_TOPIC_REQUIRED');
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('createKnowledgeEntry throws KNOWLEDGE_ENTRY_CONTENT_REQUIRED for blank content', async () => {
+    const ctx = createMockCtx(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(createKnowledgeEntry)(ctx, {
+        organizationId: 'org_1',
+        topic: 'Refunds',
+        content: '   ',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('KNOWLEDGE_ENTRY_CONTENT_REQUIRED');
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('updateKnowledgeEntry throws KNOWLEDGE_ENTRY_NOT_FOUND for a missing entry', async () => {
+    const ctx = createMockCtx(null);
+    ctx.db.get = vi.fn().mockResolvedValue(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(updateKnowledgeEntry)(ctx, {
+        entryId: 'entry_missing',
+        topic: 'Refunds',
+        content: 'How refunds work.',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('KNOWLEDGE_ENTRY_NOT_FOUND');
+  });
+
+  it('updateKnowledgeEntry throws KNOWLEDGE_ENTRY_NOT_ACTIVE for a superseded entry', async () => {
+    const ctx = createMockCtx(null);
+    ctx.db.get = vi.fn().mockResolvedValue({
+      _id: 'entry_old',
+      organizationId: 'org_1',
+      topic: 'Refunds',
+      topicKey: 'refunds',
+      status: 'superseded',
+      deletedAt: undefined,
+    });
+
+    let code: string | undefined;
+    try {
+      await handlerOf(updateKnowledgeEntry)(ctx, {
+        entryId: 'entry_old',
+        topic: 'Refunds',
+        content: 'How refunds work.',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('KNOWLEDGE_ENTRY_NOT_ACTIVE');
+  });
+
+  it('deleteKnowledgeEntry throws KNOWLEDGE_ENTRY_NOT_FOUND for a missing entry', async () => {
+    const ctx = createMockCtx(null);
+    ctx.db.get = vi.fn().mockResolvedValue(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(deleteKnowledgeEntry)(ctx, { entryId: 'entry_missing' });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('KNOWLEDGE_ENTRY_NOT_FOUND');
   });
 });

--- a/services/platform/convex/knowledge_entries/mutations.test.ts
+++ b/services/platform/convex/knowledge_entries/mutations.test.ts
@@ -201,6 +201,24 @@ describe('knowledge entry structured errors (#2000)', () => {
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
+  it('updateKnowledgeEntry throws UNAUTHENTICATED when there is no auth user', async () => {
+    const ctx = createMockCtx(null);
+    ctx.auth.getUserIdentity = vi.fn().mockResolvedValue(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(updateKnowledgeEntry)(ctx, {
+        entryId: 'entry_existing',
+        topic: 'Refunds',
+        content: 'How refunds work.',
+      });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
   it('updateKnowledgeEntry throws KNOWLEDGE_ENTRY_NOT_FOUND for a missing entry', async () => {
     const ctx = createMockCtx(null);
     ctx.db.get = vi.fn().mockResolvedValue(null);
@@ -242,6 +260,20 @@ describe('knowledge entry structured errors (#2000)', () => {
     }
 
     expect(code).toBe('KNOWLEDGE_ENTRY_NOT_ACTIVE');
+  });
+
+  it('deleteKnowledgeEntry throws UNAUTHENTICATED when there is no auth user', async () => {
+    const ctx = createMockCtx(null);
+    ctx.auth.getUserIdentity = vi.fn().mockResolvedValue(null);
+
+    let code: string | undefined;
+    try {
+      await handlerOf(deleteKnowledgeEntry)(ctx, { entryId: 'entry_existing' });
+    } catch (err) {
+      code = codeOf(err);
+    }
+
+    expect(code).toBe('UNAUTHENTICATED');
   });
 
   it('deleteKnowledgeEntry throws KNOWLEDGE_ENTRY_NOT_FOUND for a missing entry', async () => {

--- a/services/platform/convex/knowledge_entries/mutations.ts
+++ b/services/platform/convex/knowledge_entries/mutations.ts
@@ -31,7 +31,7 @@ export const createKnowledgeEntry = mutation({
   returns: v.id('knowledgeEntries'),
   handler: async (ctx, args): Promise<Id<'knowledgeEntries'>> => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
     await getOrganizationMember(ctx, args.organizationId, authUser);
     await checkOrganizationRateLimit(
       ctx,
@@ -87,14 +87,14 @@ export const updateKnowledgeEntry = mutation({
   returns: v.id('knowledgeEntries'),
   handler: async (ctx, args): Promise<Id<'knowledgeEntries'>> => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
 
     const entry = await ctx.db.get(args.entryId);
     if (!entry || entry.deletedAt !== undefined) {
-      throw new Error('Knowledge entry not found');
+      throw new ConvexError({ code: 'KNOWLEDGE_ENTRY_NOT_FOUND' });
     }
     if (entry.status !== 'active') {
-      throw new Error('Only the active version of an entry can be edited');
+      throw new ConvexError({ code: 'KNOWLEDGE_ENTRY_NOT_ACTIVE' });
     }
 
     await getOrganizationMember(ctx, entry.organizationId, authUser);
@@ -174,11 +174,11 @@ export const deleteKnowledgeEntry = mutation({
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
 
     const entry = await ctx.db.get(args.entryId);
     if (!entry || entry.deletedAt !== undefined) {
-      throw new Error('Knowledge entry not found');
+      throw new ConvexError({ code: 'KNOWLEDGE_ENTRY_NOT_FOUND' });
     }
 
     await getOrganizationMember(ctx, entry.organizationId, authUser);


### PR DESCRIPTION
## What

`services/platform/convex/knowledge_entries/` public mutations and their shared `validateTopicAndContent` helper threw raw `Error(...)`, which Convex redacts to an opaque **"Server Error"** in production — the message never reaches the client, so the Knowledge Entries UI shows no feedback when a mutation rejects.

This replaces every raw `Error` throw in the public surface with a structured `ConvexError({ code: '...' })`, matching the pattern already used in `tasks/mutations.ts`, `branding/file_actions.ts`, and the existing `KNOWLEDGE_ENTRY_DUPLICATE` guard in this same file.

## Changes

`helpers.ts` — `validateTopicAndContent` now throws:
- `KNOWLEDGE_ENTRY_TOPIC_REQUIRED`
- `KNOWLEDGE_ENTRY_TOPIC_TOO_LONG` (carries `max`)
- `KNOWLEDGE_ENTRY_CONTENT_REQUIRED`
- `KNOWLEDGE_ENTRY_CONTENT_TOO_LONG` (carries `max`)

`mutations.ts` — create/update/delete now throw:
- `UNAUTHENTICATED` (matching the repo-wide convention)
- `KNOWLEDGE_ENTRY_NOT_FOUND`
- `KNOWLEDGE_ENTRY_NOT_ACTIVE`

The helper is shared by both public and internal mutations; `ConvexError` propagates correctly through both paths, so this is safe.

## Tests

- Extended `mutations.test.ts` with a `#2000` suite asserting the structured codes for unauthenticated / blank-topic / blank-content / not-found / not-active.
- Updated `helpers.test.ts` validation cases to assert the new `ConvexError` codes instead of the old raw message strings.
- `bunx vitest --run --project server knowledge_entries` → 25 passed.
- `bunx tsc --noEmit` → clean. `bunx oxlint --type-aware` → 0 warnings / 0 errors.

Closes #2000