### PR TITLE
fix(platform): disclose auto-disabled personalization on thread share (#2071)

### DIFF
--- a/services/platform/app/features/projects/components/project-threads-tab.test.tsx
+++ b/services/platform/app/features/projects/components/project-threads-tab.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { Id } from '@/convex/_generated/dataModel';
+import { checkAccessibility } from '@/tests/utils/a11y';
+import { render, screen, waitFor } from '@/tests/utils/render';
+
+import { ProjectThreadsTab } from './project-threads-tab';
+
+// The owner toggling "Share with project" on a personalized chat must be told,
+// for that specific action, that personalization was just turned off — the
+// backend returns `autoDisabledPersonalization` precisely so the UI can say so
+// (issue #2071). These tests pin that the success toast carries the disclosure
+// only on the auto-disable transition, and not on a plain share / unshare.
+
+const mockSetMutateAsync = vi.fn();
+const mockToast = vi.fn();
+
+type ThreadFixture = {
+  _id: string;
+  threadId: string;
+  title?: string;
+  sharedWithProject?: boolean;
+  userId: string;
+};
+
+let yoursFixture: ThreadFixture[] = [];
+let sharedFixture: ThreadFixture[] = [];
+
+vi.mock('../hooks/queries', () => ({
+  useProjectThreadSegments: () => ({
+    yours: yoursFixture,
+    shared: sharedFixture,
+  }),
+}));
+
+vi.mock('../hooks/mutations', () => ({
+  useSetThreadSharedWithProject: () => ({
+    mutateAsync: mockSetMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { userId: 'user-1' } }),
+}));
+
+// The component imports the standalone `toast` fn directly; stub it so the
+// success/error toasts don't reach the real toast store.
+vi.mock('@/app/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// `<Link>` / `useNavigate` need a RouterProvider that this isolated render has
+// no access to; stub the router like the other projects component tests do.
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+const PROJECT_ID = 'proj-1' as Id<'projects'>;
+
+function renderTab() {
+  return render(
+    <ProjectThreadsTab organizationId="org-1" projectId={PROJECT_ID} />,
+  );
+}
+
+// The static page chrome stacks the StickySectionHeader (h2) above the
+// PageSection (h2/h3) without an h1 in isolation; that heading-order jump is a
+// standalone-render artifact — the tab sits under the page's h1 in the app.
+const NO_HEADING_ORDER = { rules: { 'heading-order': { enabled: false } } };
+
+describe('ProjectThreadsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    yoursFixture = [];
+    sharedFixture = [];
+  });
+
+  describe('rendering', () => {
+    it('lists the owner chats with a share toggle and the empty shared state', async () => {
+      yoursFixture = [
+        {
+          _id: 't1',
+          threadId: 'thread-1',
+          title: 'My chat',
+          sharedWithProject: false,
+          userId: 'user-1',
+        },
+      ];
+      const { container } = renderTab();
+
+      expect(
+        screen.getByRole('heading', { name: 'Your chats' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('My chat')).toBeInTheDocument();
+      expect(
+        screen.getByRole('switch', { name: 'Share with project' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('No shared chats yet.')).toBeInTheDocument();
+
+      await checkAccessibility(container, NO_HEADING_ORDER);
+    });
+  });
+
+  describe('share toggle disclosure', () => {
+    it('discloses that personalization was disabled on the auto-disable transition', async () => {
+      mockSetMutateAsync.mockResolvedValue({
+        autoDisabledPersonalization: true,
+      });
+      yoursFixture = [
+        {
+          _id: 't1',
+          threadId: 'thread-1',
+          title: 'My chat',
+          sharedWithProject: false,
+          userId: 'user-1',
+        },
+      ];
+      const { user } = renderTab();
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Share with project' }),
+      );
+
+      await waitFor(() => {
+        expect(mockSetMutateAsync).toHaveBeenCalledWith({
+          threadId: 'thread-1',
+          shared: true,
+        });
+      });
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Chat shared with project',
+          description:
+            'Personalization was turned off for this chat, so your memories and instructions stay private from other members.',
+          variant: 'success',
+        }),
+      );
+    });
+
+    it('shows no personalization disclosure when sharing a chat that was already non-personalized', async () => {
+      mockSetMutateAsync.mockResolvedValue({
+        autoDisabledPersonalization: false,
+      });
+      yoursFixture = [
+        {
+          _id: 't1',
+          threadId: 'thread-1',
+          title: 'My chat',
+          sharedWithProject: false,
+          userId: 'user-1',
+        },
+      ];
+      const { user } = renderTab();
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Share with project' }),
+      );
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Chat shared with project',
+            description: undefined,
+            variant: 'success',
+          }),
+        );
+      });
+    });
+
+    it('shows the plain unshare toast with no disclosure when hiding a chat', async () => {
+      mockSetMutateAsync.mockResolvedValue({
+        autoDisabledPersonalization: false,
+      });
+      yoursFixture = [
+        {
+          _id: 't1',
+          threadId: 'thread-1',
+          title: 'My chat',
+          sharedWithProject: true,
+          userId: 'user-1',
+        },
+      ];
+      const { user } = renderTab();
+
+      await user.click(
+        screen.getByRole('switch', { name: 'Share with project' }),
+      );
+
+      await waitFor(() => {
+        expect(mockSetMutateAsync).toHaveBeenCalledWith({
+          threadId: 'thread-1',
+          shared: false,
+        });
+      });
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Chat hidden from project',
+          description: undefined,
+          variant: 'success',
+        }),
+      );
+    });
+  });
+});

--- a/services/platform/app/features/projects/components/project-threads-tab.tsx
+++ b/services/platform/app/features/projects/components/project-threads-tab.tsx
@@ -50,11 +50,17 @@ export function ProjectThreadsTab({
 
   const handleToggleShare = async (threadId: string, nextShared: boolean) => {
     try {
-      await setShared({ threadId, shared: nextShared });
+      const { autoDisabledPersonalization } = await setShared({
+        threadId,
+        shared: nextShared,
+      });
       toast({
         title: nextShared
           ? t('threads.shareSuccess')
           : t('threads.unshareSuccess'),
+        description: autoDisabledPersonalization
+          ? t('threads.shareDisabledPersonalization')
+          : undefined,
         variant: 'success',
       });
     } catch (error) {

--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -7398,6 +7398,7 @@
       "shareToggleDisclosure": "Wenn du diesen Chat teilst, bleiben deine persönlichen Erinnerungen und Anweisungen für andere Mitglieder unsichtbar.",
       "shareSuccess": "Chat mit Projekt geteilt",
       "unshareSuccess": "Chat aus Projekt ausgeblendet",
+      "shareDisabledPersonalization": "Die Personalisierung wurde für diesen Chat deaktiviert, damit deine Erinnerungen und Anweisungen für andere Mitglieder privat bleiben.",
       "shareError": "Freigabe konnte nicht aktualisiert werden"
     },
     "agents": {

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5027,6 +5027,7 @@
       "shareToggleDisclosure": "Sharing this chat hides your personal memories and instructions from the responses other members will see.",
       "shareSuccess": "Chat shared with project",
       "unshareSuccess": "Chat hidden from project",
+      "shareDisabledPersonalization": "Personalization was turned off for this chat, so your memories and instructions stay private from other members.",
       "shareError": "Couldn't update sharing"
     },
     "agents": {

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -7399,6 +7399,7 @@
       "shareToggleDisclosure": "Si tu partages ce chat, tes souvenirs et instructions personnels resteront cachés des autres membres.",
       "shareSuccess": "Chat partagé avec le projet",
       "unshareSuccess": "Chat retiré du projet",
+      "shareDisabledPersonalization": "La personnalisation a été désactivée pour ce chat, afin que tes souvenirs et instructions restent privés vis-à-vis des autres membres.",
       "shareError": "Impossible de mettre à jour le partage"
     },
     "agents": {


### PR DESCRIPTION
## Summary

Sharing a project thread force-sets `disablePersonalization: true` so the owner's memories and custom instructions don't leak into replies other project members will read. The backend already returns `autoDisabledPersonalization` for exactly this purpose, but `handleToggleShare` awaited the mutation and **discarded** its return value, always showing the same fixed toast. The owner was never told their personalization had just been turned off for that thread.

## Changes

- `project-threads-tab.tsx`: capture the mutation result and, **only on the auto-disable transition**, add a description line to the success toast.
- New i18n key `threads.shareDisabledPersonalization` in `en`/`de`/`fr` (`de-CH` has no override for these keys → falls back to `de`).
- New component test (`project-threads-tab.test.tsx`) covering: the auto-disable transition shows the disclosure; sharing an already-non-personalized chat does not; unshare shows the plain toast.

The disclosure only fires on the `shared && !previouslyDisabled` transition — sharing a thread that already had personalization disabled, and unsharing (which intentionally does not re-enable personalization), show no extra line.

## Verification

- `bun run --filter @tale/platform test lib/i18n/messages.test.ts` — i18n parity green (23 passed)
- `bunx vitest --run --config vitest.ui.config.ts project-threads-tab` — 4 passed
- `bun run --filter @tale/platform typecheck` — clean
- `bun run --filter @tale/ui test` — 997 passed (glossary/i18n checks)
- `bun run format:check` — clean
- `oxlint` on the changed files — 0 warnings, 0 errors

Docs: N/A — reinforces the existing `threads.shareToggleDisclosure`; the share/unshare toasts have no dedicated docs section.

Closes #2071