### PR TITLE
fix(sandbox): self-heal buildkitd egress fence across restarts

### DIFF
--- a/services/sandbox-buildkitd/Dockerfile
+++ b/services/sandbox-buildkitd/Dockerfile
@@ -53,7 +53,11 @@ RUN apt-get update \
       redsocks iptables iproute2 util-linux tini ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY services/sandbox-buildkitd/buildkitd.toml /etc/buildkit/buildkitd.toml
+# Shipped read-only base. The live --config (/etc/buildkit/buildkitd.toml) is
+# regenerated from this on every start by docker-entrypoint.sh, so a restart
+# never inherits a stale dynamic [dns]/[registry] block (the egress IP can change
+# across sandbox-egress recreation, and the daemon restarts independently).
+COPY services/sandbox-buildkitd/buildkitd.toml /etc/buildkit/buildkitd.base.toml
 COPY services/sandbox-buildkitd/docker-entrypoint.sh /docker-entrypoint.sh
 COPY services/sandbox-buildkitd/entrypoint.sh /entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh /entrypoint.sh

--- a/services/sandbox-buildkitd/docker-entrypoint.sh
+++ b/services/sandbox-buildkitd/docker-entrypoint.sh
@@ -33,15 +33,29 @@ REDSOCKS_PORT=12346
 REDSOCKS_UID=10002
 EGRESS_IP=""
 EGRESS_PORT=""
+# Marker the spawner (services/sandbox/src/buildkitd.ts) probes via
+# `docker exec test -f` to decide whether a RUNNING daemon still has its egress
+# fence. Removed at the start of every run; written only after egress is fully
+# installed (or in TALE_SKIP_EGRESS dev mode). Absent on a running daemon ⇒ it
+# restarted while sandbox-egress was unreachable and is serving builds with no
+# internet → the spawner recreates it. Keep in sync with EGRESS_READY_MARKER.
+EGRESS_READY=/run/tale-buildkitd-egress-ready
+# Immutable base config baked into the image; the live --config is regenerated
+# from it on EVERY start (init_base_config) so a writable-layer copy can never
+# carry a stale dynamic [dns]/[registry] block — the daemon restarts
+# independently (--restart unless-stopped) and sandbox-egress's IP can change.
+BASE_TOML=/etc/buildkit/buildkitd.base.toml
+LIVE_TOML=/etc/buildkit/buildkitd.toml
 
 log() { echo "[sandbox-buildkitd] $*"; }
 
-# Resolve the egress endpoint (IP + port) redsocks + [dns] use. The spawner
-# passes the already-resolved on-network IP as TALE_EGRESS_IP (preferred — once
-# our resolv.conf is bind-mounted to the egress dnsmasq, the dnsmasq can't answer
-# the `sandbox-egress` docker service name, so we can't resolve it here). The
-# HTTP(S)_PROXY-hostname fallback covers single-network dev where the embedded
-# resolver still answers service names.
+# Resolve the egress endpoint (IP + port) redsocks + [dns] use. Default path:
+# resolve the `sandbox-egress` HTTP(S)_PROXY hostname via the embedded resolver
+# (re-resolved on every start + retried by resolve_egress_retry, so a changed
+# egress IP or a not-yet-up egress at boot self-corrects). TALE_EGRESS_IP is an
+# optional override for topologies where the service name isn't resolvable here
+# (e.g. resolv.conf bind-mounted to the egress dnsmasq); deliberately NOT a
+# spawner-snapshotted IP, which would itself go stale across egress recreation.
 resolve_egress() {
   url="${HTTP_PROXY:-${HTTPS_PROXY:-}}"
   [ -n "$url" ] || true
@@ -63,10 +77,62 @@ resolve_egress() {
   [ -n "${ip:-}" ] && EGRESS_IP="$ip"
 }
 
+# Bounded retry around resolve_egress. On a stack (re)start the daemon can come
+# up a few seconds before sandbox-egress is resolvable; retry briefly instead of
+# coming up permanently egress-less (the old silent failure mode — a daemon that
+# missed the resolve at boot served builds with no internet until manual repair).
+resolve_egress_retry() {
+  _i=0
+  while [ "$_i" -lt 30 ]; do
+    resolve_egress
+    [ -n "$EGRESS_IP" ] && return 0
+    _i=$((_i + 1))
+    sleep 1
+  done
+  return 1
+}
+
+# Materialize the live --config from the immutable base on EVERY start, so the
+# writable-layer copy never inherits a previous start's dynamic block. Runs on
+# both the egress and TALE_SKIP_EGRESS paths so buildkitd always has a config.
+init_base_config() {
+  [ -f "$BASE_TOML" ] || return 0
+  cat "$BASE_TOML" >"$LIVE_TOML" 2>/dev/null \
+    || log "WARN: could not materialize $LIVE_TOML from base; using existing config"
+}
+
+# Append the dynamic [registry] mirrors + [dns] block to the freshly-materialized
+# base, pinning the [dns] nameserver to the CURRENT egress IP. Because
+# init_base_config resets the file first, this is appended onto a clean base
+# every start (no accumulation, no stale nameserver).
+#
+# buildkit's image PULLS go to the pull-through MIRROR by sibling name (the
+# embedded resolver answers locally — no external-name SERVFAIL); RUN-step DNS is
+# pinned to the egress dnsmasq via [dns] (else libnetwork strips the embedded
+# 127.* and falls back to 8.8.8.8, unreachable on the internal net). The
+# `http = true` block marks the plain-HTTP mirror and MUST be its own block.
+append_dynamic_config() {
+  {
+    _ifs="$IFS"
+    IFS=';'
+    # shellcheck disable=SC2086 # intentional word-split on ';' (IFS set above)
+    for _pair in ${TALE_BUILDKITD_MIRRORS:-}; do
+      _reg="${_pair%%=*}"
+      _ref="${_pair#*=}"
+      [ -n "$_reg" ] && [ -n "$_ref" ] && [ "$_reg" != "$_pair" ] || continue
+      printf '\n[registry."%s"]\n  mirrors = ["%s"]\n\n[registry."%s"]\n  http = true\n' \
+        "$_reg" "$_ref" "$_ref"
+    done
+    IFS="$_ifs"
+    printf '\n[dns]\n  nameservers = ["%s"]\n  options = ["single-request", "ndots:0"]\n' "${EGRESS_IP}"
+  } >>"$LIVE_TOML" 2>/dev/null \
+    || log "WARN: could not write registry/dns config to $LIVE_TOML; pulls may fail"
+}
+
 install_egress() {
-  resolve_egress
+  resolve_egress_retry || true
   if [ -z "$EGRESS_IP" ]; then
-    log "WARN: no egress proxy resolved from HTTP(S)_PROXY; builds will have NO internet (this container is on an --internal network). Set HTTPS_PROXY to the sandbox-egress proxy."
+    log "WARN: no egress proxy resolved from HTTP(S)_PROXY after retries; builds will have NO internet (this container is on an --internal network). Set HTTPS_PROXY to the sandbox-egress proxy. Leaving the egress-ready marker absent so the spawner recreates this daemon on the next session."
     return 0
   fi
 
@@ -111,39 +177,10 @@ install_egress() {
       || log "WARN: could not add default route via $EGRESS_IP; egress to public IPs may fail (ENETUNREACH)"
   fi
 
-  # buildkit's image PULLS: point docker.io at the pull-through registry MIRROR
-  # by its docker NAME (TALE_BUILDKITD_MIRROR, e.g. tale-buildkitd-mirror:5000).
-  # buildkit resolves a SIBLING name via the embedded resolver locally (no
-  # forward → no SERVFAIL, unlike external registry names which buildkit cannot
-  # resolve on a user-defined net). The mirror itself reaches Docker Hub through
-  # the egress proxy. The `http = true` block marks the plain-HTTP mirror — and
-  # MUST be its own `[registry."<mirror>"]` block, not nested under docker.io.
-  #
-  # RUN-step DNS: the executor containers get a SEPARATE resolv.conf buildkit
-  # generates; pin it to the egress dnsmasq via [dns] (else libnetwork strips the
-  # embedded 127.* and falls back to 8.8.8.8, unreachable on the internal net).
-  # UDP :53 to the egress IP is RFC1918 → left direct by the REDSOCKS chain.
-  if grep -q '^\[dns\]' /etc/buildkit/buildkitd.toml 2>/dev/null; then
-    log "WARN: buildkit registry/dns config already present; not appending"
-  else
-    {
-      # One [registry."<reg>"] mirror block + its [registry."<ref>"] http block
-      # per semicolon-separated `registry=mirror_ref` pair in TALE_BUILDKITD_MIRRORS.
-      _ifs="$IFS"
-      IFS=';'
-      # shellcheck disable=SC2086 # intentional word-split on ';' (IFS set above)
-      for _pair in ${TALE_BUILDKITD_MIRRORS:-}; do
-        _reg="${_pair%%=*}"
-        _ref="${_pair#*=}"
-        [ -n "$_reg" ] && [ -n "$_ref" ] && [ "$_reg" != "$_pair" ] || continue
-        printf '\n[registry."%s"]\n  mirrors = ["%s"]\n\n[registry."%s"]\n  http = true\n' \
-          "$_reg" "$_ref" "$_ref"
-      done
-      IFS="$_ifs"
-      printf '\n[dns]\n  nameservers = ["%s"]\n  options = ["single-request", "ndots:0"]\n' "${EGRESS_IP}"
-    } >>/etc/buildkit/buildkitd.toml 2>/dev/null \
-      || log "WARN: could not write registry/dns config to buildkitd.toml; pulls may fail"
-  fi
+  # Regenerate the registry-mirror + [dns] config from the immutable base with
+  # the CURRENT egress IP (UDP :53 to it is RFC1918 → left direct by the REDSOCKS
+  # chain). Always rewritten so a restart can never inherit a stale nameserver.
+  append_dynamic_config
 
   # Drop the proxy env: pulls go to the mirror (by name) and RUN steps resolve via
   # [dns], then both connect DIRECTLY to the IPs they resolve and the REDSOCKS
@@ -160,14 +197,32 @@ redsocks { local_ip = 0.0.0.0; local_port = ${REDSOCKS_PORT}; ip = ${EGRESS_IP};
 EOF
   setpriv --reuid "$REDSOCKS_UID" --regid "$REDSOCKS_UID" --clear-groups -- \
     redsocks -c /tmp/redsocks.conf >/tmp/redsocks.log 2>&1 &
+
+  # Signal the spawner that the fence is up (redsocks + default route + current-IP
+  # [dns]). Written last, only on the success path; its absence on a running
+  # daemon is what triggers spawner recreation.
+  : >"$EGRESS_READY" 2>/dev/null \
+    || log "WARN: could not write egress-ready marker ($EGRESS_READY)"
   log "transparent egress installed (OUTPUT -> redsocks -> ${EGRESS_IP}:${EGRESS_PORT}; public tunneled, private/IMDS fenced, DNS via egress :53)"
 }
 
+# Fresh start: drop any marker from a previous run BEFORE attempting install, so
+# a stale marker (the writable layer survives `docker restart`) can never fool
+# the spawner's health probe. Re-materialize the live config from the immutable
+# base on every start (the daemon may have restarted with a stale dynamic block).
+mkdir -p /run 2>/dev/null || true
+rm -f "$EGRESS_READY" 2>/dev/null || true
+init_base_config
+
 if [ "${TALE_SKIP_EGRESS:-0}" = "1" ]; then
   log "WARN: TALE_SKIP_EGRESS=1 — transparent egress NOT installed (dev only; build RUN steps get this container's raw egress)"
+  # Dev mode is 'configured as intended' — mark ready so the spawner doesn't
+  # treat the (deliberately unfenced) daemon as broken and recreate-loop it.
+  : >"$EGRESS_READY" 2>/dev/null || true
 else
   # Best-effort: never let an iptables/redsocks hiccup stop the daemon from
-  # serving cache to sessions (proxy-aware build args still work).
+  # serving cache to sessions (proxy-aware build args still work). A failure
+  # leaves the marker absent, so the spawner recreates the daemon next session.
   set +e
   install_egress
   set -e

--- a/services/sandbox/src/buildkitd.test.ts
+++ b/services/sandbox/src/buildkitd.test.ts
@@ -10,6 +10,7 @@ import {
   buildkitdEndpoint,
   buildkitdMirrorContainerName,
   buildkitdMirrorRef,
+  EGRESS_READY_MARKER,
   MIRROR_REGISTRIES,
 } from './buildkitd.ts';
 
@@ -56,5 +57,17 @@ describe('buildkitd naming seam', () => {
     expect(buildkitdMirrorContainerName('quay.io')).toBe(
       'tale-buildkitd-mirror-quay-io',
     );
+  });
+
+  // The egress-health probe is a cross-file contract: the spawner probes the
+  // exact marker path the buildkitd entrypoint writes. A drift here would make
+  // ensureBuildkitd think every healthy daemon is broken (recreate-loop) or
+  // every broken one is healthy (the original silent-no-internet bug).
+  test('egress-ready marker path matches the buildkitd entrypoint', async () => {
+    const entrypoint = await Bun.file(
+      new URL('../../sandbox-buildkitd/docker-entrypoint.sh', import.meta.url),
+    ).text();
+    expect(EGRESS_READY_MARKER).toMatch(/^\/[\w./-]+$/);
+    expect(entrypoint).toContain(`EGRESS_READY=${EGRESS_READY_MARKER}`);
   });
 });

--- a/services/sandbox/src/buildkitd.ts
+++ b/services/sandbox/src/buildkitd.ts
@@ -20,6 +20,16 @@ const ORG_RE = /^[a-zA-Z0-9_-]{1,128}$/;
 // buildkitd.toml). On the internal sandbox network only; never host-published.
 const BUILDKITD_PORT = 1234;
 
+// Marker the buildkitd entrypoint (services/sandbox-buildkitd/
+// docker-entrypoint.sh) writes ONLY after its transparent-egress fence is fully
+// installed (redsocks + default route + a [dns] block pinned to the CURRENT
+// egress IP). We probe it before reusing a running daemon: one that restarted
+// (--restart unless-stopped) while sandbox-egress was unreachable comes up with
+// no fence and silently serves builds with no internet (RUN steps fail to
+// resolve any external host). Keep this path in sync with EGRESS_READY in the
+// entrypoint.
+export const EGRESS_READY_MARKER = '/run/tale-buildkitd-egress-ready';
+
 // Pull-through registry mirrors. buildkit's image-PULL DNS runs in the daemon
 // process via Go's resolver against docker's embedded resolver (127.0.0.11),
 // which SERVFAILs Go's queries for EXTERNAL names on a user-defined network
@@ -233,6 +243,26 @@ export async function ensureBuildkitd(
   return work;
 }
 
+/**
+ * Is a RUNNING buildkitd's egress fence actually installed? The entrypoint writes
+ * EGRESS_READY_MARKER only after redsocks + the default route + the current-IP
+ * [dns] block are in place. Absent ⇒ the daemon restarted while sandbox-egress
+ * was unreachable and is serving builds with no internet — so we recreate it
+ * rather than reuse it. Best-effort: a probe error is treated as healthy so a
+ * transient `docker exec` hiccup never needlessly tears down a working daemon.
+ */
+async function buildkitdEgressHealthy(name: string): Promise<boolean> {
+  const probe = await runDocker(
+    ['exec', name, 'test', '-f', EGRESS_READY_MARKER],
+    {
+      timeoutMs: 5_000,
+    },
+  );
+  // exit 0 = present (healthy); exit 1 = absent (broken). Other codes (exec
+  // failure) → assume healthy to avoid tearing down a daemon over a probe glitch.
+  return probe.exitCode !== 1;
+}
+
 async function ensureBuildkitdUnlocked(
   cfg: SpawnerConfig,
   organizationId: string,
@@ -240,7 +270,10 @@ async function ensureBuildkitdUnlocked(
 ): Promise<string> {
   const endpoint = buildkitdEndpoint(organizationId);
 
-  // Already running? reuse it.
+  // Already running? Reuse it ONLY if its egress fence is still installed. A
+  // daemon that restarted (--restart unless-stopped) while sandbox-egress was
+  // unreachable comes up with no fence and silently serves builds with no
+  // internet (RUN steps fail to resolve any external host) — recreate it.
   const inspect = await runDocker([
     'inspect',
     '-f',
@@ -248,13 +281,21 @@ async function ensureBuildkitdUnlocked(
     name,
   ]);
   if (inspect.exitCode === 0) {
-    if (inspect.stdout.trim() === 'true') return endpoint;
-    // Exists but not running (stopped/dead) — it would block `run --name`. Reap
-    // it; the cache lives in the volume, not the container, so nothing is lost.
+    if (inspect.stdout.trim() === 'true') {
+      if (await buildkitdEgressHealthy(name)) return endpoint;
+      console.warn(
+        `[sandbox.buildkitd] ${name} is running but its egress fence is missing ` +
+          `(likely restarted while sandbox-egress was unreachable); recreating so ` +
+          `build RUN steps regain internet. The persistent cache volume is preserved.`,
+      );
+    }
+    // Stopped/dead OR running-but-egress-broken: reap it so the `run --name`
+    // below recreates it. The cache lives in the volume, not the container, so
+    // nothing is lost.
     const rm = await runDocker(['rm', '-f', name]);
     if (rm.exitCode !== 0) {
       console.warn(
-        `[sandbox.buildkitd] could not reap dead container ${name}: ${rm.stderr.trim()}`,
+        `[sandbox.buildkitd] could not reap container ${name}: ${rm.stderr.trim()}`,
       );
     }
   }


### PR DESCRIPTION
## Problem

Running `bun docker:dev` (or any `docker compose up --build`) inside a sandbox session failed building the convex image with `Temporary failure resolving 'archive.ubuntu.com'`. A prior investigation concluded "the sandbox build network can't resolve external hosts — no code fix." That conclusion was wrong: the sandbox has a complete egress-fenced build path (shared `tale-buildkitd` + by-name pull-through mirrors + redsocks/`[dns]` RUN-step egress). The daemon had simply lost its egress fence after a restart and was serving builds with no internet.

## Root cause

`tale-buildkitd` runs `--restart unless-stopped`, but its transparent-egress setup (redsocks + default route + `[dns]` pinned to the `sandbox-egress` IP) was installed **once at container start, best-effort**, and the `[dns]` block was persisted into the container's **writable layer**. Two compounding defects:

1. On a restart while `sandbox-egress` was momentarily unreachable, the egress install silently bailed → no redsocks, no route, and a **stale `[dns]` nameserver** (the egress IP had since changed). Image *pulls* still worked (mirror by sibling name), masking the breakage as "only RUN egress fails."
2. `ensureBuildkitd` reused the running-but-broken daemon because it only checked `.State.Running`.

## Fix (root cause, no hardcoding)

- **Regenerate on every start** — the entrypoint materializes the live `buildkitd.toml` from an immutable `buildkitd.base.toml` (now shipped by the Dockerfile) on every start, so `[dns]` always tracks the *current* egress IP and can never inherit a stale one.
- **Bounded resolution retry** — absorbs the boot race where `sandbox-egress` isn't up yet, instead of coming up permanently egress-less.
- **Egress-ready marker + spawner health probe** — the entrypoint writes `/run/tale-buildkitd-egress-ready` only after the fence is fully up; `ensureBuildkitd` probes it before reusing a running daemon and **recreates a running-but-fenceless one** (the persistent cache volume is preserved). A unit test pins the marker path as a cross-file contract.

## Verification (real spawner path)

Rebuilt both images and drove the real spawner API (the same HMAC-signed `/v1/sessions` call the platform makes):

- Session create → spawner's `ensureBuildkitd` relaunches a **healthy** daemon (marker present, `[dns]` = current egress IP, redsocks running).
- An `apt-get update` + github-download build (the convex-failure pattern) **succeeds** on `tale-shared`.
- A marker-absent ("fenceless") daemon is **reaped + recreated** on the next session create.
- Restart with a corrupted `[dns]` regenerates it back to the live egress IP.

360 sandbox tests pass; tsc / shellcheck / format clean.
