### PR TITLE
fix(platform): gate member bulk-select and guard self-removal (#2043)

### DIFF
--- a/services/platform/app/features/settings/organization/components/member-table.tsx
+++ b/services/platform/app/features/settings/organization/components/member-table.tsx
@@ -80,9 +80,9 @@ export function MemberTable({
   const columns = useMemo<ColumnDef<Member>[]>(
     () => [
       // Multi-row select — canonical 40px column. Enables bulk-remove via
-      // the `BulkDeleteBar` footer. Note: `removeMember` doesn't cascade
-      // to better-auth; bulk-remove of org owners would partial-fail and
-      // the bar surfaces a destructive toast for the failed ids.
+      // the `BulkDeleteBar` footer. Selection of the current-user row and
+      // the owner row is gated by `enableRowSelection` below, so neither a
+      // self-removal nor an always-failing owner row can enter a batch.
       createSelectColumn<Member>(),
       {
         id: 'member',
@@ -165,7 +165,16 @@ export function MemberTable({
       getRowId={(row) => row._id}
       isLoading={isLoading}
       approxRowCount={approxRowCount}
-      enableRowSelection
+      // Mirror the single-row Delete gating (`member-row-actions.tsx`): the
+      // current user's own row and the owner row are not selectable for
+      // bulk-remove. Self-removal is a self-lockout + irreversible
+      // personalization wipe, and the owner is backend-protected (a bulk
+      // batch including it would partial-fail). The backend `removeMember`
+      // enforces both as defense in depth.
+      enableRowSelection={(row) =>
+        row.original._id !== memberContext?.member?._id &&
+        row.original.role?.toLowerCase() !== 'owner'
+      }
       rowSelection={rowSelection}
       onRowSelectionChange={setRowSelection}
       pagination={{

--- a/services/platform/convex/members/mutations.test.ts
+++ b/services/platform/convex/members/mutations.test.ts
@@ -188,6 +188,33 @@ describe('removeMember handler', () => {
     );
   });
 
+  it('throws when an admin tries to remove their own membership', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    const ctx = createMockCtx();
+    // target member is the caller themself (same userId as AUTH_USER._id)
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [
+        {
+          _id: 'm_self',
+          organizationId: 'org_1',
+          userId: 'user_caller',
+          role: 'admin',
+        },
+      ],
+    });
+    // caller is admin
+    ctx.runQuery.mockResolvedValueOnce({
+      page: [{ _id: 'm_self', role: 'admin' }],
+    });
+    const handler = await getHandler();
+
+    await expect(handler(ctx, { memberId: 'm_self' })).rejects.toThrow(
+      'You cannot remove your own membership',
+    );
+    // No deletion should be attempted for a self-removal.
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
   it('allows owner to remove a non-owner member', async () => {
     mockGetAuthUser.mockResolvedValue(AUTH_USER);
     const ctx = createMockCtx();

--- a/services/platform/convex/members/mutations.ts
+++ b/services/platform/convex/members/mutations.ts
@@ -173,6 +173,15 @@ export const removeMember = mutation({
       throw new Error('The organization owner cannot be removed');
     }
 
+    // Defense in depth for the UI bulk-select gate: an admin cannot remove
+    // their own membership. Self-removal is a self-lockout that also fires
+    // `cascadeOnMemberRemoved`, irreversibly wiping the caller's own
+    // userMemories/userPreferences/TTS for the org. Enforce server-side
+    // regardless of how the request is issued.
+    if (member.userId === authUser.userId) {
+      throw new Error('You cannot remove your own membership');
+    }
+
     const targetUser = member.userId
       ? findOneUser(
           await ctx.runQuery(components.betterAuth.adapter.findMany, {


### PR DESCRIPTION
## Summary

Fixes the ungated member bulk-select and the missing backend self-removal guard reported in #2043.

Previously, in the Org settings Members table, the bulk-select checkbox was rendered for **every** row — including the current user's own row and the owner row — even though the single-row action menu hides Delete for self and owner. And `removeMember` had no `authUser.userId === member.userId` check, so an admin could delete their own membership, causing a self-lockout plus an irreversible `cascadeOnMemberRemoved` wipe of their own `userMemories`/`userPreferences`/org-scoped TTS.

## Changes

- **Frontend** (`member-table.tsx`): replaced the bare `enableRowSelection` boolean with a per-row predicate that mirrors the single-row Delete gating — the current-user row and the owner row are no longer selectable for bulk-delete. Uses the same `enableRowSelection={(row) => ...}` shape already used by `agents-table.tsx` and typed on `DataTable`.
- **Backend** (`members/mutations.ts`): added a self-removal guard in `removeMember` — throws `You cannot remove your own membership` when `member.userId === authUser.userId`, as defense in depth regardless of how the request is issued.
- **Test** (`members/mutations.test.ts`): added a regression test asserting an admin cannot remove their own membership and that no deletion is attempted.

## Verification

- `bunx vitest --run --project server convex/members/mutations.test.ts` → 22 passed
- `bunx tsc --noEmit` → 0 errors
- `bunx oxlint --type-aware` on changed files → 0 warnings, 0 errors

Closes #2043