### PR TITLE
fix(platform): throw ConvexError from user profile mutations (#2012)

### DIFF
--- a/services/platform/convex/users/set_member_password.test.ts
+++ b/services/platform/convex/users/set_member_password.test.ts
@@ -52,6 +52,13 @@ vi.mock('convex/values', () => {
       null: stub,
       id: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : 'ConvexError');
+        this.data = data;
+      }
+    },
   };
 });
 
@@ -113,7 +120,9 @@ describe('setMemberPassword', () => {
     const ctx = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, defaultArgs)).rejects.toThrow('Unauthenticated');
+    await expect(handler(ctx, defaultArgs)).rejects.toMatchObject({
+      data: { code: 'unauthenticated' },
+    });
   });
 
   it('throws when password is invalid', async () => {
@@ -137,7 +146,7 @@ describe('setMemberPassword', () => {
 
     await expect(
       handler(ctx, { ...defaultArgs, newPassword: 'weak' }),
-    ).rejects.toThrow('Password does not meet policy');
+    ).rejects.toMatchObject({ data: { code: 'password_policy_violation' } });
   });
 
   it('throws when member not found', async () => {
@@ -147,7 +156,9 @@ describe('setMemberPassword', () => {
     ctx.runQuery.mockResolvedValueOnce({ page: [] });
     const handler = await getHandler();
 
-    await expect(handler(ctx, defaultArgs)).rejects.toThrow('Member not found');
+    await expect(handler(ctx, defaultArgs)).rejects.toMatchObject({
+      data: { code: 'not_found', message: 'Member not found' },
+    });
   });
 
   it('throws when caller is not admin', async () => {
@@ -171,9 +182,12 @@ describe('setMemberPassword', () => {
     });
     const handler = await getHandler();
 
-    await expect(handler(ctx, defaultArgs)).rejects.toThrow(
-      'Only admins can set member passwords',
-    );
+    await expect(handler(ctx, defaultArgs)).rejects.toMatchObject({
+      data: {
+        code: 'forbidden',
+        message: 'Only admins can set member passwords',
+      },
+    });
   });
 
   it('updates existing credential and invalidates all sessions', async () => {

--- a/services/platform/convex/users/set_member_password.ts
+++ b/services/platform/convex/users/set_member_password.ts
@@ -6,6 +6,7 @@
  */
 
 import { hashPassword } from 'better-auth/crypto';
+import { ConvexError } from 'convex/values';
 
 import {
   isPasswordValid,
@@ -31,7 +32,10 @@ export async function setMemberPassword(
 ): Promise<void> {
   const authUser = await getAuthUserIdentity(ctx);
   if (!authUser) {
-    throw new Error('Unauthenticated');
+    throw new ConvexError({
+      code: 'unauthenticated',
+      message: 'Unauthenticated',
+    });
   }
 
   // Look up the target member
@@ -44,15 +48,24 @@ export async function setMemberPassword(
   const member = isRecord(memberRaw) ? memberRaw : undefined;
   const memberOrgId = member ? getString(member, 'organizationId') : undefined;
   if (!memberOrgId) {
-    throw new Error('Member not found');
+    throw new ConvexError({
+      code: 'not_found',
+      message: 'Member not found',
+    });
   }
 
   if (!member) {
-    throw new Error('Member not found');
+    throw new ConvexError({
+      code: 'not_found',
+      message: 'Member not found',
+    });
   }
   const memberUserId = getString(member, 'userId');
   if (!memberUserId) {
-    throw new Error('Member missing userId');
+    throw new ConvexError({
+      code: 'invalid',
+      message: 'Member missing userId',
+    });
   }
 
   // Verify caller is an admin or owner of this organization
@@ -76,7 +89,10 @@ export async function setMemberPassword(
     ? getString(callerMemberRec, 'role')?.toLowerCase()
     : undefined;
   if (!isAdmin(callerRole)) {
-    throw new Error('Only admins can set member passwords');
+    throw new ConvexError({
+      code: 'forbidden',
+      message: 'Only admins can set member passwords',
+    });
   }
 
   // Validate against the target member's org policy (the password must
@@ -84,9 +100,10 @@ export async function setMemberPassword(
   const policy = await getPasswordPolicy(ctx, memberOrgId);
   if (!isPasswordValid(args.newPassword, policy)) {
     const violations = passwordPolicyViolations(args.newPassword, policy);
-    throw new Error(
-      `Password does not meet policy (failed: ${violations.join(', ')})`,
-    );
+    throw new ConvexError({
+      code: 'password_policy_violation',
+      message: `Password does not meet policy (failed: ${violations.join(', ')})`,
+    });
   }
 
   // Check if the target user already has a credential account
@@ -110,7 +127,11 @@ export async function setMemberPassword(
 
   if (existingCredential) {
     const credentialId = getString(existingCredential, '_id');
-    if (!credentialId) throw new Error('Credential account missing _id');
+    if (!credentialId)
+      throw new ConvexError({
+        code: 'credential_account_not_found',
+        message: 'Credential account missing _id',
+      });
     // Update existing credential account password
     await ctx.runMutation(components.betterAuth.adapter.updateMany, {
       input: {

--- a/services/platform/convex/users/update_user_name.test.ts
+++ b/services/platform/convex/users/update_user_name.test.ts
@@ -33,6 +33,13 @@ vi.mock('convex/values', () => {
       null: stub,
       id: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : 'ConvexError');
+        this.data = data;
+      }
+    },
   };
 });
 
@@ -79,9 +86,9 @@ describe('updateUserName', () => {
     const ctx = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, { name: 'New Name' })).rejects.toThrow(
-      'Unauthenticated',
-    );
+    await expect(handler(ctx, { name: 'New Name' })).rejects.toMatchObject({
+      data: { code: 'unauthenticated' },
+    });
   });
 
   it('throws when name is empty', async () => {
@@ -89,9 +96,9 @@ describe('updateUserName', () => {
     const ctx = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, { name: '   ' })).rejects.toThrow(
-      'Name is required',
-    );
+    await expect(handler(ctx, { name: '   ' })).rejects.toMatchObject({
+      data: { code: 'validation', message: 'Name is required' },
+    });
   });
 
   it('throws when name exceeds 100 characters', async () => {
@@ -99,8 +106,13 @@ describe('updateUserName', () => {
     const ctx = createMockCtx();
     const handler = await getHandler();
 
-    await expect(handler(ctx, { name: 'a'.repeat(101) })).rejects.toThrow(
-      'Name must be 100 characters or less',
+    await expect(handler(ctx, { name: 'a'.repeat(101) })).rejects.toMatchObject(
+      {
+        data: {
+          code: 'too_long',
+          message: 'Name must be 100 characters or less',
+        },
+      },
     );
   });
 
@@ -110,9 +122,9 @@ describe('updateUserName', () => {
     ctx.runQuery.mockResolvedValueOnce({ page: [] });
     const handler = await getHandler();
 
-    await expect(handler(ctx, { name: 'New Name' })).rejects.toThrow(
-      'User not found',
-    );
+    await expect(handler(ctx, { name: 'New Name' })).rejects.toMatchObject({
+      data: { code: 'not_found' },
+    });
   });
 
   it('updates the user name successfully', async () => {

--- a/services/platform/convex/users/update_user_name.ts
+++ b/services/platform/convex/users/update_user_name.ts
@@ -2,6 +2,8 @@
  * Update user name - Business logic
  */
 
+import { ConvexError } from 'convex/values';
+
 import { isRecord, getString } from '../../lib/utils/type-utils';
 import { components } from '../_generated/api';
 import { MutationCtx } from '../_generated/server';
@@ -17,15 +19,24 @@ export async function updateUserName(
 ): Promise<void> {
   const authUser = await getAuthUserIdentity(ctx);
   if (!authUser) {
-    throw new Error('Unauthenticated');
+    throw new ConvexError({
+      code: 'unauthenticated',
+      message: 'Unauthenticated',
+    });
   }
 
   const trimmed = args.name.trim();
   if (trimmed.length === 0) {
-    throw new Error('Name is required');
+    throw new ConvexError({
+      code: 'validation',
+      message: 'Name is required',
+    });
   }
   if (trimmed.length > 100) {
-    throw new Error('Name must be 100 characters or less');
+    throw new ConvexError({
+      code: 'too_long',
+      message: 'Name must be 100 characters or less',
+    });
   }
 
   // Look up the user record to get its _id
@@ -38,7 +49,10 @@ export async function updateUserName(
   const user = isRecord(userRaw) ? userRaw : undefined;
   const userId = user ? getString(user, '_id') : undefined;
   if (!userId) {
-    throw new Error('User not found');
+    throw new ConvexError({
+      code: 'not_found',
+      message: 'User not found',
+    });
   }
 
   await ctx.runMutation(components.betterAuth.adapter.updateMany, {


### PR DESCRIPTION
## Summary

User profile mutations threw raw `Error`s, so validation and permission failures reached the client as opaque "Server Error" with no machine-readable code.

This replaces the raw `throw new Error(...)` calls in the user-profile mutation helpers with structured `ConvexError({ code, message })`, matching the convention already used across the platform (`unauthenticated`, `validation`, `too_long`, `not_found`, `forbidden`, `password_policy_violation`, `invalid`, `credential_account_not_found`).

### Files
- `convex/users/update_user_name.ts` — unauthenticated / name required / name too long / user not found
- `convex/users/set_member_password.ts` — unauthenticated / member not found / member missing userId / not admin / password policy / credential missing _id

`mutations.ts` (updateUserPassword) and `update_user_password.ts` already used `ConvexError` and were left as-is. User-facing wording is unchanged, so no docs/i18n changes are required.

### Tests
Updated the existing unit tests to assert on the structured `{ data: { code } }` instead of a raw message string, mirroring `update_user_password.test.ts` / `user_preferences/mutations.test.ts`.

- [x] `vitest --project server convex/users/` — 16 passed
- [x] `tsc --noEmit` — clean
- [x] `oxlint --type-aware` — 0 warnings/errors
- [x] `oxfmt --check` — clean
- [x] `lint:sast` (Opengrep) — 0 findings

Closes #2012