### PR TITLE
fix(platform): add ICU plural to message and team count strings (#2053)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -1643,7 +1643,7 @@
       "description": "Nachrichten auswählen und im gewünschten Format herunterladen.",
       "selectAll": "Alle auswählen",
       "deselectAll": "Alle abwählen",
-      "messagesCount": "{count} von {total} Nachrichten ausgewählt",
+      "messagesCount": "{count, plural, one {# von {total} Nachricht ausgewählt} other {# von {total} Nachrichten ausgewählt}}",
       "downloadPdf": "Als PDF drucken",
       "downloadMarkdown": "Markdown herunterladen",
       "noMessages": "Keine Nachrichten zum Exportieren",
@@ -2114,7 +2114,7 @@
       "accept": "Änderungen übernehmen"
     },
     "bulkSend": {
-      "title": "{count} Nachrichten senden",
+      "title": "{count, plural, one {# Nachricht senden} other {# Nachrichten senden}}",
       "description": "Du sendest Antworten für {count, plural, one {# Konversation} other {# Konversationen}}. Diese Aktion kann nicht rückgängig gemacht werden.",
       "send": "Senden"
     },
@@ -7318,7 +7318,7 @@
       "columnActivity": "Letzte Aktivität",
       "sharingOrgWide": "Organisationsweit",
       "sharingTeamPrefix": "Team:",
-      "sharingMultipleTeams": "{count} Teams"
+      "sharingMultipleTeams": "{count, plural, one {# Team} other {# Teams}}"
     },
     "create": {
       "title": "Projekt erstellen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -1662,7 +1662,7 @@
       "description": "Select messages and download in your preferred format.",
       "selectAll": "Select all",
       "deselectAll": "Deselect all",
-      "messagesCount": "{count} of {total} messages selected",
+      "messagesCount": "{count, plural, one {# of {total} message selected} other {# of {total} messages selected}}",
       "downloadPdf": "Print to PDF",
       "downloadMarkdown": "Download Markdown",
       "noMessages": "No messages to export",
@@ -2114,7 +2114,7 @@
       "accept": "Accept changes"
     },
     "bulkSend": {
-      "title": "Send {count} Messages",
+      "title": "Send {count, plural, one {# Message} other {# Messages}}",
       "description": "You're about to send replies for {count, plural, one {# conversation} other {# conversations}}. This action can't be undone.",
       "send": "Send"
     },
@@ -4947,7 +4947,7 @@
       "columnActivity": "Last activity",
       "sharingOrgWide": "Org-wide",
       "sharingTeamPrefix": "Team:",
-      "sharingMultipleTeams": "{count} teams"
+      "sharingMultipleTeams": "{count, plural, one {# team} other {# teams}}"
     },
     "create": {
       "title": "Create project",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -1644,7 +1644,7 @@
       "description": "Sélectionne les messages et télécharge-les dans le format de ton choix.",
       "selectAll": "Tout sélectionner",
       "deselectAll": "Tout désélectionner",
-      "messagesCount": "{count} sur {total} messages sélectionnés",
+      "messagesCount": "{count, plural, one {# sur {total} message sélectionné} other {# sur {total} messages sélectionnés}}",
       "downloadPdf": "Imprimer en PDF",
       "downloadMarkdown": "Télécharger en Markdown",
       "noMessages": "Aucun message à exporter",
@@ -2115,7 +2115,7 @@
       "accept": "Accepter les modifications"
     },
     "bulkSend": {
-      "title": "Envoyer {count} messages",
+      "title": "Envoyer {count, plural, one {# message} other {# messages}}",
       "description": "Tu es sur le point d'envoyer des réponses pour {count, plural, one {# conversation} other {# conversations}}. Cette action est irréversible.",
       "send": "Envoyer"
     },
@@ -7319,7 +7319,7 @@
       "columnActivity": "Dernière activité",
       "sharingOrgWide": "Toute l'organisation",
       "sharingTeamPrefix": "Équipe :",
-      "sharingMultipleTeams": "{count} équipes"
+      "sharingMultipleTeams": "{count, plural, one {# équipe} other {# équipes}}"
     },
     "create": {
       "title": "Créer un projet",


### PR DESCRIPTION
## Summary

Three count strings used a bare `{count}` interpolation with a hardcoded plural noun instead of an ICU `plural` rule, so a count of 1 rendered ungrammatically (`1 messages`, `1 teams`, `Send 1 Messages`). This wraps each in an ICU `plural` rule with correct singular/plural categories across all locales.

## Changes (`services/platform/messages/{en,de,fr}.json`)

- **`chat.export.messagesCount`** — `"{count} of {total} messages selected"` → `"{count, plural, one {# of {total} message selected} other {# of {total} messages selected}}"`
- **`conversations.bulkSend.title`** — `"Send {count} Messages"` → `"Send {count, plural, one {# Message} other {# Messages}}"`
- **`projects.list.sharingMultipleTeams`** — `"{count} teams"` → `"{count, plural, one {# team} other {# teams}}"`

Equivalent ICU plural forms applied to `de.json` and `fr.json`, matching each locale's wording and the repo's existing `one`/`other` plural convention. `de-CH.json` is a partial overlay that does not define these keys (falls back to `de`), so no change was needed there.

## Verification

- `bunx vitest --run --project server lib/i18n/messages.test.ts` — **23 passed** (includes enforced key-parity & usage checks and the ICU placeholder/plural-rule checks).
- Rendering sanity-checked with `intl-messageformat`: `1 of 1 message selected`, `3 of 5 messages selected`, `Send 1 Message`, `1 team`, etc.

Closes #2053