### PR TITLE
fix(platform): return structured error codes from workflow execution mutations (#2013)

### DIFF
--- a/services/platform/app/components/error-boundaries/boundaries/layout-error-boundary.tsx
+++ b/services/platform/app/components/error-boundaries/boundaries/layout-error-boundary.tsx
@@ -23,8 +23,11 @@ export function isConvexTransientError(error: Error): boolean {
     // session + deletes the old one) briefly invalidates the cached
     // Convex access token. Live queries sent in that window reach the
     // server with a token whose session is gone and throw. The retry
-    // backoff gives the client time to refresh its token.
+    // backoff gives the client time to refresh its token. Match both
+    // Convex's native sentence form and our structured `ConvexError`
+    // payload (`{"code":"UNAUTHENTICATED"}`, #2013), which is upper-cased.
     msg.includes('Unauthenticated') ||
+    msg.includes('UNAUTHENTICATED') ||
     // Convex agent SDK reactive hooks can briefly see undefined properties
     // during WebSocket reconnection (e.g., useDeltaStreams accessing
     // streams.messages before query results settle)

--- a/services/platform/app/features/chat/components/human-input-request-card.tsx
+++ b/services/platform/app/features/chat/components/human-input-request-card.tsx
@@ -32,6 +32,7 @@ import remarkGfm from 'remark-gfm';
 
 import { Textarea } from '@/app/components/ui/forms/textarea';
 import { Tooltip } from '@/app/components/ui/overlays/tooltip';
+import { mapExecutionError } from '@/app/features/operator/lib/map-execution-error';
 import { useCopyButton } from '@/app/hooks/use-copy';
 import { useFormatDate } from '@/app/hooks/use-format-date';
 import { usePrefersReducedMotion } from '@/app/hooks/use-prefers-reduced-motion';
@@ -113,6 +114,7 @@ function HumanInputRequestCardComponent({
 }: HumanInputRequestCardProps) {
   const { t } = useT('humanInputRequest');
   const { t: tCommon } = useT('approvalCommon');
+  const { t: tShared } = useT('common');
   const { formatDate } = useFormatDate();
   const [error, setError] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<
@@ -216,14 +218,14 @@ function HumanInputRequestCardComponent({
         executionId: wfExecutionId,
       });
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : tCommon('errorSubmitFailed'),
-      );
+      // cancelExecution raises a structured code (not found / already settled);
+      // map it instead of surfacing the raw ConvexError JSON blob.
+      setError(mapExecutionError(err, tShared, tCommon('errorSubmitFailed')));
       console.error('Failed to cancel execution:', err);
     } finally {
       setIsCancelling(false);
     }
-  }, [wfExecutionId, cancelExecution, tCommon]);
+  }, [wfExecutionId, cancelExecution, tCommon, tShared]);
 
   const [showFeedback, setShowFeedback] = useState(false);
   const [feedbackText, setFeedbackText] = useState('');

--- a/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
+++ b/services/platform/app/features/chat/components/workflow-run-approval-card.tsx
@@ -38,6 +38,7 @@ import {
   useExecutionStatus,
   useWorkflowHumanInputApproval,
 } from '@/app/features/chat/hooks/use-execution-status';
+import { mapExecutionError } from '@/app/features/operator/lib/map-execution-error';
 import { useAuth } from '@/app/hooks/use-convex-auth';
 import { useCopyButton } from '@/app/hooks/use-copy';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -96,6 +97,7 @@ function WorkflowRunApprovalCardComponent({
 }: WorkflowRunApprovalCardProps) {
   const { t } = useT('workflowRunApproval');
   const { t: tCommon } = useT('approvalCommon');
+  const { t: tShared } = useT('common');
   const { user } = useAuth();
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
@@ -205,7 +207,9 @@ function WorkflowRunApprovalCardComponent({
     try {
       await cancelExecution({ executionId });
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('errorStopFailed'));
+      // cancelExecution raises a structured code (not found / already settled);
+      // map it instead of surfacing the raw ConvexError JSON blob.
+      setError(mapExecutionError(err, tShared, t('errorStopFailed')));
       console.error('Failed to cancel execution:', err);
     } finally {
       setIsCancelling(false);

--- a/services/platform/app/features/operator/components/embedded-run.tsx
+++ b/services/platform/app/features/operator/components/embedded-run.tsx
@@ -32,6 +32,7 @@ import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 
 import { useExecutionProjection } from '../hooks/use-execution-projection';
+import { mapExecutionError } from '../lib/map-execution-error';
 import { OperatorView } from './operator-view';
 
 /** Terminal execution states — a re-run is offered only once a run has settled
@@ -44,6 +45,7 @@ const RUNNING_STATUSES = new Set(['running', 'pending']);
 
 function RerunButton({ executionId }: { executionId: Id<'wfExecutions'> }) {
   const { t } = useT('operator');
+  const { t: tCommon } = useT('common');
   const { mutateAsync, isPending } = useConvexAction(
     api.workflow_executions.actions.rerunExecution,
   );
@@ -59,10 +61,11 @@ function RerunButton({ executionId }: { executionId: Id<'wfExecutions'> }) {
         toast({ title: t('rerun.notStarted'), variant: 'destructive' });
       }
     } catch (err) {
-      // The action throws on hard errors (not found / no workflow slug); surface
-      // the message rather than swallowing the rejection.
+      // The action throws structured codes on hard errors (unauthenticated /
+      // not found / no workflow slug); map them to a specific message rather
+      // than leaking the raw ConvexError JSON blob.
       toast({
-        title: err instanceof Error ? err.message : t('rerun.notStarted'),
+        title: mapExecutionError(err, tCommon, t('rerun.notStarted')),
         variant: 'destructive',
       });
     }
@@ -77,6 +80,7 @@ function RerunButton({ executionId }: { executionId: Id<'wfExecutions'> }) {
 
 function StopButton({ executionId }: { executionId: Id<'wfExecutions'> }) {
   const { t } = useT('operator');
+  const { t: tCommon } = useT('common');
   const [confirmOpen, setConfirmOpen] = useState(false);
   const { mutateAsync, isPending } = useConvexMutation(
     api.workflow_executions.mutations.cancelExecution,
@@ -87,10 +91,10 @@ function StopButton({ executionId }: { executionId: Id<'wfExecutions'> }) {
       await mutateAsync({ executionId });
       toast({ title: t('stop.stopped'), variant: 'success' });
     } catch (err) {
-      // cancelExecution throws if the run already settled (a race) — surface it
-      // rather than swallow.
+      // cancelExecution throws a structured code if the run already settled (a
+      // race) or is gone — map it rather than leak the raw ConvexError JSON.
       toast({
-        title: err instanceof Error ? err.message : t('stop.failed'),
+        title: mapExecutionError(err, tCommon, t('stop.failed')),
         variant: 'destructive',
       });
     } finally {

--- a/services/platform/app/features/operator/lib/map-execution-error.test.ts
+++ b/services/platform/app/features/operator/lib/map-execution-error.test.ts
@@ -1,0 +1,46 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it } from 'vitest';
+
+import { mapExecutionError } from './map-execution-error';
+
+// Identity translator returns the key so assertions show which message was
+// chosen; bare `fallback` is the caller's generic default.
+const t = (key: string) => key;
+const FALLBACK = 'generic';
+
+function map(err: unknown) {
+  return mapExecutionError(err, t, FALLBACK);
+}
+
+describe('mapExecutionError (#2013)', () => {
+  it('maps each execution error code to its namespaced message', () => {
+    const cases: Array<[string, string]> = [
+      ['UNAUTHENTICATED', 'executionErrors.unauthenticated'],
+      ['EXECUTION_NOT_FOUND', 'executionErrors.notFound'],
+      ['EXECUTION_NOT_CANCELABLE', 'executionErrors.notCancelable'],
+      ['EXECUTION_MISSING_SLUG', 'executionErrors.missingWorkflow'],
+    ];
+    for (const [code, key] of cases) {
+      expect(map(new ConvexError({ code }))).toBe(key);
+    }
+  });
+
+  it('ignores the extra `status` field and still maps on `code`', () => {
+    expect(
+      map(
+        new ConvexError({
+          code: 'EXECUTION_NOT_CANCELABLE',
+          status: 'completed',
+        }),
+      ),
+    ).toBe('executionErrors.notCancelable');
+  });
+
+  it('returns the fallback for an unrecognized code', () => {
+    expect(map(new ConvexError({ code: 'WAT' }))).toBe(FALLBACK);
+  });
+
+  it('returns the fallback for a non-ConvexError (the prod-redacted case)', () => {
+    expect(map(new Error('Server Error'))).toBe(FALLBACK);
+  });
+});

--- a/services/platform/app/features/operator/lib/map-execution-error.ts
+++ b/services/platform/app/features/operator/lib/map-execution-error.ts
@@ -1,0 +1,31 @@
+import { convexErrorCode } from '@/lib/utils/convex-error';
+
+/**
+ * Map an execution mutation/action `ConvexError({ code })` (#2013) to a
+ * localized message under the `common` namespace (`executionErrors.*`).
+ * `cancelExecution` and `rerunExecution` raise structured codes for expected
+ * failures; a raw `Error` message is redacted to "Server Error" in prod (and an
+ * object-payload `ConvexError` would otherwise surface its raw JSON blob), so
+ * without this the run/debug toasts can only show a generic message.
+ * Unrecognized errors fall back to the caller's generic message.
+ *
+ * `t` must be scoped to the `common` namespace (`useT('common')`).
+ */
+export function mapExecutionError(
+  err: unknown,
+  t: (key: string) => string,
+  fallback: string,
+): string {
+  switch (convexErrorCode(err)) {
+    case 'UNAUTHENTICATED':
+      return t('executionErrors.unauthenticated');
+    case 'EXECUTION_NOT_FOUND':
+      return t('executionErrors.notFound');
+    case 'EXECUTION_NOT_CANCELABLE':
+      return t('executionErrors.notCancelable');
+    case 'EXECUTION_MISSING_SLUG':
+      return t('executionErrors.missingWorkflow');
+    default:
+      return fallback;
+  }
+}

--- a/services/platform/convex/workflow_executions/actions.test.ts
+++ b/services/platform/convex/workflow_executions/actions.test.ts
@@ -1,6 +1,7 @@
 import { ConvexError } from 'convex/values';
 import { describe, expect, it, vi } from 'vitest';
 
+import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { rerunExecution } from './actions';
 
 /** Pull the structured `code` off a thrown ConvexError (the issue #2013 fix:
@@ -105,6 +106,16 @@ describe('rerunExecution', () => {
       triggerData: EXECUTION.triggerData,
       subject: { type: 'task', id: 'task_1' },
     });
+  });
+
+  it('throws UNAUTHENTICATED when the caller is not signed in', async () => {
+    // Force the auth gate (actions.ts:100) to fail; the code must surface as a
+    // structured ConvexError, not an opaque "Server Error".
+    vi.mocked(getAuthUserIdentity).mockResolvedValueOnce(null);
+    const { ctx } = createCtx({ execution: EXECUTION });
+    await expect(
+      catchCode(() => handler(ctx, { executionId: 'exec_old' })),
+    ).resolves.toBe('UNAUTHENTICATED');
   });
 
   it('throws EXECUTION_NOT_FOUND when the execution is missing', async () => {

--- a/services/platform/convex/workflow_executions/actions.test.ts
+++ b/services/platform/convex/workflow_executions/actions.test.ts
@@ -1,6 +1,21 @@
+import { ConvexError } from 'convex/values';
 import { describe, expect, it, vi } from 'vitest';
 
 import { rerunExecution } from './actions';
+
+/** Pull the structured `code` off a thrown ConvexError (the issue #2013 fix:
+ * execution-management rejections carry a code, not an opaque message). */
+async function catchCode(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ConvexError) {
+      return (err.data as { code?: unknown }).code;
+    }
+    throw err;
+  }
+  return undefined;
+}
 
 // Mock-ctx idiom (see external_runs/state_machine.test.ts).
 vi.mock('../_generated/server', async (importOriginal) => {
@@ -92,20 +107,20 @@ describe('rerunExecution', () => {
     });
   });
 
-  it('throws when the execution is missing', async () => {
+  it('throws EXECUTION_NOT_FOUND when the execution is missing', async () => {
     const { ctx } = createCtx({ execution: null });
-    await expect(handler(ctx, { executionId: 'exec_x' })).rejects.toThrow(
-      'Execution not found',
-    );
+    await expect(
+      catchCode(() => handler(ctx, { executionId: 'exec_x' })),
+    ).resolves.toBe('EXECUTION_NOT_FOUND');
   });
 
-  it('throws when the execution has no workflow slug to start from', async () => {
+  it('throws EXECUTION_MISSING_SLUG when the execution has no workflow slug to start from', async () => {
     const { ctx } = createCtx({
       execution: { ...EXECUTION, workflowSlug: undefined },
     });
-    await expect(handler(ctx, { executionId: 'exec_old' })).rejects.toThrow(
-      'no workflow slug',
-    );
+    await expect(
+      catchCode(() => handler(ctx, { executionId: 'exec_old' })),
+    ).resolves.toBe('EXECUTION_MISSING_SLUG');
   });
 
   it('refuses (already_running) when a run for the subject is in flight', async () => {

--- a/services/platform/convex/workflow_executions/actions.ts
+++ b/services/platform/convex/workflow_executions/actions.ts
@@ -1,6 +1,6 @@
 'use node';
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { jsonValueValidator } from '../../lib/shared/schemas/utils/json-value';
 import { api, internal } from '../_generated/api';
@@ -29,7 +29,7 @@ export const startWorkflowFromFile = action({
   handler: async (ctx, args): Promise<Id<'wfExecutions'> | null> => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     await ctx.runQuery(
@@ -97,7 +97,7 @@ export const rerunExecution = action({
   }> => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const execution = await ctx.runQuery(
@@ -105,7 +105,7 @@ export const rerunExecution = action({
       { executionId: args.executionId },
     );
     if (!execution) {
-      throw new Error('Execution not found');
+      throw new ConvexError({ code: 'EXECUTION_NOT_FOUND' });
     }
 
     // Closes the cross-tenant IDOR: confirm the caller belongs to the
@@ -121,9 +121,7 @@ export const rerunExecution = action({
     );
 
     if (!execution.workflowSlug) {
-      throw new Error(
-        'Cannot re-run: this execution has no workflow slug to start from',
-      );
+      throw new ConvexError({ code: 'EXECUTION_MISSING_SLUG' });
     }
 
     const subject =
@@ -187,7 +185,7 @@ export const getExecutionVariables = action({
   handler: async (ctx, args): Promise<ExecutionVariablesInspection> => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const execution = await ctx.runQuery(
@@ -195,7 +193,7 @@ export const getExecutionVariables = action({
       { executionId: args.executionId },
     );
     if (!execution) {
-      throw new Error('Execution not found');
+      throw new ConvexError({ code: 'EXECUTION_NOT_FOUND' });
     }
 
     // Throws when the caller is not a member of the execution's organization.

--- a/services/platform/convex/workflow_executions/mutations.ts
+++ b/services/platform/convex/workflow_executions/mutations.ts
@@ -1,6 +1,6 @@
 import { saveMessage } from '@convex-dev/agent';
 import type { WorkflowId } from '@convex-dev/workflow';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { isRecord, getString } from '../../lib/utils/type-utils';
 import { components, internal } from '../_generated/api';
@@ -33,13 +33,14 @@ export const cancelExecution = mutationWithRLS({
   handler: async (ctx, args) => {
     const execution = await ctx.db.get(args.executionId);
     if (!execution) {
-      throw new Error('Execution not found');
+      throw new ConvexError({ code: 'EXECUTION_NOT_FOUND' });
     }
 
     if (execution.status !== 'running' && execution.status !== 'pending') {
-      throw new Error(
-        `Cannot cancel execution with status "${execution.status}"`,
-      );
+      throw new ConvexError({
+        code: 'EXECUTION_NOT_CANCELABLE',
+        status: execution.status,
+      });
     }
 
     // Cancel the underlying component workflow

--- a/services/platform/convex/workflow_executions/mutations_error_codes.test.ts
+++ b/services/platform/convex/workflow_executions/mutations_error_codes.test.ts
@@ -40,7 +40,7 @@ const IDENTITY = {
   name: 'Exec Tester',
 };
 
-function codeOf(err: unknown): string | undefined {
+function dataOf(err: unknown): Record<string, unknown> | undefined {
   if (err === null || typeof err !== 'object' || !('data' in err)) {
     return undefined;
   }
@@ -53,10 +53,14 @@ function codeOf(err: unknown): string | undefined {
       return undefined;
     }
   }
-  if (typeof data !== 'object' || data === null || !('code' in data)) {
+  if (typeof data !== 'object' || data === null) {
     return undefined;
   }
-  const candidate: unknown = (data as { code: unknown }).code;
+  return data as Record<string, unknown>;
+}
+
+function codeOf(err: unknown): string | undefined {
+  const candidate: unknown = dataOf(err)?.code;
   return typeof candidate === 'string' ? candidate : undefined;
 }
 
@@ -67,6 +71,19 @@ async function catchCode(
     await fn();
   } catch (err) {
     return codeOf(err);
+  }
+  return undefined;
+}
+
+/** Like `catchCode` but returns the full decoded payload so a test can assert
+ * the extra fields (e.g. `status`) the contract carries alongside `code`. */
+async function catchData(
+  fn: () => Promise<unknown>,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    await fn();
+  } catch (err) {
+    return dataOf(err);
   }
   return undefined;
 }
@@ -136,16 +153,21 @@ describe('cancelExecution error codes (#2013)', () => {
     expect(code).toBe('EXECUTION_NOT_FOUND');
   });
 
-  it('throws EXECUTION_NOT_CANCELABLE for an execution in a terminal state', async () => {
+  it('throws EXECUTION_NOT_CANCELABLE (carrying the offending status) for an execution in a terminal state', async () => {
     const executionId = await seedExecution(t, 'completed');
 
-    const code = await catchCode(() =>
+    const data = await catchData(() =>
       t
         .withIdentity(IDENTITY)
         .mutation(api.workflow_executions.mutations.cancelExecution, {
           executionId,
         }),
     );
-    expect(code).toBe('EXECUTION_NOT_CANCELABLE');
+    // Assert the `status` extra field too so the contract can't silently drift —
+    // the UI relies on `code`, but `status` is part of the payload shape.
+    expect(data).toMatchObject({
+      code: 'EXECUTION_NOT_CANCELABLE',
+      status: 'completed',
+    });
   });
 });

--- a/services/platform/convex/workflow_executions/mutations_error_codes.test.ts
+++ b/services/platform/convex/workflow_executions/mutations_error_codes.test.ts
@@ -1,0 +1,151 @@
+import { convexTest } from 'convex-test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+/**
+ * #2013 regression: `cancelExecution` must reject with a structured
+ * `ConvexError({ code })` so the run/debug UI can surface a specific message. A
+ * raw `Error` is redacted to "Server Error" in prod, where the client has no way
+ * to tell a not-found from a wrong-state rejection. Mirrors the sibling
+ * `slug_mutations_error_codes.test.ts` harness (#2056).
+ *
+ * End-to-end through the real mutation + db: identity via withIdentity, org
+ * membership via a seeded `memberMirror` row (the local-table fast path that
+ * RLS reads before any Better Auth round-trip).
+ */
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'workflow_executions';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_execguard';
+const USER_ID = 'user_exec';
+const IDENTITY = {
+  subject: USER_ID,
+  email: 'exec@example.com',
+  name: 'Exec Tester',
+};
+
+function codeOf(err: unknown): string | undefined {
+  if (err === null || typeof err !== 'object' || !('data' in err)) {
+    return undefined;
+  }
+  let data: unknown = (err as { data: unknown }).data;
+  // convex-test can double-encode the payload (a JSON string of a JSON string).
+  for (let i = 0; i < 3 && typeof data === 'string'; i++) {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof data !== 'object' || data === null || !('code' in data)) {
+    return undefined;
+  }
+  const candidate: unknown = (data as { code: unknown }).code;
+  return typeof candidate === 'string' ? candidate : undefined;
+}
+
+async function catchCode(
+  fn: () => Promise<unknown>,
+): Promise<string | undefined> {
+  try {
+    await fn();
+  } catch (err) {
+    return codeOf(err);
+  }
+  return undefined;
+}
+
+function newConvexTest() {
+  return convexTest(schema, modules);
+}
+
+async function seedMember(t: ReturnType<typeof newConvexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('memberMirror', {
+      organizationId: ORG,
+      userId: USER_ID,
+      memberId: 'member_exec',
+      role: 'member',
+      createdAt: 0,
+    });
+  });
+}
+
+async function seedExecution(
+  t: ReturnType<typeof newConvexTest>,
+  status: 'completed' | 'running',
+) {
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert('wfExecutions', {
+      organizationId: ORG,
+      wfDefinitionId: 'flow',
+      status,
+      currentStepSlug: 'start',
+      startedAt: 0,
+      updatedAt: 0,
+    });
+  });
+}
+
+describe('cancelExecution error codes (#2013)', () => {
+  let t: ReturnType<typeof newConvexTest>;
+
+  beforeEach(async () => {
+    t = newConvexTest();
+    await seedMember(t);
+  });
+
+  it('throws EXECUTION_NOT_FOUND when the execution no longer exists', async () => {
+    // Insert then delete so the id is well-formed but resolves to null.
+    const executionId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert('wfExecutions', {
+        organizationId: ORG,
+        wfDefinitionId: 'flow',
+        status: 'running',
+        currentStepSlug: 'start',
+        startedAt: 0,
+        updatedAt: 0,
+      });
+      await ctx.db.delete(id);
+      return id;
+    });
+
+    const code = await catchCode(() =>
+      t
+        .withIdentity(IDENTITY)
+        .mutation(api.workflow_executions.mutations.cancelExecution, {
+          executionId,
+        }),
+    );
+    expect(code).toBe('EXECUTION_NOT_FOUND');
+  });
+
+  it('throws EXECUTION_NOT_CANCELABLE for an execution in a terminal state', async () => {
+    const executionId = await seedExecution(t, 'completed');
+
+    const code = await catchCode(() =>
+      t
+        .withIdentity(IDENTITY)
+        .mutation(api.workflow_executions.mutations.cancelExecution, {
+          executionId,
+        }),
+    );
+    expect(code).toBe('EXECUTION_NOT_CANCELABLE');
+  });
+});

--- a/services/platform/convex/workflows/executions/resume_debug_step.test.ts
+++ b/services/platform/convex/workflows/executions/resume_debug_step.test.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { toId } from '../../lib/type_cast_helpers';
@@ -21,6 +22,20 @@ function createMockCtx(execution: Record<string, unknown> | null) {
 
 const executionId = toId<'wfExecutions'>('exec-1');
 
+/** Pull the structured `code` off a thrown ConvexError (#2013: debug-resume
+ * rejections carry a code so the debug UI can map a specific message). */
+async function catchCode(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ConvexError) {
+      return (err.data as { code?: unknown }).code;
+    }
+    throw err;
+  }
+  return undefined;
+}
+
 function pausedExecution(overrides?: Record<string, unknown>) {
   return {
     _id: executionId,
@@ -37,44 +52,57 @@ beforeEach(() => {
 });
 
 describe('resumeDebugStep', () => {
-  it('throws when the execution does not exist', async () => {
+  it('throws EXECUTION_NOT_FOUND when the execution does not exist', async () => {
     await expect(
-      resumeDebugStep(createMockCtx(null), { executionId, action: 'step' }),
-    ).rejects.toThrow('Execution not found');
+      catchCode(() =>
+        resumeDebugStep(createMockCtx(null), { executionId, action: 'step' }),
+      ),
+    ).resolves.toBe('EXECUTION_NOT_FOUND');
   });
 
-  it('throws when the execution is not running', async () => {
+  it('throws EXECUTION_NOT_RESUMABLE when the execution is not running', async () => {
     await expect(
-      resumeDebugStep(createMockCtx(pausedExecution({ status: 'completed' })), {
-        executionId,
-        action: 'step',
-      }),
-    ).rejects.toThrow('Cannot resume a debug step');
+      catchCode(() =>
+        resumeDebugStep(
+          createMockCtx(pausedExecution({ status: 'completed' })),
+          {
+            executionId,
+            action: 'step',
+          },
+        ),
+      ),
+    ).resolves.toBe('EXECUTION_NOT_RESUMABLE');
   });
 
-  it('throws when the execution is not paused in debug mode', async () => {
+  it('throws EXECUTION_NOT_PAUSED when the execution is not paused in debug mode', async () => {
     await expect(
-      resumeDebugStep(
-        createMockCtx(pausedExecution({ waitingFor: 'approval-id-123' })),
-        { executionId, action: 'continue' },
+      catchCode(() =>
+        resumeDebugStep(
+          createMockCtx(pausedExecution({ waitingFor: 'approval-id-123' })),
+          { executionId, action: 'continue' },
+        ),
       ),
-    ).rejects.toThrow('not paused in debug mode');
+    ).resolves.toBe('EXECUTION_NOT_PAUSED');
 
     await expect(
-      resumeDebugStep(
-        createMockCtx(pausedExecution({ waitingFor: undefined })),
-        { executionId, action: 'step' },
+      catchCode(() =>
+        resumeDebugStep(
+          createMockCtx(pausedExecution({ waitingFor: undefined })),
+          { executionId, action: 'step' },
+        ),
       ),
-    ).rejects.toThrow('not paused in debug mode');
+    ).resolves.toBe('EXECUTION_NOT_PAUSED');
   });
 
-  it('throws when the component workflow id is missing', async () => {
+  it('throws EXECUTION_MISSING_WORKFLOW_ID when the component workflow id is missing', async () => {
     await expect(
-      resumeDebugStep(
-        createMockCtx(pausedExecution({ componentWorkflowId: undefined })),
-        { executionId, action: 'step' },
+      catchCode(() =>
+        resumeDebugStep(
+          createMockCtx(pausedExecution({ componentWorkflowId: undefined })),
+          { executionId, action: 'step' },
+        ),
       ),
-    ).rejects.toThrow('component workflow ID');
+    ).resolves.toBe('EXECUTION_MISSING_WORKFLOW_ID');
   });
 
   it('sends the per-pause debug event on the execution shard manager', async () => {

--- a/services/platform/convex/workflows/executions/resume_debug_step.ts
+++ b/services/platform/convex/workflows/executions/resume_debug_step.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WorkflowId } from '@convex-dev/workflow';
+import { ConvexError } from 'convex/values';
 
 import type { Id } from '../../_generated/dataModel';
 import type { MutationCtx } from '../../_generated/server';
@@ -28,22 +29,23 @@ export async function resumeDebugStep(
 ): Promise<null> {
   const execution = await ctx.db.get(args.executionId);
   if (!execution) {
-    throw new Error('Execution not found');
+    throw new ConvexError({ code: 'EXECUTION_NOT_FOUND' });
   }
 
   if (execution.status !== 'running') {
-    throw new Error(
-      `Cannot resume a debug step on execution with status "${execution.status}"`,
-    );
+    throw new ConvexError({
+      code: 'EXECUTION_NOT_RESUMABLE',
+      status: execution.status,
+    });
   }
 
   const pause = parseDebugWaitingFor(execution.waitingFor);
   if (!pause) {
-    throw new Error('Execution is not paused in debug mode');
+    throw new ConvexError({ code: 'EXECUTION_NOT_PAUSED' });
   }
 
   if (!execution.componentWorkflowId) {
-    throw new Error('Execution is missing its component workflow ID');
+    throw new ConvexError({ code: 'EXECUTION_MISSING_WORKFLOW_ID' });
   }
 
   const manager = workflowManagers[safeShardIndex(execution.shardIndex)];

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2025,6 +2025,12 @@
       "contactSupport": "kontaktiere den Support",
       "tryAgain": "Erneut versuchen"
     },
+    "executionErrors": {
+      "unauthenticated": "Du bist nicht angemeldet. Lade die Seite neu und versuche es erneut.",
+      "notFound": "Dieser Lauf konnte nicht mehr gefunden werden. Möglicherweise wurde er gelöscht.",
+      "notCancelable": "Dieser Lauf kann nicht mehr gestoppt werden – er ist bereits abgeschlossen.",
+      "missingWorkflow": "Dieser Lauf kann nicht erneut ausgeführt werden, da sein Workflow nicht mehr verfügbar ist."
+    },
     "keyboardShortcuts": {
       "ctrlEnter": "Ctrl+Enter",
       "escape": "Esc"

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2025,6 +2025,12 @@
       "contactSupport": "contact support",
       "tryAgain": "Try again"
     },
+    "executionErrors": {
+      "unauthenticated": "You're not signed in. Refresh the page and try again.",
+      "notFound": "That run could no longer be found. It may have been deleted.",
+      "notCancelable": "This run can no longer be stopped — it has already finished.",
+      "missingWorkflow": "This run can't be re-run because its workflow is no longer available."
+    },
     "keyboardShortcuts": {
       "ctrlEnter": "Ctrl+Enter",
       "escape": "Esc"

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2026,6 +2026,12 @@
       "contactSupport": "contacter le support",
       "tryAgain": "Réessayer"
     },
+    "executionErrors": {
+      "unauthenticated": "Tu n'es pas connecté. Actualise la page et réessaie.",
+      "notFound": "Cette exécution est introuvable. Elle a peut-être été supprimée.",
+      "notCancelable": "Cette exécution ne peut plus être arrêtée — elle est déjà terminée.",
+      "missingWorkflow": "Cette exécution ne peut pas être relancée car son workflow n'est plus disponible."
+    },
     "keyboardShortcuts": {
       "ctrlEnter": "Ctrl+Entrée",
       "escape": "Échap"


### PR DESCRIPTION
## Summary

Workflow execution management mutations/actions threw raw `Error`, which Convex redacts to an opaque "Server Error" in production. The workflow builder/debug UI had no way to distinguish a not-found from a wrong-state or unauthenticated rejection. This converts those throws to structured `ConvexError({ code })`, matching the convention already used in `workflows/triggers/slug_mutations.ts` (fixed in #2056).

## Changes

- `workflow_executions/mutations.ts` (`cancelExecution`):
  - `EXECUTION_NOT_FOUND`
  - `EXECUTION_NOT_CANCELABLE` (carries `status`)
- `workflow_executions/actions.ts` (`startWorkflowFromFile`, `rerunExecution`, `getExecutionVariables`):
  - `UNAUTHENTICATED`
  - `EXECUTION_NOT_FOUND`
  - `EXECUTION_MISSING_SLUG`
- `workflows/executions/resume_debug_step.ts`:
  - `EXECUTION_NOT_FOUND`
  - `EXECUTION_NOT_RESUMABLE` (carries `status`)
  - `EXECUTION_NOT_PAUSED`
  - `EXECUTION_MISSING_WORKFLOW_ID`

`workflows/triggers/slug_mutations.ts` (also listed in the issue) already throws `ConvexError({ code })` — no change needed there.

## Tests

- Updated `actions.test.ts` and `resume_debug_step.test.ts` to assert on the structured `code` instead of message substrings.
- Added `workflow_executions/mutations_error_codes.test.ts` (end-to-end via `convexTest`) covering `cancelExecution` → `EXECUTION_NOT_FOUND` and `EXECUTION_NOT_CANCELABLE`.

Verified locally: `vitest` (13 passing), `oxlint --type-aware` (0 errors), `tsc --noEmit` (clean).

Closes #2013