### PR TITLE
fix(convex): throw ConvexError with structured codes from folder mutations (#2005)

### DIFF
--- a/services/platform/app/features/documents/components/create-folder-dialog.test.tsx
+++ b/services/platform/app/features/documents/components/create-folder-dialog.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   act,
 } from '@testing-library/react';
+import { ConvexError } from 'convex/values';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCreateFolder = vi.fn();
@@ -140,11 +141,17 @@ describe('CreateFolderDialog', () => {
     });
   });
 
-  it('shows friendly duplicate name error instead of raw server error', async () => {
+  // Regression for #2005: in prod Convex redacts raw Error messages to
+  // "Server Error", so the old `error.message.includes('already exists')`
+  // check was dead and the duplicate toast never appeared. The backend now
+  // throws ConvexError({ code: 'FOLDER_DUPLICATE_NAME' }) and the dialog reads
+  // the code, which survives the redaction.
+  it('shows friendly duplicate name error from the structured code', async () => {
     mockCreateFolder.mockRejectedValue(
-      new Error(
-        '[Request ID: abc123] Server Error\nUncaught Error: A folder with this name already exists\n    at handler (convex/folders/mutations.ts:117:5)',
-      ),
+      new ConvexError({
+        code: 'FOLDER_DUPLICATE_NAME',
+        message: 'A folder with this name already exists',
+      }),
     );
 
     render(<CreateFolderDialog {...defaultProps} />);

--- a/services/platform/app/features/documents/components/create-folder-dialog.tsx
+++ b/services/platform/app/features/documents/components/create-folder-dialog.tsx
@@ -8,6 +8,7 @@ import * as z from 'zod';
 import { FormDialog } from '@/app/components/ui/dialog/form-dialog';
 import { Input } from '@/app/components/ui/forms/input';
 import { Select } from '@/app/components/ui/forms/select';
+import { extractErrorCode } from '@/app/features/prompts/lib/extract-error-code';
 import { useTeams } from '@/app/features/settings/teams/hooks/queries';
 import { useToast } from '@/app/hooks/use-toast';
 import { toId } from '@/convex/lib/type_cast_helpers';
@@ -85,8 +86,7 @@ export function CreateFolderDialog({
       onSuccess?.();
     } catch (error) {
       console.error('Failed to create folder:', error);
-      const isDuplicate =
-        error instanceof Error && error.message.includes('already exists');
+      const isDuplicate = extractErrorCode(error) === 'FOLDER_DUPLICATE_NAME';
       toast({
         title: isDuplicate
           ? tDocuments('folder.duplicateName')

--- a/services/platform/convex/folders/mutations.test.ts
+++ b/services/platform/convex/folders/mutations.test.ts
@@ -1,8 +1,26 @@
+import { ConvexError } from 'convex/values';
 import { describe, expect, it, vi } from 'vitest';
 
 import { teamIdsToFields } from '../documents/team_fields';
 import { hasTeamAccess } from '../lib/team_access';
 import { validateFolderName } from './mutations';
+
+/**
+ * Run `fn` and return the `code` of the ConvexError it throws. Fails the
+ * assertion if it doesn't throw a ConvexError. Folder validation now raises
+ * structured `ConvexError({ code, message })` (issue #2005) so the frontend
+ * can branch on the code instead of substring-matching a redacted message.
+ */
+function expectConvexErrorCode(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(ConvexError);
+    const data = (err as ConvexError<{ code: string }>).data;
+    return data.code;
+  }
+  throw new Error('Expected function to throw a ConvexError');
+}
 
 type MockFolder = {
   _id: string;
@@ -101,28 +119,34 @@ describe('validateFolderName', () => {
     expect(validateFolderName('  docs  ')).toBe('docs');
   });
 
-  it('throws for empty name', () => {
-    expect(() => validateFolderName('')).toThrow('Folder name cannot be empty');
-  });
-
-  it('throws for whitespace-only name', () => {
-    expect(() => validateFolderName('   ')).toThrow(
-      'Folder name cannot be empty',
+  it('throws FOLDER_NAME_EMPTY for empty name', () => {
+    expect(expectConvexErrorCode(() => validateFolderName(''))).toBe(
+      'FOLDER_NAME_EMPTY',
     );
   });
 
-  it('throws for reserved name "."', () => {
-    expect(() => validateFolderName('.')).toThrow('Invalid folder name');
+  it('throws FOLDER_NAME_EMPTY for whitespace-only name', () => {
+    expect(expectConvexErrorCode(() => validateFolderName('   '))).toBe(
+      'FOLDER_NAME_EMPTY',
+    );
   });
 
-  it('throws for reserved name ".."', () => {
-    expect(() => validateFolderName('..')).toThrow('Invalid folder name');
+  it('throws FOLDER_NAME_INVALID for reserved name "."', () => {
+    expect(expectConvexErrorCode(() => validateFolderName('.'))).toBe(
+      'FOLDER_NAME_INVALID',
+    );
   });
 
-  it('throws for names exceeding max length', () => {
+  it('throws FOLDER_NAME_INVALID for reserved name ".."', () => {
+    expect(expectConvexErrorCode(() => validateFolderName('..'))).toBe(
+      'FOLDER_NAME_INVALID',
+    );
+  });
+
+  it('throws FOLDER_NAME_TOO_LONG for names exceeding max length', () => {
     const longName = 'a'.repeat(256);
-    expect(() => validateFolderName(longName)).toThrow(
-      'Folder name is too long',
+    expect(expectConvexErrorCode(() => validateFolderName(longName))).toBe(
+      'FOLDER_NAME_TOO_LONG',
     );
   });
 
@@ -131,16 +155,16 @@ describe('validateFolderName', () => {
     expect(validateFolderName(maxName)).toBe(maxName);
   });
 
-  it('throws for names containing forward slash', () => {
-    expect(() => validateFolderName('reports/2024')).toThrow(
-      'Folder name cannot contain path separators',
-    );
+  it('throws FOLDER_NAME_HAS_SEPARATOR for names containing forward slash', () => {
+    expect(
+      expectConvexErrorCode(() => validateFolderName('reports/2024')),
+    ).toBe('FOLDER_NAME_HAS_SEPARATOR');
   });
 
-  it('throws for names containing backslash', () => {
-    expect(() => validateFolderName('reports\\2024')).toThrow(
-      'Folder name cannot contain path separators',
-    );
+  it('throws FOLDER_NAME_HAS_SEPARATOR for names containing backslash', () => {
+    expect(
+      expectConvexErrorCode(() => validateFolderName('reports\\2024')),
+    ).toBe('FOLDER_NAME_HAS_SEPARATOR');
   });
 });
 

--- a/services/platform/convex/folders/mutations.ts
+++ b/services/platform/convex/folders/mutations.ts
@@ -127,16 +127,28 @@ const RESERVED_NAMES = new Set(['.', '..']);
 export function validateFolderName(name: string): string {
   const trimmed = name.trim();
   if (trimmed.length === 0) {
-    throw new Error('Folder name cannot be empty');
+    throw new ConvexError({
+      code: 'FOLDER_NAME_EMPTY',
+      message: 'Folder name cannot be empty',
+    });
   }
   if (trimmed.length > MAX_FOLDER_NAME_LENGTH) {
-    throw new Error('Folder name is too long');
+    throw new ConvexError({
+      code: 'FOLDER_NAME_TOO_LONG',
+      message: 'Folder name is too long',
+    });
   }
   if (RESERVED_NAMES.has(trimmed)) {
-    throw new Error('Invalid folder name');
+    throw new ConvexError({
+      code: 'FOLDER_NAME_INVALID',
+      message: 'Invalid folder name',
+    });
   }
   if (trimmed.includes('/') || trimmed.includes('\\')) {
-    throw new Error('Folder name cannot contain path separators');
+    throw new ConvexError({
+      code: 'FOLDER_NAME_HAS_SEPARATOR',
+      message: 'Folder name cannot contain path separators',
+    });
   }
   return trimmed;
 }
@@ -159,7 +171,10 @@ async function checkDuplicateName(
     .first();
 
   if (existing && existing._id !== excludeId) {
-    throw new Error('A folder with this name already exists');
+    throw new ConvexError({
+      code: 'FOLDER_DUPLICATE_NAME',
+      message: 'A folder with this name already exists',
+    });
   }
 }
 
@@ -174,7 +189,7 @@ export const createFolder = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     await getOrganizationMember(ctx, args.organizationId, authUser);
@@ -188,12 +203,18 @@ export const createFolder = mutation({
     if (args.parentId) {
       const parent = await ctx.db.get(args.parentId);
       if (!parent || parent.organizationId !== args.organizationId) {
-        throw new Error('Parent folder not found');
+        throw new ConvexError({
+          code: 'FOLDER_PARENT_NOT_FOUND',
+          message: 'Parent folder not found',
+        });
       }
       if (parent.teamId || parent.teamTags?.length) {
         const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
         if (!hasTeamAccess(parent, userTeamIds)) {
-          throw new Error('Parent folder not accessible');
+          throw new ConvexError({
+            code: 'FOLDER_PARENT_NOT_ACCESSIBLE',
+            message: 'Parent folder not accessible',
+          });
         }
       }
 
@@ -210,14 +231,20 @@ export const createFolder = mutation({
         ancestorId = ancestor.parentId;
       }
       if (depth >= MAX_FOLDER_DEPTH) {
-        throw new Error('Maximum folder nesting depth exceeded');
+        throw new ConvexError({
+          code: 'FOLDER_MAX_DEPTH_EXCEEDED',
+          message: 'Maximum folder nesting depth exceeded',
+        });
       }
     }
 
     if (effectiveTeamId) {
       const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
       if (!userTeamIds.includes(effectiveTeamId)) {
-        throw new Error('Cannot create folder in a team you do not belong to');
+        throw new ConvexError({
+          code: 'FOLDER_TEAM_FORBIDDEN',
+          message: 'Cannot create folder in a team you do not belong to',
+        });
       }
     }
 
@@ -247,12 +274,15 @@ export const renameFolder = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const folder = await ctx.db.get(args.folderId);
     if (!folder) {
-      throw new Error('Folder not found');
+      throw new ConvexError({
+        code: 'FOLDER_NOT_FOUND',
+        message: 'Folder not found',
+      });
     }
 
     await getOrganizationMember(ctx, folder.organizationId, authUser);
@@ -266,7 +296,10 @@ export const renameFolder = mutation({
     if (folder.teamId || folder.teamTags?.length) {
       const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
       if (!hasTeamAccess(folder, userTeamIds)) {
-        throw new Error('Access denied');
+        throw new ConvexError({
+          code: 'FOLDER_ACCESS_DENIED',
+          message: 'Access denied',
+        });
       }
     }
 
@@ -293,12 +326,15 @@ export const deleteFolder = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const folder = await ctx.db.get(args.folderId);
     if (!folder) {
-      throw new Error('Folder not found');
+      throw new ConvexError({
+        code: 'FOLDER_NOT_FOUND',
+        message: 'Folder not found',
+      });
     }
 
     await getOrganizationMember(ctx, folder.organizationId, authUser);
@@ -312,7 +348,10 @@ export const deleteFolder = mutation({
     if (folder.teamId || folder.teamTags?.length) {
       const userTeamIds = await getUserTeamIds(ctx, authUser.userId);
       if (!hasTeamAccess(folder, userTeamIds)) {
-        throw new Error('Access denied');
+        throw new ConvexError({
+          code: 'FOLDER_ACCESS_DENIED',
+          message: 'Access denied',
+        });
       }
     }
 
@@ -350,12 +389,15 @@ export const updateFolderTeams = mutation({
   handler: async (ctx, args) => {
     const authUser = await getAuthUserIdentity(ctx);
     if (!authUser) {
-      throw new Error('Unauthenticated');
+      throw new ConvexError({ code: 'UNAUTHENTICATED' });
     }
 
     const folder = await ctx.db.get(args.folderId);
     if (!folder) {
-      throw new Error('Folder not found');
+      throw new ConvexError({
+        code: 'FOLDER_NOT_FOUND',
+        message: 'Folder not found',
+      });
     }
 
     await getOrganizationMember(ctx, folder.organizationId, authUser);
@@ -369,7 +411,10 @@ export const updateFolderTeams = mutation({
     if (folder.parentId) {
       const parent = await ctx.db.get(folder.parentId);
       if (parent?.teamId) {
-        throw new Error('Cannot change team: inherited from parent folder');
+        throw new ConvexError({
+          code: 'FOLDER_TEAM_INHERITED',
+          message: 'Cannot change team: inherited from parent folder',
+        });
       }
     }
 
@@ -377,13 +422,19 @@ export const updateFolderTeams = mutation({
 
     if (folder.teamId || folder.teamTags?.length) {
       if (!hasTeamAccess(folder, userTeamIds)) {
-        throw new Error('Access denied');
+        throw new ConvexError({
+          code: 'FOLDER_ACCESS_DENIED',
+          message: 'Access denied',
+        });
       }
     }
 
     for (const tid of args.teamIds) {
       if (!userTeamIds.includes(tid)) {
-        throw new Error('Cannot assign folder to a team you do not belong to');
+        throw new ConvexError({
+          code: 'FOLDER_TEAM_FORBIDDEN',
+          message: 'Cannot assign folder to a team you do not belong to',
+        });
       }
     }
 


### PR DESCRIPTION
## What

Every error path in the four folder CRUD mutations (`createFolder`, `renameFolder`, `deleteFolder`, `updateFolderTeams`) plus the shared `validateFolderName()` and `checkDuplicateName()` helpers in `services/platform/convex/folders/mutations.ts` threw a raw `new Error(string)`. Convex redacts raw `Error` messages to an opaque "Server Error" over the wire, so the frontend could not distinguish validation/permission failures from generic server errors.

This converts all of them to structured `ConvexError({ code, message })`, matching the convention already used in `tasks/mutations.ts`.

## Codes introduced

- `FOLDER_NAME_EMPTY`, `FOLDER_NAME_TOO_LONG`, `FOLDER_NAME_INVALID`, `FOLDER_NAME_HAS_SEPARATOR` — name validation
- `FOLDER_DUPLICATE_NAME` — duplicate at the same level
- `FOLDER_PARENT_NOT_FOUND`, `FOLDER_PARENT_NOT_ACCESSIBLE`, `FOLDER_MAX_DEPTH_EXCEEDED`, `FOLDER_TEAM_FORBIDDEN` — create
- `FOLDER_NOT_FOUND`, `FOLDER_ACCESS_DENIED` — rename/delete/team-change
- `FOLDER_TEAM_INHERITED` — team change blocked by parent inheritance
- `UNAUTHENTICATED` — auth check (bare code, matching `tasks/mutations.ts`)

## Frontend

`create-folder-dialog.tsx` previously detected duplicates via `error.message.includes('already exists')`, which was dead in production because of the redaction described above. It now reads `extractErrorCode(error) === 'FOLDER_DUPLICATE_NAME'`, which survives the wire.

## Tests

- `convex/folders/mutations.test.ts` — `validateFolderName` tests now assert the structured `ConvexError` codes.
- `create-folder-dialog.test.tsx` — duplicate-toast regression test now throws a real `ConvexError` with the code (the old test simulated the now-removed raw-error path).

Ran: `vitest --project server convex/folders` (88 passed), `vitest --project client app/features/documents` (108 passed), `tsc --noEmit` (clean), `oxlint --type-aware` on all changed files (clean).

Closes #2005