### PR TITLE
fix(convex): throw ConvexError with structured codes from MCP server actions (#2015)

### DIFF
--- a/services/platform/convex/mcp_servers/actions.ts
+++ b/services/platform/convex/mcp_servers/actions.ts
@@ -6,7 +6,7 @@
  * Server-side actions for testing MCP connections and executing tools.
  */
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
@@ -40,7 +40,7 @@ export const testConnection = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const server = await ctx.runQuery(
@@ -48,7 +48,7 @@ export const testConnection = action({
       { id: args.id },
     );
     if (!server) {
-      throw new Error('MCP server not found');
+      throw new ConvexError({ code: 'NOT_FOUND' });
     }
 
     // Set status to discovering
@@ -127,11 +127,11 @@ export const executeMcpTool = action({
       { id: args.serverId },
     );
     if (!server) {
-      throw new Error('MCP server not found');
+      throw new ConvexError({ code: 'NOT_FOUND' });
     }
 
     if (server.status !== 'active') {
-      throw new Error(`MCP server "${server.name}" is not active`);
+      throw new ConvexError({ code: 'SERVER_NOT_ACTIVE', name: server.name });
     }
 
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Convex stores JSON args as unknown; shape is guaranteed by caller

--- a/services/platform/convex/mcp_servers/actions_error_codes.test.ts
+++ b/services/platform/convex/mcp_servers/actions_error_codes.test.ts
@@ -1,0 +1,160 @@
+import { convexTest } from 'convex-test';
+import { describe, expect, it, vi } from 'vitest';
+
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+/**
+ * #2015 regression: the public MCP-server actions must reject with a structured
+ * `ConvexError({ code })` so the Integrations/MCP settings panel can surface a
+ * specific message instead of the generic "Server Error" a raw `Error` becomes
+ * in prod:
+ *   - `testConnection`  → UNAUTHENTICATED (no identity), NOT_FOUND (missing id)
+ *   - `executeMcpTool`  → NOT_FOUND (missing id), SERVER_NOT_ACTIVE (inactive)
+ *
+ * `client_factory` is mocked: it pulls in the MCP SDK (node:child_process), and
+ * none of these error paths reach `discoverTools`/`executeTool` anyway — every
+ * throw happens before the connection is opened.
+ */
+
+vi.mock('./client_factory', () => ({
+  discoverTools: vi.fn(),
+  executeTool: vi.fn(),
+}));
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'mcp_servers';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const IDENTITY = {
+  subject: 'user_mcp',
+  email: 'mcp@example.com',
+  name: 'MCP Tester',
+};
+
+function codeOf(err: unknown): string | undefined {
+  if (err === null || typeof err !== 'object' || !('data' in err)) {
+    return undefined;
+  }
+  let data: unknown = (err as { data: unknown }).data;
+  // convex-test can double-encode the payload (a JSON string of a JSON string).
+  for (let i = 0; i < 3 && typeof data === 'string'; i++) {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof data !== 'object' || data === null || !('code' in data)) {
+    return undefined;
+  }
+  const candidate: unknown = (data as { code: unknown }).code;
+  return typeof candidate === 'string' ? candidate : undefined;
+}
+
+async function catchCode(
+  fn: () => Promise<unknown>,
+): Promise<string | undefined> {
+  try {
+    await fn();
+  } catch (err) {
+    return codeOf(err);
+  }
+  return undefined;
+}
+
+function newConvexTest() {
+  return convexTest(schema, modules);
+}
+
+/** Insert an MCP server, then delete it: a well-formed id that resolves null. */
+async function danglingServerId(t: ReturnType<typeof newConvexTest>) {
+  return t.run(async (ctx) => {
+    const id = await ctx.db.insert('mcpServers', {
+      organizationId: 'org_1',
+      name: 'gone',
+      displayName: 'Gone',
+      transportType: 'streamable_http',
+      authType: 'none',
+      status: 'inactive',
+    });
+    await ctx.db.delete(id);
+    return id;
+  });
+}
+
+describe('mcp_servers action error codes (#2015)', () => {
+  it('testConnection throws UNAUTHENTICATED when no identity is present', async () => {
+    const t = newConvexTest();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('mcpServers', {
+        organizationId: 'org_1',
+        name: 'srv',
+        displayName: 'Srv',
+        transportType: 'streamable_http',
+        authType: 'none',
+        status: 'inactive',
+      }),
+    );
+    const code = await catchCode(() =>
+      t.action(api.mcp_servers.actions.testConnection, { id }),
+    );
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
+  it('testConnection throws NOT_FOUND when the server does not exist', async () => {
+    const t = newConvexTest();
+    const id = await danglingServerId(t);
+    const code = await catchCode(() =>
+      t
+        .withIdentity(IDENTITY)
+        .action(api.mcp_servers.actions.testConnection, { id }),
+    );
+    expect(code).toBe('NOT_FOUND');
+  });
+
+  it('executeMcpTool throws NOT_FOUND when the server does not exist', async () => {
+    const t = newConvexTest();
+    const serverId = await danglingServerId(t);
+    const code = await catchCode(() =>
+      t.withIdentity(IDENTITY).action(api.mcp_servers.actions.executeMcpTool, {
+        serverId,
+        toolName: 'doThing',
+      }),
+    );
+    expect(code).toBe('NOT_FOUND');
+  });
+
+  it('executeMcpTool throws SERVER_NOT_ACTIVE when the server is not active', async () => {
+    const t = newConvexTest();
+    const serverId = await t.run(async (ctx) =>
+      ctx.db.insert('mcpServers', {
+        organizationId: 'org_1',
+        name: 'inactive-srv',
+        displayName: 'Inactive Srv',
+        transportType: 'streamable_http',
+        authType: 'none',
+        status: 'inactive',
+      }),
+    );
+    const code = await catchCode(() =>
+      t.withIdentity(IDENTITY).action(api.mcp_servers.actions.executeMcpTool, {
+        serverId,
+        toolName: 'doThing',
+      }),
+    );
+    expect(code).toBe('SERVER_NOT_ACTIVE');
+  });
+});

--- a/services/platform/convex/mcp_servers/public_mutations.ts
+++ b/services/platform/convex/mcp_servers/public_mutations.ts
@@ -1,6 +1,6 @@
 'use node';
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import { action } from '../_generated/server';
@@ -78,7 +78,7 @@ export const create = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     let apiKeyEncrypted: string | undefined;
@@ -132,7 +132,7 @@ export const update = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const { id, apiKey, oauth2Config: rawOAuth2, ...rest } = args;
@@ -165,7 +165,7 @@ export const remove = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     await ctx.runMutation(internal.mcp_servers.mutations.remove, {
@@ -184,7 +184,7 @@ export const updateStatus = action({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     await ctx.runMutation(internal.mcp_servers.mutations.setStatus, {

--- a/services/platform/convex/mcp_servers/public_mutations_error_codes.test.ts
+++ b/services/platform/convex/mcp_servers/public_mutations_error_codes.test.ts
@@ -1,0 +1,144 @@
+import { convexTest } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+/**
+ * #2015 regression: the public MCP-server management actions
+ * (`create`, `update`, `remove`, `updateStatus`) must reject an unauthenticated
+ * caller with a structured `ConvexError({ code: 'UNAUTHENTICATED' })` so the
+ * Integrations/MCP settings panel can redirect to login or show a specific
+ * error. A raw `Error` is redacted to "Server Error" in prod, leaving the
+ * client with nothing to act on.
+ *
+ * End-to-end through the real action: no identity is supplied via
+ * `withIdentity`, so each handler throws before touching the database.
+ */
+
+const TEST_DIR_FROM_CONVEX_ROOT = 'mcp_servers';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+function codeOf(err: unknown): string | undefined {
+  if (err === null || typeof err !== 'object' || !('data' in err)) {
+    return undefined;
+  }
+  let data: unknown = (err as { data: unknown }).data;
+  // convex-test can double-encode the payload (a JSON string of a JSON string).
+  for (let i = 0; i < 3 && typeof data === 'string'; i++) {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof data !== 'object' || data === null || !('code' in data)) {
+    return undefined;
+  }
+  const candidate: unknown = (data as { code: unknown }).code;
+  return typeof candidate === 'string' ? candidate : undefined;
+}
+
+async function catchCode(
+  fn: () => Promise<unknown>,
+): Promise<string | undefined> {
+  try {
+    await fn();
+  } catch (err) {
+    return codeOf(err);
+  }
+  return undefined;
+}
+
+function newConvexTest() {
+  return convexTest(schema, modules);
+}
+
+describe('mcp_servers public management action error codes (#2015)', () => {
+  it('create throws UNAUTHENTICATED when no identity is present', async () => {
+    const t = newConvexTest();
+    const code = await catchCode(() =>
+      t.action(api.mcp_servers.public_mutations.create, {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        transportType: 'streamable_http',
+        authType: 'none',
+      }),
+    );
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
+  it('update throws UNAUTHENTICATED when no identity is present', async () => {
+    const t = newConvexTest();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('mcpServers', {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        transportType: 'streamable_http',
+        authType: 'none',
+        status: 'inactive',
+      }),
+    );
+    const code = await catchCode(() =>
+      t.action(api.mcp_servers.public_mutations.update, {
+        id,
+        displayName: 'Renamed',
+      }),
+    );
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
+  it('remove throws UNAUTHENTICATED when no identity is present', async () => {
+    const t = newConvexTest();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('mcpServers', {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        transportType: 'streamable_http',
+        authType: 'none',
+        status: 'inactive',
+      }),
+    );
+    const code = await catchCode(() =>
+      t.action(api.mcp_servers.public_mutations.remove, { id }),
+    );
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+
+  it('updateStatus throws UNAUTHENTICATED when no identity is present', async () => {
+    const t = newConvexTest();
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('mcpServers', {
+        organizationId: 'org_1',
+        name: 'test-server',
+        displayName: 'Test Server',
+        transportType: 'streamable_http',
+        authType: 'none',
+        status: 'inactive',
+      }),
+    );
+    const code = await catchCode(() =>
+      t.action(api.mcp_servers.public_mutations.updateStatus, {
+        id,
+        status: 'active',
+      }),
+    );
+    expect(code).toBe('UNAUTHENTICATED');
+  });
+});


### PR DESCRIPTION
## Summary

MCP server management actions threw raw `new Error(...)`, so the client only saw an opaque "Server Error" with no structured code to act on. This replaces those with `ConvexError` carrying structured codes, matching the convention used across the Convex backend (e.g. `workflows/triggers/slug_mutations.ts`, `tasks/mutations.ts`).

### Changes

`services/platform/convex/mcp_servers/public_mutations.ts`
- `create`, `update`, `remove`, `updateStatus` — unauthenticated check now throws `ConvexError({ code: 'UNAUTHENTICATED' })`.

`services/platform/convex/mcp_servers/actions.ts`
- `testConnection` — unauthenticated → `ConvexError({ code: 'UNAUTHENTICATED' })`; missing server → `ConvexError({ code: 'NOT_FOUND' })`.
- `executeMcpTool` — missing server → `ConvexError({ code: 'NOT_FOUND' })`; inactive server → `ConvexError({ code: 'SERVER_NOT_ACTIVE', name })`.

The frontend can now redirect to login on `UNAUTHENTICATED` and show structured errors for the rest.

### Verification

- `bunx vitest --run --project server mcp_servers` — 22 passed
- `bunx oxlint --type-aware` on both files — 0 warnings, 0 errors
- `bunx tsc --noEmit` — clean

Closes #2015