### PR TITLE
fix(convex): throw ConvexError from file_metadata mutations (#2001)

### DIFF
--- a/services/platform/convex/file_metadata/mutations.test.ts
+++ b/services/platform/convex/file_metadata/mutations.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { checkUploadPolicy } from '../governance/upload_enforcement';
+
 vi.mock('convex/values', () => {
   const stub = () => 'validator';
   return {
@@ -46,6 +48,12 @@ vi.mock('../_generated/api', () => ({
         uploadFileToRag: 'mock',
         extractFileMetadata: 'extract_mock',
       },
+      internal_mutations: {
+        updateFileTranscription: 'updateFileTranscription_mock',
+      },
+      transcribe_audio: {
+        transcribeAudio: 'transcribeAudio_mock',
+      },
     },
   },
 }));
@@ -65,6 +73,9 @@ function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
   const builder = {
     withIndex: vi.fn().mockReturnThis(),
     first: vi.fn().mockResolvedValue(existingDoc),
+    // The thread-org cross-check (`threadMetadata` lookup) resolves via
+    // `.unique()`; default to no matching thread so the gate is a no-op.
+    unique: vi.fn().mockResolvedValue(null),
   };
 
   const ctx = {
@@ -79,6 +90,7 @@ function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
       insert: vi.fn().mockResolvedValue('fm_new'),
       patch: vi.fn().mockResolvedValue(undefined),
     },
+    runMutation: vi.fn().mockResolvedValue(undefined),
     scheduler: {
       runAfter: vi.fn().mockResolvedValue(undefined),
     },
@@ -90,6 +102,16 @@ function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
 async function getHandler() {
   const { saveFileMetadata } = await import('./mutations');
   return (saveFileMetadata as unknown as { handler: Function }).handler;
+}
+
+async function getSkipHandler() {
+  const { skipTranscription } = await import('./mutations');
+  return (skipTranscription as unknown as { handler: Function }).handler;
+}
+
+async function getRetryHandler() {
+  const { retryTranscription } = await import('./mutations');
+  return (retryTranscription as unknown as { handler: Function }).handler;
 }
 
 const baseArgs = {
@@ -119,6 +141,53 @@ describe('saveFileMetadata (public)', () => {
     await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
       data: { code: 'UNAUTHENTICATED' },
     });
+  });
+
+  it('rejects uploads blocked by organization policy, preserving the reason', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    vi.mocked(checkUploadPolicy).mockResolvedValueOnce({
+      allowed: false,
+      reason: 'File type not permitted',
+    });
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
+      data: { code: 'UPLOAD_REJECTED', reason: 'File type not permitted' },
+    });
+    // The rejection happens before any DB write.
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a generic reason when the policy omits one', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    vi.mocked(checkUploadPolicy).mockResolvedValueOnce({ allowed: false });
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
+      data: {
+        code: 'UPLOAD_REJECTED',
+        reason: 'Upload rejected by organization policy',
+      },
+    });
+  });
+
+  it('rejects a threadId that belongs to a different organization', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    // The threadMetadata lookup resolves a row owned by another org; the
+    // fileMetadata insert/query path is never reached.
+    const { ctx, builder } = createMockCtx(null);
+    builder.unique.mockResolvedValueOnce({
+      threadId: 'thread_1',
+      organizationId: 'org_other',
+    });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { ...baseArgs, threadId: 'thread_1' }),
+    ).rejects.toMatchObject({ data: { code: 'THREAD_ORG_MISMATCH' } });
+    expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
   it('inserts new file metadata when none exists', async () => {
@@ -440,5 +509,199 @@ describe('saveFileMetadata (public)', () => {
       ragProgress: undefined,
       ragQueuedAt: expect.any(Number),
     });
+  });
+});
+
+const skipArgs = { storageId: 'storage_1', organizationId: 'org_1' };
+
+describe('skipTranscription (public)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockGetAuthUser.mockResolvedValue(null);
+    const { ctx } = createMockCtx();
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
+      data: { code: 'UNAUTHENTICATED' },
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('throws FILE_NOT_FOUND when no row matches the storageId', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
+      data: { code: 'FILE_NOT_FOUND' },
+    });
+  });
+
+  it('throws NOT_AUTHORIZED when the row belongs to another org', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_other',
+      transcriptionStatus: 'running',
+    });
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
+      data: { code: 'NOT_AUTHORIZED' },
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('throws TRANSCRIPTION_NOT_SKIPPABLE with the current status for a non-skippable row', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      transcriptionStatus: 'completed',
+    });
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
+      data: { code: 'TRANSCRIPTION_NOT_SKIPPABLE', status: 'completed' },
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('reports status "none" when the row has no transcriptionStatus', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+    });
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
+      data: { code: 'TRANSCRIPTION_NOT_SKIPPABLE', status: 'none' },
+    });
+  });
+
+  it('marks a running transcription as skipped via updateFileTranscription', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      transcriptionStatus: 'running',
+    });
+    const handler = await getSkipHandler();
+
+    await handler(ctx, skipArgs);
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'updateFileTranscription_mock',
+      {
+        storageId: 'storage_1',
+        transcriptionStatus: 'skipped',
+        transcriptionError: 'User skipped transcription',
+      },
+    );
+  });
+});
+
+const retryArgs = { storageId: 'storage_1', organizationId: 'org_1' };
+
+describe('retryTranscription (public)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockGetAuthUser.mockResolvedValue(null);
+    const { ctx } = createMockCtx();
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
+      data: { code: 'UNAUTHENTICATED' },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('throws FILE_NOT_FOUND when no row matches the storageId', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx(null);
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
+      data: { code: 'FILE_NOT_FOUND' },
+    });
+  });
+
+  it('throws NOT_AUTHORIZED when the row belongs to another org', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_other',
+      transcriptionStatus: 'failed',
+    });
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
+      data: { code: 'NOT_AUTHORIZED' },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('throws TRANSCRIPTION_NOT_RETRYABLE with the current status for a non-retryable row', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      transcriptionStatus: 'running',
+    });
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
+      data: { code: 'TRANSCRIPTION_NOT_RETRYABLE', status: 'running' },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it('reports status "none" when the row has no transcriptionStatus', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+    });
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
+      data: { code: 'TRANSCRIPTION_NOT_RETRYABLE', status: 'none' },
+    });
+  });
+
+  it('re-queues a failed transcription and reschedules the action', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      fileName: 'clip.mp3',
+      contentType: 'audio/mpeg',
+      transcriptionStatus: 'failed',
+    });
+    const handler = await getRetryHandler();
+
+    await handler(ctx, retryArgs);
+
+    expect(ctx.db.patch).toHaveBeenCalledWith('fm_1', {
+      transcriptionStatus: 'queued',
+      transcriptionError: undefined,
+      transcriptionRunId: undefined,
+      transcriptionLeaseExpiresAt: undefined,
+    });
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      'transcribeAudio_mock',
+      expect.objectContaining({
+        storageId: 'storage_1',
+        organizationId: 'org_1',
+      }),
+    );
   });
 });

--- a/services/platform/convex/file_metadata/mutations.test.ts
+++ b/services/platform/convex/file_metadata/mutations.test.ts
@@ -15,6 +15,13 @@ vi.mock('convex/values', () => {
       array: stub,
       null: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : 'ConvexError');
+        this.data = data;
+      }
+    },
   };
 });
 
@@ -109,7 +116,9 @@ describe('saveFileMetadata (public)', () => {
     const { ctx } = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, baseArgs)).rejects.toThrow('Unauthenticated');
+    await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
+      data: { code: 'UNAUTHENTICATED' },
+    });
   });
 
   it('inserts new file metadata when none exists', async () => {

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import {
   extractExtension,
@@ -46,7 +46,7 @@ export const saveFileMetadata = mutation({
   async handler(ctx, args) {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const userId = authUser.userId;
@@ -60,7 +60,13 @@ export const saveFileMetadata = mutation({
       args.size,
     );
     if (!check.allowed) {
-      throw new Error(check.reason ?? 'Upload rejected by organization policy');
+      // Preserve the policy's human-readable reason as structured data so the
+      // composer can surface why the upload was rejected; a raw Error message
+      // is redacted to "Server Error" by Convex in prod.
+      throw new ConvexError({
+        code: 'UPLOAD_REJECTED',
+        reason: check.reason ?? 'Upload rejected by organization policy',
+      });
     }
 
     // Defense-in-depth: a malicious client could pass a foreign org's
@@ -78,7 +84,7 @@ export const saveFileMetadata = mutation({
         threadMeta.organizationId !== undefined &&
         threadMeta.organizationId !== args.organizationId
       ) {
-        throw new Error('Thread does not belong to this organization');
+        throw new ConvexError({ code: 'THREAD_ORG_MISMATCH' });
       }
     }
 
@@ -279,16 +285,16 @@ export const skipTranscription = mutation({
   async handler(ctx, args) {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const metadata = await ctx.db
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
-    if (!metadata) throw new Error('File not found');
+    if (!metadata) throw new ConvexError({ code: 'FILE_NOT_FOUND' });
     if (metadata.organizationId !== args.organizationId) {
-      throw new Error('Not authorized');
+      throw new ConvexError({ code: 'NOT_AUTHORIZED' });
     }
 
     // Source-state precondition. `skipTranscription` is the Skip button
@@ -300,9 +306,10 @@ export const skipTranscription = mutation({
       metadata.transcriptionStatus !== 'queued' &&
       metadata.transcriptionStatus !== 'running'
     ) {
-      throw new Error(
-        `Cannot skip transcription in status "${metadata.transcriptionStatus ?? 'none'}" — only queued or running.`,
-      );
+      throw new ConvexError({
+        code: 'TRANSCRIPTION_NOT_SKIPPABLE',
+        status: metadata.transcriptionStatus ?? 'none',
+      });
     }
 
     // Route through `updateFileTranscription` so the `videoLinkJobs`
@@ -333,16 +340,16 @@ export const retryTranscription = mutation({
   async handler(ctx, args) {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const metadata = await ctx.db
       .query('fileMetadata')
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
-    if (!metadata) throw new Error('File not found');
+    if (!metadata) throw new ConvexError({ code: 'FILE_NOT_FOUND' });
     if (metadata.organizationId !== args.organizationId) {
-      throw new Error('Not authorized');
+      throw new ConvexError({ code: 'NOT_AUTHORIZED' });
     }
 
     // Source-state precondition. Retry is only valid from a terminal
@@ -354,9 +361,10 @@ export const retryTranscription = mutation({
       metadata.transcriptionStatus !== 'failed' &&
       metadata.transcriptionStatus !== 'skipped'
     ) {
-      throw new Error(
-        `Cannot retry transcription in status "${metadata.transcriptionStatus ?? 'none'}" — only failed or skipped.`,
-      );
+      throw new ConvexError({
+        code: 'TRANSCRIPTION_NOT_RETRYABLE',
+        status: metadata.transcriptionStatus ?? 'none',
+      });
     }
 
     await ctx.db.patch(metadata._id, {

--- a/services/platform/convex/file_metadata/transcribe_dictation.test.ts
+++ b/services/platform/convex/file_metadata/transcribe_dictation.test.ts
@@ -286,7 +286,9 @@ describe('transcribeDictation handler', () => {
           mimeType: 'audio/webm',
           organizationId: ORG_ID,
         }),
-      ).rejects.toMatchObject({ data: { code: 'DICTATION_TOO_LARGE' } });
+      ).rejects.toMatchObject({
+        data: { code: 'DICTATION_TOO_LARGE', maxBytes: 8 * 1024 * 1024 },
+      });
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 

--- a/services/platform/convex/file_metadata/transcribe_dictation.test.ts
+++ b/services/platform/convex/file_metadata/transcribe_dictation.test.ts
@@ -21,6 +21,13 @@ vi.mock('convex/values', () => {
       null: stub,
       bytes: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : 'ConvexError');
+        this.data = data;
+      }
+    },
   };
 });
 
@@ -210,7 +217,7 @@ describe('transcribeDictation handler', () => {
           mimeType: 'audio/webm',
           organizationId: ORG_ID,
         }),
-      ).rejects.toThrow(/Unauthenticated/);
+      ).rejects.toMatchObject({ data: { code: 'UNAUTHENTICATED' } });
       // Whisper must not be called before the auth check passes.
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
@@ -279,7 +286,7 @@ describe('transcribeDictation handler', () => {
           mimeType: 'audio/webm',
           organizationId: ORG_ID,
         }),
-      ).rejects.toThrow(/exceeds 8 MiB/);
+      ).rejects.toMatchObject({ data: { code: 'DICTATION_TOO_LARGE' } });
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 

--- a/services/platform/convex/file_metadata/transcribe_dictation.ts
+++ b/services/platform/convex/file_metadata/transcribe_dictation.ts
@@ -1,6 +1,6 @@
 'use node';
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { TRANSCRIPTION_SLUG } from '../../lib/shared/constants/usage';
 import { internal } from '../_generated/api';
@@ -37,7 +37,7 @@ export const transcribeDictation = action({
   returns: v.object({ text: v.string() }),
   handler: async (ctx, args): Promise<{ text: string }> => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
 
     await ctx.runQuery(
       internal.approvals.internal_queries.verifyOrganizationMembership,
@@ -53,7 +53,10 @@ export const transcribeDictation = action({
       return { text: '' };
     }
     if (args.audio.byteLength > MAX_DICTATION_BYTES) {
-      throw new Error('Dictation audio exceeds 8 MiB limit');
+      throw new ConvexError({
+        code: 'DICTATION_TOO_LARGE',
+        maxBytes: MAX_DICTATION_BYTES,
+      });
     }
 
     const modelData = await resolveTranscriptionModel(ctx, {


### PR DESCRIPTION
## Summary

`file_metadata` public mutations and the `transcribeDictation` action threw raw `Error`s, which Convex surfaces to the browser as opaque "Server Error" messages — the message and any actionable context is lost to the client.

This replaces every client-facing `throw new Error(...)` with a structured `ConvexError({ code, ... })`, matching the established pattern in `tasks/mutations.ts`, so the UI receives a stable `code` (and structured fields like `reason`/`status`/`maxBytes`) it can map to a user-readable message.

## Changes

`services/platform/convex/file_metadata/mutations.ts`
- `saveFileMetadata`: `UNAUTHENTICATED`, `UPLOAD_REJECTED` (preserves the policy `reason`), `THREAD_ORG_MISMATCH`
- `skipTranscription`: `UNAUTHENTICATED`, `FILE_NOT_FOUND`, `NOT_AUTHORIZED`, `TRANSCRIPTION_NOT_SKIPPABLE` (carries `status`)
- `retryTranscription`: `UNAUTHENTICATED`, `FILE_NOT_FOUND`, `NOT_AUTHORIZED`, `TRANSCRIPTION_NOT_RETRYABLE` (carries `status`)

`services/platform/convex/file_metadata/transcribe_dictation.ts`
- `transcribeDictation`: `UNAUTHENTICATED`, `DICTATION_TOO_LARGE` (carries `maxBytes`)

The scheduler-invoked internal-action errors in `transcribe_audio.ts` are intentionally left as raw `Error` (not direct client calls), per the issue's notes.

## Tests
- Added `ConvexError` to the `convex/values` mocks in the two affected test files and updated assertions to `toMatchObject({ data: { code: ... } })`.
- `vitest --project server` for both files: 40 passed.
- `tsc --noEmit`: clean. `oxlint --type-aware` on changed files: clean.

Closes #2001