### PR TITLE
fix(platform): cover pass-2 pii scrub rows in audit chain verifier (#1843)

### DIFF
--- a/services/platform/convex/audit_logs/verify_integrity.ts
+++ b/services/platform/convex/audit_logs/verify_integrity.ts
@@ -321,9 +321,11 @@ export async function verifyAuditChain(
   let isFirstEntry = args.fromTimestamp === undefined;
 
   // Build per-subject scrub windows from SIGNED pii_scrub checkpoints
-  // only. A row carrying `actorId === X` is allowed to skip hash
-  // recompute only when there is a signed checkpoint covering
-  // `(X, timestamp ≤ maxDeletedTimestamp)`. Without this scoping
+  // only. A row whose actor OR (user-)resource is subject X is allowed
+  // to skip hash recompute only when there is a signed checkpoint
+  // covering `(X, timestamp ≤ maxDeletedTimestamp)` — see the per-row
+  // coverage test below, which mirrors the scrub's two selection
+  // passes. Without this scoping
   // (the prior membership-only Set), a single pii_scrub checkpoint
   // for subject X authorized hash skip on every row that subject ever
   // touched, including future rows the checkpoint never attested.
@@ -395,32 +397,56 @@ export async function verifyAuditChain(
     // Scrubbed rows: chain order + previousHash linkage stays intact,
     // but recomputing the SHA-256 over the now-blanked body would
     // mismatch. Trust the stored integrityHash only when there is a
-    // signed pii_scrub checkpoint whose subject matches this row's
-    // actorId AND whose maxDeletedTimestamp is at or after this row.
+    // signed pii_scrub checkpoint whose subject covers this row AND
+    // whose maxDeletedTimestamp is at or after this row.
+    //
+    // Coverage MUST mirror `scrubSubjectAuditLogs`'s two selection
+    // passes, both keyed on the scrubbed subject:
+    //   - pass 1: the subject is the row's ACTOR
+    //     (`actorId === scrubbedSubjectId`), or
+    //   - pass 2: the subject is the row's RESOURCE
+    //     (`resourceType === 'user' && resourceId === scrubbedSubjectId`).
+    // The scrub windows are keyed by `scrubbedSubjectId`, so we probe
+    // them under both candidate keys. Pre-fix the lookup used `actorId`
+    // only, so every pass-2 row (admin actor, subject resource) missed
+    // its window and fell through to the `!hasSigningKey` legacy branch
+    // — unreachable on a signed deployment — leaving `isScrubbed` false.
+    // The hash was then recomputed over the blanked body and mismatched
+    // the stored `integrityHash`, raising a false "hash chain broken"
+    // alarm after every GDPR erasure (#1843). The signed checkpoint
+    // binds `scrubbedSubjectId` into the v2 HMAC, so widening coverage
+    // to pass-2 rows only trusts rows the scrub actually attested.
+    //
     // A bare `piiScrubbed: true` flag with no covering window is
     // suspicious and fails closed (recompute), unless the deployment
     // has no signing key configured at all (legacy unsigned mode).
     const actorId = typeof entry.actorId === 'string' ? entry.actorId : null;
+    const resourceId =
+      typeof entry.resourceId === 'string' ? entry.resourceId : null;
     let isScrubbed = false;
     if (piiScrubbed === true) {
-      if (actorId !== null) {
-        const windows = subjectScrubWindows.get(actorId);
-        if (windows && windows.some((w) => entry.timestamp <= w.maxTimestamp)) {
-          isScrubbed = true;
-        } else if (!hasSigningKey) {
-          // Legacy / unsigned-mode deployment: no signing key
-          // configured, so signed-checkpoint coverage is impossible
-          // and the bare `piiScrubbed` flag is the best signal we
-          // have. Surface the count so operators see the unsigned
-          // trust window. Round-2 v02 H2 F6: this branch is strictly
-          // gated on `!hasSigningKey` so a checkpoint-downgrade
-          // attacker on a signed deployment cannot plant an unsigned
-          // `pii_scrub` row to bypass recompute.
-          isScrubbed = true;
-          unsignedScrubCount++;
-        }
+      const candidateSubjectKeys: string[] = [];
+      if (actorId !== null) candidateSubjectKeys.push(actorId);
+      if (entry.resourceType === 'user' && resourceId !== null) {
+        candidateSubjectKeys.push(resourceId);
+      }
+      const covered = candidateSubjectKeys.some((key) => {
+        const windows = subjectScrubWindows.get(key);
+        return (
+          windows !== undefined &&
+          windows.some((w) => entry.timestamp <= w.maxTimestamp)
+        );
+      });
+      if (covered) {
+        isScrubbed = true;
       } else if (!hasSigningKey) {
-        // No actorId on the row + legacy unsigned deployment.
+        // Legacy / unsigned-mode deployment: no signing key configured,
+        // so signed-checkpoint coverage is impossible and the bare
+        // `piiScrubbed` flag is the best signal we have. Surface the
+        // count so operators see the unsigned trust window. Round-2 v02
+        // H2 F6: this branch is strictly gated on `!hasSigningKey` so a
+        // checkpoint-downgrade attacker on a signed deployment cannot
+        // plant an unsigned `pii_scrub` row to bypass recompute.
         isScrubbed = true;
         unsignedScrubCount++;
       }

--- a/services/platform/convex/audit_logs/verify_scrub.test.ts
+++ b/services/platform/convex/audit_logs/verify_scrub.test.ts
@@ -1,0 +1,173 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root. This file lives
+// at convex/audit_logs/, so resolve glob keys against that base (mirrors
+// append_only.test.ts / integrity_check.test.ts).
+const TEST_DIR_FROM_CONVEX_ROOT = 'audit_logs';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_audit_scrub_verify';
+const SUBJECT = 'user_subject_to_erase';
+const ADMIN = 'user_admin_actor';
+const SIGNING_KEY = 'test-audit-signing-key-1843';
+
+type T = TestConvex<typeof schema>;
+
+// Row where the erased subject is the ACTOR (their own activity) — pass 1.
+async function seedActorRow(t: T, action: string): Promise<void> {
+  await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+    organizationId: ORG,
+    actorId: SUBJECT,
+    actorEmail: 'subject@example.com',
+    actorType: 'user',
+    action,
+    category: 'data',
+    resourceType: 'customer',
+    resourceId: 'cust_1',
+    status: 'success',
+    newState: { name: 'Secret Subject' },
+  });
+}
+
+// Row an ADMIN authored ABOUT the subject (`resourceType: 'user'`,
+// `resourceId: <subject>`) — pass 2. This is the row the false-alarm bug
+// (#1843) hinges on: the GDPR erasure flow always writes at least one
+// (`gdpr_erasure_requested`).
+async function seedResourceRow(t: T, action: string): Promise<void> {
+  await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+    organizationId: ORG,
+    actorId: ADMIN,
+    actorEmail: 'admin@example.com',
+    actorType: 'user',
+    action,
+    category: 'admin',
+    resourceType: 'user',
+    resourceId: SUBJECT,
+    resourceName: 'Secret Subject',
+    status: 'success',
+    newState: { erasureRequestedFor: SUBJECT },
+  });
+}
+
+async function verify(t: T) {
+  return await t.query(
+    internal.audit_logs.integrity_check.verifyAuditChainForOrg,
+    { organizationId: ORG },
+  );
+}
+
+async function scrubbedFlagsByAction(t: T): Promise<Record<string, boolean>> {
+  return await t.run(async (ctx) => {
+    const flags: Record<string, boolean> = {};
+    for (const r of await ctx.db.query('auditLogs').collect()) {
+      if (r.organizationId === ORG) flags[r.action] = r.piiScrubbed === true;
+    }
+    return flags;
+  });
+}
+
+// #1843: on a signed deployment, pass-2 PII scrub (admin-authored rows about
+// the erased subject) blanks hash-covered fields, but the verifier looked up
+// its scrub-trust window by `actorId` only — which is the admin, not the
+// scrubbed subject — so pass-2 rows missed coverage and the chain falsely
+// reported "hash chain broken". These tests pin the verifier's coverage to
+// the scrub's own two-pass selection criteria.
+describe('audit chain verification after GDPR pii scrub (signed deployment)', () => {
+  let prevKey: string | undefined;
+
+  beforeEach(() => {
+    prevKey = process.env.TALE_AUDIT_SIGNING_KEY;
+    process.env.TALE_AUDIT_SIGNING_KEY = SIGNING_KEY;
+  });
+
+  afterEach(() => {
+    if (prevKey === undefined) delete process.env.TALE_AUDIT_SIGNING_KEY;
+    else process.env.TALE_AUDIT_SIGNING_KEY = prevKey;
+  });
+
+  it('stays valid after scrubbing both actor-pass and resource-pass rows', async () => {
+    const t = convexTest(schema, modules);
+    // Pass-1 row (subject as actor) + pass-2 row (subject as resource) +
+    // an unrelated row to keep the chain non-trivial.
+    await seedActorRow(t, 'customer.update');
+    await seedResourceRow(t, 'gdpr_erasure_requested');
+    await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+      organizationId: ORG,
+      actorId: ADMIN,
+      actorType: 'user',
+      action: 'customer.view',
+      category: 'data',
+      resourceType: 'customer',
+      resourceId: 'cust_2',
+      status: 'success',
+    });
+
+    const before = await verify(t);
+    expect(before.valid).toBe(true);
+
+    await t.mutation(
+      internal.audit_logs.internal_mutations.scrubSubjectAuditLogs,
+      { organizationId: ORG, userId: SUBJECT },
+    );
+
+    // Both the actor-pass and resource-pass rows were scrubbed.
+    const flags = await scrubbedFlagsByAction(t);
+    expect(flags['customer.update']).toBe(true);
+    expect(flags['gdpr_erasure_requested']).toBe(true);
+    // The unrelated admin row about a different resource is untouched.
+    expect(flags['customer.view']).toBe(false);
+
+    // The signed pii_scrub checkpoint must make the verifier accept the
+    // blanked bodies on BOTH passes — no false "hash chain broken".
+    const after = await verify(t);
+    expect(after.valid).toBe(true);
+    expect(after.firstBrokenAt).toBeUndefined();
+    // Coverage came from the SIGNED checkpoint, not the unsigned legacy
+    // fallback (which is unreachable when a key is configured).
+    expect(after.unsignedScrubCount).toBe(0);
+  });
+
+  it('stays valid when the only scrubbed row is an admin-authored pass-2 row', async () => {
+    // Mirrors the minimal real-world trigger: the erasure flow always writes
+    // a single `gdpr_erasure_requested` pass-2 row before scrubbing runs.
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+      organizationId: ORG,
+      actorId: ADMIN,
+      actorType: 'user',
+      action: 'customer.create',
+      category: 'data',
+      resourceType: 'customer',
+      resourceId: 'cust_3',
+      status: 'success',
+    });
+    await seedResourceRow(t, 'gdpr_erasure_requested');
+
+    await t.mutation(
+      internal.audit_logs.internal_mutations.scrubSubjectAuditLogs,
+      { organizationId: ORG, userId: SUBJECT },
+    );
+
+    const after = await verify(t);
+    expect(after.valid).toBe(true);
+    expect(after.firstBrokenAt).toBeUndefined();
+    expect(after.unsignedScrubCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a false **"hash chain broken"** tamper alarm that fires deterministically after every GDPR erasure on any deployment with `TALE_AUDIT_SIGNING_KEY` configured.

`scrubSubjectAuditLogs` scrubs PII in two passes:
- **pass 1** — rows where the erased subject is the **actor** (`actorId === subject`)
- **pass 2** — admin-authored rows **about** the subject (`resourceType === 'user' && resourceId === subject`); here the actor is the admin, not the subject.

Both passes blank hash-covered fields and rely on a signed `pii_scrub` checkpoint (keyed by `scrubbedSubjectId`) to tell the verifier the divergence is intentional. But `verifyAuditChain` looked its scrub-trust window up by `actorId` **only**. For a pass-2 row, `actorId` (admin) ≠ `scrubbedSubjectId` (subject), so no window matched; on a signed deployment the `!hasSigningKey` legacy fallback is unreachable, so the verifier recomputed the hash over the blanked body and reported a mismatch. The erasure flow always writes at least one pass-2 row (`gdpr_erasure_requested`), so the break was guaranteed.

## Fix

`services/platform/convex/audit_logs/verify_integrity.ts` — the per-row scrub-coverage test now mirrors the scrub's own two-pass **selection criteria**. A scrubbed row is trusted when a signed `pii_scrub` window exists for either:
- `actorId === scrubbedSubjectId` (pass 1), **or**
- `resourceType === 'user' && resourceId === scrubbedSubjectId` (pass 2),

in both cases with `entry.timestamp <= window.maxTimestamp`. Coverage is probed under both candidate subject keys. Because the v2 signed checkpoint binds `scrubbedSubjectId` into the HMAC, this only widens trust to rows the scrub actually attested — no new forgery surface beyond what pass 1 already accepted. The `!hasSigningKey` legacy/unsigned fallback (and its `unsignedScrubCount`) is preserved unchanged.

## Test

New `services/platform/convex/audit_logs/verify_scrub.test.ts` (the prior test gap): on a signed deployment, scrub a subject with both actor-pass and resource-pass rows and assert `verifyAuditChain` returns `valid: true` with `unsignedScrubCount === 0`; plus the minimal real-world trigger (a single admin-authored pass-2 row). Both tests fail without the verifier change and pass with it.

- `bunx vitest --run --project server audit_logs/` → 32 passed
- `bunx tsc --noEmit` → clean

Closes #1843