### PR TITLE
fix: add accessible name to list-filter search inputs (#1989)

### DIFF
--- a/services/platform/app/components/ui/forms/search-input.test.tsx
+++ b/services/platform/app/components/ui/forms/search-input.test.tsx
@@ -162,6 +162,57 @@ describe('SearchInput', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
     });
 
+    it('falls back to placeholder as accessible name when no label', () => {
+      render(
+        <SearchInput value="" onChange={vi.fn()} placeholder="Search agents" />,
+      );
+      // Placeholder is not an accessible name on its own, so the input is
+      // exposed via aria-label derived from the placeholder (WCAG 4.1.2).
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-label',
+        'Search agents',
+      );
+      expect(screen.getByLabelText('Search agents')).toBeInTheDocument();
+    });
+
+    it('prefers an explicit aria-label over the placeholder', () => {
+      render(
+        <SearchInput
+          value=""
+          onChange={vi.fn()}
+          placeholder="Search agents"
+          aria-label="Filter agents"
+        />,
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-label',
+        'Filter agents',
+      );
+    });
+
+    it('does not duplicate the accessible name when a visible label exists', () => {
+      render(
+        <SearchInput
+          value=""
+          onChange={vi.fn()}
+          label="Search"
+          placeholder="Search agents"
+        />,
+      );
+      // A visible <label for> already names the input; avoid a redundant
+      // aria-label that would override it.
+      expect(
+        screen.getByLabelText('Search', { exact: false }),
+      ).not.toHaveAttribute('aria-label');
+    });
+
+    it('passes axe audit with placeholder-only accessible name', async () => {
+      const { container } = render(
+        <SearchInput value="" onChange={vi.fn()} placeholder="Search agents" />,
+      );
+      await checkAccessibility(container);
+    });
+
     it('label is associated with input', () => {
       render(
         <SearchInput

--- a/services/platform/app/components/ui/forms/search-input.tsx
+++ b/services/platform/app/components/ui/forms/search-input.tsx
@@ -46,6 +46,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       id: providedId,
       onFocus,
       onBlur,
+      placeholder,
+      'aria-label': ariaLabel,
       ...props
     },
     ref,
@@ -61,6 +63,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
         .join(' ') || undefined;
     const [showShake, setShowShake] = useState(false);
     const [isReadOnly, setIsReadOnly] = useState(true);
+
+    // A placeholder is not an accessible name (it disappears on input and is
+    // unreliably announced). When there's no visible <Label> and no explicit
+    // aria-label, fall back to the placeholder so the input always exposes a
+    // programmatic accessible name (WCAG 4.1.2).
+    const accessibleName = ariaLabel ?? (label ? undefined : placeholder);
 
     useEffect(() => {
       if (hasError) {
@@ -112,6 +120,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
               className,
             )}
             required={required}
+            placeholder={placeholder}
+            aria-label={accessibleName}
             aria-invalid={hasError || undefined}
             aria-describedby={describedBy}
             aria-errormessage={hasError ? errorId : undefined}


### PR DESCRIPTION
## Summary

The list-filter search inputs on the agents and documents pages (and the shared list primitive behind them) exposed only a `placeholder` ("Search agents" / "Search documents") and no programmatic accessible name. A placeholder is not an accessible name — it disappears on input and is not reliably announced by assistive technology, violating WCAG 4.1.2 (Name, Role, Value).

## Fix

One fix in the shared `SearchInput` primitive (`services/platform/app/components/ui/forms/search-input.tsx`) covers every list page:

- When there is **no visible `<label>`** and **no explicit `aria-label`**, the input now derives its `aria-label` from the `placeholder`, so it always exposes an accessible name.
- An explicit `aria-label` still takes precedence.
- When a visible `<label for>` exists it already names the input, so no redundant `aria-label` is added (avoids double-announcement).

## Tests

Added unit/a11y tests to `search-input.test.tsx` covering the placeholder fallback, explicit-aria-label precedence, no-duplication with a visible label, and an axe audit of the placeholder-only case. Full `search-input` UI suite passes (23 tests). Lint (oxlint) and typecheck (tsc) are clean.

Closes #1989