### PR TITLE
fix(convex): harden audit integrity verifier and cron coverage (#1846)

### DIFF
--- a/services/platform/convex/audit_logs/chain_integrity_hardening.test.ts
+++ b/services/platform/convex/audit_logs/chain_integrity_hardening.test.ts
@@ -2,8 +2,10 @@ import { convexTest, type TestConvex } from 'convex-test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { internal } from '../_generated/api';
+import type { Id } from '../_generated/dataModel';
 import schema from '../schema';
 import { createAuditLog } from './helpers';
+import * as verifyIntegrityModule from './verify_integrity';
 import { verifyAuditChain } from './verify_integrity';
 
 // convex-test module map keyed relative to the convex/ root. This file lives
@@ -210,6 +212,125 @@ describe('paged resume (#1846 item 3)', () => {
     expect(p1.valid).toBe(true);
     expect(naive.valid).toBe(true);
     expect(naive.firstBrokenAt).toBeUndefined();
+  });
+});
+
+// PR #2218 review BLOCKING 1 — when retention hard-deletes the persisted
+// cursor row AND one or more rows after it, the resume must NOT compare the
+// first surviving row against the stale supplied previousExpectedHash (the
+// deleted cursor's hash), which produced a false `firstBrokenAt` / critical
+// tamper alert that re-fired every run.
+describe('deleted-cursor resume (#1846 item 3 / PR #2218 BLOCKING 1)', () => {
+  it('does not report a false break when retention deletes the cursor row and rows after it', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_deleted_cursor';
+    for (let i = 0; i < 6; i++) await seed(t, ORG, `row.${i}`);
+
+    // Page 1 verifies the oldest 2 rows and yields a full cursor.
+    const p1 = await t.run((ctx) =>
+      verifyAuditChain(ctx, { organizationId: ORG, maxEntries: 2 }),
+    );
+    expect(p1).toMatchObject({ valid: true, verifiedCount: 2 });
+
+    // Retention hard-deletes indices 0–3 — the cursor row (index 1) AND rows
+    // after it — leaving only indices 4–5.
+    const before = await rowsAsc(t, ORG);
+    await t.run(async (ctx) => {
+      for (const r of before.slice(0, 4)) {
+        await ctx.db.delete(r._id as Id<'auditLogs'>);
+      }
+    });
+    const remaining = await rowsAsc(t, ORG);
+    expect(remaining).toHaveLength(2);
+
+    // Resume with the FULL cron cursor (afterId now points at a deleted row).
+    const p2 = await t.run((ctx) =>
+      verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 2,
+        fromTimestamp: p1.lastVerifiedTimestamp,
+        afterId: p1.lastVerifiedId,
+        previousExpectedHash: p1.lastVerifiedHash,
+      }),
+    );
+
+    expect(p2.firstBrokenAt).toBeUndefined();
+    expect(p2.valid).toBe(true);
+    expect(p2.verifiedCount).toBe(2);
+  });
+
+  it('still verifies when retention deletes exactly up to the cursor row', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_deleted_cursor_boundary';
+    for (let i = 0; i < 6; i++) await seed(t, ORG, `row.${i}`);
+
+    const p1 = await t.run((ctx) =>
+      verifyAuditChain(ctx, { organizationId: ORG, maxEntries: 2 }),
+    );
+
+    // Delete exactly indices 0–1 (up to and including the cursor row).
+    const before = await rowsAsc(t, ORG);
+    await t.run(async (ctx) => {
+      for (const r of before.slice(0, 2)) {
+        await ctx.db.delete(r._id as Id<'auditLogs'>);
+      }
+    });
+
+    const p2 = await t.run((ctx) =>
+      verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 10,
+        fromTimestamp: p1.lastVerifiedTimestamp,
+        afterId: p1.lastVerifiedId,
+        previousExpectedHash: p1.lastVerifiedHash,
+      }),
+    );
+
+    expect(p2.valid).toBe(true);
+    expect(p2.firstBrokenAt).toBeUndefined();
+    expect(p2.verifiedCount).toBe(4);
+  });
+});
+
+// PR #2218 review BLOCKING 2 — an org whose verification throws must still
+// rotate to the back of the round-robin queue (its progress `updatedAt` is
+// bumped) so it can't sort to the front of every run and starve healthy orgs
+// past the per-run cap.
+describe('erroring-org rotation (#1846 item 1 / PR #2218 BLOCKING 2)', () => {
+  it('rotates a throwing org to the back instead of starving the queue', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_throwing';
+    await seed(t, ORG, 'row.0');
+
+    // Force the per-org verification to throw for this run.
+    vi.spyOn(verifyIntegrityModule, 'verifyAuditChain').mockRejectedValue(
+      new Error('boom'),
+    );
+
+    await t.action(
+      internal.audit_logs.integrity_check.runAuditIntegrityCheck,
+      {},
+    );
+
+    // The erroring org now carries a progress row with a bumped `updatedAt`
+    // (rotated to the back) but no advanced cursor.
+    const progress = await progressFor(t, ORG);
+    expect(progress).not.toBeNull();
+    expect(progress?.updatedAt).toBeGreaterThan(0);
+    expect(progress?.headReached).toBe(false);
+    expect(progress?.lastVerifiedId).toBeUndefined();
+
+    vi.restoreAllMocks();
+
+    // A never-checked org (sentinel -1) must now sort AHEAD of the touched
+    // throwing org — proving the throwing org rotated to the back rather than
+    // pinning the front of the queue forever.
+    await seed(t, 'org_fresh', 'row.0');
+    const selection = await t.query(
+      internal.audit_logs.integrity_check.selectOrgsForIntegrityRun,
+      {},
+    );
+    expect(selection.organizationIds[0]).toBe('org_fresh');
   });
 });
 

--- a/services/platform/convex/audit_logs/chain_integrity_hardening.test.ts
+++ b/services/platform/convex/audit_logs/chain_integrity_hardening.test.ts
@@ -1,0 +1,265 @@
+import { convexTest, type TestConvex } from 'convex-test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { internal } from '../_generated/api';
+import schema from '../schema';
+import { createAuditLog } from './helpers';
+import { verifyAuditChain } from './verify_integrity';
+
+// convex-test module map keyed relative to the convex/ root. This file lives
+// at convex/audit_logs/, so resolve glob keys against that base (mirrors
+// integrity_check.test.ts).
+const TEST_DIR_FROM_CONVEX_ROOT = 'audit_logs';
+function toConvexRootKey(globKey: string): string {
+  const stack: string[] = [];
+  for (const part of `${TEST_DIR_FROM_CONVEX_ROOT}/${globKey}`.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+const rawModules = import.meta.glob('../**/*.*s');
+const modules: Record<string, () => Promise<unknown>> = {};
+for (const [key, loader] of Object.entries(rawModules)) {
+  modules[toConvexRootKey(key)] = loader;
+}
+
+type T = TestConvex<typeof schema>;
+
+function args(organizationId: string, action: string) {
+  return {
+    organizationId,
+    actorId: 'tester',
+    actorType: 'system' as const,
+    action,
+    category: 'data' as const,
+    resourceType: 'customer',
+    status: 'success' as const,
+  };
+}
+
+async function seed(t: T, organizationId: string, action: string) {
+  await t.mutation(internal.audit_logs.internal_mutations.createAuditLog, {
+    ...args(organizationId, action),
+  });
+}
+
+async function rowsAsc(t: T, organizationId: string) {
+  return t.run(async (ctx) => {
+    const out = [];
+    for await (const r of ctx.db
+      .query('auditLogs')
+      .withIndex('by_organizationId_and_timestamp', (q) =>
+        q.eq('organizationId', organizationId),
+      )
+      .order('asc')) {
+      out.push(r);
+    }
+    return out;
+  });
+}
+
+async function progressFor(t: T, organizationId: string) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query('auditIntegrityProgress')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', organizationId),
+      )
+      .first(),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// #1846 item 5 — within a single mutation there is no cross-row OCC, so two
+// createAuditLog calls under Promise.all both read the same head and commit
+// the same previousHash unless appends are serialized per ctx.
+describe('intra-mutation chain fork (#1846 item 5)', () => {
+  it('serializes parallel same-org appends so the chain does not fork', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_intra_fork';
+
+    await t.run(async (ctx) => {
+      await Promise.all([
+        createAuditLog(ctx, args(ORG, 'parallel.a')),
+        createAuditLog(ctx, args(ORG, 'parallel.b')),
+        createAuditLog(ctx, args(ORG, 'parallel.c')),
+      ]);
+    });
+
+    const rows = await rowsAsc(t, ORG);
+    expect(rows).toHaveLength(3);
+    // Exactly one genesis row (empty previousHash); the rest chain forward.
+    const genesisRows = rows.filter((r) => !r.previousHash);
+    expect(genesisRows).toHaveLength(1);
+    // No two rows share a previousHash — a fork would repeat one.
+    const prevHashes = rows.map((r) => r.previousHash ?? '');
+    expect(new Set(prevHashes).size).toBe(prevHashes.length);
+
+    const result = await t.run((ctx) =>
+      verifyAuditChain(ctx, { organizationId: ORG }),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.verifiedCount).toBe(3);
+  });
+});
+
+// #1846 item 4 — the chain is ordered by the app-level timestamp; a backward
+// clock step would otherwise sort a new row before the head it chains off,
+// permanently orphaning it and tripping a false tamper alarm.
+describe('timestamp monotonicity clamp (#1846 item 4)', () => {
+  it('clamps the timestamp forward when the wall clock steps backward', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_clock_skew';
+    const nowSpy = vi.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(5_000);
+    await t.run((ctx) => createAuditLog(ctx, args(ORG, 'before.skew')));
+    // Clock steps backward (NTP correction / VM snapshot restore).
+    nowSpy.mockReturnValue(1_000);
+    await t.run((ctx) => createAuditLog(ctx, args(ORG, 'after.skew')));
+
+    const rows = await rowsAsc(t, ORG);
+    expect(rows.map((r) => r.action)).toEqual(['before.skew', 'after.skew']);
+    expect(rows[0].timestamp).toBe(5_000);
+    // Clamped to lastInsertedAt + 1 rather than the regressed 1_000.
+    expect(rows[1].timestamp).toBe(5_001);
+
+    const result = await t.run((ctx) =>
+      verifyAuditChain(ctx, { organizationId: ORG }),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.verifiedCount).toBe(2);
+  });
+});
+
+// #1846 item 3 — the documented fromTimestamp resume path used to report a
+// false break at the first row of any resumed page. A correct resume seeds the
+// linkage from the previous page's last hash and skips up to/including afterId.
+describe('paged resume (#1846 item 3)', () => {
+  it('pages a chain across runs with an exact (timestamp, _id, hash) cursor', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_resume';
+    for (let i = 0; i < 5; i++) await seed(t, ORG, `row.${i}`);
+
+    const pages = await t.run(async (ctx) => {
+      const p1 = await verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 2,
+      });
+      const p2 = await verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 2,
+        fromTimestamp: p1.lastVerifiedTimestamp,
+        afterId: p1.lastVerifiedId,
+        previousExpectedHash: p1.lastVerifiedHash,
+      });
+      const p3 = await verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 2,
+        fromTimestamp: p2.lastVerifiedTimestamp,
+        afterId: p2.lastVerifiedId,
+        previousExpectedHash: p2.lastVerifiedHash,
+      });
+      return { p1, p2, p3 };
+    });
+
+    expect(pages.p1).toMatchObject({
+      valid: true,
+      truncated: true,
+      verifiedCount: 2,
+    });
+    expect(pages.p2).toMatchObject({
+      valid: true,
+      truncated: true,
+      verifiedCount: 2,
+    });
+    expect(pages.p3).toMatchObject({
+      valid: true,
+      truncated: false,
+      verifiedCount: 1,
+    });
+    expect(
+      pages.p1.verifiedCount + pages.p2.verifiedCount + pages.p3.verifiedCount,
+    ).toBe(5);
+  });
+
+  it('does not report a false break on a fromTimestamp-only resume', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_resume_legacy';
+    for (let i = 0; i < 4; i++) await seed(t, ORG, `row.${i}`);
+
+    const { p1, naive } = await t.run(async (ctx) => {
+      const first = await verifyAuditChain(ctx, {
+        organizationId: ORG,
+        maxEntries: 2,
+      });
+      // Pre-fix this seeded previousExpectedHash from '' and forced a break at
+      // the first resumed row; now the boundary row is trusted instead.
+      const second = await verifyAuditChain(ctx, {
+        organizationId: ORG,
+        fromTimestamp: first.lastVerifiedTimestamp,
+      });
+      return { p1: first, naive: second };
+    });
+
+    expect(p1.valid).toBe(true);
+    expect(naive.valid).toBe(true);
+    expect(naive.firstBrokenAt).toBeUndefined();
+  });
+});
+
+// #1846 items 1 + 2 — the cron must page forward across runs (persisting a
+// per-org cursor) and select orgs round-robin so coverage is not capped at the
+// oldest window or the first MAX_ORGS_PER_RUN orgs.
+describe('cron coverage + progress (#1846 items 1 + 2)', () => {
+  it('persists a forward cursor and advances it as new rows are appended', async () => {
+    const t = convexTest(schema, modules);
+    const ORG = 'org_progress';
+    await seed(t, ORG, 'first');
+    await seed(t, ORG, 'second');
+
+    await t.action(
+      internal.audit_logs.integrity_check.runAuditIntegrityCheck,
+      {},
+    );
+
+    const after1 = await progressFor(t, ORG);
+    expect(after1).not.toBeNull();
+    expect(after1?.headReached).toBe(true);
+    expect(after1?.lastVerifiedId).toBeTruthy();
+    const cursor1 = after1?.lastVerifiedTimestamp ?? 0;
+
+    // New rows appended after the cursor must be picked up on the next run.
+    await seed(t, ORG, 'third');
+    await t.action(
+      internal.audit_logs.integrity_check.runAuditIntegrityCheck,
+      {},
+    );
+
+    const after2 = await progressFor(t, ORG);
+    expect(after2?.lastVerifiedTimestamp ?? 0).toBeGreaterThan(cursor1);
+    expect(after2?.headReached).toBe(true);
+  });
+
+  it('selects every audited org when under the per-run cap', async () => {
+    const t = convexTest(schema, modules);
+    await seed(t, 'org_select_a', 'a');
+    await seed(t, 'org_select_b', 'b');
+
+    const selection = await t.query(
+      internal.audit_logs.integrity_check.selectOrgsForIntegrityRun,
+      {},
+    );
+    expect(selection.totalOrgs).toBe(2);
+    expect(selection.truncated).toBe(false);
+    expect([...selection.organizationIds].sort()).toEqual([
+      'org_select_a',
+      'org_select_b',
+    ]);
+  });
+});

--- a/services/platform/convex/audit_logs/helpers.ts
+++ b/services/platform/convex/audit_logs/helpers.ts
@@ -186,7 +186,48 @@ export function buildAuditRecordHashInput(
   };
 }
 
-export async function createAuditLog(
+/**
+ * Per-mutation append serialization.
+ *
+ * `createAuditLog` reads the current chain head (`lastEntry`) and chains its
+ * new row off it. Two calls that interleave their read-before-insert inside a
+ * SINGLE mutation — e.g. `Promise.all(orgs.map((o) => createAuditLog(ctx, …)))`
+ * — both observe the same head and commit the SAME `previousHash`: a silent
+ * in-transaction chain fork the next integrity run reports as tampering.
+ * Cross-mutation forks are already prevented by the genesis-sentinel +
+ * `chainSuccessor` OCC patch, but neither mechanism fires WITHIN one
+ * transaction. Serialize every `createAuditLog` sharing a `MutationCtx` so each
+ * call observes the previous row's insert as its `lastEntry`. Keyed on the ctx
+ * object (one chain per mutation); unrelated mutations never contend, and the
+ * entry is GC'd with the ctx. Round-2 v05 M1 / #1846 item 5.
+ */
+const auditAppendTails = new WeakMap<object, Promise<unknown>>();
+
+export function createAuditLog(
+  ctx: MutationCtx,
+  args: CreateAuditLogArgs,
+): Promise<Id<'auditLogs'>> {
+  const previous = auditAppendTails.get(ctx) ?? Promise.resolve();
+  // Run after the previous append for this ctx settles (resolved OR rejected),
+  // so a failed sibling write never lets the next one race the head read.
+  const run = previous.then(
+    () => insertAuditLog(ctx, args),
+    () => insertAuditLog(ctx, args),
+  );
+  // The stored tail swallows the outcome so one append throwing can't break
+  // ordering for the next queued call; the real result/error flows out via
+  // `run` to this caller.
+  auditAppendTails.set(
+    ctx,
+    run.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return run;
+}
+
+async function insertAuditLog(
   ctx: MutationCtx,
   args: CreateAuditLogArgs,
 ): Promise<Id<'auditLogs'>> {
@@ -197,7 +238,7 @@ export async function createAuditLog(
     args.changedFields ??
     computeChangedFields(args.previousState, args.newState);
 
-  const timestamp = Date.now();
+  const now = Date.now();
 
   // Genesis sentinel: read + patch a per-org row to force OCC
   // serialization on the very first audit write per org. Without this,
@@ -211,7 +252,18 @@ export async function createAuditLog(
       q.eq('organizationId', args.organizationId),
     )
     .first();
+  // Clamp the chain timestamp to be strictly greater than this org's last
+  // inserted timestamp. The chain is ordered by this app-level `timestamp`
+  // for BOTH the head-pick (desc) and the verify walk (asc), so if the
+  // backend wall clock steps backward (NTP step correction, VM snapshot
+  // restore) a new row chains off the true head yet sorts BEFORE it — the
+  // next writer keeps picking the higher-timestamp old head, the row is
+  // permanently orphaned, and the ascending verify walk reports a false
+  // linkage break at it. `lastInsertedAt` is already read + patched here for
+  // OCC, so the monotonicity clamp costs nothing. #1846 item 4.
+  let timestamp = now;
   if (genesis) {
+    timestamp = Math.max(now, genesis.lastInsertedAt + 1);
     // Patch forces OCC contention with any concurrent writer for the
     // same org. The loser's transaction aborts and retries; on retry it
     // observes the winner's just-committed audit row as `lastEntry`.

--- a/services/platform/convex/audit_logs/helpers.ts
+++ b/services/platform/convex/audit_logs/helpers.ts
@@ -261,6 +261,14 @@ async function insertAuditLog(
   // permanently orphaned, and the ascending verify walk reports a false
   // linkage break at it. `lastInsertedAt` is already read + patched here for
   // OCC, so the monotonicity clamp costs nothing. #1846 item 4.
+  //
+  // Tradeoff (PR #2218 review): the clamp is one-directional. A large FORWARD
+  // clock step pins `lastInsertedAt` high and ratchets every later row's
+  // timestamp to `+1ms` detached from real time until the wall clock catches
+  // up. That keeps the chain monotonic and verifiable (the property that
+  // matters here), at the cost of timestamps drifting ahead of real time in
+  // that window; we accept it rather than capping forward, since a forward cap
+  // would re-open the same sort-before-head orphan hazard this clamp closes.
   let timestamp = now;
   if (genesis) {
     timestamp = Math.max(now, genesis.lastInsertedAt + 1);

--- a/services/platform/convex/audit_logs/integrity_check.ts
+++ b/services/platform/convex/audit_logs/integrity_check.ts
@@ -26,48 +26,151 @@ import { writeNotificationForOrgs } from '../notifications/helpers';
 import { verifyAuditChain } from './verify_integrity';
 
 // Bound the per-run org fan-out so a deployment with a very large org count
-// can't blow the action's time budget. Logged when hit so coverage gaps are
-// never silent.
+// can't blow the action's time budget. Orgs are selected round-robin by
+// staleness (see `selectOrgsForIntegrityRun`) so the ones not reached this
+// run ARE reached on later runs — no org is permanently outside the control.
 const MAX_ORGS_PER_RUN = 500;
-// Cap the rows verified per org per run. `verifyAuditChain` reports
-// `truncated` when it stops early, which the alert treats as a finding so a
-// chain that outgrows this window is surfaced rather than silently
-// half-checked.
+// Cap the rows verified per org per run. The cron pages FORWARD across runs
+// from each org's persisted cursor (`auditIntegrityProgress`), so a chain
+// longer than this window is fully covered over successive runs rather than
+// leaving its newest rows — where live tampering would land — unverified.
 const MAX_ENTRIES_PER_ORG = 5000;
 
-/** Org ids that have ever written an audit log (one genesis row per org). */
-export const listAuditedOrganizationIds = internalQuery({
+/**
+ * Pick which orgs to verify this run. Every org has one `auditLogChainGenesis`
+ * row; we rank them by their integrity-progress `updatedAt` (orgs never
+ * checked, or checked longest ago, first) and take the stalest
+ * `MAX_ORGS_PER_RUN`. Because each verified org's `updatedAt` is bumped to now,
+ * it rotates to the back of the queue and the next run picks up the others —
+ * so a deployment with more than `MAX_ORGS_PER_RUN` audited orgs covers all of
+ * them across runs instead of re-checking the same first window forever
+ * (#1846 item 1). Iterating one small row per org is cheap; the expensive part
+ * is the per-org chain walk, which the cap bounds.
+ */
+export const selectOrgsForIntegrityRun = internalQuery({
   args: {},
   returns: v.object({
     organizationIds: v.array(v.string()),
+    totalOrgs: v.number(),
     truncated: v.boolean(),
   }),
   handler: async (ctx) => {
-    const organizationIds: string[] = [];
-    let truncated = false;
-    for await (const row of ctx.db.query('auditLogChainGenesis')) {
-      if (organizationIds.length >= MAX_ORGS_PER_RUN) {
-        truncated = true;
-        break;
-      }
-      organizationIds.push(row.organizationId);
+    const lastCheckedByOrg = new Map<string, number>();
+    for await (const row of ctx.db.query('auditIntegrityProgress')) {
+      lastCheckedByOrg.set(row.organizationId, row.updatedAt);
     }
-    return { organizationIds, truncated };
+
+    // Never-checked orgs sort first (sentinel -1 < any real timestamp).
+    const orgs: { organizationId: string; lastChecked: number }[] = [];
+    for await (const row of ctx.db.query('auditLogChainGenesis')) {
+      orgs.push({
+        organizationId: row.organizationId,
+        lastChecked: lastCheckedByOrg.get(row.organizationId) ?? -1,
+      });
+    }
+    orgs.sort((a, b) => a.lastChecked - b.lastChecked);
+
+    const organizationIds = orgs
+      .slice(0, MAX_ORGS_PER_RUN)
+      .map((o) => o.organizationId);
+    return {
+      organizationIds,
+      totalOrgs: orgs.length,
+      truncated: orgs.length > MAX_ORGS_PER_RUN,
+    };
   },
 });
 
 /**
- * Unauthenticated chain verification for the cron. Access control is the
- * function's `internal` visibility (only schedulable/runnable from trusted
- * server contexts), not a per-call admin gate — the public `verifyIntegrity`
- * query keeps the admin gate for user-facing access.
+ * Unauthenticated chain verification for the cron, resuming from the org's
+ * persisted progress cursor so each run pages FORWARD instead of re-walking
+ * the oldest window (#1846 item 2). Access control is the function's
+ * `internal` visibility (only schedulable/runnable from trusted server
+ * contexts), not a per-call admin gate — the public `verifyIntegrity` query
+ * keeps the admin gate for user-facing access.
+ *
+ * Returns the chain-verification result plus the `nextCursor` the action
+ * should persist: advanced to the last verified row when this run made
+ * progress, otherwise the unchanged cursor. `headReached` is true only when
+ * the walk consumed the live chain without truncation.
  */
 export const verifyAuditChainForOrg = internalQuery({
   args: {
     organizationId: v.string(),
     maxEntries: v.optional(v.number()),
   },
-  handler: async (ctx, args) => verifyAuditChain(ctx, args),
+  handler: async (ctx, args) => {
+    const progress = await ctx.db
+      .query('auditIntegrityProgress')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .first();
+
+    const result = await verifyAuditChain(ctx, {
+      organizationId: args.organizationId,
+      maxEntries: args.maxEntries,
+      fromTimestamp: progress?.lastVerifiedTimestamp,
+      afterId: progress?.lastVerifiedId,
+      previousExpectedHash: progress?.previousExpectedHash,
+    });
+
+    // Advance the cursor to the last row verified this run; if nothing new was
+    // verified (caught up, no new rows), keep the prior cursor. Never advance
+    // past a detected break, so the next run re-hits and re-alerts it.
+    const nextCursor = {
+      lastVerifiedTimestamp:
+        result.lastVerifiedTimestamp ?? progress?.lastVerifiedTimestamp,
+      lastVerifiedId: result.lastVerifiedId ?? progress?.lastVerifiedId,
+      previousExpectedHash:
+        result.lastVerifiedHash ?? progress?.previousExpectedHash,
+      headReached: result.valid && !result.truncated,
+    };
+
+    return { ...result, nextCursor };
+  },
+});
+
+/**
+ * Persist an org's integrity-check progress cursor. Upserts the per-org
+ * `auditIntegrityProgress` row and bumps `updatedAt` so round-robin selection
+ * rotates this org to the back of the queue. Its own internal mutation so the
+ * action can record progress right after each verification without coupling it
+ * to the (isolated) alert writes.
+ */
+export const recordIntegrityProgress = internalMutation({
+  args: {
+    organizationId: v.string(),
+    lastVerifiedTimestamp: v.optional(v.number()),
+    lastVerifiedId: v.optional(v.string()),
+    previousExpectedHash: v.optional(v.string()),
+    headReached: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const existing = await ctx.db
+      .query('auditIntegrityProgress')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .first();
+    const patch = {
+      lastVerifiedTimestamp: args.lastVerifiedTimestamp,
+      lastVerifiedId: args.lastVerifiedId,
+      previousExpectedHash: args.previousExpectedHash,
+      headReached: args.headReached,
+      updatedAt: Date.now(),
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+    } else {
+      await ctx.db.insert('auditIntegrityProgress', {
+        organizationId: args.organizationId,
+        ...patch,
+      });
+    }
+    return null;
+  },
 });
 
 type IntegrityFindingKind = 'tampering' | 'config';
@@ -145,13 +248,13 @@ export const runAuditIntegrityCheck = internalAction({
   args: {},
   returns: v.null(),
   handler: async (ctx): Promise<null> => {
-    const { organizationIds, truncated } = await ctx.runQuery(
-      internal.audit_logs.integrity_check.listAuditedOrganizationIds,
+    const { organizationIds, totalOrgs, truncated } = await ctx.runQuery(
+      internal.audit_logs.integrity_check.selectOrgsForIntegrityRun,
       {},
     );
     if (truncated) {
       console.warn(
-        `[AuditIntegrity] org list capped at ${MAX_ORGS_PER_RUN}; remaining orgs are checked on the next daily run`,
+        `[AuditIntegrity] verifying the ${MAX_ORGS_PER_RUN} stalest of ${totalOrgs} orgs this run; the rest are picked up on the next daily run`,
       );
     }
 
@@ -176,14 +279,32 @@ export const runAuditIntegrityCheck = internalAction({
         continue;
       }
 
+      // Persist the paging cursor so the next run resumes where this one left
+      // off (forward paging across runs, #1846 item 2) and this org rotates to
+      // the back of the round-robin queue. Isolated try/catch so a failed
+      // progress write never aborts the sweep — worst case the org re-walks
+      // the same window next run.
+      try {
+        await ctx.runMutation(
+          internal.audit_logs.integrity_check.recordIntegrityProgress,
+          { organizationId, ...result.nextCursor },
+        );
+      } catch (err) {
+        console.error(
+          `[AuditIntegrity] could not record progress for org ${organizationId}:`,
+          err,
+        );
+      }
+
       // `truncated` is a coverage limit, not tampering: the chain is longer
       // than the per-run window so the newest rows weren't reached this run.
+      // The forward cursor above means they ARE reached on a later run.
       // Surface it (never silent) but do NOT treat it as a failure — and
       // never as `unsignedScrubCount`, which is only non-zero on deployments
       // with no signing key, where it is the expected legacy state.
       if (result.truncated) {
         console.warn(
-          `[AuditIntegrity] org ${organizationId}: chain exceeds the ${MAX_ENTRIES_PER_ORG}-row window; verified the oldest ${result.verifiedCount}`,
+          `[AuditIntegrity] org ${organizationId}: chain exceeds the ${MAX_ENTRIES_PER_ORG}-row window; verified ${result.verifiedCount} this run, resuming next run`,
         );
       }
 

--- a/services/platform/convex/audit_logs/integrity_check.ts
+++ b/services/platform/convex/audit_logs/integrity_check.ts
@@ -99,6 +99,37 @@ export const verifyAuditChainForOrg = internalQuery({
     organizationId: v.string(),
     maxEntries: v.optional(v.number()),
   },
+  returns: v.object({
+    valid: v.boolean(),
+    verifiedCount: v.number(),
+    checkpointsVerified: v.number(),
+    truncated: v.boolean(),
+    unsignedScrubCount: v.number(),
+    lastVerifiedTimestamp: v.optional(v.number()),
+    lastVerifiedId: v.optional(v.string()),
+    lastVerifiedHash: v.optional(v.string()),
+    firstBrokenAt: v.optional(
+      v.object({
+        logId: v.string(),
+        timestamp: v.number(),
+        expected: v.string(),
+        actual: v.string(),
+      }),
+    ),
+    checkpointMismatch: v.optional(
+      v.object({
+        checkpointId: v.string(),
+        reason: v.string(),
+      }),
+    ),
+    // The cursor the action persists via `recordIntegrityProgress`.
+    nextCursor: v.object({
+      lastVerifiedTimestamp: v.optional(v.number()),
+      lastVerifiedId: v.optional(v.string()),
+      previousExpectedHash: v.optional(v.string()),
+      headReached: v.boolean(),
+    }),
+  }),
   handler: async (ctx, args) => {
     const progress = await ctx.db
       .query('auditIntegrityProgress')
@@ -167,6 +198,46 @@ export const recordIntegrityProgress = internalMutation({
       await ctx.db.insert('auditIntegrityProgress', {
         organizationId: args.organizationId,
         ...patch,
+      });
+    }
+    return null;
+  },
+});
+
+/**
+ * Rotate an org to the back of the round-robin queue WITHOUT advancing its
+ * paging cursor. Used when `verifyAuditChainForOrg` throws: selection ranks by
+ * `updatedAt` ascending (sentinel -1 for never-checked orgs), so an org whose
+ * verification deterministically throws would sort to the front of EVERY run
+ * and — with more than `MAX_ORGS_PER_RUN` such orgs — permanently occupy all
+ * slots, starving healthy orgs past the first window and re-introducing #1846
+ * item 1's gap under error conditions. Bumping `updatedAt` (and only that, so a
+ * later successful run resumes from the same cursor) lets the erroring org
+ * rotate out so the rest of the fleet is still reached. PR #2218 review
+ * BLOCKING 2.
+ */
+export const touchIntegrityProgress = internalMutation({
+  args: {
+    organizationId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const existing = await ctx.db
+      .query('auditIntegrityProgress')
+      .withIndex('by_organizationId', (q) =>
+        q.eq('organizationId', args.organizationId),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { updatedAt: Date.now() });
+    } else {
+      // Never-checked org that throws on its first verification: insert a
+      // cursor-less progress row so its `updatedAt` rotates it to the back
+      // instead of leaving it at the sentinel -1 front of the queue forever.
+      await ctx.db.insert('auditIntegrityProgress', {
+        organizationId: args.organizationId,
+        headReached: false,
+        updatedAt: Date.now(),
       });
     }
     return null;
@@ -276,6 +347,21 @@ export const runAuditIntegrityCheck = internalAction({
           `[AuditIntegrity] could not verify org ${organizationId}:`,
           err,
         );
+        // Rotate the erroring org to the back of the round-robin queue so a
+        // deterministically-throwing org can't sort to the front of every run
+        // and starve the rest of the fleet (PR #2218 review BLOCKING 2).
+        // Isolated try/catch — a failed touch must not abort the sweep.
+        try {
+          await ctx.runMutation(
+            internal.audit_logs.integrity_check.touchIntegrityProgress,
+            { organizationId },
+          );
+        } catch (touchErr) {
+          console.error(
+            `[AuditIntegrity] could not rotate erroring org ${organizationId}:`,
+            touchErr,
+          );
+        }
         continue;
       }
 

--- a/services/platform/convex/audit_logs/schema.ts
+++ b/services/platform/convex/audit_logs/schema.ts
@@ -164,3 +164,38 @@ export const auditLogChainGenesisTable = defineTable({
   organizationId: v.string(),
   lastInsertedAt: v.number(),
 }).index('by_organizationId', ['organizationId']);
+
+/**
+ * Per-org progress cursor for the scheduled integrity check (#1505, #1846).
+ *
+ * The daily cron can only verify a bounded number of rows per org per run
+ * (`MAX_ENTRIES_PER_ORG`) and a bounded number of orgs per run
+ * (`MAX_ORGS_PER_RUN`). Without persisted progress the cron re-walked the
+ * oldest window every run, so the NEWEST rows — where live tampering would
+ * land — and every org beyond the first window were never checked (#1846
+ * items 1 + 2). This row stores how far each org's chain has been verified so
+ * the cron pages forward across runs, and `updatedAt` drives round-robin org
+ * selection so every org is reached even past `MAX_ORGS_PER_RUN`.
+ *
+ * Read + written by `audit_logs/integrity_check.ts`.
+ */
+export const auditIntegrityProgressTable = defineTable({
+  organizationId: v.string(),
+  /** Timestamp of the last verified row — resume lower bound (`fromTimestamp`). */
+  lastVerifiedTimestamp: v.optional(v.number()),
+  /** `_id` of the last verified row — exact resume cursor (`afterId`). */
+  lastVerifiedId: v.optional(v.string()),
+  /** `integrityHash` of the last verified row — seeds the next page's linkage. */
+  previousExpectedHash: v.optional(v.string()),
+  /**
+   * True when the last run reached the live chain head (no truncation). Still
+   * revisited on later runs to verify newly-appended rows.
+   */
+  headReached: v.boolean(),
+  /**
+   * When this org's cursor was last advanced. Round-robin selection verifies
+   * the stalest orgs first so a deployment with more than `MAX_ORGS_PER_RUN`
+   * audited orgs still covers all of them across runs.
+   */
+  updatedAt: v.number(),
+}).index('by_organizationId', ['organizationId']);

--- a/services/platform/convex/audit_logs/verify_integrity.ts
+++ b/services/platform/convex/audit_logs/verify_integrity.ts
@@ -131,15 +131,30 @@ export const verifyIntegrity = query({
     organizationId: v.string(),
     maxEntries: v.optional(v.number()),
     /**
-     * Page-resume cursor: when set, the walk skips rows with timestamp
-     * < `fromTimestamp` and assumes the caller has already verified the
-     * chain up to that point. The `isFirstEntry` anchor check is skipped
-     * because the caller starts mid-chain. Pre-fix, the response promised
-     * "page from `lastVerifiedTimestamp + 1`" but the query had no such
-     * arg — large-org chains could not be paged, only re-walked from
-     * scratch with bigger `maxEntries`. Round-2 review C.4.1.
+     * Page-resume cursor (lower bound). When set, the walk loads rows with
+     * `timestamp >= fromTimestamp` and skips the head-anchor check because
+     * the caller is resuming mid-chain. Pass the previous page's
+     * `lastVerifiedTimestamp`. For a correct resume, pair it with `afterId`
+     * + `previousExpectedHash` (see below) — `fromTimestamp` alone trusts
+     * the first row of the resumed page as the boundary rather than
+     * cross-checking its linkage. #1846 item 3.
      */
     fromTimestamp: v.optional(v.number()),
+    /**
+     * `_id` of the last row verified on the previous page. Rows up to and
+     * INCLUDING it are skipped. Keyed on `_id` (not a coarse `timestamp + 1`
+     * bump) so same-`timestamp` siblings of the last verified row — which
+     * `gte(fromTimestamp)` re-returns — are verified rather than silently
+     * skipped past. #1846 item 3.
+     */
+    afterId: v.optional(v.string()),
+    /**
+     * `integrityHash` of the last row verified on the previous page. Seeds
+     * the linkage check so the first row of the resumed page is verified
+     * against the real previous hash, not the empty-string genesis sentinel
+     * (which guaranteed a false `firstBrokenAt` pre-fix). #1846 item 3.
+     */
+    previousExpectedHash: v.optional(v.string()),
   },
   returns: v.object({
     valid: v.boolean(),
@@ -155,6 +170,18 @@ export const verifyIntegrity = query({
     truncated: v.boolean(),
     /** Timestamp of the last row the walk verified — useful for paging. */
     lastVerifiedTimestamp: v.optional(v.number()),
+    /**
+     * `_id` of the last row the walk verified. Pass back as `afterId` on the
+     * next page so the resume cursor is exact even across same-`timestamp`
+     * rows. Undefined when nothing was verified this call. #1846 item 3.
+     */
+    lastVerifiedId: v.optional(v.string()),
+    /**
+     * `integrityHash` of the last row the walk verified. Pass back as
+     * `previousExpectedHash` on the next page to seed its linkage check.
+     * Undefined when nothing was verified this call. #1846 item 3.
+     */
+    lastVerifiedHash: v.optional(v.string()),
     /**
      * Count of rows that verified ONLY because their `piiScrubbed` flag
      * was set without a corresponding signed scrub checkpoint covering
@@ -205,13 +232,21 @@ export const verifyIntegrity = query({
  */
 export async function verifyAuditChain(
   ctx: QueryCtx,
-  args: { organizationId: string; maxEntries?: number; fromTimestamp?: number },
+  args: {
+    organizationId: string;
+    maxEntries?: number;
+    fromTimestamp?: number;
+    afterId?: string;
+    previousExpectedHash?: string;
+  },
 ) {
   const maxEntries = args.maxEntries ?? 1000;
   let verifiedCount = 0;
   let checkpointsVerified = 0;
   let unsignedScrubCount = 0;
   let lastVerifiedTimestamp: number | undefined;
+  let lastVerifiedId: string | undefined;
+  let lastVerifiedHash: string | undefined;
   const signingKey = process.env[SIGNING_KEY_ENV];
   const hasSigningKey = typeof signingKey === 'string' && signingKey.length > 0;
 
@@ -254,6 +289,8 @@ export async function verifyAuditChain(
         truncated: false,
         unsignedScrubCount,
         lastVerifiedTimestamp,
+        lastVerifiedId,
+        lastVerifiedHash,
         checkpointMismatch: {
           checkpointId: cp._id,
           reason: 'HMAC signature does not match the active or previous key.',
@@ -268,6 +305,8 @@ export async function verifyAuditChain(
         truncated: false,
         unsignedScrubCount,
         lastVerifiedTimestamp,
+        lastVerifiedId,
+        lastVerifiedHash,
         checkpointMismatch: {
           checkpointId: cp._id,
           reason:
@@ -283,24 +322,54 @@ export async function verifyAuditChain(
   //    chain that we only walked the head of would silently mask
   //    tampering past the cut. Resume from `fromTimestamp` when the
   //    caller is paging mid-chain.
+  //
+  //    Resume skip: drop the already-verified prefix up to AND including
+  //    `afterId`, and do NOT count those skipped rows toward `maxEntries` so a
+  //    resumed page still verifies a full window of NEW rows. Keyed on `_id`
+  //    (not a coarse `timestamp + 1` bump) so same-`timestamp` siblings of the
+  //    last verified row — which `gte(fromTimestamp)` re-returns — are
+  //    verified rather than skipped past and never checked. #1846 item 3.
+  const buildIndexQuery = () =>
+    ctx.db
+      .query('auditLogs')
+      .withIndex('by_organizationId_and_timestamp', (q) =>
+        args.fromTimestamp !== undefined
+          ? q
+              .eq('organizationId', args.organizationId)
+              .gte('timestamp', args.fromTimestamp)
+          : q.eq('organizationId', args.organizationId),
+      )
+      .order('asc');
+
   const entries: Doc<'auditLogs'>[] = [];
   let truncated = false;
-  const indexQuery = ctx.db
-    .query('auditLogs')
-    .withIndex('by_organizationId_and_timestamp', (q) =>
-      args.fromTimestamp !== undefined
-        ? q
-            .eq('organizationId', args.organizationId)
-            .gte('timestamp', args.fromTimestamp)
-        : q.eq('organizationId', args.organizationId),
-    )
-    .order('asc');
-  for await (const log of indexQuery) {
+  let skipping = args.afterId !== undefined;
+  for await (const log of buildIndexQuery()) {
+    if (skipping) {
+      if (String(log._id) === args.afterId) skipping = false;
+      continue;
+    }
     if (entries.length >= maxEntries) {
       truncated = true;
       break;
     }
     entries.push(log);
+  }
+
+  // `afterId` was given but never seen (e.g. retention hard-deleted it since
+  // the last run): re-walk from the range start without skipping. The seeded
+  // `previousExpectedHash` still anchors the first surviving row's linkage, so
+  // coverage continues instead of the cursor stalling on a deleted row.
+  if (args.afterId !== undefined && skipping) {
+    entries.length = 0;
+    truncated = false;
+    for await (const log of buildIndexQuery()) {
+      if (entries.length >= maxEntries) {
+        truncated = true;
+        break;
+      }
+      entries.push(log);
+    }
   }
 
   // 4. Re-anchor across deletion boundaries. The chain head's
@@ -312,13 +381,23 @@ export async function verifyAuditChain(
   //    We verify the most recent checkpoint's anchor invariant
   //    against the live head: a re-write attack post-cut would bend
   //    `previousHash` away from `lastDeletedHash`, surfacing here.
-  let previousExpectedHash = '';
-  // Suppress the head-anchor check when paging mid-chain: the caller
-  // is resuming from `fromTimestamp` and has already verified the
-  // anchor on a prior page. Treating row N (mid-chain) as a "first
-  // entry" would force its previousHash to match a checkpoint, which
-  // it never does for non-anchor rows.
-  let isFirstEntry = args.fromTimestamp === undefined;
+  const isResume = args.fromTimestamp !== undefined;
+  // Suppress the head-anchor check when paging mid-chain: the caller is
+  // resuming and has already verified the anchor on a prior page. Treating
+  // row N (mid-chain) as a "first entry" would force its previousHash to
+  // match a checkpoint, which it never does for non-anchor rows.
+  let isFirstEntry = !isResume;
+  // Seed the linkage check. On a resume the caller passes the previous page's
+  // last `integrityHash` as `previousExpectedHash`, so the first row of this
+  // page is cross-checked against the REAL previous hash. Pre-fix this stayed
+  // `''` and the only seeding site lived inside the skipped `isFirstEntry`
+  // block, so the first resumed row's real previousHash was compared against
+  // `''` → a guaranteed false `firstBrokenAt` with zero tampering. When
+  // resuming without a supplied hash we adopt the first row's own previousHash
+  // (boundary trusted) via `needsSeed` rather than emitting a false break.
+  // #1846 item 3.
+  let previousExpectedHash = args.previousExpectedHash ?? '';
+  let needsSeed = args.previousExpectedHash === undefined;
 
   // Build per-subject scrub windows from SIGNED pii_scrub checkpoints
   // only. A row carrying `actorId === X` is allowed to skip hash
@@ -445,6 +524,8 @@ export async function verifyAuditChain(
             truncated,
             unsignedScrubCount,
             lastVerifiedTimestamp,
+            lastVerifiedId,
+            lastVerifiedHash,
             firstBrokenAt: {
               logId: _id,
               timestamp: entry.timestamp,
@@ -454,8 +535,16 @@ export async function verifyAuditChain(
           };
         }
       }
-      previousExpectedHash = entryPreviousHash;
       isFirstEntry = false;
+    }
+
+    // Seed the expected hash from the first verified row when the caller did
+    // not supply one (fresh walk, or a resume without `previousExpectedHash`):
+    // adopt this row's own previousHash so its linkage check passes and the
+    // walk anchors forward from here.
+    if (needsSeed) {
+      previousExpectedHash = entryPreviousHash;
+      needsSeed = false;
     }
 
     if (entryPreviousHash !== previousExpectedHash) {
@@ -466,6 +555,8 @@ export async function verifyAuditChain(
         truncated,
         unsignedScrubCount,
         lastVerifiedTimestamp,
+        lastVerifiedId,
+        lastVerifiedHash,
         firstBrokenAt: {
           logId: _id,
           timestamp: entry.timestamp,
@@ -485,6 +576,8 @@ export async function verifyAuditChain(
           truncated,
           unsignedScrubCount,
           lastVerifiedTimestamp,
+          lastVerifiedId,
+          lastVerifiedHash,
           firstBrokenAt: {
             logId: _id,
             timestamp: entry.timestamp,
@@ -497,6 +590,8 @@ export async function verifyAuditChain(
 
     previousExpectedHash = integrityHash;
     lastVerifiedTimestamp = entry.timestamp;
+    lastVerifiedId = String(_id);
+    lastVerifiedHash = integrityHash;
     verifiedCount++;
   }
 
@@ -507,5 +602,7 @@ export async function verifyAuditChain(
     truncated,
     unsignedScrubCount,
     lastVerifiedTimestamp,
+    lastVerifiedId,
+    lastVerifiedHash,
   };
 }

--- a/services/platform/convex/audit_logs/verify_integrity.ts
+++ b/services/platform/convex/audit_logs/verify_integrity.ts
@@ -357,10 +357,22 @@ export async function verifyAuditChain(
   }
 
   // `afterId` was given but never seen (e.g. retention hard-deleted it since
-  // the last run): re-walk from the range start without skipping. The seeded
-  // `previousExpectedHash` still anchors the first surviving row's linkage, so
-  // coverage continues instead of the cursor stalling on a deleted row.
-  if (args.afterId !== undefined && skipping) {
+  // the last run): re-walk from the range start without skipping so coverage
+  // continues instead of the cursor stalling on a deleted row.
+  //
+  // Crucially we MUST NOT trust the supplied `previousExpectedHash` for the
+  // first surviving row here: when retention deleted the cursor row AND one or
+  // more rows after it (the realistic case — a daily cutoff jumps past the
+  // cursor by more than one row), the first surviving row's `previousHash` is
+  // the hash of some row BETWEEN the deleted cursor and itself, not the stale
+  // cursor hash, so comparing them yields a guaranteed false `firstBrokenAt`
+  // with zero tampering — a critical false tamper alarm that re-fires every run
+  // (the cursor never advances past a "break"). Instead re-seed from the first
+  // surviving row's own `previousHash` (boundary trusted, exactly as the
+  // `fromTimestamp`-only resume path does) via `afterIdDeleted` → `needsSeed`
+  // below. #1846 item 3 / PR #2218 review BLOCKING 1.
+  const afterIdDeleted = args.afterId !== undefined && skipping;
+  if (afterIdDeleted) {
     entries.length = 0;
     truncated = false;
     for await (const log of buildIndexQuery()) {
@@ -396,8 +408,12 @@ export async function verifyAuditChain(
   // resuming without a supplied hash we adopt the first row's own previousHash
   // (boundary trusted) via `needsSeed` rather than emitting a false break.
   // #1846 item 3.
+  //
+  // `afterIdDeleted` forces the same re-seed even though a hash WAS supplied:
+  // the supplied hash belongs to a retention-deleted cursor row and no longer
+  // links to the first surviving row (PR #2218 review BLOCKING 1).
   let previousExpectedHash = args.previousExpectedHash ?? '';
-  let needsSeed = args.previousExpectedHash === undefined;
+  let needsSeed = args.previousExpectedHash === undefined || afterIdDeleted;
 
   // Build per-subject scrub windows from SIGNED pii_scrub checkpoints
   // only. A row carrying `actorId === X` is allowed to skip hash

--- a/services/platform/convex/schema.ts
+++ b/services/platform/convex/schema.ts
@@ -18,7 +18,11 @@ import {
 } from './agents/webhooks/schema';
 import { approvalsTable } from './approvals/schema';
 import { appInstallationsTable, appProjectBindingsTable } from './apps/schema';
-import { auditLogChainGenesisTable, auditLogsTable } from './audit_logs/schema';
+import {
+  auditIntegrityProgressTable,
+  auditLogChainGenesisTable,
+  auditLogsTable,
+} from './audit_logs/schema';
 import { chatFilterEventsTable } from './chat_filter_events/schema';
 import {
   notificationPreferencesTable,
@@ -161,6 +165,7 @@ export default defineSchema({
   approvals: approvalsTable,
   auditLogs: auditLogsTable,
   auditLogChainGenesis: auditLogChainGenesisTable,
+  auditIntegrityProgress: auditIntegrityProgressTable,
   // Generic file→cache mirror for all `v8-sync` config domains (governance
   // today). Source of truth is the per-org JSON files under
   // `$TALE_CONFIG_DIR/<org>/governance/`; this table is re-derivable. See


### PR DESCRIPTION
## Summary

Resolves the five coverage gaps and latent chain hazards reported in #1846 for the audit-log integrity verifier (`verify_integrity.ts`) and its daily cron (`integrity_check.ts`).

### 1. Orgs beyond the first 500 were never checked
`listAuditedOrganizationIds` always took the **same** first `MAX_ORGS_PER_RUN` genesis rows. Replaced with `selectOrgsForIntegrityRun`, which ranks orgs **round-robin by staleness** (`auditIntegrityProgress.updatedAt`) and verifies the stalest window each run — so every org is reached across runs, and the cron's "checked on the next run" log line is now true.

### 2. Rows past the oldest window were never verified
The cron re-walked the **oldest** rows every run, never reaching the newest segment where live tampering would land. It now **pages forward across runs** from a persisted per-org cursor (new additive `auditIntegrityProgress` table), covering the whole chain over successive runs.

### 3. The documented `fromTimestamp` resume always reported a false break
On resume, `previousExpectedHash` started `''` and the only seeding site lived inside the skipped `isFirstEntry` block, so the first resumed row's real `previousHash` was compared against `''` → guaranteed `firstBrokenAt`. `verifyAuditChain` now accepts `afterId` + `previousExpectedHash`, **seeds the linkage from the previous page's hash**, and uses an **exclusive `(timestamp, _id)` cursor** so same-`timestamp` siblings of the boundary row are verified rather than skipped. A `fromTimestamp`-only resume no longer false-breaks (boundary trusted), and a retention-deleted cursor falls back to a seeded re-walk instead of stalling.

### 4. No write-side timestamp monotonicity clamp (clock regression orphaned a row)
`createAuditLog` now clamps the chain timestamp to `max(now, genesis.lastInsertedAt + 1)`. A backward wall-clock step (NTP correction, VM snapshot restore) can no longer sort a new row before the head it chains off — eliminating the permanent false tamper alarm. The genesis row is already read+patched for OCC, so the clamp is free.

### 5. Same-mutation parallel appends could fork the chain
Within one mutation there was no OCC: two `createAuditLog` calls under `Promise.all` both read the same head and committed the same `previousHash`. `createAuditLog` now **serializes appends sharing a `MutationCtx`** (per-ctx promise chain), so each observes the previous insert as its `lastEntry`. Cross-mutation forks remain guarded by the genesis sentinel + `chainSuccessor` OCC patch.

## Tests
- New `chain_integrity_hardening.test.ts` covers all five fixes (intra-mutation fork, clock-skew clamp, paged resume + false-break guard, forward cursor advancement, org selection).
- All `convex/audit_logs/` tests pass (36), plus `governance/legal_hold` + `users` suites (29) which exercise the shared audit writer.

## Verification
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on touched files — 0 warnings/errors
- `bun run migrations:check` — green (new table is data-safe; no migration needed)
- SAST (Opengrep) pre-commit hook on changed files — 0 findings

No user-visible strings, env vars, or docs changed (internal backend control), so translations/docs are N/A.

Closes #1846