### PR TITLE
fix(convex): throw ConvexError from admin-gated governance and audit_logs queries (#2016)

### DIFF
--- a/services/platform/convex/audit_logs/queries.test.ts
+++ b/services/platform/convex/audit_logs/queries.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #2016: the `!authUser` gates in the public audit-log queries must throw
+// `ConvexError({ code: 'UNAUTHENTICATED' })` so the client can branch on the
+// structured code. `read_access.test.ts` covers the FORBIDDEN (admin) path via
+// `assertAuditLogReadAccess`; these tests lock the UNAUTHENTICATED `data.code`
+// on the four query handlers themselves.
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    query: (config: Record<string, unknown>) => config,
+  };
+});
+
+const mockGetAuthUserIdentity = vi.fn();
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls', () => ({
+  getAuthUserIdentity: (...args: unknown[]) => mockGetAuthUserIdentity(...args),
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+// Helpers/validators sit past the auth gate — stub them so importing
+// queries.ts stays a unit test.
+vi.mock('./helpers', () => ({
+  listAuditLogs: vi.fn(),
+  getActivitySummary: vi.fn(),
+}));
+vi.mock('./list_audit_logs_paginated', () => ({
+  listAuditLogsPaginated: vi.fn(),
+}));
+vi.mock('./validators', () => ({
+  auditLogFilterValidator: 'auditLogFilter:validator',
+  auditLogItemValidator: 'auditLogItem:validator',
+}));
+
+vi.mock('convex/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('convex/server')>();
+  return {
+    ...actual,
+    paginationOptsValidator: 'paginationOpts:validator',
+  };
+});
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      union: stub,
+      object: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+      id: stub,
+      any: stub,
+      record: stub,
+    },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : JSON.stringify(data));
+        this.data = data;
+      }
+    },
+  };
+});
+
+// The `query` mock replaces the Convex builder with an identity function, so
+// the runtime shape is `{ args, returns, handler }`. The module's static type
+// stays the original Convex function reference, hence the narrowing here.
+// Treated as a "third-party gap" per AGENTS.md.
+//
+// oxlint-disable-next-line typescript/no-explicit-any -- see above
+type QueryHandler = { handler: (...args: unknown[]) => Promise<any> };
+async function importQueries(): Promise<Record<string, QueryHandler>> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- see above
+  return (await import('./queries')) as unknown as Record<string, QueryHandler>;
+}
+
+const PAGINATION = { numItems: 20, cursor: null };
+
+const UNAUTH_GATED: Array<{ name: string; args: Record<string, unknown> }> = [
+  { name: 'listAuditLogs', args: { organizationId: 'org_1' } },
+  {
+    name: 'listAuditLogsPaginated',
+    args: { paginationOpts: PAGINATION, organizationId: 'org_1' },
+  },
+  {
+    name: 'listErrorLogsPaginated',
+    args: { paginationOpts: PAGINATION, organizationId: 'org_1' },
+  },
+  { name: 'getActivitySummary', args: { organizationId: 'org_1' } },
+];
+
+describe('audit_logs/queries UNAUTHENTICATED gate codes (#2016)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(UNAUTH_GATED)(
+    '$name throws ConvexError UNAUTHENTICATED when not signed in',
+    async ({ name, args }) => {
+      mockGetAuthUserIdentity.mockResolvedValue(null);
+      const handlers = await importQueries();
+      const ctx = { db: {} };
+      await expect(handlers[name].handler(ctx, args)).rejects.toMatchObject({
+        data: { code: 'UNAUTHENTICATED' },
+      });
+    },
+  );
+});

--- a/services/platform/convex/audit_logs/queries.ts
+++ b/services/platform/convex/audit_logs/queries.ts
@@ -1,5 +1,5 @@
 import { paginationOptsValidator } from 'convex/server';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import { getAuthUserIdentity, getOrganizationMember } from '../lib/rls';
@@ -17,7 +17,10 @@ import { auditLogFilterValidator, auditLogItemValidator } from './validators';
  */
 export function assertAuditLogReadAccess(member: OrganizationMember): void {
   if (!isAdmin(member.role)) {
-    throw new Error('Only admins can read audit logs');
+    throw new ConvexError({
+      code: 'FORBIDDEN',
+      message: 'Only admins can read audit logs',
+    });
   }
 }
 
@@ -35,7 +38,10 @@ export const listAuditLogs = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(
@@ -64,7 +70,10 @@ export const listAuditLogsPaginated = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(
@@ -92,7 +101,10 @@ export const listErrorLogsPaginated = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(
@@ -135,7 +147,10 @@ export const getActivitySummary = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(

--- a/services/platform/convex/audit_logs/read_access.test.ts
+++ b/services/platform/convex/audit_logs/read_access.test.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { describe, expect, it } from 'vitest';
 
 import type { OrganizationMember } from '../lib/rls/types';
@@ -31,6 +32,17 @@ describe('assertAuditLogReadAccess', () => {
       expect(() => assertAuditLogReadAccess(memberWithRole(role))).toThrow(
         'Only admins can read audit logs',
       );
+
+      let caught: unknown;
+      try {
+        assertAuditLogReadAccess(memberWithRole(role));
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ConvexError);
+      expect((caught as ConvexError<{ code: string }>).data).toMatchObject({
+        code: 'FORBIDDEN',
+      });
     },
   );
 });

--- a/services/platform/convex/governance/dsar_policy.test.ts
+++ b/services/platform/convex/governance/dsar_policy.test.ts
@@ -648,3 +648,37 @@ describe('applyPendingDsarPolicyChange', () => {
     expect(mockWriteNotification).not.toHaveBeenCalled();
   });
 });
+
+// #2016: the read gate must throw `ConvexError({ code })` so the client can
+// branch — UNAUTHENTICATED when signed out, FORBIDDEN for a non-admin/owner.
+// Message-only assertions would pass against a raw throw, so assert data.code.
+describe('getDsarPolicyForUi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws ConvexError UNAUTHENTICATED when not signed in', async () => {
+    mockGetAuthUser.mockResolvedValue(null);
+    const m = await loadDsarPolicy();
+    const ctx = createMockCtx(emptyState());
+    await expect(
+      m.getDsarPolicyForUi.handler(ctx, { organizationId: 'org_A' }),
+    ).rejects.toMatchObject({ data: { code: 'UNAUTHENTICATED' } });
+    await expect(
+      m.getDsarPolicyForUi.handler(ctx, { organizationId: 'org_A' }),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
+  it('throws ConvexError FORBIDDEN for a non-admin/owner member', async () => {
+    mockGetAuthUser.mockResolvedValue({
+      _id: 'member_user',
+      email: 'member@example.com',
+    });
+    mockGetOrganizationMember.mockResolvedValue({ role: 'member' });
+    const m = await loadDsarPolicy();
+    const ctx = createMockCtx(emptyState());
+    await expect(
+      m.getDsarPolicyForUi.handler(ctx, { organizationId: 'org_A' }),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN' } });
+  });
+});

--- a/services/platform/convex/governance/dsar_policy.ts
+++ b/services/platform/convex/governance/dsar_policy.ts
@@ -167,14 +167,21 @@ export const getDsarPolicyForUi = query({
   }),
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser)
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     const member = await getOrganizationMember(
       ctx,
       args.organizationId,
       authUser,
     );
     if (member.role !== 'owner' && member.role !== 'admin') {
-      throw new Error('Reading dsar_governance requires admin or owner role.');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Reading dsar_governance requires admin or owner role.',
+      });
     }
 
     const config = await getDsarPolicy(ctx, args.organizationId);

--- a/services/platform/convex/governance/erasure_queries.test.ts
+++ b/services/platform/convex/governance/erasure_queries.test.ts
@@ -50,6 +50,13 @@ vi.mock('convex/values', () => {
       any: stub,
       record: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : JSON.stringify(data));
+        this.data = data;
+      }
+    },
   };
 });
 

--- a/services/platform/convex/governance/erasure_queries.test.ts
+++ b/services/platform/convex/governance/erasure_queries.test.ts
@@ -189,6 +189,12 @@ describe('listErasureRequests', () => {
         organizationId: 'org_1',
       }),
     ).rejects.toThrow('Unauthenticated');
+    await expect(
+      listErasureRequests.handler(ctx, {
+        paginationOpts: PAGINATION,
+        organizationId: 'org_1',
+      }),
+    ).rejects.toMatchObject({ data: { code: 'UNAUTHENTICATED' } });
   });
 
   it('throws when caller is not an admin', async () => {
@@ -202,6 +208,12 @@ describe('listErasureRequests', () => {
         organizationId: 'org_1',
       }),
     ).rejects.toThrow('Admin role required.');
+    await expect(
+      listErasureRequests.handler(ctx, {
+        paginationOpts: PAGINATION,
+        organizationId: 'org_1',
+      }),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN' } });
   });
 
   it('shapes summaries with names resolved and threadsTargeted as a count', async () => {
@@ -293,6 +305,9 @@ describe('getErasureRequest', () => {
     await expect(
       getErasureRequest.handler(ctx, { requestId: 'er_1' }),
     ).rejects.toThrow('Admin role required.');
+    await expect(
+      getErasureRequest.handler(ctx, { requestId: 'er_1' }),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN' } });
   });
 
   it('returns row plus the gdpr_erasure_* audit chain', async () => {

--- a/services/platform/convex/governance/erasure_queries.ts
+++ b/services/platform/convex/governance/erasure_queries.ts
@@ -17,7 +17,7 @@
  */
 
 import { paginationOptsValidator } from 'convex/server';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { Doc } from '../_generated/dataModel';
 import type { QueryCtx } from '../_generated/server';
@@ -45,11 +45,17 @@ async function requireAdmin(
 ): Promise<{ userId: string; role: string }> {
   const authUser = await getAuthUserIdentity(ctx);
   if (!authUser) {
-    throw new Error('Unauthenticated');
+    throw new ConvexError({
+      code: 'UNAUTHENTICATED',
+      message: 'Unauthenticated',
+    });
   }
   const member = await getOrganizationMember(ctx, organizationId, authUser);
   if (!isAdmin(member.role)) {
-    throw new Error('Admin role required.');
+    throw new ConvexError({
+      code: 'FORBIDDEN',
+      message: 'Admin role required.',
+    });
   }
   return { userId: authUser.userId, role: member.role };
 }

--- a/services/platform/convex/governance/legal_hold_queries.test.ts
+++ b/services/platform/convex/governance/legal_hold_queries.test.ts
@@ -254,6 +254,9 @@ describe('legal_hold_queries.listLegalHolds', () => {
     await expect(
       listLegalHolds.handler(ctx, { organizationId: 'org_1' }),
     ).rejects.toThrow('Unauthenticated');
+    await expect(
+      listLegalHolds.handler(ctx, { organizationId: 'org_1' }),
+    ).rejects.toMatchObject({ data: { code: 'UNAUTHENTICATED' } });
   });
 
   it('throws when caller is not an admin', async () => {
@@ -266,6 +269,9 @@ describe('legal_hold_queries.listLegalHolds', () => {
     await expect(
       listLegalHolds.handler(ctx, { organizationId: 'org_1' }),
     ).rejects.toThrow('Admin role required.');
+    await expect(
+      listLegalHolds.handler(ctx, { organizationId: 'org_1' }),
+    ).rejects.toMatchObject({ data: { code: 'FORBIDDEN' } });
   });
 
   it('returns empty array when org has no holds', async () => {

--- a/services/platform/convex/governance/legal_hold_queries.test.ts
+++ b/services/platform/convex/governance/legal_hold_queries.test.ts
@@ -47,6 +47,13 @@ vi.mock('convex/values', () => {
       null: stub,
       id: stub,
     },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : JSON.stringify(data));
+        this.data = data;
+      }
+    },
   };
 });
 

--- a/services/platform/convex/governance/legal_hold_queries.ts
+++ b/services/platform/convex/governance/legal_hold_queries.ts
@@ -15,7 +15,7 @@
  */
 
 import { paginationOptsValidator } from 'convex/server';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { getNumber, getString, isRecord } from '../../lib/utils/type-utils';
 import { components } from '../_generated/api';
@@ -62,7 +62,10 @@ async function requireAdmin(
 ): Promise<{ userId: string; role: string }> {
   const authUser = await getAuthUserIdentity(ctx);
   if (!authUser) {
-    throw new Error('Unauthenticated');
+    throw new ConvexError({
+      code: 'UNAUTHENTICATED',
+      message: 'Unauthenticated',
+    });
   }
   const member = await getOrganizationMember(ctx, organizationId, {
     userId: authUser.userId,
@@ -70,7 +73,10 @@ async function requireAdmin(
     name: authUser.name ?? undefined,
   });
   if (!isAdmin(member.role)) {
-    throw new Error('Admin role required.');
+    throw new ConvexError({
+      code: 'FORBIDDEN',
+      message: 'Admin role required.',
+    });
   }
   return { userId: authUser.userId, role: member.role };
 }
@@ -81,7 +87,10 @@ async function requireMember(
 ): Promise<{ userId: string; role: string; isAdmin: boolean }> {
   const authUser = await getAuthUserIdentity(ctx);
   if (!authUser) {
-    throw new Error('Unauthenticated');
+    throw new ConvexError({
+      code: 'UNAUTHENTICATED',
+      message: 'Unauthenticated',
+    });
   }
   const member = await getOrganizationMember(ctx, organizationId, {
     userId: authUser.userId,

--- a/services/platform/convex/governance/queries.test.ts
+++ b/services/platform/convex/governance/queries.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #2016: the admin/auth gates in governance/queries.ts must throw
+// `ConvexError({ code })` (UNAUTHENTICATED / FORBIDDEN) so the client can
+// branch on the structured code — not a raw `Error`. The message-only
+// assertions elsewhere would pass identically against a raw throw, so these
+// tests lock the `data.code` contract on the file named in the issue title.
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    query: (config: Record<string, unknown>) => config,
+  };
+});
+
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+// Sibling modules the gated handlers only reach *after* the auth check —
+// stubbed so importing queries.ts doesn't pull their (codegen-dependent)
+// transitive graph into the unit test.
+vi.mock('../documents/get_user_names_batch', () => ({
+  getUserNamesBatch: vi.fn(async () => new Map<string, string>()),
+}));
+vi.mock('../lib/get_user_teams', () => ({
+  getUserTeamIds: vi.fn(async () => [] as string[]),
+}));
+vi.mock('./budget_enforcement', () => ({ checkBudget: vi.fn() }));
+vi.mock('./feature_enforcement', () => ({ resolveFeatureFlags: vi.fn() }));
+vi.mock('./get_org_usage_metrics', () => ({ getOrgUsageMetrics: vi.fn() }));
+vi.mock('./model_access_enforcement', () => ({ getAccessibleModels: vi.fn() }));
+vi.mock('./read_guardrails_policies', () => ({
+  readGuardrailsPolicies: vi.fn(async () => [] as unknown[]),
+}));
+vi.mock('./schema', () => ({
+  GOVERNANCE_POLICY_TYPES: ['retention_policy', 'feature_flags'],
+}));
+vi.mock('./soft_delete_helpers', () => ({ SOFT_DELETE_RESOURCE_CONFIG: {} }));
+vi.mock('./soft_delete_validators', () => ({
+  softDeleteResourceTypeValidator: 'softDeleteResourceType:validator',
+}));
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  return {
+    v: {
+      string: stub,
+      number: stub,
+      boolean: stub,
+      optional: stub,
+      union: stub,
+      object: stub,
+      literal: stub,
+      array: stub,
+      null: stub,
+      id: stub,
+      any: stub,
+      record: stub,
+    },
+    ConvexError: class ConvexError extends Error {
+      data: unknown;
+      constructor(data: unknown) {
+        super(typeof data === 'string' ? data : JSON.stringify(data));
+        this.data = data;
+      }
+    },
+  };
+});
+
+// The `query` mock replaces the Convex builder with an identity function, so
+// the runtime shape is `{ args, returns, handler }`. The module's static type
+// stays the original Convex function reference, hence the narrowing here.
+// Treated as a "third-party gap" per AGENTS.md.
+//
+// oxlint-disable-next-line typescript/no-explicit-any -- see above
+type QueryHandler = { handler: (...args: unknown[]) => Promise<any> };
+async function importQueries(): Promise<Record<string, QueryHandler>> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- see above
+  return (await import('./queries')) as unknown as Record<string, QueryHandler>;
+}
+
+function createMockCtx(identity: unknown) {
+  return {
+    auth: {
+      getUserIdentity: vi.fn(async () => identity),
+    },
+    db: {
+      // The gates throw before any db read; a throwing stub proves it.
+      query: vi.fn(() => {
+        throw new Error('db should not be queried after a failed gate');
+      }),
+    },
+  };
+}
+
+const AUTHED = { subject: 'user_1', email: 'member@example.com', name: 'Mem' };
+
+// Each entry: the gated handler, the args it needs, and the code its FORBIDDEN
+// (non-admin) branch must carry. UNAUTHENTICATED is asserted uniformly.
+const ADMIN_GATED: Array<{
+  name: string;
+  args: Record<string, unknown>;
+}> = [
+  { name: 'getPendingRetentionChange', args: { organizationId: 'org_1' } },
+  {
+    name: 'getPolicy',
+    // retention_policy is *not* member-readable -> sensitive, admin-only.
+    args: { organizationId: 'org_1', policyType: 'retention_policy' },
+  },
+  {
+    name: 'getUsageSummary',
+    args: { organizationId: 'org_1' },
+  },
+  {
+    name: 'getOrgUsageMetrics',
+    args: {
+      organizationId: 'org_1',
+      periodDays: 7,
+      granularity: 'daily',
+    },
+  },
+  { name: 'listTrashedRows', args: { organizationId: 'org_1' } },
+];
+
+describe('governance/queries admin-gate error codes (#2016)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(ADMIN_GATED)(
+    '$name throws ConvexError UNAUTHENTICATED when not signed in',
+    async ({ name, args }) => {
+      const handlers = await importQueries();
+      const ctx = createMockCtx(null);
+      await expect(handlers[name].handler(ctx, args)).rejects.toMatchObject({
+        data: { code: 'UNAUTHENTICATED' },
+      });
+    },
+  );
+
+  it.each(ADMIN_GATED)(
+    '$name throws ConvexError FORBIDDEN for a non-admin member',
+    async ({ name, args }) => {
+      mockGetOrganizationMember.mockResolvedValue({ role: 'member' });
+      const handlers = await importQueries();
+      const ctx = createMockCtx(AUTHED);
+      await expect(handlers[name].handler(ctx, args)).rejects.toMatchObject({
+        data: { code: 'FORBIDDEN' },
+      });
+    },
+  );
+});

--- a/services/platform/convex/governance/queries.ts
+++ b/services/platform/convex/governance/queries.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { query } from '../_generated/server';
 import type { QueryCtx } from '../_generated/server';
@@ -32,14 +32,20 @@ export const getPendingRetentionChange = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
     const member = await getOrganizationMember(ctx, args.organizationId, {
       userId: authUser.userId,
       email: authUser.email ?? '',
     });
     if (!isAdmin(member.role)) {
-      throw new Error('Admin role required.');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Admin role required.',
+      });
     }
     const row = await ctx.db
       .query('retentionPolicyPendingChanges')
@@ -97,7 +103,10 @@ export const getPolicy = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(ctx, args.organizationId, {
@@ -112,7 +121,10 @@ export const getPolicy = query({
       !POLICY_TYPES_READABLE_BY_MEMBER.has(args.policyType) &&
       !isAdmin(member.role)
     ) {
-      throw new Error(`Reading ${args.policyType} requires admin role.`);
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: `Reading ${args.policyType} requires admin role.`,
+      });
     }
 
     const policy = await ctx.db
@@ -155,7 +167,10 @@ export const listPolicies = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(ctx, args.organizationId, {
@@ -209,7 +224,10 @@ export const getUsageSummary = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(ctx, args.organizationId, {
@@ -218,7 +236,10 @@ export const getUsageSummary = query({
       name: authUser.name,
     });
     if (!isAdmin(member.role)) {
-      throw new Error('Only admins can view usage summaries');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Only admins can view usage summaries',
+      });
     }
 
     const now = new Date();
@@ -299,7 +320,10 @@ export const getOrgUsageMetrics = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(ctx, args.organizationId, {
@@ -308,7 +332,10 @@ export const getOrgUsageMetrics = query({
       name: authUser.name,
     });
     if (!isAdmin(member.role)) {
-      throw new Error('Only admins can view usage metrics');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Only admins can view usage metrics',
+      });
     }
 
     return getOrgUsageMetricsHandler(ctx, args);
@@ -322,7 +349,10 @@ export const getMyFeatureFlags = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const userId = authUser.userId;
@@ -438,7 +468,10 @@ export const getAccessibleModelsForUser = query({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     }
 
     const member = await getOrganizationMember(ctx, args.organizationId, {
@@ -549,14 +582,21 @@ export const listTrashedRows = query({
     args,
   ): Promise<{ rows: TrashRow[]; nextCursor: TrashCursor | null }> => {
     const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) throw new Error('Unauthenticated');
+    if (!authUser)
+      throw new ConvexError({
+        code: 'UNAUTHENTICATED',
+        message: 'Unauthenticated',
+      });
     const member = await getOrganizationMember(ctx, args.organizationId, {
       userId: authUser.userId,
       email: authUser.email,
       name: authUser.name,
     });
     if (!isAdmin(member.role)) {
-      throw new Error('Trash listing requires admin role.');
+      throw new ConvexError({
+        code: 'FORBIDDEN',
+        message: 'Trash listing requires admin role.',
+      });
     }
 
     const limit = Math.min(


### PR DESCRIPTION
## Summary

Admin/auth gates in the governance and audit-log read paths threw raw `Error`, which reaches the client as an unstructured "Server Error" — the frontend can't dispatch on it (e.g. redirect to an access-denied page). These query errors are especially impactful because they can fire on every subscription cycle.

This replaces every auth/permission-gate `throw new Error(...)` in the affected modules with `ConvexError({ code, message })`, using the stable codes the client can branch on:

- `UNAUTHENTICATED` — no auth user.
- `FORBIDDEN` — authenticated but lacks the required (admin/owner) role.

The original human-readable text is preserved in the `message` field, so existing substring assertions and logs are unaffected.

## Files changed

- `governance/queries.ts` — all 13 unauth/admin gates (`getPendingRetentionChange`, `getPolicy`, `listPolicies`, `getUsageSummary`, `getOrgUsageMetrics`, `getMyFeatureFlags`, `getAccessibleModelsForUser`, `listTrashedRows`).
- `audit_logs/queries.ts` — `assertAuditLogReadAccess` + the four `Unauthenticated` gates.
- `governance/erasure_queries.ts` — `requireAdmin`.
- `governance/legal_hold_queries.ts` — `requireAdmin` + `requireMember`.
- `governance/dsar_policy.ts` — the dsar_governance read gate.
- Test mocks (`legal_hold_queries.test.ts`, `erasure_queries.test.ts`) — added a `ConvexError` stub to the `convex/values` mock so the gate assertions exercise the new path.

## Verification

- `vitest --project server convex/governance convex/audit_logs` — 309 passed.
- `tsc --noEmit` — no new errors in the touched files.
- `oxlint --type-aware` on the changed files — 0 warnings, 0 errors.

Closes #2016