### PR TITLE
fix(platform): a11y polish — aria-modal, radiogroup arrows, single preview heading, protected-row checkbox (#1998)

### DIFF
--- a/packages/ui/src/components/overlays/responsive-dialog.test.tsx
+++ b/packages/ui/src/components/overlays/responsive-dialog.test.tsx
@@ -62,6 +62,11 @@ describe('ResponsiveDialog', () => {
       render(<Example />);
       expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
     });
+
+    it('marks the content as a modal dialog (aria-modal)', () => {
+      render(<Example />);
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
   });
 
   describe('mobile variant', () => {
@@ -77,6 +82,11 @@ describe('ResponsiveDialog', () => {
       // vaul wraps title in role="dialog" too.
       expect(screen.getByText('Title')).toBeInTheDocument();
       expect(screen.getByText('Body text')).toBeInTheDocument();
+    });
+
+    it('marks the drawer content as a modal dialog (aria-modal)', () => {
+      render(<Example />);
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
     });
   });
 

--- a/packages/ui/src/components/overlays/responsive-dialog.tsx
+++ b/packages/ui/src/components/overlays/responsive-dialog.tsx
@@ -105,6 +105,7 @@ export const ResponsiveDialogContent = forwardRef<
           <DrawerPrimitive.Overlay className="bg-bg-overlay fixed inset-0 z-50" />
           <DrawerPrimitive.Content
             ref={ref}
+            aria-modal="true"
             onOpenAutoFocus={onOpenAutoFocus}
             className={cn(
               'bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[92dvh] flex-col rounded-t-2xl',
@@ -135,6 +136,7 @@ export const ResponsiveDialogContent = forwardRef<
         />
         <DialogPrimitive.Content
           ref={ref}
+          aria-modal="true"
           onOpenAutoFocus={onOpenAutoFocus}
           className={cn(
             'bg-background fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border p-6 shadow-lg',

--- a/packages/ui/src/components/search/search-command.test.tsx
+++ b/packages/ui/src/components/search/search-command.test.tsx
@@ -326,5 +326,10 @@ describe('SearchCommand', () => {
       const { container } = renderCommand();
       await checkAccessibility(container);
     });
+
+    it('marks the content as a modal dialog (aria-modal)', () => {
+      renderCommand();
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
   });
 });

--- a/packages/ui/src/components/search/search-command.tsx
+++ b/packages/ui/src/components/search/search-command.tsx
@@ -209,7 +209,7 @@ export function SearchCommand({
                 className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md"
               />
             </Dialog.Overlay>
-            <Dialog.Content asChild aria-label={labels.title}>
+            <Dialog.Content asChild aria-modal="true" aria-label={labels.title}>
               <motion.div
                 key="search-dialog"
                 initial={

--- a/services/platform/app/components/ui/data-table/column-builders.tsx
+++ b/services/platform/app/components/ui/data-table/column-builders.tsx
@@ -339,16 +339,20 @@ export function createSelectColumn<TData>(): ColumnDef<TData> {
         />
       </div>
     ),
-    cell: ({ row }) => (
-      <div className="flex h-full items-center justify-center">
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(value) => row.toggleSelected(!!value)}
-          onClick={(e) => e.stopPropagation()}
-          aria-label={i18n.t('common:aria.selectRow')}
-        />
-      </div>
-    ),
+    // Non-selectable rows (e.g. protected agents gated out by the table's
+    // `enableRowSelection` predicate) render no checkbox at all — an inert
+    // "Select row" control is a false affordance and a confusing AT target.
+    cell: ({ row }) =>
+      row.getCanSelect() ? (
+        <div className="flex h-full items-center justify-center">
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={i18n.t('common:aria.selectRow')}
+          />
+        </div>
+      ) : null,
     meta: { skeleton: { type: 'checkbox' } },
   };
 }

--- a/services/platform/app/components/ui/data-table/data-table.test.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { render, screen, within } from '@/tests/utils/render';
 
+import { createSelectColumn } from './column-builders';
 import { DataTable } from './data-table';
 
 // ---------------------------------------------------------------------------
@@ -344,6 +345,50 @@ describe('DataTable addAction contract', () => {
       screen.getAllByRole('button', { name: 'New customer' }),
     ).toHaveLength(1);
     expect(screen.getByText('No customers')).toBeInTheDocument();
+  });
+
+  describe('row selection', () => {
+    const selectColumns: ColumnDef<TestRow>[] = [
+      createSelectColumn<TestRow>(),
+      { accessorKey: 'name', header: 'Name' },
+    ];
+
+    it('renders a "Select row" checkbox only on selectable rows', () => {
+      render(
+        <DataTable
+          columns={selectColumns}
+          data={sampleRows}
+          approxRowCount={3}
+          // Bob is non-selectable — the protected-row case.
+          enableRowSelection={(row) => row.original.name !== 'Bob'}
+        />,
+      );
+
+      // Alice + Charlie are selectable; Bob renders no checkbox affordance.
+      expect(
+        screen.getAllByRole('checkbox', { name: 'Select row' }),
+      ).toHaveLength(2);
+      const bobRow = screen.getByText('Bob').closest('tr');
+      expect(bobRow).not.toBeNull();
+      expect(
+        within(bobRow as HTMLElement).queryByRole('checkbox'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps a checkbox on every row when all rows are selectable', () => {
+      render(
+        <DataTable
+          columns={selectColumns}
+          data={sampleRows}
+          approxRowCount={3}
+          enableRowSelection
+        />,
+      );
+
+      expect(
+        screen.getAllByRole('checkbox', { name: 'Select row' }),
+      ).toHaveLength(3);
+    });
   });
 
   it('prefers an explicit actionMenu over addAction', () => {

--- a/services/platform/app/components/ui/dialog/dialog.test.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.test.tsx
@@ -49,6 +49,15 @@ describe('Dialog', () => {
   });
 
   describe('accessibility', () => {
+    it('marks the content as a modal dialog (aria-modal)', () => {
+      render(
+        <Dialog open onOpenChange={vi.fn()} title="Test Dialog">
+          <p>Content</p>
+        </Dialog>,
+      );
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
     it('passes axe audit when open', async () => {
       const { container } = render(
         <Dialog

--- a/services/platform/app/components/ui/dialog/dialog.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.tsx
@@ -179,6 +179,7 @@ export function Dialog({
             />
           )}
           <DialogPrimitive.Content
+            aria-modal="true"
             className={cn(dialogContentVariants({ size }), className)}
             onClick={(e) => e.stopPropagation()}
             {...(customHeader || !description

--- a/services/platform/app/components/ui/forms/radio-group.browser.test.tsx
+++ b/services/platform/app/components/ui/forms/radio-group.browser.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { RadioGroup } from './radio-group';
+
+// Real-Chromium coverage for the roving-tabindex keyboard contract a WAI-ARIA
+// radiogroup must honour: focus one radio, press an arrow, and selection moves
+// to the sibling. The platform `RadioGroup` delegates this to Radix
+// `RadioGroupPrimitive`, so this guards against a future swap to a hand-rolled
+// set of radios that would silently drop arrow-key navigation (the run-code
+// governance "Default Mode" picker is the canonical consumer).
+//
+// A native `keydown` is dispatched rather than `userEvent.keyboard('{ArrowDown}')`
+// because the latter does not drive Radix's RovingFocusGroup handler under the
+// vitest browser runner; a native event is exactly what a physical arrow press
+// emits. The `browser` project ships no setup file, so cleanup is explicit.
+afterEach(cleanup);
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function pressArrowDownFrom(radio: HTMLElement) {
+  radio.focus();
+  await tick(10);
+  radio.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+  await tick(60);
+}
+
+describe('RadioGroup keyboard navigation', () => {
+  it('moves selection to the next option on ArrowDown', async () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup
+        value="denylist"
+        onValueChange={onValueChange}
+        options={[
+          { value: 'denylist', label: 'Denylist' },
+          { value: 'allowlist', label: 'Allowlist' },
+        ]}
+      />,
+    );
+
+    await pressArrowDownFrom(screen.getByRole('radio', { name: /Denylist/ }));
+
+    expect(onValueChange).toHaveBeenCalledWith('allowlist');
+  });
+
+  it('wraps from the last option back to the first on ArrowDown', async () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup
+        value="allowlist"
+        onValueChange={onValueChange}
+        options={[
+          { value: 'denylist', label: 'Denylist' },
+          { value: 'allowlist', label: 'Allowlist' },
+        ]}
+      />,
+    );
+
+    await pressArrowDownFrom(screen.getByRole('radio', { name: /Allowlist/ }));
+
+    expect(onValueChange).toHaveBeenCalledWith('denylist');
+  });
+});

--- a/services/platform/app/components/ui/overlays/sheet.test.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.test.tsx
@@ -1,12 +1,21 @@
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkAccessibility } from '@/tests/utils/a11y';
-import { render } from '@/tests/utils/render';
+import { render, screen } from '@/tests/utils/render';
 
 import { Sheet } from './sheet';
 
 describe('Sheet', () => {
   describe('accessibility', () => {
+    it('marks the content as a modal dialog (aria-modal)', () => {
+      render(
+        <Sheet open onOpenChange={vi.fn()} title="Sheet Title">
+          <p>Sheet content</p>
+        </Sheet>,
+      );
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
     it('passes axe audit when open', async () => {
       const { container } = render(
         <Sheet

--- a/services/platform/app/components/ui/overlays/sheet.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.tsx
@@ -210,6 +210,7 @@ export function Sheet({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80" />
         <DialogPrimitive.Content
+          aria-modal="true"
           className={cn(sheetVariants({ side, size }), widthClass, className)}
           style={widthStyle}
           onOpenAutoFocus={onOpenAutoFocus}

--- a/services/platform/app/features/documents/components/document-preview-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// The dialog point-queries the document and resolves a storage URL; stub both
+// so the component mounts without a live Convex backend. Returning no URL lands
+// the body on the lightweight "failed to load" branch — enough to render the
+// header, which is what this test inspects.
+vi.mock('../hooks/queries', () => ({
+  useDocument: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/app/features/chat/hooks/queries', () => ({
+  useFileUrl: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/app/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { DocumentPreviewDialog } from './document-preview-dialog';
+
+describe('DocumentPreviewDialog', () => {
+  it('exposes the "Document preview" heading exactly once', () => {
+    render(
+      <DocumentPreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        fileId="storage123"
+        fileName="report.pdf"
+      />,
+    );
+
+    // The visible title and the dialog's accessible name share the same text;
+    // only the (visually-hidden) DialogTitle should be a semantic heading, so
+    // assistive tech hears "Document preview" once, not twice.
+    expect(
+      screen.getAllByRole('heading', { name: 'Document preview' }),
+    ).toHaveLength(1);
+  });
+});

--- a/services/platform/app/features/documents/components/document-preview-dialog.tsx
+++ b/services/platform/app/features/documents/components/document-preview-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { ActionRow } from '@tale/ui/action-row';
 import { Button } from '@tale/ui/button';
-import { Heading } from '@tale/ui/heading';
 import { useLocale } from '@tale/ui/i18n/locale-provider';
 import { IconButton } from '@tale/ui/icon-button';
 import { HStack, Row, Stack } from '@tale/ui/layout';
@@ -282,9 +281,16 @@ export function DocumentPreviewDialog({
       className="flex h-[85vh] flex-col overflow-hidden p-0 sm:p-0"
       customHeader={
         <Row gap={0} justify="between" className="max-h-[4.5rem] p-5">
-          <Heading level={2} tracking="tight" className="leading-none">
+          {/* Visible title only — the dialog's single accessible heading is the
+              visually-hidden `DialogTitle` the `Dialog` renders from `title`.
+              Rendering this as a heading too would expose "Document preview"
+              twice to assistive tech, so keep it a plain styled span. */}
+          <Text
+            as="span"
+            className="text-foreground text-base leading-none font-semibold tracking-tight"
+          >
             {t('preview.title')}
-          </Heading>
+          </Text>
 
           <ActionRow gap={2}>
             {resolvedUrl && (


### PR DESCRIPTION
## What & why

Resolves the four accessibility refinements from the keyboard/AT sweep in #1998 (none block a task; all WCAG 2.1 AA polish).

### 1. `aria-modal="true"` on modal dialogs
Radix does not emit `aria-modal` in this version (verified: the dialog content rendered with `aria-modal=null`). Added it to every modal dialog primitive:
- platform `Dialog` (`components/ui/dialog/dialog.tsx`)
- platform `Sheet` (`components/ui/overlays/sheet.tsx`)
- `@tale/ui` `ResponsiveDialog` — both the desktop Radix dialog **and** the mobile vaul drawer content.

### 2. Run-code "Default Mode" radiogroup — arrow-key navigation
The platform `RadioGroup` already delegates to Radix `RadioGroupPrimitive`, which provides roving-tabindex arrow navigation. Confirmed empirically in real Chromium (a native `ArrowDown` keydown on the focused radio moves selection and fires `onValueChange`). The reported failure reproduced only with `userEvent.keyboard('{ArrowDown}')`, which doesn't drive Radix's RovingFocusGroup under the test runner — a harness artifact, not an app bug. Added a real-Chromium regression test (`radio-group.browser.test.tsx`) to lock the behaviour in and guard against a future swap to hand-rolled radios.

### 3. Duplicate "Document preview" heading
The Dialog renders a visually-hidden `DialogTitle` (an `<h2>`) for its accessible name; the document-preview custom header **also** rendered a visible `<Heading level={2}>` with the same text, so AT exposed the heading twice. The visible title is now a styled `<span>`, leaving the hidden `DialogTitle` as the single heading.

### 4. Fake "Select row" checkbox on protected rows
The shared select column rendered an inert `Checkbox` (with a "Select row" label) even on rows gated out by the table's `enableRowSelection` predicate — a false affordance on protected agent rows. The cell now renders nothing when `row.getCanSelect()` is false. Tables without per-row gating are unaffected.

## Tests
- `bun run --filter @tale/platform typecheck`, `lint` — green; `@tale/ui typecheck`, `lint` — green.
- Client (jsdom) project: `aria-modal` assertions on `Dialog` + `Sheet`; new `DocumentPreviewDialog` test (heading exposed once); new `DataTable` row-selection tests (checkbox only on selectable rows). 208 passed.
- Browser (real Chromium) project: new `RadioGroup` arrow-key navigation tests + existing `form-dialog` focus-trap. All passed.
- `@tale/ui`: `ResponsiveDialog` `aria-modal` assertions (desktop + mobile drawer). 6 passed.

## Ripple Map
No user-visible strings, env vars, Convex/knowledge schema, or org-config schema changed — i18n, docs, README, and migrations are **N/A**. Change spans `@tale/ui` (responsive-dialog) alongside the platform app.

Closes #1998