### PR TITLE
fix: enforce org-membership check on file_metadata mutations (#2039)

### DIFF
--- a/services/platform/convex/file_metadata/mutations.test.ts
+++ b/services/platform/convex/file_metadata/mutations.test.ts
@@ -69,6 +69,21 @@ vi.mock('../governance/upload_enforcement', () => ({
   checkUploadPolicy: vi.fn().mockResolvedValue({ allowed: true }),
 }));
 
+// Org-membership gate (#2039). By default every test runs as a valid member;
+// the authorization tests override this to reject (non-member).
+const mockGetOrganizationMember = vi.fn();
+vi.mock('../lib/rls/organization/get_organization_member', () => ({
+  getOrganizationMember: (...args: unknown[]) =>
+    mockGetOrganizationMember(...args),
+}));
+
+const VALID_MEMBER = {
+  _id: 'member_1',
+  organizationId: 'org_1',
+  userId: 'user_1',
+  role: 'member',
+};
+
 function createMockCtx(existingDoc: Record<string, unknown> | null = null) {
   const builder = {
     withIndex: vi.fn().mockReturnThis(),
@@ -131,6 +146,7 @@ const AUTH_USER = {
 describe('saveFileMetadata (public)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetOrganizationMember.mockResolvedValue(VALID_MEMBER);
   });
 
   it('rejects unauthenticated requests', async () => {
@@ -141,6 +157,27 @@ describe('saveFileMetadata (public)', () => {
     await expect(handler(ctx, baseArgs)).rejects.toMatchObject({
       data: { code: 'UNAUTHENTICATED' },
     });
+  });
+
+  it('rejects callers who are not a member of the target org', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    // Caller holds a valid JWT but is not a member of org_1 — the gate
+    // must throw before any fileMetadata row is written or RAG is queued.
+    mockGetOrganizationMember.mockRejectedValue(
+      new Error('Not a member of organization org_1'),
+    );
+    const { ctx } = createMockCtx(null);
+    const handler = await getHandler();
+
+    await expect(handler(ctx, baseArgs)).rejects.toThrow(
+      'Not a member of organization org_1',
+    );
+    expect(mockGetOrganizationMember).toHaveBeenCalledWith(
+      ctx,
+      'org_1',
+      expect.objectContaining({ userId: 'user_1' }),
+    );
+    expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
   it('rejects uploads blocked by organization policy, preserving the reason', async () => {
@@ -517,6 +554,7 @@ const skipArgs = { storageId: 'storage_1', organizationId: 'org_1' };
 describe('skipTranscription (public)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetOrganizationMember.mockResolvedValue(VALID_MEMBER);
   });
 
   it('rejects unauthenticated requests', async () => {
@@ -538,6 +576,24 @@ describe('skipTranscription (public)', () => {
     await expect(handler(ctx, skipArgs)).rejects.toMatchObject({
       data: { code: 'FILE_NOT_FOUND' },
     });
+  });
+
+  it('rejects callers who are not a member of the file org', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    mockGetOrganizationMember.mockRejectedValue(
+      new Error('Not a member of organization org_1'),
+    );
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      transcriptionStatus: 'running',
+    });
+    const handler = await getSkipHandler();
+
+    await expect(handler(ctx, skipArgs)).rejects.toThrow(
+      'Not a member of organization org_1',
+    );
+    expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
   it('throws NOT_AUTHORIZED when the row belongs to another org', async () => {
@@ -610,6 +666,7 @@ const retryArgs = { storageId: 'storage_1', organizationId: 'org_1' };
 describe('retryTranscription (public)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetOrganizationMember.mockResolvedValue(VALID_MEMBER);
   });
 
   it('rejects unauthenticated requests', async () => {
@@ -631,6 +688,24 @@ describe('retryTranscription (public)', () => {
     await expect(handler(ctx, retryArgs)).rejects.toMatchObject({
       data: { code: 'FILE_NOT_FOUND' },
     });
+  });
+
+  it('rejects callers who are not a member of the file org', async () => {
+    mockGetAuthUser.mockResolvedValue(AUTH_USER);
+    mockGetOrganizationMember.mockRejectedValue(
+      new Error('Not a member of organization org_1'),
+    );
+    const { ctx } = createMockCtx({
+      _id: 'fm_1',
+      organizationId: 'org_1',
+      transcriptionStatus: 'failed',
+    });
+    const handler = await getRetryHandler();
+
+    await expect(handler(ctx, retryArgs)).rejects.toThrow(
+      'Not a member of organization org_1',
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
   it('throws NOT_AUTHORIZED when the row belongs to another org', async () => {

--- a/services/platform/convex/file_metadata/mutations.ts
+++ b/services/platform/convex/file_metadata/mutations.ts
@@ -12,6 +12,7 @@ import {
   checkOrganizationRateLimit,
 } from '../lib/rate_limiter/helpers';
 import { getAuthUserIdentity } from '../lib/rls/auth/get_auth_user_identity';
+import { getOrganizationMember } from '../lib/rls/organization/get_organization_member';
 
 export const saveFileMetadata = mutation({
   args: {
@@ -48,6 +49,15 @@ export const saveFileMetadata = mutation({
     if (!authUser) {
       throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
+
+    // Authorization boundary: the caller must be an (enabled) member of the
+    // org they are writing into. Without this, any authenticated user could
+    // inject fileMetadata rows into a foreign org and RAG-index
+    // attacker-controlled content into that org's namespace (knowledge
+    // poisoning) — checkUploadPolicy/the threadId gate below are not a
+    // substitute (the policy defaults to allowed, and the threadId gate only
+    // fires for thread-bound chat uploads). Mirrors documents/mutations.ts.
+    await getOrganizationMember(ctx, args.organizationId, authUser);
 
     const userId = authUser.userId;
     const ext = extractExtension(args.fileName);
@@ -293,6 +303,11 @@ export const skipTranscription = mutation({
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
     if (!metadata) throw new ConvexError({ code: 'FILE_NOT_FOUND' });
+    // Authorization boundary: assert membership against the row's own org.
+    // The self-reported organizationId === metadata.organizationId check
+    // below catches caller mistakes but is not an authorization boundary on
+    // its own (both values are caller-controlled).
+    await getOrganizationMember(ctx, metadata.organizationId, authUser);
     if (metadata.organizationId !== args.organizationId) {
       throw new ConvexError({ code: 'NOT_AUTHORIZED' });
     }
@@ -348,6 +363,11 @@ export const retryTranscription = mutation({
       .withIndex('by_storageId', (q) => q.eq('storageId', args.storageId))
       .first();
     if (!metadata) throw new ConvexError({ code: 'FILE_NOT_FOUND' });
+    // Authorization boundary: assert membership against the row's own org.
+    // The self-reported organizationId === metadata.organizationId check
+    // below catches caller mistakes but is not an authorization boundary on
+    // its own (both values are caller-controlled).
+    await getOrganizationMember(ctx, metadata.organizationId, authUser);
     if (metadata.organizationId !== args.organizationId) {
       throw new ConvexError({ code: 'NOT_AUTHORIZED' });
     }


### PR DESCRIPTION
## Summary

Closes #2039.

`file_metadata` write mutations gated only on JWT presence (`getAuthUserIdentity`) plus a self-reported `organizationId === metadata.organizationId` check — neither of which asserts the caller is actually a member of the target org. Any authenticated user could therefore:

- inject `fileMetadata` rows into a **foreign** org and RAG-index attacker-controlled content into that org's namespace (knowledge poisoning),
- drive retention cleanup against an org they don't belong to,
- clobber a transcript / re-trigger Whisper billing on a foreign `storageId`.

This mirrors the sibling `documents/mutations.ts`, which already calls `getOrganizationMember`.

## Changes

`services/platform/convex/file_metadata/mutations.ts`:
- `saveFileMetadata` — `await getOrganizationMember(ctx, args.organizationId, authUser)` after the auth check, before `checkUploadPolicy`.
- `skipTranscription` / `retryTranscription` — `await getOrganizationMember(ctx, metadata.organizationId, authUser)` after the row loads. The existing self-reported `organizationId === metadata.organizationId` checks are kept (they catch caller mistakes) but are no longer relied on as the authorization boundary.

`getOrganizationMember` throws `UnauthorizedError` for non-members and for `disabled` members (so a removed/disabled member holding a still-valid JWT is rejected).

## Tests

`services/platform/convex/file_metadata/mutations.test.ts` — added authorization tests for all three mutations (non-member is rejected before any write/schedule; valid member still succeeds).

- `bunx vitest --run --project server file_metadata/mutations.test.ts` → 19 passed
- `bunx tsc --noEmit` → clean
- `bunx oxlint --type-aware` on changed files → 0 warnings / 0 errors