### PR TITLE
fix: cap product string field lengths server-side (#2011)

### DIFF
--- a/services/platform/app/features/products/components/product-create-dialog.tsx
+++ b/services/platform/app/features/products/components/product-create-dialog.tsx
@@ -17,6 +17,13 @@ import { WizardFooter } from '@/app/components/ui/wizard/wizard-footer';
 import { WizardProgress } from '@/app/components/ui/wizard/wizard-progress';
 import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { toast } from '@/app/hooks/use-toast';
+import {
+  PRODUCT_CATEGORY_MAX,
+  PRODUCT_CURRENCY_MAX,
+  PRODUCT_DESCRIPTION_MAX,
+  PRODUCT_IMAGE_URL_MAX,
+  PRODUCT_NAME_MAX,
+} from '@/convex/products/field_limits';
 import { useT } from '@/lib/i18n/client';
 import {
   PRODUCT_STATUS,
@@ -89,13 +96,44 @@ export function ProductCreateDialog({
             tCommon('validation.required', {
               field: tProducts('edit.labels.name'),
             }),
+          )
+          .max(
+            PRODUCT_NAME_MAX,
+            tCommon('validation.maxLength', {
+              field: tProducts('edit.labels.name'),
+              max: PRODUCT_NAME_MAX,
+            }),
           ),
-        description: z.string(),
-        imageUrl: z.string(),
+        description: z.string().max(
+          PRODUCT_DESCRIPTION_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.description'),
+            max: PRODUCT_DESCRIPTION_MAX,
+          }),
+        ),
+        imageUrl: z.string().max(
+          PRODUCT_IMAGE_URL_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.imageUrl'),
+            max: PRODUCT_IMAGE_URL_MAX,
+          }),
+        ),
         stock: z.string(),
         price: z.string(),
-        currency: z.string(),
-        category: z.string(),
+        currency: z.string().max(
+          PRODUCT_CURRENCY_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.currency'),
+            max: PRODUCT_CURRENCY_MAX,
+          }),
+        ),
+        category: z.string().max(
+          PRODUCT_CATEGORY_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.category'),
+            max: PRODUCT_CATEGORY_MAX,
+          }),
+        ),
         status: z.string(),
       }),
     [tProducts, tCommon],
@@ -219,6 +257,7 @@ export function ProductCreateDialog({
             placeholder={tProducts('edit.descriptionPlaceholder')}
             disabled={isSubmitting}
             rows={3}
+            errorMessage={errors.description?.message}
           />
           <ProductImageField
             value={watch('imageUrl')}
@@ -245,7 +284,8 @@ export function ProductCreateDialog({
               {...register('currency')}
               placeholder={tProducts('edit.currencyPlaceholder')}
               disabled={isSubmitting}
-              maxLength={3}
+              maxLength={PRODUCT_CURRENCY_MAX}
+              errorMessage={errors.currency?.message}
             />
           </Grid>
           <Grid cols={2} gap={4}>
@@ -264,6 +304,8 @@ export function ProductCreateDialog({
               {...register('category')}
               placeholder={tProducts('edit.categoryPlaceholder')}
               disabled={isSubmitting}
+              maxLength={PRODUCT_CATEGORY_MAX}
+              errorMessage={errors.category?.message}
             />
           </Grid>
           <Select

--- a/services/platform/app/features/products/components/product-create-dialog.tsx
+++ b/services/platform/app/features/products/components/product-create-dialog.tsx
@@ -263,6 +263,7 @@ export function ProductCreateDialog({
             value={watch('imageUrl')}
             onChange={(v) => setValue('imageUrl', v, { shouldDirty: true })}
             disabled={isSubmitting}
+            errorMessage={errors.imageUrl?.message}
           />
         </WizardStep>
 

--- a/services/platform/app/features/products/components/product-edit-dialog.tsx
+++ b/services/platform/app/features/products/components/product-edit-dialog.tsx
@@ -249,6 +249,7 @@ export function ProductEditDialog({
         value={watch('imageUrl')}
         onChange={(v) => setValue('imageUrl', v, { shouldDirty: true })}
         disabled={isSubmitting}
+        errorMessage={errors.imageUrl?.message}
       />
 
       <Grid cols={2} gap={4}>

--- a/services/platform/app/features/products/components/product-edit-dialog.tsx
+++ b/services/platform/app/features/products/components/product-edit-dialog.tsx
@@ -13,6 +13,13 @@ import { Textarea } from '@/app/components/ui/forms/textarea';
 import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
+import {
+  PRODUCT_CATEGORY_MAX,
+  PRODUCT_CURRENCY_MAX,
+  PRODUCT_DESCRIPTION_MAX,
+  PRODUCT_IMAGE_URL_MAX,
+  PRODUCT_NAME_MAX,
+} from '@/convex/products/field_limits';
 import { useT } from '@/lib/i18n/client';
 
 import { useUpdateProduct } from '../hooks/mutations';
@@ -69,13 +76,44 @@ export function ProductEditDialog({
             tCommon('validation.required', {
               field: tProducts('edit.labels.name'),
             }),
+          )
+          .max(
+            PRODUCT_NAME_MAX,
+            tCommon('validation.maxLength', {
+              field: tProducts('edit.labels.name'),
+              max: PRODUCT_NAME_MAX,
+            }),
           ),
-        description: z.string(),
-        imageUrl: z.string(),
+        description: z.string().max(
+          PRODUCT_DESCRIPTION_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.description'),
+            max: PRODUCT_DESCRIPTION_MAX,
+          }),
+        ),
+        imageUrl: z.string().max(
+          PRODUCT_IMAGE_URL_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.imageUrl'),
+            max: PRODUCT_IMAGE_URL_MAX,
+          }),
+        ),
         stock: z.string(),
         price: z.string(),
-        currency: z.string(),
-        category: z.string(),
+        currency: z.string().max(
+          PRODUCT_CURRENCY_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.currency'),
+            max: PRODUCT_CURRENCY_MAX,
+          }),
+        ),
+        category: z.string().max(
+          PRODUCT_CATEGORY_MAX,
+          tCommon('validation.maxLength', {
+            field: tProducts('edit.labels.category'),
+            max: PRODUCT_CATEGORY_MAX,
+          }),
+        ),
         status: z.enum(PRODUCT_STATUSES),
       }),
     [tProducts, tCommon],
@@ -204,6 +242,7 @@ export function ProductEditDialog({
         placeholder={tProducts('edit.descriptionPlaceholder')}
         disabled={isSubmitting}
         rows={3}
+        errorMessage={errors.description?.message}
       />
 
       <ProductImageField
@@ -229,7 +268,8 @@ export function ProductEditDialog({
           {...register('currency')}
           placeholder={tProducts('edit.currencyPlaceholder')}
           disabled={isSubmitting}
-          maxLength={3}
+          maxLength={PRODUCT_CURRENCY_MAX}
+          errorMessage={errors.currency?.message}
         />
       </Grid>
 
@@ -249,6 +289,8 @@ export function ProductEditDialog({
           {...register('category')}
           placeholder={tProducts('edit.categoryPlaceholder')}
           disabled={isSubmitting}
+          maxLength={PRODUCT_CATEGORY_MAX}
+          errorMessage={errors.category?.message}
         />
       </Grid>
 

--- a/services/platform/app/features/products/components/product-image-field.tsx
+++ b/services/platform/app/features/products/components/product-image-field.tsx
@@ -21,6 +21,7 @@ interface ProductImageFieldProps {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  errorMessage?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ export function ProductImageField({
   value,
   onChange,
   disabled,
+  errorMessage,
 }: ProductImageFieldProps) {
   const { t: tProducts } = useT('products');
   const { uploadImage, isUploading } = useProductImageUpload();
@@ -81,6 +83,7 @@ export function ProductImageField({
         onChange={(e) => onChange(e.target.value)}
         placeholder={tProducts('edit.imageUrlPlaceholder')}
         disabled={isDisabled}
+        errorMessage={errorMessage}
       />
       <Row gap={3}>
         {value && (

--- a/services/platform/convex/lib/rest/helpers.test.ts
+++ b/services/platform/convex/lib/rest/helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { httpStatusForConvexCode } from './helpers';
+
+/**
+ * The REST wrapper (`withRestAuth`) maps typed `ConvexError` codes to HTTP
+ * statuses via `httpStatusForConvexCode`; any code resolving to a 4xx is
+ * forwarded to the client, everything else falls through to a generic 500.
+ *
+ * `validateProductFields` throws `ConvexError({ code: 'too_long' })` on the
+ * REST product write paths (`POST`/`PATCH /api/v1/products`), so `too_long`
+ * must map to 400 — otherwise an over-length client input surfaces as a 500
+ * (server error) instead of a 400 (client error).
+ */
+describe('httpStatusForConvexCode', () => {
+  it('maps over-length input (too_long) to 400, not 500', () => {
+    expect(httpStatusForConvexCode('too_long')).toBe(400);
+  });
+
+  it.each([
+    ['unauthenticated', 401],
+    ['forbidden', 403],
+    ['not_found', 404],
+    ['validation', 400],
+  ])('maps %s to %i', (code, status) => {
+    expect(httpStatusForConvexCode(code)).toBe(status);
+  });
+
+  it.each([[undefined], ['something_unrecognized']])(
+    'falls through to 500 for unrecognized code %s',
+    (code) => {
+      expect(httpStatusForConvexCode(code)).toBe(500);
+    },
+  );
+});

--- a/services/platform/convex/lib/rest/helpers.ts
+++ b/services/platform/convex/lib/rest/helpers.ts
@@ -320,7 +320,7 @@ export function withRestAuth(
   });
 }
 
-function httpStatusForConvexCode(code: string | undefined): number {
+export function httpStatusForConvexCode(code: string | undefined): number {
   switch (code) {
     case 'unauthenticated':
     case 'UNAUTHENTICATED':
@@ -338,6 +338,7 @@ function httpStatusForConvexCode(code: string | undefined): number {
     case 'validation':
     case 'EMAIL_REQUIRED':
     case 'MISSING_FILTER':
+    case 'too_long':
       return 400;
     case 'DUPLICATE_EMAIL':
     case 'DUPLICATE_EXTERNAL_ID':

--- a/services/platform/convex/products/create_product.ts
+++ b/services/platform/convex/products/create_product.ts
@@ -1,5 +1,6 @@
 import type { MutationCtx } from '../_generated/server';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
+import { validateProductFields } from './field_limits';
 import type { CreateProductResult, ProductStatus } from './types';
 import { validateProductName } from './validate_product_name';
 
@@ -22,7 +23,9 @@ export async function createProduct(
   ctx: MutationCtx,
   args: CreateProductArgs,
 ): Promise<CreateProductResult> {
+  validateProductFields(args);
   const name = validateProductName(args.name);
+
   const productId = await ctx.db.insert('products', {
     organizationId: args.organizationId,
     name,

--- a/services/platform/convex/products/create_product_with_translations.ts
+++ b/services/platform/convex/products/create_product_with_translations.ts
@@ -1,6 +1,7 @@
 import { isRecord } from '../../lib/utils/type-utils';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import { validateProductFields } from './field_limits';
 import { assertSupportedProductLocale } from './locale_validation';
 import type { ProductStatus, ProductTranslation } from './types';
 import { validateProductName } from './validate_product_name';
@@ -24,6 +25,7 @@ export async function createProductWithTranslations(
   ctx: MutationCtx,
   args: CreateProductWithTranslationsArgs,
 ): Promise<Id<'products'>> {
+  validateProductFields(args);
   for (const translation of args.translations ?? []) {
     assertSupportedProductLocale(translation.language);
   }

--- a/services/platform/convex/products/field_limits.test.ts
+++ b/services/platform/convex/products/field_limits.test.ts
@@ -1,0 +1,70 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, it } from 'vitest';
+
+import {
+  PRODUCT_CATEGORY_MAX,
+  PRODUCT_CURRENCY_MAX,
+  PRODUCT_DESCRIPTION_MAX,
+  PRODUCT_IMAGE_URL_MAX,
+  PRODUCT_NAME_MAX,
+  validateProductFields,
+} from './field_limits';
+
+describe('validateProductFields', () => {
+  it('accepts fields at their maximum length', () => {
+    expect(() =>
+      validateProductFields({
+        name: 'a'.repeat(PRODUCT_NAME_MAX),
+        description: 'b'.repeat(PRODUCT_DESCRIPTION_MAX),
+        category: 'c'.repeat(PRODUCT_CATEGORY_MAX),
+        currency: 'USD',
+        imageUrl:
+          'https://example.com/' + 'd'.repeat(PRODUCT_IMAGE_URL_MAX - 20),
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts an empty/undefined field set', () => {
+    expect(() => validateProductFields({})).not.toThrow();
+  });
+
+  it.each([
+    ['name', { name: 'a'.repeat(PRODUCT_NAME_MAX + 1) }],
+    ['description', { description: 'b'.repeat(PRODUCT_DESCRIPTION_MAX + 1) }],
+    ['category', { category: 'c'.repeat(PRODUCT_CATEGORY_MAX + 1) }],
+    ['currency', { currency: 'd'.repeat(PRODUCT_CURRENCY_MAX + 1) }],
+    ['imageUrl', { imageUrl: 'e'.repeat(PRODUCT_IMAGE_URL_MAX + 1) }],
+  ])(
+    'rejects an over-length %s with a too_long ConvexError',
+    (_field, fields) => {
+      let thrown: unknown;
+      try {
+        validateProductFields(fields);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ConvexError);
+      expect((thrown as ConvexError<{ code: string }>).data.code).toBe(
+        'too_long',
+      );
+    },
+  );
+
+  it('validates per-translation fields against the base limits', () => {
+    expect(() =>
+      validateProductFields({
+        translations: [{ name: 'x'.repeat(PRODUCT_NAME_MAX + 1) }],
+      }),
+    ).toThrow(ConvexError);
+
+    expect(() =>
+      validateProductFields({
+        translations: [
+          null,
+          undefined,
+          { name: 'ok', description: 'still ok', category: 'fine' },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/services/platform/convex/products/field_limits.ts
+++ b/services/platform/convex/products/field_limits.ts
@@ -1,0 +1,76 @@
+/**
+ * Server-side length caps for product string fields.
+ *
+ * Convex only enforces a 1 MB whole-document limit, so without these guards a
+ * single mutation could persist megabyte-scale `name`/`description`/etc.
+ * values. The limits are shared by every product write path (create, update,
+ * bulk create, REST ingest, translation upsert) and mirrored client-side by
+ * the create/edit dialog Zod schemas.
+ */
+
+import { ConvexError } from 'convex/values';
+
+/** Maximum length of a product display name (characters). */
+export const PRODUCT_NAME_MAX = 255;
+/** Maximum length of a product description (characters). */
+export const PRODUCT_DESCRIPTION_MAX = 4000;
+/** Maximum length of a product category (characters). */
+export const PRODUCT_CATEGORY_MAX = 100;
+/** Maximum length of an ISO 4217 currency code (characters). */
+export const PRODUCT_CURRENCY_MAX = 3;
+/** Maximum length of a product image URL (characters). */
+export const PRODUCT_IMAGE_URL_MAX = 2048;
+
+interface ProductTranslationStringFields {
+  name?: string;
+  description?: string;
+  category?: string;
+}
+
+interface ProductStringFields extends ProductTranslationStringFields {
+  currency?: string;
+  imageUrl?: string;
+  translations?: Array<ProductTranslationStringFields | null | undefined>;
+}
+
+function assertMax(
+  value: string | undefined | null,
+  max: number,
+  field: string,
+): void {
+  if (value != null && value.length > max) {
+    throw new ConvexError({
+      code: 'too_long',
+      message: `Product ${field} exceeds ${max} characters (got ${value.length}).`,
+    });
+  }
+}
+
+/**
+ * Throw a `too_long` ConvexError if any provided product string field exceeds
+ * its cap. Only validates fields that are present, so it is safe to call from
+ * both create (all fields) and partial-update paths. Per-translation
+ * `name`/`description`/`category` reuse the same base-field limits.
+ */
+export function validateProductFields(fields: ProductStringFields): void {
+  assertMax(fields.name, PRODUCT_NAME_MAX, 'name');
+  assertMax(fields.description, PRODUCT_DESCRIPTION_MAX, 'description');
+  assertMax(fields.category, PRODUCT_CATEGORY_MAX, 'category');
+  assertMax(fields.currency, PRODUCT_CURRENCY_MAX, 'currency');
+  assertMax(fields.imageUrl, PRODUCT_IMAGE_URL_MAX, 'imageUrl');
+
+  for (const translation of fields.translations ?? []) {
+    if (!translation) continue;
+    assertMax(translation.name, PRODUCT_NAME_MAX, 'translation name');
+    assertMax(
+      translation.description,
+      PRODUCT_DESCRIPTION_MAX,
+      'translation description',
+    );
+    assertMax(
+      translation.category,
+      PRODUCT_CATEGORY_MAX,
+      'translation category',
+    );
+  }
+}

--- a/services/platform/convex/products/helpers.ts
+++ b/services/platform/convex/products/helpers.ts
@@ -1,5 +1,6 @@
 export * from './validators';
 export * from './types';
+export * from './field_limits';
 
 export * from './assert_unique_product_name';
 export * from './create_product';

--- a/services/platform/convex/products/update_product.ts
+++ b/services/platform/convex/products/update_product.ts
@@ -2,6 +2,7 @@ import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
 import { assertUniqueProductName } from './assert_unique_product_name';
+import { validateProductFields } from './field_limits';
 import { assertSupportedProductLocale } from './locale_validation';
 import type { ProductStatus, ProductTranslation } from './types';
 import { validateProductName } from './validate_product_name';
@@ -25,6 +26,7 @@ export async function updateProduct(
   ctx: MutationCtx,
   args: UpdateProductArgs,
 ): Promise<Id<'products'>> {
+  validateProductFields(args);
   for (const translation of args.translations ?? []) {
     assertSupportedProductLocale(translation.language);
   }

--- a/services/platform/convex/products/update_products.ts
+++ b/services/platform/convex/products/update_products.ts
@@ -8,6 +8,7 @@ import { set, merge } from 'lodash';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { assertUniqueProductName } from './assert_unique_product_name';
+import { validateProductFields } from './field_limits';
 import type { UpdateProductsResult, ProductStatus } from './types';
 import { validateProductName } from './validate_product_name';
 
@@ -41,6 +42,8 @@ export async function updateProducts(
   ctx: MutationCtx,
   args: UpdateProductsArgs,
 ): Promise<UpdateProductsResult> {
+  validateProductFields(args.updates);
+
   // Validate: must provide either productId or organizationId
   if (!args.productId && !args.organizationId) {
     throw new Error(

--- a/services/platform/convex/products/upsert_product_translation.ts
+++ b/services/platform/convex/products/upsert_product_translation.ts
@@ -1,5 +1,6 @@
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import { validateProductFields } from './field_limits';
 import { assertSupportedProductLocale } from './locale_validation';
 
 export interface UpsertProductTranslationArgs {
@@ -17,6 +18,11 @@ export async function upsertProductTranslation(
   args: UpsertProductTranslationArgs,
 ): Promise<Id<'products'>> {
   assertSupportedProductLocale(args.language);
+  validateProductFields({
+    name: args.name,
+    description: args.description,
+    category: args.category,
+  });
 
   const product = await ctx.db.get(args.productId);
   if (!product) {


### PR DESCRIPTION
## Summary

Product mutations accepted unbounded string fields — `name`, `description`, `category`, `currency`, `imageUrl`, and per-translation fields had no server-side length cap (only Convex's 1 MB whole-document limit). The REST surface (`POST /api/v1/products`, `PATCH /api/v1/products/:id`) made this reachable without the UI form's minimal guards.

## Changes

- **New `services/platform/convex/products/field_limits.ts`** — shared caps (`PRODUCT_NAME_MAX=255`, `PRODUCT_DESCRIPTION_MAX=4000`, `PRODUCT_CATEGORY_MAX=100`, `PRODUCT_CURRENCY_MAX=3`, `PRODUCT_IMAGE_URL_MAX=2048`) and a `validateProductFields()` guard that throws a `too_long` `ConvexError`. Only validates fields that are present, so it is safe on partial-update paths. Per-translation `name`/`description`/`category` reuse the base limits.
- **Wired the guard into every product write chokepoint** so all entry points (user mutations, internal/REST ingest, bulk create, translation upsert) are covered: `create_product.ts`, `create_product_with_translations.ts`, `update_product.ts`, `update_products.ts`, `upsert_product_translation.ts`.
- **Mirrored the caps client-side** in the create/edit dialog Zod schemas with `.max(N)` and inline error messages (new `common.validation.maxLength` i18n key in en/de/fr).
- **Tests** — `field_limits.test.ts` covers accept-at-limit, partial sets, per-field rejection with the `too_long` code, and translation fields.

## Verification

- `vitest --run --project server convex/products/` — 14 passed
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings, 0 errors
- `oxfmt --check` — clean

Closes #2011