### PR TITLE
fix: include the entire end day in executions date-range filter (#2075)

### DIFF
--- a/services/platform/app/features/automations/executions/executions-table.tsx
+++ b/services/platform/app/features/automations/executions/executions-table.tsx
@@ -7,7 +7,7 @@ import { HStack } from '@tale/ui/layout';
 import { Text } from '@tale/ui/text';
 import { useNavigate } from '@tanstack/react-router';
 import { type ColumnDef, type Row } from '@tanstack/react-table';
-import { parseISO, formatISO } from 'date-fns';
+import { parseISO, startOfDay, endOfDay } from 'date-fns';
 import { Copy, Check } from 'lucide-react';
 import { useState, useMemo, useCallback, memo } from 'react';
 
@@ -369,12 +369,14 @@ export function ExecutionsTable({
         query: searchTerm,
         status: status?.[0],
         triggeredBy: triggeredBy,
+        // Serialize the full-day boundary instants (start of the `from` day,
+        // end of the `to` day) so the backend's inclusive `.lte('startedAt')`
+        // covers the entire end day instead of collapsing to UTC midnight and
+        // dropping today's runs — issue #2075.
         dateFrom: range?.from
-          ? formatISO(range.from, { representation: 'date' })
+          ? startOfDay(range.from).toISOString()
           : undefined,
-        dateTo: range?.to
-          ? formatISO(range.to, { representation: 'date' })
-          : undefined,
+        dateTo: range?.to ? endOfDay(range.to).toISOString() : undefined,
       },
     });
   };

--- a/services/platform/convex/workflows/executions/date_range_filter.test.ts
+++ b/services/platform/convex/workflows/executions/date_range_filter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseExecutionDateBounds } from './date_range_filter';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('parseExecutionDateBounds', () => {
+  it('returns undefined bounds when no dates are provided', () => {
+    expect(parseExecutionDateBounds()).toEqual({
+      fromDate: undefined,
+      toDate: undefined,
+    });
+  });
+
+  it('parses full ISO instants directly without adjustment', () => {
+    const from = '2026-06-24T00:00:00.000Z';
+    const to = '2026-06-24T23:59:59.999Z';
+
+    expect(parseExecutionDateBounds(from, to)).toEqual({
+      fromDate: new Date(from).getTime(),
+      toDate: new Date(to).getTime(),
+    });
+  });
+
+  it('includes runs throughout the end day for a full end-of-day instant', () => {
+    const { toDate } = parseExecutionDateBounds(
+      undefined,
+      '2026-06-24T23:59:59.999Z',
+    );
+    const middayRun = new Date('2026-06-24T07:30:00.000Z').getTime();
+
+    // The regression: a midday run must satisfy `startedAt <= toDate`.
+    expect(middayRun <= (toDate ?? 0)).toBe(true);
+  });
+
+  it('expands a bare YYYY-MM-DD end date to the last ms of that UTC day', () => {
+    const { fromDate, toDate } = parseExecutionDateBounds(
+      '2026-06-24',
+      '2026-06-24',
+    );
+    const utcMidnight = new Date('2026-06-24').getTime();
+
+    expect(fromDate).toBe(utcMidnight);
+    expect(toDate).toBe(utcMidnight + DAY_MS - 1);
+  });
+
+  it('includes a midday run on a bare end date (issue #2075 regression)', () => {
+    const { toDate } = parseExecutionDateBounds(undefined, '2026-06-24');
+    const middayRun = new Date('2026-06-24T07:30:00.000Z').getTime();
+
+    // Before the fix this collapsed to UTC midnight and excluded the run.
+    expect(middayRun <= (toDate ?? 0)).toBe(true);
+  });
+
+  it('ignores invalid date strings', () => {
+    expect(parseExecutionDateBounds('not-a-date', 'also-bad')).toEqual({
+      fromDate: undefined,
+      toDate: undefined,
+    });
+  });
+});

--- a/services/platform/convex/workflows/executions/date_range_filter.ts
+++ b/services/platform/convex/workflows/executions/date_range_filter.ts
@@ -1,0 +1,44 @@
+/**
+ * Parse the Executions date-range filter strings into inclusive epoch-ms bounds.
+ *
+ * The Executions filter serializes the picker's selection as ISO instants: the
+ * start of the `from` day and the END of the `to` day (see executions-table's
+ * `handleDateRangeChange`). Parsing those instants directly yields a correct,
+ * timezone-consistent, fully-inclusive range when compared with the numeric
+ * `startedAt` epoch via `.gte`/`.lte`.
+ *
+ * For backward compatibility with older links that serialized a bare calendar
+ * date (`YYYY-MM-DD`), a date-only `dateTo` is expanded to the last millisecond
+ * of that UTC day. Without this, `new Date('2026-06-24').getTime()` collapses to
+ * UTC midnight, so every run later than 00:00 UTC on the end day fails the
+ * `.lte` predicate and the entire end day is excluded — issue #2075.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface ExecutionDateBounds {
+  fromDate: number | undefined;
+  toDate: number | undefined;
+}
+
+function parseInstant(value: string): number | undefined {
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+export function parseExecutionDateBounds(
+  dateFrom?: string,
+  dateTo?: string,
+): ExecutionDateBounds {
+  const fromDate = dateFrom ? parseInstant(dateFrom) : undefined;
+
+  let toDate = dateTo ? parseInstant(dateTo) : undefined;
+  // A bare YYYY-MM-DD parses to UTC midnight; treat it as the whole UTC day so
+  // the end day stays inclusive (legacy URL compatibility — issue #2075).
+  if (toDate !== undefined && dateTo && DATE_ONLY.test(dateTo)) {
+    toDate += DAY_MS - 1;
+  }
+
+  return { fromDate, toDate };
+}

--- a/services/platform/convex/workflows/executions/list_executions.ts
+++ b/services/platform/convex/workflows/executions/list_executions.ts
@@ -3,6 +3,7 @@
  */
 
 import type { QueryCtx } from '../../_generated/server';
+import { parseExecutionDateBounds } from './date_range_filter';
 import type { ListExecutionsArgs, WorkflowExecution } from './types';
 
 export async function listExecutions(
@@ -16,10 +17,10 @@ export async function listExecutions(
   const limit = Math.min(requestedLimit, 200);
   const maxScan = Math.min(limit * 3, 600);
 
-  const fromDate = args.dateFrom
-    ? new Date(args.dateFrom).getTime()
-    : undefined;
-  const toDate = args.dateTo ? new Date(args.dateTo).getTime() : undefined;
+  const { fromDate, toDate } = parseExecutionDateBounds(
+    args.dateFrom,
+    args.dateTo,
+  );
   const searchLower = args.search?.toLowerCase();
   const triggeredByLower = args.triggeredBy?.toLowerCase();
 

--- a/services/platform/convex/workflows/executions/list_executions_cursor.ts
+++ b/services/platform/convex/workflows/executions/list_executions_cursor.ts
@@ -7,6 +7,7 @@
 
 import type { QueryCtx } from '../../_generated/server';
 import { paginateWithFilter, DEFAULT_PAGE_SIZE } from '../../lib/pagination';
+import { parseExecutionDateBounds } from './date_range_filter';
 import type {
   ListExecutionsCursorArgs,
   CursorPaginatedExecutionsResult,
@@ -42,10 +43,10 @@ export async function listExecutionsCursor(
   const numItems = args.numItems ?? DEFAULT_PAGE_SIZE;
 
   // Parse date filters
-  const fromDate = args.dateFrom
-    ? new Date(args.dateFrom).getTime()
-    : undefined;
-  const toDate = args.dateTo ? new Date(args.dateTo).getTime() : undefined;
+  const { fromDate, toDate } = parseExecutionDateBounds(
+    args.dateFrom,
+    args.dateTo,
+  );
 
   const statusSet = args.status?.length ? new Set(args.status) : null;
 

--- a/services/platform/convex/workflows/executions/list_executions_paginated_native.ts
+++ b/services/platform/convex/workflows/executions/list_executions_paginated_native.ts
@@ -9,6 +9,7 @@
 import type { PaginationOptions, PaginationResult } from 'convex/server';
 
 import type { QueryCtx } from '../../_generated/server';
+import { parseExecutionDateBounds } from './date_range_filter';
 import type { WorkflowExecution } from './types';
 
 interface ListExecutionsPaginatedArgs {
@@ -24,10 +25,10 @@ export async function listExecutionsPaginatedNative(
   ctx: QueryCtx,
   args: ListExecutionsPaginatedArgs,
 ): Promise<PaginationResult<WorkflowExecution>> {
-  const fromDate = args.dateFrom
-    ? new Date(args.dateFrom).getTime()
-    : undefined;
-  const toDate = args.dateTo ? new Date(args.dateTo).getTime() : undefined;
+  const { fromDate, toDate } = parseExecutionDateBounds(
+    args.dateFrom,
+    args.dateTo,
+  );
 
   const statusSet =
     args.status && args.status.length > 0 ? new Set(args.status) : null;


### PR DESCRIPTION
Closes #2075

## Problem

The Executions date-range filter excluded the entire end day. Picking "Today" (or any range whose end is today) returned essentially no rows.

Root cause was a date-to-timestamp collapse:
- The table serialized the picker `to` value as a bare `YYYY-MM-DD` string with no end-of-day handling.
- The backend ran `new Date("2026-06-24").getTime()`, which JS parses as **UTC midnight**, then filtered with `.lte("startedAt", toDate)`.
- Since `startedAt` is an epoch timestamp, any run later than 00:00 UTC on the end day failed the predicate and was dropped.

A secondary skew existed because the picker computed `startOfDay` in **local** time while the backend interpreted the serialized date as **UTC**.

## Fix

Make the picker boundaries and the backend parsing agree on a single, fully-inclusive convention:

- **Frontend** (`executions-table.tsx`): serialize the actual full-day boundary instants — `startOfDay(from).toISOString()` and `endOfDay(to).toISOString()` — instead of a bare date. This captures the user’s local-day boundaries as absolute instants, fixing both the end-day collapse and the local/UTC skew.
- **Backend** (`date_range_filter.ts`, new shared helper): `parseExecutionDateBounds` parses those instants directly. For backward compatibility with older links that carry a bare `YYYY-MM-DD` `dateTo`, it expands the value to the last millisecond of that UTC day so the end day stays inclusive. Applied to all three consumers (`list_executions`, `list_executions_cursor`, `list_executions_paginated_native`) so they no longer diverge.

## Tests

- New `date_range_filter.test.ts` covering full-ISO parsing, bare-date end-of-day expansion, the midday-run regression, and invalid input.
- Existing backend and executions-table tests pass; `tsc --noEmit` and `oxlint --type-aware` are clean.