### PR TITLE
fix(platform): preserve audit chain contiguity around custodian-hold rows (#1844)

### DIFF
--- a/services/platform/convex/audit_logs/internal_mutations.ts
+++ b/services/platform/convex/audit_logs/internal_mutations.ts
@@ -176,19 +176,35 @@ export const deleteOldLogs = internalMutation({
         break;
       }
 
-      // Skip rows whose actor OR user-typed resource is on a custodian
-      // hold. Cross-cutting iteration: we keep paging until we find a
-      // deletable row OR exhaust this batch. (`hasMore` below uses
-      // `deletedCount` rather than scanned count, so a window full of
-      // protected rows correctly reports `hasMore: false` when nothing
-      // was deletable in this slice — the cleanup will revisit later.)
+      // Custodian-hold preservation (FRCP 37(e)): a held user's audit
+      // rows — as the `actorId` OR as a user-typed resource target —
+      // must survive past their retention age. STOP the deletion sweep
+      // at the first protected row instead of skipping past it.
+      //
+      // Deleting only the contiguous unprotected PREFIX keeps the
+      // surviving hash chain contiguous by construction: every retained
+      // row's `previousHash` still references either another retained
+      // row or the checkpoint's `lastDeletedHash`. The earlier per-row
+      // `continue` stranded protected rows as non-contiguous islands —
+      // a survivor's `previousHash` pointed at a now-deleted neighbour —
+      // so the next integrity run deterministically reported a false
+      // "hash chain broken" tamper alarm (#1844). The verifier
+      // re-anchors via checkpoint only at the chain head and demands
+      // strict contiguity thereafter, with no mid-chain re-anchor.
+      //
+      // The cost — unprotected rows BEHIND a held row outlive their
+      // retention window until the hold is released — is the same trade
+      // the org-wide-hold branch in retention_cleanup.ts already makes,
+      // and is defensible: preservation duty trumps routine retention.
+      // The sweep resumes deleting that backlog automatically once the
+      // hold is lifted and the row is no longer protected.
       const targetIsHeldUser =
         (log.resourceType === 'user' ||
           log.resourceType === 'userMembership') &&
         log.resourceId !== undefined &&
         protectedUserIds.has(log.resourceId);
       if (protectedUserIds.has(log.actorId) || targetIsHeldUser) {
-        continue;
+        break;
       }
 
       // Track the chain head we're deleting so the checkpoint can

--- a/services/platform/convex/audit_logs/retention_holds.test.ts
+++ b/services/platform/convex/audit_logs/retention_holds.test.ts
@@ -1,0 +1,181 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { describe, expect, it } from 'vitest';
+
+import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
+import schema from '../schema';
+
+// convex-test module map keyed relative to the convex/ root. This file lives
+// at convex/audit_logs/, so resolve glob keys against that base (mirrors
+// append_only.test.ts).
+const TEST_DIR_FROM_CONVEX_ROOT = 'audit_logs';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+const ORG = 'org_audit_retention_holds';
+const FAR_FUTURE = 4_102_444_800_000; // 2100-01-01: every seeded row is "old".
+
+type T = TestConvex<typeof schema>;
+
+interface SeedOpts {
+  actorId?: string;
+  resourceType?: string;
+  resourceId?: string;
+}
+
+async function seedEntry(
+  t: T,
+  action: string,
+  opts: SeedOpts = {},
+): Promise<Id<'auditLogs'>> {
+  return await t.mutation(
+    internal.audit_logs.internal_mutations.createAuditLog,
+    {
+      organizationId: ORG,
+      actorId: opts.actorId ?? 'tester',
+      actorType: 'system',
+      action,
+      category: 'data',
+      resourceType: opts.resourceType ?? 'customer',
+      resourceId: opts.resourceId,
+      status: 'success',
+    },
+  );
+}
+
+async function deleteOldLogs(t: T, protectedUserIds: string[]) {
+  return await t.mutation(
+    internal.audit_logs.internal_mutations.deleteOldLogs,
+    {
+      organizationId: ORG,
+      olderThanTimestamp: FAR_FUTURE,
+      protectedUserIds,
+    },
+  );
+}
+
+async function verify(t: T) {
+  return await t.query(
+    internal.audit_logs.integrity_check.verifyAuditChainForOrg,
+    { organizationId: ORG },
+  );
+}
+
+async function actionsAsc(t: T): Promise<string[]> {
+  return await t.run(async (ctx) => {
+    const actions: string[] = [];
+    for await (const row of ctx.db
+      .query('auditLogs')
+      .withIndex('by_organizationId_and_timestamp', (q) =>
+        q.eq('organizationId', ORG),
+      )
+      .order('asc')) {
+      actions.push(row.action);
+    }
+    return actions;
+  });
+}
+
+// #1844: audit-log retention and custodian legal holds are two compliance
+// features that compose. The old `deleteOldLogs` skipped each protected row
+// per-row while hard-deleting the unprotected rows around it, stranding the
+// survivors as non-contiguous islands in the hash chain. The verifier
+// re-anchors only at the chain head and then demands strict `previousHash`
+// contiguity, so the next integrity run reported a deterministic, permanent
+// false "hash chain broken" tamper alarm. The fix stops the deletion sweep at
+// the first protected row, deleting only the contiguous unprotected prefix so
+// the surviving chain stays contiguous by construction.
+describe('audit retention around custodian-hold rows (#1844)', () => {
+  it('keeps the surviving chain contiguous and verifiable across a held actor', async () => {
+    const t = convexTest(schema, modules);
+    // Interleave a held user's rows with an unprotected actor's rows. The
+    // pre-fix per-row skip would delete a1/a2/a3 and keep only the two held
+    // rows, leaving them non-contiguous.
+    await seedEntry(t, 'a1', { actorId: 'alice' });
+    await seedEntry(t, 'a2', { actorId: 'alice' });
+    await seedEntry(t, 'held1', { actorId: 'bob-held' });
+    await seedEntry(t, 'a3', { actorId: 'alice' });
+    await seedEntry(t, 'held2', { actorId: 'bob-held' });
+
+    const result = await deleteOldLogs(t, ['bob-held']);
+
+    // Only the contiguous unprotected prefix (a1, a2) is deleted; the sweep
+    // stops at the first held row. hasMore is false — nothing more is
+    // deletable until the hold is released.
+    expect(result.deletedCount).toBe(2);
+    expect(result.hasMore).toBe(false);
+
+    // The held rows and the unprotected rows behind them all survive; a
+    // retention bookkeeping row is appended at the tail.
+    const actions = await actionsAsc(t);
+    expect(actions).toEqual([
+      'held1',
+      'a3',
+      'held2',
+      'audit_log.retention_deleted',
+    ]);
+
+    // The whole point: no false tamper alarm.
+    const verdict = await verify(t);
+    expect(verdict.valid).toBe(true);
+    expect(verdict.firstBrokenAt).toBeUndefined();
+  });
+
+  it('preserves rows that merely TARGET a held user (resourceType user)', async () => {
+    const t = convexTest(schema, modules);
+    // Row authored by an admin about the held user — the subject, not the
+    // actor, is on hold. Must still preserve chain contiguity.
+    await seedEntry(t, 'a1', { actorId: 'admin' });
+    await seedEntry(t, 'about-held', {
+      actorId: 'admin',
+      resourceType: 'user',
+      resourceId: 'carol-held',
+    });
+    await seedEntry(t, 'a2', { actorId: 'admin' });
+
+    const result = await deleteOldLogs(t, ['carol-held']);
+
+    expect(result.deletedCount).toBe(1); // only a1; stop at the held target.
+    const actions = await actionsAsc(t);
+    expect(actions).toEqual([
+      'about-held',
+      'a2',
+      'audit_log.retention_deleted',
+    ]);
+
+    const verdict = await verify(t);
+    expect(verdict.valid).toBe(true);
+  });
+
+  it('resumes deleting the backlog once the hold is released', async () => {
+    const t = convexTest(schema, modules);
+    await seedEntry(t, 'a1', { actorId: 'alice' });
+    await seedEntry(t, 'held1', { actorId: 'bob-held' });
+    await seedEntry(t, 'a2', { actorId: 'alice' });
+
+    // Hold active: only the prefix before the held row is deleted.
+    const held = await deleteOldLogs(t, ['bob-held']);
+    expect(held.deletedCount).toBe(1);
+    expect((await verify(t)).valid).toBe(true);
+
+    // Hold released: the previously protected row and the rows behind it are
+    // now eligible, and the chain stays contiguous after the cut.
+    const released = await deleteOldLogs(t, []);
+    expect(released.deletedCount).toBeGreaterThan(0);
+    const verdict = await verify(t);
+    expect(verdict.valid).toBe(true);
+    expect(verdict.firstBrokenAt).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

When audit-log retention runs while a **custodian legal hold** is active, `deleteOldLogs` skipped each protected row *per-row* while hard-deleting the unprotected rows around it. The surviving held rows became non-contiguous islands in the SHA-256 hash chain. The verifier re-anchors via checkpoint **only at the chain head** and then demands strict `previousHash` contiguity, so the next integrity run deterministically reported "hash chain broken at log <id>" — a permanent daily **false tamper alarm** for any org combining `auditLogRetentionDays` with at least one custodian hold.

## Fix

Stop the deletion sweep at the **first protected row** (`continue` → `break` in `audit_logs/internal_mutations.ts`). Only the contiguous unprotected **prefix** is deleted, so every surviving row's `previousHash` still references either another retained row or the checkpoint's `lastDeletedHash` — chain contiguity is preserved by construction.

The cost — unprotected rows *behind* a held row outlive their retention window until the hold is released — is the same trade the org-wide-hold branch in `retention_cleanup.ts` already makes, and is defensible under FRCP 37(e) (preservation duty trumps routine retention). The sweep resumes deleting that backlog automatically once the hold is lifted.

## Tests

New `audit_logs/retention_holds.test.ts` (3 cases):
- held **actor** rows interleaved with an unprotected actor → chain stays contiguous, `verifyAuditChain` returns `valid: true`;
- rows that merely **target** a held user (`resourceType: 'user'`) are preserved too;
- once the hold is released the backlog is deleted and the chain remains valid.

All three fail against the old per-row `continue` and pass with the fix. `tsc --noEmit` and `oxlint --type-aware` are clean.

Closes #1844