### PR TITLE
fix(sandbox): heal buildkitd egress fence on IP drift, not just on restart

### DIFF
--- a/services/sandbox/docs/docker-in-container.md
+++ b/services/sandbox/docs/docker-in-container.md
@@ -210,6 +210,16 @@ How it works (all spawner-managed; the user does nothing per build):
   `sandbox-egress` proxy (redsocks redirect + IMDS/RFC1918 fence; RUN-step DNS is
   pinned to the egress dnsmasq via the buildkitd's `[dns]` config). Verified:
   `apk add`/`curl` reach the internet, `169.254.169.254` (IMDS) is blocked.
+- **The fence self-heals across egress moves.** `sandbox-egress` is recreated —
+  and can land on a **new IP** — by any stack restart (`bun dev` / `docker:dev` /
+  `docker compose up` / `tale deploy`), while this `--restart unless-stopped`
+  daemon keeps running with its `[dns]`/redsocks pinned to the **old** IP (RUN-step
+  DNS would then resolve against whatever now holds that address). The spawner
+  guards against this: on every session create — and once at startup for
+  already-running/adopted sessions (`reconcileBuildCache`) — it compares the
+  daemon's live `[dns]` nameserver to the egress's **current** IP and, on a
+  mismatch, reaps + recreates the daemon (the persistent cache volume is
+  preserved; the entrypoint reinstalls the fence against the current IP).
 - **Best-effort.** If the daemon can't be reached, the session falls back to its
   own inner builder (cold cache); it never blocks session creation.
 

--- a/services/sandbox/src/backend/docker/docker-session-backend.ts
+++ b/services/sandbox/src/backend/docker/docker-session-backend.ts
@@ -529,4 +529,28 @@ export class DockerSessionBackend implements SessionBackend {
     }
     return out;
   }
+
+  /**
+   * Heal the shared buildkitd for every org with a running session, so an
+   * adopted session never builds against a daemon whose egress fence went stale
+   * across a stack restart. ensureBuildkitd recreates a drifted daemon (its
+   * `[dns]`/redsocks pinned to a since-moved sandbox-egress IP) and is a cheap
+   * no-op when the daemon is already healthy. Gated on DinD + the build-cache
+   * flag (no daemon otherwise); per-org best-effort — the cache is an
+   * optimization, so a failure is logged, never thrown.
+   */
+  async reconcileBuildCache(orgIds: readonly string[]): Promise<void> {
+    if (!(this.cfg.dockerInContainer && this.cfg.dockerBuildCache)) return;
+    for (const organizationId of new Set(orgIds)) {
+      try {
+        await ensureBuildkitd(this.cfg, organizationId);
+      } catch (err) {
+        console.warn(
+          `[sandbox.session] build-cache reconcile for org ${organizationId} ` +
+            `failed (continuing; sessions fall back to their inner builder):`,
+          err,
+        );
+      }
+    }
+  }
 }

--- a/services/sandbox/src/backend/kubernetes/k8s-session-backend.ts
+++ b/services/sandbox/src/backend/kubernetes/k8s-session-backend.ts
@@ -428,6 +428,10 @@ export class KubernetesSessionBackend implements SessionBackend {
     return out;
   }
 
+  // No shared cross-session build cache on K8s (DinD is single-container,
+  // in-pod — there is no sibling buildkitd to reconcile). See SessionBackend.
+  async reconcileBuildCache(): Promise<void> {}
+
   private readPod(sessionId: string): Promise<V1Pod> {
     return withRetry('read-session-pod', () =>
       this.client.core.readNamespacedPod(

--- a/services/sandbox/src/backend/types.ts
+++ b/services/sandbox/src/backend/types.ts
@@ -328,6 +328,19 @@ export interface SessionBackend {
   /** List live session objects (label-selected), for boot re-adoption, the
    * GET /v1/sessions route, and the TTL/idle sweep. */
   listSessions(organizationId?: string): Promise<BackendSession[]>;
+  /**
+   * Reconcile the shared cross-session build cache (the per-org buildkitd) at
+   * spawner startup, after running sessions are re-adopted. The daemon is
+   * launched once and outlives the spawner (`--restart unless-stopped`), so a
+   * stack restart that recreated sandbox-egress on a new IP leaves the daemon's
+   * egress fence stale while it keeps running — and an adopted session that
+   * reuses it would build with no DNS/egress. `createSession` only heals freshly
+   * created sessions; this closes the gap for adopted ones (ensureBuildkitd
+   * recreates a drifted daemon). Best-effort — the cache is an optimization, so
+   * a failure is never fatal. A no-op on backends without a shared build cache
+   * (Kubernetes) or when the cache is disabled.
+   */
+  reconcileBuildCache(orgIds: readonly string[]): Promise<void>;
 }
 
 export type { SpawnerConfig };

--- a/services/sandbox/src/buildkitd.test.ts
+++ b/services/sandbox/src/buildkitd.test.ts
@@ -5,13 +5,17 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  BUILDKITD_LIVE_TOML,
   buildkitdCacheVolumeName,
   buildkitdContainerName,
   buildkitdEndpoint,
   buildkitdMirrorContainerName,
   buildkitdMirrorRef,
   EGRESS_READY_MARKER,
+  egressProxyHostname,
+  firstIpv4,
   MIRROR_REGISTRIES,
+  parseDnsNameserver,
 } from './buildkitd.ts';
 
 describe('buildkitd naming seam', () => {
@@ -60,14 +64,54 @@ describe('buildkitd naming seam', () => {
   });
 
   // The egress-health probe is a cross-file contract: the spawner probes the
-  // exact marker path the buildkitd entrypoint writes. A drift here would make
-  // ensureBuildkitd think every healthy daemon is broken (recreate-loop) or
-  // every broken one is healthy (the original silent-no-internet bug).
-  test('egress-ready marker path matches the buildkitd entrypoint', async () => {
+  // exact marker path AND reads the live config the buildkitd entrypoint writes.
+  // A drift here would make ensureBuildkitd think every healthy daemon is broken
+  // (recreate-loop) or every broken one is healthy (the silent-no-internet bug).
+  test('egress-ready marker + live-config paths match the buildkitd entrypoint', async () => {
     const entrypoint = await Bun.file(
       new URL('../../sandbox-buildkitd/docker-entrypoint.sh', import.meta.url),
     ).text();
     expect(EGRESS_READY_MARKER).toMatch(/^\/[\w./-]+$/);
     expect(entrypoint).toContain(`EGRESS_READY=${EGRESS_READY_MARKER}`);
+    expect(BUILDKITD_LIVE_TOML).toMatch(/^\/[\w./-]+$/);
+    expect(entrypoint).toContain(`LIVE_TOML=${BUILDKITD_LIVE_TOML}`);
+  });
+});
+
+describe('buildkitd egress drift detection', () => {
+  test('egressProxyHostname extracts the host from the proxy URL', () => {
+    expect(egressProxyHostname('http://sandbox-egress:3128')).toBe(
+      'sandbox-egress',
+    );
+    expect(egressProxyHostname('http://10.0.0.5:3128')).toBe('10.0.0.5');
+    expect(egressProxyHostname('not-a-url')).toBeNull();
+    expect(egressProxyHostname('')).toBeNull();
+  });
+
+  test('firstIpv4 reads the IP from `getent hosts` output', () => {
+    expect(firstIpv4('172.18.0.7      sandbox-egress\n')).toBe('172.18.0.7');
+    expect(firstIpv4('  172.18.0.6 sandbox-egress sandbox-egress.tale\n')).toBe(
+      '172.18.0.6',
+    );
+    expect(firstIpv4('')).toBeNull(); // getent found nothing
+    expect(firstIpv4('sandbox-egress')).toBeNull(); // not an IP token
+  });
+
+  test('parseDnsNameserver reads the pinned [dns] IP, null when no [dns]', () => {
+    const withDns = [
+      '[registry."docker.io"]',
+      '  mirrors = ["tale-buildkitd-mirror-docker-io:5000"]',
+      '',
+      '[dns]',
+      '  nameservers = ["172.18.0.6"]',
+      '  options = ["single-request", "ndots:0"]',
+    ].join('\n');
+    expect(parseDnsNameserver(withDns)).toBe('172.18.0.6');
+    // No [dns] block at all (TALE_SKIP_EGRESS dev mode / unfenced boot).
+    expect(parseDnsNameserver('[worker.oci]\n  enabled = true\n')).toBeNull();
+    // A mirror ref must not be mistaken for a nameserver.
+    expect(
+      parseDnsNameserver('[registry."docker.io"]\n  mirrors = ["x:5000"]\n'),
+    ).toBeNull();
   });
 });

--- a/services/sandbox/src/buildkitd.ts
+++ b/services/sandbox/src/buildkitd.ts
@@ -30,6 +30,51 @@ const BUILDKITD_PORT = 1234;
 // entrypoint.
 export const EGRESS_READY_MARKER = '/run/tale-buildkitd-egress-ready';
 
+// The live buildkitd config the entrypoint regenerates on every start: it
+// appends a `[dns] nameservers = ["<egress-ip>"]` block pinned to the egress
+// IP resolved AT THAT MOMENT. We read it back to detect drift — sandbox-egress
+// is recreated (and can land on a new IP) by every stack restart (`bun dev`,
+// `docker:dev`, `docker compose up`, `tale deploy`) while this --restart
+// unless-stopped daemon keeps running with the now-stale nameserver. Keep this
+// path in sync with LIVE_TOML in the entrypoint.
+export const BUILDKITD_LIVE_TOML = '/etc/buildkit/buildkitd.toml';
+
+const IPV4_RE = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
+/**
+ * Hostname the buildkitd resolves the egress proxy by (e.g. `sandbox-egress`
+ * from `http://sandbox-egress:3128`). Returns null if the URL has no host — the
+ * caller then skips drift detection rather than guessing.
+ */
+export function egressProxyHostname(proxyUrl: string): string | null {
+  try {
+    const host = new URL(proxyUrl).hostname;
+    return host.length > 0 ? host : null;
+  } catch {
+    return null;
+  }
+}
+
+/** First IPv4 token of `getent hosts <name>` output (`172.18.0.7  name`). */
+export function firstIpv4(getentOutput: string): string | null {
+  const token = getentOutput.trim().split(/\s+/)[0] ?? '';
+  return IPV4_RE.test(token) ? token : null;
+}
+
+/**
+ * The IP the live `[dns]` block pins RUN-step resolution to, parsed from the
+ * buildkitd.toml the entrypoint writes. Null when there is no `[dns]` block —
+ * i.e. the egress fence was never installed (TALE_SKIP_EGRESS dev mode, or a
+ * boot where the egress was unreachable), in which case there is nothing to
+ * compare and drift detection is skipped.
+ */
+export function parseDnsNameserver(tomlText: string): string | null {
+  const match = tomlText.match(
+    /nameservers\s*=\s*\[\s*"(\d{1,3}(?:\.\d{1,3}){3})"/,
+  );
+  return match?.[1] ?? null;
+}
+
 // Pull-through registry mirrors. buildkit's image-PULL DNS runs in the daemon
 // process via Go's resolver against docker's embedded resolver (127.0.0.11),
 // which SERVFAILs Go's queries for EXTERNAL names on a user-defined network
@@ -244,23 +289,62 @@ export async function ensureBuildkitd(
 }
 
 /**
- * Is a RUNNING buildkitd's egress fence actually installed? The entrypoint writes
- * EGRESS_READY_MARKER only after redsocks + the default route + the current-IP
- * [dns] block are in place. Absent ⇒ the daemon restarted while sandbox-egress
- * was unreachable and is serving builds with no internet — so we recreate it
- * rather than reuse it. Best-effort: a probe error is treated as healthy so a
- * transient `docker exec` hiccup never needlessly tears down a working daemon.
+ * Is a RUNNING buildkitd's egress fence actually installed AND still pointing at
+ * the current egress? Two failure modes, both of which leave the daemon serving
+ * builds that can't reach the internet while it looks "Running":
+ *
+ *  1. Fence missing — the entrypoint writes EGRESS_READY_MARKER only after
+ *     redsocks + the default route + the [dns] block are in place. Absent ⇒ the
+ *     daemon restarted (--restart unless-stopped) while sandbox-egress was
+ *     unreachable and came up with no fence at all.
+ *  2. Fence stale — the [dns] nameserver (and the redsocks target, written from
+ *     the same egress IP) is pinned to the egress IP resolved when the fence was
+ *     LAST installed. sandbox-egress is recreated by every stack restart
+ *     (`bun dev` / `docker:dev` / `docker compose up` / `tale deploy`) and can
+ *     land on a different IP; this daemon, not being a compose service, keeps
+ *     running with the old IP. RUN-step DNS then goes to whatever now holds that
+ *     IP (a non-resolver) and every external lookup fails ("Temporary failure
+ *     resolving 'archive.ubuntu.com'"). The marker is still present, so marker
+ *     presence alone can't catch this — we compare the pinned IP to the live one.
+ *
+ * Either ⇒ recreate (the entrypoint reinstalls the fence against the CURRENT
+ * egress IP; the persistent cache volume is preserved). Best-effort: any probe
+ * we can't conclusively read is treated as healthy so a transient `docker exec`
+ * hiccup never needlessly tears down a working daemon.
  */
-async function buildkitdEgressHealthy(name: string): Promise<boolean> {
-  const probe = await runDocker(
+async function buildkitdEgressHealthy(
+  cfg: SpawnerConfig,
+  name: string,
+): Promise<boolean> {
+  // (1) Fence present at all?
+  const present = await runDocker(
     ['exec', name, 'test', '-f', EGRESS_READY_MARKER],
-    {
-      timeoutMs: 5_000,
-    },
+    { timeoutMs: 5_000 },
   );
-  // exit 0 = present (healthy); exit 1 = absent (broken). Other codes (exec
-  // failure) → assume healthy to avoid tearing down a daemon over a probe glitch.
-  return probe.exitCode !== 1;
+  if (present.exitCode === 1) return false; // definitively absent ⇒ broken
+  if (present.exitCode !== 0) return true; // exec glitch ⇒ assume healthy
+
+  // (2) Fence not stale? Compare the egress IP the live [dns] is pinned to with
+  // the egress's CURRENT IP, both read from inside the daemon (its embedded
+  // resolver answers the sibling `sandbox-egress` name).
+  const host = egressProxyHostname(cfg.egressProxy);
+  if (!host) return true; // no proxy host configured ⇒ nothing to compare
+  const toml = await runDocker(['exec', name, 'cat', BUILDKITD_LIVE_TOML], {
+    timeoutMs: 5_000,
+  });
+  const pinnedIp = parseDnsNameserver(toml.stdout);
+  if (!pinnedIp) return true; // no [dns] (skip-egress dev mode) ⇒ nothing to compare
+  const resolved = await runDocker(['exec', name, 'getent', 'hosts', host], {
+    timeoutMs: 5_000,
+  });
+  const currentIp = firstIpv4(resolved.stdout);
+  if (!currentIp || currentIp === pinnedIp) return true; // unresolvable now, or matches
+  console.warn(
+    `[sandbox.buildkitd] ${name} egress fence is stale: [dns] pinned to ${pinnedIp} ` +
+      `but ${host} now resolves to ${currentIp} (sandbox-egress was recreated). ` +
+      `Recreating so build RUN steps regain DNS + egress.`,
+  );
+  return false;
 }
 
 async function ensureBuildkitdUnlocked(
@@ -270,10 +354,12 @@ async function ensureBuildkitdUnlocked(
 ): Promise<string> {
   const endpoint = buildkitdEndpoint(organizationId);
 
-  // Already running? Reuse it ONLY if its egress fence is still installed. A
-  // daemon that restarted (--restart unless-stopped) while sandbox-egress was
-  // unreachable comes up with no fence and silently serves builds with no
-  // internet (RUN steps fail to resolve any external host) — recreate it.
+  // Already running? Reuse it ONLY if its egress fence is still installed AND
+  // still pinned to the current egress IP. A daemon that restarted (--restart
+  // unless-stopped) with sandbox-egress unreachable, or that kept running while
+  // a stack restart moved sandbox-egress to a new IP, silently serves builds
+  // with no working DNS/egress (RUN steps fail to resolve any external host) —
+  // recreate it. See buildkitdEgressHealthy.
   const inspect = await runDocker([
     'inspect',
     '-f',
@@ -282,11 +368,11 @@ async function ensureBuildkitdUnlocked(
   ]);
   if (inspect.exitCode === 0) {
     if (inspect.stdout.trim() === 'true') {
-      if (await buildkitdEgressHealthy(name)) return endpoint;
+      if (await buildkitdEgressHealthy(cfg, name)) return endpoint;
       console.warn(
-        `[sandbox.buildkitd] ${name} is running but its egress fence is missing ` +
-          `(likely restarted while sandbox-egress was unreachable); recreating so ` +
-          `build RUN steps regain internet. The persistent cache volume is preserved.`,
+        `[sandbox.buildkitd] ${name} is running but its egress fence is missing or ` +
+          `stale; recreating so build RUN steps regain internet. The persistent ` +
+          `cache volume is preserved.`,
       );
     }
     // Stopped/dead OR running-but-egress-broken: reap it so the `run --name`

--- a/services/sandbox/src/session/session-routes.test.ts
+++ b/services/sandbox/src/session/session-routes.test.ts
@@ -235,6 +235,7 @@ const fakeBackend: SessionBackend = {
     if (backendCheckThrows) throw new Error('docker daemon hiccup');
     return !backendGone.has(sessionId);
   },
+  async reconcileBuildCache() {},
 };
 
 interface SseEvent {
@@ -851,5 +852,55 @@ describe('SessionRoutes (fake runnerd)', () => {
       await routes.adoptExisting();
       expect((await routes.handleGet('adopt1')).status).toBe(200);
     });
+
+    test('adoptExisting: reconciles the shared build cache for the running orgs', async () => {
+      const reconciled: string[][] = [];
+      const reconcileBackend: SessionBackend = {
+        ...fakeBackend,
+        async listSessions(): Promise<BackendSession[]> {
+          return [
+            mkBackendSession('s1', 'org_a'),
+            mkBackendSession('s2', 'org_b'),
+          ];
+        },
+        async reconcileBuildCache(orgIds: readonly string[]) {
+          reconciled.push([...orgIds]);
+        },
+      };
+      await new SessionRoutes(cfg, reconcileBackend).adoptExisting();
+      // Called once, with every running session's org (drift healing is keyed
+      // per org; the backend dedups to the single v1 daemon).
+      expect(reconciled).toEqual([['org_a', 'org_b']]);
+    });
+
+    test('adoptExisting: no sessions ⇒ no build-cache reconcile', async () => {
+      let calls = 0;
+      const emptyBackend: SessionBackend = {
+        ...fakeBackend,
+        async listSessions(): Promise<BackendSession[]> {
+          return [];
+        },
+        async reconcileBuildCache() {
+          calls += 1;
+        },
+      };
+      await new SessionRoutes(cfg, emptyBackend).adoptExisting();
+      expect(calls).toBe(0);
+    });
   });
 });
+
+function mkBackendSession(
+  sessionId: string,
+  organizationId: string,
+): BackendSession {
+  return {
+    sessionId,
+    organizationId,
+    profile: 'agent',
+    createdAtMs: 1_000,
+    ttlMs: 60_000,
+    idleTimeoutMs: 30_000,
+    state: 'ready',
+  };
+}

--- a/services/sandbox/src/session/session-routes.ts
+++ b/services/sandbox/src/session/session-routes.ts
@@ -148,6 +148,18 @@ export class SessionRoutes {
         liveExecs: new Map(),
       });
     }
+
+    // Heal the shared build cache for every org with a running session. The
+    // buildkitd outlives the spawner, so the same stack restart that bounced
+    // this spawner may have moved sandbox-egress to a new IP — leaving the
+    // daemon's egress fence stale. An adopted session that reuses it would build
+    // with no DNS/egress (the createSession heal never fires for it). Best-effort
+    // inside the backend; a no-op when there's no shared cache or nothing drifted.
+    if (sessions.length > 0) {
+      await this.backend.reconcileBuildCache(
+        sessions.map((s) => s.organizationId),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

An in-sandbox `bun docker:dev` died building the convex image with
`Temporary failure resolving 'archive.ubuntu.com'` — **after** #2254 was supposed
to have fixed buildkitd egress fragility.

Root cause (verified live): the shared `tale-buildkitd` is a long-lived
`--restart unless-stopped` daemon, **not** a compose service. Every stack restart
(`bun dev` / `docker:dev` / `docker compose up` / `tale deploy`) recreates
`sandbox-egress`, which can land on a **new IP**, while the daemon keeps running
with its `[dns]` nameserver + redsocks target **frozen at the old egress IP**.
RUN-step DNS then resolves against whatever now holds that IP (observed: the
`sandbox-egress` IP `.6` had been reassigned to `tale-sandbox-llm-gateway`, a
non-resolver), so every external lookup in a build fails. Image **pulls** still
worked (mirror-by-name), masking it as "only apt is broken".

#2254 self-heals on daemon **restart** and on a **totally-missing** fence
(egress-ready marker absent) — but the marker stays present across IP drift, so
the spawner's presence-only health probe kept reusing the stale daemon.

## Fix (spawner-only — no buildkitd image/entrypoint change)

- **Drift detection.** `ensureBuildkitd`'s health probe now also compares the live
  `[dns]` nameserver (parsed from the daemon's `buildkitd.toml`) to the egress's
  **current** IP (`getent hosts <proxy host>` resolved inside the daemon). A
  mismatch ⇒ stale ⇒ reap + recreate (the entrypoint reinstalls the fence against
  the current IP; the persistent cache volume is preserved). No `[dns]`
  (skip-egress dev mode) or currently-unresolvable ⇒ treated healthy, so a
  transient never tears down a working daemon.
- **Adopted/reused sessions.** `ensureBuildkitd` only fires at `createSession`,
  which is skipped for a reused or re-adopted session — so a host `docker:dev`
  that bounces the spawner *and* drifts egress would leave an adopted session
  building against a stale daemon. Added `SessionBackend.reconcileBuildCache(orgIds)`,
  called from `SessionRoutes.adoptExisting()` at spawner startup, to heal it
  without a session recreate. No-op on Kubernetes (no sibling buildkitd).

Path-agnostic: the fix lives in the spawner image, which every start path ships,
and reconciles at session-create **and** at spawner startup.

## Verification

- 365 sandbox unit tests pass; `tsc` + `oxlint` clean. New tests cover the pure
  helpers (`egressProxyHostname`, `firstIpv4`, `parseDnsNameserver`), the live-toml
  path contract, and `adoptExisting → reconcileBuildCache`.
- **Live, end-to-end on the real stack:** reproduced the apt failure through a
  drifted daemon; observed the spawner log the stale-fence detection and recreate
  the daemon (`[dns]` `172.18.0.6` → `172.18.0.7`) on **both** the `createSession`
  and the startup (`adoptExisting`) paths; confirmed `apt-get update`
  (archive/security.ubuntu.com) + `curl https://github.com` succeed afterward.
- **Chat-driven E2E:** drove the Claude Code sandbox agent to re-run the original
  `bun docker:dev` — past the egress issue with zero DNS failures (images with
  `apt-get` steps build cleanly through the egress proxy).

## Ripple

- No migration (sandbox is unreleased; pure runtime logic, no schema/data change).
- No new env/config knob; no CLI-generator change.
- Updated `services/sandbox/docs/docker-in-container.md` to document the self-heal.
