### PR TITLE
fix: confirm before overwriting an existing project secret (#1983)

### DIFF
--- a/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.test.tsx
@@ -379,6 +379,67 @@ describe('ProjectSecretsTab', () => {
     });
   });
 
+  describe('overwrite protection', () => {
+    it('warns and blocks Save until the user confirms when the name collides with an existing secret', async () => {
+      secretsFixture = [{ name: 'EXISTING_SECRET' }];
+      const { user } = renderTab();
+
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+
+      // No warning until a colliding name is typed.
+      expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
+
+      await user.type(
+        screen.getByLabelText('Name', { exact: false }),
+        'existing_secret',
+      );
+      await user.type(
+        screen.getByLabelText('API key', { exact: false }),
+        'replacement-value',
+      );
+
+      // The collision is surfaced and the submit button becomes "Overwrite".
+      expect(screen.getByText('Name already in use')).toBeInTheDocument();
+      const overwriteButton = screen.getByRole('button', { name: 'Overwrite' });
+      expect(overwriteButton).toBeDisabled();
+
+      // Clicking while unconfirmed must not persist anything.
+      await user.click(overwriteButton);
+      expect(mockSetMutateAsync).not.toHaveBeenCalled();
+
+      // Confirming the overwrite enables the submit and lets the save through.
+      await user.click(
+        screen.getByRole('checkbox', { name: 'Overwrite the existing secret' }),
+      );
+      expect(overwriteButton).toBeEnabled();
+      await user.click(overwriteButton);
+
+      await waitFor(() => {
+        expect(mockSetMutateAsync).toHaveBeenCalledTimes(1);
+      });
+      expect(mockSetMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'EXISTING_SECRET' }),
+      );
+    });
+
+    it('does not warn when the name does not collide with an existing secret', async () => {
+      secretsFixture = [{ name: 'EXISTING_SECRET' }];
+      const { user } = renderTab();
+
+      await user.click(screen.getByRole('button', { name: 'Add secret' }));
+      await screen.findByRole('dialog', { name: 'Add secret' });
+
+      await user.type(
+        screen.getByLabelText('Name', { exact: false }),
+        'fresh_secret',
+      );
+
+      expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+  });
+
   describe('delete', () => {
     it('invokes deleteProjectSecret with the row name when its delete button is clicked', async () => {
       secretsFixture = [{ name: 'E2E_DEPTH_SECRET_ABC' }];

--- a/services/platform/app/features/projects/components/project-secrets-tab.tsx
+++ b/services/platform/app/features/projects/components/project-secrets-tab.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from 'react';
 
 import { ContentArea } from '@/app/components/layout/content-area';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
+import { Checkbox } from '@/app/components/ui/forms/checkbox';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
 import { toast } from '@/app/hooks/use-toast';
@@ -64,6 +65,9 @@ export function ProjectSecretsTab({
   // description. A re-save re-encrypts via the same upsert path as Add — there
   // is no reveal, because stored values are never returned to the client.
   const [editingName, setEditingName] = useState<string | null>(null);
+  // Gate that the user has acknowledged overwriting an existing secret. Reset
+  // whenever the target name changes so each collision is confirmed afresh.
+  const [confirmOverwrite, setConfirmOverwrite] = useState(false);
 
   const typeOptions = useMemo(
     () => [
@@ -83,6 +87,7 @@ export function ProjectSecretsTab({
     setPassword('');
     setDescription('');
     setEditingName(null);
+    setConfirmOverwrite(false);
   };
 
   const openEdit = (secret: { name: string; description?: string }) => {
@@ -94,6 +99,32 @@ export function ProjectSecretsTab({
     setDialogOpen(true);
   };
 
+  const isEditing = editingName !== null;
+
+  const baseName = name.trim().toUpperCase();
+  const existingNames = useMemo(
+    () => new Set(secrets.map((s) => s.name)),
+    [secrets],
+  );
+  // Names that already exist and would be overwritten by saving. Empty unless a
+  // collision is in play, which is what surfaces the warning + confirm gate.
+  const collidingNames = useMemo(() => {
+    if (isEditing || baseName.length === 0) return [];
+    const candidates =
+      type === 'basic'
+        ? [`${baseName}_USERNAME`, `${baseName}_PASSWORD`]
+        : [baseName];
+    return candidates.filter((candidate) => existingNames.has(candidate));
+  }, [baseName, type, existingNames, isEditing]);
+  const hasCollision = collidingNames.length > 0;
+
+  // For `basic`, the stored names carry the `_USERNAME`/`_PASSWORD` suffix, so
+  // validate those full names rather than the bare base.
+  const fullNames =
+    type === 'basic' && !isEditing
+      ? [`${baseName}_USERNAME`, `${baseName}_PASSWORD`]
+      : [baseName];
+
   // The single-value field is relabelled per type so the form reads like a
   // dedicated form for each credential shape.
   const valueLabel =
@@ -102,16 +133,6 @@ export function ProjectSecretsTab({
       : type === 'bearer'
         ? t('tokenLabel')
         : t('valueLabel');
-
-  const isEditing = editingName !== null;
-
-  const baseName = name.trim().toUpperCase();
-  // For `basic`, the stored names carry the `_USERNAME`/`_PASSWORD` suffix, so
-  // validate those full names rather than the bare base.
-  const fullNames =
-    type === 'basic' && !isEditing
-      ? [`${baseName}_USERNAME`, `${baseName}_PASSWORD`]
-      : [baseName];
 
   // Mirror the server's env-var-name rule (SECRET_NAME_RE) client-side so an
   // invalid or whitespace-only name is caught inline — disabling Save and showing
@@ -298,7 +319,14 @@ export function ProjectSecretsTab({
         title={isEditing ? t('editTitle') : t('addButton')}
         isSubmitting={isSaving}
         isDirty={isDirty}
-        isValid={nameValid}
+        // Invalid names block submit; a name collision also requires explicit
+        // confirmation before overwriting a stored credential.
+        isValid={
+          nameValid && (isEditing || !hasCollision || confirmOverwrite)
+        }
+        submitText={
+          !isEditing && hasCollision ? t('overwriteButton') : undefined
+        }
         onSubmit={handleSave}
       >
         {!isEditing && (
@@ -306,10 +334,11 @@ export function ProjectSecretsTab({
             id="secret-type"
             label={t('typeLabel')}
             value={type}
-            onValueChange={(next) =>
+            onValueChange={(next) => {
+              setConfirmOverwrite(false);
               // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- options are the SecretType union
-              setType(next as SecretType)
-            }
+              setType(next as SecretType);
+            }}
             options={typeOptions}
             disabled={isSaving}
           />
@@ -319,7 +348,10 @@ export function ProjectSecretsTab({
           label={t('nameLabel')}
           placeholder={NAME_PLACEHOLDER[type]}
           value={name}
-          onChange={(e) => setName(e.target.value.toUpperCase())}
+          onChange={(e) => {
+            setConfirmOverwrite(false);
+            setName(e.target.value.toUpperCase());
+          }}
           // The name is the env-var key agents resolve — editing it would orphan
           // references, so it's fixed once created.
           disabled={isSaving || isEditing}
@@ -389,6 +421,32 @@ export function ProjectSecretsTab({
           onChange={(e) => setDescription(e.target.value)}
           disabled={isSaving}
         />
+        {hasCollision && (
+          <Alert
+            variant="warning"
+            icon={ShieldAlert}
+            live="assertive"
+            title={t('overwriteWarningTitle')}
+            description={
+              <Stack gap={3}>
+                <Text as="p" variant="muted" className="text-sm">
+                  {t('overwriteWarningBody', {
+                    names: collidingNames.join(', '),
+                  })}
+                </Text>
+                <Checkbox
+                  id="secret-confirm-overwrite"
+                  label={t('overwriteConfirmLabel')}
+                  checked={confirmOverwrite}
+                  onCheckedChange={(checked) =>
+                    setConfirmOverwrite(checked === true)
+                  }
+                  disabled={isSaving}
+                />
+              </Stack>
+            }
+          />
+        )}
       </FormDialog>
     </ContentArea>
   );

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -6893,6 +6893,7 @@
     "nameShapeHint": "Großbuchstaben, Zahlen und Unterstriche; muss mit einem Buchstaben beginnen.",
     "encryptionNotConfigured": "Die Secret-Verschlüsselung ist auf diesem Server nicht eingerichtet (ENCRYPTION_SECRET_HEX fehlt). Führe `tale init` aus und versuche es erneut.",
     "saveSuccess": "Secret gespeichert",
+<<<<<<< HEAD
     "editButton": "Bearbeiten",
     "editTitle": "Secret bearbeiten",
     "editValueHint": "Gib einen neuen Wert ein, um das gespeicherte Secret zu ersetzen. Der aktuelle Wert wird nie angezeigt.",
@@ -6905,6 +6906,13 @@
       "forbidden": "Du hast keine Berechtigung, die Secrets dieses Projekts zu verwalten.",
       "projectNotFound": "Dieses Projekt wurde nicht gefunden. Es wurde möglicherweise gelöscht."
     }
+=======
+    "deleteSuccess": "Secret gelöscht",
+    "overwriteWarningTitle": "Name bereits vergeben",
+    "overwriteWarningBody": "Ein Secret mit dem Namen {names} existiert bereits. Beim Speichern wird sein gespeicherter Wert ersetzt — das kann nicht rückgängig gemacht werden.",
+    "overwriteConfirmLabel": "Vorhandenes Secret überschreiben",
+    "overwriteButton": "Überschreiben"
+>>>>>>> b60bb76a3 (fix: confirm before overwriting an existing project secret (#1983))
   },
   "tasks": {
     "attachments": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -7162,6 +7162,10 @@
     "editValueHint": "Enter a new value to replace the stored secret. The current value is never shown.",
     "updateSuccess": "Secret updated",
     "deleteSuccess": "Secret deleted",
+    "overwriteWarningTitle": "Name already in use",
+    "overwriteWarningBody": "A secret named {names} already exists. Saving will replace its stored value — this can't be undone.",
+    "overwriteConfirmLabel": "Overwrite the existing secret",
+    "overwriteButton": "Overwrite",
     "errors": {
       "nameInvalid": "Use uppercase letters, numbers, and underscores only, starting with a letter (max 64 characters).",
       "valueInvalid": "Enter a value between 1 and 8192 characters.",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -6894,6 +6894,7 @@
     "nameShapeHint": "Lettres majuscules, chiffres et traits de soulignement ; doit commencer par une lettre.",
     "encryptionNotConfigured": "Le chiffrement des secrets n'est pas configuré sur ce serveur (ENCRYPTION_SECRET_HEX manquant). Exécute `tale init`, puis réessaie.",
     "saveSuccess": "Secret enregistré",
+<<<<<<< HEAD
     "editButton": "Modifier",
     "editTitle": "Modifier le secret",
     "editValueHint": "Saisis une nouvelle valeur pour remplacer le secret enregistré. La valeur actuelle n'est jamais affichée.",
@@ -6906,6 +6907,13 @@
       "forbidden": "Tu n'as pas l'autorisation de gérer les secrets de ce projet.",
       "projectNotFound": "Ce projet est introuvable. Il a peut-être été supprimé."
     }
+=======
+    "deleteSuccess": "Secret supprimé",
+    "overwriteWarningTitle": "Nom déjà utilisé",
+    "overwriteWarningBody": "Un secret nommé {names} existe déjà. L'enregistrement remplacera sa valeur stockée — cette action est irréversible.",
+    "overwriteConfirmLabel": "Écraser le secret existant",
+    "overwriteButton": "Écraser"
+>>>>>>> b60bb76a3 (fix: confirm before overwriting an existing project secret (#1983))
   },
   "tasks": {
     "attachments": {


### PR DESCRIPTION
## Summary

Resolves the data-safety issue where the Project **Add secret** dialog silently overwrote an existing secret of the same name with no warning — a quiet way to lose a stored credential.

## What changed

- `project-secrets-tab.tsx`: the add-secret form now detects a name collision against the project's existing secrets (mirroring the save logic — the `basic` type checks both the `_USERNAME`/`_PASSWORD` suffixed names). On a collision it:
  - shows an inline **"Name already in use"** warning naming the secret(s) that would be replaced,
  - gates submission behind an explicit **"Overwrite the existing secret"** confirmation checkbox (the form is invalid until checked), and
  - relabels the submit button to **Overwrite**.
  - The confirmation resets whenever the target name or type changes, so each collision is acknowledged afresh.
- Added `overwriteWarningTitle`, `overwriteWarningBody`, `overwriteConfirmLabel`, and `overwriteButton` strings to `en`/`de`/`fr` message catalogs.
- Extended `project-secrets-tab.test.tsx` with coverage that the warning appears, Save is blocked until confirmed, and a non-colliding name is unaffected.

## Verification

- `vitest` (UI project): `project-secrets-tab` — 7 passed
- `vitest` (server project): i18n `messages` parity/usage — 23 passed
- `tsc --noEmit`: clean
- `oxlint --type-aware` on changed files: 0 warnings, 0 errors

Closes #1983