### PR TITLE
fix: validate non-blank rows and localize todo_list human-input field (#2079)

### DIFF
--- a/services/platform/app/features/chat/components/human-input-fields.test.ts
+++ b/services/platform/app/features/chat/components/human-input-fields.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { countFilledTodoRows, parseTodoList } from './human-input-fields';
+
+describe('parseTodoList', () => {
+  it('returns null for empty or malformed input', () => {
+    expect(parseTodoList('')).toBeNull();
+    expect(parseTodoList('not json')).toBeNull();
+    expect(parseTodoList('{"id":"a"}')).toBeNull();
+  });
+
+  it('keeps only well-formed rows', () => {
+    const raw = JSON.stringify([
+      { id: 'a', content: 'first' },
+      { id: 'b' },
+      { content: 'no id' },
+      { id: 'c', content: '' },
+    ]);
+    expect(parseTodoList(raw)).toEqual([
+      { id: 'a', content: 'first' },
+      { id: 'c', content: '' },
+    ]);
+  });
+});
+
+describe('countFilledTodoRows (#2079)', () => {
+  it('returns 0 when every seeded row is blank or whitespace', () => {
+    // The input seeds a row and serializes via JSON.stringify, so an
+    // untouched required field arrives as a non-empty string of blank rows.
+    expect(
+      countFilledTodoRows(JSON.stringify([{ id: 'a', content: '' }])),
+    ).toBe(0);
+    expect(
+      countFilledTodoRows(
+        JSON.stringify([
+          { id: 'a', content: '   ' },
+          { id: 'b', content: '\n\t' },
+        ]),
+      ),
+    ).toBe(0);
+  });
+
+  it('counts only rows carrying real content', () => {
+    expect(
+      countFilledTodoRows(
+        JSON.stringify([
+          { id: 'a', content: 'one' },
+          { id: 'b', content: '  ' },
+          { id: 'c', content: 'two' },
+        ]),
+      ),
+    ).toBe(2);
+  });
+
+  it('returns 0 for empty or invalid serialized values', () => {
+    expect(countFilledTodoRows('')).toBe(0);
+    expect(countFilledTodoRows('garbage')).toBe(0);
+  });
+});

--- a/services/platform/app/features/chat/components/human-input-fields.tsx
+++ b/services/platform/app/features/chat/components/human-input-fields.tsx
@@ -14,6 +14,7 @@ import {
   RadioGroupItem,
 } from '@/app/components/ui/forms/radio-group';
 import { Textarea } from '@/app/components/ui/forms/textarea';
+import { useT } from '@/lib/i18n/client';
 import type {
   HumanInputField,
   HumanInputTodoItem,
@@ -254,7 +255,7 @@ interface TodoListFieldInputProps {
   onChange: (serialized: string) => void;
 }
 
-function parseTodoList(rawValue: string): HumanInputTodoItem[] | null {
+export function parseTodoList(rawValue: string): HumanInputTodoItem[] | null {
   if (!rawValue) return null;
   try {
     const parsed: unknown = JSON.parse(rawValue);
@@ -273,6 +274,17 @@ function parseTodoList(rawValue: string): HumanInputTodoItem[] | null {
   }
 }
 
+/**
+ * Count the todo rows that carry real (non-whitespace) content. The input
+ * always serializes at least one — possibly blank — row, so a required
+ * `todo_list` field must be validated on this count rather than on the raw
+ * string being non-empty.
+ */
+export function countFilledTodoRows(rawValue: string): number {
+  const rows = parseTodoList(rawValue);
+  return (rows ?? []).filter((row) => row.content.trim().length > 0).length;
+}
+
 function makeTodoId(seed: number): string {
   return `t${seed}-${Math.random().toString(36).slice(2, 6)}`;
 }
@@ -287,11 +299,12 @@ function TodoListFieldInput({
   disabled,
   onChange,
 }: TodoListFieldInputProps) {
+  const { t } = useT('humanInputRequest');
   const initialParsed = useMemo(() => parseTodoList(rawValue), [rawValue]);
   const [items, setItems] = useState<HumanInputTodoItem[]>(() => {
     if (initialParsed && initialParsed.length > 0) return initialParsed;
     return initialTodos.length > 0
-      ? initialTodos.map((t) => ({ ...t }))
+      ? initialTodos.map((todo) => ({ ...todo }))
       : [{ id: makeTodoId(0), content: '' }];
   });
   const seedRef = useRef(items.length);
@@ -342,12 +355,15 @@ function TodoListFieldInput({
           <Input
             id={`${fieldId}-${todo.id}`}
             value={todo.content}
-            placeholder={`Sub-question ${index + 1}`}
+            placeholder={t('todoItemPlaceholder', { n: index + 1 })}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               updateContent(todo.id, e.target.value)
             }
             disabled={disabled}
-            aria-label={`${fieldLabel} item ${index + 1}`}
+            aria-label={t('todoItemAriaLabel', {
+              label: fieldLabel,
+              n: index + 1,
+            })}
             className="flex-1"
           />
           <Button
@@ -356,7 +372,7 @@ function TodoListFieldInput({
             size="icon"
             onClick={() => removeRow(todo.id)}
             disabled={disabled || items.length <= Math.max(1, minItems)}
-            title={`Remove item ${index + 1}`}
+            title={t('todoRemoveItem', { n: index + 1 })}
           >
             <Trash2 className="size-4" />
           </Button>
@@ -370,7 +386,7 @@ function TodoListFieldInput({
         className="gap-1 self-start"
       >
         <Plus className="size-4" aria-hidden="true" />
-        Add item
+        {t('todoAddItem')}
       </Button>
     </Stack>
   );

--- a/services/platform/app/features/chat/components/human-input-request-card.tsx
+++ b/services/platform/app/features/chat/components/human-input-request-card.tsx
@@ -55,7 +55,7 @@ import {
 import { useEffectiveAgent } from '../hooks/use-effective-agent';
 import { useCancelExecution } from '../hooks/use-execution-status';
 import { ApprovalCard } from './approval-card';
-import { HumanInputFields } from './human-input-fields';
+import { HumanInputFields, countFilledTodoRows } from './human-input-fields';
 import { markdownWrapperStyles } from './message-bubble/markdown-renderer';
 
 /**
@@ -345,6 +345,26 @@ function HumanInputRequestCardComponent({
       } else if (field.type === 'multi_select') {
         if (!value || !Array.isArray(value) || value.length === 0) {
           setError(t('errorSelectRequired'));
+          return;
+        }
+      } else if (field.type === 'todo_list') {
+        // The TodoListFieldInput always seeds a row and serializes via
+        // JSON.stringify, so `value` is a non-empty string even when every
+        // row is blank — the generic "non-empty string" check below would
+        // wrongly pass. Count the rows with real content instead.
+        const filled =
+          typeof value === 'string' ? countFilledTodoRows(value) : 0;
+        const minItems =
+          'minItems' in field && typeof field.minItems === 'number'
+            ? field.minItems
+            : 0;
+        const threshold = Math.max(1, minItems);
+        if (filled < threshold) {
+          setError(
+            threshold > 1
+              ? t('errorTodoListMinItems', { count: threshold })
+              : t('errorTodoListRequired'),
+          );
           return;
         }
       } else {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -3973,7 +3973,13 @@
     "updateResponse": "Antwort aktualisieren",
     "cancelEdit": "Abbrechen",
     "versionPrevious": "Vorherige Antwortversion",
-    "versionNext": "Nächste Antwortversion"
+    "versionNext": "Nächste Antwortversion",
+    "errorTodoListRequired": "Bitte füge mindestens einen Eintrag hinzu",
+    "errorTodoListMinItems": "Bitte füge mindestens {count} Einträge hinzu",
+    "todoItemPlaceholder": "Teilfrage {n}",
+    "todoItemAriaLabel": "{label} Eintrag {n}",
+    "todoRemoveItem": "Eintrag {n} entfernen",
+    "todoAddItem": "Eintrag hinzufügen"
   },
   "integrationApproval": {
     "approve": "Genehmigen",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -3973,7 +3973,13 @@
     "updateResponse": "Update response",
     "cancelEdit": "Cancel",
     "versionPrevious": "Previous response version",
-    "versionNext": "Next response version"
+    "versionNext": "Next response version",
+    "errorTodoListRequired": "Please add at least one item",
+    "errorTodoListMinItems": "Please add at least {count} items",
+    "todoItemPlaceholder": "Sub-question {n}",
+    "todoItemAriaLabel": "{label} item {n}",
+    "todoRemoveItem": "Remove item {n}",
+    "todoAddItem": "Add item"
   },
   "integrationApproval": {
     "approve": "Approve",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -3974,7 +3974,13 @@
     "updateResponse": "Mettre à jour la réponse",
     "cancelEdit": "Annuler",
     "versionPrevious": "Version de réponse précédente",
-    "versionNext": "Version de réponse suivante"
+    "versionNext": "Version de réponse suivante",
+    "errorTodoListRequired": "Merci d’ajouter au moins un élément",
+    "errorTodoListMinItems": "Merci d’ajouter au moins {count} éléments",
+    "todoItemPlaceholder": "Sous-question {n}",
+    "todoItemAriaLabel": "{label} élément {n}",
+    "todoRemoveItem": "Supprimer l’élément {n}",
+    "todoAddItem": "Ajouter un élément"
   },
   "integrationApproval": {
     "approve": "Approuver",


### PR DESCRIPTION
Closes #2079

## Problem

Two defects in the `request_human_input` `todo_list` field:

1. **Required validation passes on all-blank rows.** `TodoListFieldInput` always seeds a row and serializes via `JSON.stringify`, so `formValues[label]` is a non-empty string (e.g. `[{"id":"…","content":""}]`) even when every row is blank. The required-field check in `handleSubmit` fell through to the generic `typeof value === 'string' && !value.trim()` branch, which sees a non-empty string and wrongly passes.
2. **The field UI is hardcoded English** with no i18n (placeholder, item `aria-label`, remove-item `title`, and the "Add item" button).

## Fix

- **Validation:** added an explicit `todo_list` case to the required-field loop in `handleSubmit`. It counts rows with real (non-whitespace) content via a new exported `countFilledTodoRows` helper and requires at least `max(1, minItems)` filled rows, surfacing a localized error otherwise.
- **i18n:** `TodoListFieldInput` now uses `useT('humanInputRequest')`. The four hardcoded strings became keys with `{n}`/`{label}` interpolation (the agent-supplied `{label}` stays verbatim), plus two new validation-error keys. Translated across `en` / `de` / `fr` (`de-CH` is a sparse regional override that falls back to `de`).

## Tests
- New `human-input-fields.test.ts` covers `parseTodoList` and `countFilledTodoRows` (all-blank → 0, whitespace → 0, mixed content counted, invalid → 0).
- `bunx vitest --run lib/i18n/messages.test.ts` (locale parity) — green.
- `bunx vitest --run --project client` for the affected components — green.
- `bunx tsc --noEmit` and `bunx oxlint --type-aware` — green.