### PR TITLE
fix(platform): degrade timed-out governance logs query to retry/skeleton (#1984)

### DIFF
--- a/services/platform/app/components/error-boundaries/core/error-boundary-base.tsx
+++ b/services/platform/app/components/error-boundaries/core/error-boundary-base.tsx
@@ -163,14 +163,16 @@ export class ErrorBoundaryBase extends Component<
 
   render() {
     const { hasError, error, isRetrying } = this.state;
-    const { children, fallback, organizationId } = this.props;
+    const { children, fallback, organizationId, retryingFallback } = this.props;
     const contextValue = this.getContextValue();
 
-    // Auto-retry in progress: render nothing so Suspense ancestor shows its fallback
+    // Auto-retry in progress: render `retryingFallback` if a boundary supplied
+    // one (e.g. a table skeleton), else render nothing so a Suspense ancestor
+    // shows its fallback.
     if (hasError && isRetrying) {
       return (
         <ErrorBoundaryContext.Provider value={contextValue}>
-          {null}
+          {retryingFallback ?? null}
         </ErrorBoundaryContext.Provider>
       );
     }

--- a/services/platform/app/components/error-boundaries/core/types.ts
+++ b/services/platform/app/components/error-boundaries/core/types.ts
@@ -39,6 +39,13 @@ export interface ErrorBoundaryBaseProps {
   maxRetries?: number;
   /** Predicate to determine if an error is transient and should be retried */
   isRetryableError?: (error: Error) => boolean;
+  /**
+   * Rendered during an auto-retry's backoff window (while `isRetrying`) in
+   * place of the default `null`. Lets a boundary hold a skeleton/placeholder
+   * instead of collapsing to blank when it has no Suspense ancestor to drive
+   * the loading state. Omitting it preserves the original null behaviour.
+   */
+  retryingFallback?: ReactNode;
 }
 
 /**

--- a/services/platform/app/features/settings/audit-logs/components/audit-log-tab.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-log-tab.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { AuditLogTable } from '@/app/features/settings/audit-logs/components/audit-log-table';
+import { useListAuditLogsPaginated } from '@/app/features/settings/audit-logs/hooks/queries';
+
+interface AuditLogTabProps {
+  organizationId: string;
+  /** Category filter the page-level filter UI drives for the audit tab. */
+  category?: string;
+  userEmailMap?: Map<string, string>;
+  /**
+   * When set, reveal this row's detail dialog (notification deep link or the
+   * integrity panel's "open broken row").
+   */
+  revealLogId?: string;
+  /**
+   * Bumps whenever a fresh reveal is requested, so the same `revealLogId`
+   * re-opens after the dialog was closed.
+   */
+  revealNonce?: number;
+}
+
+/**
+ * "Audit logs" tab — the full audit trail, row by row. Owns its paginated
+ * query (mirroring {@link ErrorLogTable}) so the read lives *inside* the
+ * tab's `LogsTableBoundary`: a timed-out page then degrades to that boundary's
+ * skeleton/retry instead of escalating to the page-level error boundary.
+ */
+export function AuditLogTab({
+  organizationId,
+  category,
+  userEmailMap,
+  revealLogId,
+  revealNonce,
+}: AuditLogTabProps) {
+  const paginatedResult = useListAuditLogsPaginated({
+    organizationId,
+    category,
+    initialNumItems: 30,
+  });
+
+  return (
+    <AuditLogTable
+      paginatedResult={paginatedResult}
+      userEmailMap={userEmailMap}
+      organizationId={organizationId}
+      revealLogId={revealLogId}
+      revealNonce={revealNonce}
+    />
+  );
+}

--- a/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/audit-logs-page.tsx
@@ -10,10 +10,10 @@ import { AccessDenied } from '@/app/components/layout/access-denied';
 import { DataTableFilters } from '@/app/components/ui/data-table/data-table-filters';
 import { ActivityLogView } from '@/app/features/settings/audit-logs/components/activity-log-view';
 import { AuditIntegrityPanel } from '@/app/features/settings/audit-logs/components/audit-integrity-panel';
-import { AuditLogTable } from '@/app/features/settings/audit-logs/components/audit-log-table';
+import { AuditLogTab } from '@/app/features/settings/audit-logs/components/audit-log-tab';
 import { BlockCountersTable } from '@/app/features/settings/audit-logs/components/block-counters-table';
 import { ErrorLogTable } from '@/app/features/settings/audit-logs/components/error-log-table';
-import { useListAuditLogsPaginated } from '@/app/features/settings/audit-logs/hooks/queries';
+import { LogsTableBoundary } from '@/app/features/settings/audit-logs/components/logs-table-boundary';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
 import { SettingsSection } from '@/app/features/settings/components/settings-section';
 import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
@@ -75,12 +75,6 @@ export function AuditLogsPage({
   // actually filters something.
   const activeTab = tab ?? 'audit';
   const showCategoryFilter = activeTab === 'audit' || activeTab === 'errors';
-
-  const paginatedResult = useListAuditLogsPaginated({
-    organizationId,
-    category,
-    initialNumItems: 30,
-  });
 
   const membersQuery = useConvexQuery(api.members.queries.listByOrganization, {
     organizationId,
@@ -228,13 +222,15 @@ export function AuditLogsPage({
               value: 'audit',
               label: t('logs.auditLogs'),
               content: (
-                <AuditLogTable
-                  paginatedResult={paginatedResult}
-                  userEmailMap={userEmailMap}
-                  organizationId={organizationId}
-                  revealLogId={reveal?.logId}
-                  revealNonce={reveal?.seq}
-                />
+                <LogsTableBoundary resetKeys={[category]}>
+                  <AuditLogTab
+                    organizationId={organizationId}
+                    category={category}
+                    userEmailMap={userEmailMap}
+                    revealLogId={reveal?.logId}
+                    revealNonce={reveal?.seq}
+                  />
+                </LogsTableBoundary>
               ),
             },
             {
@@ -256,11 +252,13 @@ export function AuditLogsPage({
               value: 'errors',
               label: t('logs.errorLogs'),
               content: (
-                <ErrorLogTable
-                  organizationId={organizationId}
-                  category={category}
-                  userEmailMap={userEmailMap}
-                />
+                <LogsTableBoundary variant="errors" resetKeys={[category]}>
+                  <ErrorLogTable
+                    organizationId={organizationId}
+                    category={category}
+                    userEmailMap={userEmailMap}
+                  />
+                </LogsTableBoundary>
               ),
             },
           ]}

--- a/services/platform/app/features/settings/audit-logs/components/logs-table-boundary.test.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/logs-table-boundary.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import { LogsTableBoundary } from './logs-table-boundary';
+
+// The auto-retry backoff renders `AuditLogTable` (loading) as a skeleton — stub
+// it so the boundary's own behaviour is what's under test, not the table's deep
+// hook tree.
+vi.mock('./audit-log-table', () => ({
+  AuditLogTable: () => <div data-testid="logs-skeleton" />,
+}));
+
+// A child that throws on demand. Flipping `shouldThrow.current` to false lets a
+// boundary reset re-render it successfully.
+const shouldThrow = { current: true };
+function Boom({ message }: { message: string }) {
+  if (shouldThrow.current) throw new Error(message);
+  return <div data-testid="logs-content">logs</div>;
+}
+
+afterEach(() => {
+  shouldThrow.current = true;
+  vi.restoreAllMocks();
+});
+
+describe('LogsTableBoundary', () => {
+  it('shows an inline retry card for a non-transient error instead of rethrowing', () => {
+    // Boundary swallows the error + logs it; keep the test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <LogsTableBoundary>
+        <Boom message="boom" />
+      </LogsTableBoundary>,
+    );
+
+    expect(screen.getByText("Couldn't load logs")).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('re-renders the table when the user retries after the cause clears', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { user } = render(
+      <LogsTableBoundary>
+        <Boom message="boom" />
+      </LogsTableBoundary>,
+    );
+
+    expect(screen.getByText("Couldn't load logs")).toBeInTheDocument();
+
+    // The transient cause has cleared by the time the user clicks Retry.
+    shouldThrow.current = false;
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(screen.getByTestId('logs-content')).toBeInTheDocument();
+    expect(screen.queryByText("Couldn't load logs")).not.toBeInTheDocument();
+  });
+
+  it('auto-retries a transient timeout, showing the table skeleton during backoff', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    try {
+      render(
+        <LogsTableBoundary>
+          <Boom message="Request timed out" />
+        </LogsTableBoundary>,
+      );
+
+      // During the backoff window the skeleton stands in — no hard error card.
+      expect(screen.getByTestId('logs-skeleton')).toBeInTheDocument();
+      expect(screen.queryByText("Couldn't load logs")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/services/platform/app/features/settings/audit-logs/components/logs-table-boundary.tsx
+++ b/services/platform/app/features/settings/audit-logs/components/logs-table-boundary.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { Button } from '@tale/ui/button';
+import { Center, Stack } from '@tale/ui/layout';
+import { Text } from '@tale/ui/text';
+import type { UsePaginatedQueryResult } from 'convex/react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { type ReactNode } from 'react';
+
+import { isConvexTransientError } from '@/app/components/error-boundaries/boundaries/layout-error-boundary';
+import { ErrorBoundaryBase } from '@/app/components/error-boundaries/core/error-boundary-base';
+import type { Doc } from '@/convex/_generated/dataModel';
+import { useT } from '@/lib/i18n/client';
+
+import type { AuditLogTableVariant } from '../hooks/use-audit-log-table-config';
+import { AuditLogTable } from './audit-log-table';
+
+// Match the layout boundary so a flaky governance backend gets the same number
+// of silent retries before the user has to act.
+const MAX_RETRIES = 3;
+
+// A paginated result frozen in its first-page-loading state. Reused as the
+// auto-retry placeholder so the backoff window shows the *real* table skeleton
+// (driven by the same `DataTable` self-skeleton path the live load uses) rather
+// than a blank gap.
+const LOADING_RESULT: UsePaginatedQueryResult<Doc<'auditLogs'>> = {
+  results: [],
+  status: 'LoadingFirstPage',
+  loadMore: () => {},
+  isLoading: true,
+};
+
+interface LogsTableBoundaryProps {
+  children: ReactNode;
+  /** `errors` skeletonizes with the error-column layout. */
+  variant?: AuditLogTableVariant;
+  /**
+   * Values that reset the boundary when they change (e.g. the active category
+   * filter) so switching filters clears a stuck error instead of stranding the
+   * user on the retry card.
+   */
+  resetKeys?: unknown[];
+}
+
+/**
+ * Table-scoped error boundary for the governance logs tabs.
+ *
+ * A paginated Convex query that times out throws from the component that reads
+ * it, which would otherwise escalate to the page-level (full-panel) boundary
+ * and replace the whole Logs panel — heading, tabs, filters, export — with a
+ * hard error. Wrapping just the query-owning table subtree keeps that chrome
+ * mounted and degrades only the table:
+ *
+ * - Transient timeouts auto-retry up to {@link MAX_RETRIES} times with backoff,
+ *   showing the table skeleton during each backoff window.
+ * - If the retries are exhausted (or the error isn't transient) the table area
+ *   shows an inline retry card instead of the full-panel error.
+ */
+export function LogsTableBoundary({
+  children,
+  variant = 'audit',
+  resetKeys,
+}: LogsTableBoundaryProps) {
+  return (
+    <ErrorBoundaryBase
+      resetKeys={resetKeys}
+      maxRetries={MAX_RETRIES}
+      isRetryableError={isConvexTransientError}
+      retryingFallback={
+        <AuditLogTable paginatedResult={LOADING_RESULT} variant={variant} />
+      }
+      fallback={(fallbackProps) => (
+        <LogsTableErrorState reset={fallbackProps.reset} />
+      )}
+    >
+      {children}
+    </ErrorBoundaryBase>
+  );
+}
+
+function LogsTableErrorState({ reset }: { reset: () => void }) {
+  const { t } = useT('settings');
+
+  return (
+    <Center className="min-h-0 flex-1 px-4 py-12">
+      <Stack gap={3} className="max-w-sm items-center text-center">
+        <div
+          className="bg-muted grid size-10 place-items-center rounded-full"
+          role="img"
+          aria-label={t('logs.loadError.title')}
+        >
+          <AlertTriangle className="text-muted-foreground size-5" />
+        </div>
+        <Stack gap={1} className="items-center">
+          <Text as="span" className="font-medium">
+            {t('logs.loadError.title')}
+          </Text>
+          <Text variant="muted" className="text-sm">
+            {t('logs.loadError.description')}
+          </Text>
+        </Stack>
+        <Button variant="secondary" icon={RefreshCw} onClick={reset}>
+          {t('logs.loadError.retry')}
+        </Button>
+      </Stack>
+    </Center>
+  );
+}

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6347,6 +6347,11 @@
       "auditLogs": "Audit-Protokolle",
       "activityLogs": "Aktivitätsprotokolle",
       "errorLogs": "Fehlerprotokolle",
+      "loadError": {
+        "title": "Protokolle konnten nicht geladen werden",
+        "description": "Das Laden der Protokolle hat zu lange gedauert. Das ist meist nur vorübergehend.",
+        "retry": "Erneut versuchen"
+      },
       "activity": {
         "period": {
           "label": "Zeitraum",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -6611,6 +6611,11 @@
       "auditLogs": "Audit logs",
       "activityLogs": "Activity logs",
       "errorLogs": "Error logs",
+      "loadError": {
+        "title": "Couldn't load logs",
+        "description": "The logs took too long to load. This is usually temporary.",
+        "retry": "Retry"
+      },
       "activity": {
         "period": {
           "label": "Period",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6348,6 +6348,11 @@
       "auditLogs": "Journaux d'audit",
       "activityLogs": "Journaux d'activité",
       "errorLogs": "Journaux d'erreurs",
+      "loadError": {
+        "title": "Impossible de charger les journaux",
+        "description": "Le chargement des journaux a pris trop de temps. C'est généralement temporaire.",
+        "retry": "Réessayer"
+      },
       "activity": {
         "period": {
           "label": "Période",


### PR DESCRIPTION
## Summary

When the paginated **governance logs** query timed out, it threw from the page-level component and escalated to the full-panel error boundary — replacing the entire Logs panel (heading, tabs, filters, export) with a hard error.

This wraps each logs table in a **table-scoped error boundary** so only the table area degrades:

- Transient Convex timeouts (`isConvexTransientError`) **auto-retry** up to 3× with backoff, showing the **table skeleton** during each backoff window.
- If retries are exhausted (or the error isn't transient), the table area shows an **inline retry card** instead of the full-panel error.
- The page chrome (heading, tabs, filters, export) stays mounted throughout.

## Changes

- `error-boundary-base` / `types`: additive optional `retryingFallback` rendered during the auto-retry backoff (default stays `null`, so Suspense-driven callers are unchanged).
- New `LogsTableBoundary` (auto-retry + skeleton + inline retry card) and `AuditLogTab` (moves the audit paginated query *inside* the boundary subtree, mirroring `ErrorLogTable`).
- `audit-logs-page` wraps the Audit and Error tabs in `LogsTableBoundary`.
- New i18n keys `settings.logs.loadError.*` (en/de/fr).
- Tests for the new boundary (`logs-table-boundary.test.tsx`).

## Verification

- `tsc --noEmit` — clean
- `oxlint --type-aware` (audit-logs + error-boundaries) — 0 warnings/errors
- UI tests: audit-logs (6) + error-boundaries (11) + new boundary (3) — all green

Closes #1984