### PR TITLE
fix: clarify automations executions search placeholder (#1985)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -861,7 +861,7 @@
     "executions": {
       "title": "Ausführungen",
       "entityLabel": "Ausführungen",
-      "searchPlaceholder": "Ausführungen suchen"
+      "searchPlaceholder": "Nach Ausführungs-ID suchen"
     },
     "createDialog": {
       "title": "Automatisierung erstellen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -861,7 +861,7 @@
     "executions": {
       "title": "Executions",
       "entityLabel": "executions",
-      "searchPlaceholder": "Search executions"
+      "searchPlaceholder": "Search by execution ID"
     },
     "createDialog": {
       "title": "Create automation",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -862,7 +862,7 @@
     "executions": {
       "title": "Exécutions",
       "entityLabel": "exécutions",
-      "searchPlaceholder": "Rechercher des exécutions"
+      "searchPlaceholder": "Rechercher par ID d'exécution"
     },
     "createDialog": {
       "title": "Créer une automatisation",


### PR DESCRIPTION
Closes #1985

## Problem
The Automations → Executions "Search" box only matches an exact execution ID (via `ctx.db.normalizeId` in `list_executions_cursor.ts`), but the placeholder "Search executions" implied a broader, general-purpose search. Typing anything other than a full execution ID returned nothing, which was confusing.

## Change
Clarified the placeholder text to set the correct expectation that it is an execution-ID lookup:

- en: `Search executions` → `Search by execution ID`
- de: `Ausführungen suchen` → `Nach Ausführungs-ID suchen`
- fr: `Rechercher des exécutions` → `Rechercher par ID dexécution`

This is the lowest-risk of the two options proposed in the issue (clarify placeholder vs. extend the search backend). It resolves the UX-clarity concern without changing query semantics or indexes.

## Verification
- `bunx vitest --run executions-table.test.tsx` — passing
- JSON validity confirmed for all three locale files (no key changes, values only)