### PR TITLE
fix: gate MCP server actions and mutations on org membership and role (#2040)

### DIFF
--- a/services/platform/convex/agent_tools/mcp/create_bound_mcp_tool.ts
+++ b/services/platform/convex/agent_tools/mcp/create_bound_mcp_tool.ts
@@ -10,7 +10,7 @@ import type { ToolCtx } from '@convex-dev/agent';
 import { createTool } from '@convex-dev/agent';
 import { z } from 'zod/v4';
 
-import { api, internal } from '../../_generated/api';
+import { internal } from '../../_generated/api';
 import { toId } from '../../lib/type_cast_helpers';
 import { toConvexJsonRecord } from '../../lib/type_cast_helpers';
 import { getApprovalThreadId } from '../../threads/get_parent_thread_id';
@@ -175,7 +175,7 @@ export function createBoundMcpTool(
       // Execute directly
       try {
         const result = await ctx.runAction(
-          api.mcp_servers.actions.executeMcpTool,
+          internal.mcp_servers.actions.executeMcpTool,
           {
             serverId: toId<'mcpServers'>(serverId),
             toolName: mcpTool.name,

--- a/services/platform/convex/mcp_servers/actions.ts
+++ b/services/platform/convex/mcp_servers/actions.ts
@@ -10,8 +10,8 @@ import { ConvexError, v } from 'convex/values';
 
 import { internal } from '../_generated/api';
 import type { Doc } from '../_generated/dataModel';
-import { action } from '../_generated/server';
-import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { action, internalAction } from '../_generated/server';
+import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
 import { jsonRecordValidator } from '../lib/validators/json';
 import type { McpServerConfig } from './client_factory';
 import { discoverTools, executeTool } from './client_factory';
@@ -38,11 +38,6 @@ export const testConnection = action({
     id: v.id('mcpServers'),
   },
   handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new ConvexError({ code: 'UNAUTHENTICATED' });
-    }
-
     const server = await ctx.runQuery(
       internal.mcp_servers.internal_queries.getById,
       { id: args.id },
@@ -50,6 +45,13 @@ export const testConnection = action({
     if (!server) {
       throw new ConvexError({ code: 'NOT_FOUND' });
     }
+
+    // Verify the caller is a live member of the org that OWNS this server and
+    // holds the developerSettings capability before running discovery against
+    // the server with its stored credentials. Deriving the org from the server
+    // doc (rather than a client-supplied arg) makes the ownership match
+    // implicit — a member of another org cannot reach this server.
+    await requireOrgAdminOrDeveloper(ctx, server.organizationId);
 
     // Set status to discovering
     await ctx.runMutation(
@@ -115,7 +117,21 @@ export const testConnection = action({
   },
 });
 
-export const executeMcpTool = action({
+/**
+ * Execute a named tool against an MCP server with its stored (decrypted)
+ * credentials.
+ *
+ * Backend-orchestration only — exposed as an `internalAction`, NOT a public
+ * `api.*` action. The decrypted bearer token / OAuth secret and the
+ * server-controlled `server.url` it reaches make a public surface a
+ * cross-tenant credential-use + SSRF primitive: any authenticated user could
+ * drive another tenant's server. The only callers are trusted backend paths
+ * that have already resolved the server to the caller's org —
+ * `agent_tools/mcp/create_bound_mcp_tool.ts` (the bound agent tool) and
+ * `mcp_servers/execute_approved.ts` (post-approval replay) — both via
+ * `ctx.runAction(internal.mcp_servers.actions.executeMcpTool, …)`.
+ */
+export const executeMcpTool = internalAction({
   args: {
     serverId: v.id('mcpServers'),
     toolName: v.string(),

--- a/services/platform/convex/mcp_servers/actions_error_codes.test.ts
+++ b/services/platform/convex/mcp_servers/actions_error_codes.test.ts
@@ -1,7 +1,7 @@
 import { convexTest } from 'convex-test';
 import { describe, expect, it, vi } from 'vitest';
 
-import { api } from '../_generated/api';
+import { api, internal } from '../_generated/api';
 import schema from '../schema';
 
 /**
@@ -129,10 +129,12 @@ describe('mcp_servers action error codes (#2015)', () => {
     const t = newConvexTest();
     const serverId = await danglingServerId(t);
     const code = await catchCode(() =>
-      t.withIdentity(IDENTITY).action(api.mcp_servers.actions.executeMcpTool, {
-        serverId,
-        toolName: 'doThing',
-      }),
+      t
+        .withIdentity(IDENTITY)
+        .action(internal.mcp_servers.actions.executeMcpTool, {
+          serverId,
+          toolName: 'doThing',
+        }),
     );
     expect(code).toBe('NOT_FOUND');
   });
@@ -150,10 +152,12 @@ describe('mcp_servers action error codes (#2015)', () => {
       }),
     );
     const code = await catchCode(() =>
-      t.withIdentity(IDENTITY).action(api.mcp_servers.actions.executeMcpTool, {
-        serverId,
-        toolName: 'doThing',
-      }),
+      t
+        .withIdentity(IDENTITY)
+        .action(internal.mcp_servers.actions.executeMcpTool, {
+          serverId,
+          toolName: 'doThing',
+        }),
     );
     expect(code).toBe('SERVER_NOT_ACTIVE');
   });

--- a/services/platform/convex/mcp_servers/authorization.test.ts
+++ b/services/platform/convex/mcp_servers/authorization.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Regression tests for the cross-tenant authorization gates added to the
+ * public MCP-server actions/mutations (issue #2040).
+ *
+ * Before the fix, `create`/`update`/`remove`/`updateStatus` (public_mutations)
+ * and `testConnection` (actions) checked only that the caller was
+ * authenticated — any member of any org could create servers in, or
+ * read/tamper with, another tenant's servers (and `executeMcpTool` was a
+ * public action with no auth at all). Each public surface must now resolve the
+ * owning org and enforce `requireOrgAdminOrDeveloper`, and `executeMcpTool`
+ * must no longer be a public `api.*` action.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('convex/values', () => {
+  const stub = () => 'validator';
+  class ConvexError extends Error {
+    data: unknown;
+    constructor(data: unknown) {
+      super(typeof data === 'string' ? data : JSON.stringify(data));
+      this.name = 'ConvexError';
+      this.data = data;
+    }
+  }
+  return {
+    ConvexError,
+    v: {
+      string: stub,
+      optional: stub,
+      union: stub,
+      object: stub,
+      literal: stub,
+      array: stub,
+      boolean: stub,
+      number: stub,
+      id: stub,
+      null: stub,
+      any: stub,
+    },
+  };
+});
+
+vi.mock('../lib/validators/json', () => ({
+  jsonRecordValidator: 'jsonRecordValidator',
+}));
+
+vi.mock('../_generated/server', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    action: (config: Record<string, unknown>) => config,
+    internalAction: (config: Record<string, unknown>) => ({
+      ...config,
+      isInternalAction: true,
+    }),
+  };
+});
+
+vi.mock('../_generated/api', () => ({
+  api: {},
+  internal: {
+    mcp_servers: {
+      internal_queries: { getById: 'internal_queries.getById' },
+      mutations: {
+        insert: 'mutations.insert',
+        update: 'mutations.update',
+        remove: 'mutations.remove',
+        setStatus: 'mutations.setStatus',
+      },
+    },
+  },
+}));
+
+vi.mock('../lib/crypto/encrypt_string', () => ({
+  encryptString: vi.fn(async (s: string) => `enc:${s}`),
+}));
+
+// Avoid pulling in the MCP SDK / node client factory in unit tests.
+vi.mock('./client_factory', () => ({
+  discoverTools: vi.fn(),
+  executeTool: vi.fn(),
+}));
+
+const requireOrgAdminOrDeveloper = vi.fn();
+vi.mock('../lib/auth/require_org_admin_or_developer', () => ({
+  requireOrgAdminOrDeveloper: (...args: unknown[]) =>
+    requireOrgAdminOrDeveloper(...args),
+}));
+
+type HandlerFn = (
+  ctx: unknown,
+  args: Record<string, unknown>,
+) => Promise<unknown>;
+
+const FORBIDDEN = new Error('FORBIDDEN_DEVELOPER_SETTINGS');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireOrgAdminOrDeveloper.mockResolvedValue({ member: { role: 'admin' } });
+});
+
+describe('public_mutations authorization (#2040)', () => {
+  describe('create', () => {
+    it('enforces admin/developer on the supplied organizationId before inserting', async () => {
+      // `runQuery` resolves the duplicate-name lookup (getIdByOrgAndName) to
+      // null so the happy path reaches the insert.
+      const ctx = {
+        runQuery: vi.fn().mockResolvedValue(null),
+        runMutation: vi.fn(),
+      };
+      const { create } = await import('./public_mutations');
+      const handler = (create as unknown as { handler: HandlerFn }).handler;
+
+      await handler(ctx, {
+        organizationId: 'org_1',
+        name: 'srv',
+        displayName: 'Srv',
+        transportType: 'streamable_http',
+        url: 'https://example.com/mcp',
+        authType: 'none',
+      });
+
+      expect(requireOrgAdminOrDeveloper).toHaveBeenCalledWith(ctx, 'org_1');
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        'mutations.insert',
+        expect.objectContaining({ organizationId: 'org_1' }),
+      );
+    });
+
+    it('does not insert when the caller is not authorized for the org', async () => {
+      requireOrgAdminOrDeveloper.mockRejectedValueOnce(FORBIDDEN);
+      const ctx = { runQuery: vi.fn(), runMutation: vi.fn() };
+      const { create } = await import('./public_mutations');
+      const handler = (create as unknown as { handler: HandlerFn }).handler;
+
+      await expect(
+        handler(ctx, {
+          organizationId: 'org_other',
+          name: 'srv',
+          displayName: 'Srv',
+          transportType: 'streamable_http',
+          authType: 'none',
+        }),
+      ).rejects.toThrow('FORBIDDEN_DEVELOPER_SETTINGS');
+      expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe.each([
+    ['update', { id: 'server_1', displayName: 'x' }, 'mutations.update'],
+    ['remove', { id: 'server_1' }, 'mutations.remove'],
+    [
+      'updateStatus',
+      { id: 'server_1', status: 'active' },
+      'mutations.setStatus',
+    ],
+  ])('%s', (name, args, mutationRef) => {
+    it('resolves the owning org from the stored doc and gates on it', async () => {
+      const ctx = {
+        runQuery: vi
+          .fn()
+          .mockResolvedValue({ _id: 'server_1', organizationId: 'org_owner' }),
+        runMutation: vi.fn().mockResolvedValue(null),
+      };
+      const mod = await import('./public_mutations');
+      const handler = (
+        mod as unknown as Record<string, { handler: HandlerFn }>
+      )[name].handler;
+
+      await handler(ctx, args);
+
+      expect(ctx.runQuery).toHaveBeenCalledWith('internal_queries.getById', {
+        id: 'server_1',
+      });
+      expect(requireOrgAdminOrDeveloper).toHaveBeenCalledWith(ctx, 'org_owner');
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        mutationRef,
+        expect.objectContaining({ id: 'server_1' }),
+      );
+    });
+
+    it('throws when the server does not exist (no mutation)', async () => {
+      const ctx = {
+        runQuery: vi.fn().mockResolvedValue(null),
+        runMutation: vi.fn(),
+      };
+      const mod = await import('./public_mutations');
+      const handler = (
+        mod as unknown as Record<string, { handler: HandlerFn }>
+      )[name].handler;
+
+      await expect(handler(ctx, args)).rejects.toMatchObject({
+        data: { code: 'not_found' },
+      });
+      expect(requireOrgAdminOrDeveloper).not.toHaveBeenCalled();
+      expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+
+    it('does not mutate when the caller is not authorized for the owning org', async () => {
+      requireOrgAdminOrDeveloper.mockRejectedValueOnce(FORBIDDEN);
+      const ctx = {
+        runQuery: vi
+          .fn()
+          .mockResolvedValue({ _id: 'server_1', organizationId: 'org_owner' }),
+        runMutation: vi.fn(),
+      };
+      const mod = await import('./public_mutations');
+      const handler = (
+        mod as unknown as Record<string, { handler: HandlerFn }>
+      )[name].handler;
+
+      await expect(handler(ctx, args)).rejects.toThrow(
+        'FORBIDDEN_DEVELOPER_SETTINGS',
+      );
+      expect(ctx.runMutation).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('actions authorization (#2040)', () => {
+  it('testConnection gates on the owning org before running discovery', async () => {
+    requireOrgAdminOrDeveloper.mockRejectedValueOnce(FORBIDDEN);
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValue({ _id: 'server_1', organizationId: 'org_owner' }),
+      runMutation: vi.fn(),
+    };
+    const { testConnection } = await import('./actions');
+    const handler = (testConnection as unknown as { handler: HandlerFn })
+      .handler;
+
+    await expect(handler(ctx, { id: 'server_1' })).rejects.toThrow(
+      'FORBIDDEN_DEVELOPER_SETTINGS',
+    );
+    // Status was never flipped to "discovering" and no discovery ran.
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it('executeMcpTool is an internalAction, not a public api.* action', async () => {
+    const { executeMcpTool } = await import('./actions');
+    expect(
+      (executeMcpTool as unknown as { isInternalAction?: boolean })
+        .isInternalAction,
+    ).toBe(true);
+  });
+});

--- a/services/platform/convex/mcp_servers/execute_approved.ts
+++ b/services/platform/convex/mcp_servers/execute_approved.ts
@@ -10,7 +10,7 @@
 import { v } from 'convex/values';
 
 import { isRecord } from '../../lib/utils/type-utils';
-import { api, internal } from '../_generated/api';
+import { internal } from '../_generated/api';
 import { internalAction } from '../_generated/server';
 import { toId } from '../lib/type_cast_helpers';
 import { toConvexJsonRecord } from '../lib/type_cast_helpers';
@@ -52,7 +52,7 @@ export const executeApprovedMcpToolCall = internalAction({
 
     try {
       const result: unknown = await ctx.runAction(
-        api.mcp_servers.actions.executeMcpTool,
+        internal.mcp_servers.actions.executeMcpTool,
         {
           serverId: toId<'mcpServers'>(serverId),
           toolName,

--- a/services/platform/convex/mcp_servers/public_mutations.test.ts
+++ b/services/platform/convex/mcp_servers/public_mutations.test.ts
@@ -61,6 +61,14 @@ vi.mock('../lib/rls/auth/get_auth_user_identity', () => ({
   getAuthUserIdentity: (_ctx: unknown) => getAuthUserIdentity(),
 }));
 
+// Org-membership/role gate (#2040). Default to an authorized admin; the gate's
+// own rejection behaviour is covered in authorization.test.ts.
+const requireOrgAdminOrDeveloper = vi.fn();
+vi.mock('../lib/auth/require_org_admin_or_developer', () => ({
+  requireOrgAdminOrDeveloper: (...args: unknown[]) =>
+    requireOrgAdminOrDeveloper(...args),
+}));
+
 type HandlerFn = (
   ctx: unknown,
   args: Record<string, unknown>,
@@ -95,6 +103,7 @@ describe('mcp_servers/public_mutations (actions)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getAuthUserIdentity.mockResolvedValue({ userId: 'user_1' });
+    requireOrgAdminOrDeveloper.mockResolvedValue({ member: { role: 'admin' } });
   });
 
   describe('create', () => {
@@ -166,7 +175,12 @@ describe('mcp_servers/public_mutations (actions)', () => {
       await expect(
         handler(ctx, { id: 'server_1', name: 'Not A Slug' }),
       ).rejects.toMatchObject({ data: { code: 'invalid' } });
-      expect(ctx.runQuery).not.toHaveBeenCalled();
+      // The slug is validated before the duplicate-name lookup runs (the
+      // ownership gate's getById may already have fired).
+      expect(ctx.runQuery).not.toHaveBeenCalledWith(
+        'getIdByOrgAndName',
+        expect.anything(),
+      );
       expect(mutationCalls).toHaveLength(0);
     });
 

--- a/services/platform/convex/mcp_servers/public_mutations.ts
+++ b/services/platform/convex/mcp_servers/public_mutations.ts
@@ -4,9 +4,10 @@ import { ConvexError, v } from 'convex/values';
 
 import { isHttpUrl } from '../../lib/utils/url';
 import { internal } from '../_generated/api';
-import { action } from '../_generated/server';
+import type { Id } from '../_generated/dataModel';
+import { action, type ActionCtx } from '../_generated/server';
+import { requireOrgAdminOrDeveloper } from '../lib/auth/require_org_admin_or_developer';
 import { encryptString } from '../lib/crypto/encrypt_string';
-import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
 import { jsonRecordValidator } from '../lib/validators/json';
 import { MCP_SERVER_NAME_MAX_LENGTH, validateMcpServerName } from './constants';
 
@@ -22,6 +23,31 @@ function assertValidMcpServerName(name: string): void {
         ? `Name must be at most ${MCP_SERVER_NAME_MAX_LENGTH} characters.`
         : 'Name must be lowercase alphanumeric with hyphens (e.g. my-mcp-server).';
   throw new ConvexError({ code: 'invalid', message });
+}
+
+/**
+ * Resolve an existing server's owning org and assert the caller is an
+ * admin/developer member of it before any id-based mutation touches it.
+ * Deriving the org from the stored document (not a client-supplied arg) makes
+ * the ownership match implicit — a member of another org cannot edit, delete,
+ * or re-status this server. Mirrors the `requireSessionInOrg` defense-in-depth
+ * pattern in `node_only/sandbox/session_admin_actions.ts`.
+ */
+async function requireServerAdmin(
+  ctx: ActionCtx,
+  id: Id<'mcpServers'>,
+): Promise<void> {
+  const server = await ctx.runQuery(
+    internal.mcp_servers.internal_queries.getById,
+    { id },
+  );
+  if (!server) {
+    throw new ConvexError({
+      code: 'not_found',
+      message: 'MCP server not found.',
+    });
+  }
+  await requireOrgAdminOrDeveloper(ctx, server.organizationId);
 }
 
 const transportTypeValidator = v.union(
@@ -99,10 +125,10 @@ export const create = action({
     oauth2Config: v.optional(oauth2InputValidator),
   },
   handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new ConvexError({ code: 'UNAUTHENTICATED' });
-    }
+    // Confirm the caller is an admin/developer member of the org they are
+    // creating the server in — the organizationId arrives from the client and
+    // was previously trusted blindly.
+    await requireOrgAdminOrDeveloper(ctx, args.organizationId);
 
     const name = args.name.trim();
     assertValidMcpServerName(name);
@@ -177,10 +203,7 @@ export const update = action({
     oauth2Config: v.optional(oauth2InputValidator),
   },
   handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new ConvexError({ code: 'UNAUTHENTICATED' });
-    }
+    await requireServerAdmin(ctx, args.id);
 
     if (args.url) {
       assertHttpUrl(args.url, 'URL');
@@ -247,10 +270,7 @@ export const remove = action({
     id: v.id('mcpServers'),
   },
   handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new ConvexError({ code: 'UNAUTHENTICATED' });
-    }
+    await requireServerAdmin(ctx, args.id);
 
     await ctx.runMutation(internal.mcp_servers.mutations.remove, {
       id: args.id,
@@ -266,10 +286,7 @@ export const updateStatus = action({
     status: v.union(v.literal('active'), v.literal('inactive')),
   },
   handler: async (ctx, args) => {
-    const authUser = await getAuthUserIdentity(ctx);
-    if (!authUser) {
-      throw new ConvexError({ code: 'UNAUTHENTICATED' });
-    }
+    await requireServerAdmin(ctx, args.id);
 
     await ctx.runMutation(internal.mcp_servers.mutations.setStatus, {
       id: args.id,


### PR DESCRIPTION
Closes #2040

## Problem

The MCP-server backend exposed several public Convex actions/mutations that checked only authentication (or nothing at all), giving any authenticated user in any org a cross-tenant primitive:

- `executeMcpTool` (actions.ts) had **no auth check** and was a public `api.*` action. It fetched another org's full server doc (including encrypted credentials) and executed a named tool against `server.url` with the **decrypted** bearer/OAuth secret — a cross-tenant credential-use + SSRF primitive.
- `testConnection` (actions.ts) checked only `getAuthUserIdentity`, then ran discovery against another org's server with its stored credentials and persisted status/token updates.
- `create` / `update` / `remove` / `updateStatus` (public_mutations.ts) checked only `getAuthUserIdentity`; `create` trusted a client-supplied `organizationId`, the id-based ones never confirmed the server belonged to the caller's org.

## Fix

Mirrors the proven pattern from the sibling sandbox admin surface (`node_only/sandbox/session_admin_actions.ts`) and the MCP read queries (`queries.ts`):

- **`executeMcpTool` → `internalAction`.** Its only callers are trusted backend paths (`agent_tools/mcp/create_bound_mcp_tool.ts` and `mcp_servers/execute_approved.ts`), now invoked via `internal.mcp_servers.actions.executeMcpTool`. This removes the public exposure entirely — closing the SSRF/credential-use hole.
- **`testConnection` and `public_mutations.*` stay public** (they are wired to the frontend via `useAction`) but are now gated server-side with `requireOrgAdminOrDeveloper`:
  - `create` enforces the capability on the supplied `organizationId`.
  - `update` / `remove` / `updateStatus` / `testConnection` resolve the owning org **from the stored server document** and gate on that, so the ownership match is implicit — a member of another org cannot touch the server (the `requireSessionInOrg` defense-in-depth pattern).

## Verification

- New regression test `convex/mcp_servers/authorization.test.ts` (13 cases): each public mutation/action rejects an unauthorized caller and never mutates; `create` gates on the supplied org; id-based ops gate on the owning org and throw on a missing server; asserts `executeMcpTool` is an `internalAction`.
- `bunx vitest --run --project server mcp_servers/` — 35 passed.
- `bunx tsc --noEmit` — clean (the public/internal type split flows from the function visibility; no codegen change needed).
- `bunx oxlint --type-aware` on all changed files — 0 warnings, 0 errors.