### PR TITLE
fix(platform): deliver bulk conversation replies via integration (#2047)

### DIFF
--- a/services/platform/app/features/conversations/components/bulk-send-dialog.test.tsx
+++ b/services/platform/app/features/conversations/components/bulk-send-dialog.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { cleanup, render, screen } from '@/tests/utils/render';
+
+import { BulkSendDialog } from './bulk-send-dialog';
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BulkSendDialog', () => {
+  it('passes axe audit', async () => {
+    const { container } = render(
+      <BulkSendDialog
+        selectedCount={3}
+        isSending={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await checkAccessibility(container);
+  });
+
+  it('keeps Send disabled until the body is non-empty', async () => {
+    const { user } = render(
+      <BulkSendDialog
+        selectedCount={2}
+        isSending={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const sendButton = screen.getByRole('button', { name: 'bulkSend.send' });
+    expect(sendButton).toBeDisabled();
+
+    // Whitespace-only input must not enable Send.
+    const textarea = screen.getByLabelText('bulkSend.messageLabel');
+    await user.type(textarea, '   ');
+    expect(sendButton).toBeDisabled();
+
+    await user.type(textarea, 'Hello');
+    expect(sendButton).toBeEnabled();
+  });
+
+  it('calls onConfirm with the trimmed body', async () => {
+    const onConfirm = vi.fn();
+    const { user } = render(
+      <BulkSendDialog
+        selectedCount={1}
+        isSending={false}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const textarea = screen.getByLabelText('bulkSend.messageLabel');
+    await user.type(textarea, '  Thanks for reaching out  ');
+    await user.click(screen.getByRole('button', { name: 'bulkSend.send' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith('Thanks for reaching out');
+  });
+
+  it('disables inputs and Cancel while sending', () => {
+    render(
+      <BulkSendDialog
+        selectedCount={1}
+        isSending={true}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('bulkSend.messageLabel')).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'actions.cancel' }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'bulkSend.send' }),
+    ).toBeDisabled();
+  });
+
+  it('invokes onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn();
+    const { user } = render(
+      <BulkSendDialog
+        selectedCount={1}
+        isSending={false}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'actions.cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/platform/app/features/conversations/components/bulk-send-dialog.tsx
+++ b/services/platform/app/features/conversations/components/bulk-send-dialog.tsx
@@ -3,13 +3,15 @@ import { Heading } from '@tale/ui/heading';
 import { Row } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { Loader2Icon } from 'lucide-react';
+import { useState } from 'react';
 
+import { Textarea } from '@/app/components/ui/forms/textarea';
 import { useT } from '@/lib/i18n/client';
 
 interface BulkSendDialogProps {
   selectedCount: number;
   isSending: boolean;
-  onConfirm: () => void;
+  onConfirm: (message: string) => void;
   onCancel: () => void;
 }
 
@@ -21,6 +23,10 @@ export function BulkSendDialog({
 }: BulkSendDialogProps) {
   const { t: tConversations } = useT('conversations');
   const { t: tCommon } = useT('common');
+
+  const [message, setMessage] = useState('');
+  const trimmedMessage = message.trim();
+  const canSend = trimmedMessage.length > 0 && !isSending;
 
   return (
     <Row
@@ -35,11 +41,22 @@ export function BulkSendDialog({
         <Text variant="muted" className="mb-6">
           {tConversations('bulkSend.description', { count: selectedCount })}
         </Text>
+        <div className="mb-6">
+          <Textarea
+            id="bulk-send-message"
+            label={tConversations('bulkSend.messageLabel')}
+            placeholder={tConversations('bulkSend.messagePlaceholder')}
+            rows={6}
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            disabled={isSending}
+          />
+        </div>
         <Row gap={3} align="stretch" justify="end">
           <Button variant="secondary" onClick={onCancel} disabled={isSending}>
             {tCommon('actions.cancel')}
           </Button>
-          <Button onClick={onConfirm} disabled={isSending}>
+          <Button onClick={() => onConfirm(trimmedMessage)} disabled={!canSend}>
             {isSending && <Loader2Icon className="mr-2 size-4 animate-spin" />}
             {tConversations('bulkSend.send')}
           </Button>

--- a/services/platform/app/features/conversations/hooks/mutations.ts
+++ b/services/platform/app/features/conversations/hooks/mutations.ts
@@ -5,12 +5,6 @@ export function useGenerateUploadUrl() {
   return useConvexMutation(api.files.mutations.generateUploadUrl);
 }
 
-export function useAddMessage() {
-  return useConvexMutation(
-    api.conversations.mutations.addMessageToConversation,
-  );
-}
-
 export function useBulkArchiveConversations() {
   return useConvexMutation(
     api.conversations.mutations.bulkArchiveConversations,

--- a/services/platform/app/features/conversations/hooks/use-bulk-actions.test.ts
+++ b/services/platform/app/features/conversations/hooks/use-bulk-actions.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+import type { ConversationItem } from '@/convex/conversations/types';
+
+import type { SelectionState } from '../types/selection';
+
+const mockToast = vi.fn();
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock('@/lib/i18n/client', () => ({
+  useT: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+const mockSendMessageViaIntegration = vi.fn();
+const noopMutation = () => ({ mutateAsync: vi.fn() });
+
+vi.mock('./mutations', () => ({
+  useBulkArchiveConversations: () => noopMutation(),
+  useBulkCloseConversations: () => noopMutation(),
+  useBulkReopenConversations: () => noopMutation(),
+  useBulkSpamConversations: () => noopMutation(),
+  useBulkUnarchiveConversations: () => noopMutation(),
+  useSendMessageViaIntegration: () => ({
+    mutateAsync: mockSendMessageViaIntegration,
+  }),
+}));
+
+import { useBulkActions } from './use-bulk-actions';
+
+const UNKNOWN_CUSTOMER_EMAIL = 'unknown@example.com';
+
+function makeConversation(
+  id: string,
+  email: string,
+  overrides: Partial<ConversationItem> = {},
+): ConversationItem {
+  return {
+    _id: id,
+    _creationTime: 0,
+    organizationId: 'org-1',
+    subject: 'Original subject',
+    integrationName: 'gmail',
+    id,
+    title: 'title',
+    description: 'description',
+    customer_id: 'cust-1',
+    business_id: 'biz-1',
+    message_count: 1,
+    unread_count: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    customer: {
+      id: 'cust-1',
+      email,
+      status: 'active',
+      created_at: '2024-01-01T00:00:00Z',
+    },
+    messages: [],
+    ...overrides,
+  } as unknown as ConversationItem;
+}
+
+function individualSelection(ids: string[]): SelectionState {
+  return { type: 'individual', selectedIds: new Set(ids) };
+}
+
+function setup(
+  conversations: ConversationItem[],
+  selectionState: SelectionState,
+) {
+  const onComplete = vi.fn();
+  const { result } = renderHook(() =>
+    useBulkActions({
+      organizationId: 'org-1',
+      conversations,
+      selectionState,
+      onComplete,
+    }),
+  );
+  return { result, onComplete };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSendMessageViaIntegration.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBulkActions handleSendMessages', () => {
+  it('dispatches via integration once per selected conversation with resolved fields', async () => {
+    const conversations = [
+      makeConversation('conv-1', 'alice@example.com'),
+      makeConversation('conv-2', 'bob@example.com'),
+    ];
+    const { result, onComplete } = setup(
+      conversations,
+      individualSelection(['conv-1', 'conv-2']),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessages('  Hello there  ');
+    });
+
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        organizationId: 'org-1',
+        integrationName: 'gmail',
+        content: 'Hello there',
+        text: 'Hello there',
+        to: ['alice@example.com'],
+        subject: 'panel.replySubjectPrefix:{"subject":"Original subject"}',
+      }),
+    );
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'conv-2',
+        to: ['bob@example.com'],
+      }),
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a default subject when the conversation has none', async () => {
+    const conversations = [
+      makeConversation('conv-1', 'alice@example.com', { subject: undefined }),
+    ];
+    const { result } = setup(conversations, individualSelection(['conv-1']));
+
+    await act(async () => {
+      await result.current.handleSendMessages('Hi');
+    });
+
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'panel.replySubjectPrefix:{"subject":"panel.defaultSubject"}',
+      }),
+    );
+  });
+
+  it('counts conversations with missing or unknown email as failures and does not dispatch them', async () => {
+    const conversations = [
+      makeConversation('conv-1', 'alice@example.com'),
+      makeConversation('conv-2', UNKNOWN_CUSTOMER_EMAIL),
+      makeConversation('conv-3', ''),
+    ];
+    const { result, onComplete } = setup(
+      conversations,
+      individualSelection(['conv-1', 'conv-2', 'conv-3']),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessages('Hello');
+    });
+
+    // Only the conversation with a usable email is dispatched.
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'conv-1' }),
+    );
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'bulk.messagesSent',
+        description:
+          'bulk.messagesSentDescription:{"successCount":1,"failedCount":2}',
+        variant: 'default',
+      }),
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the destructive toast variant when every send fails', async () => {
+    const conversations = [
+      makeConversation('conv-1', UNKNOWN_CUSTOMER_EMAIL),
+      makeConversation('conv-2', ''),
+    ];
+    const { result, onComplete } = setup(
+      conversations,
+      individualSelection(['conv-1', 'conv-2']),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessages('Hello');
+    });
+
+    expect(mockSendMessageViaIntegration).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description:
+          'bulk.messagesSentDescription:{"successCount":0,"failedCount":2}',
+        variant: 'destructive',
+      }),
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('tallies integration failures into the failed count', async () => {
+    mockSendMessageViaIntegration
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('integration down'));
+    const conversations = [
+      makeConversation('conv-1', 'alice@example.com'),
+      makeConversation('conv-2', 'bob@example.com'),
+    ];
+    const { result } = setup(
+      conversations,
+      individualSelection(['conv-1', 'conv-2']),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessages('Hello');
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description:
+          'bulk.messagesSentDescription:{"successCount":1,"failedCount":1}',
+        variant: 'default',
+      }),
+    );
+  });
+
+  it('does nothing when the message body is empty after trimming', async () => {
+    const conversations = [makeConversation('conv-1', 'alice@example.com')];
+    const { result, onComplete } = setup(
+      conversations,
+      individualSelection(['conv-1']),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessages('   ');
+    });
+
+    expect(mockSendMessageViaIntegration).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to every loaded conversation for an "all" selection', async () => {
+    const conversations = [
+      makeConversation('conv-1', 'alice@example.com'),
+      makeConversation('conv-2', 'bob@example.com'),
+    ];
+    const { result } = setup(conversations, { type: 'all' });
+
+    await act(async () => {
+      await result.current.handleSendMessages('Hello');
+    });
+
+    expect(mockSendMessageViaIntegration).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/platform/app/features/conversations/hooks/use-bulk-actions.ts
+++ b/services/platform/app/features/conversations/hooks/use-bulk-actions.ts
@@ -8,13 +8,15 @@ import { useT } from '@/lib/i18n/client';
 import type { SelectionState } from '../types/selection';
 import { isAllSelection } from '../types/selection';
 import {
-  useAddMessage,
   useBulkArchiveConversations,
   useBulkCloseConversations,
   useBulkReopenConversations,
   useBulkSpamConversations,
   useBulkUnarchiveConversations,
+  useSendMessageViaIntegration,
 } from './mutations';
+
+const UNKNOWN_CUSTOMER_EMAIL = 'unknown@example.com';
 
 function getSelectedConversationIds(
   selectionState: SelectionState,
@@ -23,6 +25,15 @@ function getSelectedConversationIds(
   return isAllSelection(selectionState)
     ? conversations.map((c) => c._id)
     : Array.from(selectionState.selectedIds);
+}
+
+function getSelectedConversations(
+  selectionState: SelectionState,
+  conversations: ConversationItem[],
+) {
+  return isAllSelection(selectionState)
+    ? conversations
+    : conversations.filter((c) => selectionState.selectedIds.has(c._id));
 }
 
 interface UseBulkActionsOptions {
@@ -45,7 +56,8 @@ export function useBulkActions({
   const { mutateAsync: bulkReopen } = useBulkReopenConversations();
   const { mutateAsync: bulkSpam } = useBulkSpamConversations();
   const { mutateAsync: bulkUnarchive } = useBulkUnarchiveConversations();
-  const { mutateAsync: addMessage } = useAddMessage();
+  const { mutateAsync: sendMessageViaIntegration } =
+    useSendMessageViaIntegration();
 
   const [isBulkProcessing, setIsBulkProcessing] = useState(false);
   const [bulkSendDialog, setBulkSendDialog] = useState({
@@ -61,66 +73,92 @@ export function useBulkActions({
     setBulkSendDialog({ isOpen: false, isSending: false });
   }, []);
 
-  const handleSendMessages = useCallback(async () => {
-    if (isBulkProcessing) return;
+  const handleSendMessages = useCallback(
+    async (message: string) => {
+      if (isBulkProcessing) return;
 
-    setIsBulkProcessing(true);
-    setBulkSendDialog({ isOpen: true, isSending: true });
+      const body = message.trim();
+      if (!body) return;
 
-    try {
-      const conversationIds = getSelectedConversationIds(
-        selectionState,
-        conversations,
-      );
+      setIsBulkProcessing(true);
+      setBulkSendDialog({ isOpen: true, isSending: true });
 
-      const results = await Promise.allSettled(
-        conversationIds.map((conversationId) =>
-          addMessage({
-            conversationId: toId<'conversations'>(conversationId),
-            organizationId,
-            sender: 'Agent',
-            content: 'Message sent',
-            isCustomer: false,
-            status: 'sent',
+      try {
+        const selectedConversations = getSelectedConversations(
+          selectionState,
+          conversations,
+        );
+
+        // Dispatch a real reply to each customer through the conversation's
+        // integration — mirroring the single-conversation reply path. A
+        // conversation without a usable customer email cannot be delivered, so
+        // it is counted as a failure rather than silently dropped.
+        const results = await Promise.allSettled(
+          selectedConversations.map((conversation) => {
+            const customerEmail = conversation.customer.email;
+            if (!customerEmail || customerEmail === UNKNOWN_CUSTOMER_EMAIL) {
+              return Promise.reject(
+                new Error(tConversations('panel.customerEmailNotFound')),
+              );
+            }
+
+            const subject =
+              conversation.subject || tConversations('panel.defaultSubject');
+            const replySubject = tConversations('panel.replySubjectPrefix', {
+              subject,
+            });
+
+            return sendMessageViaIntegration({
+              conversationId: toId<'conversations'>(conversation._id),
+              organizationId,
+              integrationName: conversation.integrationName ?? 'outlook',
+              content: body,
+              to: [customerEmail],
+              subject: replySubject,
+              text: body,
+            });
           }),
-        ),
-      );
+        );
 
-      const successCount = results.filter(
-        (r) => r.status === 'fulfilled',
-      ).length;
-      const failedCount = results.filter((r) => r.status === 'rejected').length;
+        const successCount = results.filter(
+          (r) => r.status === 'fulfilled',
+        ).length;
+        const failedCount = results.filter(
+          (r) => r.status === 'rejected',
+        ).length;
 
-      toast({
-        title: tConversations('bulk.messagesSent'),
-        description: tConversations('bulk.messagesSentDescription', {
-          successCount,
-          failedCount,
-        }),
-        variant: successCount > 0 ? 'default' : 'destructive',
-      });
+        toast({
+          title: tConversations('bulk.messagesSent'),
+          description: tConversations('bulk.messagesSentDescription', {
+            successCount,
+            failedCount,
+          }),
+          variant: successCount > 0 ? 'default' : 'destructive',
+        });
 
-      setBulkSendDialog({ isOpen: false, isSending: false });
-      onComplete();
-    } catch (error) {
-      console.error('Error sending messages:', error);
-      toast({
-        title: tConversations('bulk.sendFailed'),
-        variant: 'destructive',
-      });
-      setBulkSendDialog({ isOpen: false, isSending: false });
-    } finally {
-      setIsBulkProcessing(false);
-    }
-  }, [
-    isBulkProcessing,
-    selectionState,
-    conversations,
-    addMessage,
-    organizationId,
-    tConversations,
-    onComplete,
-  ]);
+        setBulkSendDialog({ isOpen: false, isSending: false });
+        onComplete();
+      } catch (error) {
+        console.error('Error sending messages:', error);
+        toast({
+          title: tConversations('bulk.sendFailed'),
+          variant: 'destructive',
+        });
+        setBulkSendDialog({ isOpen: false, isSending: false });
+      } finally {
+        setIsBulkProcessing(false);
+      }
+    },
+    [
+      isBulkProcessing,
+      selectionState,
+      conversations,
+      sendMessageViaIntegration,
+      organizationId,
+      tConversations,
+      onComplete,
+    ],
+  );
 
   const handleBulkResolve = useCallback(async () => {
     if (isBulkProcessing) return;

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -2116,6 +2116,8 @@
     "bulkSend": {
       "title": "{count} Nachrichten senden",
       "description": "Du sendest Antworten für {count, plural, one {# Konversation} other {# Konversationen}}. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "messageLabel": "Nachricht",
+      "messagePlaceholder": "Antwort eingeben...",
       "send": "Senden"
     },
     "updating": "Konversationen werden aktualisiert...",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -2116,6 +2116,8 @@
     "bulkSend": {
       "title": "Send {count} Messages",
       "description": "You're about to send replies for {count, plural, one {# conversation} other {# conversations}}. This action can't be undone.",
+      "messageLabel": "Message",
+      "messagePlaceholder": "Type your reply...",
       "send": "Send"
     },
     "updating": "Updating conversations...",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -2117,6 +2117,8 @@
     "bulkSend": {
       "title": "Envoyer {count} messages",
       "description": "Tu es sur le point d'envoyer des réponses pour {count, plural, one {# conversation} other {# conversations}}. Cette action est irréversible.",
+      "messageLabel": "Message",
+      "messagePlaceholder": "Saisis ta réponse...",
       "send": "Envoyer"
     },
     "updating": "Mise à jour des conversations...",


### PR DESCRIPTION
## Summary

Fixes the two defects in the Conversations inbox bulk **Send messages** action reported in #2047:

1. **Hardcoded untranslated placeholder** — `handleSendMessages` inserted a bare `'Message sent'` literal (no i18n key) for every selected conversation regardless of user intent.
2. **Never delivered** — it used the plain DB-insert path (`addMessageToConversation`), which only writes a `conversationMessages` row and emits an internal event; nothing was ever dispatched to the customer, yet the success toast implied delivery.

## Changes

- **`BulkSendDialog`** now contains a real message-body composer (`Textarea`). The Send button stays disabled until the body is non-empty, so the action can no longer send empty/placeholder content.
- **`useBulkActions.handleSendMessages`** now accepts the composed body and routes each selected conversation through **`sendMessageViaIntegration`**, mirroring the single-conversation reply path in `conversation-panel.tsx`: it resolves the conversation's `customer.email`, `integrationName`, and a `Re:`-prefixed subject. Conversations without a usable customer email are counted as failures (surfaced in the existing success/failed toast) instead of being silently dropped.
- Removed the now-unused `useAddMessage` hook.
- Added i18n keys `conversations.bulkSend.messageLabel` / `messagePlaceholder` to `en`, `de`, and `fr`.

## Verification

- `bunx tsc --noEmit` — clean
- `bunx oxlint --type-aware` (changed files) — clean
- `bunx oxfmt --check` — clean
- `bunx knip` — clean (no unused exports)
- i18n parity/usage test (`lib/i18n/messages.test.ts`) — 23 passed
- Conversations UI tests (`vitest.ui.config.ts app/features/conversations`) — 32 passed

Closes #2047