### PR TITLE
fix(platform): cover customer name in conversations inbox search (#1996)

### DIFF
--- a/services/platform/app/features/conversations/components/conversations.tsx
+++ b/services/platform/app/features/conversations/components/conversations.tsx
@@ -117,6 +117,9 @@ export function Conversations({
         'description',
         'subject',
         'externalMessageId',
+        // The customer name is the most prominent label on each row, so the
+        // search must cover it too — it lives on the nested `customer` object.
+        (c) => c.customer?.name,
       ]);
     }
 

--- a/services/platform/lib/utils/filtering.test.ts
+++ b/services/platform/lib/utils/filtering.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterByTextSearch } from './filtering';
+
+interface Conversation {
+  title: string;
+  subject: string;
+  customer: { name?: string } | null;
+}
+
+const conversations: Conversation[] = [
+  {
+    title: 'Refund request',
+    subject: 'Order #12',
+    customer: { name: 'Alice Johnson' },
+  },
+  {
+    title: 'Shipping delay',
+    subject: 'Where is it',
+    customer: { name: 'Bob Smith' },
+  },
+  { title: 'General question', subject: 'Hi', customer: null },
+];
+
+describe('filterByTextSearch', () => {
+  it('returns all items when the search term is empty', () => {
+    expect(filterByTextSearch(conversations, '', ['title'])).toHaveLength(3);
+    expect(filterByTextSearch(conversations, '   ', ['title'])).toHaveLength(3);
+  });
+
+  it('matches a top-level field case-insensitively', () => {
+    const results = filterByTextSearch(conversations, 'refund', ['title']);
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Refund request');
+  });
+
+  it('matches a nested field via an accessor function', () => {
+    const results = filterByTextSearch(conversations, 'johnson', [
+      (c) => c.customer?.name,
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0].customer?.name).toBe('Alice Johnson');
+  });
+
+  it('finds the customer name even when no subject/title matches', () => {
+    const results = filterByTextSearch(conversations, 'bob', [
+      'title',
+      'subject',
+      (c) => c.customer?.name,
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0].customer?.name).toBe('Bob Smith');
+  });
+
+  it('does not throw when an accessor resolves to null/undefined', () => {
+    const results = filterByTextSearch(conversations, 'alice', [
+      (c) => c.customer?.name,
+    ]);
+    expect(results).toHaveLength(1);
+  });
+
+  it('supports startsWith match mode', () => {
+    expect(
+      filterByTextSearch(
+        conversations,
+        'ali',
+        [(c) => c.customer?.name],
+        'startsWith',
+      ),
+    ).toHaveLength(1);
+    expect(
+      filterByTextSearch(
+        conversations,
+        'johnson',
+        [(c) => c.customer?.name],
+        'startsWith',
+      ),
+    ).toHaveLength(0);
+  });
+});

--- a/services/platform/lib/utils/filtering.ts
+++ b/services/platform/lib/utils/filtering.ts
@@ -49,11 +49,21 @@ export function filterByFields<T>(items: T[], filters: FieldFilter<T>[]): T[] {
 }
 
 /**
+ * A field to search within {@link filterByTextSearch}: either a top-level key
+ * of the item, or an accessor that returns the value to match (used to reach
+ * nested fields such as a related customer's name).
+ */
+export type SearchField<T> =
+  | keyof T
+  | ((item: T) => string | number | null | undefined);
+
+/**
  * Filter items by text search across multiple fields
  *
  * @param items - Array of items to filter
  * @param searchTerm - Search term (case-insensitive)
- * @param fields - Array of fields to search in
+ * @param fields - Fields to search in: top-level keys or accessor functions
+ *   (the latter let callers match nested values, e.g. `(c) => c.customer.name`)
  * @param matchMode - Match mode: 'includes' (substring) or 'startsWith'
  * @returns Filtered array
  *
@@ -68,7 +78,7 @@ export function filterByFields<T>(items: T[], filters: FieldFilter<T>[]): T[] {
 export function filterByTextSearch<T>(
   items: T[],
   searchTerm: string,
-  fields: (keyof T)[],
+  fields: SearchField<T>[],
   matchMode: 'includes' | 'startsWith' = 'includes',
 ): T[] {
   if (!searchTerm || searchTerm.trim() === '') return items;
@@ -77,7 +87,7 @@ export function filterByTextSearch<T>(
 
   return items.filter((item) => {
     return fields.some((field) => {
-      const value = item[field];
+      const value = typeof field === 'function' ? field(item) : item[field];
       if (value == null) return false;
 
       const normalizedValue = String(value).toLowerCase();

--- a/services/platform/lib/utils/filtering.ts
+++ b/services/platform/lib/utils/filtering.ts
@@ -53,7 +53,7 @@ export function filterByFields<T>(items: T[], filters: FieldFilter<T>[]): T[] {
  * of the item, or an accessor that returns the value to match (used to reach
  * nested fields such as a related customer's name).
  */
-export type SearchField<T> =
+type SearchField<T> =
   | keyof T
   | ((item: T) => string | number | null | undefined);
 


### PR DESCRIPTION
## Summary

The conversations inbox search filtered by subject/body but **not** the customer name — the most prominent label on each row — so searching for a visible customer returned zero results.

## Changes
- Extend `filterByTextSearch` (`lib/utils/filtering.ts`) to accept **accessor functions** in addition to top-level keys, so callers can match nested values such as a related customer's name. Accessor return type is constrained to stringifiable primitives.
- Include the resolved customer name (`(c) => c.customer?.name`) in the conversations inbox search fields (`app/features/conversations/components/conversations.tsx`).
- Add unit tests for `filterByTextSearch` covering accessor-based (nested) matching, the empty-search case, null-safe accessors, and `startsWith` mode.

## Verification
- `vitest --run --project server lib/utils/filtering.test.ts` → 6/6 pass
- `tsc --noEmit` → clean
- `oxlint --type-aware` → 0 errors/warnings

Closes #1996