### PR TITLE
fix(platform): coerce governance feedback search params (#2034)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/settings/governance/feedback.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/feedback.search.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchSchema } from './feedback';
+
+// Regression coverage for #2034: a shared/bookmarked
+// `/dashboard/$id/settings/governance/feedback?period=90` (or `?comments=1`)
+// URL is parsed by the router as the JSON number 90/1, which must not crash the
+// route via SearchParamError.
+describe('governance feedback searchSchema', () => {
+  it('coerces numeric period values to the string enum', () => {
+    expect(searchSchema.parse({ period: 90 }).period).toBe('90');
+    expect(searchSchema.parse({ period: 30 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 7 }).period).toBe('7');
+    expect(searchSchema.parse({ period: 1 }).period).toBe('1');
+  });
+
+  it('accepts string period values, including "all"', () => {
+    expect(searchSchema.parse({ period: '90' }).period).toBe('90');
+    expect(searchSchema.parse({ period: 'all' }).period).toBe('all');
+  });
+
+  it('falls back to the default window for out-of-range period values', () => {
+    expect(searchSchema.parse({ period: 999 }).period).toBe('7');
+    expect(searchSchema.parse({ period: 'nonsense' }).period).toBe('7');
+  });
+
+  it('leaves an omitted period undefined', () => {
+    expect(searchSchema.parse({}).period).toBeUndefined();
+  });
+
+  it('coerces a numeric comments flag to the string enum', () => {
+    expect(searchSchema.parse({ comments: 1 }).comments).toBe('1');
+    expect(searchSchema.parse({ comments: '1' }).comments).toBe('1');
+  });
+
+  it('falls back to undefined for an out-of-range comments value', () => {
+    expect(searchSchema.parse({ comments: 0 }).comments).toBeUndefined();
+    expect(searchSchema.parse({ comments: 2 }).comments).toBeUndefined();
+    expect(searchSchema.parse({}).comments).toBeUndefined();
+  });
+
+  it('leaves unaffected string params intact', () => {
+    expect(searchSchema.parse({ kind: 'arena' }).kind).toBe('arena');
+    expect(searchSchema.parse({ agent: 'foo' }).agent).toBe('foo');
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/settings/governance/feedback.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/feedback.tsx
@@ -14,10 +14,23 @@ import { SettingsPage } from '@/app/features/settings/components/settings-page';
 import { ensureConvexQuery } from '@/app/lib/loader-preload';
 import { api } from '@/convex/_generated/api';
 
-const searchSchema = z.object({
-  period: z.enum(['1', '7', '30', '90', 'all']).optional(),
+export const searchSchema = z.object({
+  // The router parses a bare `?period=90` (or `?comments=1`) as the JSON number
+  // 90/1, which fails a plain string enum and crashes the page via
+  // SearchParamError (issue #2034). Coerce to a string first, then fall back so
+  // a shared/bookmarked URL never renders the error boundary. Same bug class as
+  // #1987 (agents), #2024 (automations), and #2033 (projects).
+  period: z.coerce
+    .string()
+    .pipe(z.enum(['1', '7', '30', '90', 'all']))
+    .catch('7')
+    .optional(),
   kind: z.enum(['all', 'message', 'arena']).optional(),
-  comments: z.enum(['1']).optional(),
+  comments: z.coerce
+    .string()
+    .pipe(z.enum(['1']))
+    .optional()
+    .catch(undefined),
   agent: z.string().optional(),
   model: z.string().optional(),
   provider: z.string().optional(),


### PR DESCRIPTION
## Summary

The governance feedback analytics route at `/dashboard/$id/settings/governance/feedback` crashed on shareable deep-links. TanStack Router's default `parseSearch` runs `JSON.parse` on each query value, so a bare `?period=90` became the number `90` and `?comments=1` became `1`. Those failed the string `z.enum([...])` validators, throwing `SearchParamError` straight into the error boundary.

## Fix

Mirror the established pattern from #1987, #2024, #2033 — coerce to a string before validating against the enum, with a graceful fallback:

- `period`: `z.coerce.string().pipe(z.enum(['1','7','30','90','all'])).catch('7').optional()` — out-of-range values fall back to the default 7-day window.
- `comments`: `z.coerce.string().pipe(z.enum(['1'])).optional().catch(undefined)` — anything other than `1` simply leaves the comment-only filter off.

`kind` is unchanged (its values aren't valid JSON numbers, so it was never affected).

## Tests

Added `feedback.search.test.ts` with regression coverage for numeric/string period and comments values, out-of-range fallback, and omitted params. `vitest` (server project), `tsc --noEmit`, and `oxlint --type-aware` all pass.

Closes #2034