### PR TITLE
fix: report the actual per-type ceiling in the chat upload size-limit toast (#2048)

### DIFF
--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts
@@ -36,7 +36,12 @@ vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
 vi.mock('@/app/hooks/use-toast', () => ({ toast: vi.fn() }));
 
 vi.mock('@/lib/i18n/client', () => ({
-  useT: () => ({ t: (key: string) => key }),
+  useT: () => ({
+    // Echo the key, appending interpolation params so tests can assert the
+    // reported limit (e.g. the `maxSize` in the file-too-large toast).
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
 }));
 
 vi.mock('../utils/get-audio-duration', () => ({
@@ -136,5 +141,49 @@ describe('useConvexFileUpload — per-type size ceiling (#2048)', () => {
     expect(
       toastMock.mock.calls.some(([arg]) => arg?.title === 'invalidFiles'),
     ).toBe(true);
+  });
+
+  it('reports the elevated media ceiling (2048MB), not the 100MB generic cap, in the rejection toast', async () => {
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    await act(async () => {
+      // 3 GB audio file — above the 2 GB media per-type cap, so it is rejected.
+      await result.current.uploadFiles([
+        makeAudioFile('huge.mp3', 3 * 1024 * MB),
+      ]);
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+    const tooLargeToast = toastMock.mock.calls.find(
+      ([arg]) => arg?.title === 'invalidFiles',
+    );
+    expect(tooLargeToast).toBeTruthy();
+    // The toast must state the media ceiling (2 GB = 2048 MB), not 100 MB.
+    expect(tooLargeToast?.[0]?.description).toContain('2048');
+    expect(tooLargeToast?.[0]?.description).not.toContain('100');
+  });
+
+  it('reports the governance policy cap in the rejection toast', async () => {
+    useUploadPolicyMock.mockReturnValue({
+      policyEnabled: true,
+      maxFileSize: 50 * MB,
+      documentMaxFileSize: 50 * MB,
+      allowedTypes: ['audio/mpeg'],
+      blockedExtensions: [],
+      allowedExtensions: [],
+    });
+
+    const { result } = renderHook(() => useConvexFileUpload(config));
+
+    await act(async () => {
+      await result.current.uploadFiles([
+        makeAudioFile('podcast.mp3', 150 * MB),
+      ]);
+    });
+
+    const tooLargeToast = toastMock.mock.calls.find(
+      ([arg]) => arg?.title === 'invalidFiles',
+    );
+    expect(tooLargeToast?.[0]?.description).toContain('50');
   });
 });

--- a/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
+++ b/services/platform/app/features/chat/hooks/use-convex-file-upload.ts
@@ -101,7 +101,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
   const uploadFiles = useCallback(
     async (files: File[]) => {
       const validFiles: { file: File; resolvedType: string }[] = [];
-      const rejectedTooLarge: File[] = [];
+      const rejectedTooLarge: { file: File; limit: number }[] = [];
       const rejectedType: File[] = [];
       const rejectedAudioDuration: File[] = [];
 
@@ -141,7 +141,7 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
           ? Math.min(mergedConfig.maxFileSize, typeCeiling)
           : typeCeiling;
         if (file.size > perTypeLimit) {
-          rejectedTooLarge.push(file);
+          rejectedTooLarge.push({ file, limit: perTypeLimit });
         } else if (!isAllowedType) {
           rejectedType.push(file);
         } else {
@@ -184,16 +184,31 @@ export function useConvexFileUpload(config: ConvexFileUploadConfig) {
       }
 
       if (rejectedTooLarge.length > 0) {
-        const maxSizeMB = Math.round(mergedConfig.maxFileSize / (1024 * 1024));
-        const names = rejectedTooLarge.map((f) => f.name).join(', ');
-        toast({
-          title: t('invalidFiles'),
-          description: t('fileSizeExceededMultiple', {
-            names,
-            maxSize: maxSizeMB,
-          }),
-          variant: 'destructive',
-        });
+        // Report the ceiling each file actually exceeded, not a single global
+        // `maxFileSize`. Media gets the elevated per-type cap, so a rejected
+        // video and a rejected document have different bounds; group by the
+        // limit so each toast states the right number rather than always 100 MB.
+        const byLimit = new Map<number, File[]>();
+        for (const { file, limit } of rejectedTooLarge) {
+          const group = byLimit.get(limit);
+          if (group) {
+            group.push(file);
+          } else {
+            byLimit.set(limit, [file]);
+          }
+        }
+        for (const [limit, groupFiles] of byLimit) {
+          const maxSizeMB = Math.round(limit / (1024 * 1024));
+          const names = groupFiles.map((f) => f.name).join(', ');
+          toast({
+            title: t('invalidFiles'),
+            description: t('fileSizeExceededMultiple', {
+              names,
+              maxSize: maxSizeMB,
+            }),
+            variant: 'destructive',
+          });
+        }
       }
 
       if (rejectedAudioDuration.length > 0) {


### PR DESCRIPTION
## Summary

Follow-up to #2156, which fixed the primary defect in #2048 (the `Math.min(maxFileSize, mediaCeiling)` clamp that wrongly rejected 100–200 MB audio/video at the per-file gate). This PR closes the **second defect** the issue called out: the file-too-large rejection toast always reported `mergedConfig.maxFileSize` (100 MB) regardless of file type, so when a media file *was* rejected (e.g. above the 2 GB media cap, or against a governance policy cap) the toast stated the wrong limit.

## Changes

- `services/platform/app/features/chat/hooks/use-convex-file-upload.ts`
  - `rejectedTooLarge` now records the actual ceiling each file exceeded (`{ file, limit }`) instead of bare `File`s.
  - The rejection toast groups rejected files by the limit they exceeded and reports that limit, so media states its elevated per-type cap (2 GB) and documents state the generic cap (100 MB) — never a blanket 100 MB.
- `services/platform/app/features/chat/hooks/use-convex-file-upload.cap.test.ts`
  - The i18n `t` mock now echoes interpolation params so the reported `maxSize` is assertable.
  - Added two regression tests: a 3 GB media file's toast reports `2048` (MB) not `100`; and a policy-capped rejection reports the policy value.

## Verification

- `vitest --run --project client use-convex-file-upload.cap.test.ts` — 4 passed
- `tsc --noEmit` — clean (exit 0)
- `oxlint --type-aware` on changed files — 0 warnings, 0 errors

Closes #2048