### PR TITLE
fix(platform): coerce agents metrics period search param (#1987)

### DIFF
--- a/services/platform/app/routes/dashboard/$id/agents/metrics.search.test.ts
+++ b/services/platform/app/routes/dashboard/$id/agents/metrics.search.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchSchema } from './metrics';
+
+// Regression coverage for #1987: a shared/bookmarked
+// `/agents/metrics?period=90` URL is parsed by the router as the JSON
+// number 90, which must not crash the route via SearchParamError.
+describe('agents metrics searchSchema', () => {
+  it('coerces numeric period values to the string enum', () => {
+    expect(searchSchema.parse({ period: 90 }).period).toBe('90');
+    expect(searchSchema.parse({ period: 30 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 7 }).period).toBe('7');
+  });
+
+  it('accepts string period values', () => {
+    expect(searchSchema.parse({ period: '90' }).period).toBe('90');
+  });
+
+  it('falls back to the default window for out-of-range values', () => {
+    expect(searchSchema.parse({ period: 999 }).period).toBe('30');
+    expect(searchSchema.parse({ period: 'nonsense' }).period).toBe('30');
+  });
+
+  it('leaves an omitted period undefined', () => {
+    expect(searchSchema.parse({}).period).toBeUndefined();
+  });
+});

--- a/services/platform/app/routes/dashboard/$id/agents/metrics.tsx
+++ b/services/platform/app/routes/dashboard/$id/agents/metrics.tsx
@@ -17,8 +17,16 @@ const WorkforceDashboard = lazyComponent(() =>
   })),
 );
 
-const searchSchema = z.object({
-  period: z.enum(['7', '30', '90']).optional(),
+export const searchSchema = z.object({
+  // The router parses a bare `?period=90` as the JSON number 90, which fails a
+  // plain string enum and crashes the page (issue #1987). Coerce to a string
+  // first, then fall back to the default window for any out-of-range value so a
+  // shared/bookmarked URL never renders the error boundary.
+  period: z.coerce
+    .string()
+    .pipe(z.enum(['7', '30', '90']))
+    .catch('30')
+    .optional(),
 });
 
 export const Route = createFileRoute('/dashboard/$id/agents/metrics')({


### PR DESCRIPTION
## Summary

A shared or bookmarked `/dashboard/{org}/agents/metrics?period=90` URL crashed the page with a full-page error boundary. TanStack Router's default `parseSearch` runs `JSON.parse` on each query value, so a bare `?period=90` became the JSON **number** `90`. The route's `z.enum(['7','30','90'])` expects strings, so it threw a `SearchParamError` (`invalid_value`, `path:[period]`) and the route rendered "Something went wrong". Selecting the period from the in-app combobox worked because it navigates with a string.

## Fix

`searchSchema.period` now coerces to a string first, then validates against the enum, falling back to the default `'30'` window for any out-of-range value — so a shared/bookmarked URL never renders the error boundary:

```ts
period: z.coerce.string().pipe(z.enum(['7', '30', '90'])).catch('30').optional()
```

This mirrors the same fix already applied to the sibling automations (#2024), project (#2033), and governance feedback (#2034) metrics routes.

## Tests

Added `metrics.search.test.ts` regression coverage: numeric periods coerce to the string enum, strings pass through, out-of-range values fall back to `'30'`, and an omitted period stays `undefined`. `bunx tsc --noEmit` and `oxlint --type-aware` are clean.

Closes #1987