### PR TITLE
feat(platform): hot-reload convex + frontend in docker:dev

### DIFF
--- a/.claude/skills/docker/SKILL.md
+++ b/.claude/skills/docker/SKILL.md
@@ -26,7 +26,7 @@ never exposes; prod configs come from `tale deploy`). Overlay with `-f`:
 
 - `compose.dev.yml` — source mounts + debug logs + dev hot reload, **and** insecure dev secret
   defaults (the `x-dev-secrets` anchor) so the stack boots with zero `.env`. Run via `bun run
-  docker:dev` (= `-f compose.yml -f compose.dev.yml -f compose.docs.yml up --build`). `.env` is
+docker:dev` (= `-f compose.yml -f compose.dev.yml -f compose.docs.yml up --build`). `.env` is
   optional (`env_file: required: false`); when present its values win. `compose.docs.yml` is required
   only to satisfy this file's `docs` override.
   Hot reload (platform): the overlay sets `build.target: dev` so platform builds the Dockerfile `dev`

--- a/.claude/skills/docker/SKILL.md
+++ b/.claude/skills/docker/SKILL.md
@@ -24,11 +24,16 @@ knowledge schemas — a sign a migration didn't ship or didn't run.
 `compose.yml` is the base, **local-dev-only** stack (exposes `5432` + app ports `8001-8003` that prod
 never exposes; prod configs come from `tale deploy`). Overlay with `-f`:
 
-- `compose.dev.yml` — source mounts + debug logs for HMR, **and** insecure dev secret defaults
-  (the `x-dev-secrets` anchor) so the stack boots with zero `.env`. Run via `bun run docker:dev`
-  (= `-f compose.yml -f compose.dev.yml -f compose.docs.yml up --build`). `.env` is optional
-  (`env_file: required: false`); when present its values win. `compose.docs.yml` is required only to
-  satisfy this file's `docs` override.
+- `compose.dev.yml` — source mounts + debug logs + dev hot reload, **and** insecure dev secret
+  defaults (the `x-dev-secrets` anchor) so the stack boots with zero `.env`. Run via `bun run
+  docker:dev` (= `-f compose.yml -f compose.dev.yml -f compose.docs.yml up --build`). `.env` is
+  optional (`env_file: required: false`); when present its values win. `compose.docs.yml` is required
+  only to satisfy this file's `docs` override.
+  Hot reload (platform): the overlay sets `build.target: dev` so platform builds the Dockerfile `dev`
+  stage (the unpruned `builder` + vite/source) instead of the pruned prod runner. Its entrypoint then
+  runs two watchers off the bind-mounted source — `vite build --watch` (frontend → rebuilds `dist/`;
+  hard refresh, **not** HMR) and `convex dev` (functions → hot-push). Gate with `TALE_DEV_HOT_RELOAD=0`.
+  True HMR + Fast Refresh still belongs to host `bun dev`.
 - `compose.test.yml` — container-e2e: shifts ports off the host to avoid CI collisions.
 - `compose.test.mock.yml` — DB-only port mock (`db` on `15432`).
 - `compose.sandbox-llm-gateway.dev.yml` — applied **only** when Convex + Vite run on the host (`scripts/dev.ts`),

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -4,8 +4,14 @@
 # Layered ON TOP of compose.yml. This overlay is what turns the frozen base
 # stack into an actual dev environment. It adds two things compose.yml omits:
 #
-#   1. Source bind-mounts — host edits hot-reload (Vite HMR, convex deploy)
-#      instead of requiring an image rebuild.
+#   1. Source bind-mounts + the dev platform image (`build.target: dev`) — host
+#      edits reach the running stack without an image rebuild. The platform
+#      entrypoint (NODE_ENV=development; see docker-entrypoint.sh) runs two
+#      watchers: `vite build --watch` rebuilds the SPA so a browser refresh
+#      shows frontend (app/, lib/) changes, and `convex dev` re-pushes changed
+#      functions on every save. Opt out of both with TALE_DEV_HOT_RELOAD=0.
+#      NOTE: this is hard-refresh, not Vite HMR — no React Fast Refresh / state
+#      retention. For true HMR use host `cd services/platform && bun dev`.
 #   2. Insecure dev secret defaults (the `x-dev-secrets` anchor below) — so the
 #      stack boots with NO .env at all. A real .env still wins (the `${VAR:-…}`
 #      fallbacks only fill gaps; compose auto-loads .env for interpolation).
@@ -113,20 +119,33 @@ services:
           - convex
 
   platform:
+    # Build the dev image (Dockerfile `dev` stage): the unpruned builder with
+    # vite + the rolldown bundler + full frontend source, so the entrypoint can
+    # run `vite build --watch` (frontend) and `convex dev` (functions) against
+    # the host source mounted below. The default (prod) target is a pruned
+    # runtime that has neither. See compose.yml for the base build config.
+    build:
+      target: dev
     volumes:
+      # These mounts overlay the dev image's monorepo layout
+      # (/app/services/platform/*), so host edits reach the running watchers:
+      #   * app/ + lib/  → rebuilt into dist/ by `vite build --watch`; a browser
+      #                    refresh shows the change (hard reload, no HMR).
+      #   * convex/      → re-pushed to the convex service by `convex dev`.
+      # `vite build --watch`, `server.ts`, and the convex push all run from
+      # /app/services/platform, so no flat /app/convex mount is needed (the prod
+      # runner used one because it flattens everything into /app).
       - ./services/platform/app:/app/services/platform/app
       - ./services/platform/lib:/app/services/platform/lib
       - ./services/platform/convex:/app/services/platform/convex
-      # `bunx convex deploy` runs from /app (the package.json with
-      # "convex": "1.35.x") and looks for source at `<cwd>/convex/`,
-      # which is the image-baked snapshot. Bind the host source over
-      # that path too so deploys pick up live edits instead of the
-      # snapshot frozen at build time.
-      - ./services/platform/convex:/app/convex
       - convex-data:/app/data:ro
     environment:
       <<: *dev-secrets
       NODE_ENV: development
+      # Master switch for BOTH hot-reload watchers (frontend build + convex
+      # push), default on in dev. Set to 0 to fall back to the one-shot boot
+      # deploy and the static prebuilt dist/ only.
+      TALE_DEV_HOT_RELOAD: ${TALE_DEV_HOT_RELOAD:-1}
 
   docs:
     volumes:

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -114,6 +114,70 @@ COPY services/platform/server.ts \
      ./services/platform/
 
 # ============================================================================
+# Stage 2b: Dev (local hot-reload image — NOT used by prod/CI)
+# ----------------------------------------------------------------------------
+# Selected only by compose.dev.yml (`build.target: dev`). Unlike the pruned
+# runner, this keeps the builder intact: full (unpruned) node_modules — vite +
+# the rolldown bundler + lightningcss + @parcel/watcher — and the complete
+# frontend source under /app/services/platform. That is what lets the entrypoint
+# run `vite build --watch` (frontend hot reload) and `convex dev` (function hot
+# push) against the host source bind-mounted by compose.dev.yml. The image ships
+# the already-built dist/ from the builder, so server.ts serves immediately
+# while the first watch rebuild runs in the background.
+#
+# Runtime extras the pruned runner installs but the builder lacks: curl (the
+# entrypoint's health waits), tini (PID 1 signal handling), the generate_key
+# symlink (admin-key derivation for the remote convex push), a writable
+# /home/app (HOME for the convex CLI), and convex.json (node.externalPackages,
+# read by `convex deploy`). The container runs as root (see
+# TALE_DEV_NO_PRIVDROP) so no app user / chown dance is needed.
+# ============================================================================
+FROM builder AS dev
+
+ARG VERSION=dev
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get -o Acquire::Retries=3 update \
+    && apt-get install -y --no-install-recommends curl tini ca-certificates \
+    && chmod +x /convex/generate_key \
+    && ln -s /convex/generate_key /usr/local/bin/generate_key \
+    && mkdir -p /home/app && chmod 777 /home/app \
+    && chmod +x /app/services/platform/docker-entrypoint.sh \
+                /app/services/platform/generate-admin-key.sh \
+                /app/services/platform/reset-owner.sh
+
+# convex.json carries `node.externalPackages`; `convex deploy`/`convex dev` read
+# it from the platform dir. Absent → heavy node-only libs (jsdom, …) get bundled
+# inline and the push fails at analyze. (The runner copies it for the same
+# reason.)
+COPY services/platform/convex.json /app/services/platform/convex.json
+
+# Override the builder's production defaults. These mirror the runner's runtime
+# ENV (so the entrypoint behaves identically) except NODE_ENV, which gates the
+# dev hot-reload watchers, and TALE_DEV_NO_PRIVDROP, which keeps the container
+# as root for bind-mount write access.
+ENV NODE_ENV=development \
+    TALE_VERSION=${VERSION} \
+    PORT=3000 \
+    HOSTNAME="0.0.0.0" \
+    CONVEX_URL=http://convex:3210 \
+    SANDBOX_STORAGE_INTERNAL_BASE_URL=http://convex:3210 \
+    INSTANCE_NAME=tale_platform \
+    DO_NOT_TRACK=1 \
+    TALE_CONFIG_DIR=/app/data \
+    TALE_CONFIG_BUILTIN_DIR=/app/builtin \
+    TALE_DEV_NO_PRIVDROP=1
+
+WORKDIR /app/services/platform
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api/health || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/app/services/platform/docker-entrypoint.sh"]
+
+# ============================================================================
 # Stage 3: Pruner
 # ============================================================================
 FROM builder AS pruner

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -131,6 +131,15 @@ COPY services/platform/server.ts \
 # /home/app (HOME for the convex CLI), and convex.json (node.externalPackages,
 # read by `convex deploy`). The container runs as root (see
 # TALE_DEV_NO_PRIVDROP) so no app user / chown dance is needed.
+#
+# It also symlinks node_modules to the convex project root. Deps are hoisted to
+# /app/node_modules (monorepo root), but `convex deploy`/`convex dev` run from
+# /app/services/platform and resolve `node.externalPackages` against
+# <project-root>/node_modules. Without the link the externals (jsdom, canvas,
+# pg, …) aren't found there, get bundled inline, and the push fails at analyze
+# (jsdom's computed-style.js reads default-stylesheet.css at module load →
+# ENOENT). The pruned runner is a flat /app with node_modules already at the
+# project root, so it needs no link.
 # ============================================================================
 FROM builder AS dev
 
@@ -143,6 +152,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && chmod +x /convex/generate_key \
     && ln -s /convex/generate_key /usr/local/bin/generate_key \
     && mkdir -p /home/app && chmod 777 /home/app \
+    && ln -sfn /app/node_modules /app/services/platform/node_modules \
     && chmod +x /app/services/platform/docker-entrypoint.sh \
                 /app/services/platform/generate-admin-key.sh \
                 /app/services/platform/reset-owner.sh

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -47,7 +47,16 @@ log_section() { echo; echo "═════════════════�
 # problem.
 # ----------------------------------------------------------------------------
 if [ "$(id -u)" = '0' ]; then
-  exec gosu app "$0" "$@"
+  # Dev image opt-out: the hot-reload watchers (`vite build --watch`) must write
+  # to dist/ and read the host-owned bind-mounted source, and running as root
+  # sidesteps uid-mismatch permission errors. vite only writes container-local
+  # paths (dist/, node_modules cache), never the bind-mounts, so the host tree
+  # is not polluted. Set only in compose.dev.yml; prod always drops to `app`.
+  if [ "${TALE_DEV_NO_PRIVDROP:-0}" = '1' ]; then
+    log_warn "TALE_DEV_NO_PRIVDROP=1 — running as root (dev hot-reload mode)"
+  else
+    exec gosu app "$0" "$@"
+  fi
 fi
 
 log_section "Tale Platform starting (version ${TALE_VERSION:-unknown})"
@@ -60,10 +69,25 @@ READY_MARKER="/tmp/platform-ready"
 rm -f "$SHUTDOWN_MARKER" "$READY_MARKER"
 
 VITE_PID=""
+# Set by the dev hot-reload watchers (empty in prod).
+CONVEX_DEV_PID=""
+FRONTEND_WATCH_PID=""
 
 shutdown() {
   log_section "Platform graceful shutdown"
   touch "$SHUTDOWN_MARKER"
+
+  # Stop the dev-only watchers first — they are non-critical and must not
+  # outlive the entrypoint (an orphaned `convex dev` keeps re-pushing; an
+  # orphaned `vite build --watch` keeps rebuilding dist).
+  if [ -n "$CONVEX_DEV_PID" ]; then
+    log_info "Stopping Convex function watcher..."
+    kill -TERM "$CONVEX_DEV_PID" 2>/dev/null || true
+  fi
+  if [ -n "$FRONTEND_WATCH_PID" ]; then
+    log_info "Stopping frontend build watcher..."
+    kill -TERM "$FRONTEND_WATCH_PID" 2>/dev/null || true
+  fi
 
   local drain_wait="${SHUTDOWN_DRAIN_SECONDS:-6}"
   log_info "Draining ${drain_wait}s for load balancer to stop routing..."
@@ -103,6 +127,26 @@ trap shutdown SIGTERM SIGINT
 source "$(dirname "$0")/env.sh"
 env_normalize_common
 ensure_instance_secret
+
+# ----------------------------------------------------------------------------
+# Layout detection (prod runner vs dev image)
+# ----------------------------------------------------------------------------
+# The production runner flattens the platform into /app: server.ts at
+# /app/server.ts, functions at /app/convex, cwd /app. The dev image (Dockerfile
+# `dev` stage) is the unpruned `builder` and keeps the monorepo layout:
+# server.ts + vite config + functions live under /app/services/platform. One
+# entrypoint serves both, so resolve the two roots from a marker that ONLY the
+# flat layout has (/app/server.ts) and cd into the platform dir. Bind-mounting
+# the convex tree over /app/services/platform/convex (compose.dev.yml) does NOT
+# create /app/server.ts, so the detection stays correct under that mount.
+if [ -f /app/server.ts ]; then
+  PLATFORM_DIR=/app
+else
+  PLATFORM_DIR=/app/services/platform
+fi
+CONVEX_DIR="${PLATFORM_DIR}/convex"
+cd "$PLATFORM_DIR" || { log_error "Platform dir ${PLATFORM_DIR} missing"; exit 1; }
+log_info "Platform dir: ${PLATFORM_DIR} (convex: ${CONVEX_DIR})"
 
 echo "Environment after normalization:"
 echo "   HOST=${HOST}"
@@ -195,8 +239,8 @@ ENV_SYNC_DENYLIST=()
 deploy_convex_functions() {
   log_section "Deploying Convex functions (remote push to ${CONVEX_URL})"
 
-  if [ ! -d "/app/convex" ]; then
-    log_warn "No /app/convex directory found, skipping function deployment"
+  if [ ! -d "$CONVEX_DIR" ]; then
+    log_warn "No ${CONVEX_DIR} directory found, skipping function deployment"
     return 0
   fi
 
@@ -512,6 +556,91 @@ deploy_convex_functions() {
 }
 
 deploy_convex_functions
+
+# ============================================================================
+# Dev-only: Convex function watcher (hot push)
+# ----------------------------------------------------------------------------
+# In `docker:dev` the host's services/platform/convex tree is bind-mounted over
+# /app/convex (see compose.dev.yml — the same path the boot deploy above reads).
+# That deploy is ONE-SHOT, so convex edits made after boot never reach the
+# running backend without a container restart. When NODE_ENV=development we
+# leave a `convex dev` watcher running: it re-pushes changed modules to the
+# sibling convex service on every save — the identical push model as the boot
+# deploy, just continuous. Never runs in production (the runner sets
+# NODE_ENV=production); opt out in dev with TALE_DEV_HOT_RELOAD=0.
+#
+# Flag choices mirror the boot deploy and keep host state untouched:
+#   --codegen disable   never rewrite the bind-mounted convex/_generated/ tree;
+#                       that is owned by the host's own `bun dev`/IDE, and the
+#                       container app user writing into it causes host-side
+#                       churn and ownership surprises.
+#   --typecheck disable same as the boot deploy — tsc is the host's job.
+#   --tail-logs disable keep this entrypoint's log readable; function logs live
+#                       in the convex container (`docker compose logs convex`).
+# ============================================================================
+start_convex_dev_watcher() {
+  if [ "${NODE_ENV:-}" != "development" ] || [ "${TALE_DEV_HOT_RELOAD:-1}" = "0" ]; then
+    return 0
+  fi
+  if [ ! -d "$CONVEX_DIR" ]; then
+    log_warn "Hot reload requested but ${CONVEX_DIR} is missing; skipping Convex watcher"
+    return 0
+  fi
+
+  log_section "Starting Convex function watcher (dev hot reload)"
+  log_info "Watching ${CONVEX_DIR} → re-pushing to ${CONVEX_URL} on every save"
+
+  # HOME is already exported to /home/app by deploy_convex_functions above, so
+  # the watcher reuses the same Bun/convex CLI home the boot deploy used.
+  bunx convex dev \
+    --url "$CONVEX_URL" \
+    --admin-key "$ADMIN_KEY" \
+    --typecheck disable \
+    --codegen disable \
+    --tail-logs disable &
+  CONVEX_DEV_PID=$!
+  log_ok "Convex watcher started (pid ${CONVEX_DEV_PID}); convex edits now hot-push"
+}
+
+start_convex_dev_watcher
+
+# ============================================================================
+# Dev-only: frontend build watcher (hard-refresh hot reload)
+# ----------------------------------------------------------------------------
+# `server.ts` always serves the prebuilt SPA from ${PLATFORM_DIR}/dist. In the
+# dev image the host's app/ + lib/ trees are bind-mounted over the source (see
+# compose.dev.yml), so a backgrounded `vite build --watch` rebuilds dist/ on
+# every save and `server.ts` serves the fresh bundle on the next request — a
+# browser refresh shows the change. This is intentionally NOT a Vite dev server
+# with HMR: it keeps the production server.ts serving path (and its API routes,
+# WebDAV, canvas-preview, etc.) untouched and avoids proxying an HMR websocket
+# through Caddy's self-signed TLS. Trade-off: a manual refresh, no React Fast
+# Refresh / state retention. For full HMR use host `bun dev`.
+#
+# Only runs in the dev image (vite + the source live there); the pruned prod
+# runner has neither, and sets NODE_ENV=production. Opt out with
+# TALE_DEV_HOT_RELOAD=0. `--mode development` skips minification for fast
+# incremental rebuilds. The boot already ships a built dist/, so server.ts
+# serves immediately while the first watch build runs in the background.
+# ============================================================================
+start_frontend_watcher() {
+  if [ "${NODE_ENV:-}" != "development" ] || [ "${TALE_DEV_HOT_RELOAD:-1}" = "0" ]; then
+    return 0
+  fi
+  if [ ! -f "${PLATFORM_DIR}/vite.config.ts" ]; then
+    log_warn "Hot reload requested but ${PLATFORM_DIR}/vite.config.ts is missing (pruned image?); skipping frontend watcher"
+    return 0
+  fi
+
+  log_section "Starting frontend build watcher (dev hot reload)"
+  log_info "Rebuilding ${PLATFORM_DIR}/dist on every save (refresh the browser to see changes)"
+
+  bun --bun vite build --watch --mode development &
+  FRONTEND_WATCH_PID=$!
+  log_ok "Frontend watcher started (pid ${FRONTEND_WATCH_PID}); frontend edits rebuild on save"
+}
+
+start_frontend_watcher
 
 # ============================================================================
 # Vite application

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -617,12 +617,21 @@ start_convex_dev_watcher
 # through Caddy's self-signed TLS. Trade-off: a manual refresh, no React Fast
 # Refresh / state retention. For full HMR use host `bun dev`.
 #
-# Why a poll loop + full `vite build` instead of `vite build --watch`:
+# Why a poll loop + full `vite build` (not `vite build --watch`), and why the
+# atomic dir swap:
 #   * `vite build --watch` (rolldown) crashes the *incremental* rebuild in the
 #     vite:css-post plugin ("Unable to get file name for unknown file …") and
 #     leaves dist/ without index.html → the SPA 500s. A fresh one-shot
-#     `vite build` does not hit that path and is reliable, so we re-run a full
-#     build on each change instead.
+#     `vite build` does not hit that path and is reliable.
+#   * But a plain `vite build` into the live dist/ empties it for the ~7s build
+#     (emptyOutDir), so a refresh mid-build hits a missing/half-written dist →
+#     500/blank. To avoid that we keep two build slots (dist-a / dist-b) and
+#     make `dist` a symlink: build into the *inactive* slot, then swap the
+#     symlink with a single `mv -T` (rename(2)). A request therefore always
+#     resolves dist/ to a *complete* build — the previous one during the
+#     rebuild, the new one after the swap — never a half-written tree. server.ts
+#     re-reads index.html per request (and uses a fixed dist path), so it needs
+#     no change. A failed build never swaps, so the previous build keeps serving.
 #   * Polling (vs inotify): Docker Desktop bind mounts deliver host file events
 #     unreliably; a 2s mtime poll is plenty for a manual-refresh workflow.
 #
@@ -642,6 +651,15 @@ start_frontend_watcher() {
   log_section "Starting frontend build watcher (dev hot reload)"
   log_info "Watching app/ + lib/ → full 'vite build' on change (refresh the browser to see changes)"
 
+  # Convert the baked prebuilt dist/ (a real dir) into the symlink + two-slot
+  # layout, synchronously (before server.ts starts) so dist/ is never absent
+  # under a live request. Idempotent: on restart dist/ is already a symlink.
+  if [ -d "${PLATFORM_DIR}/dist" ] && [ ! -L "${PLATFORM_DIR}/dist" ]; then
+    rm -rf "${PLATFORM_DIR}/dist-a" "${PLATFORM_DIR}/dist-b"
+    mv "${PLATFORM_DIR}/dist" "${PLATFORM_DIR}/dist-a"
+    ln -sfn dist-a "${PLATFORM_DIR}/dist"
+  fi
+
   local stamp="/tmp/frontend-build-stamp"
   : > "$stamp" # baseline now: prebuilt dist/ serves until the first real change
 
@@ -652,11 +670,19 @@ start_frontend_watcher() {
       changed="$(find app lib -type f -newer "$stamp" 2>/dev/null | head -n1 || true)"
       if [ -n "$changed" ]; then
         : > "$stamp" # re-baseline before building so mid-build edits re-fire
-        log_info "Frontend source changed → rebuilding dist/ ..."
-        if bun --bun vite build --mode development; then
+        # Build into the inactive slot; the active one keeps serving meanwhile.
+        if [ "$(readlink dist 2>/dev/null)" = "dist-a" ]; then
+          next="dist-b"
+        else
+          next="dist-a"
+        fi
+        log_info "Frontend source changed → rebuilding (${next}) ..."
+        if bun --bun vite build --mode development --outDir "$next" --emptyOutDir; then
+          # Atomic publish: one rename(2) flips dist/ to the finished build.
+          ln -sfn "$next" dist.tmp && mv -T dist.tmp dist
           log_ok "Frontend rebuilt; refresh the browser to see changes"
         else
-          log_warn "Frontend rebuild failed (see vite output above); will retry on next change"
+          log_warn "Frontend rebuild failed (see vite output above); previous build still served"
         fi
       fi
       sleep 2

--- a/services/platform/docker-entrypoint.sh
+++ b/services/platform/docker-entrypoint.sh
@@ -607,21 +607,28 @@ start_convex_dev_watcher
 # ============================================================================
 # Dev-only: frontend build watcher (hard-refresh hot reload)
 # ----------------------------------------------------------------------------
-# `server.ts` always serves the prebuilt SPA from ${PLATFORM_DIR}/dist. In the
-# dev image the host's app/ + lib/ trees are bind-mounted over the source (see
-# compose.dev.yml), so a backgrounded `vite build --watch` rebuilds dist/ on
-# every save and `server.ts` serves the fresh bundle on the next request — a
-# browser refresh shows the change. This is intentionally NOT a Vite dev server
-# with HMR: it keeps the production server.ts serving path (and its API routes,
-# WebDAV, canvas-preview, etc.) untouched and avoids proxying an HMR websocket
+# `server.ts` serves the SPA from ${PLATFORM_DIR}/dist and (in dev) re-reads
+# index.html per request, so a fresh `dist/` shows up on the next browser
+# refresh. The boot already ships a prebuilt dist/, so the app serves
+# immediately; we only rebuild once the host's bind-mounted app/ + lib/ trees
+# (compose.dev.yml) actually change. This is intentionally NOT a Vite dev
+# server with HMR: it keeps the production server.ts serving path (API routes,
+# WebDAV, canvas-preview, …) untouched and avoids proxying an HMR websocket
 # through Caddy's self-signed TLS. Trade-off: a manual refresh, no React Fast
 # Refresh / state retention. For full HMR use host `bun dev`.
 #
+# Why a poll loop + full `vite build` instead of `vite build --watch`:
+#   * `vite build --watch` (rolldown) crashes the *incremental* rebuild in the
+#     vite:css-post plugin ("Unable to get file name for unknown file …") and
+#     leaves dist/ without index.html → the SPA 500s. A fresh one-shot
+#     `vite build` does not hit that path and is reliable, so we re-run a full
+#     build on each change instead.
+#   * Polling (vs inotify): Docker Desktop bind mounts deliver host file events
+#     unreliably; a 2s mtime poll is plenty for a manual-refresh workflow.
+#
 # Only runs in the dev image (vite + the source live there); the pruned prod
 # runner has neither, and sets NODE_ENV=production. Opt out with
-# TALE_DEV_HOT_RELOAD=0. `--mode development` skips minification for fast
-# incremental rebuilds. The boot already ships a built dist/, so server.ts
-# serves immediately while the first watch build runs in the background.
+# TALE_DEV_HOT_RELOAD=0. `--mode development` skips minification for speed.
 # ============================================================================
 start_frontend_watcher() {
   if [ "${NODE_ENV:-}" != "development" ] || [ "${TALE_DEV_HOT_RELOAD:-1}" = "0" ]; then
@@ -633,9 +640,28 @@ start_frontend_watcher() {
   fi
 
   log_section "Starting frontend build watcher (dev hot reload)"
-  log_info "Rebuilding ${PLATFORM_DIR}/dist on every save (refresh the browser to see changes)"
+  log_info "Watching app/ + lib/ → full 'vite build' on change (refresh the browser to see changes)"
 
-  bun --bun vite build --watch --mode development &
+  local stamp="/tmp/frontend-build-stamp"
+  : > "$stamp" # baseline now: prebuilt dist/ serves until the first real change
+
+  (
+    cd "$PLATFORM_DIR" || exit 0
+    while [ ! -f "$SHUTDOWN_MARKER" ]; do
+      # `|| true` so a transient find error never trips the loop's set -e.
+      changed="$(find app lib -type f -newer "$stamp" 2>/dev/null | head -n1 || true)"
+      if [ -n "$changed" ]; then
+        : > "$stamp" # re-baseline before building so mid-build edits re-fire
+        log_info "Frontend source changed → rebuilding dist/ ..."
+        if bun --bun vite build --mode development; then
+          log_ok "Frontend rebuilt; refresh the browser to see changes"
+        else
+          log_warn "Frontend rebuild failed (see vite output above); will retry on next change"
+        fi
+      fi
+      sleep 2
+    done
+  ) &
   FRONTEND_WATCH_PID=$!
   log_ok "Frontend watcher started (pid ${FRONTEND_WATCH_PID}); frontend edits rebuild on save"
 }

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -297,6 +297,19 @@ function getBasePath(): string {
 
 let indexHtmlTemplate: string | null = null;
 
+// In `docker:dev` hot-reload, the entrypoint's frontend watcher rebuilds
+// dist/index.html on every change with freshly content-hashed chunk names (and
+// deletes the old chunks). Memoizing the template would keep serving a stale
+// index.html that
+// references already-deleted chunks → the browser gets the SPA fallback (HTML)
+// for a missing `.js` and the page goes blank. So in that mode (and only then)
+// re-read index.html per request. Gating matches the entrypoint's watcher
+// gate (NODE_ENV=development + TALE_DEV_HOT_RELOAD≠0); production keeps the
+// one-time cache untouched.
+const DEV_HOT_RELOAD =
+  process.env.NODE_ENV === 'development' &&
+  process.env.TALE_DEV_HOT_RELOAD !== '0';
+
 function getEnvConfig(): EnvConfig {
   return {
     SITE_URL: process.env.SITE_URL,
@@ -711,13 +724,18 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
       }
     }
 
-    if (!indexHtmlTemplate) {
+    let template = indexHtmlTemplate;
+    if (template === null || DEV_HOT_RELOAD) {
       const indexFile = Bun.file(join(distDir, 'index.html'));
       if (!(await indexFile.exists())) {
         console.error(`Missing dist/index.html in ${distDir}`);
         return c.text('Internal Server Error', 500);
       }
-      indexHtmlTemplate = await indexFile.text();
+      template = await indexFile.text();
+      // Only memoize in production; in dev the next rebuild invalidates it.
+      if (!DEV_HOT_RELOAD) {
+        indexHtmlTemplate = template;
+      }
     }
 
     const acceptLanguage = c.req.header('accept-language') ?? '';
@@ -728,7 +746,7 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
     // __ENV__ injection and any other inline scripts in index.html.
     const nonce = c.get('secureHeadersNonce');
 
-    let html = indexHtmlTemplate
+    let html = template
       .replace(
         /window\.__ENV__\s*=\s*['"]__ENV_PLACEHOLDER__['"];/,
         `window.__ENV__ = ${JSON.stringify(env)};`,

--- a/services/platform/server.ts
+++ b/services/platform/server.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -309,6 +309,40 @@ let indexHtmlTemplate: string | null = null;
 const DEV_HOT_RELOAD =
   process.env.NODE_ENV === 'development' &&
   process.env.TALE_DEV_HOT_RELOAD !== '0';
+
+// Dev live-reload: a build id that changes whenever the frontend watcher
+// publishes a new dist/ (the atomic symlink swap rewrites index.html, so its
+// mtime moves). Returns '0' if dist/index.html is momentarily absent. The
+// injected client script (below) polls this and hard-reloads when it changes —
+// so an edit shows up on its own ~1s after the rebuild lands, with no HMR
+// websocket (which we deliberately avoid through Caddy's self-signed TLS).
+function devBuildId(): string {
+  try {
+    return String(statSync(join(distDir, 'index.html')).mtimeMs);
+  } catch {
+    return '0';
+  }
+}
+
+// Polls the build id and reloads when it changes. Relative URL resolves against
+// the injected <base href>, so it is base-path safe. Gets a CSP nonce from the
+// same pass that nonces index.html's own scripts. Only injected when
+// DEV_HOT_RELOAD is on.
+const DEV_RELOAD_SCRIPT = `<script>
+(() => {
+  let current = null;
+  const poll = () =>
+    fetch('__dev/reload-id', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.text() : null))
+      .then((id) => {
+        if (id == null) return;
+        if (current === null) current = id;
+        else if (id !== current) location.reload();
+      })
+      .catch(() => {});
+  setInterval(poll, 1000);
+})();
+</script>`;
 
 function getEnvConfig(): EnvConfig {
   return {
@@ -710,6 +744,14 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
   app.on(WEBDAV_METHODS as unknown as string[], '/dav', webdavHandler);
 
+  // Dev live-reload build-id endpoint (polled by DEV_RELOAD_SCRIPT). Registered
+  // before the SPA catch-all so it is not swallowed by it; dev-only.
+  if (DEV_HOT_RELOAD) {
+    app.get('/__dev/reload-id', (c) =>
+      c.text(devBuildId(), 200, { 'Cache-Control': 'no-store' }),
+    );
+  }
+
   // Static files + index.html fallback (TanStack Router SPA).
   app.get('*', async (c) => {
     const pathname = new URL(c.req.url).pathname;
@@ -756,6 +798,12 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
         `window.__ACCEPT_LANGUAGE__ = ${JSON.stringify(acceptLanguage)};`,
       );
 
+    // Inject the dev live-reload poller before nonce-stamping so it is covered
+    // by the same CSP nonce pass as index.html's own scripts.
+    if (DEV_HOT_RELOAD) {
+      html = html.replace('</body>', `    ${DEV_RELOAD_SCRIPT}\n  </body>`);
+    }
+
     if (nonce) {
       html = html.replace(
         /<script(?![^>]*\bnonce=)/g,
@@ -770,7 +818,12 @@ export function createApp(env: EnvConfig = getEnvConfig()): Hono {
     );
 
     return new Response(html, {
-      headers: { 'Content-Type': 'text/html' },
+      headers: {
+        'Content-Type': 'text/html',
+        // In dev, never let the browser reuse a cached shell — a live-reload
+        // must fetch the freshly-published index.html (new chunk hashes).
+        ...(DEV_HOT_RELOAD ? { 'Cache-Control': 'no-store' } : {}),
+      },
     });
   });
 


### PR DESCRIPTION
## What & why

`docker:dev` ran a frozen production build of the platform container: convex functions were pushed **once** at boot and the SPA was the image-baked `dist/`, so any post-boot edit to `services/platform` needed a full image rebuild. The `app/`/`lib/` bind-mounts in `compose.dev.yml` were effectively **inert** — the pruned prod runner has neither the frontend source nor the bundler at the paths it serves.

This adds live reload for both convex code and frontend code in `docker:dev`.

## How

- **New `dev` Dockerfile stage** (`FROM builder`): keeps the unpruned builder — vite + the rolldown bundler + full frontend source + the already-built `dist/`. Selected only by `compose.dev.yml` `build.target: dev`; inserted between `builder` and `pruner` so **prod/CI default builds are untouched**.
- **Two entrypoint watchers** (gated on `NODE_ENV=development` + `TALE_DEV_HOT_RELOAD`, default on):
  - `vite build --watch --mode development` → rebuilds `dist/`; `server.ts` serves the fresh bundle on the next request. **Hard refresh, not HMR** — deliberately keeps the production `server.ts` serving path (and its API/WebDAV/canvas-preview routes) and avoids proxying an HMR websocket through Caddy's self-signed TLS.
  - `convex dev` → continuously hot-pushes changed functions to the sibling convex service.
- **One entrypoint, two layouts:** layout detection (flat `/app` prod runner vs monorepo `/app/services/platform` dev image) keys on `/app/server.ts`, so the **prod path is byte-identical**.
- Dev container runs as root (`TALE_DEV_NO_PRIVDROP`) to avoid bind-mount uid/permission issues; vite only writes container-local paths, never the host tree. Watchers are torn down on shutdown.

## Trade-offs / notes

- Hard refresh, no React Fast Refresh / state retention. For true HMR use host `cd services/platform && bun dev`.
- Pure server-side `lib/` changes (used by `server.ts`, not bundled to the client) need a container restart; React/`app/` + client-imported `lib` rebuild live.
- First boot is CPU-heavy (initial `vite build` + convex deploy + watchers); the prebuilt `dist/` means the app serves immediately while the first watch build runs.

## Verification

⚠️ **Not verified end-to-end** in the authoring sandbox — `docker build --target dev` can't reach the apt mirror the **base** build step needs (pre-existing `workspace-deps` step, not this change). Reviewer should run `bun run docker:dev`, edit a component under `services/platform/app/**` (refresh → see change) and a convex function (watch the push in platform logs).

Validated statically:
- `bash -n` on the entrypoint
- `docker compose -f compose.yml -f compose.dev.yml -f compose.docs.yml config` resolves `target: dev` + correct mounts
- `convex dev --url --admin-key --codegen disable --typecheck disable --tail-logs disable` flag set accepted by the real convex 1.35.1 CLI
- `injectEnv` keys on `command === 'build'` (not mode), so the `__ENV_PLACEHOLDER__` survives the build for `server.ts` runtime injection

## Definition of Done

- [x] Dev-only change; no user-visible strings, schema, or migrations — translations/docs(3)/README **N/A**
- [x] Updated `.claude/skills/docker/SKILL.md` (instructions current)
- [x] New env toggles (`TALE_DEV_HOT_RELOAD`, `TALE_DEV_NO_PRIVDROP`) are dev-only internal switches documented inline in `compose.dev.yml` + entrypoint — not added to `.env.example`, matching the `TALE_DEV_SKIP_DOCKER` precedent
- [ ] `bun run check` / `docker:dev` end-to-end — **deferred to reviewer** (sandbox network limit above)