### PR TITLE
fix: localize "Unknown Customer" fallback + fix missing pagination i18n key in conversations (#1978)

### DIFF
--- a/services/platform/app/features/conversations/components/conversations-list.test.tsx
+++ b/services/platform/app/features/conversations/components/conversations-list.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+import type { Conversation } from '../types';
+import { ConversationsList } from './conversations-list';
+
+// Builds a conversation fixture. Fields that the list reads (title, customer,
+// unread_count, etc.) can be overridden per test; the rest are filler.
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    _id: 'conv-1',
+    _creationTime: Date.now(),
+    organizationId: 'org-1',
+    id: 'conv-1',
+    title: 'Re: Refund request',
+    subject: 'Re: Refund request',
+    description: 'A conversation about a refund',
+    channel: 'Email',
+    type: 'General',
+    customer_id: 'cust-1',
+    customerId: 'cust-1',
+    business_id: 'biz-1',
+    message_count: 1,
+    unread_count: 0,
+    last_message_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    status: 'open',
+    customer: {
+      id: 'cust-1',
+      name: 'Sarah Johnson',
+      email: 'sarah@company.com',
+      status: 'active',
+      source: 'api',
+      locale: 'en',
+      created_at: new Date().toISOString(),
+    },
+    messages: [],
+    ...overrides,
+  } as unknown as Conversation;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ConversationsList accessibility', () => {
+  it('uses the conversation subject as the select button accessible name', () => {
+    render(
+      <ConversationsList
+        conversations={[
+          makeConversation({ id: 'c1', title: 'Re: Refund request' }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Re: Refund request' }),
+    ).toBeInTheDocument();
+  });
+
+  it('gives two name-less conversations distinct accessible names from their subjects', () => {
+    render(
+      <ConversationsList
+        conversations={[
+          makeConversation({
+            id: 'c1',
+            title: 'Where is my package?',
+            customer: undefined,
+          }),
+          makeConversation({
+            id: 'c2',
+            title: 'Cancel my subscription',
+            customer: undefined,
+          }),
+        ]}
+      />,
+    );
+
+    // Both rows are name-less, but their subject-derived labels keep them
+    // distinguishable to screen-reader users.
+    expect(
+      screen.getByRole('button', { name: 'Where is my package?' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel my subscription' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the localized unknownCustomer fallback when neither name nor subject exist', () => {
+    render(
+      <ConversationsList
+        conversations={[
+          makeConversation({
+            id: 'c1',
+            title: '',
+            subject: '',
+            customer: undefined,
+          }),
+        ]}
+      />,
+    );
+
+    // From conversations.unknownCustomer in en.json. The heading and the select
+    // button both fall back to the localized label.
+    expect(screen.getAllByText('Unknown customer').length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: 'Unknown customer' }),
+    ).toBeInTheDocument();
+  });
+
+  it('labels the load-more spinner with the localized pagination string', () => {
+    render(
+      <ConversationsList
+        conversations={[makeConversation({ id: 'c1' })]}
+        paginationStatus="LoadingMore"
+      />,
+    );
+
+    // From common.pagination.loading in en.json (the old
+    // conversations.history.loadingMore key never existed).
+    expect(screen.getByLabelText('Loading more...')).toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/conversations/components/conversations-list.tsx
+++ b/services/platform/app/features/conversations/components/conversations-list.tsx
@@ -167,6 +167,11 @@ const ConversationRow = memo(function ConversationRow({
 }: ConversationRowProps) {
   const { t: tCommon } = useT('common');
 
+  // Localized fallback for a name-less customer. The backend now returns an
+  // undefined name (instead of a hardcoded "Unknown Customer"), so the label is
+  // translated here per locale.
+  const unknownCustomer = t ? t('unknownCustomer') : '';
+
   const handleCheckboxChange = (checked: boolean | 'indeterminate') => {
     if (typeof checked === 'boolean' && conversation) {
       onCheck?.(conversation.id, checked);
@@ -196,11 +201,14 @@ const ConversationRow = memo(function ConversationRow({
           if (conversation) onSelect?.(conversation);
         }}
         aria-pressed={isSelected}
+        // Derive the accessible name from the conversation subject first so
+        // rows stay distinguishable to screen readers even when several share
+        // the same (or no) customer name.
         aria-label={
           conversation
-            ? conversation.customer?.name ||
-              conversation.title ||
-              'Conversation'
+            ? conversation.title ||
+              conversation.customer?.name ||
+              unknownCustomer
             : undefined
         }
         className="absolute inset-0 z-0"
@@ -231,7 +239,7 @@ const ConversationRow = memo(function ConversationRow({
                   {conversation
                     ? conversation.customer?.name ||
                       conversation?.title ||
-                      'Unknown'
+                      unknownCustomer
                     : 'Conversation name'}
                 </SkeletonBox>
               </Heading>
@@ -346,6 +354,7 @@ export function ConversationsList({
   const { formatDateSmart } = useFormatDate();
   const { t } = useT('conversations');
   const { t: tDialogs } = useT('dialogs');
+  const { t: tCommon } = useT('common');
 
   const tRef = useRef(t);
   tRef.current = t;
@@ -442,7 +451,7 @@ export function ConversationsList({
                 <Loader2
                   className="text-muted-foreground size-5 animate-spin motion-reduce:animate-none"
                   role="status"
-                  aria-label={t('history.loadingMore')}
+                  aria-label={tCommon('pagination.loading')}
                 />
               </Center>
             )}

--- a/services/platform/convex/conversations/transform_conversation.test.ts
+++ b/services/platform/convex/conversations/transform_conversation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Doc } from '../_generated/dataModel';
+import type { QueryCtx } from '../_generated/server';
+import { transformConversation } from './transform_conversation';
+
+// transformConversation fetches a pending approval for the conversation; the
+// name-fallback behavior under test does not depend on it, so stub it out.
+vi.mock('../approvals/helpers', () => ({
+  getPendingApprovalForResource: vi.fn().mockResolvedValue(null),
+}));
+
+// Minimal ctx whose message query resolves to "no messages" and whose
+// `db.get` is unused (every test prefetches the customer via options.customer).
+function createMockCtx() {
+  const builder = {
+    withIndex: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(null),
+  };
+
+  const ctx = {
+    db: {
+      query: vi.fn().mockReturnValue(builder),
+      get: vi.fn().mockResolvedValue(null),
+    },
+  };
+
+  return ctx as unknown as QueryCtx;
+}
+
+function makeConversation(
+  overrides: Partial<Doc<'conversations'>> = {},
+): Doc<'conversations'> {
+  return {
+    _id: 'conv_1',
+    _creationTime: 1_700_000_000_000,
+    organizationId: 'org_1',
+    customerId: 'cust_1',
+    subject: 'Help with my order',
+    status: 'open',
+    metadata: {},
+    ...overrides,
+  } as unknown as Doc<'conversations'>;
+}
+
+function makeCustomerDoc(
+  overrides: Partial<Doc<'customers'>> = {},
+): Doc<'customers'> {
+  return {
+    _id: 'cust_1',
+    _creationTime: 1_700_000_000_000,
+    organizationId: 'org_1',
+    email: 'customer@example.com',
+    metadata: {},
+    ...overrides,
+  } as unknown as Doc<'customers'>;
+}
+
+describe('transformConversation customer name fallback', () => {
+  it('leaves name undefined for a found customer that has no name', async () => {
+    const ctx = createMockCtx();
+    const conversation = makeConversation();
+    // A customer doc that exists but carries no name (and an empty-string name
+    // should be treated the same way).
+    const customer = makeCustomerDoc({ name: undefined });
+
+    const result = await transformConversation(ctx, conversation, { customer });
+
+    expect(result.customer.name).toBeUndefined();
+    // Email is still populated so downstream consumers have a real identifier.
+    expect(result.customer.email).toBe('customer@example.com');
+  });
+
+  it('leaves name undefined for an empty-string customer name', async () => {
+    const ctx = createMockCtx();
+    const conversation = makeConversation();
+    const customer = makeCustomerDoc({ name: '' });
+
+    const result = await transformConversation(ctx, conversation, { customer });
+
+    expect(result.customer.name).toBeUndefined();
+  });
+
+  it('leaves name undefined in the no-customer fallback', async () => {
+    const ctx = createMockCtx();
+    const conversation = makeConversation();
+
+    // A prefetched `null` is trusted as "no customer for this conversation".
+    const result = await transformConversation(ctx, conversation, {
+      customer: null,
+    });
+
+    expect(result.customer.name).toBeUndefined();
+  });
+
+  it('preserves a real customer name when present', async () => {
+    const ctx = createMockCtx();
+    const conversation = makeConversation();
+    const customer = makeCustomerDoc({ name: 'Ada Lovelace' });
+
+    const result = await transformConversation(ctx, conversation, { customer });
+
+    expect(result.customer.name).toBe('Ada Lovelace');
+  });
+});

--- a/services/platform/convex/conversations/transform_conversation.ts
+++ b/services/platform/convex/conversations/transform_conversation.ts
@@ -67,10 +67,11 @@ export async function transformConversation(
     })(),
   ]);
 
-  // Build customer info from fetched data
+  // Build customer info from fetched data. A missing name is left undefined so
+  // the client can render a localized fallback (e.g. conversations.unknownCustomer)
+  // instead of a hardcoded, untranslatable English string.
   let customer: CustomerInfo = {
     id: conversation.customerId || 'unknown',
-    name: 'Unknown Customer',
     email: 'unknown@example.com',
     locale: 'en',
     status: 'active',
@@ -82,7 +83,7 @@ export async function transformConversation(
     const custMeta = customerDoc.metadata ?? {};
     customer = {
       id: customerDoc._id,
-      name: customerDoc.name || 'Unknown Customer',
+      name: customerDoc.name || undefined,
       email: customerDoc.email || 'unknown@example.com',
       locale: typeof custMeta.locale === 'string' ? custMeta.locale : 'en',
       status: typeof custMeta.status === 'string' ? custMeta.status : 'active',

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2095,6 +2095,7 @@
   },
   "conversations": {
     "title": "Konversationen",
+    "unknownCustomer": "Unbekannter Kunde",
     "messagePlaceholder": "Nachricht eingeben",
     "suggestEditsPlaceholder": "Änderungen am Text vorschlagen (optional)",
     "fallbackImageAttachment": "Bildanhang",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2095,6 +2095,7 @@
   },
   "conversations": {
     "title": "Conversations",
+    "unknownCustomer": "Unknown customer",
     "messagePlaceholder": "Type a message",
     "suggestEditsPlaceholder": "Suggest edits to the text (optional)",
     "fallbackImageAttachment": "Image attachment",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2096,6 +2096,7 @@
   },
   "conversations": {
     "title": "Conversations",
+    "unknownCustomer": "Client inconnu",
     "messagePlaceholder": "Saisis un message",
     "suggestEditsPlaceholder": "Suggère des modifications au texte (optionnel)",
     "fallbackImageAttachment": "Pièce jointe image",


### PR DESCRIPTION
## Summary

Fixes two localization/a11y gaps in the conversations inbox (#1978):

1. **Untranslatable "Unknown Customer"** — the backend transform hardcoded the English string `"Unknown Customer"`. It now returns `undefined` for a missing customer name, and the client renders a localized fallback from the new `conversations.unknownCustomer` key.
2. **Rows indistinguishable to screen readers** — every name-less row's select button shared the identical accessible name. The button's `aria-label` is now derived from the conversation **subject** first, so rows stay distinguishable.
3. **Missing pagination i18n key** — the load-more spinner referenced `conversations.history.loadingMore`, which doesn't exist, so its `aria-label` resolved to the raw key. It now uses the existing localized `common.pagination.loading`.

## Changes

- `convex/conversations/transform_conversation.ts` — omit name in the fallback customer object; `customerDoc.name || undefined` (the validator already allows an optional name).
- `app/features/conversations/components/conversations-list.tsx` — localized `unknownCustomer` fallback for the heading; subject-first row `aria-label`; spinner uses `common.pagination.loading`.
- `messages/{en,de,fr}.json` — add `conversations.unknownCustomer` (de-CH inherits via overlay).

## Verification

- `vitest` i18n parity/usage suite — 23 passed
- server conversations tests — 20 passed
- conversations UI component tests — 32 passed
- `tsc --noEmit` — clean
- `oxlint --type-aware` on changed files — 0 warnings/errors

Closes #1978