### PR TITLE
fix: throw structured ConvexError codes from member management mutations (#2006)

### DIFF
--- a/services/platform/convex/members/mutations.test.ts
+++ b/services/platform/convex/members/mutations.test.ts
@@ -27,7 +27,16 @@ vi.mock('../audit_logs/helpers', () => ({
 
 vi.mock('convex/values', () => {
   const stub = () => 'validator';
+  class ConvexError extends Error {
+    data: unknown;
+    constructor(data: unknown) {
+      super(typeof data === 'string' ? data : JSON.stringify(data));
+      this.name = 'ConvexError';
+      this.data = data;
+    }
+  }
   return {
+    ConvexError,
     v: {
       string: stub,
       number: stub,
@@ -123,7 +132,7 @@ describe('removeMember handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { memberId: 'm_1' })).rejects.toThrow(
-      'Unauthenticated',
+      'UNAUTHENTICATED',
     );
   });
 
@@ -134,7 +143,7 @@ describe('removeMember handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { memberId: 'm_1' })).rejects.toThrow(
-      'Member not found',
+      'MEMBER_NOT_FOUND',
     );
   });
 
@@ -159,7 +168,7 @@ describe('removeMember handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { memberId: 'm_target' })).rejects.toThrow(
-      'Only admins can remove members',
+      'MEMBER_REMOVE_FORBIDDEN',
     );
   });
 
@@ -184,7 +193,7 @@ describe('removeMember handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { memberId: 'm_owner' })).rejects.toThrow(
-      'The organization owner cannot be removed',
+      'MEMBER_OWNER_REMOVAL_FORBIDDEN',
     );
   });
 
@@ -250,7 +259,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_1', role: 'editor' }),
-    ).rejects.toThrow('Unauthenticated');
+    ).rejects.toThrow('UNAUTHENTICATED');
   });
 
   it('throws when caller is not admin', async () => {
@@ -275,7 +284,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_target', role: 'admin' }),
-    ).rejects.toThrow('Only admins can update member roles');
+    ).rejects.toThrow('MEMBER_ROLE_UPDATE_FORBIDDEN');
   });
 
   it('throws when trying to change the owner role', async () => {
@@ -300,7 +309,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_owner', role: 'member' }),
-    ).rejects.toThrow('The organization owner role cannot be changed');
+    ).rejects.toThrow('MEMBER_OWNER_ROLE_IMMUTABLE');
   });
 
   it('throws when trying to assign owner role manually', async () => {
@@ -325,7 +334,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_target', role: 'owner' }),
-    ).rejects.toThrow('The owner role cannot be assigned manually');
+    ).rejects.toThrow('MEMBER_OWNER_ROLE_ASSIGN_FORBIDDEN');
   });
 
   it('throws when target is the organization creator', async () => {
@@ -359,7 +368,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_creator', role: 'member' }),
-    ).rejects.toThrow('The organization creator role cannot be changed');
+    ).rejects.toThrow('MEMBER_CREATOR_ROLE_IMMUTABLE');
   });
 
   it('throws when demoting the last admin', async () => {
@@ -404,9 +413,7 @@ describe('updateMemberRole handler', () => {
 
     await expect(
       handler(ctx, { memberId: 'm_target', role: 'member' }),
-    ).rejects.toThrow(
-      'Cannot demote the last admin. The organization must have at least one admin or owner.',
-    );
+    ).rejects.toThrow('MEMBER_LAST_ADMIN');
   });
 
   it('allows demoting admin when owner exists', async () => {
@@ -596,7 +603,7 @@ describe('transferOwnership handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { targetMemberId: 'm_target' })).rejects.toThrow(
-      'Unauthenticated',
+      'UNAUTHENTICATED',
     );
   });
 
@@ -607,7 +614,7 @@ describe('transferOwnership handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { targetMemberId: 'm_target' })).rejects.toThrow(
-      'Member not found',
+      'MEMBER_NOT_FOUND',
     );
   });
 
@@ -632,7 +639,7 @@ describe('transferOwnership handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { targetMemberId: 'm_target' })).rejects.toThrow(
-      'Only the organization owner can transfer ownership',
+      'OWNERSHIP_TRANSFER_FORBIDDEN',
     );
   });
 
@@ -657,7 +664,7 @@ describe('transferOwnership handler', () => {
     const handler = await getHandler();
 
     await expect(handler(ctx, { targetMemberId: 'm_target' })).rejects.toThrow(
-      'Target member is already the owner',
+      'MEMBER_ALREADY_OWNER',
     );
   });
 

--- a/services/platform/convex/members/mutations.test.ts
+++ b/services/platform/convex/members/mutations.test.ts
@@ -262,6 +262,18 @@ describe('updateMemberRole handler', () => {
     ).rejects.toThrow('UNAUTHENTICATED');
   });
 
+  it('throws when member not found', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // target member lookup — empty
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { memberId: 'm_1', role: 'editor' }),
+    ).rejects.toThrow('MEMBER_NOT_FOUND');
+  });
+
   it('throws when caller is not admin', async () => {
     mockGetAuthUser.mockResolvedValue(AUTH_USER);
     const ctx = createMockCtx();
@@ -586,6 +598,112 @@ describe('addMember handler', () => {
 // ---------------------------------------------------------------------------
 // transferOwnership
 // ---------------------------------------------------------------------------
+
+describe('updateMemberDisplayName handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function getHandler() {
+    const { updateMemberDisplayName } = await import('./mutations');
+    return (updateMemberDisplayName as unknown as { handler: Function })
+      .handler;
+  }
+
+  it('throws when unauthenticated', async () => {
+    mockGetAuthUser.mockResolvedValue(null);
+    const ctx = createMockCtx();
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { memberId: 'm_1', displayName: 'New Name' }),
+    ).rejects.toThrow('UNAUTHENTICATED');
+  });
+
+  it('throws when member not found', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // target member lookup — empty
+    ctx.runQuery.mockResolvedValueOnce({ page: [] });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { memberId: 'm_1', displayName: 'New Name' }),
+    ).rejects.toThrow('MEMBER_NOT_FOUND');
+  });
+
+  it('throws when a non-admin edits another members name', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // target member is someone else
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'm_target',
+          organizationId: 'org_1',
+          userId: 'user_target',
+          role: 'member',
+        },
+      ],
+    });
+    // target user lookup
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'user_target', name: 'Old Name' }],
+    });
+    // caller member lookup — non-admin
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_caller', role: 'member' }],
+    });
+    const handler = await getHandler();
+
+    await expect(
+      handler(ctx, { memberId: 'm_target', displayName: 'New Name' }),
+    ).rejects.toThrow('MEMBER_NAME_UPDATE_FORBIDDEN');
+  });
+
+  it('allows a member to update their own name without an admin check', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // target member is the caller themselves
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'm_self',
+          organizationId: 'org_1',
+          userId: 'user_caller',
+          role: 'member',
+        },
+      ],
+    });
+    // target user lookup (own profile)
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'user_caller', name: 'Old Name' }],
+    });
+    // updateMany for the name change
+    ctx.runMutation.mockResolvedValueOnce(undefined);
+    const handler = await getHandler();
+
+    const result = await handler(ctx, {
+      memberId: 'm_self',
+      displayName: 'New Name',
+    });
+
+    expect(result).toBeNull();
+    // Own-profile edit skips the caller-admin lookup: only member + user
+    // queries run (no third caller-member query).
+    expect(ctx.runQuery).toHaveBeenCalledTimes(2);
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      'betterAuth:adapter:updateMany',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          model: 'user',
+          where: [{ field: '_id', value: 'user_caller', operator: 'eq' }],
+          update: { name: 'New Name' },
+        }),
+      }),
+    );
+  });
+});
 
 describe('transferOwnership handler', () => {
   beforeEach(() => {

--- a/services/platform/convex/members/mutations.ts
+++ b/services/platform/convex/members/mutations.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { isRecord, getString } from '../../lib/utils/type-utils';
 import { components } from '../_generated/api';
@@ -137,7 +137,7 @@ export const removeMember = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const member = findOneMember(
@@ -148,7 +148,7 @@ export const removeMember = mutation({
       }),
     );
     if (!member?.organizationId) {
-      throw new Error('Member not found');
+      throw new ConvexError({ code: 'MEMBER_NOT_FOUND' });
     }
 
     const callerMember = findOneMember(
@@ -166,11 +166,11 @@ export const removeMember = mutation({
       }),
     );
     if (!isAdmin(callerMember?.role)) {
-      throw new Error('Only admins can remove members');
+      throw new ConvexError({ code: 'MEMBER_REMOVE_FORBIDDEN' });
     }
 
     if (member.role?.toLowerCase() === 'owner') {
-      throw new Error('The organization owner cannot be removed');
+      throw new ConvexError({ code: 'MEMBER_OWNER_REMOVAL_FORBIDDEN' });
     }
 
     const targetUser = member.userId
@@ -245,7 +245,7 @@ export const updateMemberRole = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const member = findOneMember(
@@ -256,7 +256,7 @@ export const updateMemberRole = mutation({
       }),
     );
     if (!member?.organizationId) {
-      throw new Error('Member not found');
+      throw new ConvexError({ code: 'MEMBER_NOT_FOUND' });
     }
 
     const callerMember = findOneMember(
@@ -274,15 +274,15 @@ export const updateMemberRole = mutation({
       }),
     );
     if (!isAdmin(callerMember?.role)) {
-      throw new Error('Only admins can update member roles');
+      throw new ConvexError({ code: 'MEMBER_ROLE_UPDATE_FORBIDDEN' });
     }
 
     if (member.role?.toLowerCase() === 'owner') {
-      throw new Error('The organization owner role cannot be changed');
+      throw new ConvexError({ code: 'MEMBER_OWNER_ROLE_IMMUTABLE' });
     }
 
     if (args.role.toLowerCase() === 'owner') {
-      throw new Error('The owner role cannot be assigned manually');
+      throw new ConvexError({ code: 'MEMBER_OWNER_ROLE_ASSIGN_FORBIDDEN' });
     }
 
     const orgResult = await ctx.runQuery(
@@ -303,13 +303,16 @@ export const updateMemberRole = mutation({
     if (isRecord(orgRaw)) {
       const rawMetadata = getString(orgRaw, 'metadata');
       if (rawMetadata) {
+        let creatorId: unknown;
         try {
           const parsed: unknown = JSON.parse(rawMetadata);
-          if (isRecord(parsed) && parsed.creatorId === member.userId) {
-            throw new Error('The organization creator role cannot be changed');
-          }
+          if (isRecord(parsed)) creatorId = parsed.creatorId;
         } catch (e) {
-          if (e instanceof Error && e.message.includes('creator')) throw e;
+          // Malformed metadata can't pin a creator; log and skip the guard.
+          console.warn('Failed to parse organization metadata', e);
+        }
+        if (creatorId === member.userId) {
+          throw new ConvexError({ code: 'MEMBER_CREATOR_ROLE_IMMUTABLE' });
         }
       }
     }
@@ -346,9 +349,7 @@ export const updateMemberRole = mutation({
         (m: { role?: string }) => isAdmin(m.role),
       ).length;
       if (adminCount <= 1) {
-        throw new Error(
-          'Cannot demote the last admin. The organization must have at least one admin or owner.',
-        );
+        throw new ConvexError({ code: 'MEMBER_LAST_ADMIN' });
       }
     }
 
@@ -401,7 +402,7 @@ export const transferOwnership = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const targetMember = findOneMember(
@@ -412,7 +413,7 @@ export const transferOwnership = mutation({
       }),
     );
     if (!targetMember?.organizationId) {
-      throw new Error('Member not found');
+      throw new ConvexError({ code: 'MEMBER_NOT_FOUND' });
     }
 
     const callerMember = findOneMember(
@@ -430,11 +431,11 @@ export const transferOwnership = mutation({
       }),
     );
     if (callerMember?.role?.toLowerCase() !== 'owner') {
-      throw new Error('Only the organization owner can transfer ownership');
+      throw new ConvexError({ code: 'OWNERSHIP_TRANSFER_FORBIDDEN' });
     }
 
     if (targetMember.role?.toLowerCase() === 'owner') {
-      throw new Error('Target member is already the owner');
+      throw new ConvexError({ code: 'MEMBER_ALREADY_OWNER' });
     }
 
     // Promote target to owner
@@ -517,7 +518,7 @@ export const updateMemberDisplayName = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const member = findOneMember(
@@ -528,7 +529,7 @@ export const updateMemberDisplayName = mutation({
       }),
     );
     if (!member?.userId || !member.organizationId) {
-      throw new Error('Member not found');
+      throw new ConvexError({ code: 'MEMBER_NOT_FOUND' });
     }
 
     const targetUser = findOneUser(
@@ -559,7 +560,7 @@ export const updateMemberDisplayName = mutation({
       );
       callerRole = callerMember?.role;
       if (!isAdmin(callerMember?.role)) {
-        throw new Error('Only admins can update other members names');
+        throw new ConvexError({ code: 'MEMBER_NAME_UPDATE_FORBIDDEN' });
       }
     }
 


### PR DESCRIPTION
## Summary

`services/platform/convex/members/mutations.ts` threw raw `new Error(string)` for every auth/permission/business rejection. Convex redacts raw `Error` messages to an opaque "Server Error" on the client, so the UI could not surface a meaningful reason. This aligns the member-management mutations with the established `ConvexError({ code })` pattern (used by `tasks/mutations.ts`, `knowledge_entries`, etc.).

## Changes

Converted all user-facing rejections in the four mutations called out in the issue to `ConvexError({ code })`:

- **`removeMember`** — `UNAUTHENTICATED`, `MEMBER_NOT_FOUND`, `MEMBER_REMOVE_FORBIDDEN`, `MEMBER_OWNER_REMOVAL_FORBIDDEN`
- **`updateMemberRole`** — `UNAUTHENTICATED`, `MEMBER_NOT_FOUND`, `MEMBER_ROLE_UPDATE_FORBIDDEN`, `MEMBER_OWNER_ROLE_IMMUTABLE`, `MEMBER_OWNER_ROLE_ASSIGN_FORBIDDEN`, `MEMBER_CREATOR_ROLE_IMMUTABLE`, `MEMBER_LAST_ADMIN`
- **`updateMemberDisplayName`** — `UNAUTHENTICATED`, `MEMBER_NOT_FOUND`, `MEMBER_NAME_UPDATE_FORBIDDEN`
- **`transferOwnership`** — `UNAUTHENTICATED`, `MEMBER_NOT_FOUND`, `OWNERSHIP_TRANSFER_FORBIDDEN`, `MEMBER_ALREADY_OWNER`

Also restructured the creator-role guard so the `MEMBER_CREATOR_ROLE_IMMUTABLE` rejection is no longer smuggled through a `try/catch` that matched on `Error.message` (which would break once the throw became a `ConvexError`). Malformed org metadata is now logged and the guard is skipped.

`addMember` is intentionally left unchanged — it is not in scope for this issue.

## Tests

- Updated `members/mutations.test.ts` assertions to expect the new structured codes and added a `ConvexError` stub to the `convex/values` mock.
- `bunx vitest --run --project server members/mutations.test.ts` → green
- `bunx oxlint --type-aware` (changed files) → 0 warnings/0 errors
- `bunx tsc --noEmit` → exit 0

Closes #2006