### PR TITLE
fix(platform): defer chat upload success toast until indexing completes (#1457)

### DIFF
--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.indexing-toast.cap.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.indexing-toast.cap.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUploadPolicy } from '@/app/features/settings/governance/hooks/queries';
+import { toast } from '@/app/hooks/use-toast';
+
+import { useConvexFileUpload } from './use-convex-file-upload';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for #1457: a PDF (or any RAG-indexable file) must NOT
+// flash "uploaded successfully" the instant its bytes land, because indexing
+// runs asynchronously afterwards and can still fail with an "Index failed"
+// badge. The composer defers that toast to `useFileIndexingStatus`, which owns
+// the terminal status. Files that are not indexed (e.g. indexing disabled for
+// the conversation) keep the immediate toast.
+//
+// `detectMediaMime` resolves to `null` so the resolved type comes from the
+// real `resolveFileType`, exercising the genuine `isRagIndexableFile` gate.
+// ---------------------------------------------------------------------------
+
+const generateUploadUrl = vi.fn().mockResolvedValue('https://upload.test/url');
+const saveFileMetadata = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./mutations', () => ({
+  useGenerateUploadUrl: () => ({ mutateAsync: generateUploadUrl }),
+}));
+
+vi.mock('@/app/hooks/use-convex-mutation', () => ({
+  useConvexMutation: () => ({ mutateAsync: saveFileMetadata }),
+}));
+
+vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
+  useUploadPolicy: vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../utils/get-audio-duration', () => ({
+  getAudioDuration: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/utils/compress-image', () => ({ compressImage: vi.fn() }));
+
+vi.mock('@/lib/shared/file-types', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/shared/file-types')>();
+  return {
+    ...actual,
+    // Force the non-media path so resolveFileType drives the resolved type.
+    detectMediaMime: vi.fn().mockResolvedValue(null),
+  };
+});
+
+const toastMock = vi.mocked(toast);
+const useUploadPolicyMock = vi.mocked(useUploadPolicy);
+
+const MB = 1024 * 1024;
+
+function makePdf(name = 'report.pdf'): File {
+  return new File([new Uint8Array([1, 2, 3])], name, {
+    type: 'application/pdf',
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ storageId: 'storage-1' }),
+    } as Response),
+  );
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:preview'),
+    revokeObjectURL: vi.fn(),
+  });
+  useUploadPolicyMock.mockReturnValue({
+    policyEnabled: false,
+    maxFileSize: 100 * MB,
+    documentMaxFileSize: 100 * MB,
+    allowedTypes: [],
+    blockedExtensions: [],
+    allowedExtensions: [],
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('useConvexFileUpload — deferred indexing toast (#1457)', () => {
+  it('does NOT show "uploaded successfully" immediately for an indexable PDF', async () => {
+    const { result } = renderHook(() =>
+      useConvexFileUpload({ organizationId: 'org-1' }),
+    );
+
+    await act(async () => {
+      await result.current.uploadFiles([makePdf()]);
+    });
+
+    await waitFor(() => expect(result.current.attachments).toHaveLength(1));
+    // Metadata was saved (so backend queues indexing) ...
+    expect(saveFileMetadata).toHaveBeenCalledTimes(1);
+    // ... but the success toast is deferred until indexing finishes.
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'fileUploaded'),
+    ).toBe(false);
+  });
+
+  it('shows "uploaded successfully" immediately when indexing is disabled', async () => {
+    const { result } = renderHook(() =>
+      useConvexFileUpload({ organizationId: 'org-1', disableIndexing: true }),
+    );
+
+    await act(async () => {
+      await result.current.uploadFiles([makePdf()]);
+    });
+
+    await waitFor(() => expect(result.current.attachments).toHaveLength(1));
+    expect(
+      toastMock.mock.calls.some(([arg]) => arg?.title === 'fileUploaded'),
+    ).toBe(true);
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.test.ts
@@ -297,7 +297,13 @@ describe('useConvexFileUpload — concurrent-batch cap & dedup', () => {
   });
 
   it('counts a just-committed file against the cap during the commit→render gap', async () => {
-    const { result } = renderHook(() => useConvexFileUpload(config));
+    // Indexing is disabled so the `fileUploaded` success toast still fires
+    // synchronously on commit (for RAG-indexable files it is deferred until
+    // indexing finishes, #1457) — the test uses that toast as its timing hook
+    // into the commit→render gap below.
+    const { result } = renderHook(() =>
+      useConvexFileUpload({ ...config, disableIndexing: true }),
+    );
 
     const CAP = CHAT_MAX_FILE_COUNT;
 

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -17,6 +17,7 @@ import {
   detectMediaMime,
   getMaxFileSizeForType,
   isAudioOrVideo,
+  isRagIndexableFile,
   resolveFileType,
 } from '@/lib/shared/file-types';
 import { compressImage } from '@/lib/utils/compress-image';
@@ -478,10 +479,30 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
             pendingUploadsRef.current.delete(fileId);
             setAttachments((prev) => [...prev, attachment]);
 
-            toast({
-              title: t('fileUploaded'),
-              description: t('uploadedSuccessfully', { filename: file.name }),
-            });
+            // Files that get RAG-indexed (PDFs, docs, text — anything the
+            // backend queues; mirrors `shouldIndex` in saveFileMetadata) are
+            // not "done" once the bytes land: indexing runs asynchronously and
+            // can still fail with an "Index failed" badge. Showing
+            // "uploaded successfully" here would contradict that outcome
+            // (#1457). For those files we defer the success toast until
+            // indexing reaches a terminal state — `useFileIndexingStatus`
+            // fires success on `completed` and an error toast on `failed`.
+            // Non-indexed files (images, audio/video, unsupported types) have
+            // no further processing gate, so they keep the immediate toast.
+            const willIndex =
+              !config.disableIndexing &&
+              !isAudioOrVideo(resolvedType) &&
+              isRagIndexableFile(
+                fileToUpload.name,
+                resolvedType || 'application/octet-stream',
+              );
+
+            if (!willIndex) {
+              toast({
+                title: t('fileUploaded'),
+                description: t('uploadedSuccessfully', { filename: file.name }),
+              });
+            }
           } catch (error) {
             console.error('Upload error:', error);
             toast({

--- a/services/platform/app/features/chat/hooks/use-file-indexing-status.toast.test.ts
+++ b/services/platform/app/features/chat/hooks/use-file-indexing-status.toast.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toast } from '@/app/hooks/use-toast';
+import type { Id } from '@/convex/_generated/dataModel';
+
+import { useFileIndexingStatus } from './use-file-indexing-status';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for #1457 — the *firing* half of the deferred toast.
+//
+// The composer suppresses the immediate "uploaded successfully" toast for
+// RAG-indexable files because indexing runs asynchronously and can still
+// fail. `useFileIndexingStatus` owns the terminal signal: when a tracked file
+// transitions out of a pending state (`queued`/`running`) it fires the
+// deferred success toast on `completed`, or the destructive "Index failed"
+// toast on `failed`. Keying on the *transition* (not the absolute status)
+// keeps a remount of an already-finished file silent and fires the success
+// toast exactly once per upload.
+//
+// The sibling suite `use-convex-file-upload.indexing-toast.cap.test.ts` covers
+// the suppression half; this suite covers the firing half (success + the
+// previously-untested error branch + the remount-silence guard).
+// ---------------------------------------------------------------------------
+
+interface MetadataRow {
+  storageId: Id<'_storage'>;
+  ragStatus?: 'queued' | 'running' | 'completed' | 'failed';
+  ragError?: string;
+  ragProgress?: string;
+  fileName: string;
+}
+
+// Mutable backing value the mocked `useQuery` reads on every render, so a
+// rerender can simulate the reactive Convex query observing a new status.
+let metadataValue: MetadataRow[] | undefined;
+
+vi.mock('convex/react', () => ({
+  useQuery: vi.fn(() => metadataValue),
+  // Polling action — return a no-op async fn so the effect is inert.
+  useAction: vi.fn(() => vi.fn().mockResolvedValue(undefined)),
+}));
+
+vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+const toastMock = vi.mocked(toast);
+
+const STORAGE_ID = 'storage-1' as Id<'_storage'>;
+
+function attachment() {
+  return {
+    fileId: STORAGE_ID,
+    fileName: 'report.pdf',
+    fileType: 'application/pdf',
+    fileSize: 3,
+  };
+}
+
+function row(status: MetadataRow['ragStatus']): MetadataRow {
+  return { storageId: STORAGE_ID, ragStatus: status, fileName: 'report.pdf' };
+}
+
+function successToasts() {
+  return toastMock.mock.calls.filter(([arg]) => arg?.title === 'fileUploaded');
+}
+
+function failureToasts() {
+  return toastMock.mock.calls.filter(
+    ([arg]) => arg?.title === 'indexingFailed',
+  );
+}
+
+beforeEach(() => {
+  metadataValue = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useFileIndexingStatus — deferred toast firing (#1457)', () => {
+  it('fires the success toast exactly once on queued → completed', () => {
+    metadataValue = [row('queued')];
+    const { rerender } = renderHook(() =>
+      useFileIndexingStatus([attachment()], 'org-1'),
+    );
+    expect(successToasts()).toHaveLength(0);
+
+    // Indexing finishes.
+    metadataValue = [row('completed')];
+    rerender();
+
+    expect(successToasts()).toHaveLength(1);
+    expect(successToasts()[0]?.[0]).toMatchObject({
+      title: 'fileUploaded',
+      description: 'uploadedSuccessfully',
+    });
+    expect(failureToasts()).toHaveLength(0);
+
+    // A further reactive update of the now-terminal file fires nothing more.
+    rerender();
+    expect(successToasts()).toHaveLength(1);
+  });
+
+  it('fires the destructive "Index failed" toast on running → failed', () => {
+    metadataValue = [row('running')];
+    const { rerender } = renderHook(() =>
+      useFileIndexingStatus([attachment()], 'org-1'),
+    );
+    expect(failureToasts()).toHaveLength(0);
+
+    metadataValue = [row('failed')];
+    rerender();
+
+    expect(failureToasts()).toHaveLength(1);
+    expect(failureToasts()[0]?.[0]).toMatchObject({
+      title: 'indexingFailed',
+      description: 'indexingFailedDescription',
+      variant: 'destructive',
+    });
+    expect(successToasts()).toHaveLength(0);
+  });
+
+  it('stays silent when the first observed status is already terminal (remount)', () => {
+    // A file that finished before this hook ever observed a pending state —
+    // e.g. a remount — must not re-announce its outcome.
+    metadataValue = [row('completed')];
+    const { rerender } = renderHook(() =>
+      useFileIndexingStatus([attachment()], 'org-1'),
+    );
+    rerender();
+
+    expect(successToasts()).toHaveLength(0);
+    expect(failureToasts()).toHaveLength(0);
+  });
+});

--- a/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
@@ -4,8 +4,10 @@ import { useAction } from 'convex/react';
 import { useQuery } from 'convex/react';
 import { useEffect, useMemo, useRef } from 'react';
 
+import { toast } from '@/app/hooks/use-toast';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
 
 import type { FileAttachment } from './use-convex-file-upload';
 
@@ -31,6 +33,7 @@ export function useFileIndexingStatus(
   attachments: FileAttachment[],
   organizationId: string,
 ) {
+  const { t } = useT('chat');
   const fileIds = useMemo(
     () =>
       attachments
@@ -58,6 +61,45 @@ export function useFileIndexingStatus(
     }
     return map;
   }, [metadata]);
+
+  // Deferred upload feedback (#1457): the composer suppresses the
+  // "uploaded successfully" toast for files that get RAG-indexed because
+  // indexing runs asynchronously and can still fail. We own the terminal
+  // signal here — when a tracked file transitions out of a pending state
+  // (queued/running) into `completed` we fire the success toast, and into
+  // `failed` we fire the "Index failed" error toast. Keying on the
+  // transition (not the absolute status) means a remount that observes an
+  // already-finished file stays silent, and the success toast fires exactly
+  // once per upload.
+  const prevStatusRef = useRef(new Map<Id<'_storage'>, RagStatus>());
+
+  useEffect(() => {
+    if (!metadata) return;
+    const prev = prevStatusRef.current;
+    for (const m of metadata) {
+      const before = prev.get(m.storageId);
+      const current = m.ragStatus;
+      if (before === current) continue;
+      const wasPending = before === 'queued' || before === 'running';
+      if (wasPending && current === 'completed') {
+        toast({
+          title: t('fileUploaded'),
+          description: t('uploadedSuccessfully', { filename: m.fileName }),
+        });
+      } else if (wasPending && current === 'failed') {
+        toast({
+          title: t('indexingFailed'),
+          description: t('indexingFailedDescription', { filename: m.fileName }),
+          variant: 'destructive',
+        });
+      }
+      if (current === undefined) {
+        prev.delete(m.storageId);
+      } else {
+        prev.set(m.storageId, current);
+      }
+    }
+  }, [metadata, t]);
 
   const isIndexing = useMemo(() => {
     if (!metadata || fileIds.length === 0) return false;

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1464,6 +1464,7 @@
     "uploadingFile": "Datei wird hochgeladen",
     "indexing": "Indizierung...",
     "indexingFailed": "Indizierung fehlgeschlagen",
+    "indexingFailedDescription": "{filename} konnte nicht für die Suche indiziert werden.",
     "viewImage": "Bild anzeigen",
     "fileTypes": {
       "image": "BILD",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1483,6 +1483,7 @@
     "uploadingFile": "Uploading file",
     "indexing": "Indexing...",
     "indexingFailed": "Index failed",
+    "indexingFailedDescription": "{filename} could not be indexed for search.",
     "viewImage": "View image",
     "fileTypes": {
       "image": "IMG",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1465,6 +1465,7 @@
     "uploadingFile": "Téléversement du fichier",
     "indexing": "Indexation...",
     "indexingFailed": "Échec de l'indexation",
+    "indexingFailedDescription": "{filename} n'a pas pu être indexé pour la recherche.",
     "viewImage": "Voir l'image",
     "fileTypes": {
       "image": "IMG",


### PR DESCRIPTION
## Problem

When a PDF (or any RAG-indexable file) is attached in Chat, the composer flashed **"uploaded successfully"** the instant the bytes finished uploading — but indexing runs **asynchronously afterwards** and can still fail, leaving an **"Index failed"** badge on the same file. The toast contradicted the actual outcome.

Closes #1457

## Fix

- `use-convex-file-upload.ts`: for files the backend will RAG-index (mirrors `shouldIndex` in `saveFileMetadata` — non-audio, indexing not disabled, `isRagIndexableFile`), the immediate "uploaded successfully" toast is **suppressed**. Non-indexed files (images, audio/video, unsupported types, or conversations with indexing disabled) keep the instant toast since they have no further processing gate.
- `use-file-indexing-status.ts`: now owns the terminal signal. When a tracked file transitions out of a pending state (`queued`/`running`) it fires the deferred **success** toast on `completed`, or an **"Index failed"** error toast on `failed`. Keying on the transition (not the absolute status) keeps a remount of an already-finished file silent and fires the success toast exactly once per upload.
- Added i18n key `chat.indexingFailedDescription` (en/de/fr) for the failure toast body.

## Tests

- New regression suite `use-convex-file-upload.indexing-toast.cap.test.ts`: an indexable PDF saves metadata but shows **no** immediate success toast; with `disableIndexing` the immediate toast still fires.
- `vitest --project client` (upload-hook suites) — 4 passed
- `vitest --project server lib/i18n/messages.test.ts` (i18n parity/usage enforce) — 23 passed
- `oxlint --type-aware` on changed files — 0 warnings / 0 errors
- `tsc --noEmit` — clean