### PR TITLE
fix(platform): show conversation status-tab count badges, drop dead ?priority= param

### DIFF
--- a/services/platform/app/features/conversations/components/conversations-navigation.test.tsx
+++ b/services/platform/app/features/conversations/components/conversations-navigation.test.tsx
@@ -28,6 +28,10 @@ vi.mock('@/app/hooks/use-ability', () => ({
   }),
 }));
 
+vi.mock('../hooks/queries', () => ({
+  useApproxConversationCountByStatus: () => ({ data: 3 }),
+}));
+
 describe('ConversationsNavigation', () => {
   describe('accessibility', () => {
     it('passes axe audit', async () => {

--- a/services/platform/app/features/conversations/components/conversations-navigation.tsx
+++ b/services/platform/app/features/conversations/components/conversations-navigation.tsx
@@ -4,7 +4,10 @@ import {
   TabNavigation,
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
+import { DEFAULT_COUNT_CAP } from '@/convex/lib/helpers/count_items_in_org';
 import { useT } from '@/lib/i18n/client';
+
+import { useApproxConversationCountByStatus } from '../hooks/queries';
 
 interface ConversationsNavigationProps {
   organizationId: string;
@@ -12,15 +15,41 @@ interface ConversationsNavigationProps {
 
 const STATUSES = ['open', 'closed', 'spam', 'archived'] as const;
 
+function CountBadge({ count }: { count: number }) {
+  return (
+    <span className="bg-muted text-muted-foreground flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-medium tabular-nums">
+      {count >= DEFAULT_COUNT_CAP ? `${DEFAULT_COUNT_CAP}+` : count}
+    </span>
+  );
+}
+
 export function ConversationsNavigation({
   organizationId,
 }: ConversationsNavigationProps) {
   const { t } = useT('conversations');
 
-  const navigationItems: TabNavigationItem[] = STATUSES.map((status) => ({
-    label: t(`status.${status}`),
-    href: `/dashboard/${organizationId}/conversations/${status}`,
-  }));
+  // Per-status approximate counts. These share the subscription primed by the
+  // parent route loader's prefetch, so they paint without a refetch on first
+  // nav, and surface as a trailing badge on each tab.
+  const counts: Record<(typeof STATUSES)[number], number | undefined> = {
+    open: useApproxConversationCountByStatus(organizationId, 'open').data,
+    closed: useApproxConversationCountByStatus(organizationId, 'closed').data,
+    spam: useApproxConversationCountByStatus(organizationId, 'spam').data,
+    archived: useApproxConversationCountByStatus(organizationId, 'archived')
+      .data,
+  };
+
+  const navigationItems: TabNavigationItem[] = STATUSES.map((status) => {
+    const count = counts[status];
+    return {
+      label: t(`status.${status}`),
+      href: `/dashboard/${organizationId}/conversations/${status}`,
+      trailing:
+        count !== undefined && count > 0 ? (
+          <CountBadge count={count} />
+        ) : undefined,
+    };
+  });
 
   return <TabNavigation items={navigationItems} standalone={false} prefetch />;
 }

--- a/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
+++ b/services/platform/app/routes/dashboard/$id/conversations/$status.tsx
@@ -29,7 +29,6 @@ const conversationStatusMap: Record<ValidStatus, ConversationStatus> = {
 };
 
 const searchSchema = z.object({
-  priority: z.string().optional(),
   search: z.string().optional(),
 });
 
@@ -54,7 +53,7 @@ export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
       );
       // Prime the paginated list cache so the first page paints without a
       // skeleton flash on first nav. Args mirror useListConversationsPaginated's
-      // base args (priority/search are in-page filters — live subscription).
+      // base args (search is an in-page filter — live subscription).
       void primeCachedPaginatedQuery(
         context.convexQueryClient.convexClient,
         api.conversations.queries.listConversationsPaginated,
@@ -68,7 +67,7 @@ export const Route = createFileRoute('/dashboard/$id/conversations/$status')({
 
 function ConversationsStatusPage() {
   const { id: organizationId, status } = Route.useParams();
-  const { priority, search } = Route.useSearch();
+  const { search } = Route.useSearch();
 
   const mappedStatus =
     (isValidStatus(status) ? conversationStatusMap[status] : undefined) ??
@@ -92,7 +91,6 @@ function ConversationsStatusPage() {
   const paginatedResult = useListConversationsPaginated({
     organizationId,
     status: mappedStatus,
-    priority: priority && priority.length > 0 ? priority : undefined,
     initialNumItems: INITIAL_NUM_ITEMS,
   });
 


### PR DESCRIPTION
## Summary

Two small conversations-inbox refinements from #1982:

1. **Status-tab count badges now render.** The per-status approximate counts were already prefetched on the conversations route loader but never displayed (the prefetch was load-bearing only). `ConversationsNavigation` now subscribes to those same counts and renders each as a trailing badge on its status tab (open / closed / spam / archived), shown only when the count is > 0 and capped as `20+` (matching the backend `DEFAULT_COUNT_CAP`). Because the badge query shares the subscription primed by the route loader's prefetch, the badges paint without a refetch on first nav.
2. **Dead `?priority=` route param removed.** The conversations status route accepted a `?priority=` search param, but no UI ever set or cleared it. Removed it from the route's search schema and its plumbing into `useListConversationsPaginated`. (The backend query still supports priority filtering via the hook should a UI control be added later.)

## Testing
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings / 0 errors
- UI tests: `app/features/conversations` — 7 files / 32 tests pass (includes the navigation a11y/axe test, updated to stub the new count query)

Closes #1982