### PR TITLE
fix(platform): render notifications bell i18n keys and ICU placeholders (#2055)

### DIFF
--- a/services/platform/convex/agents/guardrails/internal_mutations.ts
+++ b/services/platform/convex/agents/guardrails/internal_mutations.ts
@@ -19,6 +19,16 @@ import { emitEvent } from '../../workflows/triggers/emit_event';
 type NoticeKind = Doc<'agentGuardrailNotices'>['kind'];
 
 /**
+ * Render integer cents as a USD amount (e.g. `1234` -> `$12.34`). Notification
+ * params are stored on the row and interpolated at bell-render time, so money
+ * is formatted here (costs are USD across the app) rather than in the locale
+ * strings, which must stay currency-symbol free.
+ */
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
  * Check-then-insert on the dedupe index. Returns true when this call
  * created the notice (i.e. the caller owns the side effects).
  */
@@ -96,8 +106,8 @@ export const recordBudgetWarnCrossing = internalMutation({
       params: {
         agentSlug: args.agentSlug,
         pct: args.budgetPct,
-        spentCents: args.spentCents,
-        monthlyCents: args.monthlyCents,
+        spent: formatUsd(args.spentCents),
+        monthly: formatUsd(args.monthlyCents),
       },
       link: { kind: 'agent', agentSlug: args.agentSlug },
     });
@@ -132,8 +142,8 @@ export const recordBudgetPause = internalMutation({
       bodyKey: 'agentBudgetExceededBody',
       params: {
         agentSlug: args.agentSlug,
-        spentCents: args.spentCents,
-        monthlyCents: args.monthlyCents,
+        spent: formatUsd(args.spentCents),
+        monthly: formatUsd(args.monthlyCents),
       },
       link: { kind: 'agent', agentSlug: args.agentSlug },
     });

--- a/services/platform/convex/collab/notify_workforce.ts
+++ b/services/platform/convex/collab/notify_workforce.ts
@@ -88,12 +88,17 @@ export async function notifyTaskReviewRequested(
     agentSlug?: string;
   },
 ): Promise<void> {
+  // The default body names the agent (`{agentSlug}`); when no agent slug is
+  // available (e.g. a workflow-initiated review) fall back to a generic body
+  // with no `{agentSlug}` placeholder so the bell never renders a raw token.
   await insertWorkforceNotification(ctx, {
     userId: args.reviewerUserId,
     organizationId: args.task.organizationId,
     type: 'task_review_requested',
     titleKey: 'taskReviewRequested',
-    bodyKey: 'taskReviewRequestedBody',
+    bodyKey: args.agentSlug
+      ? 'taskReviewRequestedBody'
+      : 'taskReviewRequestedBodyNoAgent',
     params: reviewParams(args.task, {
       approvalId: String(args.approvalId),
       ...(args.agentSlug ? { agentSlug: args.agentSlug } : {}),

--- a/services/platform/convex/notifications/notification_messages.ts
+++ b/services/platform/convex/notifications/notification_messages.ts
@@ -79,6 +79,15 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
     dsarPolicyLoosenCancelled: 'Pending data-erasure policy change cancelled',
     dsarPolicyLoosenCancelledBody:
       'A pending data-erasure (DSAR) policy change was cancelled before it took effect.',
+    agentBudgetWarnTitle: 'Agent approaching its budget',
+    agentBudgetWarnBody:
+      '{agentSlug} has used {pct}% of its monthly budget ({spent} of {monthly}).',
+    agentBudgetExceededTitle: 'Agent budget exceeded — runs paused',
+    agentBudgetExceededBody:
+      '{agentSlug} reached its monthly budget ({spent} of {monthly}) and has been paused. Runs resume next month or when you raise the limit.',
+    agentCircuitTrippedTitle: 'Agent runs paused — safety limit reached',
+    agentCircuitTrippedBody:
+      '{agentSlug} hit the safety limit of {windowRuns} runs in {windowHours}h on "{taskTitle}". Change the task status to resume automation.',
   },
   de: {
     title: 'Benachrichtigungen',
@@ -132,6 +141,17 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
       'Vorgemerkte Änderung der Löschrichtlinie abgebrochen',
     dsarPolicyLoosenCancelledBody:
       'Eine vorgemerkte Änderung der Löschrichtlinie (DSAR) wurde abgebrochen, bevor sie wirksam wurde.',
+    agentBudgetWarnTitle: 'Agent nähert sich seinem Budget',
+    agentBudgetWarnBody:
+      '{agentSlug} hat {pct} % seines Monatsbudgets verbraucht ({spent} von {monthly}).',
+    agentBudgetExceededTitle:
+      'Agent-Budget überschritten — Ausführungen pausiert',
+    agentBudgetExceededBody:
+      '{agentSlug} hat sein Monatsbudget erreicht ({spent} von {monthly}) und wurde pausiert. Ausführungen laufen nächsten Monat weiter oder sobald du das Limit erhöhst.',
+    agentCircuitTrippedTitle:
+      'Agent-Ausführungen pausiert — Sicherheitslimit erreicht',
+    agentCircuitTrippedBody:
+      '{agentSlug} hat das Sicherheitslimit von {windowRuns} Ausführungen in {windowHours}h bei "{taskTitle}" erreicht. Ändere den Aufgabenstatus, um die Automatisierung fortzusetzen.',
   },
   fr: {
     title: 'Notifications',
@@ -187,6 +207,16 @@ export const NOTIFICATIONS_I18N: Record<NotificationLocale, LocaleStrings> = {
       "Modification en attente de la politique d'effacement annulée",
     dsarPolicyLoosenCancelledBody:
       "Une modification en attente de la politique d'effacement (DSAR) a été annulée avant de prendre effet.",
+    agentBudgetWarnTitle: "L'agent approche de son budget",
+    agentBudgetWarnBody:
+      '{agentSlug} a utilisé {pct} % de son budget mensuel ({spent} sur {monthly}).',
+    agentBudgetExceededTitle: "Budget de l'agent dépassé — exécutions en pause",
+    agentBudgetExceededBody:
+      '{agentSlug} a atteint son budget mensuel ({spent} sur {monthly}) et a été mis en pause. Les exécutions reprennent le mois prochain ou lorsque tu augmentes la limite.',
+    agentCircuitTrippedTitle:
+      "Exécutions de l'agent en pause — limite de sécurité atteinte",
+    agentCircuitTrippedBody:
+      "{agentSlug} a atteint la limite de sécurité de {windowRuns} exécutions en {windowHours} h sur « {taskTitle} ». Change le statut de la tâche pour reprendre l'automatisation.",
   },
 };
 

--- a/services/platform/lib/i18n/keys-dynamic.txt
+++ b/services/platform/lib/i18n/keys-dynamic.txt
@@ -43,6 +43,12 @@ notifications.dsarPolicyLoosenApplied
 notifications.dsarPolicyLoosenAppliedBody
 notifications.dsarPolicyLoosenCancelled
 notifications.dsarPolicyLoosenCancelledBody
+notifications.agentBudgetWarnTitle
+notifications.agentBudgetWarnBody
+notifications.agentBudgetExceededTitle
+notifications.agentBudgetExceededBody
+notifications.agentCircuitTrippedTitle
+notifications.agentCircuitTrippedBody
 
 # `tEntity('searchPlaceholder')` in app/hooks/use-table-config-factory.ts is
 # resolved against a runtime `entityNamespace` parameter — the regex scanner

--- a/services/platform/lib/i18n/notification-keys.test.ts
+++ b/services/platform/lib/i18n/notification-keys.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression guard for the Notifications bell (issue #2055).
+ *
+ * The bell renders a stored `titleKey`/`bodyKey` under a fixed namespace and
+ * interpolates the row's `params`. Two ways it used to show raw template text:
+ *
+ *   1. Agent budget / circuit-breaker org notifications referenced six keys
+ *      (`agentBudget*`, `agentCircuit*`) that did not exist in the
+ *      `notifications` namespace, so the bell printed the raw key string.
+ *   2. `task_review_requested` used a single body with an `{agentSlug}`
+ *      placeholder; when no agent slug was present the bell printed the raw
+ *      `{agentSlug}` token.
+ *
+ * These tests assert the keys exist in every base locale and that, given the
+ * params the Convex mutations actually pass, nothing renders as a raw key or a
+ * leftover `{placeholder}` — including the no-agentSlug path. None of these
+ * messages use ICU plural/select, so plain `{name}` interpolation (i18next is
+ * configured with `escapeValue: false`, prefix `{`, suffix `}`) models the
+ * real render faithfully.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import deMessages from '@/messages/de.json';
+import enMessages from '@/messages/en.json';
+import frMessages from '@/messages/fr.json';
+
+type Bundle = Record<string, Record<string, string>>;
+
+const LOCALES: Record<string, Bundle> = {
+  en: enMessages as unknown as Bundle,
+  de: deMessages as unknown as Bundle,
+  fr: frMessages as unknown as Bundle,
+};
+
+/** Substitute `{name}` placeholders the way i18next does (no ICU here). */
+function render(template: string, params: Record<string, unknown>): string {
+  return template.replace(/\{(\w+)\}/g, (raw, name: string) =>
+    name in params ? String(params[name]) : raw,
+  );
+}
+
+/** Any `{...}` left after substitution is an unfilled placeholder. */
+function hasRawPlaceholder(s: string): boolean {
+  return /\{\w+\}/.test(s);
+}
+
+// The keys + the params their Convex mutations pass, per namespace.
+const NOTIFICATION_CASES: {
+  key: string;
+  params: Record<string, unknown>;
+}[] = [
+  {
+    key: 'agentBudgetWarnTitle',
+    params: {
+      agentSlug: 'researcher',
+      pct: 80,
+      spent: '$8.00',
+      monthly: '$10.00',
+    },
+  },
+  {
+    key: 'agentBudgetWarnBody',
+    params: {
+      agentSlug: 'researcher',
+      pct: 80,
+      spent: '$8.00',
+      monthly: '$10.00',
+    },
+  },
+  {
+    key: 'agentBudgetExceededTitle',
+    params: { agentSlug: 'researcher', spent: '$10.00', monthly: '$10.00' },
+  },
+  {
+    key: 'agentBudgetExceededBody',
+    params: { agentSlug: 'researcher', spent: '$10.00', monthly: '$10.00' },
+  },
+  {
+    key: 'agentCircuitTrippedTitle',
+    params: {
+      agentSlug: 'researcher',
+      taskTitle: 'Ship it',
+      windowRuns: 5,
+      windowHours: 1,
+    },
+  },
+  {
+    key: 'agentCircuitTrippedBody',
+    params: {
+      agentSlug: 'researcher',
+      taskTitle: 'Ship it',
+      windowRuns: 5,
+      windowHours: 1,
+    },
+  },
+];
+
+describe('notifications namespace — agent budget & circuit-breaker keys', () => {
+  for (const [locale, bundle] of Object.entries(LOCALES)) {
+    for (const { key, params } of NOTIFICATION_CASES) {
+      it(`${locale}: ${key} exists and fully substitutes`, () => {
+        const template = bundle.notifications?.[key];
+        expect(
+          template,
+          `missing notifications.${key} in ${locale}`,
+        ).toBeTruthy();
+        expect(hasRawPlaceholder(render(template, params))).toBe(false);
+      });
+    }
+  }
+});
+
+describe('inbox.taskReviewRequested — no raw {agentSlug} when slug is absent', () => {
+  for (const [locale, bundle] of Object.entries(LOCALES)) {
+    it(`${locale}: with an agent slug, the body names the agent`, () => {
+      const template = bundle.inbox?.taskReviewRequestedBody;
+      expect(template).toBeTruthy();
+      const out = render(template, {
+        agentSlug: 'researcher',
+        taskTitle: 'Ship it',
+      });
+      expect(hasRawPlaceholder(out)).toBe(false);
+      expect(out).toContain('researcher');
+    });
+
+    it(`${locale}: with no agent slug, the fallback body fully substitutes`, () => {
+      const template = bundle.inbox?.taskReviewRequestedBodyNoAgent;
+      expect(
+        template,
+        `missing inbox.taskReviewRequestedBodyNoAgent in ${locale}`,
+      ).toBeTruthy();
+      // The no-agent fallback must not reference agentSlug at all.
+      expect(template).not.toContain('{agentSlug}');
+      const out = render(template, { taskTitle: 'Ship it' });
+      expect(hasRawPlaceholder(out)).toBe(false);
+    });
+  }
+});

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -4423,7 +4423,13 @@
     "dsarPolicyLoosenApplied": "Löschrichtlinie gelockert",
     "dsarPolicyLoosenAppliedBody": "Eine schwächere Löschrichtlinie (DSAR) wurde nach dem 24-Stunden-Karenzfenster wirksam.",
     "dsarPolicyLoosenCancelled": "Vorgemerkte Änderung der Löschrichtlinie abgebrochen",
-    "dsarPolicyLoosenCancelledBody": "Eine vorgemerkte Änderung der Löschrichtlinie (DSAR) wurde abgebrochen, bevor sie wirksam wurde."
+    "dsarPolicyLoosenCancelledBody": "Eine vorgemerkte Änderung der Löschrichtlinie (DSAR) wurde abgebrochen, bevor sie wirksam wurde.",
+    "agentBudgetWarnTitle": "Agent nähert sich seinem Budget",
+    "agentBudgetWarnBody": "{agentSlug} hat {pct} % seines Monatsbudgets verbraucht ({spent} von {monthly}).",
+    "agentBudgetExceededTitle": "Agent-Budget überschritten — Ausführungen pausiert",
+    "agentBudgetExceededBody": "{agentSlug} hat sein Monatsbudget erreicht ({spent} von {monthly}) und wurde pausiert. Ausführungen laufen nächsten Monat weiter oder sobald du das Limit erhöhst.",
+    "agentCircuitTrippedTitle": "Agent-Ausführungen pausiert — Sicherheitslimit erreicht",
+    "agentCircuitTrippedBody": "{agentSlug} hat das Sicherheitslimit von {windowRuns} Ausführungen in {windowHours}h bei \"{taskTitle}\" erreicht. Ändere den Aufgabenstatus, um die Automatisierung fortzusetzen."
   },
   "personalization": {
     "page": {
@@ -6666,6 +6672,7 @@
     "mentionByBody": "{actor} hat dich in \"{title}\" erwähnt.",
     "taskReviewRequested": "Review angefragt",
     "taskReviewRequestedBody": "{agentSlug} hat \"{taskTitle}\" abgeschlossen — freigeben oder Änderungen anfordern.",
+    "taskReviewRequestedBodyNoAgent": "Agenten-Arbeit an \"{taskTitle}\" ist bereit zur Prüfung — freigeben oder Änderungen anfordern.",
     "taskReviewApproved": "Review freigegeben",
     "taskReviewApprovedBody": "\"{taskTitle}\" wurde freigegeben und abgeschlossen.",
     "taskReviewChangesRequested": "Änderungen angefordert",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -4423,7 +4423,13 @@
     "dsarPolicyLoosenApplied": "Data-erasure policy weakened",
     "dsarPolicyLoosenAppliedBody": "A weaker data-erasure (DSAR) policy took effect after the 24-hour grace window.",
     "dsarPolicyLoosenCancelled": "Pending data-erasure policy change cancelled",
-    "dsarPolicyLoosenCancelledBody": "A pending data-erasure (DSAR) policy change was cancelled before it took effect."
+    "dsarPolicyLoosenCancelledBody": "A pending data-erasure (DSAR) policy change was cancelled before it took effect.",
+    "agentBudgetWarnTitle": "Agent approaching its budget",
+    "agentBudgetWarnBody": "{agentSlug} has used {pct}% of its monthly budget ({spent} of {monthly}).",
+    "agentBudgetExceededTitle": "Agent budget exceeded — runs paused",
+    "agentBudgetExceededBody": "{agentSlug} reached its monthly budget ({spent} of {monthly}) and has been paused. Runs resume next month or when you raise the limit.",
+    "agentCircuitTrippedTitle": "Agent runs paused — safety limit reached",
+    "agentCircuitTrippedBody": "{agentSlug} hit the safety limit of {windowRuns} runs in {windowHours}h on \"{taskTitle}\". Change the task status to resume automation."
   },
   "personalization": {
     "page": {
@@ -6928,6 +6934,7 @@
     "mentionByBody": "{actor} mentioned you on \"{title}\".",
     "taskReviewRequested": "Review requested",
     "taskReviewRequestedBody": "{agentSlug} finished \"{taskTitle}\" — approve or request changes.",
+    "taskReviewRequestedBodyNoAgent": "Agent work on \"{taskTitle}\" is ready for review — approve or request changes.",
     "taskReviewApproved": "Review approved",
     "taskReviewApprovedBody": "\"{taskTitle}\" was approved and completed.",
     "taskReviewChangesRequested": "Changes requested",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -4424,7 +4424,13 @@
     "dsarPolicyLoosenApplied": "Politique d'effacement assouplie",
     "dsarPolicyLoosenAppliedBody": "Une politique d'effacement (DSAR) assouplie a pris effet après le délai de grâce de 24 heures.",
     "dsarPolicyLoosenCancelled": "Modification en attente de la politique d'effacement annulée",
-    "dsarPolicyLoosenCancelledBody": "Une modification en attente de la politique d'effacement (DSAR) a été annulée avant de prendre effet."
+    "dsarPolicyLoosenCancelledBody": "Une modification en attente de la politique d'effacement (DSAR) a été annulée avant de prendre effet.",
+    "agentBudgetWarnTitle": "L'agent approche de son budget",
+    "agentBudgetWarnBody": "{agentSlug} a utilisé {pct} % de son budget mensuel ({spent} sur {monthly}).",
+    "agentBudgetExceededTitle": "Budget de l'agent dépassé — exécutions en pause",
+    "agentBudgetExceededBody": "{agentSlug} a atteint son budget mensuel ({spent} sur {monthly}) et a été mis en pause. Les exécutions reprennent le mois prochain ou lorsque tu augmentes la limite.",
+    "agentCircuitTrippedTitle": "Exécutions de l'agent en pause — limite de sécurité atteinte",
+    "agentCircuitTrippedBody": "{agentSlug} a atteint la limite de sécurité de {windowRuns} exécutions en {windowHours} h sur « {taskTitle} ». Change le statut de la tâche pour reprendre l'automatisation."
   },
   "personalization": {
     "page": {
@@ -6667,6 +6673,7 @@
     "mentionByBody": "{actor} t'a mentionné dans «Â {title}Â ».",
     "taskReviewRequested": "Revue demandée",
     "taskReviewRequestedBody": "{agentSlug} a terminé « {taskTitle} » — approuvez ou demandez des modifications.",
+    "taskReviewRequestedBodyNoAgent": "Le travail de l'agent sur « {taskTitle} » est prêt pour la revue — approuvez ou demandez des modifications.",
     "taskReviewApproved": "Revue approuvée",
     "taskReviewApprovedBody": "« {taskTitle} » a été approuvée et terminée.",
     "taskReviewChangesRequested": "Modifications demandées",


### PR DESCRIPTION
## Summary

Fixes two i18n defects on the Notifications bell (issue #2055):

- **[117] Agent budget & circuit-breaker org notifications rendered raw i18n keys.** The six `titleKey`/`bodyKey` strings written by `convex/agents/guardrails/internal_mutations.ts` (`agentBudgetWarn*`, `agentBudgetExceeded*`, `agentCircuitTripped*`) had no entries in the `notifications` namespace, so the bell printed the raw key. Added all six to `en/de/fr` and registered them in `lib/i18n/keys-dynamic.txt`. Spent/monthly amounts are formatted to USD in the mutation (`formatUsd`) so the locale strings stay currency-symbol free.
- **[118] `task_review_requested` rendered a raw `{agentSlug}` when no agent slug was present.** Added a no-agent fallback body `inbox.taskReviewRequestedBodyNoAgent` (no `{agentSlug}` placeholder) and made `notifyTaskReviewRequested` pick it when `agentSlug` is absent.

## Tests

- New regression test `lib/i18n/notification-keys.test.ts`: asserts all six notification keys exist per locale and fully substitute, and that the task-review body fully substitutes both with and without an agent slug (the no-agent fallback references no `{agentSlug}`).
- `bunx vitest --run --project server` (i18n parity/usage + guardrails + new test), `tsc --noEmit`, and `oxlint --type-aware` all green locally.

Closes #2055