### PR TITLE
fix(platform): throw ConvexError for vendor not-found and conflict cases (#2004)

### DIFF
--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -327,9 +327,13 @@ function httpStatusForConvexCode(code: string | undefined): number {
     case 'forbidden':
       return 403;
     case 'not_found':
+    case 'VENDOR_NOT_FOUND':
       return 404;
     case 'validation':
       return 400;
+    case 'DUPLICATE_EMAIL':
+    case 'DUPLICATE_EXTERNAL_ID':
+      return 409;
     default:
       // Codes we don't recognize fall through to the 500 path so the
       // outer console.error still logs them; no silent swallow.

--- a/services/platform/convex/vendors/internal_mutations.ts
+++ b/services/platform/convex/vendors/internal_mutations.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { ConvexJsonValue } from '../../lib/shared/schemas/utils/json-value';
 import { internalMutation } from '../_generated/server';
@@ -96,13 +96,19 @@ export const updateVendor = internalMutation({
 
     const existingVendor = await ctx.db.get(vendorId);
     if (!existingVendor) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
     if (
       callerOrgId !== undefined &&
       existingVendor.organizationId !== callerOrgId
     ) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
 
     const checkEmailConflict =
@@ -135,13 +141,17 @@ export const updateVendor = internalMutation({
     ]);
 
     if (emailConflict && emailConflict._id !== vendorId) {
-      throw new Error(`Vendor with email ${updateData.email} already exists`);
+      throw new ConvexError({
+        code: 'DUPLICATE_EMAIL',
+        message: `Vendor with email ${updateData.email} already exists`,
+      });
     }
 
     if (externalIdConflict && externalIdConflict._id !== vendorId) {
-      throw new Error(
-        `Vendor with external ID ${updateData.externalId} already exists`,
-      );
+      throw new ConvexError({
+        code: 'DUPLICATE_EXTERNAL_ID',
+        message: `Vendor with external ID ${updateData.externalId} already exists`,
+      });
     }
 
     const cleanUpdateData = Object.fromEntries(
@@ -167,13 +177,19 @@ export const deleteVendor = internalMutation({
   handler: async (ctx, args) => {
     const vendor = await ctx.db.get(args.vendorId);
     if (!vendor) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
     if (
       args.callerOrgId !== undefined &&
       vendor.organizationId !== args.callerOrgId
     ) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
 
     await assertNotHeld(

--- a/services/platform/convex/vendors/mutation_error_codes.test.ts
+++ b/services/platform/convex/vendors/mutation_error_codes.test.ts
@@ -1,0 +1,249 @@
+// Regression gate for issue #2004 — vendors mutations must throw structured
+// `ConvexError` (not raw `Error`) for not-found and conflict cases so that
+// `withRestAuth` can map them to 404/409 and the UI gets actionable errors
+// instead of opaque 500s.
+//
+// The mutation/internalMutation factories are mocked to hand the config
+// straight through (same pattern as sandbox/internal_mutations.test.ts) so the
+// handler bodies are unit-testable without a running backend.
+
+import { ConvexError } from 'convex/values';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../lib/rls', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    mutationWithRLS: (config: Record<string, unknown>) => config,
+  };
+});
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    internalMutation: (config: Record<string, unknown>) => config,
+  };
+});
+
+vi.mock('../governance/legal_hold_guard', () => ({
+  assertNotHeld: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as internalMutations from './internal_mutations';
+import * as mutations from './mutations';
+
+interface MutHandler {
+  handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+function asHandler(m: unknown): MutHandler {
+  return m as MutHandler;
+}
+
+// Run a handler and return whatever it throws (or null if it resolves).
+async function captureError(
+  m: unknown,
+  ctx: unknown,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  try {
+    await asHandler(m).handler(ctx, args);
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error instanceof ConvexError) {
+    const data = error.data;
+    if (typeof data === 'object' && data !== null && 'code' in data) {
+      const code = (data as { code: unknown }).code;
+      return typeof code === 'string' ? code : undefined;
+    }
+  }
+  return undefined;
+}
+
+// A fluent query builder whose `.first()` resolves to a configurable row.
+function makeQueryBuilder(firstResult: unknown) {
+  const builder = {
+    withIndex: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+  };
+  return builder;
+}
+
+describe('vendors mutations error codes (issue #2004)', () => {
+  describe('client-callable mutations.ts', () => {
+    it('updateVendor throws VENDOR_NOT_FOUND ConvexError when vendor is missing', async () => {
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(null) },
+      };
+      const err = await captureError(mutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        name: 'New',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+
+    it('updateVendor throws DUPLICATE_EMAIL ConvexError on email conflict', async () => {
+      const existing = {
+        _id: 'v1',
+        organizationId: 'org1',
+        email: 'old@example.com',
+      };
+      const conflict = { _id: 'v2' };
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(existing),
+          query: vi.fn().mockReturnValue(makeQueryBuilder(conflict)),
+        },
+      };
+      const err = await captureError(mutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        email: 'new@example.com',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DUPLICATE_EMAIL');
+    });
+
+    it('updateVendor throws DUPLICATE_EXTERNAL_ID ConvexError on externalId conflict', async () => {
+      const existing = {
+        _id: 'v1',
+        organizationId: 'org1',
+        externalId: 'ext-old',
+      };
+      const conflict = { _id: 'v2' };
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(existing),
+          query: vi.fn().mockReturnValue(makeQueryBuilder(conflict)),
+        },
+      };
+      const err = await captureError(mutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        externalId: 'ext-new',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DUPLICATE_EXTERNAL_ID');
+    });
+
+    it('deleteVendor throws VENDOR_NOT_FOUND ConvexError when vendor is missing', async () => {
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(null) },
+      };
+      const err = await captureError(mutations.deleteVendor, ctx, {
+        vendorId: 'v1',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+  });
+
+  describe('REST-path internal_mutations.ts', () => {
+    it('updateVendor throws VENDOR_NOT_FOUND ConvexError when vendor is missing', async () => {
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(null) },
+      };
+      const err = await captureError(internalMutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        name: 'New',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+
+    it('updateVendor throws VENDOR_NOT_FOUND ConvexError on cross-tenant access', async () => {
+      const existing = { _id: 'v1', organizationId: 'org1' };
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(existing) },
+      };
+      const err = await captureError(internalMutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        name: 'New',
+        callerOrgId: 'org2',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+
+    it('updateVendor throws DUPLICATE_EMAIL ConvexError on email conflict', async () => {
+      const existing = {
+        _id: 'v1',
+        organizationId: 'org1',
+        email: 'old@example.com',
+      };
+      const conflict = { _id: 'v2' };
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(existing),
+          query: vi.fn().mockReturnValue(makeQueryBuilder(conflict)),
+        },
+      };
+      const err = await captureError(internalMutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        email: 'new@example.com',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DUPLICATE_EMAIL');
+    });
+
+    it('updateVendor throws DUPLICATE_EXTERNAL_ID ConvexError on externalId conflict', async () => {
+      const existing = {
+        _id: 'v1',
+        organizationId: 'org1',
+        externalId: 'ext-old',
+      };
+      const conflict = { _id: 'v2' };
+      const ctx = {
+        db: {
+          get: vi.fn().mockResolvedValue(existing),
+          query: vi.fn().mockReturnValue(makeQueryBuilder(conflict)),
+        },
+      };
+      const err = await captureError(internalMutations.updateVendor, ctx, {
+        vendorId: 'v1',
+        externalId: 'ext-new',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('DUPLICATE_EXTERNAL_ID');
+    });
+
+    it('deleteVendor throws VENDOR_NOT_FOUND ConvexError when vendor is missing', async () => {
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(null) },
+      };
+      const err = await captureError(internalMutations.deleteVendor, ctx, {
+        vendorId: 'v1',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+
+    it('deleteVendor throws VENDOR_NOT_FOUND ConvexError on cross-tenant access', async () => {
+      const existing = { _id: 'v1', organizationId: 'org1' };
+      const ctx = {
+        db: { get: vi.fn().mockResolvedValue(existing) },
+      };
+      const err = await captureError(internalMutations.deleteVendor, ctx, {
+        vendorId: 'v1',
+        callerOrgId: 'org2',
+      });
+
+      expect(err).toBeInstanceOf(ConvexError);
+      expect(errorCode(err)).toBe('VENDOR_NOT_FOUND');
+    });
+  });
+});

--- a/services/platform/convex/vendors/mutations.ts
+++ b/services/platform/convex/vendors/mutations.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import {
   jsonRecordValidator,
@@ -37,7 +37,10 @@ export const updateVendor = mutationWithRLS({
 
     const existingVendor = await ctx.db.get(vendorId);
     if (!existingVendor) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
 
     const checkEmailConflict =
@@ -70,13 +73,17 @@ export const updateVendor = mutationWithRLS({
     ]);
 
     if (emailConflict && emailConflict._id !== vendorId) {
-      throw new Error(`Vendor with email ${updateData.email} already exists`);
+      throw new ConvexError({
+        code: 'DUPLICATE_EMAIL',
+        message: `Vendor with email ${updateData.email} already exists`,
+      });
     }
 
     if (externalIdConflict && externalIdConflict._id !== vendorId) {
-      throw new Error(
-        `Vendor with external ID ${updateData.externalId} already exists`,
-      );
+      throw new ConvexError({
+        code: 'DUPLICATE_EXTERNAL_ID',
+        message: `Vendor with external ID ${updateData.externalId} already exists`,
+      });
     }
 
     const cleanUpdateData = Object.fromEntries(
@@ -96,7 +103,10 @@ export const deleteVendor = mutationWithRLS({
   handler: async (ctx, args) => {
     const vendor = await ctx.db.get(args.vendorId);
     if (!vendor) {
-      throw new Error('Vendor not found');
+      throw new ConvexError({
+        code: 'VENDOR_NOT_FOUND',
+        message: 'Vendor not found',
+      });
     }
 
     await assertNotHeld(


### PR DESCRIPTION
## Summary

Resolves the remaining raw `Error` throws in the vendors mutations (not-found guards and update/delete duplicate-conflict checks) that caused opaque 500s in both the UI and REST API paths.

Issue #1993 covered the duplicate-add case on `createVendor`; this PR covers the **not-found** and **update/delete conflict** cases that were left out.

## Changes

- **`services/platform/convex/vendors/mutations.ts`** (client-callable `mutationWithRLS`): replaced `throw new Error(...)` with structured `ConvexError`:
  - `updateVendor` not-found → `ConvexError({ code: 'VENDOR_NOT_FOUND' })`
  - `updateVendor` email conflict → `ConvexError({ code: 'DUPLICATE_EMAIL' })`
  - `updateVendor` externalId conflict → `ConvexError({ code: 'DUPLICATE_EXTERNAL_ID' })`
  - `deleteVendor` not-found → `ConvexError({ code: 'VENDOR_NOT_FOUND' })`
- **`services/platform/convex/vendors/internal_mutations.ts`** (REST path via `withRestAuth`): same conversions for `updateVendor` (incl. cross-tenant guard) and `deleteVendor` (incl. cross-tenant guard).
- **`services/platform/convex/lib/rest/helpers.ts`**: extended `httpStatusForConvexCode` so `withRestAuth` maps `VENDOR_NOT_FOUND → 404`, `DUPLICATE_EMAIL → 409`, `DUPLICATE_EXTERNAL_ID → 409` instead of falling through to 500.
- **`services/platform/convex/vendors/mutation_error_codes.test.ts`**: new regression test asserting every not-found/conflict path throws a `ConvexError` with the correct code (both client and REST handlers).

`createVendor` raw-error duplicates remain out of scope here (tracked by #1993).

## Verification

- `bunx vitest --run --project server convex/vendors/` → 16 passed (10 new)
- `bunx tsc --noEmit` → clean for changed files
- `bunx oxlint --type-aware` → 0 warnings / 0 errors
- `oxfmt --check` → clean

Closes #2004