### PR TITLE
chore(convex): default INDEX_RETENTION_DELAY to 24h in the convex image

### DIFF
--- a/services/convex/Dockerfile
+++ b/services/convex/Dockerfile
@@ -155,6 +155,16 @@ ENV NODE_ENV=production \
     APPLICATION_MAX_CONCURRENT_MUTATIONS=32 \
     APPLICATION_MAX_CONCURRENT_V8_ACTIONS=32 \
     APPLICATION_MAX_CONCURRENT_NODE_ACTIONS=32 \
+    # Index retention window (seconds; default upstream is 4*60=240s). Bumped to
+    # 24h so reads pinned to an older snapshot — slow paginated queries, a
+    # migration/export paginating at a consistent timestamp, long-lived
+    # subscriptions — don't get forced to restart with "reads too far behind"
+    # once they fall outside the default 4-minute window. Trade-off: a larger
+    # window keeps more index tombstones around between sweeps, so index scans on
+    # high-churn tables do more work (upstream knobs.rs warns of UDF slowdowns
+    # with many tombstones). Override at runtime via .env if churn-driven query
+    # latency becomes an issue. DOCUMENT_RETENTION_DELAY (default 14d) is separate.
+    INDEX_RETENTION_DELAY=86400 \
     DO_NOT_TRACK=1 \
     # CA cert path for self-signed mode (entrypoint checks if file exists)
     CADDY_CA_CERT_PATH=/caddy-data/caddy/pki/authorities/local/root.crt \


### PR DESCRIPTION
## What

Set `INDEX_RETENTION_DELAY=86400` (24h) as a default in the `tale-convex` image ENV (`services/convex/Dockerfile`).

## Why

The Convex backend knob `INDEX_RETENTION_DELAY` (from upstream `crates/common/src/knobs.rs`) controls the index retention window — how long old index entries (tombstones from updates/deletes) are kept before the retention sweep vacuums them. The env var is in **seconds**; upstream default is `4 * 60` = **240s (4 min)**.

```rust
/// INDEX_RETENTION_DELAY determines the size of the index retention window.
/// Larger window means we keep around old snapshots for longer, which can cause
/// performance problems in UDFs if there are many tombstones.
/// Smaller window means we break snapshot reads faster.
```

A 4-minute window forces any read pinned to an older snapshot — a slow paginated query, a migration/export paginating at a consistent timestamp, a long-lived subscription — to restart with "reads too far behind" once it ages out. Bumping to 24h gives those long single-snapshot reads room to complete.

## Trade-off

A larger window keeps more index tombstones around between retention sweeps, so index scans on high-churn tables (chat messages, agent-turn status, task status, usage ledger) do more work — upstream's own doc comment warns of UDF slowdowns when there are many tombstones. Set as an image ENV **default** so it stays overridable per-deployment via `.env`.

The sibling `DOCUMENT_RETENTION_DELAY` (default 14d, governs document/WAL history) is unaffected.

## Notes

- Env-only change to image defaults — no data migration.
- Override path intact: compose `env_file: .env` / `environment:` win over image ENV.
