### PR TITLE
fix(platform): structured secret errors, name validation, atomic basic write (#2058)

### DIFF
--- a/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { Id } from '@/convex/_generated/dataModel';
@@ -19,6 +20,7 @@ import { ProjectSecretsTab } from './project-secrets-tab';
 // button invokes deleteProjectSecret with that secret's name.
 
 const mockSetMutateAsync = vi.fn().mockResolvedValue(undefined);
+const mockSetPairMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockDeleteMutateAsync = vi.fn().mockResolvedValue(undefined);
 let secretsFixture: { name: string; description?: string }[] = [];
 
@@ -28,6 +30,10 @@ vi.mock('../hooks/secrets', () => ({
     mutateAsync: mockSetMutateAsync,
     isPending: false,
   }),
+  useSetProjectSecretPair: () => ({
+    mutateAsync: mockSetPairMutateAsync,
+    isPending: false,
+  }),
   useDeleteProjectSecret: () => ({
     mutateAsync: mockDeleteMutateAsync,
     isPending: false,
@@ -35,10 +41,12 @@ vi.mock('../hooks/secrets', () => ({
 }));
 
 // The component imports the standalone `toast` fn directly; stub it so the
-// success/error toasts don't reach the real toast store.
+// success/error toasts don't reach the real toast store while still letting
+// tests assert what was shown.
+const mockToast = vi.fn();
 vi.mock('@/app/hooks/use-toast', () => ({
-  toast: vi.fn(),
-  useToast: () => ({ toast: vi.fn() }),
+  toast: (...args: unknown[]) => mockToast(...args),
+  useToast: () => ({ toast: mockToast }),
 }));
 
 // FormDialog (the dialog shell) reads the org id from the router for its error
@@ -151,6 +159,103 @@ describe('ProjectSecretsTab', () => {
           value: 'tale-e2e-depth-secret-value',
         }),
       );
+    });
+
+    it('writes a "basic" credential through the single atomic pair action', async () => {
+      const { user } = renderTab();
+
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+
+      // Switch the type to "Username & password" so the form collects a pair.
+      await user.click(screen.getByRole('combobox', { name: /type/i }));
+      await user.click(
+        await screen.findByRole('option', { name: /username & password/i }),
+      );
+
+      // `Name` substring-matches `Username` too once both fields render, so
+      // anchor to the field whose accessible name starts with "Name".
+      await user.type(screen.getByLabelText(/^name/i), 'svc');
+      await user.type(
+        screen.getByLabelText('Username', { exact: false }),
+        'alice',
+      );
+      // The password field carries a show/hide toggle whose aria-label also
+      // contains "password"; anchor to the field label itself.
+      await user.type(screen.getByLabelText(/^password/i), 's3cret');
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // The pair is written by ONE atomic action — never two sequential
+      // setProjectSecret calls (the non-atomic path the bug fixed).
+      await waitFor(() => {
+        expect(mockSetPairMutateAsync).toHaveBeenCalledTimes(1);
+      });
+      expect(mockSetMutateAsync).not.toHaveBeenCalled();
+      expect(mockSetPairMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: 'org-1',
+          projectId: PROJECT_ID,
+          baseName: 'SVC',
+          username: 'alice',
+          password: 's3cret',
+        }),
+      );
+    });
+
+    it('blocks a malformed name client-side without calling the action', async () => {
+      const { user } = renderTab();
+
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+
+      const nameField = screen.getByLabelText('Name', { exact: false });
+      const save = screen.getByRole('button', { name: 'Save' });
+      const invalidMessage =
+        'Name must start with a letter and use only A–Z, 0–9 and underscores.';
+
+      // Leading digit fails the `^[A-Z][A-Z0-9_]{0,63}$` shape.
+      await user.type(nameField, '1bad');
+      await user.type(
+        screen.getByLabelText('API key', { exact: false }),
+        'some-value',
+      );
+
+      // Inline field error surfaces before any submit; Save stays disabled.
+      expect(await screen.findByText(invalidMessage)).toBeInTheDocument();
+      expect(save).toBeDisabled();
+      expect(mockSetMutateAsync).not.toHaveBeenCalled();
+      expect(mockSetPairMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('maps a SECRET_FORBIDDEN ConvexError to its specific toast', async () => {
+      mockSetMutateAsync.mockRejectedValueOnce(
+        new ConvexError({ code: 'SECRET_FORBIDDEN' }),
+      );
+      const { user } = renderTab();
+
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+
+      await user.type(
+        screen.getByLabelText('Name', { exact: false }),
+        'good_name',
+      );
+      await user.type(
+        screen.getByLabelText('API key', { exact: false }),
+        'some-value',
+      );
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title:
+              "You don't have permission to manage this project's secrets.",
+            variant: 'destructive',
+          }),
+        );
+      });
     });
   });
 

--- a/services/platform/app/features/projects/components/project-secrets-tab.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.tsx
@@ -16,11 +16,13 @@ import { toast } from '@/app/hooks/use-toast';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useT } from '@/lib/i18n/client';
 import { SECRET_NAME_MAX, SECRET_NAME_RE } from '@/lib/shared/schemas/secrets';
+import { convexErrorCode } from '@/lib/utils/convex-error';
 
 import {
   useDeleteProjectSecret,
   useProjectSecrets,
   useSetProjectSecret,
+  useSetProjectSecretPair,
 } from '../hooks/secrets';
 
 /** Credential shapes the form knows how to collect. All map onto the generic
@@ -47,6 +49,7 @@ export function ProjectSecretsTab({
   const { t: tCommon } = useT('common');
   const { secrets } = useProjectSecrets(projectId);
   const setSecret = useSetProjectSecret();
+  const setSecretPair = useSetProjectSecretPair();
   const deleteSecret = useDeleteProjectSecret();
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -102,12 +105,23 @@ export function ProjectSecretsTab({
 
   const isEditing = editingName !== null;
 
+  const baseName = name.trim().toUpperCase();
+  // For `basic`, the stored names carry the `_USERNAME`/`_PASSWORD` suffix, so
+  // validate those full names rather than the bare base.
+  const fullNames =
+    type === 'basic' && !isEditing
+      ? [`${baseName}_USERNAME`, `${baseName}_PASSWORD`]
+      : [baseName];
+
   // Mirror the server's env-var-name rule (SECRET_NAME_RE) client-side so an
   // invalid or whitespace-only name is caught inline — disabling Save and showing
   // a message — instead of round-tripping to a generic SECRET_NAME_INVALID toast
   // that leaves the dialog stuck. An existing secret's name is fixed and already
   // valid, so only the create path is checked.
-  const nameValid = isEditing || SECRET_NAME_RE.test(name.trim());
+  const nameValid =
+    isEditing ||
+    (name.trim().length > 0 &&
+      fullNames.every((secretName) => SECRET_NAME_RE.test(secretName)));
   const nameError =
     !isEditing && name.length > 0 && !nameValid ? t('nameInvalid') : undefined;
 
@@ -118,10 +132,43 @@ export function ProjectSecretsTab({
       username.length > 0 ||
       password.length > 0;
 
+  const isSaving = setSecret.isPending || setSecretPair.isPending;
+
+  // Map a save failure to the most specific toast we can. The secrets actions
+  // raise `ConvexError({ code })` for expected failures; an unrecognized throw
+  // (or a raw encryption error, redacted to "Server Error" in prod) falls back
+  // to the actionable encryption hint or the generic message.
+  const saveErrorTitle = (error: unknown): string => {
+    switch (convexErrorCode(error)) {
+      case 'SECRET_NAME_INVALID':
+        return t('errors.nameInvalid');
+      case 'SECRET_VALUE_INVALID':
+        return t('errors.valueInvalid');
+      case 'UNAUTHENTICATED':
+        return t('errors.unauthenticated');
+      case 'SECRET_FORBIDDEN':
+        return t('errors.forbidden');
+      case 'PROJECT_NOT_FOUND':
+        return t('errors.projectNotFound');
+      default: {
+        const message = error instanceof Error ? error.message : String(error);
+        // The encryption key is a server env var (`tale init` generates it);
+        // surface that actionable cause instead of a generic failure.
+        return /ENCRYPTION_SECRET_HEX/.test(message)
+          ? t('encryptionNotConfigured')
+          : tCommon('errors.generic');
+      }
+    }
+  };
+
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
-    const baseName = name.trim().toUpperCase();
     const desc = description.trim() || undefined;
+    // Block the round-trip on a malformed name and point at the field.
+    if (!isEditing && (baseName.length === 0 || !nameValid)) {
+      toast({ title: t('errors.nameInvalid'), variant: 'destructive' });
+      return;
+    }
     try {
       if (isEditing && editingName) {
         // Editing keeps the existing key; the upsert re-encrypts the new value.
@@ -138,19 +185,14 @@ export function ProjectSecretsTab({
         return;
       }
       if (type === 'basic') {
-        // Two secrets so each value is independently injectable as an env var.
-        await setSecret.mutateAsync({
+        // Both secrets are written in a single atomic action so a failure on
+        // the second value never orphans the first.
+        await setSecretPair.mutateAsync({
           organizationId,
           projectId,
-          name: `${baseName}_USERNAME`,
-          value: username,
-          description: desc,
-        });
-        await setSecret.mutateAsync({
-          organizationId,
-          projectId,
-          name: `${baseName}_PASSWORD`,
-          value: password,
+          baseName,
+          username,
+          password,
           description: desc,
         });
       } else {
@@ -167,15 +209,7 @@ export function ProjectSecretsTab({
       setDialogOpen(false);
     } catch (error) {
       console.error('Save secret error:', error);
-      const message = error instanceof Error ? error.message : String(error);
-      toast({
-        // The encryption key is a server env var (`tale init` generates it);
-        // surface that actionable cause instead of a generic failure.
-        title: /ENCRYPTION_SECRET_HEX/.test(message)
-          ? t('encryptionNotConfigured')
-          : tCommon('errors.generic'),
-        variant: 'destructive',
-      });
+      toast({ title: saveErrorTitle(error), variant: 'destructive' });
     }
   };
 
@@ -262,7 +296,7 @@ export function ProjectSecretsTab({
           setDialogOpen(open);
         }}
         title={isEditing ? t('editTitle') : t('addButton')}
-        isSubmitting={setSecret.isPending}
+        isSubmitting={isSaving}
         isDirty={isDirty}
         isValid={nameValid}
         onSubmit={handleSave}
@@ -277,7 +311,7 @@ export function ProjectSecretsTab({
               setType(next as SecretType)
             }
             options={typeOptions}
-            disabled={setSecret.isPending}
+            disabled={isSaving}
           />
         )}
         <Input
@@ -288,11 +322,14 @@ export function ProjectSecretsTab({
           onChange={(e) => setName(e.target.value.toUpperCase())}
           // The name is the env-var key agents resolve — editing it would orphan
           // references, so it's fixed once created.
-          disabled={setSecret.isPending || isEditing}
+          disabled={isSaving || isEditing}
           // `basic` appends `_USERNAME` / `_PASSWORD`, so leave room under the cap.
           maxLength={type === 'basic' ? 50 : SECRET_NAME_MAX}
           required
           errorMessage={nameError}
+          description={
+            isEditing || type === 'basic' ? undefined : t('nameShapeHint')
+          }
         />
         {type === 'basic' && !isEditing && (
           <Text variant="caption" className="-mt-2">
@@ -307,7 +344,7 @@ export function ProjectSecretsTab({
               label={valueLabel}
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              disabled={setSecret.isPending}
+              disabled={isSaving}
               required
             />
             <Text variant="caption" className="-mt-2">
@@ -321,7 +358,7 @@ export function ProjectSecretsTab({
               label={t('usernameLabel')}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              disabled={setSecret.isPending}
+              disabled={isSaving}
               required
             />
             <Input
@@ -330,7 +367,7 @@ export function ProjectSecretsTab({
               label={t('passwordLabel')}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              disabled={setSecret.isPending}
+              disabled={isSaving}
               required
             />
           </>
@@ -341,7 +378,7 @@ export function ProjectSecretsTab({
             label={valueLabel}
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            disabled={setSecret.isPending}
+            disabled={isSaving}
             required
           />
         )}
@@ -350,7 +387,7 @@ export function ProjectSecretsTab({
           label={t('descriptionLabel')}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          disabled={setSecret.isPending}
+          disabled={isSaving}
         />
       </FormDialog>
     </ContentArea>

--- a/services/platform/app/features/projects/hooks/secrets.ts
+++ b/services/platform/app/features/projects/hooks/secrets.ts
@@ -15,6 +15,10 @@ export function useSetProjectSecret() {
   return useConvexAction(api.projects.secrets.actions.setProjectSecret);
 }
 
+export function useSetProjectSecretPair() {
+  return useConvexAction(api.projects.secrets.actions.setProjectSecretPair);
+}
+
 export function useDeleteProjectSecret() {
   return useConvexAction(api.projects.secrets.actions.deleteProjectSecret);
 }

--- a/services/platform/convex/projects/secrets/actions.ts
+++ b/services/platform/convex/projects/secrets/actions.ts
@@ -1,6 +1,6 @@
 'use node';
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import { SECRET_NAME_RE } from '../../../lib/shared/schemas/secrets';
 import { internal } from '../../_generated/api';
@@ -12,13 +12,37 @@ import {
   KeyRotatedError,
 } from '../../lib/secret_box';
 
+const SECRET_VALUE_MAX = 8192;
+
+/**
+ * Normalize (trim + upper-case) and shape-check a secret name, raising a
+ * structured `ConvexError` the UI maps to a specific toast. Returns the
+ * canonical name to store. The shape check runs on the FULL name (including any
+ * `_USERNAME`/`_PASSWORD` suffix), so an over-long base that overflows the
+ * 64-char budget once suffixed is rejected here too.
+ */
+function normalizeSecretName(raw: string): string {
+  const name = raw.trim().toUpperCase();
+  if (!SECRET_NAME_RE.test(name)) {
+    throw new ConvexError({ code: 'SECRET_NAME_INVALID' });
+  }
+  return name;
+}
+
+/** Reject empty / over-long secret values with a structured `ConvexError`. */
+function assertSecretValue(value: string): void {
+  if (value.length === 0 || value.length > SECRET_VALUE_MAX) {
+    throw new ConvexError({ code: 'SECRET_VALUE_INVALID' });
+  }
+}
+
 async function requireAdmin(
   ctx: ActionCtx,
   organizationId: string,
   projectId: string,
 ): Promise<{ userId: string }> {
   const authUser = await getAuthUserIdentity(ctx);
-  if (!authUser) throw new Error('Unauthenticated');
+  if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
   await ctx.runQuery(
     internal.projects.secrets.internal.requireProjectAdminInternal,
     {
@@ -49,15 +73,9 @@ export const setProjectSecret = action({
       args.organizationId,
       args.projectId,
     );
-    const name = args.name.trim().toUpperCase();
-    if (!SECRET_NAME_RE.test(name)) {
-      throw new Error('SECRET_NAME_INVALID');
-    }
-    const value = args.value;
-    if (value.length === 0 || value.length > 8192) {
-      throw new Error('SECRET_VALUE_INVALID');
-    }
-    const encrypted = encryptSecret(value);
+    const name = normalizeSecretName(args.name);
+    assertSecretValue(args.value);
+    const encrypted = encryptSecret(args.value);
     await ctx.runMutation(
       internal.projects.secrets.internal.upsertProjectSecretInternal,
       {
@@ -70,6 +88,56 @@ export const setProjectSecret = action({
         authTag: encrypted.authTag,
         keyFingerprint: encrypted.keyFingerprint,
         updatedBy: userId,
+      },
+    );
+    return null;
+  },
+});
+
+/**
+ * Create or update a `basic` credential as the `_USERNAME`/`_PASSWORD` secret
+ * pair in a SINGLE transaction. The previous client-side approach issued two
+ * sequential `setProjectSecret` calls; a failure on the second write orphaned
+ * the first with no rollback. Encrypting both values here and handing them to
+ * one internal mutation makes the write atomic — either both rows land or
+ * neither does.
+ */
+export const setProjectSecretPair = action({
+  args: {
+    organizationId: v.string(),
+    projectId: v.id('projects'),
+    baseName: v.string(),
+    username: v.string(),
+    password: v.string(),
+    description: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { userId } = await requireAdmin(
+      ctx,
+      args.organizationId,
+      args.projectId,
+    );
+    // Validate the base shape first, then each suffixed name (so a base that
+    // overflows the 64-char budget once suffixed is rejected with the same
+    // SECRET_NAME_INVALID code).
+    const base = normalizeSecretName(args.baseName);
+    const usernameName = normalizeSecretName(`${base}_USERNAME`);
+    const passwordName = normalizeSecretName(`${base}_PASSWORD`);
+    assertSecretValue(args.username);
+    assertSecretValue(args.password);
+    const description = args.description?.trim() || undefined;
+    const encryptedUsername = encryptSecret(args.username);
+    const encryptedPassword = encryptSecret(args.password);
+    await ctx.runMutation(
+      internal.projects.secrets.internal.upsertProjectSecretPairInternal,
+      {
+        organizationId: args.organizationId,
+        projectId: args.projectId,
+        description,
+        updatedBy: userId,
+        username: { name: usernameName, ...encryptedUsername },
+        password: { name: passwordName, ...encryptedPassword },
       },
     );
     return null;

--- a/services/platform/convex/projects/secrets/internal.ts
+++ b/services/platform/convex/projects/secrets/internal.ts
@@ -5,10 +5,14 @@
  * through here.
  */
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
-import type { Doc } from '../../_generated/dataModel';
-import { internalMutation, internalQuery } from '../../_generated/server';
+import type { Doc, Id } from '../../_generated/dataModel';
+import {
+  internalMutation,
+  internalQuery,
+  type MutationCtx,
+} from '../../_generated/server';
 import { getUserTeamIds } from '../../lib/get_user_teams';
 import { getOrganizationMember } from '../../lib/rls';
 import { checkProjectAccess } from '../access';
@@ -25,7 +29,7 @@ export const requireProjectAdminInternal = internalQuery({
   handler: async (ctx, args): Promise<{ projectName: string }> => {
     const project = await ctx.db.get(args.projectId);
     if (!project || project.organizationId !== args.organizationId) {
-      throw new Error('PROJECT_NOT_FOUND');
+      throw new ConvexError({ code: 'PROJECT_NOT_FOUND' });
     }
     const member = await getOrganizationMember(ctx, args.organizationId, {
       userId: args.userId,
@@ -34,11 +38,72 @@ export const requireProjectAdminInternal = internalQuery({
     });
     const teamIds = await getUserTeamIds(ctx, member.userId);
     if (!checkProjectAccess(project, teamIds, member.role).canAdminister) {
-      throw new Error('SECRET_FORBIDDEN');
+      throw new ConvexError({ code: 'SECRET_FORBIDDEN' });
     }
     return { projectName: project.name };
   },
 });
+
+/** A single encrypted secret row's writable fields (sans org/project scope). */
+type SecretRowFields = {
+  name: string;
+  description?: string;
+  ciphertext: string;
+  nonce: string;
+  authTag: string;
+  keyFingerprint: string;
+  updatedBy: string;
+};
+
+/**
+ * Upsert one encrypted secret row within an existing mutation transaction.
+ * Shared by the single-secret and atomic-pair entry points so both write
+ * exactly the same row shape; when called from the pair mutation every
+ * `upsertSecretRow` runs inside the same transaction, so a later failure rolls
+ * the earlier write back.
+ */
+async function upsertSecretRow(
+  ctx: MutationCtx,
+  scope: { organizationId: string; projectId: Id<'projects'> },
+  fields: SecretRowFields,
+): Promise<void> {
+  const existing = await ctx.db
+    .query('projectSecrets')
+    .withIndex('by_project_name', (q) =>
+      q
+        .eq('organizationId', scope.organizationId)
+        .eq('projectId', scope.projectId)
+        .eq('name', fields.name),
+    )
+    .first();
+  const now = Date.now();
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      description: fields.description,
+      ciphertext: fields.ciphertext,
+      nonce: fields.nonce,
+      authTag: fields.authTag,
+      keyFingerprint: fields.keyFingerprint,
+      updatedBy: fields.updatedBy,
+      updatedAt: now,
+    });
+  } else {
+    await ctx.db.insert('projectSecrets', {
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      name: fields.name,
+      description: fields.description,
+      ciphertext: fields.ciphertext,
+      nonce: fields.nonce,
+      authTag: fields.authTag,
+      keyFingerprint: fields.keyFingerprint,
+      createdBy: fields.updatedBy,
+      updatedBy: fields.updatedBy,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}
 
 export const upsertProjectSecretInternal = internalMutation({
   args: {
@@ -53,40 +118,61 @@ export const upsertProjectSecretInternal = internalMutation({
     updatedBy: v.string(),
   },
   handler: async (ctx, args): Promise<null> => {
-    const existing = await ctx.db
-      .query('projectSecrets')
-      .withIndex('by_project_name', (q) =>
-        q
-          .eq('organizationId', args.organizationId)
-          .eq('projectId', args.projectId)
-          .eq('name', args.name),
-      )
-      .first();
-    const now = Date.now();
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        description: args.description,
-        ciphertext: args.ciphertext,
-        nonce: args.nonce,
-        authTag: args.authTag,
-        keyFingerprint: args.keyFingerprint,
-        updatedBy: args.updatedBy,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert('projectSecrets', {
-        organizationId: args.organizationId,
-        projectId: args.projectId,
+    await upsertSecretRow(
+      ctx,
+      { organizationId: args.organizationId, projectId: args.projectId },
+      {
         name: args.name,
         description: args.description,
         ciphertext: args.ciphertext,
         nonce: args.nonce,
         authTag: args.authTag,
         keyFingerprint: args.keyFingerprint,
-        createdBy: args.updatedBy,
         updatedBy: args.updatedBy,
-        createdAt: now,
-        updatedAt: now,
+      },
+    );
+    return null;
+  },
+});
+
+/** One encrypted secret's name + ciphertext bundle, used by the pair upsert. */
+const encryptedSecretValidator = v.object({
+  name: v.string(),
+  ciphertext: v.string(),
+  nonce: v.string(),
+  authTag: v.string(),
+  keyFingerprint: v.string(),
+});
+
+/**
+ * Atomically upsert the two secrets of a `basic` credential
+ * (`_USERNAME`/`_PASSWORD`). Both writes share one mutation transaction, so a
+ * failure on the second never leaves the first orphaned — the whole mutation
+ * rolls back.
+ */
+export const upsertProjectSecretPairInternal = internalMutation({
+  args: {
+    organizationId: v.string(),
+    projectId: v.id('projects'),
+    description: v.optional(v.string()),
+    updatedBy: v.string(),
+    username: encryptedSecretValidator,
+    password: encryptedSecretValidator,
+  },
+  handler: async (ctx, args): Promise<null> => {
+    const scope = {
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+    };
+    for (const part of [args.username, args.password]) {
+      await upsertSecretRow(ctx, scope, {
+        name: part.name,
+        description: args.description,
+        ciphertext: part.ciphertext,
+        nonce: part.nonce,
+        authTag: part.authTag,
+        keyFingerprint: part.keyFingerprint,
+        updatedBy: args.updatedBy,
       });
     }
     return null;

--- a/services/platform/convex/projects/secrets/queries.ts
+++ b/services/platform/convex/projects/secrets/queries.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { Id } from '../../_generated/dataModel';
 import { query, type QueryCtx } from '../../_generated/server';
@@ -12,9 +12,9 @@ async function assertProjectAdmin(
   projectId: Id<'projects'>,
 ): Promise<void> {
   const project = await ctx.db.get(projectId);
-  if (!project) throw new Error('PROJECT_NOT_FOUND');
+  if (!project) throw new ConvexError({ code: 'PROJECT_NOT_FOUND' });
   const authUser = await getAuthUserIdentity(ctx);
-  if (!authUser) throw new Error('Unauthenticated');
+  if (!authUser) throw new ConvexError({ code: 'UNAUTHENTICATED' });
   const member = await getOrganizationMember(
     ctx,
     project.organizationId,
@@ -22,7 +22,7 @@ async function assertProjectAdmin(
   );
   const teamIds = await getUserTeamIds(ctx, member.userId);
   if (!checkProjectAccess(project, teamIds, member.role).canAdminister) {
-    throw new Error('SECRET_FORBIDDEN');
+    throw new ConvexError({ code: 'SECRET_FORBIDDEN' });
   }
 }
 

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6885,13 +6885,21 @@
     "usernameLabel": "Benutzername",
     "passwordLabel": "Passwort",
     "basicNameHint": "Wird als zwei Secrets gespeichert — dein Name plus die Suffixe _USERNAME und _PASSWORD.",
+    "nameShapeHint": "Großbuchstaben, Zahlen und Unterstriche; muss mit einem Buchstaben beginnen.",
     "encryptionNotConfigured": "Die Secret-Verschlüsselung ist auf diesem Server nicht eingerichtet (ENCRYPTION_SECRET_HEX fehlt). Führe `tale init` aus und versuche es erneut.",
     "saveSuccess": "Secret gespeichert",
     "editButton": "Bearbeiten",
     "editTitle": "Secret bearbeiten",
     "editValueHint": "Gib einen neuen Wert ein, um das gespeicherte Secret zu ersetzen. Der aktuelle Wert wird nie angezeigt.",
     "updateSuccess": "Secret aktualisiert",
-    "deleteSuccess": "Secret gelöscht"
+    "deleteSuccess": "Secret gelöscht",
+    "errors": {
+      "nameInvalid": "Nur Großbuchstaben, Zahlen und Unterstriche verwenden, beginnend mit einem Buchstaben (max. 64 Zeichen).",
+      "valueInvalid": "Einen Wert mit 1 bis 8192 Zeichen eingeben.",
+      "unauthenticated": "Deine Sitzung ist abgelaufen. Melde dich erneut an und versuche es noch einmal.",
+      "forbidden": "Du hast keine Berechtigung, die Secrets dieses Projekts zu verwalten.",
+      "projectNotFound": "Dieses Projekt wurde nicht gefunden. Es wurde möglicherweise gelöscht."
+    }
   },
   "tasks": {
     "attachments": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7149,13 +7149,21 @@
     "usernameLabel": "Username",
     "passwordLabel": "Password",
     "basicNameHint": "Stored as two secrets — your name plus the _USERNAME and _PASSWORD suffixes.",
+    "nameShapeHint": "Uppercase letters, numbers, and underscores; must start with a letter.",
     "encryptionNotConfigured": "Secret encryption isn't set up on this server (ENCRYPTION_SECRET_HEX is missing). Run `tale init`, then try again.",
     "saveSuccess": "Secret saved",
     "editButton": "Edit",
     "editTitle": "Edit secret",
     "editValueHint": "Enter a new value to replace the stored secret. The current value is never shown.",
     "updateSuccess": "Secret updated",
-    "deleteSuccess": "Secret deleted"
+    "deleteSuccess": "Secret deleted",
+    "errors": {
+      "nameInvalid": "Use uppercase letters, numbers, and underscores only, starting with a letter (max 64 characters).",
+      "valueInvalid": "Enter a value between 1 and 8192 characters.",
+      "unauthenticated": "Your session has expired. Sign in again, then retry.",
+      "forbidden": "You don't have permission to manage this project's secrets.",
+      "projectNotFound": "We couldn't find that project. It may have been deleted."
+    }
   },
   "tasks": {
     "attachments": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6886,13 +6886,21 @@
     "usernameLabel": "Nom d'utilisateur",
     "passwordLabel": "Mot de passe",
     "basicNameHint": "Enregistré sous forme de deux secrets — ton nom plus les suffixes _USERNAME et _PASSWORD.",
+    "nameShapeHint": "Lettres majuscules, chiffres et traits de soulignement ; doit commencer par une lettre.",
     "encryptionNotConfigured": "Le chiffrement des secrets n'est pas configuré sur ce serveur (ENCRYPTION_SECRET_HEX manquant). Exécute `tale init`, puis réessaie.",
     "saveSuccess": "Secret enregistré",
     "editButton": "Modifier",
     "editTitle": "Modifier le secret",
     "editValueHint": "Saisis une nouvelle valeur pour remplacer le secret enregistré. La valeur actuelle n'est jamais affichée.",
     "updateSuccess": "Secret mis à jour",
-    "deleteSuccess": "Secret supprimé"
+    "deleteSuccess": "Secret supprimé",
+    "errors": {
+      "nameInvalid": "Utilise uniquement des lettres majuscules, des chiffres et des traits de soulignement, en commençant par une lettre (max. 64 caractères).",
+      "valueInvalid": "Saisis une valeur de 1 à 8192 caractères.",
+      "unauthenticated": "Ta session a expiré. Reconnecte-toi, puis réessaie.",
+      "forbidden": "Tu n'as pas l'autorisation de gérer les secrets de ce projet.",
+      "projectNotFound": "Ce projet est introuvable. Il a peut-être été supprimé."
+    }
   },
   "tasks": {
     "attachments": {


### PR DESCRIPTION
## Summary

Resolves the three defects in the project Secrets flow reported in #2058:

1. **Raw `Error` throws → structured `ConvexError`.** `setProjectSecret` (and the rest of the secrets module) threw plain `Error`s (`SECRET_NAME_INVALID`, `SECRET_VALUE_INVALID`, `Unauthenticated`, `SECRET_FORBIDDEN`, `PROJECT_NOT_FOUND`), which the prod runtime redacts to "Server Error", so the UI could only show a generic toast. These now throw `ConvexError({ code })` across `actions.ts`, `internal.ts`, and `queries.ts`.
2. **No client-side name-shape validation.** The dialog now validates the name against the same `^[A-Z][A-Z0-9_]{0,63}$` shape as the server (applied to the full `_USERNAME`/`_PASSWORD` suffixed name), shows an inline field error, and blocks the round-trip on a malformed name. Each error code maps to a specific i18n toast (en/de/fr).
3. **Non-atomic `basic` write.** A `basic` credential was written as two sequential `setProjectSecret` actions; a failure on the second (`_PASSWORD`) orphaned the first (`_USERNAME`). New `setProjectSecretPair` action encrypts both values and hands them to a single `upsertProjectSecretPairInternal` mutation, so both rows land in one transaction or neither does.

## Tests

- `bunx vitest --run --config vitest.ui.config.ts app/features/projects/components/project-secrets-tab.test.tsx` — 8 passed (adds: atomic-pair path, client-side name rejection, error-code → toast mapping)
- `bunx vitest --run lib/i18n/messages.test.ts` — 23 passed (locale parity/usage enforced)
- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` on changed files — 0 warnings, 0 errors

Closes #2058