### PR TITLE
fix: Agent webhook "will only be shown once" warning is false (#2064)

### DIFF
--- a/services/platform/messages/de.json
+++ b/services/platform/messages/de.json
@@ -5433,7 +5433,7 @@
         "notPublished": "Veröffentliche diesen Agent, um Webhook-Zugriff zu aktivieren.",
         "createButton": "Webhook erstellen",
         "createdTitle": "Webhook erstellt",
-        "urlWarning": "Kopiere diese URL jetzt — sie wird nur einmal angezeigt.",
+        "urlWarning": "Speichere diese Webhook-URL. Das Token in der URL dient als Authentifizierungsnachweis.",
         "webhookUrl": "Webhook-URL",
         "copyUrl": "Webhook-URL kopieren",
         "copyExample": "Beispiel kopieren",

--- a/services/platform/messages/en.json
+++ b/services/platform/messages/en.json
@@ -5695,7 +5695,7 @@
         "notPublished": "Publish this agent to enable webhook access.",
         "createButton": "Create webhook",
         "createdTitle": "Webhook created",
-        "urlWarning": "Copy this URL now. It will only be shown once.",
+        "urlWarning": "Save this webhook URL. The token in the URL acts as the authentication credential.",
         "webhookUrl": "Webhook URL",
         "copyUrl": "Copy webhook URL",
         "copyExample": "Copy example",

--- a/services/platform/messages/fr.json
+++ b/services/platform/messages/fr.json
@@ -5434,7 +5434,7 @@
         "notPublished": "Publie cet agent pour activer l'accès par webhook.",
         "createButton": "Créer un webhook",
         "createdTitle": "Webhook créé",
-        "urlWarning": "Copie cette URL maintenant. Elle ne sera affichée qu'une seule fois.",
+        "urlWarning": "Enregistre cette URL de webhook. Le jeton dans l'URL sert d'identifiant d'authentification.",
         "webhookUrl": "URL du webhook",
         "copyUrl": "Copier l'URL du webhook",
         "copyExample": "Copier l'exemple",


### PR DESCRIPTION
Closes #2064

## Problem
The agent webhook `SecretRevealDialog` warned "Copy this URL now. It will only be shown once." However, the token-bearing webhook URL is permanently stored and served in plaintext, and is shown in the table (with a Copy button) on every visit/reload. The warning was therefore false.

## Fix
Aligns the agent webhook warning copy with the honest wording already used by the sibling **workflow/automations** webhook UI, which documents the same pattern correctly:

> "Save this webhook URL. The token in the URL acts as the authentication credential."

This is a copy/correctness fix (token retrievability is by design and matches the workflows webhook surface). Updated `settings.agents.webhook.urlWarning` across all locales that define it:

- `en.json`
- `de.json`
- `fr.json`

(`de-CH.json` does not define this key and falls back, so no change needed.)