### PR TITLE
fix: show 'not scanned yet' label instead of perpetual spinner in websites table (#2073)

### DIFF
--- a/services/platform/app/features/websites/hooks/use-websites-table-config.test.tsx
+++ b/services/platform/app/features/websites/hooks/use-websites-table-config.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { AppShell } from '@tale/ui/app-shell';
+import { render, renderHook, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { Doc } from '@/convex/_generated/dataModel';
+import { i18n } from '@/lib/i18n/i18n';
+
+import { useWebsitesTableConfig } from './use-websites-table-config';
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <AppShell i18n={i18n} locale={{ mode: 'client' }}>
+      {children}
+    </AppShell>
+  );
+}
+
+type CellRenderer = (ctx: {
+  row: { original: Partial<Doc<'websites'>> };
+}) => ReactNode;
+
+/** Render the `lastScannedAt` column cell for a given website row. */
+function renderLastScannedCell(website: Partial<Doc<'websites'>>) {
+  const { result } = renderHook(() => useWebsitesTableConfig(), {
+    wrapper: Providers,
+  });
+  const column = result.current.columns.find(
+    (c) => 'accessorKey' in c && c.accessorKey === 'lastScannedAt',
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only narrowing of ColumnDef cell to its callable form
+  const cell = column?.cell as CellRenderer;
+  return render(<Providers>{cell({ row: { original: website } })}</Providers>);
+}
+
+describe('useWebsitesTableConfig — lastScannedAt cell', () => {
+  it('shows a static "Not scanned yet" label for a never-scanned website', () => {
+    renderLastScannedCell({ status: 'idle' });
+
+    expect(screen.getByText('Not scanned yet')).toBeInTheDocument();
+    // Must NOT misrepresent an idle/terminal state as work-in-progress.
+    expect(
+      screen.queryByRole('status', { name: 'Scanning' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows "Not scanned yet" even when a scan errored without a timestamp', () => {
+    renderLastScannedCell({ status: 'error' });
+
+    expect(screen.getByText('Not scanned yet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('status', { name: 'Scanning' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a labelled spinner only while actively scanning', () => {
+    renderLastScannedCell({ status: 'scanning' });
+
+    // Spinner carries an accessible name so screen-reader users get the state.
+    const spinner = screen.getByRole('status', { name: 'Scanning' });
+    expect(spinner).toBeInTheDocument();
+    expect(screen.queryByText('Not scanned yet')).not.toBeInTheDocument();
+  });
+
+  it('renders the timestamp once a scan has completed', async () => {
+    renderLastScannedCell({
+      status: 'active',
+      lastScannedAt: Date.UTC(2026, 0, 15, 12, 0, 0),
+    });
+
+    // CopyableTimestamp resolves the formatted date asynchronously; awaiting
+    // its copy control flushes that effect and proves the timestamp rendered.
+    expect(await screen.findByRole('button')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('status', { name: 'Scanning' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Not scanned yet')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
+++ b/services/platform/app/features/websites/hooks/use-websites-table-config.tsx
@@ -94,18 +94,39 @@ export const useWebsitesTableConfig = createTableConfigHook<'websites'>(
       ),
       size: 128,
       meta: { headerLabel: tTables('headers.scanned') },
-      cell: ({ row }) =>
-        row.original.lastScannedAt ? (
-          <CopyableTimestamp
-            date={row.original.lastScannedAt}
-            preset="long"
-            alignRight
-          />
-        ) : (
-          <Row gap={0} align="stretch" justify="end">
-            <Loader className="text-muted-foreground size-4 animate-spin" />
-          </Row>
-        ),
+      cell: ({ row }) => {
+        // A successful scan stamps `lastScannedAt`; until then the cell must
+        // not pretend work is in progress. Show the spinner only while the
+        // website is actively `scanning`, and surface a static, labelled
+        // "Not scanned yet" for every terminal/idle state (freshly added,
+        // `idle`, `error`, or environments where the crawler never ran).
+        if (row.original.lastScannedAt) {
+          return (
+            <CopyableTimestamp
+              date={row.original.lastScannedAt}
+              preset="long"
+              alignRight
+            />
+          );
+        }
+        if (row.original.status === 'scanning') {
+          return (
+            <Row gap={0} align="stretch" justify="end">
+              <Loader
+                role="status"
+                aria-hidden={false}
+                aria-label={tEntity('filter.status.scanning')}
+                className="text-muted-foreground size-4 animate-spin"
+              />
+            </Row>
+          );
+        }
+        return (
+          <Text as="span" variant="caption" className="block w-full text-right">
+            {tEntity('viewDialog.notScannedYet')}
+          </Text>
+        );
+      },
     },
     {
       accessorKey: 'scanInterval',


### PR DESCRIPTION
## Summary

The Websites table's **Last scanned** column rendered an infinitely-spinning `<Loader>` for any row without a `lastScannedAt` — freshly-added websites, `idle`/`error` rows, and any environment where the crawler never ran. The ternary keyed only on `lastScannedAt`, never on `status`, so a terminal/idle state was misrepresented as a busy in-progress operation. The bare lucide `Loader` also carried no accessible label (lucide icons are `aria-hidden` by default), so screen-reader users got no state at all.

## Changes

- `services/platform/app/features/websites/hooks/use-websites-table-config.tsx` — the `lastScannedAt` cell now:
  - renders the existing static **"Not scanned yet"** label (`websites.viewDialog.notScannedYet`, already present in all locales — `de-CH` resolves it via its `de` fallback) for every never-scanned/terminal/idle state, matching the contrast already used by `website-view-dialog.tsx`;
  - shows the spinner **only** when `status === 'scanning'`, and gives it `role="status"` + an `aria-label` (reusing `websites.filter.status.scanning`) so the in-progress state is announced;
  - keeps rendering the timestamp once a scan has completed.
- `services/platform/app/features/websites/hooks/use-websites-table-config.test.tsx` — new focused tests covering all four states (never-scanned, errored-without-timestamp, actively-scanning labelled spinner, completed timestamp).

No new i18n keys were added — existing keys are reused, so there is no translation ripple.

## Verification

- `bunx vitest --run --config vitest.ui.config.ts app/features/websites` → 5 files, 11 tests pass (incl. the existing axe audit).
- `bunx oxlint --type-aware` on changed files → 0 warnings, 0 errors.
- `bunx tsc --noEmit` → clean.
- `oxfmt --check` → formatted.

Closes #2073