### PR TITLE
fix: scan all pages for list search/filter, not just loaded ones (#2054)

### DIFF
--- a/services/platform/app/components/ui/data-table/data-table.tsx
+++ b/services/platform/app/components/ui/data-table/data-table.tsx
@@ -444,6 +444,10 @@ export function DataTable<TData, TValue = unknown>({
     if (!isDataLoading) {
       // Has data
       if (data.length > 0) return 'data';
+      // A filter narrowed the loaded rows to zero, but infinite-scroll is still
+      // draining backend pages — show loading, not "no results", so a match on
+      // an un-loaded page isn't prematurely reported as empty (#2054).
+      if (hasActiveFilters && infiniteScroll?.hasMore) return 'skeleton';
       // Has filters
       if (hasActiveFilters) return 'filtered-empty';
       // Has empty state
@@ -469,6 +473,7 @@ export function DataTable<TData, TValue = unknown>({
     data.length,
     emptyState,
     hasActiveFilters,
+    infiniteScroll?.hasMore,
   ]);
 
   const isSkeleton =

--- a/services/platform/app/features/conversations/components/conversations-list.tsx
+++ b/services/platform/app/features/conversations/components/conversations-list.tsx
@@ -103,6 +103,12 @@ interface ConversationsListProps {
   loadMore?: (numItems: number) => void;
   /** Number of placeholder rows to render while `conversations` is undefined. */
   skeletonRows?: number;
+  /**
+   * Whether a client-side search/read-filter is active. When true, remaining
+   * backend pages are eagerly drained so the filter scans the full dataset
+   * rather than only already-loaded pages (#2054).
+   */
+  isFiltering?: boolean;
 }
 
 const priorityConfig = {
@@ -342,6 +348,7 @@ export function ConversationsList({
   paginationStatus,
   loadMore,
   skeletonRows = 12,
+  isFiltering = false,
 }: ConversationsListProps) {
   const { formatDateSmart } = useFormatDate();
   const { t } = useT('conversations');
@@ -383,6 +390,16 @@ export function ConversationsList({
     return () => observer.disconnect();
   }, [handleIntersect]);
 
+  // While a search/read-filter is active the client-side filter only matches
+  // already-loaded pages, and a filter that empties the loaded buffer hides the
+  // scroll sentinel above — so drive pagination directly here, draining pages
+  // until a match loads or the list is exhausted (#2054).
+  useEffect(() => {
+    if (isFiltering && paginationStatus === 'CanLoadMore' && loadMore) {
+      loadMore(PAGE_SIZE);
+    }
+  }, [isFiltering, paginationStatus, loadMore]);
+
   // One real tree, always. Loading, empty and populated states all render
   // inside the SAME <Skeletonize> wrapper so the base layout never shifts
   // between states (mirrors the DataTable body-state pattern):
@@ -394,6 +411,14 @@ export function ConversationsList({
   const isEmpty = conversations !== undefined && conversations.length === 0;
   const placeholderCount = Math.min(skeletonRows, 12);
 
+  // A filter narrowed the loaded buffer to zero, but more pages are still
+  // draining — show loading, not "no conversations", so a match on an un-loaded
+  // page isn't prematurely reported as empty (#2054).
+  const isSearchingMore =
+    isEmpty &&
+    isFiltering &&
+    (paginationStatus === 'CanLoadMore' || paginationStatus === 'LoadingMore');
+
   return (
     <Skeletonize
       loading={isLoading}
@@ -404,17 +429,29 @@ export function ConversationsList({
       className={cn(isEmpty && 'flex min-h-0 flex-1 flex-col')}
     >
       {isEmpty ? (
-        // Centered in the available space, no row dividers/border — it's a
-        // message, not a row, so it shouldn't read as a boxed-off list item.
-        <Stack
-          gap={0}
-          align="center"
-          justify="center"
-          className="flex-1 px-4 py-16 text-center"
-        >
-          <Inbox className="text-muted-foreground/60 mb-3 size-6" />
-          <Text variant="muted">{t('list.empty')}</Text>
-        </Stack>
+        isSearchingMore ? (
+          // Still draining backend pages for a match — show a spinner rather
+          // than the empty message so we don't flash a false "no results".
+          <Center className="min-h-0 flex-1 px-4 py-16">
+            <Loader2
+              className="text-muted-foreground size-5 animate-spin motion-reduce:animate-none"
+              role="status"
+              aria-label={t('history.loadingMore')}
+            />
+          </Center>
+        ) : (
+          // Centered in the available space, no row dividers/border — it's a
+          // message, not a row, so it shouldn't read as a boxed-off list item.
+          <Stack
+            gap={0}
+            align="center"
+            justify="center"
+            className="flex-1 px-4 py-16 text-center"
+          >
+            <Inbox className="text-muted-foreground/60 mb-3 size-6" />
+            <Text variant="muted">{t('list.empty')}</Text>
+          </Stack>
+        )
       ) : (
         <div className="divide-border divide-y border-b">
           <>

--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -129,6 +129,12 @@ export function Conversations({
     return results;
   }, [paginatedResult.results, searchQuery, initialSearch, readFilter]);
 
+  // Search and the read-status filter run client-side over the loaded pages
+  // only, so while either is active we must keep draining backend pages — a
+  // match beyond the first page would otherwise be silently missed (#2054).
+  const isFiltering =
+    Boolean(searchQuery || initialSearch) || readFilter !== 'all';
+
   const {
     selectionState,
     handleConversationCheck,
@@ -375,6 +381,7 @@ export function Conversations({
           paginationStatus={paginatedResult.status}
           loadMore={paginatedResult.loadMore}
           skeletonRows={skeletonRows}
+          isFiltering={isFiltering}
         />
       </ConversationListPanel>
 

--- a/services/platform/app/hooks/use-list-page.test.ts
+++ b/services/platform/app/hooks/use-list-page.test.ts
@@ -65,6 +65,106 @@ describe('useListPage — infiniteScroll mode (default)', () => {
       expect(props.infiniteScroll.hasMore).toBe(true);
     }
   });
+
+  it('does not eagerly drain backend pages while idle (no active filter)', () => {
+    const loadMore = vi.fn();
+
+    renderListPage({
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'CanLoadMore',
+        loadMore,
+        isLoading: false,
+      },
+      search: { fields: ['name'] },
+    });
+
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('eagerly drains backend pages while a search is active (#2054)', () => {
+    const loadMore = vi.fn();
+
+    const { result } = renderListPage({
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'CanLoadMore',
+        loadMore,
+        isLoading: false,
+      },
+      search: { fields: ['name'] },
+    });
+
+    const props = result.current.tableProps;
+    if (props.search) {
+      act(() => {
+        props.search?.onChange('Item 99');
+      });
+    }
+
+    // A search that matches nothing in the loaded buffer must keep loading
+    // more backend pages instead of stranding the user on a false "no results".
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('eagerly drains backend pages while a managed field filter is active', () => {
+    const loadMore = vi.fn();
+
+    const { result } = renderListPage({
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'CanLoadMore',
+        loadMore,
+        isLoading: false,
+      },
+      filters: {
+        definitions: [
+          {
+            key: 'category',
+            title: 'Category',
+            options: [
+              { value: 'even', label: 'Even' },
+              { value: 'odd', label: 'Odd' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const props = result.current.tableProps;
+    act(() => {
+      props.filters?.[0]?.onChange(['even']);
+    });
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('does not drain when backend is exhausted even with an active search', () => {
+    const loadMore = vi.fn();
+
+    const { result } = renderListPage({
+      dataSource: {
+        type: 'paginated',
+        results: makeItems(10),
+        status: 'Exhausted',
+        loadMore,
+        isLoading: false,
+      },
+      search: { fields: ['name'] },
+    });
+
+    const props = result.current.tableProps;
+    if (props.search) {
+      act(() => {
+        props.search?.onChange('Item 99');
+      });
+    }
+
+    expect(loadMore).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/platform/app/hooks/use-list-page.ts
+++ b/services/platform/app/hooks/use-list-page.ts
@@ -204,6 +204,22 @@ export function useListPage<TData>(
   const filterValues =
     filters && !isControlledFilters(filters) ? managedFilterStates : null;
 
+  // Whether a client-side search/filter is currently narrowing the dataset.
+  // When true in infinite-scroll mode we must eagerly drain ALL backend pages
+  // so the filter scans the full dataset rather than only already-loaded pages
+  // (#2054) — otherwise a match on an un-loaded page is silently missed.
+  const hasActiveClientFilter = useMemo(() => {
+    const searchActive = search
+      ? isManagedSearch(search)
+        ? managedSearchValue.trim().length > 0
+        : search.value.trim().length > 0
+      : false;
+    const managedFilterActive = filterValues
+      ? Object.values(filterValues).some((values) => values.length > 0)
+      : false;
+    return searchActive || managedFilterActive;
+  }, [search, managedSearchValue, filterValues]);
+
   // 5. Process data (search + filters)
   const processed = useMemo(() => {
     let data = [...rawData];
@@ -372,6 +388,20 @@ export function useListPage<TData>(
       filteredCount: processed.length,
       isLoading,
     };
+  }
+
+  // Infinite-scroll mode normally fetches the next backend page only as the user
+  // scrolls. But while a client-side search/filter is active we eagerly drain
+  // the remaining pages so the filter scans the entire dataset — without this,
+  // matches on un-loaded pages are silently missed, and a filter that narrows
+  // the loaded buffer to zero suppresses the scroll sentinel, stranding the user
+  // on a false "no results" (#2054).
+  if (
+    hasActiveClientFilter &&
+    dataSource.type === 'paginated' &&
+    dataSource.status === 'CanLoadMore'
+  ) {
+    dataSource.loadMore(pageSize * 3);
   }
 
   return {


### PR DESCRIPTION
## Summary

Three list views (knowledge-entries, websites, conversations) ran search/filter purely **client-side over the already-loaded paginated buffer** while using infinite-scroll. The backend queries had no search arg and the eager full-load drain only existed in the `'pagination'` display mode, so:

- matches on un-loaded pages were silently missed, and
- when a filter narrowed the loaded rows to zero, the infinite-scroll sentinel was suppressed (gated on `data.length > 0` / the empty branch had no sentinel), so no further pages loaded — the user saw a false "no results" / "No conversations" even though a match existed deeper.

This implements the client-only fix the issue calls for: **keep auto-loading backend pages while a search/filter is active, even when the filtered view is empty**, so the client-side filter scans the full dataset. Infinite-scroll UX is preserved when no filter is active.

## Changes

- **`app/hooks/use-list-page.ts`** (knowledge-entries [68] + websites [75]): detect an active client-side search / managed field filter (`hasActiveClientFilter`) and, in infinite-scroll mode, eagerly drain remaining backend pages (`loadMore`) until exhausted — mirroring the existing `'pagination'`-mode drain.
- **`app/components/ui/data-table/data-table.tsx`**: when a filter empties the loaded buffer but pages are still draining (`hasActiveFilters && infiniteScroll.hasMore`), show the loading/skeleton state instead of "no results", so a deep match isn't prematurely reported as empty.
- **`app/features/conversations/components/conversations.tsx` + `conversations-list.tsx`** (conversations [80]): thread an `isFiltering` flag; drive pagination directly while a search/read-filter is active (the empty-buffer branch has no sentinel), and show a spinner instead of "No conversations" while still draining.

## Tests

- Extended `app/hooks/use-list-page.test.ts` with cases covering: no drain while idle, drain on active search, drain on active managed filter, and no drain when the backend is exhausted.
- `bunx vitest --run` (use-list-page + conversations + data-table UI suites): **all pass**.
- `bunx tsc --noEmit`: clean. `bunx oxlint --type-aware`: clean.

Closes #2054