### PR TITLE
fix(convex): truncate over-long imported task titles instead of rejecting

### DIFF
--- a/services/platform/convex/tasks/helpers.ts
+++ b/services/platform/convex/tasks/helpers.ts
@@ -16,6 +16,22 @@ export const TASK_LABELS_MAX = 50;
 export const TASK_LABEL_CHARS_MAX = 50;
 
 /**
+ * Coerce an externally-sourced task title (e.g. a GitHub issue title) to fit
+ * `TASK_TITLE_MAX`. Unlike the human/agent create paths — which *reject* an
+ * over-long title so the author can shorten it — an imported title is not under
+ * anyone's control at the import site (GitHub allows longer titles than our
+ * board), so truncating with an ellipsis keeps the import working instead of
+ * failing the whole task. The full title stays reachable via `externalUrl`.
+ * Returns an empty string only when the input is blank; callers supply a
+ * fallback for that (GitHub issues always carry a title, so it's defensive).
+ */
+export function truncateImportedTitle(title: string): string {
+  const trimmed = title.trim();
+  if (trimmed.length <= TASK_TITLE_MAX) return trimmed;
+  return `${trimmed.slice(0, TASK_TITLE_MAX - 1).trimEnd()}…`;
+}
+
+/**
  * Claim the next per-project task number by incrementing the project's
  * `taskCounter` in the same transaction as the insert. Monotonic and
  * gap-tolerant — numbers are never recycled, so identifiers stay stable even

--- a/services/platform/convex/tasks/internal_mutations.test.ts
+++ b/services/platform/convex/tasks/internal_mutations.test.ts
@@ -77,6 +77,15 @@ async function taskStatus(t: T, taskId: string | null): Promise<string> {
   });
 }
 
+async function taskTitle(t: T, taskId: string | null): Promise<string> {
+  if (!taskId) throw new Error('expected a taskId');
+  return await t.run(async (ctx) => {
+    const task = await ctx.db.get(taskId as Id<'tasks'>);
+    if (!task) throw new Error('task not found');
+    return task.title;
+  });
+}
+
 // The update-only reconcile call: org-scope, NO projectId, never creates.
 function reconcile(t: T, externalId: string, externalState: 'open' | 'closed') {
   return t.mutation(
@@ -169,5 +178,57 @@ describe('agentUpsertTaskByExternalRef — createIfMissing (update-only reconcil
     expect(res.created).toBe(false);
     expect(res.taskId).toBe(created.taskId);
     expect(await taskStatus(t, created.taskId)).toBe('done');
+  });
+});
+
+describe('agentUpsertTaskByExternalRef — title coercion', () => {
+  // Regression: a GitHub issue title longer than TASK_TITLE_MAX (200) used to
+  // throw TASK_TITLE_INVALID and make "Create task" unusable for long issues
+  // (e.g. issue #2090, 240 chars). External titles aren't editable at the
+  // import site, so they must be truncated rather than rejected.
+  it('truncates an over-long external title instead of rejecting it', async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+    const longTitle = `Improvement: ${'x'.repeat(300)}`;
+
+    const res = await t.mutation(
+      internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+      {
+        organizationId: ORG,
+        actorId: 'user_1',
+        projectId: projectA,
+        externalSystem: 'github',
+        externalId: 'owner/repo#2090',
+        title: longTitle,
+        externalState: 'open',
+      },
+    );
+
+    expect(res.created).toBe(true);
+    const title = await taskTitle(t, res.taskId);
+    expect(title.length).toBe(200);
+    expect(title.endsWith('…')).toBe(true);
+    expect(longTitle.startsWith(title.slice(0, -1))).toBe(true);
+  });
+
+  it('falls back to the external ref when the source title is blank', async () => {
+    const t = convexTest(schema, modules);
+    const projectA = await seedProject(t, 'Alpha');
+
+    const res = await t.mutation(
+      internal.tasks.internal_mutations.agentUpsertTaskByExternalRef,
+      {
+        organizationId: ORG,
+        actorId: 'user_1',
+        projectId: projectA,
+        externalSystem: 'github',
+        externalId: 'owner/repo#1',
+        title: '   ',
+        externalState: 'open',
+      },
+    );
+
+    expect(res.created).toBe(true);
+    expect(await taskTitle(t, res.taskId)).toBe('github owner/repo#1');
   });
 });

--- a/services/platform/convex/tasks/internal_mutations.ts
+++ b/services/platform/convex/tasks/internal_mutations.ts
@@ -43,6 +43,7 @@ import {
   TASK_METRIC_ACTIONS,
   TASK_TITLE_MAX,
   TERMINAL_STATUSES,
+  truncateImportedTitle,
 } from './helpers';
 import {
   extractMentions,
@@ -333,7 +334,13 @@ export const agentUpsertTaskByExternalRef = internalMutation({
     ctx,
     args,
   ): Promise<{ taskId: Id<'tasks'> | null; created: boolean }> => {
-    const title = trimTitle(args.title);
+    // External titles (e.g. GitHub issue titles) can exceed our board's
+    // `TASK_TITLE_MAX` and aren't editable at the import site, so truncate
+    // rather than reject — failing here makes "Create task" unusable for any
+    // long issue. Fall back to the external ref if the source title is blank.
+    const title =
+      truncateImportedTitle(args.title) ||
+      `${args.externalSystem} ${args.externalId}`;
     const description = args.description?.trim() || undefined;
     const now = Date.now();
     const createIfMissing = args.createIfMissing ?? true;


### PR DESCRIPTION
## Problem

Creating a task from a GitHub issue in the **issue resolution desk** fails with a generic error whenever the issue title is longer than the board's `TASK_TITLE_MAX` (200 chars). Issue #2090 (240 chars) reproduces it:

```
Uncaught ConvexError: {"code":"TASK_TITLE_INVALID"}
    at trimTitle (convex/tasks/internal_mutations.ts:104)
    at handler (convex/tasks/internal_mutations.ts:346)
```

`createTaskFromExternalIssue` → `agentUpsertTaskByExternalRef` ran the title through `trimTitle()`, which **rejects** anything over 200 chars. But that title comes straight from GitHub (which allows longer titles than our board), and the import flow has **no editable title field** for the user to shorten it — so any long issue is simply un-importable.

## Fix

- New `truncateImportedTitle()` helper in `tasks/helpers.ts`: trims, and if over `TASK_TITLE_MAX`, truncates to 200 chars with an ellipsis. The full title stays reachable via the task's `externalUrl`.
- `agentUpsertTaskByExternalRef` now coerces the imported title instead of throwing, with a defensive fallback to `"<system> <externalId>"` if the source title is ever blank (GitHub always supplies one).
- The **human/agent-typed** create paths (`validateTitle` in `mutations.ts`, `trimTitle` in `agentCreateTask`) are untouched and still reject over-long titles — those fields are user-editable, so a hard error there is correct.

## Out of scope (intentionally)

- Client-side form-validation parity for the *human* create-task form (separate concern, already tracked as issue #1991).

## Testing

- `bunx tsc --noEmit` clean.
- Two new regression tests in `internal_mutations.test.ts`: a 300-char title truncates to exactly 200 ending in `…`; a blank title falls back to the external ref. All 7 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)