### PR TITLE
chore(convex): bump convex backend + dashboard image to 2026-06-26

### DIFF
--- a/services/convex/Dockerfile
+++ b/services/convex/Dockerfile
@@ -13,7 +13,7 @@
 # ============================================================================
 # Stage 1: Convex Dashboard assets (Next.js standalone build)
 # ============================================================================
-FROM ghcr.io/get-convex/convex-dashboard:5f66740ae8dd506577d27294adc55b81e4fbe91b AS convex-dashboard
+FROM ghcr.io/get-convex/convex-dashboard:903b8b96c4bceb34c62e366cf36e8f4774955e6b AS convex-dashboard
 
 # ============================================================================
 # Stage 2: Runtime — Convex backend + Dashboard + builtin seed
@@ -22,7 +22,7 @@ FROM ghcr.io/get-convex/convex-dashboard:5f66740ae8dd506577d27294adc55b81e4fbe91
 # Must stay on Debian-based convex-backend image (glibc); Alpine would break
 # the binaries. Platform service uses the same base for `generate_key`.
 # ============================================================================
-FROM ghcr.io/get-convex/convex-backend:5f66740ae8dd506577d27294adc55b81e4fbe91b AS runner
+FROM ghcr.io/get-convex/convex-backend:903b8b96c4bceb34c62e366cf36e8f4774955e6b AS runner
 
 WORKDIR /app
 

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -11,7 +11,7 @@ FROM oven/bun:1.3.12 AS bun-bin
 # ============================================================================
 # Stage 1: Dependencies
 # ============================================================================
-FROM ghcr.io/get-convex/convex-backend:5f66740ae8dd506577d27294adc55b81e4fbe91b AS workspace-deps
+FROM ghcr.io/get-convex/convex-backend:903b8b96c4bceb34c62e366cf36e8f4774955e6b AS workspace-deps
 
 COPY --from=bun-bin /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # ============================================================================
 # Stage 2: Builder
 # ============================================================================
-FROM ghcr.io/get-convex/convex-backend:5f66740ae8dd506577d27294adc55b81e4fbe91b AS builder
+FROM ghcr.io/get-convex/convex-backend:903b8b96c4bceb34c62e366cf36e8f4774955e6b AS builder
 
 COPY --from=bun-bin /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
@@ -169,7 +169,7 @@ RUN HUSKY=0 bun install --production \
 # `generate_key` (glibc Rust binary) is available for computing the admin
 # key used when pushing functions/env vars to the remote convex service.
 # ============================================================================
-FROM ghcr.io/get-convex/convex-backend:5f66740ae8dd506577d27294adc55b81e4fbe91b AS runner
+FROM ghcr.io/get-convex/convex-backend:903b8b96c4bceb34c62e366cf36e8f4774955e6b AS runner
 
 COPY --from=bun-bin /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx


### PR DESCRIPTION
## What

Bumps the pinned self-hosted Convex image from `5f66740` (**2026-02-21**) to `903b8b9` (**2026-06-26**) — the latest upstream `precompiled-2026-06-26-903b8b9` release, ~4 months of fixes (1450 commits upstream).

Both `convex-backend` and `convex-dashboard` images were confirmed to exist on GHCR at the new SHA before pinning. All **5** `FROM` pins move in lockstep:

- `services/convex/Dockerfile` — `convex-dashboard` + `convex-backend` (the backend service)
- `services/platform/Dockerfile` — 3× `convex-backend` (the base is kept here for the `generate_key` glibc binary used to compute admin keys)

## Scope

Image only. The npm `convex` client in `services/platform/package.json` stays at `1.35.1` — new developer-facing APIs (`ctx.meta`, `useStaleSnapshot`, `transactionLimits`, `server-only`, `AsyncLocalStorage`, …) require a matching client bump to actually use. What this PR delivers is the backend-runtime + dashboard **bugfix / perf / security** improvements.

## Operational notes

- The self-hosted backend runs **forward-only** DB migrations on startup; once the new image migrates the data, **rollback to the old image is not supported**. Recommend a non-destructive upgrade-in-place check on real data before production.